### PR TITLE
Refine Version page around tagged releases and generation-owned system flake recovery

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -390,6 +402,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -766,6 +784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +951,8 @@ dependencies = [
  "libc",
  "nasty-common",
  "reqwest",
+ "rnix",
+ "rowan",
  "schemars",
  "serde",
  "serde_json",
@@ -1100,7 +1129,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -1120,7 +1149,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1299,6 +1328,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rnix"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f15e00b0ab43abd70d50b6f8cd021290028f9b7fdd7cdfa6c35997173bc1ba9"
+dependencies = [
+ "rowan",
+]
+
+[[package]]
+name = "rowan"
+version = "0.15.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "memoffset",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1362,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1636,6 +1693,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
 name = "nasty-system"
 version = "0.0.2"
 dependencies = [
+ "base64",
  "libc",
  "nasty-common",
  "reqwest",

--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -113,8 +113,7 @@ use nasty_system::network::NetworkConfig;
 use nasty_system::protocol::ProtocolStatus;
 use nasty_system::settings::{Settings, SettingsUpdate};
 use nasty_system::update::{
-    BcachefsToolsInfo, BcachefsToolsSwitchRequest, UpdateInfo, UpdateStatus, VersionInfo,
-    VersionSwitchRequest,
+    UpdateInfo, UpdateStatus, VersionInfo, VersionSwitchRequest,
 };
 use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats};
 
@@ -321,38 +320,10 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
                 },
                 Method {
                     name: "system.version.cleanup",
-                    desc: "Restore `/etc/nixos` from the last backup if a Version-page switch was abandoned or failed.",
+                    desc: "Purge any stale legacy backup directory left by older Version-page builds.",
                     role: "admin",
                     params: MethodParams::None,
                     result: None,
-                },
-            ],
-        ),
-        (
-            "bcachefs-tools",
-            vec![
-                Method {
-                    name: "bcachefs.tools.info",
-                    desc: "Return bcachefs-tools version info (pinned ref, running version, custom/default flag).",
-                    role: "any",
-                    params: MethodParams::None,
-                    result: Some(gen_schema::<BcachefsToolsInfo>(generator)),
-                },
-                Method {
-                    name: "bcachefs.tools.switch",
-                    desc: "Switch bcachefs-tools to a specific git ref (tag, branch, or commit SHA). Runs `nixos-rebuild switch` in background.",
-                    role: "admin",
-                    params: MethodParams::Schema(gen_schema::<BcachefsToolsSwitchRequest>(
-                        generator,
-                    )),
-                    result: None,
-                },
-                Method {
-                    name: "bcachefs.tools.status",
-                    desc: "Return the current bcachefs-tools switch operation status.",
-                    role: "any",
-                    params: MethodParams::None,
-                    result: Some(gen_schema::<UpdateStatus>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -12,7 +12,11 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-pub enum Role { Admin, ReadOnly, Operator }
+pub enum Role {
+    Admin,
+    ReadOnly,
+    Operator,
+}
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct Session {
@@ -88,34 +92,31 @@ pub struct ChangePasswordRequest {
 
 // ── Imports from other crates ─────────────────────────────────────
 
+use nasty_sharing::iscsi::{AddAclRequest, AddLunRequest, CreateTargetRequest, IscsiTarget};
+use nasty_sharing::nfs::{CreateNfsShareRequest, NfsShare, UpdateNfsShareRequest};
+use nasty_sharing::nvmeof::{
+    AddHostRequest, AddNamespaceRequest, AddPortRequest, CreateSubsystemRequest, NvmeofSubsystem,
+};
+use nasty_sharing::smb::{CreateSmbShareRequest, SmbShare, UpdateSmbShareRequest};
 use nasty_storage::filesystem::{
-    Filesystem, BlockDevice,
-    CreateFilesystemRequest, DestroyFilesystemRequest, UpdateFilesystemOptionsRequest,
-    DeviceAddRequest, DeviceActionRequest, DeviceSetLabelRequest,
-    DeviceSetStateRequest, FsUsage, ScrubStatus, ReconcileStatus,
+    BlockDevice, CreateFilesystemRequest, DestroyFilesystemRequest, DeviceActionRequest,
+    DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem, FsUsage,
+    ReconcileStatus, ScrubStatus, UpdateFilesystemOptionsRequest,
 };
 use nasty_storage::subvolume::{
-    Subvolume, Snapshot,
-    CreateSubvolumeRequest, DeleteSubvolumeRequest,
-    CreateSnapshotRequest, DeleteSnapshotRequest, CloneSnapshotRequest,
-    ResizeSubvolumeRequest, SetPropertiesRequest, RemovePropertiesRequest,
-    FindByPropertyRequest,
+    CloneSnapshotRequest, CreateSnapshotRequest, CreateSubvolumeRequest, DeleteSnapshotRequest,
+    DeleteSubvolumeRequest, FindByPropertyRequest, RemovePropertiesRequest, ResizeSubvolumeRequest,
+    SetPropertiesRequest, Snapshot, Subvolume,
 };
-use nasty_system::{SystemInfo, SystemHealth, SystemStats, DiskHealth};
-use nasty_system::protocol::ProtocolStatus;
-use nasty_system::alerts::{AlertRule, AlertRuleUpdate, ActiveAlert};
+use nasty_system::alerts::{ActiveAlert, AlertRule, AlertRuleUpdate};
 use nasty_system::network::NetworkConfig;
+use nasty_system::protocol::ProtocolStatus;
 use nasty_system::settings::{Settings, SettingsUpdate};
-use nasty_system::update::{BcachefsToolsInfo, BcachefsToolsSwitchRequest, UpdateInfo, UpdateStatus};
-use nasty_sharing::nfs::{NfsShare, CreateNfsShareRequest, UpdateNfsShareRequest};
-use nasty_sharing::smb::{SmbShare, CreateSmbShareRequest, UpdateSmbShareRequest};
-use nasty_sharing::iscsi::{
-    IscsiTarget, CreateTargetRequest, AddLunRequest, AddAclRequest,
+use nasty_system::update::{
+    BcachefsToolsInfo, BcachefsToolsSwitchRequest, UpdateInfo, UpdateStatus, VersionInfo,
+    VersionSwitchRequest,
 };
-use nasty_sharing::nvmeof::{
-    NvmeofSubsystem, CreateSubsystemRequest,
-    AddNamespaceRequest, AddPortRequest, AddHostRequest,
-};
+use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats};
 
 // ── Method registry ───────────────────────────────────────────────
 
@@ -142,296 +143,824 @@ fn gen_schema<T: JsonSchema>(generator: &mut SchemaGenerator) -> Value {
 
 fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> {
     vec![
-        ("Authentication", vec![
-            Method { name: "auth.me", desc: "Return the current session's username and role.", role: "any",
-                params: MethodParams::None,
-                result: Some(gen_schema::<Session>(generator)) },
-            Method { name: "auth.logout", desc: "Invalidate the current session token.", role: "any",
-                params: MethodParams::None, result: None },
-            Method { name: "auth.change_password", desc: "Change a user's password. Admins can change any user; users can change their own.", role: "any",
-                params: MethodParams::Schema(gen_schema::<ChangePasswordRequest>(generator)), result: None },
-            Method { name: "auth.create_user", desc: "Create a new local user account.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateUserRequest>(generator)), result: None },
-            Method { name: "auth.delete_user", desc: "Delete a user. Cannot delete your own account.", role: "admin",
-                params: MethodParams::Literal("`{\"username\": string}`"), result: None },
-            Method { name: "auth.list_users", desc: "List all users (no password hashes).", role: "any",
-                params: MethodParams::None,
-                result: Some(gen_schema::<Vec<UserInfo>>(generator)) },
-            Method { name: "auth.token.list", desc: "List all API tokens (without token values).", role: "admin",
-                params: MethodParams::None,
-                result: Some(gen_schema::<Vec<ApiTokenInfo>>(generator)) },
-            Method { name: "auth.token.create", desc: "Create a long-lived API token. Returns the token value — shown only once.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string, \"role\": Role, \"pool\": string?, \"expires_in_secs\": integer?}`"),
-                result: Some(gen_schema::<ApiToken>(generator)) },
-            Method { name: "auth.token.delete", desc: "Delete an API token by ID.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-        ]),
-        ("System", vec![
-            Method { name: "system.info", desc: "Return hostname, OS version, uptime, bcachefs-tools version info.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<SystemInfo>(generator)) },
-            Method { name: "system.health", desc: "Return health status of all systemd services.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<SystemHealth>(generator)) },
-            Method { name: "system.stats", desc: "Return current CPU, memory, network interface, and disk I/O statistics.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<SystemStats>(generator)) },
-            Method { name: "system.disks", desc: "Return S.M.A.R.T. health data for all drives. Requires SMART protocol to be enabled.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<DiskHealth>>(generator)) },
-            Method { name: "system.alerts", desc: "Evaluate alert rules against current system state and return any active alerts.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<ActiveAlert>>(generator)) },
-            Method { name: "system.reboot", desc: "Reboot the system.", role: "admin",
-                params: MethodParams::None, result: None },
-            Method { name: "system.shutdown", desc: "Shut down the system.", role: "admin",
-                params: MethodParams::None, result: None },
-        ]),
-        ("System Update", vec![
-            Method { name: "system.update.version", desc: "Return current version and latest available version.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<UpdateInfo>(generator)) },
-            Method { name: "system.update.check", desc: "Check for available updates against the upstream repository.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<UpdateInfo>(generator)) },
-            Method { name: "system.update.apply", desc: "Fetch and apply the latest NixOS generation. Runs `nixos-rebuild switch` in the background.", role: "admin",
-                params: MethodParams::None, result: None },
-            Method { name: "system.update.rollback", desc: "Roll back to the previous NixOS generation.", role: "admin",
-                params: MethodParams::None, result: None },
-            Method { name: "system.update.status", desc: "Return the current update operation status and log.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<UpdateStatus>(generator)) },
-        ]),
-        ("bcachefs-tools", vec![
-            Method { name: "bcachefs.tools.info", desc: "Return bcachefs-tools version info (pinned ref, running version, custom/default flag).", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<BcachefsToolsInfo>(generator)) },
-            Method { name: "bcachefs.tools.switch", desc: "Switch bcachefs-tools to a specific git ref (tag, branch, or commit SHA). Runs `nixos-rebuild switch` in background.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<BcachefsToolsSwitchRequest>(generator)), result: None },
-            Method { name: "bcachefs.tools.status", desc: "Return the current bcachefs-tools switch operation status.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<UpdateStatus>(generator)) },
-        ]),
-        ("Settings", vec![
-            Method { name: "system.settings.get", desc: "Return current system settings.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Settings>(generator)) },
-            Method { name: "system.settings.update", desc: "Update system settings. Only provided fields are changed.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<SettingsUpdate>(generator)),
-                result: Some(gen_schema::<Settings>(generator)) },
-            Method { name: "system.settings.timezones", desc: "Return list of valid IANA timezone strings.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<String>>(generator)) },
-        ]),
-        ("Network", vec![
-            Method { name: "system.network.get", desc: "Return current network configuration including live interface state.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<NetworkConfig>(generator)) },
-            Method { name: "system.network.update", desc: "Update network configuration (DHCP or static). Applied immediately without rebooting.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<NetworkConfig>(generator)), result: None },
-        ]),
-        ("Protocols & Services", vec![
-            Method { name: "service.protocol.list", desc: "List all protocols and their current status.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<ProtocolStatus>>(generator)) },
-            Method { name: "service.protocol.enable", desc: "Enable a protocol service. Available names: `nfs`, `smb`, `iscsi`, `nvmeof`, `ssh`, `avahi`, `smart`.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<ProtocolStatus>(generator)) },
-            Method { name: "service.protocol.disable", desc: "Disable a protocol service.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<ProtocolStatus>(generator)) },
-        ]),
-        ("Alert Rules", vec![
-            Method { name: "alert.rules.list", desc: "List all alert rules.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<AlertRule>>(generator)) },
-            Method { name: "alert.rules.create", desc: "Create a new alert rule.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AlertRule>(generator)),
-                result: Some(gen_schema::<AlertRule>(generator)) },
-            Method { name: "alert.rules.update", desc: "Update an existing alert rule. Only provided fields are changed.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AlertRuleUpdate>(generator)),
-                result: Some(gen_schema::<AlertRule>(generator)) },
-            Method { name: "alert.rules.delete", desc: "Delete an alert rule by ID.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-        ]),
-        ("Block Devices", vec![
-            Method { name: "device.list", desc: "List all block devices and partitions visible to the system.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<BlockDevice>>(generator)) },
-            Method { name: "device.wipe", desc: "Erase all filesystem signatures from a device (wipefs). The device must not be in use.", role: "admin",
-                params: MethodParams::Literal("`{\"path\": string}`"), result: None },
-        ]),
-        ("Filesystems", vec![
-            Method { name: "fs.list", desc: "List all filesystems. Filesystem-scoped tokens see only their assigned filesystem.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<Filesystem>>(generator)) },
-            Method { name: "fs.get", desc: "Get a single filesystem by name.", role: "any",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.create", desc: "Format and mount a new bcachefs filesystem.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateFilesystemRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.destroy", desc: "Unmount and unregister a filesystem. Does not wipe the devices.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DestroyFilesystemRequest>(generator)), result: None },
-            Method { name: "fs.mount", desc: "Mount a known filesystem.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.unmount", desc: "Unmount a filesystem.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string}`"), result: None },
-            Method { name: "fs.options.update", desc: "Update runtime-mutable bcachefs filesystem options (written to sysfs).", role: "admin",
-                params: MethodParams::Schema(gen_schema::<UpdateFilesystemOptionsRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.usage", desc: "Return detailed bcachefs `fs usage` breakdown.", role: "any",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<FsUsage>(generator)) },
-            Method { name: "fs.scrub.start", desc: "Start a scrub on a mounted filesystem.", role: "admin",
-                params: MethodParams::Literal("`{\"name\": string}`"), result: None },
-            Method { name: "fs.scrub.status", desc: "Return current scrub status.", role: "any",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<ScrubStatus>(generator)) },
-            Method { name: "fs.reconcile.status", desc: "Return bcachefs background work (reconcile) status.", role: "any",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<ReconcileStatus>(generator)) },
-            Method { name: "bcachefs.usage", desc: "Return raw `bcachefs fs usage` output for a filesystem.", role: "any",
-                params: MethodParams::Literal("`{\"name\": string}`"),
-                result: Some(gen_schema::<FsUsage>(generator)) },
-        ]),
-        ("Filesystem Devices", vec![
-            Method { name: "fs.device.add", desc: "Add a device to an existing mounted filesystem.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceAddRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.device.remove", desc: "Remove a device from a filesystem. The device should be fully evacuated first.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.device.evacuate", desc: "Evacuate all data from a device to the remaining filesystem members. Long-running — returns `{\"status\": \"started\"}` immediately. Filesystem events are broadcast every 3s during evacuation.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)), result: None },
-            Method { name: "fs.device.set_state", desc: "Set persistent device state (`rw`, `ro`, `failed`, `spare`).", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceSetStateRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.device.set_label", desc: "Set or update the hierarchical label on a device in a mounted filesystem. Written live via sysfs.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceSetLabelRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.device.online", desc: "Bring a device back online.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-            Method { name: "fs.device.offline", desc: "Take a device offline.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
-                result: Some(gen_schema::<Filesystem>(generator)) },
-        ]),
-        ("Subvolumes", vec![
-            Method { name: "subvolume.list", desc: "List subvolumes in a filesystem.", role: "any",
-                params: MethodParams::Literal("`{\"pool\": string}`"),
-                result: Some(gen_schema::<Vec<Subvolume>>(generator)) },
-            Method { name: "subvolume.list_all", desc: "List all subvolumes across all pools.", role: "any",
-                params: MethodParams::None,
-                result: Some(gen_schema::<Vec<Subvolume>>(generator)) },
-            Method { name: "subvolume.get", desc: "Get a single subvolume.", role: "any",
-                params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.create", desc: "Create a new bcachefs subvolume (filesystem or block-backed).", role: "operator",
-                params: MethodParams::Schema(gen_schema::<CreateSubvolumeRequest>(generator)),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.delete", desc: "Delete a subvolume and all its snapshots.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<DeleteSubvolumeRequest>(generator)), result: None },
-            Method { name: "subvolume.attach", desc: "Attach the loop device for a block subvolume (mounts `vol.img` via losetup).", role: "operator",
-                params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.detach", desc: "Detach the loop device for a block subvolume.", role: "operator",
-                params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.resize", desc: "Resize a block subvolume's backing image.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<ResizeSubvolumeRequest>(generator)),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.set_properties", desc: "Set arbitrary key-value metadata on a subvolume (stored as POSIX xattrs in the `user.*` namespace). Used by the CSI driver.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<SetPropertiesRequest>(generator)),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.remove_properties", desc: "Remove specific metadata keys from a subvolume.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<RemovePropertiesRequest>(generator)),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-            Method { name: "subvolume.find_by_property", desc: "Find subvolumes matching a specific metadata key-value pair.", role: "any",
-                params: MethodParams::Schema(gen_schema::<FindByPropertyRequest>(generator)),
-                result: Some(gen_schema::<Vec<Subvolume>>(generator)) },
-        ]),
-        ("Snapshots", vec![
-            Method { name: "snapshot.list", desc: "List snapshots for all subvolumes in a filesystem.", role: "any",
-                params: MethodParams::Literal("`{\"pool\": string}`"),
-                result: Some(gen_schema::<Vec<Snapshot>>(generator)) },
-            Method { name: "snapshot.create", desc: "Create a snapshot of a subvolume.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<CreateSnapshotRequest>(generator)),
-                result: Some(gen_schema::<Snapshot>(generator)) },
-            Method { name: "snapshot.delete", desc: "Delete a snapshot.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<DeleteSnapshotRequest>(generator)), result: None },
-            Method { name: "snapshot.clone", desc: "Clone a snapshot into a new independent subvolume.", role: "operator",
-                params: MethodParams::Schema(gen_schema::<CloneSnapshotRequest>(generator)),
-                result: Some(gen_schema::<Subvolume>(generator)) },
-        ]),
-        ("NFS Shares", vec![
-            Method { name: "share.nfs.list", desc: "List all NFS shares.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<NfsShare>>(generator)) },
-            Method { name: "share.nfs.get", desc: "Get an NFS share by ID.", role: "any",
-                params: MethodParams::Literal("`{\"id\": string}`"),
-                result: Some(gen_schema::<NfsShare>(generator)) },
-            Method { name: "share.nfs.create", desc: "Create an NFS share.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateNfsShareRequest>(generator)),
-                result: Some(gen_schema::<NfsShare>(generator)) },
-            Method { name: "share.nfs.update", desc: "Update an NFS share.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<UpdateNfsShareRequest>(generator)),
-                result: Some(gen_schema::<NfsShare>(generator)) },
-            Method { name: "share.nfs.delete", desc: "Delete an NFS share.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-        ]),
-        ("SMB Shares", vec![
-            Method { name: "share.smb.list", desc: "List all SMB shares.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<SmbShare>>(generator)) },
-            Method { name: "share.smb.get", desc: "Get an SMB share by ID.", role: "any",
-                params: MethodParams::Literal("`{\"id\": string}`"),
-                result: Some(gen_schema::<SmbShare>(generator)) },
-            Method { name: "share.smb.create", desc: "Create an SMB share.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateSmbShareRequest>(generator)),
-                result: Some(gen_schema::<SmbShare>(generator)) },
-            Method { name: "share.smb.update", desc: "Update an SMB share.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<UpdateSmbShareRequest>(generator)),
-                result: Some(gen_schema::<SmbShare>(generator)) },
-            Method { name: "share.smb.delete", desc: "Delete an SMB share.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-        ]),
-        ("iSCSI Targets", vec![
-            Method { name: "share.iscsi.list", desc: "List all iSCSI targets.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<IscsiTarget>>(generator)) },
-            Method { name: "share.iscsi.get", desc: "Get an iSCSI target by ID.", role: "any",
-                params: MethodParams::Literal("`{\"id\": string}`"),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-            Method { name: "share.iscsi.create", desc: "Create an iSCSI target. Optionally attach a LUN and ACLs in one call.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateTargetRequest>(generator)),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-            Method { name: "share.iscsi.delete", desc: "Delete an iSCSI target.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-            Method { name: "share.iscsi.add_lun", desc: "Add a LUN to an iSCSI target.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AddLunRequest>(generator)),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-            Method { name: "share.iscsi.remove_lun", desc: "Remove a LUN from an iSCSI target.", role: "admin",
-                params: MethodParams::Literal("`{\"target_id\": string, \"lun_id\": integer}`"),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-            Method { name: "share.iscsi.add_acl", desc: "Allow an iSCSI initiator IQN to connect.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AddAclRequest>(generator)),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-            Method { name: "share.iscsi.remove_acl", desc: "Remove an iSCSI initiator ACL.", role: "admin",
-                params: MethodParams::Literal("`{\"target_id\": string, \"initiator_iqn\": string}`"),
-                result: Some(gen_schema::<IscsiTarget>(generator)) },
-        ]),
-        ("NVMe-oF Subsystems", vec![
-            Method { name: "share.nvmeof.list", desc: "List all NVMe-oF subsystems.", role: "any",
-                params: MethodParams::None, result: Some(gen_schema::<Vec<NvmeofSubsystem>>(generator)) },
-            Method { name: "share.nvmeof.get", desc: "Get an NVMe-oF subsystem by ID.", role: "any",
-                params: MethodParams::Literal("`{\"id\": string}`"),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.create", desc: "Create an NVMe-oF subsystem. Optionally attach a namespace, port, and host ACLs in one call.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<CreateSubsystemRequest>(generator)),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.delete", desc: "Delete an NVMe-oF subsystem.", role: "admin",
-                params: MethodParams::Literal("`{\"id\": string}`"), result: None },
-            Method { name: "share.nvmeof.add_namespace", desc: "Add a namespace (block device) to a subsystem.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AddNamespaceRequest>(generator)),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.remove_namespace", desc: "Remove a namespace from a subsystem.", role: "admin",
-                params: MethodParams::Literal("`{\"subsystem_id\": string, \"nsid\": integer}`"),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.add_port", desc: "Add a transport port to a subsystem.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AddPortRequest>(generator)),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.remove_port", desc: "Remove a transport port from a subsystem.", role: "admin",
-                params: MethodParams::Literal("`{\"subsystem_id\": string, \"port_id\": integer}`"),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.add_host", desc: "Allow a host NQN to connect to a subsystem.", role: "admin",
-                params: MethodParams::Schema(gen_schema::<AddHostRequest>(generator)),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-            Method { name: "share.nvmeof.remove_host", desc: "Disallow a host NQN from a subsystem.", role: "admin",
-                params: MethodParams::Literal("`{\"subsystem_id\": string, \"nqn\": string}`"),
-                result: Some(gen_schema::<NvmeofSubsystem>(generator)) },
-        ]),
+        (
+            "Authentication",
+            vec![
+                Method {
+                    name: "auth.me",
+                    desc: "Return the current session's username and role.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Session>(generator)),
+                },
+                Method {
+                    name: "auth.logout",
+                    desc: "Invalidate the current session token.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: None,
+                },
+                Method {
+                    name: "auth.change_password",
+                    desc: "Change a user's password. Admins can change any user; users can change their own.",
+                    role: "any",
+                    params: MethodParams::Schema(gen_schema::<ChangePasswordRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "auth.create_user",
+                    desc: "Create a new local user account.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateUserRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "auth.delete_user",
+                    desc: "Delete a user. Cannot delete your own account.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"username\": string}`"),
+                    result: None,
+                },
+                Method {
+                    name: "auth.list_users",
+                    desc: "List all users (no password hashes).",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<UserInfo>>(generator)),
+                },
+                Method {
+                    name: "auth.token.list",
+                    desc: "List all API tokens (without token values).",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<ApiTokenInfo>>(generator)),
+                },
+                Method {
+                    name: "auth.token.create",
+                    desc: "Create a long-lived API token. Returns the token value — shown only once.",
+                    role: "admin",
+                    params: MethodParams::Literal(
+                        "`{\"name\": string, \"role\": Role, \"pool\": string?, \"expires_in_secs\": integer?}`",
+                    ),
+                    result: Some(gen_schema::<ApiToken>(generator)),
+                },
+                Method {
+                    name: "auth.token.delete",
+                    desc: "Delete an API token by ID.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "System",
+            vec![
+                Method {
+                    name: "system.info",
+                    desc: "Return hostname, OS version, uptime, bcachefs-tools version info.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<SystemInfo>(generator)),
+                },
+                Method {
+                    name: "system.health",
+                    desc: "Return health status of all systemd services.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<SystemHealth>(generator)),
+                },
+                Method {
+                    name: "system.stats",
+                    desc: "Return current CPU, memory, network interface, and disk I/O statistics.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<SystemStats>(generator)),
+                },
+                Method {
+                    name: "system.disks",
+                    desc: "Return S.M.A.R.T. health data for all drives. Requires SMART protocol to be enabled.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<DiskHealth>>(generator)),
+                },
+                Method {
+                    name: "system.alerts",
+                    desc: "Evaluate alert rules against current system state and return any active alerts.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<ActiveAlert>>(generator)),
+                },
+                Method {
+                    name: "system.reboot",
+                    desc: "Reboot the system.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
+                },
+                Method {
+                    name: "system.shutdown",
+                    desc: "Shut down the system.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "System Update",
+            vec![
+                Method {
+                    name: "system.update.version",
+                    desc: "Return current version and latest available version.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateInfo>(generator)),
+                },
+                Method {
+                    name: "system.update.check",
+                    desc: "Check for available updates against the upstream repository.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateInfo>(generator)),
+                },
+                Method {
+                    name: "system.update.apply",
+                    desc: "Fetch and apply the latest NixOS generation. Runs `nixos-rebuild switch` in the background.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
+                },
+                Method {
+                    name: "system.update.rollback",
+                    desc: "Roll back to the previous NixOS generation.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
+                },
+                Method {
+                    name: "system.update.status",
+                    desc: "Return the current update operation status and log.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateStatus>(generator)),
+                },
+                Method {
+                    name: "system.version.get",
+                    desc: "Return exact input URLs from `/etc/nixos/flake.nix` and locked revs from `/etc/nixos/flake.lock` for the Version page.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<VersionInfo>(generator)),
+                },
+                Method {
+                    name: "system.version.switch",
+                    desc: "Update selected flake inputs on the installed system and rebuild only if `flake.lock` changed.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<VersionSwitchRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "system.version.cleanup",
+                    desc: "Restore `/etc/nixos` from the last backup if a Version-page switch was abandoned or failed.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "bcachefs-tools",
+            vec![
+                Method {
+                    name: "bcachefs.tools.info",
+                    desc: "Return bcachefs-tools version info (pinned ref, running version, custom/default flag).",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<BcachefsToolsInfo>(generator)),
+                },
+                Method {
+                    name: "bcachefs.tools.switch",
+                    desc: "Switch bcachefs-tools to a specific git ref (tag, branch, or commit SHA). Runs `nixos-rebuild switch` in background.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<BcachefsToolsSwitchRequest>(
+                        generator,
+                    )),
+                    result: None,
+                },
+                Method {
+                    name: "bcachefs.tools.status",
+                    desc: "Return the current bcachefs-tools switch operation status.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateStatus>(generator)),
+                },
+            ],
+        ),
+        (
+            "Settings",
+            vec![
+                Method {
+                    name: "system.settings.get",
+                    desc: "Return current system settings.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Settings>(generator)),
+                },
+                Method {
+                    name: "system.settings.update",
+                    desc: "Update system settings. Only provided fields are changed.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<SettingsUpdate>(generator)),
+                    result: Some(gen_schema::<Settings>(generator)),
+                },
+                Method {
+                    name: "system.settings.timezones",
+                    desc: "Return list of valid IANA timezone strings.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<String>>(generator)),
+                },
+            ],
+        ),
+        (
+            "Network",
+            vec![
+                Method {
+                    name: "system.network.get",
+                    desc: "Return current network configuration including live interface state.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<NetworkConfig>(generator)),
+                },
+                Method {
+                    name: "system.network.update",
+                    desc: "Update network configuration (DHCP or static). Applied immediately without rebooting.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<NetworkConfig>(generator)),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "Protocols & Services",
+            vec![
+                Method {
+                    name: "service.protocol.list",
+                    desc: "List all protocols and their current status.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<ProtocolStatus>>(generator)),
+                },
+                Method {
+                    name: "service.protocol.enable",
+                    desc: "Enable a protocol service. Available names: `nfs`, `smb`, `iscsi`, `nvmeof`, `ssh`, `avahi`, `smart`.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<ProtocolStatus>(generator)),
+                },
+                Method {
+                    name: "service.protocol.disable",
+                    desc: "Disable a protocol service.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<ProtocolStatus>(generator)),
+                },
+            ],
+        ),
+        (
+            "Alert Rules",
+            vec![
+                Method {
+                    name: "alert.rules.list",
+                    desc: "List all alert rules.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<AlertRule>>(generator)),
+                },
+                Method {
+                    name: "alert.rules.create",
+                    desc: "Create a new alert rule.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AlertRule>(generator)),
+                    result: Some(gen_schema::<AlertRule>(generator)),
+                },
+                Method {
+                    name: "alert.rules.update",
+                    desc: "Update an existing alert rule. Only provided fields are changed.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AlertRuleUpdate>(generator)),
+                    result: Some(gen_schema::<AlertRule>(generator)),
+                },
+                Method {
+                    name: "alert.rules.delete",
+                    desc: "Delete an alert rule by ID.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "Block Devices",
+            vec![
+                Method {
+                    name: "device.list",
+                    desc: "List all block devices and partitions visible to the system.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<BlockDevice>>(generator)),
+                },
+                Method {
+                    name: "device.wipe",
+                    desc: "Erase all filesystem signatures from a device (wipefs). The device must not be in use.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"path\": string}`"),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "Filesystems",
+            vec![
+                Method {
+                    name: "fs.list",
+                    desc: "List all filesystems. Filesystem-scoped tokens see only their assigned filesystem.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<Filesystem>>(generator)),
+                },
+                Method {
+                    name: "fs.get",
+                    desc: "Get a single filesystem by name.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.create",
+                    desc: "Format and mount a new bcachefs filesystem.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateFilesystemRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.destroy",
+                    desc: "Unmount and unregister a filesystem. Does not wipe the devices.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DestroyFilesystemRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "fs.mount",
+                    desc: "Mount a known filesystem.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.unmount",
+                    desc: "Unmount a filesystem.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: None,
+                },
+                Method {
+                    name: "fs.options.update",
+                    desc: "Update runtime-mutable bcachefs filesystem options (written to sysfs).",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<UpdateFilesystemOptionsRequest>(
+                        generator,
+                    )),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.usage",
+                    desc: "Return detailed bcachefs `fs usage` breakdown.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<FsUsage>(generator)),
+                },
+                Method {
+                    name: "fs.scrub.start",
+                    desc: "Start a scrub on a mounted filesystem.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: None,
+                },
+                Method {
+                    name: "fs.scrub.status",
+                    desc: "Return current scrub status.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<ScrubStatus>(generator)),
+                },
+                Method {
+                    name: "fs.reconcile.status",
+                    desc: "Return bcachefs background work (reconcile) status.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<ReconcileStatus>(generator)),
+                },
+                Method {
+                    name: "bcachefs.usage",
+                    desc: "Return raw `bcachefs fs usage` output for a filesystem.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<FsUsage>(generator)),
+                },
+            ],
+        ),
+        (
+            "Filesystem Devices",
+            vec![
+                Method {
+                    name: "fs.device.add",
+                    desc: "Add a device to an existing mounted filesystem.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceAddRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.device.remove",
+                    desc: "Remove a device from a filesystem. The device should be fully evacuated first.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.device.evacuate",
+                    desc: "Evacuate all data from a device to the remaining filesystem members. Long-running — returns `{\"status\": \"started\"}` immediately. Filesystem events are broadcast every 3s during evacuation.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "fs.device.set_state",
+                    desc: "Set persistent device state (`rw`, `ro`, `failed`, `spare`).",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceSetStateRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.device.set_label",
+                    desc: "Set or update the hierarchical label on a device in a mounted filesystem. Written live via sysfs.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceSetLabelRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.device.online",
+                    desc: "Bring a device back online.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+                Method {
+                    name: "fs.device.offline",
+                    desc: "Take a device offline.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
+                    result: Some(gen_schema::<Filesystem>(generator)),
+                },
+            ],
+        ),
+        (
+            "Subvolumes",
+            vec![
+                Method {
+                    name: "subvolume.list",
+                    desc: "List subvolumes in a filesystem.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"pool\": string}`"),
+                    result: Some(gen_schema::<Vec<Subvolume>>(generator)),
+                },
+                Method {
+                    name: "subvolume.list_all",
+                    desc: "List all subvolumes across all pools.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<Subvolume>>(generator)),
+                },
+                Method {
+                    name: "subvolume.get",
+                    desc: "Get a single subvolume.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.create",
+                    desc: "Create a new bcachefs subvolume (filesystem or block-backed).",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<CreateSubvolumeRequest>(generator)),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.delete",
+                    desc: "Delete a subvolume and all its snapshots.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<DeleteSubvolumeRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "subvolume.attach",
+                    desc: "Attach the loop device for a block subvolume (mounts `vol.img` via losetup).",
+                    role: "operator",
+                    params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.detach",
+                    desc: "Detach the loop device for a block subvolume.",
+                    role: "operator",
+                    params: MethodParams::Literal("`{\"pool\": string, \"name\": string}`"),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.resize",
+                    desc: "Resize a block subvolume's backing image.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<ResizeSubvolumeRequest>(generator)),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.set_properties",
+                    desc: "Set arbitrary key-value metadata on a subvolume (stored as POSIX xattrs in the `user.*` namespace). Used by the CSI driver.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<SetPropertiesRequest>(generator)),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.remove_properties",
+                    desc: "Remove specific metadata keys from a subvolume.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<RemovePropertiesRequest>(generator)),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "subvolume.find_by_property",
+                    desc: "Find subvolumes matching a specific metadata key-value pair.",
+                    role: "any",
+                    params: MethodParams::Schema(gen_schema::<FindByPropertyRequest>(generator)),
+                    result: Some(gen_schema::<Vec<Subvolume>>(generator)),
+                },
+            ],
+        ),
+        (
+            "Snapshots",
+            vec![
+                Method {
+                    name: "snapshot.list",
+                    desc: "List snapshots for all subvolumes in a filesystem.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"pool\": string}`"),
+                    result: Some(gen_schema::<Vec<Snapshot>>(generator)),
+                },
+                Method {
+                    name: "snapshot.create",
+                    desc: "Create a snapshot of a subvolume.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<CreateSnapshotRequest>(generator)),
+                    result: Some(gen_schema::<Snapshot>(generator)),
+                },
+                Method {
+                    name: "snapshot.delete",
+                    desc: "Delete a snapshot.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<DeleteSnapshotRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "snapshot.clone",
+                    desc: "Clone a snapshot into a new independent subvolume.",
+                    role: "operator",
+                    params: MethodParams::Schema(gen_schema::<CloneSnapshotRequest>(generator)),
+                    result: Some(gen_schema::<Subvolume>(generator)),
+                },
+            ],
+        ),
+        (
+            "NFS Shares",
+            vec![
+                Method {
+                    name: "share.nfs.list",
+                    desc: "List all NFS shares.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<NfsShare>>(generator)),
+                },
+                Method {
+                    name: "share.nfs.get",
+                    desc: "Get an NFS share by ID.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: Some(gen_schema::<NfsShare>(generator)),
+                },
+                Method {
+                    name: "share.nfs.create",
+                    desc: "Create an NFS share.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateNfsShareRequest>(generator)),
+                    result: Some(gen_schema::<NfsShare>(generator)),
+                },
+                Method {
+                    name: "share.nfs.update",
+                    desc: "Update an NFS share.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<UpdateNfsShareRequest>(generator)),
+                    result: Some(gen_schema::<NfsShare>(generator)),
+                },
+                Method {
+                    name: "share.nfs.delete",
+                    desc: "Delete an NFS share.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "SMB Shares",
+            vec![
+                Method {
+                    name: "share.smb.list",
+                    desc: "List all SMB shares.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<SmbShare>>(generator)),
+                },
+                Method {
+                    name: "share.smb.get",
+                    desc: "Get an SMB share by ID.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: Some(gen_schema::<SmbShare>(generator)),
+                },
+                Method {
+                    name: "share.smb.create",
+                    desc: "Create an SMB share.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateSmbShareRequest>(generator)),
+                    result: Some(gen_schema::<SmbShare>(generator)),
+                },
+                Method {
+                    name: "share.smb.update",
+                    desc: "Update an SMB share.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<UpdateSmbShareRequest>(generator)),
+                    result: Some(gen_schema::<SmbShare>(generator)),
+                },
+                Method {
+                    name: "share.smb.delete",
+                    desc: "Delete an SMB share.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+            ],
+        ),
+        (
+            "iSCSI Targets",
+            vec![
+                Method {
+                    name: "share.iscsi.list",
+                    desc: "List all iSCSI targets.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<IscsiTarget>>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.get",
+                    desc: "Get an iSCSI target by ID.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.create",
+                    desc: "Create an iSCSI target. Optionally attach a LUN and ACLs in one call.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateTargetRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.delete",
+                    desc: "Delete an iSCSI target.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+                Method {
+                    name: "share.iscsi.add_lun",
+                    desc: "Add a LUN to an iSCSI target.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AddLunRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.remove_lun",
+                    desc: "Remove a LUN from an iSCSI target.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"target_id\": string, \"lun_id\": integer}`"),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.add_acl",
+                    desc: "Allow an iSCSI initiator IQN to connect.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AddAclRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.remove_acl",
+                    desc: "Remove an iSCSI initiator ACL.",
+                    role: "admin",
+                    params: MethodParams::Literal(
+                        "`{\"target_id\": string, \"initiator_iqn\": string}`",
+                    ),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+            ],
+        ),
+        (
+            "NVMe-oF Subsystems",
+            vec![
+                Method {
+                    name: "share.nvmeof.list",
+                    desc: "List all NVMe-oF subsystems.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<NvmeofSubsystem>>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.get",
+                    desc: "Get an NVMe-oF subsystem by ID.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.create",
+                    desc: "Create an NVMe-oF subsystem. Optionally attach a namespace, port, and host ACLs in one call.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<CreateSubsystemRequest>(generator)),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.delete",
+                    desc: "Delete an NVMe-oF subsystem.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"id\": string}`"),
+                    result: None,
+                },
+                Method {
+                    name: "share.nvmeof.add_namespace",
+                    desc: "Add a namespace (block device) to a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AddNamespaceRequest>(generator)),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.remove_namespace",
+                    desc: "Remove a namespace from a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Literal(
+                        "`{\"subsystem_id\": string, \"nsid\": integer}`",
+                    ),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.add_port",
+                    desc: "Add a transport port to a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AddPortRequest>(generator)),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.remove_port",
+                    desc: "Remove a transport port from a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Literal(
+                        "`{\"subsystem_id\": string, \"port_id\": integer}`",
+                    ),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.add_host",
+                    desc: "Allow a host NQN to connect to a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Schema(gen_schema::<AddHostRequest>(generator)),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.remove_host",
+                    desc: "Disallow a host NQN from a subsystem.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"subsystem_id\": string, \"nqn\": string}`"),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+            ],
+        ),
     ]
 }
 
@@ -449,7 +978,8 @@ fn type_str_from_schema(schema: &Value) -> String {
         return t.to_string();
     }
     if let Some(arr) = schema.get("type").and_then(|v| v.as_array()) {
-        let parts: Vec<&str> = arr.iter()
+        let parts: Vec<&str> = arr
+            .iter()
             .filter_map(|v| v.as_str())
             .filter(|&s| s != "null")
             .collect();
@@ -462,7 +992,8 @@ fn type_str_from_schema(schema: &Value) -> String {
         }
     }
     if let Some(vals) = schema.get("enum").and_then(|v| v.as_array()) {
-        let parts: Vec<String> = vals.iter()
+        let parts: Vec<String> = vals
+            .iter()
             .filter_map(|v| v.as_str())
             .map(|s| format!("`{s}`"))
             .collect();
@@ -486,7 +1017,8 @@ fn render_properties(schema: &Value, defs: &Value) -> Option<String> {
     if props.is_empty() {
         return None;
     }
-    let required: Vec<&str> = schema.get("required")
+    let required: Vec<&str> = schema
+        .get("required")
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
@@ -495,9 +1027,14 @@ fn render_properties(schema: &Value, defs: &Value) -> Option<String> {
     for (name, prop) in props {
         let is_req = required.contains(&name.as_str());
         let type_s = type_str_from_schema(prop);
-        let desc = prop.get("description").and_then(|v| v.as_str()).unwrap_or("");
-        rows.push_str(&format!("| `{name}` | {type_s} | {} | {desc} |\n",
-            if is_req { "yes" } else { "no" }));
+        let desc = prop
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        rows.push_str(&format!(
+            "| `{name}` | {type_s} | {} | {desc} |\n",
+            if is_req { "yes" } else { "no" }
+        ));
     }
 
     Some(format!(
@@ -526,7 +1063,10 @@ fn collect_defs(groups: &[(&str, Vec<Method>)]) -> BTreeMap<String, Value> {
     let mut all = BTreeMap::new();
     for (_, methods) in groups {
         for m in methods {
-            for schema in [&m.params, &MethodParams::Schema(m.result.clone().unwrap_or(Value::Null))] {
+            for schema in [
+                &m.params,
+                &MethodParams::Schema(m.result.clone().unwrap_or(Value::Null)),
+            ] {
                 let v = match schema {
                     MethodParams::Schema(v) => v,
                     _ => continue,
@@ -559,7 +1099,9 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     out.push_str("## Transport\n\n");
     out.push_str("Connect to `ws://<host>/ws` with a valid session cookie or `Authorization: Bearer <token>` header.\n\n");
     out.push_str("**Request:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"pool.list\", \"params\": {}}\n```\n\n");
-    out.push_str("**Response:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"result\": [...]}\n```\n\n");
+    out.push_str(
+        "**Response:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"result\": [...]}\n```\n\n",
+    );
     out.push_str("**Error:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"error\": {\"code\": -32603, \"message\": \"filesystem not found: mypool\"}}\n```\n\n");
     out.push_str("## Authentication\n\n");
     out.push_str("Send `POST /api/login` with `{\"username\": \"...\", \"password\": \"...\"}` to receive a session token. ");
@@ -569,10 +1111,14 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     out.push_str("| `admin` | Full access to all methods |\n");
     out.push_str("| `operator` | Create/delete subvolumes and snapshots; read pools. Cannot manage users, destroy pools, or change system settings. |\n");
     out.push_str("| `readonly` | Read-only access to all list/get methods |\n\n");
-    out.push_str("API tokens can additionally be scoped to a single **filesystem** (restricts visibility) ");
+    out.push_str(
+        "API tokens can additionally be scoped to a single **filesystem** (restricts visibility) ",
+    );
     out.push_str("and for operator tokens to a single **owner** (restricts to subvolumes owned by that token).\n\n");
     out.push_str("## Real-time Events\n\n");
-    out.push_str("After any successful mutation the server broadcasts an event on the same WebSocket:\n");
+    out.push_str(
+        "After any successful mutation the server broadcasts an event on the same WebSocket:\n",
+    );
     out.push_str("```json\n{\"event\": \"pool\"}\n```\n");
     out.push_str("Clients should re-fetch the relevant resource when they receive an event. ");
     out.push_str("Event types: `filesystem`, `subvolume`, `snapshot`, `share.nfs`, `share.smb`, `share.iscsi`, `share.nvmeof`, `protocol`, `settings`, `alert`.\n\n");
@@ -581,7 +1127,8 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     // TOC
     out.push_str("## Contents\n\n");
     for (group, _) in groups {
-        let anchor = group.to_lowercase()
+        let anchor = group
+            .to_lowercase()
             .replace([' ', '/'], "-")
             .replace(['&', '(', ')', '.'], "");
         out.push_str(&format!("- [{group}](#{anchor})\n"));
@@ -628,7 +1175,10 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
 
     // Object definitions
     out.push_str("---\n\n## Object Definitions\n\n");
-    let mut def_names: Vec<&String> = defs_json.as_object().map(|m| m.keys().collect()).unwrap_or_default();
+    let mut def_names: Vec<&String> = defs_json
+        .as_object()
+        .map(|m| m.keys().collect())
+        .unwrap_or_default();
     def_names.sort();
 
     for name in def_names {
@@ -637,7 +1187,8 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
 
         // Enum
         if let Some(vals) = schema.get("enum").and_then(|v| v.as_array()) {
-            let parts: Vec<String> = vals.iter()
+            let parts: Vec<String> = vals
+                .iter()
                 .filter_map(|v| v.as_str())
                 .map(|s| format!("`{s}`"))
                 .collect();
@@ -646,8 +1197,15 @@ fn generate_markdown(groups: &[(&str, Vec<Method>)]) -> String {
         }
         // oneOf enum (schemars renders Rust enums as oneOf sometimes)
         if let Some(variants) = schema.get("oneOf").and_then(|v| v.as_array()) {
-            let parts: Vec<String> = variants.iter()
-                .filter_map(|v| v.get("enum")?.as_array()?.first()?.as_str().map(|s| format!("`{s}`")))
+            let parts: Vec<String> = variants
+                .iter()
+                .filter_map(|v| {
+                    v.get("enum")?
+                        .as_array()?
+                        .first()?
+                        .as_str()
+                        .map(|s| format!("`{s}`"))
+                })
                 .collect();
             if !parts.is_empty() {
                 out.push_str(&format!("Enum: {}\n\n", parts.join(", ")));
@@ -672,8 +1230,8 @@ fn main() {
     let md = generate_markdown(&groups);
 
     let out_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()  // engine/
-        .and_then(|p| p.parent())  // nasty/
+        .parent() // engine/
+        .and_then(|p| p.parent()) // nasty/
         .map(|p| p.join("docs/api.md"))
         .expect("could not resolve output path");
 

--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -113,7 +113,7 @@ use nasty_system::network::NetworkConfig;
 use nasty_system::protocol::ProtocolStatus;
 use nasty_system::settings::{Settings, SettingsUpdate};
 use nasty_system::update::{
-    UpdateInfo, UpdateStatus, VersionInfo, VersionSwitchRequest,
+    UpdateInfo, UpdateStatus, VersionInfo, VersionSwitchRequest, VersionTaggedReleaseStatus,
 };
 use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats};
 
@@ -310,6 +310,20 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
                     role: "any",
                     params: MethodParams::None,
                     result: Some(gen_schema::<VersionInfo>(generator)),
+                },
+                Method {
+                    name: "system.version.tagged_release_notice",
+                    desc: "Return the latest official tagged release and whether the current `nasty.url` already matches its standard `github:nasty-project/nasty/vX.Y.Z` form.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<VersionTaggedReleaseStatus>(generator)),
+                },
+                Method {
+                    name: "system.version.upgrade_tagged_release",
+                    desc: "Bootstrap a new wrapper `flake.nix` from the latest official tagged release template and start a switch rebuild.",
+                    role: "admin",
+                    params: MethodParams::None,
+                    result: None,
                 },
                 Method {
                     name: "system.version.switch",

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -136,10 +136,7 @@ async fn main() -> anyhow::Result<()> {
     // Runs before sd_notify_ready() — nginx won't serve until this completes.
     info!("Warming caches...");
     let t0 = std::time::Instant::now();
-    tokio::join!(
-        state.system.info(),
-        state.updates.bcachefs_info(&state.system),
-    );
+    state.system.info().await;
     info!("Caches warm in {}ms", t0.elapsed().as_millis());
 
     // Check ACME cert renewal in background (non-blocking)
@@ -828,4 +825,3 @@ async fn wait_for_auth(socket: &mut WebSocket, state: &AppState, client_ip: &str
         }
     }
 }
-

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -198,20 +198,20 @@ async fn main() -> anyhow::Result<()> {
 async fn run_bootstrap_system_flake_cli(args: &[String]) -> anyhow::Result<()> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         println!(
-            "Usage: nasty-engine bootstrap-system-flake --dest-dir <dir> --template-file <path> --nasty-url <url> --system <system>"
+            "Usage: nasty-engine bootstrap-system-flake --dest-dir <dir> --template-file <path> --system <system>"
         );
         return Ok(());
     }
 
     let dest_dir = required_flag_value(args, "--dest-dir")?;
     let template_file = required_flag_value(args, "--template-file")?;
-    let nasty_url = required_flag_value(args, "--nasty-url")?;
     let local_system = required_flag_value(args, "--system")?;
+    let nasty_version = env!("CARGO_PKG_VERSION");
 
     let result = nasty_system::update::bootstrap_system_flake_from_template_path(
         &template_file,
         &dest_dir,
-        &nasty_url,
+        nasty_version,
         &local_system,
     )
     .await

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -2,20 +2,18 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::{
+    Json, Router,
     extract::{
-        DefaultBodyLimit,
-        Multipart,
-        State,
+        DefaultBodyLimit, Multipart, State,
         ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::StatusCode,
     response::IntoResponse,
     routing::{delete, get, post},
-    Json, Router,
 };
 use serde::Deserialize;
 use tracing::info;
-use tracing_subscriber::{reload, prelude::*};
+use tracing_subscriber::{prelude::*, reload};
 
 mod auth;
 mod router;
@@ -27,7 +25,8 @@ use auth::{AuthService, Session};
 use router::handle_rpc_request;
 
 /// Handle for dynamically reloading the tracing filter at runtime.
-pub type LogReloadHandle = reload::Handle<tracing_subscriber::EnvFilter, tracing_subscriber::Registry>;
+pub type LogReloadHandle =
+    reload::Handle<tracing_subscriber::EnvFilter, tracing_subscriber::Registry>;
 
 /// Broadcast channel for notifying all WebSocket clients of state changes.
 /// The payload is the collection name (e.g. "filesystem", "subvolume", "share.nfs").
@@ -64,10 +63,19 @@ pub const METRICS_BASE: &str = "http://127.0.0.1:2138";
 async fn main() -> anyhow::Result<()> {
     let version = env!("CARGO_PKG_VERSION");
     let built = env!("NASTY_BUILD_DATE");
+    let args = std::env::args().collect::<Vec<_>>();
 
     // --version flag
-    if std::env::args().any(|a| a == "--version" || a == "-V") {
+    if args.iter().any(|a| a == "--version" || a == "-V") {
         println!("nasty-engine {version} (built: {built})");
+        return Ok(());
+    }
+
+    if matches!(
+        args.get(1).map(String::as_str),
+        Some("bootstrap-system-flake")
+    ) {
+        run_bootstrap_system_flake_cli(&args[2..]).await?;
         return Ok(());
     }
 
@@ -82,17 +90,16 @@ async fn main() -> anyhow::Result<()> {
 
     let (event_tx, _) = tokio::sync::broadcast::channel::<String>(64);
 
-    let subvolumes = Arc::new(nasty_storage::SubvolumeService::new(nasty_storage::FilesystemService::new()));
+    let subvolumes = Arc::new(nasty_storage::SubvolumeService::new(
+        nasty_storage::FilesystemService::new(),
+    ));
     let nvmeof = Arc::new(nasty_sharing::NvmeofService::new());
 
     let state = Arc::new(AppState {
         auth: AuthService::new().await,
         events: event_tx,
         log_reload: reload_handle,
-        system: nasty_system::SystemService::new(
-            None,
-            Some(built.to_string()),
-        ),
+        system: nasty_system::SystemService::new(None, Some(built.to_string())),
         settings: nasty_system::settings::SettingsService::new().await,
         alerts: nasty_system::alerts::AlertService::new().await,
         network: nasty_system::network::NetworkService::new(),
@@ -159,10 +166,16 @@ async fn main() -> anyhow::Result<()> {
         .route("/ws/vm/{vm_id}/vnc", get(vm_console::vnc_handler))
         .route("/ws/vm/{vm_id}/serial", get(vm_console::serial_handler))
         .route("/api/login", post(login_handler))
-        .route("/api/upload/vm-image", post(upload_vm_image_handler).layer(DefaultBodyLimit::max(10_737_418_240)))
+        .route(
+            "/api/upload/vm-image",
+            post(upload_vm_image_handler).layer(DefaultBodyLimit::max(10_737_418_240)),
+        )
         .route("/api/files/browse", get(files_browse_handler))
         .route("/api/files", delete(files_delete_handler))
-        .route("/api/files/upload", post(files_upload_handler).layer(DefaultBodyLimit::max(10_737_418_240)))
+        .route(
+            "/api/files/upload",
+            post(files_upload_handler).layer(DefaultBodyLimit::max(10_737_418_240)),
+        )
         .route("/api/files/mkdir", post(files_mkdir_handler))
         .route("/api/auth/check", get(auth_check_handler))
         .route("/health", get(health))
@@ -173,9 +186,49 @@ async fn main() -> anyhow::Result<()> {
     info!("Listening on {addr}");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service_with_connect_info::<std::net::SocketAddr>()).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
+}
+
+async fn run_bootstrap_system_flake_cli(args: &[String]) -> anyhow::Result<()> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!(
+            "Usage: nasty-engine bootstrap-system-flake --dest-dir <dir> --template-file <path> --nasty-url <url> --system <system>"
+        );
+        return Ok(());
+    }
+
+    let dest_dir = required_flag_value(args, "--dest-dir")?;
+    let template_file = required_flag_value(args, "--template-file")?;
+    let nasty_url = required_flag_value(args, "--nasty-url")?;
+    let local_system = required_flag_value(args, "--system")?;
+
+    let result = nasty_system::update::bootstrap_system_flake_from_template_path(
+        &template_file,
+        &dest_dir,
+        &nasty_url,
+        &local_system,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    println!("{}", result.flake_path);
+    Ok(())
+}
+
+fn required_flag_value(args: &[String], flag: &str) -> anyhow::Result<String> {
+    let idx = args
+        .iter()
+        .position(|arg| arg == flag)
+        .ok_or_else(|| anyhow::anyhow!("missing required flag: {flag}"))?;
+    args.get(idx + 1)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing value for flag: {flag}"))
 }
 
 /// Notify systemd that the service is ready (Type=notify).
@@ -206,7 +259,8 @@ async fn upload_vm_image_handler(
     State(state): State<Arc<AppState>>,
     mut multipart: Multipart,
 ) -> impl IntoResponse {
-    let client_ip = headers.get("x-real-ip")
+    let client_ip = headers
+        .get("x-real-ip")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown")
         .to_string();
@@ -223,46 +277,89 @@ async fn upload_vm_image_handler(
     let token = match token {
         Some(t) => t,
         None => {
-            info!("VM image upload rejected: missing auth token (from {})", client_ip);
-            return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({ "error": "Missing authorization token" }))).into_response();
+            info!(
+                "VM image upload rejected: missing auth token (from {})",
+                client_ip
+            );
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": "Missing authorization token" })),
+            )
+                .into_response();
         }
     };
 
     let session = match state.auth.validate(&token, &client_ip).await {
         Ok(s) => s,
         Err(e) => {
-            info!("VM image upload rejected: invalid token (from {})", client_ip);
-            return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({ "error": format!("Invalid token: {}", e) }))).into_response();
+            info!(
+                "VM image upload rejected: invalid token (from {})",
+                client_ip
+            );
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": format!("Invalid token: {}", e) })),
+            )
+                .into_response();
         }
     };
 
     // Get or create the images subvolume
     let filesystems = state.filesystems.list().await.unwrap_or_default();
-    let fs_name = filesystems.first().map(|f| f.name.clone()).unwrap_or_default();
-    
+    let fs_name = filesystems
+        .first()
+        .map(|f| f.name.clone())
+        .unwrap_or_default();
+
     if fs_name.is_empty() {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "No filesystems available" }))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "No filesystems available" })),
+        )
+            .into_response();
     }
 
     let images_path = {
         let fs = match state.filesystems.get(&fs_name).await {
             Ok(f) => f,
-            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": e.to_string() }))).into_response(),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e.to_string() })),
+                )
+                    .into_response();
+            }
         };
         let mp = match fs.mount_point {
             Some(ref p) => p.clone(),
-            None => return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "Filesystem not mounted" }))).into_response(),
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "Filesystem not mounted" })),
+                )
+                    .into_response();
+            }
         };
         let path = format!("{mp}/.nasty/images");
         if let Err(e) = tokio::fs::create_dir_all(&path).await {
-            return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": format!("Failed to create .nasty/images: {e}") }))).into_response();
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({ "error": format!("Failed to create .nasty/images: {e}") }),
+                ),
+            )
+                .into_response();
         }
         path
     };
 
     // Process the uploaded file
     let Some(mut field) = multipart.next_field().await.ok().flatten() else {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "No file provided" }))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "No file provided" })),
+        )
+            .into_response();
     };
 
     let raw_name = field.file_name().unwrap_or("").to_string();
@@ -274,11 +371,21 @@ async fn upload_vm_image_handler(
         .to_string();
 
     if file_name.is_empty() {
-        info!("VM image upload rejected: empty filename (user '{}')", session.username);
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": "No file provided" }))).into_response();
+        info!(
+            "VM image upload rejected: empty filename (user '{}')",
+            session.username
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "No file provided" })),
+        )
+            .into_response();
     }
 
-    info!("User '{}' uploading VM image: '{}' to {}", session.username, file_name, images_path);
+    info!(
+        "User '{}' uploading VM image: '{}' to {}",
+        session.username, file_name, images_path
+    );
 
     let extensions = ["iso", "qcow2", "img", "raw"];
     let ext = std::path::Path::new(&file_name)
@@ -294,19 +401,29 @@ async fn upload_vm_image_handler(
     let dest_path = std::path::Path::new(&images_path).join(&file_name);
 
     if dest_path.exists() {
-        return (StatusCode::CONFLICT, Json(serde_json::json!({ "error": format!("Image '{}' already exists", file_name) }))).into_response();
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": format!("Image '{}' already exists", file_name) })),
+        )
+            .into_response();
     }
 
     // Stream file content to disk
     let mut file = match tokio::fs::File::create(&dest_path).await {
         Ok(f) => f,
         Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": format!("Failed to create file: {}", e) }))).into_response();
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to create file: {}", e) })),
+            )
+                .into_response();
         }
     };
 
     use tokio::io::AsyncWriteExt;
-    let cleanup = || async { let _ = tokio::fs::remove_file(&dest_path).await; };
+    let cleanup = || async {
+        let _ = tokio::fs::remove_file(&dest_path).await;
+    };
     let start = std::time::Instant::now();
     let mut total_bytes: u64 = 0;
     loop {
@@ -316,16 +433,36 @@ async fn upload_vm_image_handler(
                 if let Err(e) = file.write_all(&chunk).await {
                     drop(file);
                     cleanup().await;
-                    tracing::error!("VM image upload write failed after {} bytes for '{}': {}", total_bytes, file_name, e);
-                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": format!("Failed to write chunk: {}", e) }))).into_response();
+                    tracing::error!(
+                        "VM image upload write failed after {} bytes for '{}': {}",
+                        total_bytes,
+                        file_name,
+                        e
+                    );
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(
+                            serde_json::json!({ "error": format!("Failed to write chunk: {}", e) }),
+                        ),
+                    )
+                        .into_response();
                 }
             }
             Ok(None) => break,
             Err(e) => {
                 drop(file);
                 cleanup().await;
-                tracing::error!("VM image upload stream failed after {} bytes for '{}': {}", total_bytes, file_name, e);
-                return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": format!("Failed to read chunk: {}", e) }))).into_response();
+                tracing::error!(
+                    "VM image upload stream failed after {} bytes for '{}': {}",
+                    total_bytes,
+                    file_name,
+                    e
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("Failed to read chunk: {}", e) })),
+                )
+                    .into_response();
             }
         }
     }
@@ -333,18 +470,37 @@ async fn upload_vm_image_handler(
         drop(file);
         cleanup().await;
         tracing::error!("VM image upload sync failed for '{}': {}", file_name, e);
-        return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({ "error": format!("Failed to sync file: {}", e) }))).into_response();
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("Failed to sync file: {}", e) })),
+        )
+            .into_response();
     }
 
     let elapsed = start.elapsed();
     let size_mib = total_bytes as f64 / (1024.0 * 1024.0);
-    let rate_mibs = if elapsed.as_secs_f64() > 0.0 { size_mib / elapsed.as_secs_f64() } else { 0.0 };
-    info!("User '{}' uploaded VM image: '{}' ({:.1} MiB in {:.1}s, {:.1} MiB/s)", session.username, file_name, size_mib, elapsed.as_secs_f64(), rate_mibs);
-    (StatusCode::OK, Json(serde_json::json!({
-        "name": file_name,
-        "path": dest_path.to_string_lossy(),
-        "filesystem": fs_name,
-    }))).into_response()
+    let rate_mibs = if elapsed.as_secs_f64() > 0.0 {
+        size_mib / elapsed.as_secs_f64()
+    } else {
+        0.0
+    };
+    info!(
+        "User '{}' uploaded VM image: '{}' ({:.1} MiB in {:.1}s, {:.1} MiB/s)",
+        session.username,
+        file_name,
+        size_mib,
+        elapsed.as_secs_f64(),
+        rate_mibs
+    );
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "name": file_name,
+            "path": dest_path.to_string_lossy(),
+            "filesystem": fs_name,
+        })),
+    )
+        .into_response()
 }
 
 // ── File Browser endpoints ──────────────────────────────────────
@@ -362,7 +518,9 @@ fn is_inside_block_subvolume(path: &std::path::Path) -> bool {
             return true;
         }
         match p.parent() {
-            Some(parent) if parent.starts_with(FILES_ROOT) && parent != std::path::Path::new(FILES_ROOT) => {
+            Some(parent)
+                if parent.starts_with(FILES_ROOT) && parent != std::path::Path::new(FILES_ROOT) =>
+            {
                 p = parent;
             }
             _ => break,
@@ -389,38 +547,70 @@ async fn files_browse_handler(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
     // Auth check
-    let token = headers.get("authorization")
+    let token = headers
+        .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(|s| s.to_string());
     let token = match token {
         Some(t) => t,
-        None => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({"error": "Missing token"}))).into_response(),
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Missing token"})),
+            )
+                .into_response();
+        }
     };
-    let client_ip = headers.get("x-real-ip").and_then(|v| v.to_str().ok()).unwrap_or("unknown");
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
     if state.auth.validate(&token, client_ip).await.is_err() {
-        return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({"error": "Invalid token"}))).into_response();
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid token"})),
+        )
+            .into_response();
     }
 
     let req_path = params.get("path").map(|s| s.as_str()).unwrap_or("");
     let dir = match safe_path(req_path) {
         Ok(p) => p,
-        Err(status) => return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response(),
+        Err(status) => {
+            return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        }
     };
 
     let meta = match tokio::fs::metadata(&dir).await {
         Ok(m) => m,
-        Err(_) => return (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "Not found"}))).into_response(),
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Not found"})),
+            )
+                .into_response();
+        }
     };
 
     if !meta.is_dir() {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "Not a directory"}))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Not a directory"})),
+        )
+            .into_response();
     }
 
     let mut entries = Vec::new();
     let mut read_dir = match tokio::fs::read_dir(&dir).await {
         Ok(r) => r,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
     };
 
     while let Ok(Some(entry)) = read_dir.next_entry().await {
@@ -428,7 +618,8 @@ async fn files_browse_handler(
         let meta = entry.metadata().await.ok();
         let is_dir = meta.as_ref().map(|m| m.is_dir()).unwrap_or(false);
         let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-        let modified = meta.as_ref()
+        let modified = meta
+            .as_ref()
             .and_then(|m| m.modified().ok())
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .map(|d| d.as_secs())
@@ -447,15 +638,27 @@ async fn files_browse_handler(
         let a_dir = a["is_dir"].as_bool().unwrap_or(false);
         let b_dir = b["is_dir"].as_bool().unwrap_or(false);
         b_dir.cmp(&a_dir).then_with(|| {
-            a["name"].as_str().unwrap_or("").to_lowercase().cmp(&b["name"].as_str().unwrap_or("").to_lowercase())
+            a["name"]
+                .as_str()
+                .unwrap_or("")
+                .to_lowercase()
+                .cmp(&b["name"].as_str().unwrap_or("").to_lowercase())
         })
     });
 
-    let display_path = dir.strip_prefix(FILES_ROOT).unwrap_or(&dir).to_string_lossy().to_string();
-    (StatusCode::OK, Json(serde_json::json!({
-        "path": display_path,
-        "entries": entries,
-    }))).into_response()
+    let display_path = dir
+        .strip_prefix(FILES_ROOT)
+        .unwrap_or(&dir)
+        .to_string_lossy()
+        .to_string();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "path": display_path,
+            "entries": entries,
+        })),
+    )
+        .into_response()
 }
 
 /// Validate bearer token from request headers. Returns client_ip on success.
