### PR TITLE
Trim OVMF from installer closure

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -84,7 +84,7 @@ in
 {
   # Pre-built packages in the ISO's Nix store so nixos-install
   # can reuse them instead of recompiling from source.
-  system.extraDependencies = [ nixpkgs nasty-engine pkgs.OVMF pkgs.OVMF.fd ]
+  system.extraDependencies = [ nixpkgs nasty-engine ]
     ++ lib.optional (nasty-rootfs-toplevel != null) nasty-rootfs-toplevel
     ++ lib.optional (installerNastySource != null) installerNastySource
     ++ lib.optional (nasty-webui != null) nasty-webui;

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -402,12 +402,6 @@ in {
     # Prevent k3s from starting on boot — engine manages this.
     systemd.services.k3s.wantedBy = lib.mkForce [];
 
-    # ── VM support (OVMF firmware symlinks) ────────────────────
-    # The engine expects OVMF firmware at a well-known path. NixOS stores
-    # it in the Nix store, so we create stable symlinks.
-    environment.etc."nasty/ovmf/OVMF_CODE.fd".source = "${pkgs.OVMF.fd}/FV/OVMF_CODE.fd";
-    environment.etc."nasty/ovmf/OVMF_VARS.fd".source = "${pkgs.OVMF.fd}/FV/OVMF_VARS.fd";
-
     # ── System packages ────────────────────────────────────────
 
     environment.systemPackages = with pkgs; [
@@ -434,7 +428,6 @@ in {
       dig               # DNS debugging
       nano              # quick file editing
       qemu              # QEMU/KVM for virtual machines
-      OVMF              # UEFI firmware for VMs
       pciutils          # lspci for passthrough device discovery
       k3s               # lightweight Kubernetes for app runtime (optional)
       kubernetes-helm   # Helm chart manager for app deployment


### PR DESCRIPTION
As title stated, now GitHub is happy with our image of size no more than 2GB :)