### PR TITLE
Use unified local rebuild system name

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -10,9 +10,7 @@ const VERSION_PATH: &str = "/var/lib/nasty/version";
 /// Fallback version path — baked in by NixOS at build time (may be a local SHA).
 const VERSION_PATH_FALLBACK: &str = "/etc/nasty-version";
 const UPDATE_UNIT: &str = "nasty-update";
-const LOCAL_FLAKE_DIR: &str = "/etc/nixos";
-const SYSTEM_CONFIG_PATH: &str = "/var/lib/nasty/system-config";
-const DEFAULT_CONFIG: &str = "nasty";
+const LOCAL_FLAKE_TARGET: &str = "/etc/nixos#nasty";
 const LOCAL_REPO: &str = "/etc/nixos";
 const BCACHEFS_SWITCH_UNIT: &str = "nasty-bcachefs-switch";
 const NIXOS_FLAKE_DIR: &str = "/etc/nixos";
@@ -435,7 +433,7 @@ impl UpdateService {
             ),
         };
 
-        let local_flake = local_flake().await;
+        let local_flake = local_flake();
         let script = format!(
             r#"#!/bin/bash
 set -euo pipefail
@@ -900,7 +898,7 @@ echo "==> Switch to generation {gen_id} complete!"
             format!(r#"rm -f {BCACHEFS_DEBUG_CHECKS_STATE}"#)
         };
 
-        let local_flake = local_flake().await;
+        let local_flake = local_flake();
         let script = format!(
             r#"#!/bin/bash
 set -euo pipefail
@@ -1426,20 +1424,9 @@ async fn bcachefs_version() -> (String, Option<bool>) {
     (version, kernel_rust)
 }
 
-/// Public wrapper for use by lib.rs cached info.
-/// Read the system config name from the state file, defaulting to "nasty" (bare metal).
-async fn read_system_config() -> String {
-    tokio::fs::read_to_string(SYSTEM_CONFIG_PATH).await
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_CONFIG.to_string())
-}
-
 /// Build the full flake reference for nixos-rebuild.
-async fn local_flake() -> String {
-    let config = read_system_config().await;
-    format!("{LOCAL_FLAKE_DIR}#{config}")
+fn local_flake() -> &'static str {
+    LOCAL_FLAKE_TARGET
 }
 
 pub async fn read_flake_nix_default_ref_pub() -> String {

--- a/nixos/cloud.nix
+++ b/nixos/cloud.nix
@@ -46,15 +46,6 @@
     nvmeof.enable = true;
   };
 
-  # Tell the update engine which flake config to rebuild.
-  # aarch64 uses nasty-cloud-aarch64, x86_64 uses nasty-cloud.
-  system.activationScripts.nasty-system-config = ''
-    mkdir -p /var/lib/nasty
-    CFG="nasty-cloud"
-    [ "$(uname -m)" = "aarch64" ] && CFG="nasty-cloud-aarch64"
-    echo "$CFG" > /var/lib/nasty/system-config
-  '';
-
   # No mDNS/Avahi on cloud — no local network discovery needed
   services.avahi.enable = lib.mkForce false;
 

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -243,6 +243,18 @@ in
       mkdir -p /mnt/etc/nixos
       cp -rL --no-preserve=mode /etc/nasty-system-flake/. /mnt/etc/nixos/
 
+      echo "==> Detecting local system identifier..."
+      LOCAL_SYSTEM=$(nix --extra-experimental-features 'nix-command flakes' eval --impure --raw --expr builtins.currentSystem)
+      if [ -z "$LOCAL_SYSTEM" ]; then
+        echo "Error: failed to detect local system identifier"
+        exit 1
+      fi
+      if ! grep -q '"local-system"' /mnt/etc/nixos/flake.nix; then
+        echo "Error: local system placeholder not found in /mnt/etc/nixos/flake.nix"
+        exit 1
+      fi
+      ${pkgs.gnused}/bin/sed -i "s/\"local-system\"/\"$LOCAL_SYSTEM\"/" /mnt/etc/nixos/flake.nix
+
       echo "==> Generating hardware configuration..."
       nixos-generate-config --root /mnt --dir /tmp/hw-config
 

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -40,8 +40,7 @@
       };
     in {
       nixosConfigurations = {
-        nasty = mkSystem "x86_64-linux";
-        nasty-aarch64 = mkSystem "aarch64-linux";
+        nasty = mkSystem "local-system";
       };
     };
 }


### PR DESCRIPTION
Generate the installed /etc/nixos wrapper flake with a local-system placeholder and replace it during ISO installation using the live builtins.currentSystem value. 

Simplify nasty-system updates so new generations always rebuild /etc/nixos#nasty, and drop the cloud system-config override that pointed the engine at names not exported by the wrapper flake.