### PR TITLE
Provision nasty-top into PATH of nasty

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,6 +76,26 @@
         "type": "github"
       }
     },
+    "nasty-top": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776522196,
+        "narHash": "sha256-W56aPHsHr/0TQaZRNXCQ23MQv7/89ujSvbn0GZ72hYc=",
+        "ref": "master",
+        "rev": "13f55abb06f0a97580400462d0c128443e9fed87",
+        "revCount": 24,
+        "type": "git",
+        "url": "ssh://git@github.com/nasty-project/nasty-top.git"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/nasty-project/nasty-top"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -131,6 +151,7 @@
     "root": {
       "inputs": {
         "bcachefs-tools": "bcachefs-tools",
+        "nasty-top": "nasty-top",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nasty-top.url = "https://github.com/nasty-project/nasty-top";
+    nasty-top.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── bcachefs override (optional) ──────────────────────────────
     # Pinned to v1.37 release tag.
@@ -13,9 +15,10 @@
 
   };
 
-  outputs = { self, nixpkgs, bcachefs-tools, ... }: let
+  outputs = { self, nixpkgs, bcachefs-tools, nasty-top, ... }: let
     # Helper to build packages for a given system
     mkPkgs = system: nixpkgs.legacyPackages.${system};
+    mkNastyTop = system: nasty-top.packages.${system}.default;
     nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
     rootLock = builtins.fromJSON (builtins.readFile ./flake.lock);
     installerNastyOwner = "nasty-project";
@@ -115,6 +118,7 @@
             };
             inputs = {
               bcachefs-tools = [ "bcachefs-tools" ];
+              nasty-top = [ "nasty-top" ];
               nixpkgs = [ "nixpkgs" ];
             };
           };
@@ -243,6 +247,7 @@
       engine = mkEngine "x86_64-linux";
       webui = mkWebui "x86_64-linux";
       bcachefs-tools = mkBcachefsTools "x86_64-linux";
+      nasty-top = mkNastyTop "x86_64-linux";
       nasty-rootfs = (mkNixosConfigs "x86_64-linux").nasty-rootfs.config.system.build.toplevel;
       nasty-cloud-image = (mkNixosConfigs "x86_64-linux").nasty-cloud.config.system.build.OCIImage;
       default = mkEngine "x86_64-linux";
@@ -252,6 +257,7 @@
       engine = mkEngine "aarch64-linux";
       webui = mkWebui "aarch64-linux";
       bcachefs-tools = mkBcachefsTools "aarch64-linux";
+      nasty-top = mkNastyTop "aarch64-linux";
       nasty-rootfs = (mkNixosConfigs "aarch64-linux").nasty-rootfs.config.system.build.toplevel;
       nasty-cloud-image = (mkNixosConfigs "aarch64-linux").nasty-cloud.config.system.build.OCIImage;
       default = mkEngine "aarch64-linux";

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -4,6 +4,8 @@ let
   cfg = config.services.nasty;
   inherit (lib) mkEnableOption mkOption mkIf types;
   nastySystemFlakeSnapshot = args.nastySystemFlakeSnapshot or null;
+  nastyFlake = builtins.getFlake (toString ../..);
+  nastyTopPackage = nastyFlake.packages.${pkgs.stdenv.hostPlatform.system}.nasty-top;
 
   useSelfSigned = cfg.tls.selfSigned && cfg.tls.certFile == null && cfg.tls.keyFile == null;
   tlsCertFile = if cfg.tls.certFile != null then cfg.tls.certFile else "/var/lib/nasty/tls/cert.pem";
@@ -492,6 +494,7 @@ in {
       kubectl           # Kubernetes CLI (also available via k3s kubectl)
       lego              # ACME client for Let's Encrypt certificates
       croc              # peer-to-peer file transfer for sending debug reports
+      nastyTopPackage   # top-like TUI for bcachefs stats and activity
 
       (writeShellScriptBin "nasty-report" ''
         set -euo pipefail


### PR DESCRIPTION
As stated in the title. This is a minimal change that enables end users to use nasty-top directly from their PATH.