@@ -463,17 +666,30 @@ async fn validate_bearer(
     headers: &axum::http::HeaderMap,
     auth: &AuthService,
 ) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
-    let token = headers.get("authorization")
+    let token = headers
+        .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
         .map(|s| s.to_string());
     let token = match token {
         Some(t) => t,
-        None => return Err((StatusCode::UNAUTHORIZED, Json(serde_json::json!({"error": "Missing token"})))),
+        None => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Missing token"})),
+            ));
+        }
     };
-    let client_ip = headers.get("x-real-ip").and_then(|v| v.to_str().ok()).unwrap_or("unknown").to_string();
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
     if auth.validate(&token, &client_ip).await.is_err() {
-        return Err((StatusCode::UNAUTHORIZED, Json(serde_json::json!({"error": "Invalid token"}))));
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid token"})),
+        ));
     }
     Ok(client_ip)
 }
@@ -502,12 +718,20 @@ async fn files_delete_handler(
 
     let req_path = match params.get("path") {
         Some(p) if !p.is_empty() => p.as_str(),
-        _ => return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "path is required"}))).into_response(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "path is required"})),
+            )
+                .into_response();
+        }
     };
 
     let target = match safe_path(req_path) {
         Ok(p) => p,
-        Err(status) => return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response(),
+        Err(status) => {
+            return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        }
     };
 
     // Refuse to delete filesystem/subvolume roots (depth 1 under /fs, e.g. /fs/mypool)
@@ -523,7 +747,13 @@ async fn files_delete_handler(
 
     let meta = match tokio::fs::metadata(&target).await {
         Ok(m) => m,
-        Err(_) => return (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "Not found"}))).into_response(),
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Not found"})),
+            )
+                .into_response();
+        }
     };
 
     let result = if meta.is_dir() {
@@ -537,7 +767,11 @@ async fn files_delete_handler(
             info!("Deleted {}", target.display());
             (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -555,11 +789,17 @@ async fn files_upload_handler(
     let req_path = params.get("path").map(|s| s.as_str()).unwrap_or("");
     let dir = match safe_path(req_path) {
         Ok(p) => p,
-        Err(status) => return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response(),
+        Err(status) => {
+            return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        }
     };
 
     if !dir.is_dir() {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "Target is not a directory"}))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Target is not a directory"})),
+        )
+            .into_response();
     }
 
     // Protect block subvolume directories
@@ -570,7 +810,13 @@ async fn files_upload_handler(
     // Read multipart field
     let field = match multipart.next_field().await {
         Ok(Some(f)) => f,
-        _ => return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "No file in request"}))).into_response(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "No file in request"})),
+            )
+                .into_response();
+        }
     };
 
     let file_name = field.file_name().unwrap_or("upload").to_string();
@@ -582,14 +828,24 @@ async fn files_upload_handler(
         .to_string();
 
     if file_name.is_empty() || file_name == "." || file_name == ".." {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "Invalid filename"}))).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid filename"})),
+        )
+            .into_response();
     }
 
     let dest = dir.join(&file_name);
 
     let mut file = match tokio::fs::File::create(&dest).await {
         Ok(f) => f,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
     };
 
     let mut total: u64 = 0;
@@ -601,31 +857,50 @@ async fn files_upload_handler(
                 total += chunk.len() as u64;
                 if let Err(e) = tokio::io::AsyncWriteExt::write_all(&mut file, &chunk).await {
                     let _ = tokio::fs::remove_file(&dest).await;
-                    return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response();
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": e.to_string()})),
+                    )
+                        .into_response();
                 }
             }
             Ok(None) => break,
             Err(e) => {
                 let _ = tokio::fs::remove_file(&dest).await;
-                return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": e.to_string()})),
+                )
+                    .into_response();
             }
         }
     }
 
     if let Err(e) = file.sync_all().await {
         let _ = tokio::fs::remove_file(&dest).await;
-        return (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response();
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response();
     }
 
     let elapsed = t0.elapsed();
     let speed_mb = (total as f64 / (1024.0 * 1024.0)) / elapsed.as_secs_f64();
-    info!("Uploaded {} ({} bytes, {:.1} MB/s)", file_name, total, speed_mb);
+    info!(
+        "Uploaded {} ({} bytes, {:.1} MB/s)",
+        file_name, total, speed_mb
+    );
 
-    (StatusCode::OK, Json(serde_json::json!({
-        "name": file_name,
-        "path": dest.to_string_lossy(),
-        "size": total,
-    }))).into_response()
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "name": file_name,
+            "path": dest.to_string_lossy(),
+            "size": total,
+        })),
+    )
+        .into_response()
 }
 
 /// Create a directory.  POST /api/files/mkdir?path=first/subdir/newdir
@@ -640,7 +915,13 @@ async fn files_mkdir_handler(
 
     let req_path = match params.get("path") {
         Some(p) if !p.is_empty() => p.as_str(),
-        _ => return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"error": "path is required"}))).into_response(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "path is required"})),
+            )
+                .into_response();
+        }
     };
 
     // Validate parent is under /fs
@@ -649,18 +930,31 @@ async fn files_mkdir_handler(
         None => "",
     };
     if safe_path(parent.is_empty().then_some("").unwrap_or(parent)).is_err() && !parent.is_empty() {
-        return (StatusCode::FORBIDDEN, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Invalid path"})),
+        )
+            .into_response();
     }
 
     let full = std::path::Path::new(FILES_ROOT).join(req_path.trim_start_matches('/'));
 
     // Protect block subvolume directories
-    if is_inside_block_subvolume(&full) || is_inside_block_subvolume(full.parent().unwrap_or(&full)) {
-        return (StatusCode::FORBIDDEN, Json(serde_json::json!({"error": "Cannot create directories inside block subvolumes"}))).into_response();
+    if is_inside_block_subvolume(&full) || is_inside_block_subvolume(full.parent().unwrap_or(&full))
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot create directories inside block subvolumes"})),
+        )
+            .into_response();
     }
 
     if full.exists() {
-        return (StatusCode::CONFLICT, Json(serde_json::json!({"error": "Already exists"}))).into_response();
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Already exists"})),
+        )
+            .into_response();
     }
 
     match tokio::fs::create_dir(&full).await {
@@ -668,7 +962,11 @@ async fn files_mkdir_handler(
             info!("Created directory {}", full.display());
             (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(serde_json::json!({"error": e.to_string()}))).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
     }
 }
 
@@ -685,15 +983,29 @@ async fn login_handler(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LoginRequest>,
 ) -> impl IntoResponse {
-    let client_ip = headers.get("x-real-ip").and_then(|v| v.to_str().ok()).unwrap_or("unknown");
-    match state.auth.login(&req.username, &req.password, client_ip).await {
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    match state
+        .auth
+        .login(&req.username, &req.password, client_ip)
+        .await
+    {
         Ok(token) => {
-            info!("Login successful: user '{}' from {}", req.username, client_ip);
+            info!(
+                "Login successful: user '{}' from {}",
+                req.username, client_ip
+            );
             (StatusCode::OK, Json(serde_json::json!({ "token": token }))).into_response()
         }
         Err(_) => {
             tracing::warn!("Login failed: user '{}' from {}", req.username, client_ip);
-            (StatusCode::UNAUTHORIZED, Json(serde_json::json!({ "error": "invalid credentials" }))).into_response()
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": "invalid credentials" })),
+            )
+                .into_response()
         }
     }
 }
@@ -764,7 +1076,11 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
 
 /// Wait for the first message which must be: {"token": "..."}
 /// Returns the session if valid, or None if auth failed (socket is closed).
-async fn wait_for_auth(socket: &mut WebSocket, state: &AppState, client_ip: &str) -> Option<Session> {
+async fn wait_for_auth(
+    socket: &mut WebSocket,
+    state: &AppState,
+    client_ip: &str,
+) -> Option<Session> {
     let msg = tokio::time::timeout(std::time::Duration::from_secs(10), socket.recv())
         .await
         .ok()??

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -123,8 +123,6 @@ fn is_read_only(method: &str) -> bool {
                 | "system.version.get"
                 | "system.log.level"
                 | "system.settings.timezones"
-                | "bcachefs.tools.info"
-                | "bcachefs.tools.status"
         )
 }
 
@@ -438,7 +436,6 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "system.update.apply" => match state.updates.apply().await {
             Ok(()) => {
                 state.system.invalidate_bcachefs_cache().await;
-                state.updates.invalidate_bcachefs_cache().await;
                 ok(req, "ok")
             }
             Err(e) => err(req, e),
@@ -446,7 +443,6 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "system.update.rollback" => match state.updates.rollback().await {
             Ok(()) => {
                 state.system.invalidate_bcachefs_cache().await;
-                state.updates.invalidate_bcachefs_cache().await;
                 ok(req, "ok")
             }
             Err(e) => err(req, e),
@@ -465,7 +461,6 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(p) => match state.updates.version_switch(p).await {
                     Ok(()) => {
                         state.system.invalidate_bcachefs_cache().await;
-                        state.updates.invalidate_bcachefs_cache().await;
                         ok(req, serde_json::json!({"status": "started"}))
                     }
                     Err(e) => err(req, e),
@@ -533,7 +528,6 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(p) => match state.updates.switch_generation(p.generation).await {
                     Ok(()) => {
                         state.system.invalidate_bcachefs_cache().await;
-                        state.updates.invalidate_bcachefs_cache().await;
                         ok(req, serde_json::json!({"status": "started"}))
                     }
                     Err(e) => err(req, e),
@@ -568,23 +562,6 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Err(e) => invalid(req, e),
             }
         }
-
-        // ── bcachefs-tools version switching ──────────────────────
-        "bcachefs.tools.info" => ok(req, state.updates.bcachefs_info(&state.system).await),
-        "bcachefs.tools.switch" => {
-            match parse_params::<nasty_system::update::BcachefsToolsSwitchRequest>(req) {
-                Ok(p) => match state.updates.bcachefs_switch(p).await {
-                    Ok(()) => {
-                        state.system.invalidate_bcachefs_cache().await;
-                        state.updates.invalidate_bcachefs_cache().await;
-                        ok(req, serde_json::json!({"status": "started"}))
-                    }
-                    Err(e) => err(req, e),
-                },
-                Err(e) => invalid(req, e),
-            }
-        }
-        "bcachefs.tools.status" => ok(req, state.updates.bcachefs_status().await),
 
         "system.reboot" => match state.updates.reboot().await {
             Ok(()) => ok(req, "ok"),

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use nasty_common::{ErrorCode, Request, Response};
+use serde::Deserialize;
 use tracing::debug;
 
 use crate::AppState;
@@ -10,29 +10,60 @@ fn is_operator_allowed(method: &str) -> bool {
     is_read_only(method)
         || matches!(
             method,
-            "subvolume.create" | "subvolume.delete" | "subvolume.attach" | "subvolume.detach"
-            | "subvolume.resize" | "subvolume.update" | "subvolume.clone"
-            | "subvolume.set_properties" | "subvolume.remove_properties"
-            | "snapshot.create" | "snapshot.delete" | "snapshot.clone"
-            | "share.nfs.create" | "share.nfs.update" | "share.nfs.delete"
-            | "share.smb.create" | "share.smb.update" | "share.smb.delete"
-            | "smb.user.create" | "smb.user.delete" | "smb.user.set_password"
-            | "share.iscsi.create" | "share.iscsi.delete"
-            | "share.iscsi.add_lun" | "share.iscsi.remove_lun"
-            | "share.iscsi.add_acl" | "share.iscsi.remove_acl"
-            | "share.nvmeof.create" | "share.nvmeof.delete"
-            | "share.nvmeof.add_namespace" | "share.nvmeof.remove_namespace"
-            | "share.nvmeof.add_port" | "share.nvmeof.remove_port"
-            | "share.nvmeof.add_host" | "share.nvmeof.remove_host"
-            | "vm.create" | "vm.update" | "vm.delete"
-            | "vm.start" | "vm.stop" | "vm.kill"
-            | "vm.snapshot" | "vm.clone"
-            | "apps.enable" | "apps.disable"
-            | "apps.install" | "apps.remove"
-            | "apps.install_chart"
-            | "apps.repo.add" | "apps.repo.remove" | "apps.repo.update"
-            | "apps.ingress.set" | "apps.ingress.remove"
-            | "firmware.update"
+            "subvolume.create"
+                | "subvolume.delete"
+                | "subvolume.attach"
+                | "subvolume.detach"
+                | "subvolume.resize"
+                | "subvolume.update"
+                | "subvolume.clone"
+                | "subvolume.set_properties"
+                | "subvolume.remove_properties"
+                | "snapshot.create"
+                | "snapshot.delete"
+                | "snapshot.clone"
+                | "share.nfs.create"
+                | "share.nfs.update"
+                | "share.nfs.delete"
+                | "share.smb.create"
+                | "share.smb.update"
+                | "share.smb.delete"
+                | "smb.user.create"
+                | "smb.user.delete"
+                | "smb.user.set_password"
+                | "share.iscsi.create"
+                | "share.iscsi.delete"
+                | "share.iscsi.add_lun"
+                | "share.iscsi.remove_lun"
+                | "share.iscsi.add_acl"
+                | "share.iscsi.remove_acl"
+                | "share.nvmeof.create"
+                | "share.nvmeof.delete"
+                | "share.nvmeof.add_namespace"
+                | "share.nvmeof.remove_namespace"
+                | "share.nvmeof.add_port"
+                | "share.nvmeof.remove_port"
+                | "share.nvmeof.add_host"
+                | "share.nvmeof.remove_host"
+                | "vm.create"
+                | "vm.update"
+                | "vm.delete"
+                | "vm.start"
+                | "vm.stop"
+                | "vm.kill"
+                | "vm.snapshot"
+                | "vm.clone"
+                | "apps.enable"
+                | "apps.disable"
+                | "apps.install"
+                | "apps.remove"
+                | "apps.install_chart"
+                | "apps.repo.add"
+                | "apps.repo.remove"
+                | "apps.repo.update"
+                | "apps.ingress.set"
+                | "apps.ingress.remove"
+                | "firmware.update"
         )
 }
 
@@ -60,16 +91,40 @@ fn is_read_only(method: &str) -> bool {
         || method.ends_with(".get")
         || matches!(
             method,
-            "system.info" | "system.health" | "system.stats" | "system.disks" | "system.network.get"
-            | "system.alerts" | "system.settings.get" | "system.tailscale.get" | "system.acme.status" | "system.metrics.history" | "system.metrics.prometheus" | "alert.rules.list"
-            | "device.list" | "auth.me" | "auth.list_users" | "auth.token.list"
-            | "fs.usage" | "fs.scrub.status" | "fs.reconcile.status"
-            | "bcachefs.usage"
-            | "service.protocol.list" | "subvolume.list_all" | "subvolume.find_by_property" | "subvolume.children" | "smb.user.list"
-            | "system.update.version" | "system.update.status" | "system.reboot_required" | "system.generations.list"
-            | "system.log.level"
-            | "system.settings.timezones"
-            | "bcachefs.tools.info" | "bcachefs.tools.status"
+            "system.info"
+                | "system.health"
+                | "system.stats"
+                | "system.disks"
+                | "system.network.get"
+                | "system.alerts"
+                | "system.settings.get"
+                | "system.tailscale.get"
+                | "system.acme.status"
+                | "system.metrics.history"
+                | "system.metrics.prometheus"
+                | "alert.rules.list"
+                | "device.list"
+                | "auth.me"
+                | "auth.list_users"
+                | "auth.token.list"
+                | "fs.usage"
+                | "fs.scrub.status"
+                | "fs.reconcile.status"
+                | "bcachefs.usage"
+                | "service.protocol.list"
+                | "subvolume.list_all"
+                | "subvolume.find_by_property"
+                | "subvolume.children"
+                | "smb.user.list"
+                | "system.update.version"
+                | "system.update.status"
+                | "system.reboot_required"
+                | "system.generations.list"
+                | "system.version.get"
+                | "system.log.level"
+                | "system.settings.timezones"
+                | "bcachefs.tools.info"
+                | "bcachefs.tools.status"
         )
 }
 
@@ -111,7 +166,10 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
 
     // Force password change — only allow auth methods until the password is changed
     if session.must_change_password
-        && !matches!(request.method.as_str(), "auth.change_password" | "auth.me" | "auth.logout")
+        && !matches!(
+            request.method.as_str(),
+            "auth.change_password" | "auth.me" | "auth.logout"
+        )
     {
         let resp = Response::error(
             request.id,
@@ -128,11 +186,7 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
         Role::Operator => !is_operator_allowed(&request.method),
     };
     if denied {
-        let resp = Response::error(
-            request.id,
-            ErrorCode::InternalError,
-            "Permission denied",
-        );
+        let resp = Response::error(request.id, ErrorCode::InternalError, "Permission denied");
         return serde_json::to_string(&resp).unwrap();
     }
 
@@ -140,9 +194,17 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
     let response = route(&request, state, session).await;
     let elapsed = t0.elapsed();
     if elapsed.as_millis() > 5000 {
-        tracing::error!("RPC very slow: {} took {}ms", request.method, elapsed.as_millis());
+        tracing::error!(
+            "RPC very slow: {} took {}ms",
+            request.method,
+            elapsed.as_millis()
+        );
     } else if elapsed.as_millis() > 1000 {
-        tracing::warn!("RPC slow: {} took {}ms", request.method, elapsed.as_millis());
+        tracing::warn!(
+            "RPC slow: {} took {}ms",
+            request.method,
+            elapsed.as_millis()
+        );
     } else {
         debug!("RPC done: {} in {}ms", request.method, elapsed.as_millis());
     }
@@ -160,19 +222,29 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
 async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
     match req.method.as_str() {
         // ── Auth ──────────────────────────────────────────────────
-        "auth.me" => ok(req, serde_json::json!({
-            "username": session.username,
-            "role": session.role,
-        })),
+        "auth.me" => ok(
+            req,
+            serde_json::json!({
+                "username": session.username,
+                "role": session.role,
+            }),
+        ),
         "auth.logout" => match state.auth.logout(&session.token).await {
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
         },
         "auth.change_password" => {
             #[derive(Deserialize)]
-            struct P { username: String, new_password: String }
+            struct P {
+                username: String,
+                new_password: String,
+            }
             match parse_params::<P>(req) {
-                Ok(p) => match state.auth.change_password(session, &p.username, &p.new_password).await {
+                Ok(p) => match state
+                    .auth
+                    .change_password(session, &p.username, &p.new_password)
+                    .await
+                {
                     Ok(()) => ok(req, "ok"),
                     Err(e) => err(req, e),
                 },
@@ -181,24 +253,30 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "auth.create_user" => {
             #[derive(Deserialize)]
-            struct P { username: String, password: String, role: Role }
+            struct P {
+                username: String,
+                password: String,
+                role: Role,
+            }
             match parse_params::<P>(req) {
-                Ok(p) => match state.auth.create_user(session, &p.username, &p.password, p.role).await {
+                Ok(p) => match state
+                    .auth
+                    .create_user(session, &p.username, &p.password, p.role)
+                    .await
+                {
                     Ok(()) => ok(req, "ok"),
                     Err(e) => err(req, e),
                 },
                 Err(e) => invalid(req, e),
             }
         }
-        "auth.delete_user" => {
-            match require_str(req, "username") {
-                Ok(username) => match state.auth.delete_user(session, username).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
-                Err(r) => r,
-            }
-        }
+        "auth.delete_user" => match require_str(req, "username") {
+            Ok(username) => match state.auth.delete_user(session, username).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         "auth.list_users" => ok(req, state.auth.list_users().await),
         "auth.token.list" => match state.auth.list_api_tokens(session).await {
             Ok(v) => ok(req, v),
@@ -206,9 +284,27 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "auth.token.create" => {
             #[derive(Deserialize)]
-            struct P { name: String, role: Role, filesystem: Option<String>, expires_in_secs: Option<u64>, #[serde(default)] allowed_ips: Vec<String> }
+            struct P {
+                name: String,
+                role: Role,
+                filesystem: Option<String>,
+                expires_in_secs: Option<u64>,
+                #[serde(default)]
+                allowed_ips: Vec<String>,
+            }
             match parse_params::<P>(req) {
-                Ok(p) => match state.auth.create_api_token(session, &p.name, p.role, p.filesystem, p.expires_in_secs, p.allowed_ips).await {
+                Ok(p) => match state
+                    .auth
+                    .create_api_token(
+                        session,
+                        &p.name,
+                        p.role,
+                        p.filesystem,
+                        p.expires_in_secs,
+                        p.allowed_ips,
+                    )
+                    .await
+                {
                     Ok(t) => ok(req, t),
                     Err(e) => err(req, e),
                 },
@@ -227,19 +323,24 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "system.info" => ok(req, state.system.info().await),
         "system.health" => ok(req, state.system.health().await),
         "system.stats" => match fetch_metrics_json::<nasty_system::SystemStats>(
-            &state.metrics_client, "/api/stats"
-        ).await {
+            &state.metrics_client,
+            "/api/stats",
+        )
+        .await
+        {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
         "system.network.get" => ok(req, state.network.get().await),
-        "system.network.update" => match parse_params::<nasty_system::network::NetworkConfig>(req) {
-            Ok(p) => match state.network.update(p).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
-            Err(e) => invalid(req, e),
-        },
+        "system.network.update" => {
+            match parse_params::<nasty_system::network::NetworkConfig>(req) {
+                Ok(p) => match state.network.update(p).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         "system.metrics.prometheus" => {
             let url = format!("{}/metrics", crate::METRICS_BASE);
             match state.metrics_client.get(&url).send().await {
@@ -254,14 +355,24 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             let kind = str_param(req, "kind").unwrap_or("net");
             let name = str_param(req, "name");
             let range = str_param(req, "range").unwrap_or("5m");
-            let mut url = format!("{}/api/history?kind={kind}&range={range}", crate::METRICS_BASE);
+            let mut url = format!(
+                "{}/api/history?kind={kind}&range={range}",
+                crate::METRICS_BASE
+            );
             if let Some(n) = name {
                 url.push_str(&format!("&name={n}"));
             }
-            match state.metrics_client.get(&url).send().await
+            match state
+                .metrics_client
+                .get(&url)
+                .send()
+                .await
                 .and_then(|r| Ok(r.error_for_status()?))
             {
-                Ok(resp) => match resp.json::<Vec<nasty_common::metrics_types::ResourceHistory>>().await {
+                Ok(resp) => match resp
+                    .json::<Vec<nasty_common::metrics_types::ResourceHistory>>()
+                    .await
+                {
                     Ok(v) => ok(req, v),
                     Err(e) => err(req, format!("metrics parse error: {e}")),
                 },
@@ -269,10 +380,17 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "system.disks" => {
-            if state.protocols.is_enabled(nasty_system::protocol::Protocol::Smart).await {
+            if state
+                .protocols
+                .is_enabled(nasty_system::protocol::Protocol::Smart)
+                .await
+            {
                 match fetch_metrics_json::<Vec<nasty_system::DiskHealth>>(
-                    &state.metrics_client, "/api/disks"
-                ).await {
+                    &state.metrics_client,
+                    "/api/disks",
+                )
+                .await
+                {
                     Ok(v) => ok(req, v),
                     Err(e) => err(req, e),
                 }
@@ -318,14 +436,43 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(e) => err(req, e),
         },
         "system.update.apply" => match state.updates.apply().await {
-            Ok(()) => { state.system.invalidate_bcachefs_cache().await; state.updates.invalidate_bcachefs_cache().await; ok(req, "ok") }
+            Ok(()) => {
+                state.system.invalidate_bcachefs_cache().await;
+                state.updates.invalidate_bcachefs_cache().await;
+                ok(req, "ok")
+            }
             Err(e) => err(req, e),
         },
         "system.update.rollback" => match state.updates.rollback().await {
-            Ok(()) => { state.system.invalidate_bcachefs_cache().await; state.updates.invalidate_bcachefs_cache().await; ok(req, "ok") }
+            Ok(()) => {
+                state.system.invalidate_bcachefs_cache().await;
+                state.updates.invalidate_bcachefs_cache().await;
+                ok(req, "ok")
+            }
             Err(e) => err(req, e),
         },
         "system.update.status" => ok(req, state.updates.status().await),
+        "system.version.get" => match state.updates.version_info().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "system.version.cleanup" => match state.updates.version_cleanup().await {
+            Ok(()) => ok(req, "ok"),
+            Err(e) => err(req, e),
+        },
+        "system.version.switch" => {
+            match parse_params::<nasty_system::update::VersionSwitchRequest>(req) {
+                Ok(p) => match state.updates.version_switch(p).await {
+                    Ok(()) => {
+                        state.system.invalidate_bcachefs_cache().await;
+                        state.updates.invalidate_bcachefs_cache().await;
+                        ok(req, serde_json::json!({"status": "started"}))
+                    }
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         "system.update.channel.get" => ok(req, state.updates.get_channel().await),
         "firmware.available" => ok(req, state.firmware.is_available().await),
         "firmware.devices" => ok(req, state.firmware.list_devices().await),
@@ -354,22 +501,20 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "system.log.set_level" => {
             #[derive(Deserialize)]
-            struct P { filter: String }
+            struct P {
+                filter: String,
+            }
             match parse_params::<P>(req) {
-                Ok(p) => {
-                    match tracing_subscriber::EnvFilter::try_new(&p.filter) {
-                        Ok(new_filter) => {
-                            match state.log_reload.reload(new_filter) {
-                                Ok(()) => {
-                                    tracing::info!("Log filter changed to: {}", p.filter);
-                                    ok(req, "ok")
-                                }
-                                Err(e) => err(req, format!("failed to reload filter: {e}")),
-                            }
+                Ok(p) => match tracing_subscriber::EnvFilter::try_new(&p.filter) {
+                    Ok(new_filter) => match state.log_reload.reload(new_filter) {
+                        Ok(()) => {
+                            tracing::info!("Log filter changed to: {}", p.filter);
+                            ok(req, "ok")
                         }
-                        Err(e) => err(req, format!("invalid filter: {e}")),
-                    }
-                }
+                        Err(e) => err(req, format!("failed to reload filter: {e}")),
+                    },
+                    Err(e) => err(req, format!("invalid filter: {e}")),
+                },
                 Err(e) => invalid(req, e),
             }
         }
@@ -381,7 +526,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "system.generations.switch" => {
             #[derive(Deserialize)]
-            struct P { generation: u64 }
+            struct P {
+                generation: u64,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.updates.switch_generation(p.generation).await {
                     Ok(()) => {
@@ -396,7 +543,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "system.generations.label" => {
             #[derive(Deserialize)]
-            struct P { generation: u64, label: Option<String> }
+            struct P {
+                generation: u64,
+                label: Option<String>,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.updates.label_generation(p.generation, p.label).await {
                     Ok(()) => ok(req, "ok"),
@@ -407,7 +557,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "system.generations.delete" => {
             #[derive(Deserialize)]
-            struct P { generation: u64 }
+            struct P {
+                generation: u64,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.updates.delete_generation(p.generation).await {
                     Ok(()) => ok(req, "ok"),
@@ -419,17 +571,19 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
 
         // ── bcachefs-tools version switching ──────────────────────
         "bcachefs.tools.info" => ok(req, state.updates.bcachefs_info(&state.system).await),
-        "bcachefs.tools.switch" => match parse_params::<nasty_system::update::BcachefsToolsSwitchRequest>(req) {
-            Ok(p) => match state.updates.bcachefs_switch(p).await {
-                Ok(()) => {
-                    state.system.invalidate_bcachefs_cache().await;
-                    state.updates.invalidate_bcachefs_cache().await;
-                    ok(req, serde_json::json!({"status": "started"}))
-                }
-                Err(e) => err(req, e),
-            },
-            Err(e) => invalid(req, e),
-        },
+        "bcachefs.tools.switch" => {
+            match parse_params::<nasty_system::update::BcachefsToolsSwitchRequest>(req) {
+                Ok(p) => match state.updates.bcachefs_switch(p).await {
+                    Ok(()) => {
+                        state.system.invalidate_bcachefs_cache().await;
+                        state.updates.invalidate_bcachefs_cache().await;
+                        ok(req, serde_json::json!({"status": "started"}))
+                    }
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         "bcachefs.tools.status" => ok(req, state.updates.bcachefs_status().await),
 
         "system.reboot" => match state.updates.reboot().await {
@@ -477,20 +631,30 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "system.alerts" => {
             // Evaluate current alert rules against live system state
             let stats = match fetch_metrics_json::<nasty_system::SystemStats>(
-                &state.metrics_client, "/api/stats"
-            ).await {
+                &state.metrics_client,
+                "/api/stats",
+            )
+            .await
+            {
                 Ok(v) => v,
                 Err(e) => return err(req, e),
             };
             let fs_list = state.filesystems.list().await;
-            let disk_health: Vec<nasty_system::DiskHealth> = if state.protocols.is_enabled(nasty_system::protocol::Protocol::Smart).await {
-                fetch_metrics_json(&state.metrics_client, "/api/disks").await.unwrap_or_default()
+            let disk_health: Vec<nasty_system::DiskHealth> = if state
+                .protocols
+                .is_enabled(nasty_system::protocol::Protocol::Smart)
+                .await
+            {
+                fetch_metrics_json(&state.metrics_client, "/api/disks")
+                    .await
+                    .unwrap_or_default()
             } else {
                 Vec::new()
             };
 
             let filesystems = fs_list.unwrap_or_default();
-            let fs_usage_list: Vec<nasty_system::alerts::FsUsage> = filesystems.iter()
+            let fs_usage_list: Vec<nasty_system::alerts::FsUsage> = filesystems
+                .iter()
                 .map(|p| nasty_system::alerts::FsUsage {
                     name: p.name.clone(),
                     used_bytes: p.used_bytes,
@@ -514,13 +678,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 let fs = fs.clone();
                 health_tasks.spawn(async move {
                     let degraded = fs.options.degraded.unwrap_or(false);
-                    let devices: Vec<nasty_system::alerts::BcachefsDeviceHealth> = fs.devices.iter().map(|d| {
-                        nasty_system::alerts::BcachefsDeviceHealth {
+                    let devices: Vec<nasty_system::alerts::BcachefsDeviceHealth> = fs
+                        .devices
+                        .iter()
+                        .map(|d| nasty_system::alerts::BcachefsDeviceHealth {
                             path: d.path.clone(),
                             state: d.state.clone().unwrap_or_else(|| "rw".into()),
-                            has_errors: d.has_data.as_deref().map_or(false, |s| s.contains("error")),
-                        }
-                    }).collect();
+                            has_errors: d
+                                .has_data
+                                .as_deref()
+                                .map_or(false, |s| s.contains("error")),
+                        })
+                        .collect();
 
                     // Run IO error count, scrub status, and reconcile status in parallel
                     let (io_error_count, scrub_result, reconcile_result) = tokio::join!(
@@ -537,12 +706,15 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     let reconcile_stalled = match reconcile_result {
                         Ok(s) => {
                             let raw = s.raw.to_lowercase();
-                            let scan_pending = raw.lines()
+                            let scan_pending = raw
+                                .lines()
                                 .find(|l| l.contains("scan pending"))
                                 .and_then(|l| l.split_whitespace().last())
                                 .and_then(|n| n.parse::<u64>().ok())
-                                .unwrap_or(0) > 0;
-                            let work_pending = raw.lines()
+                                .unwrap_or(0)
+                                > 0;
+                            let work_pending = raw
+                                .lines()
                                 .find(|l| l.trim().starts_with("pending:"))
                                 .map(|l| l.split_whitespace().skip(1).any(|n| n != "0"))
                                 .unwrap_or(false);
@@ -575,10 +747,23 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     .unwrap_or_default();
             let kernel_alert = nasty_system::alerts::KernelErrorAlert {
                 total_count: kernel_summary.total_count,
-                categories: kernel_summary.by_category.iter().map(|c| c.category.clone()).collect(),
+                categories: kernel_summary
+                    .by_category
+                    .iter()
+                    .map(|c| c.category.clone())
+                    .collect(),
             };
 
-            let alerts = state.alerts.evaluate(&stats, &fs_usage_list, &disk_summary, &bcachefs_health, &kernel_alert).await;
+            let alerts = state
+                .alerts
+                .evaluate(
+                    &stats,
+                    &fs_usage_list,
+                    &disk_summary,
+                    &bcachefs_health,
+                    &kernel_alert,
+                )
+                .await;
             ok(req, alerts)
         }
         "alert.rules.list" => ok(req, state.alerts.list_rules().await),
@@ -634,19 +819,21 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             },
             Err(e) => invalid(req, e),
         },
-        "fs.destroy" => match parse_params::<nasty_storage::filesystem::DestroyFilesystemRequest>(req) {
-            Ok(p) => {
-                if let Some(reason) = check_filesystem_in_use(state, &p.name).await {
-                    err(req, reason)
-                } else {
-                    match state.filesystems.destroy(p).await {
-                        Ok(()) => ok(req, "ok"),
-                        Err(e) => err(req, e),
+        "fs.destroy" => {
+            match parse_params::<nasty_storage::filesystem::DestroyFilesystemRequest>(req) {
+                Ok(p) => {
+                    if let Some(reason) = check_filesystem_in_use(state, &p.name).await {
+                        err(req, reason)
+                    } else {
+                        match state.filesystems.destroy(p).await {
+                            Ok(()) => ok(req, "ok"),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
         "fs.mount" => match require_str(req, "name") {
             Ok(name) => match state.filesystems.mount(name).await {
                 Ok(v) => {
@@ -696,7 +883,11 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "device.wipe" => match parse_params::<serde_json::Value>(req) {
             Ok(p) => {
-                let path = p.get("path").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let path = p
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
                 match state.filesystems.device_wipe(&path).await {
                     Ok(()) => ok(req, "ok"),
                     Err(e) => err(req, e),
@@ -725,37 +916,42 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             },
             Err(e) => invalid(req, e),
         },
-        "fs.device.evacuate" => match parse_params::<nasty_storage::filesystem::DeviceActionRequest>(req) {
-            Ok(p) => {
-                // Validate synchronously before returning
-                match state.filesystems.get(&p.filesystem).await {
-                    Err(e) => err(req, e),
-                    Ok(fs) if !fs.mounted => err(req, nasty_storage::FilesystemError::CommandFailed(
-                        "filesystem must be mounted to evacuate a device".into(),
-                    )),
-                    Ok(_) => {
-                        // Run in background — bcachefs evacuate can take many minutes.
-                        // Emit filesystem events every 3 s so UI shows live device state.
-                        let fs_svc = state.filesystems.clone();
-                        let events = state.events.clone();
-                        tokio::spawn(async move {
-                            let poll_events = events.clone();
-                            let poll = tokio::spawn(async move {
-                                loop {
-                                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                                    let _ = poll_events.send("filesystem".to_string());
-                                }
+        "fs.device.evacuate" => {
+            match parse_params::<nasty_storage::filesystem::DeviceActionRequest>(req) {
+                Ok(p) => {
+                    // Validate synchronously before returning
+                    match state.filesystems.get(&p.filesystem).await {
+                        Err(e) => err(req, e),
+                        Ok(fs) if !fs.mounted => err(
+                            req,
+                            nasty_storage::FilesystemError::CommandFailed(
+                                "filesystem must be mounted to evacuate a device".into(),
+                            ),
+                        ),
+                        Ok(_) => {
+                            // Run in background — bcachefs evacuate can take many minutes.
+                            // Emit filesystem events every 3 s so UI shows live device state.
+                            let fs_svc = state.filesystems.clone();
+                            let events = state.events.clone();
+                            tokio::spawn(async move {
+                                let poll_events = events.clone();
+                                let poll = tokio::spawn(async move {
+                                    loop {
+                                        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                                        let _ = poll_events.send("filesystem".to_string());
+                                    }
+                                });
+                                let _ = fs_svc.device_evacuate(p).await;
+                                poll.abort();
+                                let _ = events.send("filesystem".to_string());
                             });
-                            let _ = fs_svc.device_evacuate(p).await;
-                            poll.abort();
-                            let _ = events.send("filesystem".to_string());
-                        });
-                        ok(req, serde_json::json!({"status": "started"}))
+                            ok(req, serde_json::json!({"status": "started"}))
+                        }
                     }
                 }
-            },
-            Err(e) => invalid(req, e),
-        },
+                Err(e) => invalid(req, e),
+            }
+        }
         "fs.device.set_state" => match parse_params(req) {
             Ok(p) => match state.filesystems.device_set_state(p).await {
                 Ok(v) => ok(req, v),
@@ -849,10 +1045,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "subvolume.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != fs_name) {
+                if session
+                    .filesystem
+                    .as_deref()
+                    .map_or(false, |p| p != fs_name)
+                {
                     err(req, "access denied")
                 } else {
-                    match state.subvolumes.list(fs_name, session.owner.as_deref()).await {
+                    match state
+                        .subvolumes
+                        .list(fs_name, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
@@ -862,10 +1066,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "subvolume.get" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != fs_name) {
+                if session
+                    .filesystem
+                    .as_deref()
+                    .map_or(false, |p| p != fs_name)
+                {
                     err(req, "access denied")
                 } else {
-                    match state.subvolumes.get(fs_name, name, session.owner.as_deref()).await {
+                    match state
+                        .subvolumes
+                        .get(fs_name, name, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
@@ -874,49 +1086,69 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             (Err(r), _) | (_, Err(r)) => r,
         },
         "subvolume.children" => match (require_str(req, "filesystem"), require_str(req, "name")) {
-            (Ok(fs_name), Ok(name)) => {
-                match state.subvolumes.list_children(fs_name, name).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                }
-            }
+            (Ok(fs_name), Ok(name)) => match state.subvolumes.list_children(fs_name, name).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
             (Err(r), _) | (_, Err(r)) => r,
         },
-        "subvolume.create" => match parse_params::<nasty_storage::subvolume::CreateSubvolumeRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |f| f != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    let owner = session.owner.clone();
-                    match state.subvolumes.create(p, owner).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
+        "subvolume.create" => {
+            match parse_params::<nasty_storage::subvolume::CreateSubvolumeRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        let owner = session.owner.clone();
+                        match state.subvolumes.create(p, owner).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
-        "subvolume.delete" => match parse_params::<nasty_storage::subvolume::DeleteSubvolumeRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |f| f != p.filesystem) {
-                    err(req, "access denied")
-                } else if let Some(conflict) = check_subvolume_in_use(state, &p.filesystem, &p.name).await {
-                    err(req, conflict)
-                } else {
-                    match state.subvolumes.delete(p, session.owner.as_deref()).await {
-                        Ok(()) => ok(req, "ok"),
-                        Err(e) => err(req, e),
+        }
+        "subvolume.delete" => {
+            match parse_params::<nasty_storage::subvolume::DeleteSubvolumeRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else if let Some(conflict) =
+                        check_subvolume_in_use(state, &p.filesystem, &p.name).await
+                    {
+                        err(req, conflict)
+                    } else {
+                        match state.subvolumes.delete(p, session.owner.as_deref()).await {
+                            Ok(()) => ok(req, "ok"),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
         "subvolume.attach" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != fs_name) {
+                if session
+                    .filesystem
+                    .as_deref()
+                    .map_or(false, |p| p != fs_name)
+                {
                     err(req, "access denied")
                 } else {
-                    match state.subvolumes.attach(fs_name, name, session.owner.as_deref()).await {
+                    match state
+                        .subvolumes
+                        .attach(fs_name, name, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
@@ -926,10 +1158,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "subvolume.detach" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != fs_name) {
+                if session
+                    .filesystem
+                    .as_deref()
+                    .map_or(false, |p| p != fs_name)
+                {
                     err(req, "access denied")
                 } else {
-                    match state.subvolumes.detach(fs_name, name, session.owner.as_deref()).await {
+                    match state
+                        .subvolumes
+                        .detach(fs_name, name, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
@@ -938,104 +1178,160 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             (Err(r), _) | (_, Err(r)) => r,
         },
 
-        "subvolume.resize" => match parse_params::<nasty_storage::subvolume::ResizeSubvolumeRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |f| f != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    match state.subvolumes.resize(p, session.owner.as_deref()).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
+        "subvolume.resize" => {
+            match parse_params::<nasty_storage::subvolume::ResizeSubvolumeRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match state.subvolumes.resize(p, session.owner.as_deref()).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
 
-        "subvolume.update" => match parse_params::<nasty_storage::subvolume::UpdateSubvolumeRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |f| f != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    match state.subvolumes.update(p, session.owner.as_deref()).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
+        "subvolume.update" => {
+            match parse_params::<nasty_storage::subvolume::UpdateSubvolumeRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match state.subvolumes.update(p, session.owner.as_deref()).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
 
-        "subvolume.clone" => match parse_params::<nasty_storage::subvolume::CloneSubvolumeRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |f| f != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    match state.subvolumes.clone_subvolume(p, session.owner.as_deref()).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
+        "subvolume.clone" => {
+            match parse_params::<nasty_storage::subvolume::CloneSubvolumeRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match state
+                            .subvolumes
+                            .clone_subvolume(p, session.owner.as_deref())
+                            .await
+                        {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
 
-        "subvolume.set_properties" => match parse_params::<nasty_storage::subvolume::SetPropertiesRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |sp| sp != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    match state.subvolumes.set_properties(p, session.owner.as_deref()).await {
+        "subvolume.set_properties" => {
+            match parse_params::<nasty_storage::subvolume::SetPropertiesRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |sp| sp != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match state
+                            .subvolumes
+                            .set_properties(p, session.owner.as_deref())
+                            .await
+                        {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
+                    }
+                }
+                Err(e) => invalid(req, e),
+            }
+        }
+        "subvolume.remove_properties" => {
+            match parse_params::<nasty_storage::subvolume::RemovePropertiesRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .map_or(false, |sp| sp != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match state
+                            .subvolumes
+                            .remove_properties(p, session.owner.as_deref())
+                            .await
+                        {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
+                    }
+                }
+                Err(e) => invalid(req, e),
+            }
+        }
+        "subvolume.find_by_property" => {
+            match parse_params::<nasty_storage::subvolume::FindByPropertyRequest>(req) {
+                Ok(p) => {
+                    // Enforce filesystem-scoped token restriction
+                    let effective_fs = match (&session.filesystem, &p.filesystem) {
+                        (Some(sp), Some(rp)) if sp != rp => {
+                            return err(req, "access denied");
+                        }
+                        (Some(sp), None) => Some(nasty_storage::subvolume::FindByPropertyRequest {
+                            filesystem: Some(sp.clone()),
+                            key: p.key.clone(),
+                            value: p.value.clone(),
+                        }),
+                        _ => None,
+                    };
+                    let req_effective = effective_fs.unwrap_or(p);
+                    match state
+                        .subvolumes
+                        .find_by_property(req_effective, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
-        "subvolume.remove_properties" => match parse_params::<nasty_storage::subvolume::RemovePropertiesRequest>(req) {
-            Ok(p) => {
-                if session.filesystem.as_deref().map_or(false, |sp| sp != p.filesystem) {
-                    err(req, "access denied")
-                } else {
-                    match state.subvolumes.remove_properties(p, session.owner.as_deref()).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
-                    }
-                }
-            }
-            Err(e) => invalid(req, e),
-        },
-        "subvolume.find_by_property" => match parse_params::<nasty_storage::subvolume::FindByPropertyRequest>(req) {
-            Ok(p) => {
-                // Enforce filesystem-scoped token restriction
-                let effective_fs = match (&session.filesystem, &p.filesystem) {
-                    (Some(sp), Some(rp)) if sp != rp => {
-                        return err(req, "access denied");
-                    }
-                    (Some(sp), None) => Some(nasty_storage::subvolume::FindByPropertyRequest {
-                        filesystem: Some(sp.clone()),
-                        key: p.key.clone(),
-                        value: p.value.clone(),
-                    }),
-                    _ => None,
-                };
-                let req_effective = effective_fs.unwrap_or(p);
-                match state.subvolumes.find_by_property(req_effective, session.owner.as_deref()).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                }
-            }
-            Err(e) => invalid(req, e),
-        },
+        }
 
         // ── Snapshots ───────────────────────────────────────────
         "snapshot.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != fs_name) {
+                if session
+                    .filesystem
+                    .as_deref()
+                    .map_or(false, |p| p != fs_name)
+                {
                     err(req, "access denied")
                 } else {
-                    match state.snapshots.list(fs_name, session.owner.as_deref()).await {
+                    match state
+                        .snapshots
+                        .list(fs_name, session.owner.as_deref())
+                        .await
+                    {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }
@@ -1058,7 +1354,11 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(e) => invalid(req, e),
         },
         "snapshot.clone" => match parse_params(req) {
-            Ok(p) => match state.snapshots.clone_snapshot(p, session.owner.as_deref()).await {
+            Ok(p) => match state
+                .snapshots
+                .clone_snapshot(p, session.owner.as_deref())
+                .await
+            {
                 Ok(v) => ok(req, v),
                 Err(e) => err(req, e),
             },
@@ -1153,7 +1453,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "smb.user.set_password" => {
             #[derive(Deserialize)]
-            struct P { username: String, password: String }
+            struct P {
+                username: String,
+                password: String,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.smb.set_user_password(&p.username, &p.password).await {
                     Ok(()) => ok(req, "ok"),
@@ -1175,20 +1478,24 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             },
             Err(r) => r,
         },
-        "share.iscsi.create" => match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
-            Ok(p) => {
-                if let Some(ref dp) = p.device_path {
-                    if let Some(conflict) = check_block_device_conflict(state, dp, "iscsi").await {
-                        return err(req, conflict);
+        "share.iscsi.create" => {
+            match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
+                Ok(p) => {
+                    if let Some(ref dp) = p.device_path {
+                        if let Some(conflict) =
+                            check_block_device_conflict(state, dp, "iscsi").await
+                        {
+                            return err(req, conflict);
+                        }
+                    }
+                    match state.iscsi.create(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
                     }
                 }
-                match state.iscsi.create(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
         "share.iscsi.delete" => match parse_params(req) {
             Ok(p) => match state.iscsi.delete(p).await {
                 Ok(()) => ok(req, "ok"),
@@ -1198,7 +1505,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "share.iscsi.add_lun" => match parse_params::<nasty_sharing::iscsi::AddLunRequest>(req) {
             Ok(p) => {
-                if let Some(conflict) = check_block_device_conflict(state, &p.backstore_path, "iscsi").await {
+                if let Some(conflict) =
+                    check_block_device_conflict(state, &p.backstore_path, "iscsi").await
+                {
                     err(req, conflict)
                 } else {
                     match state.iscsi.add_lun(p).await {
@@ -1243,20 +1552,24 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             },
             Err(r) => r,
         },
-        "share.nvmeof.create" => match parse_params::<nasty_sharing::nvmeof::CreateSubsystemRequest>(req) {
-            Ok(p) => {
-                if let Some(ref device_path) = p.device_path {
-                    if let Some(conflict) = check_block_device_conflict(state, device_path, "nvmeof").await {
-                        return err(req, conflict);
+        "share.nvmeof.create" => {
+            match parse_params::<nasty_sharing::nvmeof::CreateSubsystemRequest>(req) {
+                Ok(p) => {
+                    if let Some(ref device_path) = p.device_path {
+                        if let Some(conflict) =
+                            check_block_device_conflict(state, device_path, "nvmeof").await
+                        {
+                            return err(req, conflict);
+                        }
+                    }
+                    match state.nvmeof.create(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
                     }
                 }
-                match state.nvmeof.create(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
         "share.nvmeof.delete" => match parse_params(req) {
             Ok(p) => match state.nvmeof.delete(p).await {
                 Ok(()) => ok(req, "ok"),
@@ -1264,19 +1577,23 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             },
             Err(e) => invalid(req, e),
         },
-        "share.nvmeof.add_namespace" => match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
-            Ok(p) => {
-                if let Some(conflict) = check_block_device_conflict(state, &p.device_path, "nvmeof").await {
-                    err(req, conflict)
-                } else {
-                    match state.nvmeof.add_namespace(p).await {
-                        Ok(v) => ok(req, v),
-                        Err(e) => err(req, e),
+        "share.nvmeof.add_namespace" => {
+            match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
+                Ok(p) => {
+                    if let Some(conflict) =
+                        check_block_device_conflict(state, &p.device_path, "nvmeof").await
+                    {
+                        err(req, conflict)
+                    } else {
+                        match state.nvmeof.add_namespace(p).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
                     }
                 }
+                Err(e) => invalid(req, e),
             }
-            Err(e) => invalid(req, e),
-        },
+        }
         "share.nvmeof.remove_namespace" => match parse_params(req) {
             Ok(p) => match state.nvmeof.remove_namespace(p).await {
                 Ok(v) => ok(req, v),
@@ -1407,7 +1724,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(()) => ok(req, "ok"),
                 Err(e) => err(req, e),
             }
-        },
+        }
         "apps.disable" => match state.apps.disable().await {
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
@@ -1442,7 +1759,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(n) => n,
                 Err(r) => return r,
             };
-            let tail = req.params.as_ref()
+            let tail = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("tail"))
                 .and_then(|v| v.as_u64())
                 .map(|v| v as u32);
@@ -1450,7 +1769,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(v) => ok(req, v),
                 Err(e) => err(req, e),
             }
-        },
+        }
         "apps.install_chart" => match parse_params(req) {
             Ok(p) => match state.apps.install_chart(p).await {
                 Ok(v) => ok(req, v),
@@ -1501,7 +1820,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "apps.forward.start" => match parse_params::<serde_json::Value>(req) {
             Ok(p) => {
                 let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                let local_port = p.get("local_port").and_then(|v| v.as_u64()).map(|v| v as u16);
+                let local_port = p
+                    .get("local_port")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as u16);
                 match state.apps.port_forward_start(name, local_port).await {
                     Ok(info) => ok(req, info),
                     Err(e) => err(req, e),
@@ -1637,25 +1959,38 @@ async fn list_vm_images(state: &AppState) -> VmImageListResult {
     let mut subvolume_exists = false;
 
     for fs in &filesystems {
-        if !fs.mounted { continue; }
-        let Some(ref mp) = fs.mount_point else { continue };
+        if !fs.mounted {
+            continue;
+        }
+        let Some(ref mp) = fs.mount_point else {
+            continue;
+        };
         let dir = format!("{mp}/.nasty/images");
-        if !std::path::Path::new(&dir).is_dir() { continue; }
+        if !std::path::Path::new(&dir).is_dir() {
+            continue;
+        }
         subvolume_exists = true;
 
         if let Ok(mut entries) = tokio::fs::read_dir(&dir).await {
             while let Ok(Some(entry)) = entries.next_entry().await {
                 let path = entry.path();
-                let is_image = path.extension()
+                let is_image = path
+                    .extension()
                     .and_then(|e| e.to_str())
-                    .map(|e| VM_IMAGE_EXTENSIONS.iter().any(|ext| e.eq_ignore_ascii_case(ext)))
+                    .map(|e| {
+                        VM_IMAGE_EXTENSIONS
+                            .iter()
+                            .any(|ext| e.eq_ignore_ascii_case(ext))
+                    })
                     .unwrap_or(false);
 
                 if is_image {
-                    let name = path.file_name()
+                    let name = path
+                        .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
-                    let size = tokio::fs::metadata(&path).await
+                    let size = tokio::fs::metadata(&path)
+                        .await
                         .map(|m| m.len())
                         .unwrap_or(0);
                     images.push(serde_json::json!({
@@ -1669,17 +2004,25 @@ async fn list_vm_images(state: &AppState) -> VmImageListResult {
         }
     }
 
-    VmImageListResult { subvolume_exists, images }
+    VmImageListResult {
+        subvolume_exists,
+        images,
+    }
 }
 
 /// Ensure the `.nasty/images` directory exists on a filesystem. Creates it if missing.
 async fn ensure_images_subvolume(state: &AppState, filesystem: &str) -> Result<String, String> {
-    let mount_point = state.filesystems.get(filesystem).await
+    let mount_point = state
+        .filesystems
+        .get(filesystem)
+        .await
         .map_err(|e| e.to_string())?
-        .mount_point.ok_or_else(|| "filesystem not mounted".to_string())?;
+        .mount_point
+        .ok_or_else(|| "filesystem not mounted".to_string())?;
 
     let images_path = format!("{mount_point}/.nasty/images");
-    tokio::fs::create_dir_all(&images_path).await
+    tokio::fs::create_dir_all(&images_path)
+        .await
         .map_err(|e| format!("failed to create .nasty/images: {e}"))?;
 
     Ok(images_path)
@@ -1773,7 +2116,11 @@ async fn check_subvolume_in_use(state: &AppState, filesystem: &str, name: &str) 
 /// Check if a filesystem has any subvolumes with dependencies that would prevent destruction.
 async fn check_filesystem_in_use(state: &AppState, name: &str) -> Option<String> {
     // Get all subvolumes on this filesystem
-    let subvols = state.subvolumes.list_all(None, None).await.unwrap_or_default();
+    let subvols = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .unwrap_or_default();
     let fs_subvols: Vec<_> = subvols.iter().filter(|sv| sv.filesystem == name).collect();
 
     if fs_subvols.is_empty() {
@@ -1814,7 +2161,11 @@ async fn resolve_vm_disks(
     state: &AppState,
     vm: &nasty_vm::VmConfig,
 ) -> Vec<nasty_vm::VmDiskSubvolume> {
-    let all_subvols = state.subvolumes.list_all(None, None).await.unwrap_or_default();
+    let all_subvols = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .unwrap_or_default();
     let mut resolved = Vec::new();
     for disk in &vm.disks {
         for sv in &all_subvols {
@@ -1852,7 +2203,8 @@ async fn vm_snapshot(
             &format!("/run/nasty/vm/{}.qmp", req.id),
             "guest-fsfreeze-freeze",
             None,
-        ).await;
+        )
+        .await;
     }
 
     for disk in &disks {
@@ -1863,7 +2215,10 @@ async fn vm_snapshot(
             read_only: Some(true),
         };
         state.snapshots.create(snap_req, None).await.map_err(|e| {
-            format!("failed to snapshot {}/{}: {e}", disk.filesystem, disk.subvolume)
+            format!(
+                "failed to snapshot {}/{}: {e}",
+                disk.filesystem, disk.subvolume
+            )
         })?;
     }
 
@@ -1873,7 +2228,8 @@ async fn vm_snapshot(
             &format!("/run/nasty/vm/{}.qmp", req.id),
             "guest-fsfreeze-thaw",
             None,
-        ).await;
+        )
+        .await;
     }
 
     Ok(disks)
@@ -1901,9 +2257,16 @@ async fn vm_clone(
             name: disk.subvolume.clone(),
             new_name: clone_name.clone(),
         };
-        let cloned = state.subvolumes.clone_subvolume(clone_req, None).await.map_err(|e| {
-            format!("failed to clone {}/{}: {e}", disk.filesystem, disk.subvolume)
-        })?;
+        let cloned = state
+            .subvolumes
+            .clone_subvolume(clone_req, None)
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to clone {}/{}: {e}",
+                    disk.filesystem, disk.subvolume
+                )
+            })?;
 
         new_disks.push(nasty_vm::VmDisk {
             path: cloned.block_device.unwrap_or_default(),
@@ -1923,7 +2286,11 @@ async fn vm_clone(
         name: req.new_name.clone(),
         cpus: Some(src.cpus),
         memory_mib: Some(src.memory_mib),
-        disks: if new_disks.is_empty() { None } else { Some(new_disks) },
+        disks: if new_disks.is_empty() {
+            None
+        } else {
+            Some(new_disks)
+        },
         networks: Some(src.networks.clone()),
         passthrough_devices: None, // Don't clone passthrough — can't share devices
         boot_iso: None,
@@ -1933,7 +2300,11 @@ async fn vm_clone(
         autostart: Some(false),
     };
 
-    state.vms.create(create_req).await.map_err(|e| e.to_string())
+    state
+        .vms
+        .create(create_req)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Read bcachefs error counters from sysfs. Returns total read+write error count.

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -121,6 +121,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.reboot_required"
                 | "system.generations.list"
                 | "system.version.get"
+                | "system.version.tagged_release_notice"
                 | "system.log.level"
                 | "system.settings.timezones"
         )
@@ -452,6 +453,21 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
+        "system.version.tagged_release_notice" => {
+            match state.updates.version_tagged_release_status().await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            }
+        }
+        "system.version.upgrade_tagged_release" => {
+            match state.updates.upgrade_tagged_release().await {
+                Ok(()) => {
+                    state.system.invalidate_bcachefs_cache().await;
+                    ok(req, serde_json::json!({"status": "started"}))
+                }
+                Err(e) => err(req, e),
+            }
+        }
         "system.version.cleanup" => match state.updates.version_cleanup().await {
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -14,3 +14,5 @@ tracing.workspace = true
 reqwest.workspace = true
 schemars.workspace = true
 libc.workspace = true
+rnix = "0.12"
+rowan = "0.15"

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -14,5 +14,6 @@ tracing.workspace = true
 reqwest.workspace = true
 schemars.workspace = true
 libc.workspace = true
+base64.workspace = true
 rnix = "0.12"
 rowan = "0.15"

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -24,11 +24,10 @@ struct CachedInfo {
     bcachefs_commit: Option<String>,
     bcachefs_pinned_ref: Option<String>,
     debug_symbols: bool,
-    debug_checks: bool,
     /// Whether the RUNNING module is custom (version differs from default).
     bcachefs_is_custom_running: bool,
-    /// Whether the RUNNING module has debug checks (sysfs reflects loaded module).
-    bcachefs_debug_checks_running: bool,
+    /// Whether the RUNNING module has debug checks.
+    bcachefs_debug_checks: bool,
 }
 
 pub struct SystemService {
@@ -55,7 +54,7 @@ pub struct SystemInfo {
     pub bcachefs_version: String,
     /// Short (12-char) commit SHA of the pinned bcachefs-tools in flake.lock
     pub bcachefs_commit: Option<String>,
-    /// The ref stored in the state file: tag name (e.g. "v1.37.1") or short SHA
+    /// The ref currently pinned in `/etc/nixos/flake.lock` for `bcachefs-tools`.
     pub bcachefs_pinned_ref: Option<String>,
     /// True when the RUNNING bcachefs module version differs from the default.
     pub bcachefs_is_custom: bool,
@@ -109,16 +108,9 @@ impl SystemService {
         Self { cached: Arc::new(RwLock::new(None)), engine_commit, engine_built }
     }
 
-    /// Invalidate cached bcachefs info — call after bcachefs switch or reboot.
+    /// Invalidate cached bcachefs info — call after rebuild or reboot.
     pub async fn invalidate_bcachefs_cache(&self) {
         *self.cached.write().await = None;
-    }
-
-    /// Return cached debug_symbols and debug_checks for the loaded module.
-    /// Used by UpdateService to avoid re-running expensive detection on every page load.
-    pub async fn cached_debug_flags(&self) -> (bool, bool) {
-        let cached = self.get_cached_bcachefs().await;
-        (cached.debug_symbols, cached.debug_checks)
     }
 
     async fn get_cached_bcachefs(&self) -> CachedInfo {
@@ -129,15 +121,10 @@ impl SystemService {
             }
         }
         // Compute — run subprocess calls in parallel.
-        let (bcachefs_version, bcachefs_commit, pinned_ref_raw, debug_symbols, debug_checks, default_ref) = tokio::join!(
+        let (bcachefs_version, bcachefs_commit, (pinned_ref, _), debug_symbols, debug_checks, default_ref) = tokio::join!(
             bcachefs_version(),
             read_bcachefs_commit(),
-            async {
-                tokio::fs::read_to_string("/var/lib/nasty/bcachefs-tools-ref").await
-                    .ok()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            },
+            crate::update::read_flake_lock_bcachefs_pub(),
             bcachefs_has_debug_symbols(),
             bcachefs_has_debug_checks(),
             crate::update::read_flake_nix_default_ref_pub(),
@@ -146,17 +133,13 @@ impl SystemService {
         // Strip leading 'v' from default ref for comparison (e.g. "v1.37.2" vs "1.37.2").
         let default_bare = default_ref.strip_prefix('v').unwrap_or(&default_ref);
         let bcachefs_is_custom_running = bcachefs_version != default_bare && bcachefs_version != "unknown";
-        // Debug checks running: sysfs reflects the actually loaded module, so no
-        // reboot_required guard needed (unlike the old state-file approach).
-        let bcachefs_debug_checks_running = debug_checks;
         let info = CachedInfo {
             bcachefs_version,
             bcachefs_commit,
-            bcachefs_pinned_ref: pinned_ref_raw,
+            bcachefs_pinned_ref: pinned_ref,
             debug_symbols,
-            debug_checks,
             bcachefs_is_custom_running,
-            bcachefs_debug_checks_running,
+            bcachefs_debug_checks: debug_checks,
         };
         *self.cached.write().await = Some(info.clone());
         info
@@ -180,7 +163,7 @@ impl SystemService {
             timezone,
             ntp_synced,
             bcachefs_debug_symbols: cached.debug_symbols,
-            bcachefs_debug_checks: cached.bcachefs_debug_checks_running,
+            bcachefs_debug_checks: cached.bcachefs_debug_checks,
             kvm_available: std::path::Path::new("/dev/kvm").exists(),
         }
     }

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1367,22 +1367,22 @@ async fn latest_official_nasty_release_tag() -> Result<String, UpdateError> {
 pub async fn bootstrap_system_flake_from_template_path(
     template_path: &str,
     dest_dir: &str,
-    nasty_url: &str,
+    nasty_version: &str,
     local_system: &str,
 ) -> Result<BootstrapSystemFlakeResult, UpdateError> {
     let template = tokio::fs::read_to_string(template_path)
         .await
         .map_err(|e| UpdateError::CommandFailed(format!("read {template_path}: {e}")))?;
-    bootstrap_system_flake_from_template(&template, dest_dir, nasty_url, local_system).await
+    bootstrap_system_flake_from_template(&template, dest_dir, nasty_version, local_system).await
 }
 
 pub async fn bootstrap_system_flake_from_template(
     template: &str,
     dest_dir: &str,
-    nasty_url: &str,
+    nasty_version: &str,
     local_system: &str,
 ) -> Result<BootstrapSystemFlakeResult, UpdateError> {
-    let rendered = render_system_flake_template(template, nasty_url, local_system)?;
+    let rendered = render_system_flake_template(template, nasty_version, local_system)?;
     tokio::fs::create_dir_all(dest_dir)
         .await
         .map_err(|e| UpdateError::CommandFailed(format!("mkdir {dest_dir}: {e}")))?;
@@ -1395,23 +1395,41 @@ pub async fn bootstrap_system_flake_from_template(
 
 fn render_system_flake_template(
     template: &str,
-    nasty_url: &str,
+    nasty_version: &str,
     local_system: &str,
 ) -> Result<String, UpdateError> {
-    if !template.contains("@NASTY_URL@") {
+    if !template.contains("@NASTY_VERSION@") {
         return Err(UpdateError::CommandFailed(
-            "system flake template is missing @NASTY_URL@ placeholder".into(),
+            "system flake template is missing @NASTY_VERSION@ placeholder".into(),
         ));
     }
-    if !template.contains("\"local-system\"") {
+    if !template.contains("@LOCAL_SYSTEM@") {
         return Err(UpdateError::CommandFailed(
-            "system flake template is missing \"local-system\" placeholder".into(),
+            "system flake template is missing @LOCAL_SYSTEM@ placeholder".into(),
         ));
     }
+    let nasty_tag = normalize_release_tag(nasty_version)?;
 
     Ok(template
-        .replace("@NASTY_URL@", nasty_url)
-        .replace("\"local-system\"", &format!("\"{local_system}\"")))
+        .replace("@NASTY_VERSION@", &nasty_tag)
+        .replace("@LOCAL_SYSTEM@", local_system))
+}
+
+fn normalize_release_tag(version_or_tag: &str) -> Result<String, UpdateError> {
+    let trimmed = version_or_tag.trim();
+    let tag = if trimmed.starts_with('v') {
+        trimmed.to_string()
+    } else {
+        format!("v{trimmed}")
+    };
+
+    if parse_release_tag_version(&tag).is_none() {
+        return Err(UpdateError::CommandFailed(format!(
+            "invalid tagged release version: {version_or_tag}"
+        )));
+    }
+
+    Ok(tag)
 }
 
 async fn detect_local_system() -> Result<String, UpdateError> {
@@ -1945,17 +1963,17 @@ mod tests {
     #[test]
     fn renders_system_flake_template() {
         let template = r#"
-inputs = { nasty.url = "@NASTY_URL@"; };
+inputs = { nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@"; };
 "#
         .to_string()
             + r#"
 outputs = { nixpkgs, nasty, ... }: {
-  nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "local-system"; };
+  nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "@LOCAL_SYSTEM@"; };
 };
 "#;
         let rendered = super::render_system_flake_template(
             &template,
-            "github:nasty-project/nasty/v0.0.3",
+            "0.0.3",
             "x86_64-linux",
         )
         .expect("rendered");

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -395,7 +395,7 @@ impl UpdateService {
         )
         .await?;
         let bootstrapped_flake =
-            render_system_flake_template(&template, &release_status.latest_url, &local_system)?;
+            render_system_flake_template(&template, &release_status.latest_tag, &local_system)?;
 
         let _ = tokio::process::Command::new("systemctl")
             .args(["reset-failed", UPDATE_UNIT])

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -3,9 +3,7 @@ use rowan::ast::AstNode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use thiserror::Error;
-use tokio::sync::RwLock;
 use tracing::info;
 
 /// Primary version path — writable by the update script, not managed by NixOS.
@@ -15,12 +13,7 @@ const VERSION_PATH_FALLBACK: &str = "/etc/nasty-version";
 const UPDATE_UNIT: &str = "nasty-update";
 const LOCAL_FLAKE_TARGET: &str = "/etc/nixos#nasty";
 const LOCAL_REPO: &str = "/etc/nixos";
-const BCACHEFS_SWITCH_UNIT: &str = "nasty-bcachefs-switch";
 const NIXOS_FLAKE_DIR: &str = "/etc/nixos";
-const BCACHEFS_TOOLS_REPO: &str = "github:koverstreet/bcachefs-tools";
-const BCACHEFS_REF_STATE: &str = "/var/lib/nasty/bcachefs-tools-ref";
-const BCACHEFS_DEBUG_CHECKS_STATE: &str = "/var/lib/nasty/bcachefs-debug-checks";
-const BCACHEFS_SWITCH_RESULT: &str = "/var/lib/nasty/bcachefs-switch-result";
 const UPDATE_WEBUI_CHANGED: &str = "/var/lib/nasty/update-webui-changed";
 const RELEASE_CHANNEL_PATH: &str = "/var/lib/nasty/release-channel";
 const GC_CONFIG_PATH: &str = "/var/lib/nasty/gc-config.json";
@@ -168,39 +161,6 @@ async fn write_channel(channel: ReleaseChannel) -> Result<(), std::io::Error> {
 const GITHUB_TOKEN_PATH: &str = "/var/lib/nasty/github-token";
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
-pub struct BcachefsToolsInfo {
-    /// The ref in flake.lock original (e.g. "v1.37.0", "master", commit sha)
-    pub pinned_ref: Option<String>,
-    /// The resolved full commit sha from flake.lock locked
-    pub pinned_rev: Option<String>,
-    /// Version of the bcachefs kernel module currently loaded (from modinfo)
-    pub running_version: String,
-    /// True when the user has configured a non-default bcachefs-tools version
-    pub is_custom: bool,
-    /// True when the actually loaded module differs from the default version
-    pub is_custom_running: bool,
-    /// The default ref from flake.nix (e.g. "v1.37.0")
-    pub default_ref: String,
-    /// Whether the running kernel was built with Rust support (CONFIG_RUST=y)
-    pub kernel_rust: Option<bool>,
-    /// Whether the loaded module has debug symbols (-g)
-    pub debug_symbols: bool,
-    /// Whether debug checks are configured for the next build
-    pub debug_checks: bool,
-    /// Whether the loaded module has CONFIG_BCACHEFS_DEBUG
-    pub debug_checks_running: bool,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct BcachefsToolsSwitchRequest {
-    /// A git ref: tag (v1.37.0), branch (master), or commit hash
-    pub git_ref: String,
-    /// Build with CONFIG_BCACHEFS_DEBUG for extra runtime assertions. Has performance cost.
-    #[serde(default)]
-    pub debug_checks: bool,
-}
-
-#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct VersionInputInfo {
     /// Flake input name (e.g. `nixpkgs`).
     pub name: String,
@@ -325,20 +285,11 @@ struct NixosGeneration {
     current: bool,
 }
 
-pub struct UpdateService {
-    cached_info: Arc<RwLock<Option<BcachefsToolsInfo>>>,
-}
+pub struct UpdateService;
 
 impl UpdateService {
     pub fn new() -> Self {
-        Self {
-            cached_info: Arc::new(RwLock::new(None)),
-        }
-    }
-
-    /// Invalidate cached bcachefs info — call after switch or rebuild.
-    pub async fn invalidate_bcachefs_cache(&self) {
-        *self.cached_info.write().await = None;
+        Self
     }
 
     /// Get current installed version
@@ -354,8 +305,6 @@ impl UpdateService {
     /// Read the exact upstream input URLs and locked revs from the live
     /// `/etc/nixos` flake on the installed system.
     pub async fn version_info(&self) -> Result<VersionInfo, UpdateError> {
-        self.restore_version_backup_if_needed().await?;
-
         let urls = read_flake_input_urls().await?;
         let revs = read_flake_lock_revs().await;
 
@@ -376,11 +325,11 @@ impl UpdateService {
         Ok(VersionInfo { inputs })
     }
 
-    /// Best-effort page-leave cleanup for the Version tab.
-    /// If a failed/abandoned switch left a backup behind and no rebuild is
-    /// running anymore, restore it so `/etc/nixos` does not stay half-edited.
+    /// Legacy endpoint kept for compatibility with older web UIs.
+    /// Newer builds do not restore from a backup; they only purge any stale
+    /// backup directory left behind by an older implementation.
     pub async fn version_cleanup(&self) -> Result<(), UpdateError> {
-        self.restore_version_backup_if_needed().await
+        self.purge_stale_version_backup().await
     }
 
     /// Get or set the release channel.
@@ -470,11 +419,6 @@ impl UpdateService {
         if status.state == "running" {
             return Err(UpdateError::AlreadyRunning);
         }
-
-        // Sanitize hardware-configuration.nix before updating.
-        // If the user ever ran nixos-generate-config while pools were mounted,
-        // those fileSystems entries would block boot after filesystem destruction.
-        sanitize_hardware_config().await;
 
         // Clean up any previous update unit
         let _ = tokio::process::Command::new("systemctl")
@@ -624,12 +568,11 @@ echo "==> Update complete!"
     /// lock file changed.
     pub async fn version_switch(&self, req: VersionSwitchRequest) -> Result<(), UpdateError> {
         let update_status = self.status().await;
-        let bcachefs_status = self.bcachefs_status().await;
-        if update_status.state == "running" || bcachefs_status.state == "running" {
+        if update_status.state == "running" {
             return Err(UpdateError::AlreadyRunning);
         }
 
-        self.restore_version_backup_if_needed().await?;
+        self.purge_stale_version_backup().await?;
 
         let current_urls = read_flake_input_urls().await?;
         let mut seen = HashSet::new();
@@ -683,8 +626,6 @@ echo "==> Update complete!"
             ));
         }
 
-        sanitize_hardware_config().await;
-
         let _ = tokio::process::Command::new("systemctl")
             .args(["reset-failed", UPDATE_UNIT])
             .output()
@@ -728,9 +669,6 @@ WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_
 echo "false" > {UPDATE_WEBUI_CHANGED}
 
 echo "==> Updating local system flake..."
-rm -rf {VERSION_SWITCH_BACKUP_DIR}
-cp -a {NIXOS_FLAKE_DIR} {VERSION_SWITCH_BACKUP_DIR}
-
 cd {NIXOS_FLAKE_DIR}
 LOCK_BEFORE=$(sha256sum flake.lock 2>/dev/null | awk '{{print $1}}' || true)
 cp {flake_temp_path} flake.nix
@@ -750,8 +688,6 @@ if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
 else
     echo "==> No flake.lock changes detected; skipping rebuild."
 fi
-
-rm -rf {VERSION_SWITCH_BACKUP_DIR}
 echo "==> Update complete!"
 "#
         );
@@ -1088,305 +1024,6 @@ echo "==> Switch to generation {gen_id} complete!"
         Ok(())
     }
 
-    pub async fn bcachefs_info(&self, system: &crate::SystemService) -> BcachefsToolsInfo {
-        {
-            let guard = self.cached_info.read().await;
-            if let Some(ref cached) = *guard {
-                return cached.clone();
-            }
-        }
-        let info = self.bcachefs_info_uncached(system).await;
-        *self.cached_info.write().await = Some(info.clone());
-        info
-    }
-
-    async fn bcachefs_info_uncached(&self, system: &crate::SystemService) -> BcachefsToolsInfo {
-        // Run subprocess calls and file reads concurrently.
-        let (
-            (_, kernel_rust),
-            running_version,
-            (lock_ref, pinned_rev),
-            default_ref,
-            debug_checks,
-            (debug_symbols, debug_checks_running),
-        ) = tokio::join!(
-            bcachefs_version(),
-            bcachefs_loaded_module_version(),
-            read_flake_lock_bcachefs(),
-            read_flake_nix_default_ref(),
-            // debug_checks from state file: reflects what will be built next (controls toggle)
-            read_debug_checks_enabled(),
-            // debug_symbols + debug_checks from cached module inspection (avoids
-            // expensive xz decompression on every page load)
-            system.cached_debug_flags(),
-        );
-        // Use the state file as the canonical display ref when the user has switched.
-        // flake.lock's original.ref always mirrors flake.nix (not updated by --override-input),
-        // so it would show the old version even after a successful switch to a new rev.
-        let state_ref = tokio::fs::read_to_string(BCACHEFS_REF_STATE)
-            .await
-            .ok()
-            .map(|s| {
-                let s = s.trim().to_string();
-                // Full 40-char SHA saved by the switch script — truncate for display
-                if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit()) {
-                    s[..12].to_string()
-                } else {
-                    s
-                }
-            })
-            .filter(|s| !s.is_empty());
-        let pinned_ref = state_ref.clone().or(lock_ref);
-        let is_custom = state_ref
-            .as_deref()
-            .map(|r| r != default_ref)
-            .unwrap_or(false);
-        // Compare loaded module version against default (strip 'v' prefix for comparison)
-        let default_bare = default_ref.strip_prefix('v').unwrap_or(&default_ref);
-        let is_custom_running = running_version != default_bare && running_version != "unknown";
-        BcachefsToolsInfo {
-            pinned_ref,
-            pinned_rev,
-            running_version,
-            is_custom,
-            is_custom_running,
-            default_ref,
-            kernel_rust,
-            debug_symbols,
-            debug_checks,
-            debug_checks_running,
-        }
-    }
-
-    pub async fn bcachefs_switch(
-        &self,
-        req: BcachefsToolsSwitchRequest,
-    ) -> Result<(), UpdateError> {
-        // Refuse if either update unit is running
-        let update_status = self.status().await;
-        let switch_status = self.bcachefs_status().await;
-        if update_status.state == "running" || switch_status.state == "running" {
-            return Err(UpdateError::AlreadyRunning);
-        }
-
-        let git_ref = req.git_ref.trim().to_string();
-        if git_ref.is_empty() {
-            return Err(UpdateError::CommandFailed(
-                "git_ref must not be empty".into(),
-            ));
-        }
-
-        // Clean up previous unit and result file
-        for action in &["reset-failed", "stop"] {
-            let _ = tokio::process::Command::new("systemctl")
-                .args([action, BCACHEFS_SWITCH_UNIT])
-                .output()
-                .await;
-        }
-        let _ = tokio::fs::remove_file(BCACHEFS_SWITCH_RESULT).await;
-
-        let default_ref = read_flake_nix_default_ref().await;
-        let is_default = git_ref == default_ref;
-
-        // Persist the chosen ref so regular updates can re-apply it.
-        // State file is written by the script after resolving the ref to a commit SHA.
-        // For the default ref we clear it here; for custom refs the script overwrites it
-        // with the pinned SHA so branch names like "master" don't drift on future updates.
-        if is_default {
-            let _ = tokio::fs::remove_file(BCACHEFS_REF_STATE).await;
-        }
-
-        let input_url = format!("{BCACHEFS_TOOLS_REPO}/{git_ref}");
-
-        // Toggle debug checks in flake.nix by replacing the marker line.
-        // When enabled: marker becomes an echo that appends the flag to the DKMS Makefile.
-        // When disabled: marker is restored to a plain comment.
-        let debug_checks_sed = if req.debug_checks {
-            r#"sed -i 's|.*@NASTY_DEBUG_CHECKS_LINE@.*|                echo "\tccflags-y += -DCONFIG_BCACHEFS_DEBUG" >> src/fs/bcachefs/Makefile  # @NASTY_DEBUG_CHECKS_LINE@|' flake.nix"#
-        } else {
-            r#"sed -i 's|.*@NASTY_DEBUG_CHECKS_LINE@.*|                # @NASTY_DEBUG_CHECKS_LINE@|' flake.nix"#
-        };
-        let debug_checks_state = if req.debug_checks {
-            format!(r#"echo "1" > {BCACHEFS_DEBUG_CHECKS_STATE}"#)
-        } else {
-            format!(r#"rm -f {BCACHEFS_DEBUG_CHECKS_STATE}"#)
-        };
-
-        let local_flake = local_flake();
-        let script = format!(
-            r#"#!/bin/bash
-set -euo pipefail
-export PATH="/run/current-system/sw/bin:$PATH"
-# Write 'failed' up front; overwritten with 'success' at the end.
-# Survives engine restarts so polling can read the outcome even after
-# the transient systemd unit has been garbage-collected.
-echo "failed" > {BCACHEFS_SWITCH_RESULT}
-SWITCH_LOG=/var/lib/nasty/bcachefs-switch.log
-PREV_REF=$(cat {BCACHEFS_REF_STATE} 2>/dev/null || echo "{default_ref}")
-printf '%s  started  %s  (was: %s)\n' "$(date -u '+%Y-%m-%d %H:%M:%S')" "{git_ref}" "$PREV_REF" >> "$SWITCH_LOG"
-echo "==> Switching bcachefs to {git_ref}..."
-cd {NIXOS_FLAKE_DIR}
-nix flake lock --override-input bcachefs-tools "{input_url}"
-# Resolve the symbolic ref (e.g. "master") to the exact commit SHA that was
-# just pinned in flake.lock. Store the SHA so future system updates re-use
-# the same commit rather than advancing with the branch tip.
-RESOLVED_SHA=$(jq -r '.nodes["bcachefs-tools"].locked.rev' flake.lock 2>/dev/null || true)
-if [ "{git_ref}" != "{default_ref}" ]; then
-    if echo "{git_ref}" | grep -qE '^v[0-9]'; then
-        echo "{git_ref}" > {BCACHEFS_REF_STATE}
-        echo "==> Pinned to tag {git_ref}"
-    elif [ -n "$RESOLVED_SHA" ]; then
-        echo "$RESOLVED_SHA" > {BCACHEFS_REF_STATE}
-        echo "==> Pinned to commit $RESOLVED_SHA"
-    fi
-fi
-# Update debug checks flag in flake.nix and persist state
-{debug_checks_sed}
-{debug_checks_state}
-# /etc/nixos is the active flake payload, not necessarily a Git checkout.
-# Persist the selected ref and flake changes directly, then rebuild from them.
-echo "==> Rebuilding system..."
-NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}
-echo "success" > {BCACHEFS_SWITCH_RESULT}
-printf '%s  success  %s\n' "$(date -u '+%Y-%m-%d %H:%M:%S')" "{git_ref}" >> "$SWITCH_LOG"
-echo "==> bcachefs switch complete!"
-"#
-        );
-
-        let script_path = "/tmp/nasty-bcachefs-switch.sh";
-        tokio::fs::write(script_path, &script)
-            .await
-            .map_err(|e| UpdateError::CommandFailed(format!("write script: {e}")))?;
-
-        let path = std::env::var("PATH").unwrap_or_default();
-        let output = tokio::process::Command::new("systemd-run")
-            .args([
-                "--unit",
-                BCACHEFS_SWITCH_UNIT,
-                "--no-block",
-                "--description",
-                "NASty bcachefs version switch",
-                "--property=Type=oneshot",
-                "--property=StandardOutput=journal",
-                "--property=StandardError=journal",
-                "--setenv",
-                &format!("PATH={path}"),
-                "--",
-                "bash",
-                script_path,
-            ])
-            .output()
-            .await
-            .map_err(|e| UpdateError::CommandFailed(format!("systemd-run: {e}")))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(UpdateError::CommandFailed(format!(
-                "failed to start: {stderr}"
-            )));
-        }
-        info!("bcachefs switch to {git_ref} started");
-        Ok(())
-    }
-
-    pub async fn bcachefs_status(&self) -> UpdateStatus {
-        let output = tokio::process::Command::new("systemctl")
-            .args([
-                "show",
-                BCACHEFS_SWITCH_UNIT,
-                "--property=ActiveState,SubState,Result",
-            ])
-            .output()
-            .await;
-
-        let state = match output {
-            Ok(out) => {
-                let text = String::from_utf8_lossy(&out.stdout);
-                let mut active_state = "";
-                let mut result = "";
-                for line in text.lines() {
-                    if let Some(val) = line.strip_prefix("ActiveState=") {
-                        active_state = val.trim();
-                    }
-                    if let Some(val) = line.strip_prefix("Result=") {
-                        result = val.trim();
-                    }
-                }
-                match active_state {
-                    "active" | "activating" | "reloading" => "running".to_string(),
-                    _ => {
-                        // Unit finished, missing, or never ran.
-                        // systemd Result=success is reliable when the unit still exists;
-                        // for cleaned-up or missing units it may be empty.
-                        // The result file is the authoritative fallback: the script writes
-                        // "failed" at the top and overwrites with "success" at the bottom,
-                        // so it always reflects the true outcome.
-                        // We remove it after reading a terminal state so stale results
-                        // don't surface on the next page load.
-                        let state = if result == "success" {
-                            "success".to_string()
-                        } else if active_state == "failed" {
-                            "failed".to_string()
-                        } else {
-                            tokio::fs::read_to_string(BCACHEFS_SWITCH_RESULT)
-                                .await
-                                .ok()
-                                .map(|s| match s.trim() {
-                                    "success" => "success".to_string(),
-                                    "failed" => "failed".to_string(),
-                                    _ => "idle".to_string(),
-                                })
-                                .unwrap_or_else(|| "idle".to_string())
-                        };
-                        if state == "success" || state == "failed" {
-                            let _ = tokio::fs::remove_file(BCACHEFS_SWITCH_RESULT).await;
-                        }
-                        state
-                    }
-                }
-            }
-            Err(_) => "idle".to_string(),
-        };
-
-        let invocation_id = tokio::process::Command::new("systemctl")
-            .args([
-                "show",
-                BCACHEFS_SWITCH_UNIT,
-                "--property=InvocationID",
-                "--value",
-            ])
-            .output()
-            .await
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .unwrap_or_default();
-
-        let mut journal_args = vec![
-            "-u".to_string(),
-            BCACHEFS_SWITCH_UNIT.to_string(),
-            "--no-pager".to_string(),
-            "--output=cat".to_string(),
-        ];
-        if !invocation_id.is_empty() {
-            journal_args.push(format!("_SYSTEMD_INVOCATION_ID={invocation_id}"));
-        } else {
-            journal_args.extend(["-n".to_string(), "200".to_string()]);
-        }
-
-        let log = tokio::process::Command::new("journalctl")
-            .args(&journal_args)
-            .output()
-            .await
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-            .unwrap_or_default();
-
-        UpdateStatus {
-            state,
-            log,
-            reboot_required: is_reboot_required().await,
-            webui_changed: false,
-        }
-    }
-
     /// Get the current status of a running/completed update
     pub async fn status(&self) -> UpdateStatus {
         // Use systemctl show to get detailed state
@@ -1479,7 +1116,7 @@ echo "==> bcachefs switch complete!"
         }
     }
 
-    async fn restore_version_backup_if_needed(&self) -> Result<(), UpdateError> {
+    async fn purge_stale_version_backup(&self) -> Result<(), UpdateError> {
         if tokio::fs::metadata(VERSION_SWITCH_BACKUP_DIR)
             .await
             .is_err()
@@ -1487,75 +1124,13 @@ echo "==> bcachefs switch complete!"
             return Ok(());
         }
 
-        if self.status().await.state == "running" {
-            return Ok(());
-        }
-
-        let restore = format!(
-            r#"set -euo pipefail
-rm -rf {NIXOS_FLAKE_DIR}
-cp -a {VERSION_SWITCH_BACKUP_DIR} {NIXOS_FLAKE_DIR}
-rm -rf {VERSION_SWITCH_BACKUP_DIR}
-"#
-        );
-        run_bash_script(&restore).await?;
-        info!("Restored {NIXOS_FLAKE_DIR} from backup after an incomplete version switch");
+        tokio::fs::remove_dir_all(VERSION_SWITCH_BACKUP_DIR)
+            .await
+            .map_err(|e| {
+                UpdateError::CommandFailed(format!("remove stale {VERSION_SWITCH_BACKUP_DIR}: {e}"))
+            })?;
         Ok(())
     }
-}
-
-/// Remove any `fileSystems."/fs/..."` blocks from hardware-configuration.nix.
-///
-/// Filesystem mounts are managed at runtime by the engine. If a user ran
-/// `nixos-generate-config` while pools were mounted, those entries end up in
-/// hardware-configuration.nix and will block boot after the filesystem is destroyed
-/// (systemd waits forever for a device UUID that no longer exists).
-async fn sanitize_hardware_config() {
-    let path = format!("{LOCAL_REPO}/hardware-configuration.nix");
-    let content = match tokio::fs::read_to_string(&path).await {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-    let sanitized = strip_pool_mounts(&content);
-    if sanitized != content {
-        info!(
-            "Removed filesystem mount entries from hardware-configuration.nix to prevent boot failure"
-        );
-        if let Err(e) = tokio::fs::write(&path, sanitized).await {
-            tracing::warn!("Failed to write sanitized hardware-configuration.nix: {e}");
-        }
-    }
-}
-
-fn strip_pool_mounts(content: &str) -> String {
-    let mut result = String::with_capacity(content.len());
-    let mut skip = false;
-    let mut depth = 0i32;
-    for line in content.lines() {
-        if !skip && line.trim_start().starts_with("fileSystems.\"/storage/") {
-            skip = true;
-            depth = 0;
-        }
-        if skip {
-            for c in line.chars() {
-                match c {
-                    '{' => depth += 1,
-                    '}' => {
-                        depth -= 1;
-                        if depth <= 0 {
-                            skip = false;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            continue;
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-    result
 }
 
 /// TODO: Remove once repo access no longer requires token fallbacks.
@@ -1731,63 +1306,6 @@ async fn read_github_token() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Run `bcachefs version` and return the version string, or "unknown" on failure.
-/// Strips trailing noise like "kernel: unable to read kernel config".
-/// Returns (version_string, kernel_rust).
-/// `bcachefs version` may emit extra lines, e.g.:
-///   "1.37.1\nkernel: CONFIG_RUST=y"
-///   "1.37.0\nkernel: unable to read kernel config"
-/// Returns the version of the bcachefs kernel module that is currently loaded,
-/// by reading the version field from modinfo. This is the authoritative running
-/// version — it reflects what is actually mounted and active, not what is
-/// installed in current-system (which may differ when a reboot is pending).
-async fn bcachefs_loaded_module_version() -> String {
-    tokio::process::Command::new("modinfo")
-        .args(["bcachefs", "--field", "version"])
-        .output()
-        .await
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                let v = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                if v.is_empty() { None } else { Some(v) }
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-async fn bcachefs_version() -> (String, Option<bool>) {
-    let raw = tokio::process::Command::new("bcachefs")
-        .arg("version")
-        .output()
-        .await
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "unknown".to_string());
-
-    let version = raw
-        .split_whitespace()
-        .next()
-        .unwrap_or("unknown")
-        .to_string();
-
-    // Parse optional "kernel: CONFIG_RUST=y" / "kernel: CONFIG_RUST=n" line
-    let kernel_rust = raw
-        .lines()
-        .find(|l| l.contains("CONFIG_RUST"))
-        .map(|l| l.contains("CONFIG_RUST=y"));
-
-    (version, kernel_rust)
-}
-
 /// Build the full flake reference for nixos-rebuild.
 fn local_flake() -> &'static str {
     LOCAL_FLAKE_TARGET
@@ -1795,6 +1313,10 @@ fn local_flake() -> &'static str {
 
 pub async fn read_flake_nix_default_ref_pub() -> String {
     read_flake_nix_default_ref().await
+}
+
+pub async fn read_flake_lock_bcachefs_pub() -> (Option<String>, Option<String>) {
+    read_flake_lock_bcachefs().await
 }
 
 /// Public wrapper for use by lib.rs cached info.
@@ -1821,25 +1343,6 @@ async fn save_generation_labels(
         .await
         .map_err(|e| UpdateError::CommandFailed(format!("write labels: {e}")))?;
     Ok(())
-}
-
-async fn run_bash_script(script: &str) -> Result<(), UpdateError> {
-    let output = tokio::process::Command::new("bash")
-        .args(["-lc", script])
-        .output()
-        .await
-        .map_err(|e| UpdateError::CommandFailed(format!("bash: {e}")))?;
-
-    if output.status.success() {
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        Err(UpdateError::CommandFailed(if stderr.is_empty() {
-            "bash command failed".into()
-        } else {
-            stderr
-        }))
-    }
 }
 
 fn parse_flake_input_urls(content: &str) -> Result<HashMap<String, ParsedFlakeInput>, UpdateError> {
@@ -2029,15 +1532,6 @@ async fn read_locked_nasty_version() -> Option<String> {
     let node = &v["nodes"]["nasty"];
     let rev = node["locked"]["rev"].as_str()?;
     Some(rev[..rev.len().min(7)].to_string())
-}
-
-/// Read debug checks *configured* state (what the next DKMS build will use).
-/// State file is the sole source of truth — survives git reset --hard.
-/// Note: the *running* module state is detected separately via modinfo in lib.rs.
-async fn read_debug_checks_enabled() -> bool {
-    tokio::fs::metadata(BCACHEFS_DEBUG_CHECKS_STATE)
-        .await
-        .is_ok()
 }
 
 /// Parse flake.lock to extract the bcachefs-tools pinned ref and rev.

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1,8 +1,11 @@
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use rnix::ast::{self};
+use rowan::ast::AstNode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::RwLock;
 use tracing::info;
 
 /// Primary version path — writable by the update script, not managed by NixOS.
@@ -21,8 +24,10 @@ const BCACHEFS_SWITCH_RESULT: &str = "/var/lib/nasty/bcachefs-switch-result";
 const UPDATE_WEBUI_CHANGED: &str = "/var/lib/nasty/update-webui-changed";
 const RELEASE_CHANNEL_PATH: &str = "/var/lib/nasty/release-channel";
 const GC_CONFIG_PATH: &str = "/var/lib/nasty/gc-config.json";
+const VERSION_SWITCH_BACKUP_DIR: &str = "/var/lib/nasty/etc-nixos-backup";
 const DEFAULT_NASTY_OWNER: &str = "nasty-project";
 const DEFAULT_NASTY_REPO: &str = "nasty";
+const VERSION_INPUT_NAMES: [&str; 3] = ["nixpkgs", "bcachefs-tools", "nasty"];
 
 // ── Garbage collection config ────────────────────────────────────
 
@@ -38,11 +43,16 @@ pub struct GcConfig {
     pub max_age_days: u32,
 }
 
-fn default_keep_generations() -> u32 { 20 }
+fn default_keep_generations() -> u32 {
+    20
+}
 
 impl Default for GcConfig {
     fn default() -> Self {
-        Self { keep_generations: 20, max_age_days: 0 }
+        Self {
+            keep_generations: 20,
+            max_age_days: 0,
+        }
     }
 }
 
@@ -57,7 +67,8 @@ impl GcConfig {
     pub async fn save(&self) -> Result<(), UpdateError> {
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| UpdateError::CommandFailed(e.to_string()))?;
-        tokio::fs::write(GC_CONFIG_PATH, json).await
+        tokio::fs::write(GC_CONFIG_PATH, json)
+            .await
             .map_err(|e| UpdateError::CommandFailed(e.to_string()))
     }
 }
@@ -97,8 +108,13 @@ impl ReleaseChannel {
     /// GitHub API endpoint for checking latest commit.
     pub fn github_api_url(&self) -> String {
         match self {
-            Self::Mild => "https://api.github.com/repos/nasty-project/nasty/releases/latest".to_string(),
-            _ => format!("https://api.github.com/repos/nasty-project/nasty/commits/{}", self.git_ref()),
+            Self::Mild => {
+                "https://api.github.com/repos/nasty-project/nasty/releases/latest".to_string()
+            }
+            _ => format!(
+                "https://api.github.com/repos/nasty-project/nasty/commits/{}",
+                self.git_ref()
+            ),
         }
     }
 
@@ -151,7 +167,6 @@ async fn write_channel(channel: ReleaseChannel) -> Result<(), std::io::Error> {
 // and revert check() to use git ls-remote directly.
 const GITHUB_TOKEN_PATH: &str = "/var/lib/nasty/github-token";
 
-
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct BcachefsToolsInfo {
     /// The ref in flake.lock original (e.g. "v1.37.0", "master", commit sha)
@@ -183,6 +198,39 @@ pub struct BcachefsToolsSwitchRequest {
     /// Build with CONFIG_BCACHEFS_DEBUG for extra runtime assertions. Has performance cost.
     #[serde(default)]
     pub debug_checks: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct VersionInputInfo {
+    /// Flake input name (e.g. `nixpkgs`).
+    pub name: String,
+    /// Exact `input.url` string from `/etc/nixos/flake.nix`.
+    pub url: String,
+    /// Locked commit SHA from `/etc/nixos/flake.lock` (shortened to 12 chars).
+    pub rev: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct VersionInfo {
+    /// Inputs shown on the Version page in fixed display order.
+    pub inputs: Vec<VersionInputInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct VersionSwitchInput {
+    /// Flake input name.
+    pub name: String,
+    /// Replacement URL to write to `/etc/nixos/flake.nix`.
+    pub url: String,
+    /// Whether this input should be refreshed in `flake.lock`.
+    #[serde(default)]
+    pub update: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct VersionSwitchRequest {
+    /// Requested URLs and update flags for the Version page.
+    pub inputs: Vec<VersionSwitchInput>,
 }
 
 #[derive(Debug, Error)]
@@ -223,6 +271,13 @@ struct NastyInputSource {
     owner: String,
     repo: String,
     tracked_ref: String,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedFlakeInput {
+    url: String,
+    value_start: usize,
+    value_end: usize,
 }
 
 impl NastyInputSource {
@@ -296,13 +351,49 @@ impl UpdateService {
         }
     }
 
+    /// Read the exact upstream input URLs and locked revs from the live
+    /// `/etc/nixos` flake on the installed system.
+    pub async fn version_info(&self) -> Result<VersionInfo, UpdateError> {
+        self.restore_version_backup_if_needed().await?;
+
+        let urls = read_flake_input_urls().await?;
+        let revs = read_flake_lock_revs().await;
+
+        let mut inputs = Vec::with_capacity(VERSION_INPUT_NAMES.len());
+        for name in VERSION_INPUT_NAMES {
+            let url = urls.get(name).cloned().ok_or_else(|| {
+                UpdateError::CommandFailed(format!(
+                    "missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"
+                ))
+            })?;
+            inputs.push(VersionInputInfo {
+                name: name.to_string(),
+                url,
+                rev: revs.get(name).cloned(),
+            });
+        }
+
+        Ok(VersionInfo { inputs })
+    }
+
+    /// Best-effort page-leave cleanup for the Version tab.
+    /// If a failed/abandoned switch left a backup behind and no rebuild is
+    /// running anymore, restore it so `/etc/nixos` does not stay half-edited.
+    pub async fn version_cleanup(&self) -> Result<(), UpdateError> {
+        self.restore_version_backup_if_needed().await
+    }
+
     /// Get or set the release channel.
     pub async fn get_channel(&self) -> ReleaseChannel {
         read_channel().await
     }
 
-    pub async fn set_channel(&self, channel: ReleaseChannel) -> Result<ReleaseChannel, UpdateError> {
-        write_channel(channel).await
+    pub async fn set_channel(
+        &self,
+        channel: ReleaseChannel,
+    ) -> Result<ReleaseChannel, UpdateError> {
+        write_channel(channel)
+            .await
             .map_err(|e| UpdateError::CommandFailed(format!("write channel: {e}")))?;
         info!("Release channel set to {}", channel.display_name());
         Ok(channel)
@@ -325,7 +416,9 @@ impl UpdateService {
                     &nasty_input.owner,
                     &nasty_input.repo,
                     pattern,
-                ).await {
+                )
+                .await
+                {
                     Ok(tag) => tag,
                     Err(_) => "unknown".to_string(),
                 }
@@ -335,7 +428,9 @@ impl UpdateService {
                     &nasty_input.owner,
                     &nasty_input.repo,
                     &nasty_input.tracked_ref,
-                ).await {
+                )
+                .await
+                {
                     Ok(sha) => sha,
                     Err(_) => {
                         let token = read_github_token().await;
@@ -343,7 +438,8 @@ impl UpdateService {
                             token.as_deref(),
                             &nasty_input.repo_url(),
                             &format!("refs/heads/{}", nasty_input.tracked_ref),
-                        ).await?
+                        )
+                        .await?
                     }
                 }
             }
@@ -398,7 +494,8 @@ impl UpdateService {
         let nasty_input = read_nasty_input_source().await;
 
         // TODO: Remove token env var once the repo access model is finalized.
-        let token_env = token.as_ref()
+        let token_env = token
+            .as_ref()
             .map(|t| format!("access-tokens = github.com={t}"))
             .unwrap_or_default();
 
@@ -410,7 +507,8 @@ impl UpdateService {
                     &nasty_input.owner,
                     &nasty_input.repo,
                     pattern,
-                ).await?;
+                )
+                .await?;
                 (
                     format!(
                         "echo \"==> Pinning NASty to release {latest_tag}...\"\n\
@@ -478,22 +576,23 @@ echo "==> Update complete!"
 
         // Write script to a temp file
         let script_path = "/tmp/nasty-update.sh";
-        tokio::fs::write(script_path, &script).await
-            .map_err(|e| UpdateError::CommandFailed(format!("failed to write update script: {e}")))?;
+        tokio::fs::write(script_path, &script).await.map_err(|e| {
+            UpdateError::CommandFailed(format!("failed to write update script: {e}"))
+        })?;
 
         // Launch as a transient systemd service
         // This avoids the engine's ProtectSystem restrictions
         let mut cmd = tokio::process::Command::new("systemd-run");
         cmd.args([
-                "--unit",
-                UPDATE_UNIT,
-                "--no-block",
-                "--description",
-                "NASty system update",
-                "--property=Type=oneshot",
-                "--property=StandardOutput=journal",
-                "--property=StandardError=journal",
-            ]);
+            "--unit",
+            UPDATE_UNIT,
+            "--no-block",
+            "--description",
+            "NASty system update",
+            "--property=Type=oneshot",
+            "--property=StandardOutput=journal",
+            "--property=StandardError=journal",
+        ]);
 
         // Pass engine's PATH so the script can find git, nixos-rebuild, etc.
         let path = std::env::var("PATH").unwrap_or_default();
@@ -503,11 +602,7 @@ echo "==> Update complete!"
             cmd.args(["--setenv", &format!("NIX_CONFIG={token_env}")]);
         }
 
-        cmd.args([
-                "--",
-                "bash",
-                script_path,
-            ]);
+        cmd.args(["--", "bash", script_path]);
 
         let output = cmd
             .output()
@@ -522,6 +617,179 @@ echo "==> Update complete!"
         }
 
         info!("System update started");
+        Ok(())
+    }
+
+    /// Update selected flake inputs on the installed system and rebuild if the
+    /// lock file changed.
+    pub async fn version_switch(&self, req: VersionSwitchRequest) -> Result<(), UpdateError> {
+        let update_status = self.status().await;
+        let bcachefs_status = self.bcachefs_status().await;
+        if update_status.state == "running" || bcachefs_status.state == "running" {
+            return Err(UpdateError::AlreadyRunning);
+        }
+
+        self.restore_version_backup_if_needed().await?;
+
+        let current_urls = read_flake_input_urls().await?;
+        let mut seen = HashSet::new();
+        let mut requested = HashMap::new();
+        for input in req.inputs {
+            if !VERSION_INPUT_NAMES.contains(&input.name.as_str()) {
+                return Err(UpdateError::CommandFailed(format!(
+                    "unknown input: {}",
+                    input.name
+                )));
+            }
+            if !seen.insert(input.name.clone()) {
+                return Err(UpdateError::CommandFailed(format!(
+                    "duplicate input: {}",
+                    input.name
+                )));
+            }
+            let url = input.url.trim().to_string();
+            if url.is_empty() {
+                return Err(UpdateError::CommandFailed(format!(
+                    "{} url must not be empty",
+                    input.name
+                )));
+            }
+            requested.insert(input.name.clone(), VersionSwitchInput { url, ..input });
+        }
+
+        let mut updates = Vec::new();
+        let mut url_changes = Vec::new();
+        for name in VERSION_INPUT_NAMES {
+            let current_url = current_urls.get(name).ok_or_else(|| {
+                UpdateError::CommandFailed(format!(
+                    "missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"
+                ))
+            })?;
+            let input = requested.get(name).ok_or_else(|| {
+                UpdateError::CommandFailed(format!("missing request entry for {name}"))
+            })?;
+            let url_changed = input.url != *current_url;
+            if input.update || url_changed {
+                updates.push(name.to_string());
+            }
+            if url_changed {
+                url_changes.push((name.to_string(), input.url.clone()));
+            }
+        }
+
+        if updates.is_empty() {
+            return Err(UpdateError::CommandFailed(
+                "nothing to switch: enable at least one update or change an input URL".into(),
+            ));
+        }
+
+        sanitize_hardware_config().await;
+
+        let _ = tokio::process::Command::new("systemctl")
+            .args(["reset-failed", UPDATE_UNIT])
+            .output()
+            .await;
+        let _ = tokio::process::Command::new("systemctl")
+            .args(["stop", UPDATE_UNIT])
+            .output()
+            .await;
+
+        let flake_path = format!("{NIXOS_FLAKE_DIR}/flake.nix");
+        let current_flake = tokio::fs::read_to_string(&flake_path)
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("read {flake_path}: {e}")))?;
+        let flake_replacements = url_changes
+            .iter()
+            .map(|(name, url)| (name.clone(), url.clone()))
+            .collect::<HashMap<_, _>>();
+        let rewritten_flake = rewrite_flake_input_urls(&current_flake, &flake_replacements)?;
+        let flake_temp_path = "/tmp/nasty-version-flake.nix";
+        tokio::fs::write(flake_temp_path, &rewritten_flake)
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("write {flake_temp_path}: {e}")))?;
+
+        let update_steps = updates
+            .iter()
+            .map(|name| format!("nix flake update {name}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let local_flake = local_flake();
+        let script = format!(
+            r#"#!/bin/bash
+set -euo pipefail
+export PATH="/run/current-system/sw/bin:$PATH"
+_nginx_conf() {{
+    grep -o "/nix/store/[^' ]*nginx\.conf" \
+        /run/current-system/etc/systemd/system/nginx.service 2>/dev/null | head -1 || true
+}}
+_NGINX_CONF_BEFORE=$(_nginx_conf)
+WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+echo "false" > {UPDATE_WEBUI_CHANGED}
+
+echo "==> Updating local system flake..."
+rm -rf {VERSION_SWITCH_BACKUP_DIR}
+cp -a {NIXOS_FLAKE_DIR} {VERSION_SWITCH_BACKUP_DIR}
+
+cd {NIXOS_FLAKE_DIR}
+LOCK_BEFORE=$(sha256sum flake.lock 2>/dev/null | awk '{{print $1}}' || true)
+cp {flake_temp_path} flake.nix
+{update_steps}
+LOCK_AFTER=$(sha256sum flake.lock 2>/dev/null | awk '{{print $1}}' || true)
+
+if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
+    echo "==> Rebuilding system..."
+    NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}
+    _NGINX_CONF_AFTER=$(_nginx_conf)
+    WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
+    if [ -n "$WEBUI_BEFORE" ] && [ "$WEBUI_BEFORE" != "$WEBUI_AFTER" ]; then
+        echo "true" > {UPDATE_WEBUI_CHANGED}
+    fi
+    NASTY_REV=$(jq -r '.nodes["nasty"].locked.rev // empty' flake.lock 2>/dev/null || true)
+    [ -n "$NASTY_REV" ] && echo "${{NASTY_REV:0:7}}" > {VERSION_PATH}
+else
+    echo "==> No flake.lock changes detected; skipping rebuild."
+fi
+
+rm -rf {VERSION_SWITCH_BACKUP_DIR}
+echo "==> Update complete!"
+"#
+        );
+
+        let script_path = "/tmp/nasty-version-switch.sh";
+        tokio::fs::write(script_path, &script).await.map_err(|e| {
+            UpdateError::CommandFailed(format!("failed to write version switch script: {e}"))
+        })?;
+
+        let path = std::env::var("PATH").unwrap_or_default();
+        let output = tokio::process::Command::new("systemd-run")
+            .args([
+                "--unit",
+                UPDATE_UNIT,
+                "--no-block",
+                "--description",
+                "NASty version switch",
+                "--property=Type=oneshot",
+                "--property=StandardOutput=journal",
+                "--property=StandardError=journal",
+                "--setenv",
+                &format!("PATH={path}"),
+                "--",
+                "bash",
+                script_path,
+            ])
+            .output()
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("systemd-run: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(UpdateError::CommandFailed(format!(
+                "failed to start version switch: {stderr}"
+            )));
+        }
+
+        info!("Version switch started for inputs: {}", updates.join(", "));
         Ok(())
     }
 
@@ -623,7 +891,9 @@ echo "==> Update complete!"
             .args(["list-generations", "--json"])
             .output()
             .await
-            .map_err(|e| UpdateError::CommandFailed(format!("nixos-rebuild list-generations: {e}")))?;
+            .map_err(|e| {
+                UpdateError::CommandFailed(format!("nixos-rebuild list-generations: {e}"))
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -728,14 +998,19 @@ echo "==> Switch to generation {gen_id} complete!"
 
         let output = tokio::process::Command::new("systemd-run")
             .args([
-                "--unit", UPDATE_UNIT,
+                "--unit",
+                UPDATE_UNIT,
                 "--no-block",
-                "--description", &format!("NASty switch to generation {gen_id}"),
+                "--description",
+                &format!("NASty switch to generation {gen_id}"),
                 "--property=Type=oneshot",
                 "--property=StandardOutput=journal",
                 "--property=StandardError=journal",
-                "--setenv", &format!("PATH={path}"),
-                "--", "bash", script_path,
+                "--setenv",
+                &format!("PATH={path}"),
+                "--",
+                "bash",
+                script_path,
             ])
             .output()
             .await
@@ -753,11 +1028,19 @@ echo "==> Switch to generation {gen_id} complete!"
     }
 
     /// Set or clear a label on a generation.
-    pub async fn label_generation(&self, gen_id: u64, label: Option<String>) -> Result<(), UpdateError> {
+    pub async fn label_generation(
+        &self,
+        gen_id: u64,
+        label: Option<String>,
+    ) -> Result<(), UpdateError> {
         let mut labels = load_generation_labels().await;
         match label {
-            Some(l) if !l.is_empty() => { labels.insert(gen_id, l); }
-            _ => { labels.remove(&gen_id); }
+            Some(l) if !l.is_empty() => {
+                labels.insert(gen_id, l);
+            }
+            _ => {
+                labels.remove(&gen_id);
+            }
         }
         save_generation_labels(&labels).await
     }
@@ -768,9 +1051,11 @@ echo "==> Switch to generation {gen_id} complete!"
         let profile_link = format!("/nix/var/nix/profiles/system-{gen_id}-link");
         let current_link = "/nix/var/nix/profiles/system";
 
-        let gen_target = tokio::fs::read_link(&profile_link).await
-            .map_err(|_| UpdateError::CommandFailed(format!("generation {gen_id} does not exist")))?;
-        let current_target = tokio::fs::read_link(current_link).await
+        let gen_target = tokio::fs::read_link(&profile_link).await.map_err(|_| {
+            UpdateError::CommandFailed(format!("generation {gen_id} does not exist"))
+        })?;
+        let current_target = tokio::fs::read_link(current_link)
+            .await
             .map_err(|e| UpdateError::CommandFailed(format!("cannot read current profile: {e}")))?;
 
         if gen_target == current_target {
@@ -789,8 +1074,9 @@ echo "==> Switch to generation {gen_id} complete!"
         }
 
         // Remove the profile link
-        tokio::fs::remove_file(&profile_link).await
-            .map_err(|e| UpdateError::CommandFailed(format!("failed to remove generation {gen_id}: {e}")))?;
+        tokio::fs::remove_file(&profile_link).await.map_err(|e| {
+            UpdateError::CommandFailed(format!("failed to remove generation {gen_id}: {e}"))
+        })?;
 
         // Clean up the label if any
         let mut labels = load_generation_labels().await;
@@ -816,7 +1102,14 @@ echo "==> Switch to generation {gen_id} complete!"
 
     async fn bcachefs_info_uncached(&self, system: &crate::SystemService) -> BcachefsToolsInfo {
         // Run subprocess calls and file reads concurrently.
-        let ((_, kernel_rust), running_version, (lock_ref, pinned_rev), default_ref, debug_checks, (debug_symbols, debug_checks_running)) = tokio::join!(
+        let (
+            (_, kernel_rust),
+            running_version,
+            (lock_ref, pinned_rev),
+            default_ref,
+            debug_checks,
+            (debug_symbols, debug_checks_running),
+        ) = tokio::join!(
             bcachefs_version(),
             bcachefs_loaded_module_version(),
             read_flake_lock_bcachefs(),
@@ -830,7 +1123,8 @@ echo "==> Switch to generation {gen_id} complete!"
         // Use the state file as the canonical display ref when the user has switched.
         // flake.lock's original.ref always mirrors flake.nix (not updated by --override-input),
         // so it would show the old version even after a successful switch to a new rev.
-        let state_ref = tokio::fs::read_to_string(BCACHEFS_REF_STATE).await
+        let state_ref = tokio::fs::read_to_string(BCACHEFS_REF_STATE)
+            .await
             .ok()
             .map(|s| {
                 let s = s.trim().to_string();
@@ -843,14 +1137,31 @@ echo "==> Switch to generation {gen_id} complete!"
             })
             .filter(|s| !s.is_empty());
         let pinned_ref = state_ref.clone().or(lock_ref);
-        let is_custom = state_ref.as_deref().map(|r| r != default_ref).unwrap_or(false);
+        let is_custom = state_ref
+            .as_deref()
+            .map(|r| r != default_ref)
+            .unwrap_or(false);
         // Compare loaded module version against default (strip 'v' prefix for comparison)
         let default_bare = default_ref.strip_prefix('v').unwrap_or(&default_ref);
         let is_custom_running = running_version != default_bare && running_version != "unknown";
-        BcachefsToolsInfo { pinned_ref, pinned_rev, running_version, is_custom, is_custom_running, default_ref, kernel_rust, debug_symbols, debug_checks, debug_checks_running }
+        BcachefsToolsInfo {
+            pinned_ref,
+            pinned_rev,
+            running_version,
+            is_custom,
+            is_custom_running,
+            default_ref,
+            kernel_rust,
+            debug_symbols,
+            debug_checks,
+            debug_checks_running,
+        }
     }
 
-    pub async fn bcachefs_switch(&self, req: BcachefsToolsSwitchRequest) -> Result<(), UpdateError> {
+    pub async fn bcachefs_switch(
+        &self,
+        req: BcachefsToolsSwitchRequest,
+    ) -> Result<(), UpdateError> {
         // Refuse if either update unit is running
         let update_status = self.status().await;
         let switch_status = self.bcachefs_status().await;
@@ -860,14 +1171,17 @@ echo "==> Switch to generation {gen_id} complete!"
 
         let git_ref = req.git_ref.trim().to_string();
         if git_ref.is_empty() {
-            return Err(UpdateError::CommandFailed("git_ref must not be empty".into()));
+            return Err(UpdateError::CommandFailed(
+                "git_ref must not be empty".into(),
+            ));
         }
 
         // Clean up previous unit and result file
         for action in &["reset-failed", "stop"] {
             let _ = tokio::process::Command::new("systemctl")
                 .args([action, BCACHEFS_SWITCH_UNIT])
-                .output().await;
+                .output()
+                .await;
         }
         let _ = tokio::fs::remove_file(BCACHEFS_SWITCH_RESULT).await;
 
@@ -940,27 +1254,36 @@ echo "==> bcachefs switch complete!"
         );
 
         let script_path = "/tmp/nasty-bcachefs-switch.sh";
-        tokio::fs::write(script_path, &script).await
+        tokio::fs::write(script_path, &script)
+            .await
             .map_err(|e| UpdateError::CommandFailed(format!("write script: {e}")))?;
 
         let path = std::env::var("PATH").unwrap_or_default();
         let output = tokio::process::Command::new("systemd-run")
             .args([
-                "--unit", BCACHEFS_SWITCH_UNIT,
+                "--unit",
+                BCACHEFS_SWITCH_UNIT,
                 "--no-block",
-                "--description", "NASty bcachefs version switch",
+                "--description",
+                "NASty bcachefs version switch",
                 "--property=Type=oneshot",
                 "--property=StandardOutput=journal",
                 "--property=StandardError=journal",
-                "--setenv", &format!("PATH={path}"),
-                "--", "bash", script_path,
+                "--setenv",
+                &format!("PATH={path}"),
+                "--",
+                "bash",
+                script_path,
             ])
-            .output().await
+            .output()
+            .await
             .map_err(|e| UpdateError::CommandFailed(format!("systemd-run: {e}")))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(UpdateError::CommandFailed(format!("failed to start: {stderr}")));
+            return Err(UpdateError::CommandFailed(format!(
+                "failed to start: {stderr}"
+            )));
         }
         info!("bcachefs switch to {git_ref} started");
         Ok(())
@@ -968,8 +1291,13 @@ echo "==> bcachefs switch complete!"
 
     pub async fn bcachefs_status(&self) -> UpdateStatus {
         let output = tokio::process::Command::new("systemctl")
-            .args(["show", BCACHEFS_SWITCH_UNIT, "--property=ActiveState,SubState,Result"])
-            .output().await;
+            .args([
+                "show",
+                BCACHEFS_SWITCH_UNIT,
+                "--property=ActiveState,SubState,Result",
+            ])
+            .output()
+            .await;
 
         let state = match output {
             Ok(out) => {
@@ -977,8 +1305,12 @@ echo "==> bcachefs switch complete!"
                 let mut active_state = "";
                 let mut result = "";
                 for line in text.lines() {
-                    if let Some(val) = line.strip_prefix("ActiveState=") { active_state = val.trim(); }
-                    if let Some(val) = line.strip_prefix("Result=") { result = val.trim(); }
+                    if let Some(val) = line.strip_prefix("ActiveState=") {
+                        active_state = val.trim();
+                    }
+                    if let Some(val) = line.strip_prefix("Result=") {
+                        result = val.trim();
+                    }
                 }
                 match active_state {
                     "active" | "activating" | "reloading" => "running".to_string(),
@@ -996,12 +1328,13 @@ echo "==> bcachefs switch complete!"
                         } else if active_state == "failed" {
                             "failed".to_string()
                         } else {
-                            tokio::fs::read_to_string(BCACHEFS_SWITCH_RESULT).await
+                            tokio::fs::read_to_string(BCACHEFS_SWITCH_RESULT)
+                                .await
                                 .ok()
                                 .map(|s| match s.trim() {
                                     "success" => "success".to_string(),
-                                    "failed"  => "failed".to_string(),
-                                    _         => "idle".to_string(),
+                                    "failed" => "failed".to_string(),
+                                    _ => "idle".to_string(),
                                 })
                                 .unwrap_or_else(|| "idle".to_string())
                         };
@@ -1016,14 +1349,22 @@ echo "==> bcachefs switch complete!"
         };
 
         let invocation_id = tokio::process::Command::new("systemctl")
-            .args(["show", BCACHEFS_SWITCH_UNIT, "--property=InvocationID", "--value"])
-            .output().await
+            .args([
+                "show",
+                BCACHEFS_SWITCH_UNIT,
+                "--property=InvocationID",
+                "--value",
+            ])
+            .output()
+            .await
             .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
             .unwrap_or_default();
 
         let mut journal_args = vec![
-            "-u".to_string(), BCACHEFS_SWITCH_UNIT.to_string(),
-            "--no-pager".to_string(), "--output=cat".to_string(),
+            "-u".to_string(),
+            BCACHEFS_SWITCH_UNIT.to_string(),
+            "--no-pager".to_string(),
+            "--output=cat".to_string(),
         ];
         if !invocation_id.is_empty() {
             journal_args.push(format!("_SYSTEMD_INVOCATION_ID={invocation_id}"));
@@ -1032,11 +1373,18 @@ echo "==> bcachefs switch complete!"
         }
 
         let log = tokio::process::Command::new("journalctl")
-            .args(&journal_args).output().await
+            .args(&journal_args)
+            .output()
+            .await
             .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
             .unwrap_or_default();
 
-        UpdateStatus { state, log, reboot_required: is_reboot_required().await, webui_changed: false }
+        UpdateStatus {
+            state,
+            log,
+            reboot_required: is_reboot_required().await,
+            webui_changed: false,
+        }
     }
 
     /// Get the current status of a running/completed update
@@ -1114,7 +1462,8 @@ echo "==> bcachefs switch complete!"
         // Read hint file written by the update script.
         // Default to true when state is success and the file is missing (conservative).
         let webui_changed = if state == "success" {
-            tokio::fs::read_to_string(UPDATE_WEBUI_CHANGED).await
+            tokio::fs::read_to_string(UPDATE_WEBUI_CHANGED)
+                .await
                 .ok()
                 .map(|s| s.trim() == "true")
                 .unwrap_or(true)
@@ -1128,6 +1477,30 @@ echo "==> bcachefs switch complete!"
             reboot_required: is_reboot_required().await,
             webui_changed,
         }
+    }
+
+    async fn restore_version_backup_if_needed(&self) -> Result<(), UpdateError> {
+        if tokio::fs::metadata(VERSION_SWITCH_BACKUP_DIR)
+            .await
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        if self.status().await.state == "running" {
+            return Ok(());
+        }
+
+        let restore = format!(
+            r#"set -euo pipefail
+rm -rf {NIXOS_FLAKE_DIR}
+cp -a {VERSION_SWITCH_BACKUP_DIR} {NIXOS_FLAKE_DIR}
+rm -rf {VERSION_SWITCH_BACKUP_DIR}
+"#
+        );
+        run_bash_script(&restore).await?;
+        info!("Restored {NIXOS_FLAKE_DIR} from backup after an incomplete version switch");
+        Ok(())
     }
 }
 
@@ -1145,7 +1518,9 @@ async fn sanitize_hardware_config() {
     };
     let sanitized = strip_pool_mounts(&content);
     if sanitized != content {
-        info!("Removed filesystem mount entries from hardware-configuration.nix to prevent boot failure");
+        info!(
+            "Removed filesystem mount entries from hardware-configuration.nix to prevent boot failure"
+        );
         if let Err(e) = tokio::fs::write(&path, sanitized).await {
             tracing::warn!("Failed to write sanitized hardware-configuration.nix: {e}");
         }
@@ -1220,12 +1595,17 @@ async fn check_latest_tag(
         }
     }
 
-    Err(UpdateError::CommandFailed(format!("no tags matching '{pattern}' found")))
+    Err(UpdateError::CommandFailed(format!(
+        "no tags matching '{pattern}' found"
+    )))
 }
 
-
 /// Check latest commit on a branch via GitHub API.
-async fn check_via_github_api_branch(owner: &str, repo: &str, branch: &str) -> Result<String, UpdateError> {
+async fn check_via_github_api_branch(
+    owner: &str,
+    repo: &str,
+    branch: &str,
+) -> Result<String, UpdateError> {
     let token = tokio::fs::read_to_string(GITHUB_TOKEN_PATH)
         .await
         .map(|s| s.trim().to_string())
@@ -1325,7 +1705,10 @@ async fn read_current_version() -> String {
 async fn is_reboot_required() -> bool {
     let paths = [
         ("/run/booted-system/kernel", "/run/current-system/kernel"),
-        ("/run/booted-system/kernel-modules", "/run/current-system/kernel-modules"),
+        (
+            "/run/booted-system/kernel-modules",
+            "/run/current-system/kernel-modules",
+        ),
     ];
     for (booted_path, current_path) in paths {
         let booted = tokio::fs::read_link(booted_path).await;
@@ -1390,10 +1773,15 @@ async fn bcachefs_version() -> (String, Option<bool>) {
         })
         .unwrap_or_else(|| "unknown".to_string());
 
-    let version = raw.split_whitespace().next().unwrap_or("unknown").to_string();
+    let version = raw
+        .split_whitespace()
+        .next()
+        .unwrap_or("unknown")
+        .to_string();
 
     // Parse optional "kernel: CONFIG_RUST=y" / "kernel: CONFIG_RUST=n" line
-    let kernel_rust = raw.lines()
+    let kernel_rust = raw
+        .lines()
         .find(|l| l.contains("CONFIG_RUST"))
         .map(|l| l.contains("CONFIG_RUST=y"));
 
@@ -1435,22 +1823,158 @@ async fn save_generation_labels(
     Ok(())
 }
 
-/// Parse flake.nix to extract the default bcachefs-tools ref from the input URL.
-async fn read_flake_nix_default_ref() -> String {
-    let path = format!("{NIXOS_FLAKE_DIR}/flake.nix");
-    let content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.starts_with("bcachefs-tools.url") {
-            // e.g. bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.37.0";
-            if let Some(slash_pos) = line.rfind('/') {
-                let rest = &line[slash_pos + 1..];
-                let end = rest.find('"').unwrap_or(rest.len());
-                return rest[..end].to_string();
-            }
+async fn run_bash_script(script: &str) -> Result<(), UpdateError> {
+    let output = tokio::process::Command::new("bash")
+        .args(["-lc", script])
+        .output()
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("bash: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(UpdateError::CommandFailed(if stderr.is_empty() {
+            "bash command failed".into()
+        } else {
+            stderr
+        }))
+    }
+}
+
+fn parse_flake_input_urls(content: &str) -> Result<HashMap<String, ParsedFlakeInput>, UpdateError> {
+    let parsed = rnix::Root::parse(content);
+    if !parsed.errors().is_empty() {
+        let first = parsed.errors()[0].to_string();
+        return Err(UpdateError::CommandFailed(format!(
+            "failed to parse {NIXOS_FLAKE_DIR}/flake.nix: {first}"
+        )));
+    }
+
+    let mut urls = HashMap::new();
+    let root = parsed.tree();
+    for node in root
+        .syntax()
+        .descendants()
+        .filter_map(ast::AttrpathValue::cast)
+    {
+        let Some(attrpath) = node.attrpath() else {
+            continue;
+        };
+        let normalized_path = attrpath
+            .syntax()
+            .text()
+            .to_string()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
+        let Some(name) = VERSION_INPUT_NAMES
+            .iter()
+            .find(|candidate| normalized_path == format!("{candidate}.url"))
+        else {
+            continue;
+        };
+        let Some(value) = node.value() else { continue };
+        let raw_value = value.syntax().text().to_string();
+        let Some(url) = unquote_nix_string(&raw_value) else {
+            continue;
+        };
+        let range = value.syntax().text_range();
+        urls.insert(
+            (*name).to_string(),
+            ParsedFlakeInput {
+                url,
+                value_start: u32::from(range.start()) as usize,
+                value_end: u32::from(range.end()) as usize,
+            },
+        );
+    }
+
+    for name in VERSION_INPUT_NAMES {
+        if !urls.contains_key(name) {
+            return Err(UpdateError::CommandFailed(format!(
+                "missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"
+            )));
         }
     }
-    "unknown".to_string()
+
+    Ok(urls)
+}
+
+fn rewrite_flake_input_urls(
+    content: &str,
+    replacements: &HashMap<String, String>,
+) -> Result<String, UpdateError> {
+    if replacements.is_empty() {
+        return Ok(content.to_string());
+    }
+
+    let parsed = parse_flake_input_urls(content)?;
+    let mut edits = Vec::new();
+    for (name, replacement) in replacements {
+        let current = parsed.get(name).ok_or_else(|| {
+            UpdateError::CommandFailed(format!("missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"))
+        })?;
+        edits.push((
+            current.value_start,
+            current.value_end,
+            serde_json::to_string(replacement).map_err(|e| {
+                UpdateError::CommandFailed(format!("serialize replacement URL for {name}: {e}"))
+            })?,
+        ));
+    }
+
+    edits.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut rewritten = content.to_string();
+    for (start, end, replacement) in edits {
+        rewritten.replace_range(start..end, &replacement);
+    }
+    Ok(rewritten)
+}
+
+fn unquote_nix_string(raw: &str) -> Option<String> {
+    serde_json::from_str::<String>(raw).ok()
+}
+
+async fn read_flake_input_urls() -> Result<HashMap<String, String>, UpdateError> {
+    let path = format!("{NIXOS_FLAKE_DIR}/flake.nix");
+    let content = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("read {path}: {e}")))?;
+    Ok(parse_flake_input_urls(&content)?
+        .into_iter()
+        .map(|(name, parsed)| (name, parsed.url))
+        .collect())
+}
+
+async fn read_flake_lock_revs() -> HashMap<String, String> {
+    let path = format!("{NIXOS_FLAKE_DIR}/flake.lock");
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    let v: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut revs = HashMap::new();
+    for name in VERSION_INPUT_NAMES {
+        if let Some(rev) = v["nodes"][name]["locked"]["rev"].as_str() {
+            revs.insert(name.to_string(), rev[..rev.len().min(12)].to_string());
+        }
+    }
+    revs
+}
+
+/// Parse flake.nix to extract the default bcachefs-tools ref from the input URL.
+async fn read_flake_nix_default_ref() -> String {
+    read_flake_input_urls()
+        .await
+        .ok()
+        .and_then(|urls| urls.get("bcachefs-tools").cloned())
+        .and_then(|url| url.rsplit('/').next().map(|s| s.to_string()))
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 async fn read_nasty_input_source() -> NastyInputSource {
@@ -1491,7 +2015,11 @@ async fn read_nasty_input_source() -> NastyInputSource {
         .filter(|s| !s.is_empty())
         .unwrap_or("main")
         .to_string();
-    NastyInputSource { owner, repo, tracked_ref }
+    NastyInputSource {
+        owner,
+        repo,
+        tracked_ref,
+    }
 }
 
 async fn read_locked_nasty_version() -> Option<String> {
@@ -1507,7 +2035,9 @@ async fn read_locked_nasty_version() -> Option<String> {
 /// State file is the sole source of truth — survives git reset --hard.
 /// Note: the *running* module state is detected separately via modinfo in lib.rs.
 async fn read_debug_checks_enabled() -> bool {
-    tokio::fs::metadata(BCACHEFS_DEBUG_CHECKS_STATE).await.is_ok()
+    tokio::fs::metadata(BCACHEFS_DEBUG_CHECKS_STATE)
+        .await
+        .is_ok()
 }
 
 /// Parse flake.lock to extract the bcachefs-tools pinned ref and rev.
@@ -1523,7 +2053,8 @@ async fn read_flake_lock_bcachefs() -> (Option<String>, Option<String>) {
     };
     let node = &v["nodes"]["bcachefs-tools"];
     let pinned_ref = node["original"]["ref"].as_str().map(|s| s.to_string());
-    let pinned_rev = node["locked"]["rev"].as_str()
+    let pinned_rev = node["locked"]["rev"]
+        .as_str()
         .map(|s| s[..s.len().min(12)].to_string()); // short rev, 12 chars
     (pinned_ref, pinned_rev)
 }

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1,8 +1,10 @@
+use base64::Engine as _;
 use rnix::ast::{self};
 use rowan::ast::AstNode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 use thiserror::Error;
 use tracing::info;
 
@@ -20,7 +22,9 @@ const GC_CONFIG_PATH: &str = "/var/lib/nasty/gc-config.json";
 const VERSION_SWITCH_BACKUP_DIR: &str = "/var/lib/nasty/etc-nixos-backup";
 const DEFAULT_NASTY_OWNER: &str = "nasty-project";
 const DEFAULT_NASTY_REPO: &str = "nasty";
+const DEFAULT_NASTY_REF: &str = "main";
 const VERSION_INPUT_NAMES: [&str; 3] = ["nixpkgs", "bcachefs-tools", "nasty"];
+const SYSTEM_FLAKE_TEMPLATE_PATH: &str = "nixos/system-flake/flake.nix.template";
 
 // ── Garbage collection config ────────────────────────────────────
 
@@ -176,6 +180,24 @@ pub struct VersionInfo {
     pub inputs: Vec<VersionInputInfo>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct VersionTaggedReleaseStatus {
+    /// Exact current `nasty.url` string from `/etc/nixos/flake.nix`.
+    pub current_url: String,
+    /// Latest official NASty release tag available upstream.
+    pub latest_tag: String,
+    /// Standard shorthand URL for the latest official tagged release.
+    pub latest_url: String,
+    /// True when `nasty.url` already matches the newest official tagged release.
+    pub current_is_latest_standard_url: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BootstrapSystemFlakeResult {
+    /// Path of the written flake.nix.
+    pub flake_path: String,
+}
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct VersionSwitchInput {
     /// Flake input name.
@@ -323,6 +345,148 @@ impl UpdateService {
         }
 
         Ok(VersionInfo { inputs })
+    }
+
+    /// Return the latest official tagged release and whether the current
+    /// `nasty.url` already matches its standard GitHub shorthand form.
+    pub async fn version_tagged_release_status(
+        &self,
+    ) -> Result<VersionTaggedReleaseStatus, UpdateError> {
+        let urls = read_flake_input_urls().await?;
+        let current_url = urls.get("nasty").cloned().ok_or_else(|| {
+            UpdateError::CommandFailed(format!("missing nasty.url in {NIXOS_FLAKE_DIR}/flake.nix"))
+        })?;
+        let latest_tag = latest_official_nasty_release_tag().await?;
+        let latest_url = official_nasty_release_url(&latest_tag);
+
+        Ok(VersionTaggedReleaseStatus {
+            current_is_latest_standard_url: current_url.trim() == latest_url,
+            current_url,
+            latest_tag,
+            latest_url,
+        })
+    }
+
+    /// Bootstrap `/etc/nixos/flake.nix` from the latest official tagged
+    /// release's wrapper-flake template, then run a switch rebuild.
+    pub async fn upgrade_tagged_release(&self) -> Result<(), UpdateError> {
+        let update_status = self.status().await;
+        if update_status.state == "running" {
+            return Err(UpdateError::AlreadyRunning);
+        }
+
+        self.purge_stale_version_backup().await?;
+
+        let release_status = self.version_tagged_release_status().await?;
+        if release_status.current_is_latest_standard_url {
+            return Err(UpdateError::CommandFailed(
+                "system already tracks the newest official tagged NASty release".to_string(),
+            ));
+        }
+
+        let local_system = detect_local_system().await?;
+        let token = read_github_token().await;
+        let template = fetch_github_text_file(
+            token.as_deref(),
+            DEFAULT_NASTY_OWNER,
+            DEFAULT_NASTY_REPO,
+            SYSTEM_FLAKE_TEMPLATE_PATH,
+            &release_status.latest_tag,
+        )
+        .await?;
+        let bootstrapped_flake =
+            render_system_flake_template(&template, &release_status.latest_url, &local_system)?;
+
+        let _ = tokio::process::Command::new("systemctl")
+            .args(["reset-failed", UPDATE_UNIT])
+            .output()
+            .await;
+        let _ = tokio::process::Command::new("systemctl")
+            .args(["stop", UPDATE_UNIT])
+            .output()
+            .await;
+
+        let flake_temp_path = "/tmp/nasty-upgrade-flake.nix";
+        tokio::fs::write(flake_temp_path, &bootstrapped_flake)
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("write {flake_temp_path}: {e}")))?;
+
+        let local_flake = local_flake();
+        let script = format!(
+            r#"#!/bin/bash
+set -euo pipefail
+export PATH="/run/current-system/sw/bin:$PATH"
+_nginx_conf() {{
+    grep -o "/nix/store/[^' ]*nginx\.conf" \
+        /run/current-system/etc/systemd/system/nginx.service 2>/dev/null | head -1 || true
+}}
+_NGINX_CONF_BEFORE=$(_nginx_conf)
+WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+echo "false" > {UPDATE_WEBUI_CHANGED}
+
+echo "==> Updating local system flake..."
+cd {NIXOS_FLAKE_DIR}
+cp {flake_temp_path} flake.nix
+nix flake update nixpkgs
+nix flake update bcachefs-tools
+nix flake update nasty
+
+echo "==> Rebuilding system..."
+NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}
+
+_NGINX_CONF_AFTER=$(_nginx_conf)
+WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
+if [ -n "$WEBUI_BEFORE" ] && [ "$WEBUI_BEFORE" != "$WEBUI_AFTER" ]; then
+    echo "true" > {UPDATE_WEBUI_CHANGED}
+fi
+
+echo "{latest_tag}" > {VERSION_PATH}
+echo "==> Update complete!"
+"#,
+            latest_tag = release_status.latest_tag,
+        );
+
+        let script_path = "/tmp/nasty-upgrade-tagged-release.sh";
+        tokio::fs::write(script_path, &script).await.map_err(|e| {
+            UpdateError::CommandFailed(format!(
+                "failed to write tagged release upgrade script: {e}"
+            ))
+        })?;
+
+        let path = std::env::var("PATH").unwrap_or_default();
+        let output = tokio::process::Command::new("systemd-run")
+            .args([
+                "--unit",
+                UPDATE_UNIT,
+                "--no-block",
+                "--description",
+                "NASty tagged release upgrade",
+                "--property=Type=oneshot",
+                "--property=StandardOutput=journal",
+                "--property=StandardError=journal",
+                "--setenv",
+                &format!("PATH={path}"),
+                "--",
+                "bash",
+                script_path,
+            ])
+            .output()
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("systemd-run: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(UpdateError::CommandFailed(format!(
+                "failed to start tagged release upgrade: {stderr}"
+            )));
+        }
+
+        info!(
+            "Tagged release upgrade started: {} -> {}",
+            release_status.current_url.trim(),
+            release_status.latest_tag
+        );
+        Ok(())
     }
 
     /// Legacy endpoint kept for compatibility with older web UIs.
@@ -1163,16 +1327,161 @@ async fn check_latest_tag(
     let stdout = String::from_utf8_lossy(&output.stdout);
     // First line is the latest tag (sorted by version descending)
     // Format: "sha\trefs/tags/v0.0.1"
-    if let Some(line) = stdout.lines().next() {
+    for line in stdout.lines() {
         if let Some(tag_ref) = line.split('\t').nth(1) {
-            let tag = tag_ref.strip_prefix("refs/tags/").unwrap_or(tag_ref);
-            return Ok(tag.to_string());
+            let tag = normalize_git_tag_ref(tag_ref);
+            if !tag.is_empty() {
+                return Ok(tag.to_string());
+            }
         }
     }
 
     Err(UpdateError::CommandFailed(format!(
         "no tags matching '{pattern}' found"
     )))
+}
+
+async fn latest_official_nasty_release_tag() -> Result<String, UpdateError> {
+    let token = read_github_token().await;
+    let latest_tag = tokio::time::timeout(
+        Duration::from_secs(60),
+        check_latest_tag(
+            token.as_deref(),
+            DEFAULT_NASTY_OWNER,
+            DEFAULT_NASTY_REPO,
+            "v*",
+        ),
+    )
+    .await
+    .map_err(|_| UpdateError::CommandFailed("timed out fetching latest tagged release".into()))??;
+
+    if parse_release_tag_version(&latest_tag).is_none() {
+        return Err(UpdateError::CommandFailed(format!(
+            "latest official tagged release is not a semantic vX.Y.Z tag: {latest_tag}"
+        )));
+    }
+
+    Ok(latest_tag)
+}
+
+pub async fn bootstrap_system_flake_from_template_path(
+    template_path: &str,
+    dest_dir: &str,
+    nasty_url: &str,
+    local_system: &str,
+) -> Result<BootstrapSystemFlakeResult, UpdateError> {
+    let template = tokio::fs::read_to_string(template_path)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("read {template_path}: {e}")))?;
+    bootstrap_system_flake_from_template(&template, dest_dir, nasty_url, local_system).await
+}
+
+pub async fn bootstrap_system_flake_from_template(
+    template: &str,
+    dest_dir: &str,
+    nasty_url: &str,
+    local_system: &str,
+) -> Result<BootstrapSystemFlakeResult, UpdateError> {
+    let rendered = render_system_flake_template(template, nasty_url, local_system)?;
+    tokio::fs::create_dir_all(dest_dir)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("mkdir {dest_dir}: {e}")))?;
+    let flake_path = format!("{dest_dir}/flake.nix");
+    tokio::fs::write(&flake_path, rendered)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("write {flake_path}: {e}")))?;
+    Ok(BootstrapSystemFlakeResult { flake_path })
+}
+
+fn render_system_flake_template(
+    template: &str,
+    nasty_url: &str,
+    local_system: &str,
+) -> Result<String, UpdateError> {
+    if !template.contains("@NASTY_URL@") {
+        return Err(UpdateError::CommandFailed(
+            "system flake template is missing @NASTY_URL@ placeholder".into(),
+        ));
+    }
+    if !template.contains("\"local-system\"") {
+        return Err(UpdateError::CommandFailed(
+            "system flake template is missing \"local-system\" placeholder".into(),
+        ));
+    }
+
+    Ok(template
+        .replace("@NASTY_URL@", nasty_url)
+        .replace("\"local-system\"", &format!("\"{local_system}\"")))
+}
+
+async fn detect_local_system() -> Result<String, UpdateError> {
+    let output = tokio::process::Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "eval",
+            "--impure",
+            "--raw",
+            "--expr",
+            "builtins.currentSystem",
+        ])
+        .output()
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("detect local system: {e}")))?;
+
+    if !output.status.success() {
+        return Err(UpdateError::CommandFailed(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    let system = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if system.is_empty() {
+        return Err(UpdateError::CommandFailed(
+            "failed to detect local system identifier".into(),
+        ));
+    }
+    Ok(system)
+}
+
+async fn fetch_github_text_file(
+    token: Option<&str>,
+    owner: &str,
+    repo: &str,
+    path: &str,
+    git_ref: &str,
+) -> Result<String, UpdateError> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}");
+    let mut req = reqwest::Client::new()
+        .get(&url)
+        .header("Accept", "application/vnd.github.v3+json")
+        .header("User-Agent", "nasty-engine");
+    if let Some(token) = token.filter(|t| !t.is_empty()) {
+        req = req.header("Authorization", format!("Bearer {token}"));
+    }
+    let body: serde_json::Value = req
+        .send()
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("GitHub API request failed: {e}")))?
+        .json()
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("failed to parse GitHub response: {e}")))?;
+
+    let encoding = body["encoding"].as_str().unwrap_or_default();
+    let content = body["content"].as_str().ok_or_else(|| {
+        UpdateError::CommandFailed("missing file content in GitHub response".into())
+    })?;
+    if encoding != "base64" {
+        return Err(UpdateError::CommandFailed(format!(
+            "unsupported GitHub content encoding: {encoding}"
+        )));
+    }
+    let normalized = content.replace('\n', "");
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(normalized)
+        .map_err(|e| UpdateError::CommandFailed(format!("failed to decode GitHub file: {e}")))?;
+    String::from_utf8(decoded)
+        .map_err(|e| UpdateError::CommandFailed(format!("GitHub file is not valid UTF-8: {e}")))
 }
 
 /// Check latest commit on a branch via GitHub API.
@@ -1488,7 +1797,7 @@ async fn read_nasty_input_source() -> NastyInputSource {
             return NastyInputSource {
                 owner: DEFAULT_NASTY_OWNER.to_string(),
                 repo: DEFAULT_NASTY_REPO.to_string(),
-                tracked_ref: "main".to_string(),
+                tracked_ref: DEFAULT_NASTY_REF.to_string(),
             };
         }
     };
@@ -1498,7 +1807,7 @@ async fn read_nasty_input_source() -> NastyInputSource {
             return NastyInputSource {
                 owner: DEFAULT_NASTY_OWNER.to_string(),
                 repo: DEFAULT_NASTY_REPO.to_string(),
-                tracked_ref: "main".to_string(),
+                tracked_ref: DEFAULT_NASTY_REF.to_string(),
             };
         }
     };
@@ -1516,13 +1825,54 @@ async fn read_nasty_input_source() -> NastyInputSource {
     let tracked_ref = node["original"]["ref"]
         .as_str()
         .filter(|s| !s.is_empty())
-        .unwrap_or("main")
+        .unwrap_or(DEFAULT_NASTY_REF)
         .to_string();
     NastyInputSource {
         owner,
         repo,
         tracked_ref,
     }
+}
+
+fn normalize_git_tag_ref(tag_ref: &str) -> &str {
+    tag_ref
+        .strip_prefix("refs/tags/")
+        .unwrap_or(tag_ref)
+        .strip_suffix("^{}")
+        .unwrap_or_else(|| tag_ref.strip_prefix("refs/tags/").unwrap_or(tag_ref))
+}
+
+fn official_nasty_release_url(tag: &str) -> String {
+    format!("github:{DEFAULT_NASTY_OWNER}/{DEFAULT_NASTY_REPO}/{tag}")
+}
+
+#[cfg(test)]
+fn parse_official_nasty_release_tag(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    let rest = trimmed.strip_prefix("github:")?;
+    let mut parts = rest.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    let git_ref = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    if owner != DEFAULT_NASTY_OWNER || repo != DEFAULT_NASTY_REPO {
+        return None;
+    }
+    parse_release_tag_version(git_ref).map(|_| git_ref.to_string())
+}
+
+fn parse_release_tag_version(tag: &str) -> Option<(u64, u64, u64)> {
+    let raw = tag.strip_prefix('v')?;
+    let mut parts = raw.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
 }
 
 async fn read_locked_nasty_version() -> Option<String> {
@@ -1551,4 +1901,65 @@ async fn read_flake_lock_bcachefs() -> (Option<String>, Option<String>) {
         .as_str()
         .map(|s| s[..s.len().min(12)].to_string()); // short rev, 12 chars
     (pinned_ref, pinned_rev)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        normalize_git_tag_ref, parse_official_nasty_release_tag, parse_release_tag_version,
+    };
+
+    #[test]
+    fn normalizes_annotated_git_tag_refs() {
+        assert_eq!(normalize_git_tag_ref("refs/tags/v0.0.3^{}"), "v0.0.3");
+        assert_eq!(normalize_git_tag_ref("refs/tags/v0.0.3"), "v0.0.3");
+    }
+
+    #[test]
+    fn parses_only_official_release_tags() {
+        assert_eq!(
+            parse_official_nasty_release_tag("github:nasty-project/nasty/v0.0.2"),
+            Some("v0.0.2".to_string())
+        );
+        assert_eq!(
+            parse_official_nasty_release_tag("github:nasty-project/nasty/main"),
+            None
+        );
+        assert_eq!(
+            parse_official_nasty_release_tag("github:someone-else/nasty/v0.0.2"),
+            None
+        );
+        assert_eq!(
+            parse_official_nasty_release_tag("github:nasty-project/nasty/v0.0.2-rc1"),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_semver_release_tags() {
+        assert_eq!(parse_release_tag_version("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_release_tag_version("v1.2"), None);
+        assert_eq!(parse_release_tag_version("main"), None);
+    }
+
+    #[test]
+    fn renders_system_flake_template() {
+        let template = r#"
+inputs = { nasty.url = "@NASTY_URL@"; };
+"#
+        .to_string()
+            + r#"
+outputs = { nixpkgs, nasty, ... }: {
+  nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "local-system"; };
+};
+"#;
+        let rendered = super::render_system_flake_template(
+            &template,
+            "github:nasty-project/nasty/v0.0.3",
+            "x86_64-linux",
+        )
+        .expect("rendered");
+        assert!(rendered.contains("github:nasty-project/nasty/v0.0.3"));
+        assert!(rendered.contains("\"x86_64-linux\""));
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,48 +16,10 @@
   outputs = { self, nixpkgs, bcachefs-tools, ... }: let
     # Helper to build packages for a given system
     mkPkgs = system: nixpkgs.legacyPackages.${system};
+    nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
     rootLock = builtins.fromJSON (builtins.readFile ./flake.lock);
     installerNastyOwner = "nasty-project";
     installerNastyRepo = "nasty";
-    installerNastyRef = "v0.0.2";
-    installerNastyUrl = "github:${installerNastyOwner}/${installerNastyRepo}/${installerNastyRef}";
-    installerSystemFlakeNix = builtins.replaceStrings
-      [ "@NASTY_URL@" ]
-      [ installerNastyUrl ]
-      (builtins.readFile ./nixos/system-flake/flake.nix.template);
-    installerSystemFlakeLock = builtins.toJSON {
-      version = rootLock.version;
-      root = "root";
-      nodes = (builtins.removeAttrs rootLock.nodes [ "root" ]) // {
-        nasty = {
-          locked = {
-            type = "path";
-            path = self.outPath;
-            narHash = self.narHash;
-            lastModified = self.lastModified;
-          };
-          original = {
-            type = "github";
-            owner = installerNastyOwner;
-            repo = installerNastyRepo;
-            ref = installerNastyRef;
-          };
-          inputs = {
-            bcachefs-tools = [ "bcachefs-tools" ];
-            nixpkgs = [ "nixpkgs" ];
-          };
-        };
-        root = {
-          inputs = {
-            bcachefs-tools = "bcachefs-tools";
-            nasty = "nasty";
-            nixpkgs = "nixpkgs";
-          };
-        };
-      };
-    };
-
-    nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
 
     mkEngine = system: let pkgs = mkPkgs system; in pkgs.rustPlatform.buildRustPackage {
       pname = "nasty-engine";
@@ -129,6 +91,42 @@
       nasty-engine = mkEngine system;
       nasty-webui = mkWebui system;
       nasty-bcachefs-tools = mkBcachefsTools system;
+      installerNastyRef = "v${nasty-version}";
+      installerSystemFlakeNix = builtins.replaceStrings
+        [ "@NASTY_VERSION@" "@LOCAL_SYSTEM@" ]
+        [ installerNastyRef system ]
+        (builtins.readFile ./nixos/system-flake/flake.nix.template);
+      installerSystemFlakeLock = builtins.toJSON {
+        version = rootLock.version;
+        root = "root";
+        nodes = (builtins.removeAttrs rootLock.nodes [ "root" ]) // {
+          nasty = {
+            locked = {
+              type = "path";
+              path = self.outPath;
+              narHash = self.narHash;
+              lastModified = self.lastModified;
+            };
+            original = {
+              type = "github";
+              owner = installerNastyOwner;
+              repo = installerNastyRepo;
+              ref = installerNastyRef;
+            };
+            inputs = {
+              bcachefs-tools = [ "bcachefs-tools" ];
+              nixpkgs = [ "nixpkgs" ];
+            };
+          };
+          root = {
+            inputs = {
+              bcachefs-tools = "bcachefs-tools";
+              nasty = "nasty";
+              nixpkgs = "nixpkgs";
+            };
+          };
+        };
+      };
       nastySystemFlakeSnapshot = pkgs.runCommand "nasty-system-flake-snapshot" {} ''
         mkdir -p "$out"
         cp ${self}/flake.nix "$out/flake.nix"

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     rootLock = builtins.fromJSON (builtins.readFile ./flake.lock);
     installerNastyOwner = "nasty-project";
     installerNastyRepo = "nasty";
-    installerNastyRef = "main";
+    installerNastyRef = "v0.0.2";
     installerNastyUrl = "github:${installerNastyOwner}/${installerNastyRepo}/${installerNastyRef}";
     installerSystemFlakeNix = builtins.replaceStrings
       [ "@NASTY_URL@" ]
@@ -129,6 +129,11 @@
       nasty-engine = mkEngine system;
       nasty-webui = mkWebui system;
       nasty-bcachefs-tools = mkBcachefsTools system;
+      nastySystemFlakeSnapshot = pkgs.runCommand "nasty-system-flake-snapshot" {} ''
+        mkdir -p "$out"
+        cp ${self}/flake.nix "$out/flake.nix"
+        cp ${self}/flake.lock "$out/flake.lock"
+      '';
       installerSystemFlake = pkgs.runCommand "nasty-system-flake" {} ''
         mkdir -p "$out"
         cp ${./nixos/system-flake/hardware-configuration.nix} "$out/hardware-configuration.nix"
@@ -140,7 +145,7 @@
       # Full NASty appliance configuration
       nasty = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -152,7 +157,7 @@
 
       nasty-rootfs = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -208,7 +213,7 @@
       # QEMU VM for testing
       nasty-vm = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -222,7 +227,7 @@
       # Cloud/CI disk image (Oracle Cloud compatible)
       nasty-cloud = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
         modules = [
           "${nixpkgs}/nixos/modules/virtualisation/oci-image.nix"
           ./nixos/modules/bcachefs.nix

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -257,7 +257,6 @@ in
       ${nasty-engine}/bin/nasty-engine bootstrap-system-flake \
         --dest-dir /mnt/etc/nixos \
         --template-file /etc/nasty-source/nixos/system-flake/flake.nix.template \
-        --nasty-url github:nasty-project/nasty/v0.0.2 \
         --system "$LOCAL_SYSTEM" >/dev/null
 
       echo "==> Generating hardware configuration..."

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -92,6 +92,7 @@ in
   # Bundle the slim local system flake on the ISO. The installed appliance keeps
   # only a wrapper flake plus machine-local modules under /etc/nixos.
   environment.etc."nasty-system-flake".source = installerSystemFlake;
+  environment.etc."nasty-source".source = lib.mkIf (installerNastySource != null) installerNastySource;
 
   # ── Branding ──────────────────────────────────────────────
   image.baseName = lib.mkForce "nasty";
@@ -239,9 +240,9 @@ in
       mkdir -p /mnt/boot
       mount "$PART1" /mnt/boot
 
-      echo "==> Copying local system flake..."
+      echo "==> Bootstrapping local system flake..."
       mkdir -p /mnt/etc/nixos
-      cp -rL --no-preserve=mode /etc/nasty-system-flake/. /mnt/etc/nixos/
+      cp /etc/nasty-system-flake/flake.lock /mnt/etc/nixos/flake.lock
 
       echo "==> Detecting local system identifier..."
       LOCAL_SYSTEM=$(nix --extra-experimental-features 'nix-command flakes' eval --impure --raw --expr builtins.currentSystem)
@@ -249,11 +250,15 @@ in
         echo "Error: failed to detect local system identifier"
         exit 1
       fi
-      if ! grep -q '"local-system"' /mnt/etc/nixos/flake.nix; then
-        echo "Error: local system placeholder not found in /mnt/etc/nixos/flake.nix"
+      if [ ! -f /etc/nasty-source/nixos/system-flake/flake.nix.template ]; then
+        echo "Error: missing /etc/nasty-source/nixos/system-flake/flake.nix.template"
         exit 1
       fi
-      ${pkgs.gnused}/bin/sed -i "s/\"local-system\"/\"$LOCAL_SYSTEM\"/" /mnt/etc/nixos/flake.nix
+      ${nasty-engine}/bin/nasty-engine bootstrap-system-flake \
+        --dest-dir /mnt/etc/nixos \
+        --template-file /etc/nasty-source/nixos/system-flake/flake.nix.template \
+        --nasty-url github:nasty-project/nasty/v0.0.2 \
+        --system "$LOCAL_SYSTEM" >/dev/null
 
       echo "==> Generating hardware configuration..."
       nixos-generate-config --root /mnt --dir /tmp/hw-config

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, nasty-engine ? null, nasty-webui ? null, nasty-version ? "dev", nasty-bcachefs-tools ? pkgs.bcachefs-tools, ... }:
+{ config, lib, pkgs, nasty-engine ? null, nasty-webui ? null, nasty-version ? "dev", nasty-bcachefs-tools ? pkgs.bcachefs-tools, nastySystemFlakeSnapshot ? null, ... }:
 
 let
   cfg = config.services.nasty;
@@ -215,6 +215,57 @@ in {
 
     # Version file for update system
     environment.etc."nasty-version".text = nasty-version;
+
+    # Keep a generation-owned copy of the managed wrapper flake in /etc so the
+    # exact flake used to build the active generation is readable from
+    # /run/current-system/etc/nasty-system-flake and can be restored on boot.
+    environment.etc."nasty-system-flake".source = lib.mkIf (nastySystemFlakeSnapshot != null) nastySystemFlakeSnapshot;
+
+    systemd.services.recover-generation-flake = mkIf (nastySystemFlakeSnapshot != null) {
+      description = "Recover /etc/nixos flake files from the active system generation";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "nasty-engine.service" ];
+      after = [ "local-fs.target" ];
+      aliases = [ "nasty-restore-system-flake.service" ];
+      restartTriggers = [ nastySystemFlakeSnapshot ];
+      unitConfig.ConditionPathExists = "/etc/nasty-system-flake/flake.nix";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = pkgs.writeShellScript "recover-generation-flake" ''
+          set -euo pipefail
+
+          ${pkgs.coreutils}/bin/install -d -m 0755 /etc/nixos
+
+          sync_file() {
+            local name="$1"
+            local src="/etc/nasty-system-flake/$name"
+            local dst="/etc/nixos/$name"
+
+            if [ ! -e "$src" ]; then
+              return 0
+            fi
+
+            if [ -e "$dst" ] && ${pkgs.diffutils}/bin/cmp -s "$src" "$dst"; then
+              return 0
+            fi
+
+            ${pkgs.coreutils}/bin/install -m 0644 -T "$src" "$dst"
+          }
+
+          sync_file flake.nix
+          sync_file flake.lock
+        '';
+      };
+    };
+
+    # systemd starts the recovery unit on boot; activation starts it again so a
+    # freshly switched generation re-applies its own flake snapshot immediately.
+    system.activationScripts.recover-generation-flake = mkIf (nastySystemFlakeSnapshot != null) ''
+      if [ -d /run/systemd/system ]; then
+        ${pkgs.systemd}/bin/systemctl start recover-generation-flake.service >/dev/null 2>&1 || true
+      fi
+    '';
 
     # Apply hostname saved in settings.json on every boot.
     systemd.services.nasty-apply-hostname = {

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -7,9 +7,9 @@
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.37.5";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
-    # Installer payload template. The ISO builder substitutes the tracked
-    # upstream URL here and ships a generated flake.lock alongside it.
-    nasty.url = "@NASTY_URL@";
+    # Installer payload template. Bootstrap substitutes the tagged release
+    # and local system placeholders when writing /etc/nixos/flake.nix.
+    nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
     nasty.inputs.nixpkgs.follows = "nixpkgs";
     nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
@@ -51,7 +51,7 @@
         };
     in {
       nixosConfigurations = {
-        nasty = mkSystem "local-system";
+        nasty = mkSystem "@LOCAL_SYSTEM@";
       };
     };
 }

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -14,30 +14,41 @@
     nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 
-  outputs = { nixpkgs, nasty, ... }:
+  outputs = { self, nixpkgs, nasty, ... }:
     let
       nasty-version =
         (builtins.fromTOML (builtins.readFile "${nasty}/engine/Cargo.toml")).workspace.package.version;
 
-      mkSystem = system: nixpkgs.lib.nixosSystem {
-        inherit system;
-        specialArgs = {
-          nasty-engine = nasty.packages.${system}.engine;
-          nasty-webui = nasty.packages.${system}.webui;
-          nasty-version = nasty-version;
-          nasty-bcachefs-tools = nasty.packages.${system}.bcachefs-tools;
+      mkSystem = system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # Preserve the exact wrapper flake used for this build inside the
+          # system closure so it remains readable via /run/current-system/etc.
+          nastySystemFlakeSnapshot = pkgs.runCommand "nasty-system-flake-snapshot" {} ''
+            mkdir -p "$out"
+            cp ${self}/flake.nix "$out/flake.nix"
+            cp ${self}/flake.lock "$out/flake.lock"
+          '';
+        in nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = {
+            nasty-engine = nasty.packages.${system}.engine;
+            nasty-webui = nasty.packages.${system}.webui;
+            nasty-version = nasty-version;
+            nasty-bcachefs-tools = nasty.packages.${system}.bcachefs-tools;
+            inherit nastySystemFlakeSnapshot;
+          };
+          modules = [
+            "${nasty}/nixos/binary-cache.nix"
+            "${nasty}/nixos/modules/bcachefs.nix"
+            "${nasty}/nixos/modules/linuxquota.nix"
+            "${nasty}/nixos/modules/nasty.nix"
+            "${nasty}/nixos/appliance-base.nix"
+            # Machine-local overlay files live directly under /etc/nixos.
+            ./hardware-configuration.nix
+            ./networking.nix
+          ];
         };
-        modules = [
-          "${nasty}/nixos/binary-cache.nix"
-          "${nasty}/nixos/modules/bcachefs.nix"
-          "${nasty}/nixos/modules/linuxquota.nix"
-          "${nasty}/nixos/modules/nasty.nix"
-          "${nasty}/nixos/appliance-base.nix"
-          # Machine-local overlay files live directly under /etc/nixos.
-          ./hardware-configuration.nix
-          ./networking.nix
-        ];
-      };
     in {
       nixosConfigurations = {
         nasty = mkSystem "local-system";

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -355,19 +355,6 @@ export interface UpdateInfo {
 	channel: ReleaseChannel;
 }
 
-export interface BcachefsToolsInfo {
-	pinned_ref: string | null;
-	pinned_rev: string | null;
-	running_version: string;
-	is_custom: boolean;
-	is_custom_running: boolean;
-	default_ref: string;
-	kernel_rust: boolean | null;
-	debug_symbols: boolean;
-	debug_checks: boolean;
-	debug_checks_running: boolean;
-}
-
 export interface VersionInputInfo {
 	name: string;
 	url: string;

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -368,6 +368,16 @@ export interface BcachefsToolsInfo {
 	debug_checks_running: boolean;
 }
 
+export interface VersionInputInfo {
+	name: string;
+	url: string;
+	rev: string | null;
+}
+
+export interface VersionInfo {
+	inputs: VersionInputInfo[];
+}
+
 export interface Generation {
 	generation: number;
 	date: string;

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -365,6 +365,13 @@ export interface VersionInfo {
 	inputs: VersionInputInfo[];
 }
 
+export interface VersionTaggedReleaseStatus {
+	current_url: string;
+	latest_tag: string;
+	latest_url: string;
+	current_is_latest_standard_url: boolean;
+}
+
 export interface Generation {
 	generation: number;
 	date: string;

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -128,11 +128,6 @@
 	});
 
 	onMount(() => {
-		const onPageHide = () => {
-			void client.call('system.version.cleanup').catch(() => {});
-		};
-
-		window.addEventListener('pagehide', onPageHide);
 		const onReconnect = () => {
 			Promise.all([
 				loadVersionPage(),
@@ -151,14 +146,12 @@
 		client.onReconnect(onReconnect);
 
 		return () => {
-			window.removeEventListener('pagehide', onPageHide);
 			client.offReconnect(onReconnect);
 		};
 	});
 
 	onDestroy(() => {
 		stopPolling();
-		void client.call('system.version.cleanup').catch(() => {});
 	});
 
 	function versionLabel(name: string): string {
@@ -192,7 +185,6 @@
 	}
 
 	async function loadVersionPage() {
-		await client.call('system.version.cleanup').catch(() => {});
 		await withToast(async () => {
 			const [nextInfo, nextVersion] = await Promise.all([
 				client.call<VersionInfo>('system.version.get'),
@@ -222,7 +214,7 @@
 
 		if (!await confirm(
 			'Switch upstream inputs?',
-			`This will back up /etc/nixos, write the selected input URLs into flake.nix, refresh these inputs in flake.lock: ${refreshedLabel}. Changed URLs are always refreshed even if their update toggle is off. If flake.lock changes, the system rebuild starts immediately. Changed URLs: ${changedLabel}.`
+			`This will write the selected input URLs directly into /etc/nixos/flake.nix and refresh these inputs in flake.lock: ${refreshedLabel}. Changed URLs are always refreshed even if their update toggle is off. If flake.lock changes, the system rebuild starts immediately. Changed URLs: ${changedLabel}.`
 		)) return;
 
 		await doVersionSwitch();

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -175,6 +175,10 @@
 		}));
 	}
 
+	function isForcedVersionUpdate(row: VersionRow): boolean {
+		return row.url.trim() !== row.initialUrl;
+	}
+
 	function setTab(tab: Tab) {
 		activeTab = tab;
 		if (typeof window !== 'undefined') {
@@ -214,7 +218,7 @@
 
 		if (!await confirm(
 			'Switch upstream inputs?',
-			`This will write the selected input URLs directly into /etc/nixos/flake.nix and refresh these inputs in flake.lock: ${refreshedLabel}. Changed URLs are always refreshed even if their update toggle is off. If flake.lock changes, the system rebuild starts immediately. Changed URLs: ${changedLabel}.`
+			`This will write the selected input URLs directly into /etc/nixos/flake.nix and refresh these inputs in flake.lock: ${refreshedLabel}. URL changes are always refreshed to keep flake.lock consistent. If flake.lock changes, the system rebuild starts immediately. Changed URLs: ${changedLabel}.`
 		)) return;
 
 		await doVersionSwitch();
@@ -384,16 +388,12 @@
 		>Firmware</button>
 	</div>
 
-	{#if activeTab === 'version'}
-		<Card class="mb-6">
-			<CardHeader>
-				<CardTitle>Upstream</CardTitle>
-				<CardDescription>
-					Read directly from the installed system’s <code class="font-mono">/etc/nixos/flake.nix</code> and <code class="font-mono">/etc/nixos/flake.lock</code>.
-					Changed input URLs are refreshed automatically so the lock file stays consistent.
-				</CardDescription>
-			</CardHeader>
-			<CardContent class="space-y-4">
+		{#if activeTab === 'version'}
+			<Card class="mb-6">
+				<CardHeader>
+					<CardTitle>Upstream</CardTitle>
+				</CardHeader>
+				<CardContent class="space-y-4">
 				{#if info}
 					<div class="rounded-lg border border-border/60 bg-muted/20 px-4 py-3 text-sm">
 						<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Installed NASty</div>
@@ -419,24 +419,22 @@
 										class="font-mono text-sm"
 									/>
 								</div>
-								<label class="flex items-center gap-2 text-sm text-muted-foreground lg:w-28 lg:justify-end">
-									<input
-										type="checkbox"
-										bind:checked={row.update}
-										disabled={startingSwitch || status?.state === 'running'}
-										class="h-4 w-4 rounded border-input"
-									/>
-									<span>Update</span>
-								</label>
+									<label class="flex items-center gap-2 text-sm text-muted-foreground lg:w-28 lg:justify-end">
+										<input
+											type="checkbox"
+											checked={row.update || isForcedVersionUpdate(row)}
+											disabled={startingSwitch || status?.state === 'running' || isForcedVersionUpdate(row)}
+											onchange={(event) => {
+												row.update = (event.currentTarget as HTMLInputElement).checked;
+											}}
+											class="h-4 w-4 rounded border-input"
+										/>
+										<span>Update</span>
+									</label>
+								</div>
 							</div>
-							{#if row.url.trim() !== row.initialUrl}
-								<p class="mt-2 text-xs text-blue-400">
-									URL changed from <code class="font-mono">{row.initialUrl}</code>. This input will be refreshed on Switch even if its toggle is off.
-								</p>
-							{/if}
-						</div>
-					{/each}
-				</div>
+						{/each}
+					</div>
 
 				<div class="flex flex-wrap items-center justify-between gap-3">
 					<p class="text-xs text-muted-foreground">

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -3,23 +3,51 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { UpdateInfo, UpdateStatus, BcachefsToolsInfo, Generation, FirmwareDevice, FirmwareUpdateResult } from '$lib/types';
-	import { Tag, Trash2, ArrowRightLeft, Pencil, X, Check } from '@lucide/svelte';
+	import type {
+		UpdateInfo,
+		UpdateStatus,
+		Generation,
+		FirmwareDevice,
+		FirmwareUpdateResult,
+		VersionInfo
+	} from '$lib/types';
+	import { Tag, Trash2, ArrowRightLeft, X, Check } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Card, CardContent } from '$lib/components/ui/card';
+	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Input } from '$lib/components/ui/input';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
-	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 
-	let activeTab: 'system' | 'generations' | 'bcachefs' | 'firmware' = $state(
-		typeof window !== 'undefined' && window.location.hash === '#bcachefs' ? 'bcachefs'
-		: typeof window !== 'undefined' && window.location.hash === '#generations' ? 'generations'
+	type Tab = 'version' | 'generations' | 'firmware';
+	type VersionRow = {
+		name: string;
+		label: string;
+		url: string;
+		rev: string | null;
+		update: boolean;
+		initialUrl: string;
+		initialRev: string | null;
+	};
+
+	const client = getClient();
+
+	let activeTab: Tab = $state(
+		typeof window !== 'undefined' && window.location.hash === '#generations' ? 'generations'
 		: typeof window !== 'undefined' && window.location.hash === '#firmware' ? 'firmware'
-		: 'system'
+		: 'version'
 	);
 
-	// ── Generations tab state ───────────────────────────────
+	let info: UpdateInfo | null = $state(null);
+	let versionInfo: VersionInfo | null = $state(null);
+	let versionRows: VersionRow[] = $state([]);
+	let status: UpdateStatus | null = $state(null);
+	let loading = $state(true);
+	let startingSwitch = $state(false);
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	let logEl: HTMLPreElement | undefined = $state();
+	let logCollapsed = $state(true);
+
 	let generations: Generation[] = $state([]);
 	let generationsLoading = $state(false);
 	let generationsLoaded = $state(false);
@@ -27,36 +55,6 @@
 	let editLabelValue = $state('');
 	let labelFilter = $state('');
 
-	const filteredGenerations = $derived(
-		labelFilter
-			? generations.filter(g => g.label?.toLowerCase().includes(labelFilter.toLowerCase()))
-			: generations
-	);
-
-	const availableLabels = $derived(
-		[...new Set(generations.map(g => g.label).filter((l): l is string => !!l))].sort()
-	);
-
-	let info: UpdateInfo | null = $state(null);
-	let status: UpdateStatus | null = $state(null);
-	let engineCommit: string | null = $state(null);
-	let loading = $state(true);
-	let checking = $state(false);
-	let pollInterval: ReturnType<typeof setInterval> | null = null;
-	let logEl: HTMLPreElement | undefined = $state();
-	let logCollapsed = $state(true);
-
-	// bcachefs-tools switching state
-	let bcachefsInfo: BcachefsToolsInfo | null = $state(null);
-	let bcachefsStatus: UpdateStatus | null = $state(null);
-	let bcachefsRef = $state('');
-	let bcachefsDebugChecks = $state(false);
-	let bcachefsSwitching = $state(false);
-	let bcachefsLogEl: HTMLPreElement | undefined = $state();
-	let bcachefsPollInterval: ReturnType<typeof setInterval> | null = null;
-	let bcachefsLogCollapsed = $state(false);
-
-	// ── Firmware tab state ─────────────────────────────────
 	let firmwareAvailable = $state(false);
 	let firmwareDevices: FirmwareDevice[] = $state([]);
 	let firmwareLoading = $state(false);
@@ -64,10 +62,16 @@
 	let firmwareUpdating: Record<string, boolean> = $state({});
 
 	const phases = [
-		{ label: 'Fetch',    marker: '==> Updating local system flake' },
-		{ label: 'Build',    marker: '==> Rebuilding' },
+		{ label: 'Fetch', marker: '==> Updating local system flake' },
+		{ label: 'Build', marker: '==> Rebuilding' },
 		{ label: 'Activate', marker: 'activating the configuration' },
-		{ label: 'Done',     marker: '==> Update complete!' },
+		{ label: 'Done', marker: '==> Update complete!' }
+	];
+
+	const genPhases = [
+		{ label: 'Switch', marker: '==> Switching to generation' },
+		{ label: 'Activate', marker: '==> Activating generation' },
+		{ label: 'Done', marker: '==> Switch to generation' }
 	];
 
 	const currentPhase = $derived.by(() => {
@@ -79,12 +83,6 @@
 		return reached;
 	});
 
-	const genPhases = [
-		{ label: 'Switch',   marker: '==> Switching to generation' },
-		{ label: 'Activate', marker: '==> Activating generation' },
-		{ label: 'Done',     marker: '==> Switch to generation' },
-	];
-
 	const genCurrentPhase = $derived.by(() => {
 		const log = status?.log ?? '';
 		let reached = -1;
@@ -94,44 +92,34 @@
 		return reached;
 	});
 
-	const bcachefsPhases = [
-		{ label: 'Fetch',    marker: '==> Switching' },
-		{ label: 'Build',    marker: '==> Rebuilding' },
-		{ label: 'Activate', marker: 'activating the configuration' },
-		{ label: 'Done',     marker: '==> bcachefs switch complete!' },
-	];
+	const versionDirty = $derived.by(() =>
+		versionRows.some((row) => row.url.trim() !== row.initialUrl || row.update)
+	);
 
-	const bcachefsCurrentPhase = $derived.by(() => {
-		const log = bcachefsStatus?.log ?? '';
-		let reached = -1;
-		for (let i = 0; i < bcachefsPhases.length; i++) {
-			if (log.includes(bcachefsPhases[i].marker)) reached = i;
-		}
-		return reached;
+	const versionSelectionCount = $derived.by(() =>
+		versionRows.filter((row) => row.update || row.url.trim() !== row.initialUrl).length
+	);
+
+	const filteredGenerations = $derived(
+		labelFilter
+			? generations.filter((g) => g.label?.toLowerCase().includes(labelFilter.toLowerCase()))
+			: generations
+	);
+
+	const availableLabels = $derived(
+		[...new Set(generations.map((g) => g.label).filter((l): l is string => !!l))].sort()
+	);
+
+	const versionStatusVisible = $derived.by(() => {
+		if (!status || status.state === 'idle') return false;
+		const log = status.log ?? '';
+		return currentPhase >= 0 || log.includes('No flake.lock changes detected');
 	});
 
-	const bcachefsDebugChanged = $derived(
-		bcachefsInfo != null && bcachefsDebugChecks !== (bcachefsInfo as BcachefsToolsInfo).debug_checks
-	);
-
-	const bcachefsCanSwitch = $derived(
-		bcachefsRef.trim() !== '' || bcachefsDebugChanged
-	);
-
-	const bcachefsWarnVisible = $derived(
-		bcachefsRef.trim() !== '' && bcachefsRef.trim() !== ((bcachefsInfo as BcachefsToolsInfo | null)?.default_ref ?? '')
-	);
-
-	// True when the entered ref looks like a branch name rather than a tag (v*) or commit SHA ([0-9a-f]{7,40})
-	const bcachefsRefIsBranch = $derived.by(() => {
-		const r = bcachefsRef.trim();
-		if (!r) return false;
-		if (/^v\d/.test(r)) return false;           // tag: v1.37.0
-		if (/^[0-9a-f]{7,40}$/.test(r)) return false; // commit SHA
-		return true;
+	const generationStatusVisible = $derived.by(() => {
+		if (!status || status.state === 'idle') return false;
+		return genCurrentPhase >= 0;
 	});
-
-	const client = getClient();
 
 	$effect(() => {
 		if (status?.log && logEl) {
@@ -139,141 +127,126 @@
 		}
 	});
 
-	$effect(() => {
-		if (bcachefsStatus?.log && bcachefsLogEl) {
-			bcachefsLogEl.scrollTop = bcachefsLogEl.scrollHeight;
-		}
-	});
-
-	$effect(() => {
-		if (bcachefsStatus?.state === 'running') {
-			startBcachefsPolling();
-		}
-	});
-
-	const onReconnect = () => {
-		Promise.all([loadVersion(), loadBcachefsInfo()]);
-	};
-
 	onMount(() => {
-		const t0 = performance.now();
-		Promise.all([loadVersion(), loadStatus(), loadBcachefsInfo(), loadBcachefsStatus(),
-			client.call('system.info').then((si: any) => { engineCommit = si.engine_commit ?? null; }).catch(() => {}),
-		]).then(() => {
-			if (localStorage.getItem('nasty-debug') === '1') {
-				console.debug(`[page] update: ${(performance.now() - t0).toFixed(0)}ms total`);
-			}
+		const onPageHide = () => {
+			void client.call('system.version.cleanup').catch(() => {});
+		};
+
+		window.addEventListener('pagehide', onPageHide);
+		const onReconnect = () => {
+			Promise.all([
+				loadVersionPage(),
+				loadStatus(),
+				activeTab === 'firmware' && firmwareLoaded ? loadFirmware() : Promise.resolve()
+			]);
+		};
+
+		Promise.all([
+			loadVersionPage(),
+			loadStatus()
+		]).finally(() => {
 			loading = false;
 		});
+
 		client.onReconnect(onReconnect);
-		return () => client.offReconnect(onReconnect);
+
+		return () => {
+			window.removeEventListener('pagehide', onPageHide);
+			client.offReconnect(onReconnect);
+		};
 	});
 
 	onDestroy(() => {
 		stopPolling();
-		stopBcachefsPolling();
+		void client.call('system.version.cleanup').catch(() => {});
 	});
 
-	async function loadVersion() {
+	function versionLabel(name: string): string {
+		switch (name) {
+			case 'nixpkgs': return 'nixpkgs';
+			case 'bcachefs-tools': return 'bcachefs-tools';
+			case 'nasty': return 'nasty';
+			default: return name;
+		}
+	}
+
+	function syncVersionRows(next: VersionInfo) {
+		versionRows = next.inputs.map((input) => ({
+			name: input.name,
+			label: versionLabel(input.name),
+			url: input.url,
+			rev: input.rev,
+			update: false,
+			initialUrl: input.url,
+			initialRev: input.rev
+		}));
+	}
+
+	function setTab(tab: Tab) {
+		activeTab = tab;
+		if (typeof window !== 'undefined') {
+			window.location.hash = tab === 'version' ? '#version' : `#${tab}`;
+		}
+		if (tab === 'generations' && !generationsLoaded) void loadGenerations();
+		if (tab === 'firmware' && !firmwareLoaded) void loadFirmware();
+	}
+
+	async function loadVersionPage() {
+		await client.call('system.version.cleanup').catch(() => {});
 		await withToast(async () => {
-			info = await client.call<UpdateInfo>('system.update.version');
+			const [nextInfo, nextVersion] = await Promise.all([
+				client.call<VersionInfo>('system.version.get'),
+				client.call<UpdateInfo>('system.update.version')
+			]);
+			versionInfo = nextInfo;
+			info = nextVersion;
+			syncVersionRows(nextInfo);
 		});
 	}
 
 	async function loadStatus() {
 		await withToast(async () => {
 			status = await client.call<UpdateStatus>('system.update.status');
-			if (status?.state === 'running') {
-				startPolling();
-			}
+			if (status?.state === 'running') startPolling();
 		});
 	}
 
-	async function checkForUpdates() {
-		checking = true;
-		const result = await withToast(
-			() => client.call<UpdateInfo>('system.update.check'),
-			'Update check complete'
-		);
-		if (result !== undefined) {
-			info = result;
-		}
-		checking = false;
+	async function requestVersionSwitch() {
+		if (!versionDirty) return;
+		const changedUrls = versionRows.filter((row) => row.url.trim() !== row.initialUrl);
+		const refreshed = versionRows.filter((row) => row.update || row.url.trim() !== row.initialUrl);
+		const changedLabel = changedUrls.length > 0
+			? changedUrls.map((row) => row.name).join(', ')
+			: 'none';
+		const refreshedLabel = refreshed.map((row) => row.name).join(', ');
+
+		if (!await confirm(
+			'Switch upstream inputs?',
+			`This will back up /etc/nixos, write the selected input URLs into flake.nix, refresh these inputs in flake.lock: ${refreshedLabel}. Changed URLs are always refreshed even if their update toggle is off. If flake.lock changes, the system rebuild starts immediately. Changed URLs: ${changedLabel}.`
+		)) return;
+
+		await doVersionSwitch();
 	}
 
-	async function applyUpdate() {
-		if (!await confirm('Apply System Update?', 'NASty will fetch and apply the latest version. Services will restart. If the update includes UI changes, you will be prompted to reload the page. This can take several minutes.')) return;
-		doApplyUpdate();
-	}
-
-	async function doApplyUpdate() {
+	async function doVersionSwitch() {
+		startingSwitch = true;
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
-		const ok = await withToast(
-			() => client.call('system.update.apply'),
-			'Update started'
+		const result = await withToast(
+			() => client.call('system.version.switch', {
+				inputs: versionRows.map((row) => ({
+					name: row.name,
+					url: row.url.trim(),
+					update: row.update
+				}))
+			}),
+			'Version switch started'
 		);
-		if (ok !== undefined) {
+		if (result !== undefined) {
 			startPolling();
 		}
+		startingSwitch = false;
 	}
-
-	async function changeChannel(channel: string) {
-		if (channel === info?.channel) return;
-		const descriptions: Record<string, string> = {
-			mild: 'Tagged releases only. Safe, tested, boring.',
-			spicy: 'Pre-release builds. New features, occasional heartburn.',
-			nasty: 'Latest commit on main. Bleeding edge — you asked for it.',
-		};
-		const flavorOrder: Record<string, number> = { mild: 0, spicy: 1, nasty: 2 };
-		const isDowngrade = (flavorOrder[channel] ?? 0) < (flavorOrder[info?.channel ?? 'nasty'] ?? 0);
-		const warning = isDowngrade
-			? ' This may downgrade your system to an older version.'
-			: '';
-		if (!await confirm(
-			`Switch to ${channel} flavor?`,
-			`${descriptions[channel] ?? ''}${warning} You should check for updates after switching.`
-		)) return;
-		const result = await withToast(
-			() => client.call('system.update.channel.set', { channel }),
-			`Switched to ${channel} flavor`
-		);
-		if (result !== undefined && info) {
-			info = { ...info, channel: channel as any };
-		}
-	}
-
-	// ── Firmware functions ──────────────────────────────────
-
-	async function loadFirmware() {
-		firmwareLoading = true;
-		try {
-			firmwareAvailable = await client.call<boolean>('firmware.available');
-			if (firmwareAvailable) {
-				firmwareDevices = await client.call<FirmwareDevice[]>('firmware.check');
-			}
-		} catch { /* ignore */ }
-		firmwareLoading = false;
-		firmwareLoaded = true;
-	}
-
-	async function updateFirmware(deviceId: string) {
-		if (!await confirm('Apply firmware update?', 'This will flash new firmware to the device. Do not power off during the update. A reboot may be required.')) return;
-		firmwareUpdating[deviceId] = true;
-		const result = await withToast(
-			() => client.call<FirmwareUpdateResult>('firmware.update', { device_id: deviceId }),
-			'Firmware update applied'
-		);
-		firmwareUpdating[deviceId] = false;
-		if (result?.reboot_required) {
-			rebootState.set();
-		}
-		await loadFirmware();
-	}
-
-	$effect(() => {
-		if (activeTab === 'firmware' && !firmwareLoaded) loadFirmware();
-	});
 
 	function startPolling() {
 		stopPolling();
@@ -282,22 +255,15 @@
 				status = await client.call<UpdateStatus>('system.update.status');
 				if (status && (status.state === 'success' || status.state === 'failed')) {
 					stopPolling();
-					await loadVersion();
-					// Refresh engine commit display
-					try { engineCommit = (await client.call<any>('system.info')).engine_commit ?? null; } catch {}
+					await loadVersionPage();
 					if (status.state === 'success') {
-						// Mark as up-to-date since we just applied the update
-						if (info) {
-							info.current_version = info.latest_version ?? info.current_version;
-							info.update_available = false;
-						}
 						if (status.webui_changed) refreshState.set();
 						if (status.reboot_required) rebootState.set();
 						setTimeout(() => { logCollapsed = true; }, 3000);
 					}
 				}
 			} catch {
-				// Connection may drop during update, keep polling
+				// Rebuild can restart services and briefly drop the socket.
 			}
 		}, 3000);
 	}
@@ -309,93 +275,12 @@
 		}
 	}
 
-	async function loadBcachefsInfo() {
-		await withToast(async () => {
-			bcachefsInfo = await client.call<BcachefsToolsInfo>('bcachefs.tools.info');
-			if (bcachefsInfo) {
-				bcachefsDebugChecks = bcachefsInfo.debug_checks;
-			}
-		});
-		sysInfoRefresh.trigger(); // keep sidebar bcachefs version in sync
-	}
-
-	async function loadBcachefsStatus() {
-		await withToast(async () => {
-			bcachefsStatus = await client.call<UpdateStatus>('bcachefs.tools.status');
-			if (bcachefsStatus?.state === 'running') {
-				startBcachefsPolling();
-			}
-		});
-	}
-
-	async function requestBcachefsSwitch() {
-		const ref = bcachefsRef.trim() || bcachefsInfo?.pinned_ref || bcachefsInfo?.default_ref || '';
-		if (!ref) return;
-		const desc = bcachefsRef.trim()
-			? `Switch bcachefs-tools to ${ref}?`
-			: `Rebuild bcachefs-tools ${ref} with updated build flags?`;
-		if (!await confirm(
-			desc,
-			'The system will rebuild with the new version. The first build may take 5–20 minutes. If the new version introduced an incompatible on-disk format, downgrading may leave filesystems unmountable.'
-		)) return;
-		doBcachefsSwitch();
-	}
-
-	async function doBcachefsSwitch() {
-		const ref = bcachefsRef.trim() || bcachefsInfo?.pinned_ref || bcachefsInfo?.default_ref || '';
-		if (!ref) return;
-		bcachefsSwitching = true;
-		bcachefsLogCollapsed = false;
-		bcachefsStatus = { state: 'running', log: '', reboot_required: false, webui_changed: false };
-		const result = await withToast(
-			() => client.call('bcachefs.tools.switch', { git_ref: ref, debug_checks: bcachefsDebugChecks }),
-			'bcachefs switch started'
-		);
-		if (result !== undefined) {
-			startBcachefsPolling();
-		}
-		bcachefsSwitching = false;
-	}
-
-	function startBcachefsPolling() {
-		stopBcachefsPolling();
-		bcachefsPollInterval = setInterval(async () => {
-			try {
-				bcachefsStatus = await client.call<UpdateStatus>('bcachefs.tools.status');
-				// Only stop on terminal states. 'idle' can occur transiently when systemd
-				// restarts during switch-to-configuration and the unit state is briefly lost.
-				if (bcachefsStatus && (bcachefsStatus.state === 'success' || bcachefsStatus.state === 'failed')) {
-					stopBcachefsPolling();
-					await loadBcachefsInfo();
-					if (bcachefsStatus.state === 'success') {
-						// No page reload needed — only bcachefs-tools changed, not the webui JS.
-						if (bcachefsStatus.reboot_required) rebootState.set();
-						bcachefsRef = '';
-						setTimeout(() => { bcachefsLogCollapsed = true; }, 5000);
-					}
-				}
-			} catch {
-				// Connection may drop during rebuild, keep polling
-			}
-		}, 3000);
-	}
-
-	function stopBcachefsPolling() {
-		if (bcachefsPollInterval) {
-			clearInterval(bcachefsPollInterval);
-			bcachefsPollInterval = null;
-		}
-	}
-
-	/** Break systemd's single-line "Consumed …" summary into one stat per line. */
 	function formatLog(log: string): string {
 		return log.replace(
 			/(^.+: Consumed .+)$/m,
 			(line) => line.replace(/, /g, ',\n  ')
 		);
 	}
-
-	// ── Generations ─────────────────────────────────────────
 
 	async function loadGenerations() {
 		generationsLoading = true;
@@ -414,21 +299,20 @@
 			'The system will activate this generation. Services will restart. A reboot may be required if the kernel changed.'
 		)) return;
 
+		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
 		const ok = await withToast(
 			() => client.call('system.generations.switch', { generation: gen }),
 			`Switching to generation ${gen}`
 		);
-		if (ok !== undefined) {
-			startPolling();
-		}
+		if (ok !== undefined) startPolling();
 	}
 
 	async function saveLabel(gen: number) {
 		await withToast(
 			() => client.call('system.generations.label', {
 				generation: gen,
-				label: editLabelValue.trim() || null,
+				label: editLabelValue.trim() || null
 			}),
 			editLabelValue.trim() ? 'Label saved' : 'Label removed'
 		);
@@ -453,135 +337,142 @@
 		editingLabel = gen.generation;
 		editLabelValue = gen.label ?? '';
 	}
+
+	async function loadFirmware() {
+		firmwareLoading = true;
+		try {
+			firmwareAvailable = await client.call<boolean>('firmware.available');
+			if (firmwareAvailable) {
+				firmwareDevices = await client.call<FirmwareDevice[]>('firmware.check');
+			}
+		} catch {
+			// Ignore fwupd errors in the page shell.
+		}
+		firmwareLoading = false;
+		firmwareLoaded = true;
+	}
+
+	async function updateFirmware(deviceId: string) {
+		if (!await confirm(
+			'Apply firmware update?',
+			'This will flash new firmware to the device. Do not power off during the update. A reboot may be required.'
+		)) return;
+		firmwareUpdating[deviceId] = true;
+		const result = await withToast(
+			() => client.call<FirmwareUpdateResult>('firmware.update', { device_id: deviceId }),
+			'Firmware update applied'
+		);
+		firmwareUpdating[deviceId] = false;
+		if (result?.reboot_required) rebootState.set();
+		await loadFirmware();
+	}
 </script>
-
-
-<!-- Global banners — shown regardless of active tab -->
-
 
 {#if loading}
 	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<!-- Tab bar -->
 	<div class="mb-6 flex border-b border-border">
 		<button
-			onclick={() => activeTab = 'system'}
-			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'system'
+			onclick={() => setTab('version')}
+			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'version'
 				? 'border-b-2 border-primary text-foreground'
 				: 'text-muted-foreground hover:text-foreground'}"
-		>System</button>
+		>Version</button>
 		<button
-			onclick={() => { activeTab = 'generations'; loadGenerations(); }}
+			onclick={() => setTab('generations')}
 			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'generations'
 				? 'border-b-2 border-primary text-foreground'
 				: 'text-muted-foreground hover:text-foreground'}"
 		>Generations</button>
 		<button
-			onclick={() => activeTab = 'bcachefs'}
-			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'bcachefs'
-				? 'border-b-2 border-primary text-foreground'
-				: 'text-muted-foreground hover:text-foreground'}"
-		>bcachefs</button>
-		<button
-			onclick={() => activeTab = 'firmware'}
+			onclick={() => setTab('firmware')}
 			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'firmware'
 				? 'border-b-2 border-primary text-foreground'
 				: 'text-muted-foreground hover:text-foreground'}"
 		>Firmware</button>
 	</div>
 
-	<!-- System tab -->
-	{#if activeTab === 'system'}
+	{#if activeTab === 'version'}
 		<Card class="mb-6">
-			<CardContent class="py-4">
-				<div class="flex flex-wrap items-start justify-between gap-6">
-					<!-- Left: version info + buttons -->
-					<div>
-						<div class="mb-3 flex items-center gap-8">
-							<div>
-								<div class="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Installed</div>
-								<div class="font-mono text-xl font-semibold">{info?.current_version ?? 'unknown'}</div>
-								{#if engineCommit && engineCommit !== info?.current_version}
-									<div class="text-xs text-muted-foreground">engine: <span class="font-mono">{engineCommit}</span></div>
-								{/if}
-							</div>
-							{#if info?.latest_version}
-								<div class="text-lg text-muted-foreground/30">→</div>
-								<div>
-									<div class="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Available</div>
-									<div class="font-mono text-xl font-semibold {info.update_available ? 'text-blue-400' : ''}">{info.latest_version}</div>
-								</div>
-							{/if}
-							{#if info?.update_available === true}
-								<span class="rounded-md border border-amber-600 bg-amber-950 px-2.5 py-0.5 text-xs font-medium text-amber-400">Update available</span>
-							{:else if info?.update_available === false}
-								<span class="rounded-md border border-green-700 bg-green-950 px-2.5 py-0.5 text-xs font-medium text-green-400">Up to date</span>
-							{/if}
-						</div>
-						<div class="flex gap-2">
-							<Button size="sm" onclick={checkForUpdates} disabled={checking || status?.state === 'running'}>
-								{checking ? 'Checking...' : 'Check for Updates'}
-							</Button>
-							{#if info?.update_available}
-								<Button
-									variant="default"
-									size="sm"
-									onclick={applyUpdate}
-									disabled={status?.state === 'running'}
-								>
-									Update Now
-								</Button>
-							{/if}
-						</div>
+			<CardHeader>
+				<CardTitle>Upstream</CardTitle>
+				<CardDescription>
+					Read directly from the installed system’s <code class="font-mono">/etc/nixos/flake.nix</code> and <code class="font-mono">/etc/nixos/flake.lock</code>.
+					Changed input URLs are refreshed automatically so the lock file stays consistent.
+				</CardDescription>
+			</CardHeader>
+			<CardContent class="space-y-4">
+				{#if info}
+					<div class="rounded-lg border border-border/60 bg-muted/20 px-4 py-3 text-sm">
+						<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Installed NASty</div>
+						<div class="mt-1 font-mono text-lg font-semibold">{info.current_version}</div>
 					</div>
+				{/if}
 
-					<!-- Right: flavor selector -->
-					{#if info}
-						<div>
-							<div class="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Flavor</div>
-							<div class="flex rounded-md overflow-hidden border border-border">
-								<button
-									title="Tagged releases only. Safe, tested, boring."
-									class="px-3 py-1 text-xs transition-colors {info.channel === 'mild' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted text-muted-foreground'}"
-									onclick={() => changeChannel('mild')}
-									disabled={status?.state === 'running'}
-								>Mild</button>
-								<button
-									title="Pre-release branch. New features, occasional heartburn."
-									class="px-3 py-1 text-xs transition-colors {info.channel === 'spicy' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted text-muted-foreground'}"
-									onclick={() => changeChannel('spicy')}
-									disabled={status?.state === 'running'}
-								>Spicy</button>
-								<button
-									title="Latest development branch. Bleeding edge — you asked for it."
-									class="px-3 py-1 text-xs transition-colors {info.channel === 'nasty' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted text-muted-foreground'}"
-									onclick={() => changeChannel('nasty')}
-									disabled={status?.state === 'running'}
-								>Nasty</button>
+				<div class="space-y-3">
+					{#each versionRows as row}
+						<div class="rounded-lg border border-border/60 p-4">
+							<div class="mb-2 flex items-center justify-between gap-3">
+								<div class="font-medium">{row.label}</div>
+								<div class="flex items-center gap-2 text-xs">
+									<span class="text-muted-foreground">locked</span>
+									<Badge variant="secondary" class="font-mono">{row.rev ?? 'unknown'}</Badge>
+								</div>
 							</div>
-							<p class="mt-1 text-xs text-muted-foreground max-w-[220px]">
-								{#if info.channel === 'mild'}
-									Safe, tested, boring.
-								{:else if info.channel === 'spicy'}
-									New features, occasional heartburn.
-								{:else}
-									Bleeding edge — you asked for it.
-								{/if}
-							</p>
+							<div class="flex flex-col gap-3 lg:flex-row lg:items-center">
+								<div class="flex-1">
+									<Input
+										bind:value={row.url}
+										disabled={startingSwitch || status?.state === 'running'}
+										class="font-mono text-sm"
+									/>
+								</div>
+								<label class="flex items-center gap-2 text-sm text-muted-foreground lg:w-28 lg:justify-end">
+									<input
+										type="checkbox"
+										bind:checked={row.update}
+										disabled={startingSwitch || status?.state === 'running'}
+										class="h-4 w-4 rounded border-input"
+									/>
+									<span>Update</span>
+								</label>
+							</div>
+							{#if row.url.trim() !== row.initialUrl}
+								<p class="mt-2 text-xs text-blue-400">
+									URL changed from <code class="font-mono">{row.initialUrl}</code>. This input will be refreshed on Switch even if its toggle is off.
+								</p>
+							{/if}
 						</div>
-					{/if}
+					{/each}
+				</div>
+
+				<div class="flex flex-wrap items-center justify-between gap-3">
+					<p class="text-xs text-muted-foreground">
+						{#if versionSelectionCount > 0}
+							{versionSelectionCount} input{versionSelectionCount === 1 ? '' : 's'} selected for refresh.
+						{:else}
+							No refresh selected yet.
+						{/if}
+					</p>
+					<Button
+						size="sm"
+						onclick={requestVersionSwitch}
+						disabled={!versionDirty || startingSwitch || status?.state === 'running'}
+					>
+						{startingSwitch ? 'Starting...' : 'Switch'}
+					</Button>
 				</div>
 			</CardContent>
 		</Card>
 
-		{#if status && (status.state === 'running' || status.state === 'failed')}
+		{#if versionStatusVisible}
 			<Card class="mb-6">
 				<CardContent class="py-5">
 					<div class="mb-5 flex items-center">
 						{#each phases as phase, i}
 							{@const done = currentPhase >= i}
-							{@const active = status.state === 'running' && currentPhase === i - 1}
-							{@const failed = status.state === 'failed' && !done}
+							{@const active = status?.state === 'running' && currentPhase === i - 1}
+							{@const failed = status?.state === 'failed' && !done}
 							<div class="flex items-center gap-0">
 								<div class="flex flex-col items-center gap-1">
 									<div class="flex h-7 w-7 items-center justify-center rounded-full border-2 text-xs font-semibold transition-all {
@@ -595,22 +486,22 @@
 									<span class="text-[0.65rem] font-medium {done ? 'text-blue-400' : active ? 'text-blue-400/70' : failed ? 'text-red-500/70' : 'text-muted-foreground/40'}">{phase.label}</span>
 								</div>
 								{#if i < phases.length - 1}
-									<div class="mb-3.5 h-px w-12 {currentPhase > i ? 'bg-blue-500' : 'bg-border'} mx-1"></div>
+									<div class="mx-1 mb-3.5 h-px w-12 {currentPhase > i ? 'bg-blue-500' : 'bg-border'}"></div>
 								{/if}
 							</div>
 						{/each}
-						{#if status.state === 'failed'}
+						{#if status?.state === 'failed'}
 							<span class="ml-4 text-sm text-destructive">Failed</span>
 						{/if}
 					</div>
 
-					{#if status.log}
+					{#if status?.log}
 						{#if status.state !== 'running'}
 							<button
 								onclick={() => logCollapsed = !logCollapsed}
-								class="mt-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+								class="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
 							>
-								<span class="transition-transform {logCollapsed ? '' : 'rotate-180'} inline-block">▾</span>
+								<span class="inline-block transition-transform {logCollapsed ? '' : 'rotate-180'}">▾</span>
 								{logCollapsed ? 'Show output' : 'Hide output'}
 							</button>
 						{/if}
@@ -618,29 +509,23 @@
 							<pre bind:this={logEl} class="mt-3 max-h-64 overflow-auto rounded bg-secondary p-3 text-xs leading-relaxed">{formatLog(status.log)}</pre>
 						{/if}
 					{/if}
-					{#if status.state === 'failed'}
+
+					{#if status?.state === 'failed'}
 						<div class="mt-4 flex gap-2">
-							<Button size="sm" onclick={doApplyUpdate}>Retry</Button>
+							<Button size="sm" onclick={doVersionSwitch}>Retry</Button>
 							<Button variant="secondary" size="sm" onclick={() => status = { state: 'idle', log: '', reboot_required: false, webui_changed: false }}>Dismiss</Button>
 						</div>
 					{/if}
 				</CardContent>
 			</Card>
 		{/if}
-
-		<p class="text-xs text-muted-foreground">
-			Updates are fetched and applied atomically. If the build fails, the running system is not affected.
-			Use the Generations tab to switch to any previous system version.
-		</p>
-
-	<!-- Generations tab -->
 	{:else if activeTab === 'generations'}
 		<Card>
 			<CardContent class="py-5">
 				<div class="mb-4 flex items-center justify-between">
 					<div>
 						<h2 class="text-base font-semibold">System Generations</h2>
-						<p class="text-xs text-muted-foreground">Each update creates a new generation. Switch to any previous version or label known-good configurations.</p>
+						<p class="text-xs text-muted-foreground">Each successful rebuild creates a new generation. Switch back to any previous version or label known-good configurations.</p>
 					</div>
 					<div class="flex items-center gap-2">
 						{#if availableLabels.length > 0}
@@ -702,7 +587,10 @@
 														bind:value={editLabelValue}
 														class="w-28 rounded-md border border-input bg-background px-2 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
 														placeholder="e.g. stable"
-														onkeydown={(e) => { if (e.key === 'Enter') saveLabel(gen.generation); if (e.key === 'Escape') editingLabel = null; }}
+														onkeydown={(e) => {
+															if (e.key === 'Enter') saveLabel(gen.generation);
+															if (e.key === 'Escape') editingLabel = null;
+														}}
 													/>
 													<button onclick={() => saveLabel(gen.generation)} class="text-green-400 hover:text-green-300" title="Save">
 														<Check class="h-3.5 w-3.5" />
@@ -714,14 +602,15 @@
 											{:else if gen.label}
 												<button
 													onclick={() => startEditLabel(gen)}
-													class="flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-xs text-foreground hover:bg-accent transition-colors"
+													class="flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-xs text-foreground transition-colors hover:bg-accent"
 												>
 													<Tag class="h-3 w-3" />{gen.label}
 												</button>
 											{:else}
 												<button
 													onclick={() => startEditLabel(gen)}
-													class="text-muted-foreground/50 hover:text-muted-foreground transition-colors" title="Add label"
+													class="text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+													title="Add label"
 												>
 													<Tag class="h-3.5 w-3.5" />
 												</button>
@@ -732,7 +621,7 @@
 												{#if !gen.current}
 													<button
 														onclick={() => switchGeneration(gen.generation)}
-														class="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+														class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 														title="Switch to this generation"
 														disabled={status?.state === 'running'}
 													>
@@ -740,7 +629,7 @@
 													</button>
 													<button
 														onclick={() => deleteGeneration(gen.generation)}
-														class="rounded-md p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+														class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
 														title="Delete this generation"
 														disabled={gen.booted || status?.state === 'running'}
 													>
@@ -758,14 +647,14 @@
 			</CardContent>
 		</Card>
 
-		{#if status && status.state !== 'idle'}
+		{#if generationStatusVisible}
 			<Card class="mt-6">
 				<CardContent class="py-5">
 					<div class="mb-5 flex items-center">
 						{#each genPhases as phase, i}
 							{@const done = genCurrentPhase >= i}
-							{@const active = status.state === 'running' && genCurrentPhase === i - 1}
-							{@const failed = status.state === 'failed' && !done}
+							{@const active = status?.state === 'running' && genCurrentPhase === i - 1}
+							{@const failed = status?.state === 'failed' && !done}
 							<div class="flex items-center gap-0">
 								<div class="flex flex-col items-center gap-1">
 									<div class="flex h-7 w-7 items-center justify-center rounded-full border-2 text-xs font-semibold transition-all {
@@ -779,22 +668,22 @@
 									<span class="text-[0.65rem] font-medium {done ? 'text-blue-400' : active ? 'text-blue-400/70' : failed ? 'text-red-500/70' : 'text-muted-foreground/40'}">{phase.label}</span>
 								</div>
 								{#if i < genPhases.length - 1}
-									<div class="mb-3.5 h-px w-12 {genCurrentPhase > i ? 'bg-blue-500' : 'bg-border'} mx-1"></div>
+									<div class="mx-1 mb-3.5 h-px w-12 {genCurrentPhase > i ? 'bg-blue-500' : 'bg-border'}"></div>
 								{/if}
 							</div>
 						{/each}
-						{#if status.state === 'failed'}
+						{#if status?.state === 'failed'}
 							<span class="ml-4 text-sm text-destructive">Failed</span>
 						{/if}
 					</div>
 
-					{#if status.log}
+					{#if status?.log}
 						{#if status.state !== 'running'}
 							<button
 								onclick={() => logCollapsed = !logCollapsed}
-								class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+								class="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
 							>
-								<span class="transition-transform {logCollapsed ? '' : 'rotate-180'} inline-block">▾</span>
+								<span class="inline-block transition-transform {logCollapsed ? '' : 'rotate-180'}">▾</span>
 								{logCollapsed ? 'Show output' : 'Hide output'}
 							</button>
 						{/if}
@@ -805,185 +694,6 @@
 				</CardContent>
 			</Card>
 		{/if}
-
-	<!-- bcachefs tab -->
-	{:else if activeTab === 'bcachefs'}
-		{#if bcachefsInfo?.is_custom_running}
-			<div class="mb-4 flex items-center gap-3 rounded-lg border border-amber-700 bg-amber-950 px-4 py-3 text-sm text-amber-200">
-				<span class="flex-1"><strong>Non-standard version in use.</strong> You are running a custom bcachefs version ({bcachefsInfo.running_version}) instead of the default ({bcachefsInfo.default_ref}). Switch back when stability is more important than bleeding-edge fixes.</span>
-				<Button variant="secondary" size="xs" onclick={() => { bcachefsRef = bcachefsInfo!.default_ref; }} disabled={bcachefsSwitching || bcachefsStatus?.state === 'running'}>
-					Restore default
-				</Button>
-			</div>
-		{/if}
-		{#if bcachefsInfo?.debug_checks_running}
-			<div class="mb-4 rounded-lg border border-blue-800 bg-blue-950 px-4 py-3 text-sm text-blue-200">
-				<strong>Debug checks enabled.</strong> The bcachefs kernel module is running with extra runtime assertions (CONFIG_BCACHEFS_DEBUG). This adds overhead to every filesystem operation. Disable when no longer needed for development or debugging.
-			</div>
-		{/if}
-
-		<Card class="mb-6">
-			<CardContent class="py-5">
-				<div class="mb-5 flex flex-wrap items-start gap-6">
-					<div>
-						<div class="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Pinned</div>
-						<div class="font-mono text-sm font-semibold">
-							{#if bcachefsInfo?.pinned_ref}
-								{bcachefsInfo.pinned_ref}{#if bcachefsInfo.pinned_rev && !/^[0-9a-f]+$/i.test(bcachefsInfo.pinned_ref)} <span class="text-muted-foreground">({bcachefsInfo.pinned_rev})</span>{/if}
-							{:else}
-								<span class="text-muted-foreground">unknown</span>
-							{/if}
-						</div>
-					</div>
-					<div>
-						<div class="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Running</div>
-						<div class="font-mono text-sm font-semibold">{bcachefsInfo?.running_version ?? 'unknown'}{bcachefsInfo?.is_custom && bcachefsInfo?.pinned_rev && !/^v\d/.test(bcachefsInfo.pinned_ref ?? '') ? ' @ ' + bcachefsInfo.pinned_rev : ''}</div>
-					{#if bcachefsInfo?.kernel_rust != null}
-						<div class="mt-0.5 text-xs text-muted-foreground">
-							kernel Rust: <span class="{bcachefsInfo.kernel_rust ? 'text-green-400' : 'text-yellow-400'}">{bcachefsInfo.kernel_rust ? 'yes' : 'no'}</span>
-						</div>
-					{/if}
-					</div>
-					<div>
-						<div class="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Default</div>
-						<div class="font-mono text-sm font-semibold text-muted-foreground">{bcachefsInfo?.default_ref ?? 'unknown'}</div>
-					</div>
-				</div>
-
-				<div class="mb-3 flex flex-wrap gap-2">
-					<input
-						type="text"
-						class="h-9 w-96 rounded-md border border-input bg-background px-3 py-1 font-mono text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
-						placeholder="e.g. v1.38.0, master, 098dad22ef7725620930587a047813469fceedce"
-						bind:value={bcachefsRef}
-						disabled={bcachefsSwitching || bcachefsStatus?.state === 'running'}
-					/>
-					{#if bcachefsInfo?.default_ref}
-						<Button
-							variant="secondary"
-							size="sm"
-							onclick={() => { bcachefsRef = bcachefsInfo!.default_ref; }}
-							disabled={bcachefsSwitching || bcachefsStatus?.state === 'running'}
-						>
-							{bcachefsInfo.default_ref}
-						</Button>
-					{/if}
-					<Button
-						variant="secondary"
-						size="sm"
-						onclick={() => { bcachefsRef = 'master'; }}
-						disabled={bcachefsSwitching || bcachefsStatus?.state === 'running'}
-					>
-						master
-					</Button>
-				</div>
-
-				{#if bcachefsWarnVisible}
-					<div class="mb-3 rounded-lg border border-amber-700 bg-amber-950 px-4 py-3 text-sm text-amber-200 space-y-1.5">
-						<div><strong>Build time:</strong> bcachefs-tools is compiled from source — the first build can take 5–20 minutes depending on your hardware.</div>
-						<div><strong>Compatibility risk:</strong> If a newer on-disk format was already written to your filesystems, downgrading may leave them unmountable. Reach out to the bcachefs devs if you run into problems.</div>
-					</div>
-				{/if}
-				{#if bcachefsRefIsBranch}
-					<div class="mb-3 rounded-lg border border-blue-800 bg-blue-950 px-4 py-3 text-sm text-blue-200">
-						<strong>Branch detected:</strong> <code class="font-mono">{bcachefsRef.trim()}</code> will be resolved
-						to the exact commit it points to right now and pinned there. Future system updates won't follow the
-						branch tip. Use a specific tag or commit SHA for full control.
-					</div>
-				{/if}
-
-				<div class="mb-3 flex items-start gap-6">
-					<label class="flex items-start gap-2 text-sm text-muted-foreground" title="Debug symbols are inherited from the NixOS kernel config (CONFIG_DEBUG_INFO=y)">
-						<input
-							type="checkbox"
-							checked={bcachefsInfo?.debug_symbols ?? false}
-							disabled
-							class="mt-0.5 rounded border-input opacity-50"
-						/>
-						<span>
-							<span class="text-muted-foreground font-medium">Debug symbols</span>
-							<span class="block text-xs text-muted-foreground/50 mt-0.5">Inherited from NixOS kernel config (CONFIG_DEBUG_INFO=y).<br/>Adds source-level debug info for readable stack traces.<br/>No runtime cost.</span>
-						</span>
-					</label>
-					<label class="flex items-start gap-2 text-sm text-muted-foreground cursor-pointer">
-						<input
-							type="checkbox"
-							bind:checked={bcachefsDebugChecks}
-							disabled={bcachefsSwitching || bcachefsStatus?.state === 'running'}
-							class="mt-0.5 rounded border-input"
-						/>
-						<span>
-							<span class="text-foreground font-medium">Debug checks</span>
-							<span class="block text-xs text-muted-foreground/70 mt-0.5">Enables extra runtime assertions inside bcachefs<br/>(btree locking, iterator validation, bkey verification).<br/><strong>Has performance cost</strong> — use for development and debugging, not production.</span>
-						</span>
-					</label>
-				</div>
-
-				<Button
-					variant="default"
-					size="sm"
-					onclick={requestBcachefsSwitch}
-					disabled={!bcachefsCanSwitch || bcachefsSwitching || bcachefsStatus?.state === 'running'}
-				>
-					{bcachefsSwitching ? 'Starting...' : 'Switch'}
-				</Button>
-			</CardContent>
-		</Card>
-
-		{#if bcachefsStatus && bcachefsStatus.state !== 'idle'}
-			<Card class="mb-6">
-				<CardContent class="py-5">
-					<div class="mb-5 flex items-center">
-						{#each bcachefsPhases as phase, i}
-							{@const done = bcachefsCurrentPhase >= i}
-							{@const active = bcachefsStatus.state === 'running' && bcachefsCurrentPhase === i - 1}
-							{@const failed = bcachefsStatus.state === 'failed' && !done}
-							<div class="flex items-center gap-0">
-								<div class="flex flex-col items-center gap-1">
-									<div class="flex h-7 w-7 items-center justify-center rounded-full border-2 text-xs font-semibold transition-all {
-										done   ? 'border-blue-500 bg-blue-500 text-white' :
-										active ? 'border-blue-400 bg-transparent text-blue-400 animate-pulse' :
-										failed ? 'border-red-700 bg-transparent text-red-500' :
-										         'border-border bg-transparent text-muted-foreground/30'
-									}">
-										{#if done}✓{:else if active}…{:else if failed}✕{:else}{i + 1}{/if}
-									</div>
-									<span class="text-[0.65rem] font-medium {done ? 'text-blue-400' : active ? 'text-blue-400/70' : failed ? 'text-red-500/70' : 'text-muted-foreground/40'}">{phase.label}</span>
-								</div>
-								{#if i < bcachefsPhases.length - 1}
-									<div class="mb-3.5 h-px w-12 {bcachefsCurrentPhase > i ? 'bg-blue-500' : 'bg-border'} mx-1"></div>
-								{/if}
-							</div>
-						{/each}
-						{#if bcachefsStatus.state === 'failed'}
-							<span class="ml-4 text-sm text-destructive">Failed</span>
-						{/if}
-					</div>
-
-					{#if bcachefsStatus.log}
-						{#if bcachefsStatus.state !== 'running'}
-							<button
-								onclick={() => bcachefsLogCollapsed = !bcachefsLogCollapsed}
-								class="mt-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-							>
-								<span class="transition-transform {bcachefsLogCollapsed ? '' : 'rotate-180'} inline-block">▾</span>
-								{bcachefsLogCollapsed ? 'Show output' : 'Hide output'}
-							</button>
-						{/if}
-						{#if bcachefsStatus.state === 'running' || !bcachefsLogCollapsed}
-							<pre bind:this={bcachefsLogEl} class="mt-3 max-h-64 overflow-auto rounded bg-secondary p-3 text-xs leading-relaxed">{formatLog(bcachefsStatus.log)}</pre>
-						{/if}
-					{/if}
-					{#if bcachefsStatus.state === 'failed'}
-						<div class="mt-4 flex gap-2">
-							<Button size="sm" onclick={doBcachefsSwitch} disabled={!bcachefsRef.trim()}>Retry</Button>
-							<Button variant="secondary" size="sm" onclick={() => bcachefsStatus = { state: 'idle', log: '', reboot_required: false, webui_changed: false }}>Dismiss</Button>
-						</div>
-					{/if}
-				</CardContent>
-			</Card>
-		{/if}
-	<!-- Firmware tab -->
 	{:else if activeTab === 'firmware'}
 		{#if firmwareLoading}
 			<p class="text-muted-foreground">Checking firmware...</p>
@@ -996,7 +706,7 @@
 		{:else}
 			<Card class="mb-4">
 				<CardContent class="py-5">
-					<div class="flex items-center justify-between mb-4">
+					<div class="mb-4 flex items-center justify-between">
 						<div>
 							<h3 class="text-lg font-semibold">Firmware Updates</h3>
 							<p class="text-sm text-muted-foreground">Manage device firmware via fwupd (LVFS).</p>
@@ -1012,11 +722,11 @@
 						<table class="w-full text-sm">
 							<thead>
 								<tr>
-									<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Device</th>
+									<th class="w-px border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap">Device</th>
 									<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Vendor</th>
 									<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Version</th>
 									<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Update</th>
-									<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
+									<th class="w-px border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap">Actions</th>
 								</tr>
 							</thead>
 							<tbody>

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -9,12 +9,13 @@
 		Generation,
 		FirmwareDevice,
 		FirmwareUpdateResult,
-		VersionInfo
+		VersionInfo,
+		VersionTaggedReleaseStatus
 	} from '$lib/types';
-	import { Tag, Trash2, ArrowRightLeft, X, Check } from '@lucide/svelte';
+	import { Tag, Trash2, ArrowRightLeft, X, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
-	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
@@ -30,7 +31,14 @@
 		initialRev: string | null;
 	};
 
+	type TaggedReleaseBannerState =
+		| { kind: 'loading' }
+		| { kind: 'switching' }
+		| { kind: 'failure' }
+		| ({ kind: 'ready' } & VersionTaggedReleaseStatus);
+
 	const client = getClient();
+	const VERSION_PAGE_ACTION_KEY = 'nasty.version-page.action';
 
 	let activeTab: Tab = $state(
 		typeof window !== 'undefined' && window.location.hash === '#generations' ? 'generations'
@@ -39,14 +47,17 @@
 	);
 
 	let info: UpdateInfo | null = $state(null);
-	let versionInfo: VersionInfo | null = $state(null);
+	let taggedReleaseBanner: TaggedReleaseBannerState = $state({ kind: 'loading' });
 	let versionRows: VersionRow[] = $state([]);
 	let status: UpdateStatus | null = $state(null);
 	let loading = $state(true);
 	let startingSwitch = $state(false);
+	let startingUpgrade = $state(false);
+	let upstreamExpanded = $state(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	let logEl: HTMLPreElement | undefined = $state();
 	let logCollapsed = $state(true);
+	let taggedReleaseBannerRequestId = 0;
 
 	let generations: Generation[] = $state([]);
 	let generationsLoading = $state(false);
@@ -94,6 +105,10 @@
 
 	const versionDirty = $derived.by(() =>
 		versionRows.some((row) => row.url.trim() !== row.initialUrl || row.update)
+	);
+
+	const upstreamBusy = $derived.by(() =>
+		startingSwitch || startingUpgrade || status?.state === 'running'
 	);
 
 	const versionSelectionCount = $derived.by(() =>
@@ -188,21 +203,68 @@
 		if (tab === 'firmware' && !firmwareLoaded) void loadFirmware();
 	}
 
+	function readVersionPageAction(): string | null {
+		if (typeof window === 'undefined') return null;
+		return window.sessionStorage.getItem(VERSION_PAGE_ACTION_KEY);
+	}
+
+	function writeVersionPageAction(action: string | null) {
+		if (typeof window === 'undefined') return;
+		if (action) {
+			window.sessionStorage.setItem(VERSION_PAGE_ACTION_KEY, action);
+		} else {
+			window.sessionStorage.removeItem(VERSION_PAGE_ACTION_KEY);
+		}
+	}
+
 	async function loadVersionPage() {
 		await withToast(async () => {
 			const [nextInfo, nextVersion] = await Promise.all([
 				client.call<VersionInfo>('system.version.get'),
 				client.call<UpdateInfo>('system.update.version')
 			]);
-			versionInfo = nextInfo;
 			info = nextVersion;
 			syncVersionRows(nextInfo);
+			if (readVersionPageAction() === 'version-switch') {
+				taggedReleaseBanner = { kind: 'switching' };
+			} else {
+				void loadTaggedReleaseBanner();
+			}
 		});
+	}
+
+	async function loadTaggedReleaseBanner() {
+		if (readVersionPageAction() === 'version-switch') {
+			taggedReleaseBanner = { kind: 'switching' };
+			return;
+		}
+		const requestId = ++taggedReleaseBannerRequestId;
+		taggedReleaseBanner = { kind: 'loading' };
+		try {
+			const releaseStatus = await client.call<VersionTaggedReleaseStatus>(
+				'system.version.tagged_release_notice'
+			);
+			if (requestId === taggedReleaseBannerRequestId) {
+				taggedReleaseBanner = { kind: 'ready', ...releaseStatus };
+			}
+		} catch {
+			if (requestId === taggedReleaseBannerRequestId) {
+				taggedReleaseBanner = { kind: 'failure' };
+			}
+		}
 	}
 
 	async function loadStatus() {
 		await withToast(async () => {
 			status = await client.call<UpdateStatus>('system.update.status');
+			if (readVersionPageAction() === 'version-switch') {
+				if (status?.state === 'running') {
+					taggedReleaseBanner = { kind: 'switching' };
+				} else {
+					writeVersionPageAction(null);
+					void loadTaggedReleaseBanner();
+				}
+			}
 			if (status?.state === 'running') startPolling();
 		});
 	}
@@ -226,6 +288,8 @@
 
 	async function doVersionSwitch() {
 		startingSwitch = true;
+		writeVersionPageAction('version-switch');
+		taggedReleaseBanner = { kind: 'switching' };
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
 		const result = await withToast(
@@ -240,19 +304,42 @@
 		);
 		if (result !== undefined) {
 			startPolling();
+		} else {
+			writeVersionPageAction(null);
+			void loadTaggedReleaseBanner();
 		}
 		startingSwitch = false;
+	}
+
+	async function upgradeTaggedRelease() {
+		if (taggedReleaseBanner.kind !== 'ready' || taggedReleaseBanner.current_is_latest_standard_url) return;
+		startingUpgrade = true;
+		logCollapsed = false;
+		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
+		const result = await withToast(
+			() => client.call('system.version.upgrade_tagged_release'),
+			'Tagged release upgrade started'
+		);
+		if (result !== undefined) {
+			startPolling();
+		} else {
+			await loadVersionPage();
+		}
+		startingUpgrade = false;
 	}
 
 	function startPolling() {
 		stopPolling();
 		pollInterval = setInterval(async () => {
 			try {
-				status = await client.call<UpdateStatus>('system.update.status');
-				if (status && (status.state === 'success' || status.state === 'failed')) {
-					stopPolling();
-					await loadVersionPage();
-					if (status.state === 'success') {
+					status = await client.call<UpdateStatus>('system.update.status');
+					if (status && (status.state === 'success' || status.state === 'failed')) {
+						if (readVersionPageAction() === 'version-switch') {
+							writeVersionPageAction(null);
+						}
+						stopPolling();
+						await loadVersionPage();
+						if (status.state === 'success') {
 						if (status.webui_changed) refreshState.set();
 						if (status.reboot_required) rebootState.set();
 						setTimeout(() => { logCollapsed = true; }, 3000);
@@ -388,69 +475,126 @@
 		>Firmware</button>
 	</div>
 
-		{#if activeTab === 'version'}
-			<Card class="mb-6">
-				<CardHeader>
-					<CardTitle>Upstream</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-4">
-				{#if info}
-					<div class="rounded-lg border border-border/60 bg-muted/20 px-4 py-3 text-sm">
-						<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Installed NASty</div>
-						<div class="mt-1 font-mono text-lg font-semibold">{info.current_version}</div>
+	{#if activeTab === 'version'}
+		<Card class="mb-6">
+			<CardContent class="space-y-4 pt-6">
+				<div
+					class="rounded-lg border px-4 py-4 text-sm {taggedReleaseBanner.kind === 'failure'
+						? 'border-amber-500/40 bg-amber-500/10'
+						: taggedReleaseBanner.kind === 'ready' && !taggedReleaseBanner.current_is_latest_standard_url
+							? 'border-emerald-500/40 bg-emerald-500/10'
+							: 'border-border/60 bg-muted/20'}"
+				>
+					<div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+						<div class="min-w-0 flex-1">
+							<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Tagged Release</div>
+							{#if taggedReleaseBanner.kind === 'loading'}
+								<div class="mt-1 font-medium">Fetching newest version...</div>
+							{:else if taggedReleaseBanner.kind === 'switching'}
+								<div class="mt-1 font-medium">Switching to another Version...</div>
+							{:else if taggedReleaseBanner.kind === 'failure'}
+								<div class="mt-1 font-medium">Network failure, unable to fetch newest tagged release</div>
+							{:else if taggedReleaseBanner.current_is_latest_standard_url}
+								<div class="mt-1 font-medium">Already at newest tagged release</div>
+								<div class="mt-1 text-xs text-muted-foreground">
+									<code class="font-mono">{taggedReleaseBanner.latest_tag}</code>
+								</div>
+							{:else}
+								<div class="mt-1 font-medium">
+									The newest tagged release is {taggedReleaseBanner.latest_tag}, click to switch
+								</div>
+								<div class="mt-1 text-xs text-muted-foreground">
+									<code class="font-mono">{taggedReleaseBanner.latest_url}</code>
+								</div>
+							{/if}
+						</div>
+						<div class="flex flex-wrap items-start justify-end gap-3">
+							{#if info}
+								<div class="min-w-[11rem] rounded-lg border border-border/60 bg-background/60 px-4 py-3 text-sm">
+									<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Installed NASty</div>
+									<div class="mt-1 font-mono text-lg font-semibold">{info.current_version}</div>
+								</div>
+							{/if}
+							{#if taggedReleaseBanner.kind === 'ready' && !taggedReleaseBanner.current_is_latest_standard_url}
+								<Button size="sm" onclick={upgradeTaggedRelease} disabled={startingUpgrade || status?.state === 'running'}>
+									{startingUpgrade ? 'Starting...' : 'Upgrade'}
+								</Button>
+							{/if}
+						</div>
 					</div>
-				{/if}
+				</div>
 
-				<div class="space-y-3">
-					{#each versionRows as row}
-						<div class="rounded-lg border border-border/60 p-4">
-							<div class="mb-2 flex items-center justify-between gap-3">
-								<div class="font-medium">{row.label}</div>
-								<div class="flex items-center gap-2 text-xs">
-									<span class="text-muted-foreground">locked</span>
-									<Badge variant="secondary" class="font-mono">{row.rev ?? 'unknown'}</Badge>
-								</div>
-							</div>
-							<div class="flex flex-col gap-3 lg:flex-row lg:items-center">
-								<div class="flex-1">
-									<Input
-										bind:value={row.url}
-										disabled={startingSwitch || status?.state === 'running'}
-										class="font-mono text-sm"
-									/>
-								</div>
-									<label class="flex items-center gap-2 text-sm text-muted-foreground lg:w-28 lg:justify-end">
-										<input
-											type="checkbox"
-											checked={row.update || isForcedVersionUpdate(row)}
-											disabled={startingSwitch || status?.state === 'running' || isForcedVersionUpdate(row)}
-											onchange={(event) => {
-												row.update = (event.currentTarget as HTMLInputElement).checked;
-											}}
-											class="h-4 w-4 rounded border-input"
-										/>
-										<span>Update</span>
-									</label>
-								</div>
-							</div>
-						{/each}
-					</div>
-
-				<div class="flex flex-wrap items-center justify-between gap-3">
-					<p class="text-xs text-muted-foreground">
-						{#if versionSelectionCount > 0}
-							{versionSelectionCount} input{versionSelectionCount === 1 ? '' : 's'} selected for refresh.
-						{:else}
-							No refresh selected yet.
-						{/if}
-					</p>
-					<Button
-						size="sm"
-						onclick={requestVersionSwitch}
-						disabled={!versionDirty || startingSwitch || status?.state === 'running'}
+				<div class="rounded-lg border border-border/60">
+					<button
+						onclick={() => { upstreamExpanded = !upstreamExpanded; }}
+						class="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-muted/20"
 					>
-						{startingSwitch ? 'Starting...' : 'Switch'}
-					</Button>
+						{#if upstreamExpanded}
+							<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+						{:else}
+							<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+						{/if}
+						<div class="flex-1">
+							<div class="font-medium">Upstream</div>
+							<div class="text-xs text-muted-foreground">Edit live flake input URLs and rebuild from /etc/nixos.</div>
+						</div>
+					</button>
+
+					{#if upstreamExpanded}
+						<div class="space-y-4 border-t border-border/60 p-4 {upstreamBusy ? 'pointer-events-none opacity-50' : ''}">
+							<div class="space-y-3">
+								{#each versionRows as row}
+									<div class="rounded-lg border border-border/60 p-4">
+										<div class="mb-2 flex items-center justify-between gap-3">
+											<div class="font-medium">{row.label}</div>
+											<div class="flex items-center gap-2 text-xs">
+												<span class="text-muted-foreground">locked</span>
+												<Badge variant="secondary" class="font-mono">{row.rev ?? 'unknown'}</Badge>
+											</div>
+										</div>
+										<div class="flex flex-col gap-3 lg:flex-row lg:items-center">
+											<div class="flex-1">
+												<Input
+													bind:value={row.url}
+													disabled={startingSwitch || status?.state === 'running'}
+													class="font-mono text-sm"
+												/>
+											</div>
+											<label class="flex items-center gap-2 text-sm text-muted-foreground lg:w-28 lg:justify-end">
+												<input
+													type="checkbox"
+													checked={row.update || isForcedVersionUpdate(row)}
+													disabled={startingSwitch || status?.state === 'running' || isForcedVersionUpdate(row)}
+													onchange={(event) => {
+														row.update = (event.currentTarget as HTMLInputElement).checked;
+													}}
+													class="h-4 w-4 rounded border-input"
+												/>
+												<span>Update</span>
+											</label>
+										</div>
+									</div>
+								{/each}
+							</div>
+
+							<div class="flex flex-wrap items-center justify-between gap-3">
+								<p class="text-xs text-muted-foreground">
+									{#if versionSelectionCount > 0}
+										{versionSelectionCount} input{versionSelectionCount === 1 ? '' : 's'} selected for refresh.
+									{:else}
+										No refresh selected yet.
+									{/if}
+								</p>
+								<Button
+									size="sm"
+									onclick={requestVersionSwitch}
+									disabled={!versionDirty || startingSwitch || status?.state === 'running'}
+								>
+									{startingSwitch ? 'Starting...' : 'Switch'}
+								</Button>
+							</div>
+						</div>
+					{/if}
 				</div>
 			</CardContent>
 		</Card>


### PR DESCRIPTION

  This branch reworks the Version page and the installed wrapper-flake lifecycle so NASty updates are driven by the live `/etc/nixos` flake inputs rather than the old channel/flavor UI.

  ## What changed

  ### Version page redesign
  The Version page now reads the exact live input URLs and locked revs from `/etc/nixos/flake.nix` and `/etc/nixos/flake.lock`, and lets the user edit those inputs directly.

  The intended model is:

  - `flake.nix` is the source of truth for upstream input URLs
  - `flake.lock` is the source of truth for the exact locked revisions
  - a Version-page switch rewrites selected input URLs into `/etc/nixos/flake.nix`
  - URL changes always force a lock refresh for consistency
  - the rebuild only runs if `flake.lock` actually changed

  This is meant to make the update flow explicit and honest: we are mutating the live system flake directly, not hiding that behind abstract channels or flavors.

  ### Tagged release banner and upgrade path
  The top of the Version page now has a dedicated tagged-release panel.

  Behavior:
  - it fetches the newest official `vX.Y.Z` tagged release from `github:nasty-project/nasty`
  - if the current `nasty.url` is exactly the newest standard release URL, it shows `Already at newest tagged release`
  - otherwise it offers `Upgrade`
  - on version-switch operations it suppresses release detection and shows `Switching to another Version...`
  - on fetch failure / timeout it shows `Network failure, unable to fetch newest tagged release`

  The tagged-release `Upgrade` path is designed to:
  - fetch the upstream `nixos/system-flake/flake.nix.template` from the target tagged release
  - bootstrap a new local `/etc/nixos/flake.nix` from that template
  - update `nixpkgs`, `bcachefs-tools`, and `nasty`
  - run `nixos-rebuild switch`

  ### Bootstrap logic moved into Rust
  The installer and the tagged-release upgrade path now share Rust bootstrap logic inside `nasty-system` / `nasty-engine`.

  The wrapper template no longer expects a fully substituted `nasty.url`.
  Instead it uses placeholders that are filled during bootstrap:
  - `@NASTY_VERSION@`
  - `@LOCAL_SYSTEM@`

  For the installer path, `nasty-engine bootstrap-system-flake` now computes the tagged release internally from its built-in package version (from `engine/Cargo.toml`
  `[workspace.package].version`) and writes the local wrapper flake from the template.

  ### Generation-owned wrapper flake snapshot and recovery
  The installed wrapper flake is now embedded into each generation closure and exposed at:

  - `/run/current-system/etc/nasty-system-flake/flake.nix`
  - `/run/current-system/etc/nasty-system-flake/flake.lock`

  A boot/activation service now restores:

  - `/etc/nixos/flake.nix`
  - `/etc/nixos/flake.lock`

  from that generation-owned snapshot.

  This is meant to recover from interrupted Version-page operations or partial flake mutations, so booting a generation also restores the exact wrapper flake that built that generation.

  The recovery service only rewrites `flake.nix` and `flake.lock`. It does not touch other machine-local files like `hardware-configuration.nix` or `networking.nix`.

  ## Design intent

  The “standard release path” for users is intentionally narrow:

  - install from a tagged-release ISO
  - use the provided wrapper flake template
  - keep `nasty.url` on the standard `github:nasty-project/nasty/vX.Y.Z` form
  - let the Version page manage transitions between tagged releases using our provided flake template and lock shape

  In other words, the happy path is designed to follow the tagged release and wrapper-flake template that NASty ships, rather than arbitrary custom repo URLs.

  Custom URLs are still visible/editable in the Version page, but the first-class upgrade UX is optimized for the standard release path above.

  ## Maintainer note

  On each new tagged release, please also update the default `bcachefs-tools` version in:

  - `nixos/system-flake/flake.nix.template`

  That template is part of the standard release path, so fresh installs and template-based tagged upgrades are expected to follow the release-authored `bcachefs-tools` pin there.
