### PR TITLE
ci: add fmt/clippy/test/svelte-check gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  engine:
+    name: Engine (fmt, clippy, test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
+
+      - name: Tests
+        run: cargo test --workspace --no-fail-fast
+
+  webui:
+    name: WebUI (svelte-check, build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webui
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Install
+        run: npm ci --legacy-peer-deps
+
+      - name: Type check
+        run: npm run check
+
+      - name: Build
+        run: npm run build

--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -953,7 +953,7 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
 
 fn type_str_from_schema(schema: &Value) -> String {
     if let Some(r) = schema.get("$ref").and_then(|v| v.as_str()) {
-        return format!("`{}`", r.split('/').last().unwrap_or(r));
+        return format!("`{}`", r.split('/').next_back().unwrap_or(r));
     }
     if let Some(items) = schema.get("items") {
         let inner = type_str_from_schema(items);
@@ -970,11 +970,11 @@ fn type_str_from_schema(schema: &Value) -> String {
             .collect();
         return parts.join(" | ");
     }
-    if let Some(variants) = schema.get("oneOf").or_else(|| schema.get("anyOf")) {
-        if let Some(arr) = variants.as_array() {
-            let parts: Vec<String> = arr.iter().map(type_str_from_schema).collect();
-            return parts.join(" \\| ");
-        }
+    if let Some(variants) = schema.get("oneOf").or_else(|| schema.get("anyOf"))
+        && let Some(arr) = variants.as_array()
+    {
+        let parts: Vec<String> = arr.iter().map(type_str_from_schema).collect();
+        return parts.join(" \\| ");
     }
     if let Some(vals) = schema.get("enum").and_then(|v| v.as_array()) {
         let parts: Vec<String> = vals
@@ -1039,7 +1039,7 @@ fn render_result_summary(schema: &Value) -> String {
         return "`array`".into();
     }
     if let Some(r) = schema.get("$ref").and_then(|v| v.as_str()) {
-        return format!("`{}`", r.split('/').last().unwrap_or(r));
+        return format!("`{}`", r.split('/').next_back().unwrap_or(r));
     }
     "`object`".into()
 }

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -13,6 +13,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use bollard::Docker;
 use bollard::models::{
     ContainerCreateBody, HostConfig, PortBinding, RestartPolicy, RestartPolicyNameEnum,
 };
@@ -20,7 +21,6 @@ use bollard::query_parameters::{
     CreateContainerOptions, CreateImageOptions, ListContainersOptions, LogsOptions,
     RemoveContainerOptions, StopContainerOptions,
 };
-use bollard::Docker;
 use futures_util::TryStreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -103,19 +103,19 @@ pub fn validate_simple_volumes(
         let src = &v.host_path;
 
         if src.contains("..") {
-            return Err(AppsError::ForbiddenBind(format!("'{src}' escapes via '..'")));
+            return Err(AppsError::ForbiddenBind(format!(
+                "'{src}' escapes via '..'"
+            )));
         }
         if src == "/" {
             return Err(AppsError::ForbiddenBind(
-                "host root '/' is never allowed as a bind mount".to_string()
+                "host root '/' is never allowed as a bind mount".to_string(),
             ));
         }
-        let in_app_dir = src == &app_data_dir
-            || src.starts_with(&format!("{app_data_dir}/"));
+        let in_app_dir = src == &app_data_dir || src.starts_with(&format!("{app_data_dir}/"));
         // Engine state dir is off-limits even with allow_unsafe — that's where
         // auth.json, settings.json, audit.log, OIDC client secrets live.
-        let in_engine_state = src == "/var/lib/nasty"
-            || src.starts_with("/var/lib/nasty/");
+        let in_engine_state = src == "/var/lib/nasty" || src.starts_with("/var/lib/nasty/");
         if in_engine_state && !in_app_dir {
             return Err(AppsError::ForbiddenBind(format!(
                 "'{src}' targets engine state — not allowed even with allow_unsafe"
@@ -123,9 +123,7 @@ pub fn validate_simple_volumes(
         }
 
         if !allow_unsafe {
-            let allowed = in_app_dir
-                || src == "/fs"
-                || src.starts_with("/fs/");
+            let allowed = in_app_dir || src == "/fs" || src.starts_with("/fs/");
             if !allowed {
                 return Err(AppsError::ForbiddenBind(format!(
                     "'{src}' is outside '{app_data_dir}/' and '/fs/'. Set allow_unsafe to override."
@@ -366,15 +364,25 @@ pub struct AppsService {
     docker: std::sync::Mutex<Option<Docker>>,
 }
 
+impl Default for AppsService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AppsService {
     pub fn new() -> Self {
         let docker = Docker::connect_with_unix_defaults()
-            .or_else(|_| Docker::connect_with_unix("/var/run/docker.sock", 120, &bollard::API_DEFAULT_VERSION))
+            .or_else(|_| {
+                Docker::connect_with_unix("/var/run/docker.sock", 120, bollard::API_DEFAULT_VERSION)
+            })
             .ok();
         if docker.is_none() {
             info!("Docker not available at startup — will connect on demand");
         }
-        Self { docker: std::sync::Mutex::new(docker) }
+        Self {
+            docker: std::sync::Mutex::new(docker),
+        }
     }
 
     /// Get a reference to the bollard Docker client (for use by deploy streaming).
@@ -390,7 +398,9 @@ impl AppsService {
         drop(guard);
         // Try to connect (Docker may have started after engine)
         let d = Docker::connect_with_unix_defaults()
-            .or_else(|_| Docker::connect_with_unix("/var/run/docker.sock", 120, &bollard::API_DEFAULT_VERSION))
+            .or_else(|_| {
+                Docker::connect_with_unix("/var/run/docker.sock", 120, bollard::API_DEFAULT_VERSION)
+            })
             .map_err(|_| AppsError::NotReady("Docker socket not available".into()))?;
         *self.docker.lock().unwrap() = Some(d.clone());
         info!("Connected to Docker socket");
@@ -451,11 +461,11 @@ impl AppsService {
             let mut ready = false;
             for _ in 0..15 {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                if let Ok(docker) = Docker::connect_with_unix_defaults() {
-                    if docker.ping().await.is_ok() {
-                        ready = true;
-                        break;
-                    }
+                if let Ok(docker) = Docker::connect_with_unix_defaults()
+                    && docker.ping().await.is_ok()
+                {
+                    ready = true;
+                    break;
                 }
             }
 
@@ -493,13 +503,18 @@ impl AppsService {
         // Stop all managed containers
         if let Ok(apps) = self.list().await {
             for app in &apps {
-                if app.status == "running" {
-                    if let Ok(docker) = self.docker() {
-                        let _ = docker.stop_container(
+                if app.status == "running"
+                    && let Ok(docker) = self.docker()
+                {
+                    let _ = docker
+                        .stop_container(
                             &container_name(&app.name),
-                            Some(StopContainerOptions { t: Some(10), signal: None }),
-                        ).await;
-                    }
+                            Some(StopContainerOptions {
+                                t: Some(10),
+                                signal: None,
+                            }),
+                        )
+                        .await;
                 }
             }
         }
@@ -639,11 +654,18 @@ impl AppsService {
         }
 
         // Build env
-        let env: Vec<String> = req.env.iter().map(|e| format!("{}={}", e.name, e.value)).collect();
+        let env: Vec<String> = req
+            .env
+            .iter()
+            .map(|e| format!("{}={}", e.name, e.value))
+            .collect();
 
         // Resource limits
         let nano_cpus = req.cpu_limit.as_ref().and_then(|c| parse_cpu_limit(c));
-        let memory = req.memory_limit.as_ref().and_then(|m| parse_memory_limit(m));
+        let memory = req
+            .memory_limit
+            .as_ref()
+            .and_then(|m| parse_memory_limit(m));
 
         // Build labels
         let mut labels = HashMap::new();
@@ -693,7 +715,12 @@ impl AppsService {
             )
             .await?;
 
-        self.docker()?.start_container(&cname, None::<bollard::query_parameters::StartContainerOptions>).await?;
+        self.docker()?
+            .start_container(
+                &cname,
+                None::<bollard::query_parameters::StartContainerOptions>,
+            )
+            .await?;
 
         info!("Installed app '{}' (image: {})", req.name, req.image);
 
@@ -706,7 +733,12 @@ impl AppsService {
         });
         let manifest_path = format!("{}/{}.json", COMPOSE_DIR, req.name);
         let _ = tokio::fs::create_dir_all(COMPOSE_DIR).await;
-        if let Err(e) = tokio::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap()).await {
+        if let Err(e) = tokio::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .await
+        {
             warn!("Failed to save app manifest: {e}");
         }
 
@@ -747,7 +779,13 @@ impl AppsService {
         // Stop and remove the old container
         let _ = self
             .docker()?
-            .stop_container(&cname, Some(StopContainerOptions { t: Some(10), signal: None }))
+            .stop_container(
+                &cname,
+                Some(StopContainerOptions {
+                    t: Some(10),
+                    signal: None,
+                }),
+            )
             .await;
         let _ = self
             .docker()?
@@ -782,7 +820,13 @@ impl AppsService {
         // Stop and remove
         let _ = self
             .docker()?
-            .stop_container(&cname, Some(StopContainerOptions { t: Some(10), signal: None }))
+            .stop_container(
+                &cname,
+                Some(StopContainerOptions {
+                    t: Some(10),
+                    signal: None,
+                }),
+            )
             .await;
         self.docker()?
             .remove_container(
@@ -821,7 +865,8 @@ impl AppsService {
             return Ok(Vec::new());
         }
         let mut apps = Vec::new();
-        let mut entries = tokio::fs::read_dir(apps_dir).await
+        let mut entries = tokio::fs::read_dir(apps_dir)
+            .await
             .map_err(|e| AppsError::CommandFailed(format!("read apps dir: {e}")))?;
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
@@ -835,12 +880,18 @@ impl AppsService {
                         .await
                         .ok()
                         .and_then(|content| {
-                            let parsed: serde_json::Value = serde_yaml_ng::from_str(&content).ok()?;
-                            Some(parsed.get("services")?
-                                .as_object()?
-                                .values()
-                                .filter_map(|svc| svc.get("image")?.as_str().map(|s| s.to_string()))
-                                .collect())
+                            let parsed: serde_json::Value =
+                                serde_yaml_ng::from_str(&content).ok()?;
+                            Some(
+                                parsed
+                                    .get("services")?
+                                    .as_object()?
+                                    .values()
+                                    .filter_map(|svc| {
+                                        svc.get("image")?.as_str().map(|s| s.to_string())
+                                    })
+                                    .collect(),
+                            )
                         })
                         .unwrap_or_default();
                     let image = if images.len() == 1 {
@@ -867,23 +918,34 @@ impl AppsService {
                 }
             } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
                 // Simple app: manifest JSON
-                if let Ok(content) = tokio::fs::read_to_string(&path).await {
-                    if let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content) {
-                        let app_name = manifest.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
-                        let image = manifest.get("image").and_then(|i| i.as_str()).unwrap_or("").to_string();
-                        let unsafe_mode = manifest.get("allow_unsafe").and_then(|b| b.as_bool()).unwrap_or(false);
-                        if !app_name.is_empty() {
-                            apps.push(App {
-                                name: app_name,
-                                image,
-                                status: "stopped".to_string(),
-                                created: String::new(),
-                                kind: "simple".to_string(),
-                                containers: Vec::new(),
-                                ports: Vec::new(),
-                                unsafe_mode,
-                            });
-                        }
+                if let Ok(content) = tokio::fs::read_to_string(&path).await
+                    && let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content)
+                {
+                    let app_name = manifest
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let image = manifest
+                        .get("image")
+                        .and_then(|i| i.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let unsafe_mode = manifest
+                        .get("allow_unsafe")
+                        .and_then(|b| b.as_bool())
+                        .unwrap_or(false);
+                    if !app_name.is_empty() {
+                        apps.push(App {
+                            name: app_name,
+                            image,
+                            status: "stopped".to_string(),
+                            created: String::new(),
+                            kind: "simple".to_string(),
+                            containers: Vec::new(),
+                            ports: Vec::new(),
+                            unsafe_mode,
+                        });
                     }
                 }
             }
@@ -978,7 +1040,9 @@ impl AppsService {
                 let mut created = String::new();
 
                 for c in &compose_containers {
-                    let svc_name = c.labels.as_ref()
+                    let svc_name = c
+                        .labels
+                        .as_ref()
                         .and_then(|l| l.get("com.docker.compose.service"))
                         .cloned()
                         .unwrap_or_default();
@@ -993,7 +1057,12 @@ impl AppsService {
                         any_running = true;
                     }
 
-                    let container_id = c.id.as_deref().unwrap_or("").chars().take(12).collect::<String>();
+                    let container_id =
+                        c.id.as_deref()
+                            .unwrap_or("")
+                            .chars()
+                            .take(12)
+                            .collect::<String>();
                     all_ports.extend(extract_ports(c));
                     containers.push(AppContainer {
                         name: svc_name,
@@ -1085,8 +1154,7 @@ impl AppsService {
         } else {
             host_config.port_bindings.as_ref().unwrap_or(&network_ports)
         };
-        let mut idx = 0;
-        for (key, bindings) in port_source {
+        for (idx, (key, bindings)) in port_source.iter().enumerate() {
             let parts: Vec<&str> = key.split('/').collect();
             let container_port: u16 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
             let protocol = parts
@@ -1109,7 +1177,6 @@ impl AppsService {
                 host_port,
                 protocol,
             });
-            idx += 1;
         }
         ports.sort_by_key(|p| p.container_port);
 
@@ -1150,7 +1217,9 @@ impl AppsService {
         }
 
         // Resource limits
-        let cpu_limit = host_config.nano_cpus.map(|n| format!("{:.1}", n as f64 / 1_000_000_000.0));
+        let cpu_limit = host_config
+            .nano_cpus
+            .map(|n| format!("{:.1}", n as f64 / 1_000_000_000.0));
         let memory_limit = host_config.memory.and_then(|m| {
             if m <= 0 {
                 None
@@ -1199,12 +1268,20 @@ impl AppsService {
             .await
             .map_err(|_| AppsError::AppNotFound(name.to_string()))?;
 
-        let output: String = logs.iter().map(|l| l.to_string()).collect::<Vec<_>>().join("");
+        let output: String = logs
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("");
         Ok(output)
     }
 
     /// Get logs for a specific container by ID or name (no nasty- prefix).
-    pub async fn container_logs(&self, container_id: &str, tail: Option<u32>) -> Result<String, AppsError> {
+    pub async fn container_logs(
+        &self,
+        container_id: &str,
+        tail: Option<u32>,
+    ) -> Result<String, AppsError> {
         self.require_ready().await?;
 
         let tail_str = tail.unwrap_or(100).to_string();
@@ -1223,7 +1300,11 @@ impl AppsService {
             .await
             .map_err(|_| AppsError::AppNotFound(container_id.to_string()))?;
 
-        let output: String = logs.iter().map(|l| l.to_string()).collect::<Vec<_>>().join("");
+        let output: String = logs
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("");
         Ok(output)
     }
 
@@ -1236,7 +1317,14 @@ impl AppsService {
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
         if Path::new(&compose_file).exists() {
             let output = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name, "stop"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "stop",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1250,7 +1338,13 @@ impl AppsService {
                 return Err(AppsError::AppNotFound(name.to_string()));
             }
             self.docker()?
-                .stop_container(&cname, Some(StopContainerOptions { t: Some(10), signal: None }))
+                .stop_container(
+                    &cname,
+                    Some(StopContainerOptions {
+                        t: Some(10),
+                        signal: None,
+                    }),
+                )
                 .await?;
         }
 
@@ -1265,7 +1359,14 @@ impl AppsService {
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
         if Path::new(&compose_file).exists() {
             let output = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name, "start"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "start",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1279,7 +1380,10 @@ impl AppsService {
                 return Err(AppsError::AppNotFound(name.to_string()));
             }
             self.docker()?
-                .start_container(&cname, None::<bollard::query_parameters::StartContainerOptions>)
+                .start_container(
+                    &cname,
+                    None::<bollard::query_parameters::StartContainerOptions>,
+                )
                 .await?;
         }
 
@@ -1308,10 +1412,7 @@ impl AppsService {
         .await?;
 
         // Write a .env file with project name
-        let env_content = format!(
-            "COMPOSE_PROJECT_NAME={name}\n",
-            name = req.name,
-        );
+        let env_content = format!("COMPOSE_PROJECT_NAME={name}\n", name = req.name,);
         tokio::fs::write(format!("{}/.env", project_dir), &env_content).await?;
 
         // Validate compose file before deploying
@@ -1334,7 +1435,8 @@ impl AppsService {
                     "up",
                     "-d",
                     "--no-build",
-                    "--pull", "missing",
+                    "--pull",
+                    "missing",
                 ])
                 .output(),
         )
@@ -1344,7 +1446,16 @@ impl AppsService {
         let cleanup = |project_dir: String, name: String, compose_path: String| async move {
             // Tear down any partially created containers before removing the dir
             let _ = Command::new("docker")
-                .args(["compose", "-f", &compose_path, "--project-name", &name, "down", "-v", "--remove-orphans"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_path,
+                    "--project-name",
+                    &name,
+                    "down",
+                    "-v",
+                    "--remove-orphans",
+                ])
                 .output()
                 .await;
             let _ = tokio::fs::remove_dir_all(&project_dir).await;
@@ -1371,13 +1482,15 @@ impl AppsService {
         }
 
         // Auto-create ingress for the first exposed port
-        if let Ok(app) = self.get(&req.name).await {
-            if let Some(first_port) = app.ports.first() {
-                let _ = self.ingress_set(SetIngressRequest {
+        if let Ok(app) = self.get(&req.name).await
+            && let Some(first_port) = app.ports.first()
+        {
+            let _ = self
+                .ingress_set(SetIngressRequest {
                     name: req.name.clone(),
                     host_port: first_port.host_port,
-                }).await;
-            }
+                })
+                .await;
         }
 
         info!("Installed compose app '{}'", req.name);
@@ -1412,7 +1525,8 @@ impl AppsService {
                     "up",
                     "-d",
                     "--no-build",
-                    "--pull", "missing",
+                    "--pull",
+                    "missing",
                     "--remove-orphans",
                 ])
                 .output(),
@@ -1525,14 +1639,14 @@ impl AppsService {
                 let parts: Vec<&str> = comment.split_whitespace().collect();
                 if parts.len() >= 2 {
                     let name = parts[0].to_string();
-                    if let Some(port_str) = parts[1].strip_prefix("port:") {
-                        if let Ok(port) = port_str.parse::<u16>() {
-                            rules.push(AppIngress {
-                                path: format!("/apps/{name}/"),
-                                name,
-                                host_port: port,
-                            });
-                        }
+                    if let Some(port_str) = parts[1].strip_prefix("port:")
+                        && let Ok(port) = port_str.parse::<u16>()
+                    {
+                        rules.push(AppIngress {
+                            path: format!("/apps/{name}/"),
+                            name,
+                            host_port: port,
+                        });
                     }
                 }
             }
@@ -1617,9 +1731,9 @@ impl AppsService {
     // ── Image inspection ────────────────────────────────────
 
     pub async fn inspect_image(&self, image: &str) -> Result<ImageInspectResult, AppsError> {
-        let ports = inspect_image_ports(image).await.map_err(|e| {
-            AppsError::CommandFailed(format!("image inspect failed: {e}"))
-        })?;
+        let ports = inspect_image_ports(image)
+            .await
+            .map_err(|e| AppsError::CommandFailed(format!("image inspect failed: {e}")))?;
         Ok(ImageInspectResult { ports })
     }
 
@@ -1646,7 +1760,16 @@ impl AppsService {
                 let path = compose_file.to_string_lossy().to_string();
                 info!("Restoring compose app '{name}'");
                 let _ = Command::new("docker")
-                    .args(["compose", "-f", &path, "--project-name", &name, "up", "-d", "--no-build"])
+                    .args([
+                        "compose",
+                        "-f",
+                        &path,
+                        "--project-name",
+                        &name,
+                        "up",
+                        "-d",
+                        "--no-build",
+                    ])
                     .output()
                     .await;
             }
@@ -1720,16 +1843,16 @@ impl AppsService {
 
     /// Look up the host port Docker actually assigned for a given container port.
     async fn get_mapped_port(&self, container: &str, container_port: u16) -> Option<u16> {
-        let info = self.docker().ok()?.inspect_container(container, None).await.ok()?;
+        let info = self
+            .docker()
+            .ok()?
+            .inspect_container(container, None)
+            .await
+            .ok()?;
         let ports = info.network_settings?.ports?;
         let key = format!("{container_port}/tcp");
         let bindings = ports.get(&key)?.as_ref()?;
-        bindings
-            .first()?
-            .host_port
-            .as_ref()?
-            .parse::<u16>()
-            .ok()
+        bindings.first()?.host_port.as_ref()?.parse::<u16>().ok()
     }
 
     /// Total memory usage of Docker (daemon + containers), excluding page cache.
@@ -1756,7 +1879,12 @@ impl AppsService {
 
     /// Total Docker disk usage (images + containers + volumes).
     async fn docker_disk_usage(&self) -> Option<u64> {
-        let df = self.docker().ok()?.df(None::<bollard::query_parameters::DataUsageOptions>).await.ok()?;
+        let df = self
+            .docker()
+            .ok()?
+            .df(None::<bollard::query_parameters::DataUsageOptions>)
+            .await
+            .ok()?;
         let mut total: u64 = 0;
         if let Some(ref images) = df.images_disk_usage {
             total += images.total_size.unwrap_or(0) as u64;
@@ -1775,7 +1903,14 @@ impl AppsService {
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
         if Path::new(&compose_file).exists() {
             let output = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name, "restart"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "restart",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1788,7 +1923,15 @@ impl AppsService {
             if !self.container_exists(&cname).await {
                 return Err(AppsError::AppNotFound(name.to_string()));
             }
-            self.docker()?.restart_container(&cname, Some(bollard::query_parameters::RestartContainerOptions { t: Some(10), signal: None })).await?;
+            self.docker()?
+                .restart_container(
+                    &cname,
+                    Some(bollard::query_parameters::RestartContainerOptions {
+                        t: Some(10),
+                        signal: None,
+                    }),
+                )
+                .await?;
         }
 
         info!("Restarted app '{name}'");
@@ -1804,7 +1947,14 @@ impl AppsService {
         if Path::new(&compose_file).exists() {
             // docker compose pull + up -d (recreates with new images)
             let pull = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name, "pull"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "pull",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1814,8 +1964,17 @@ impl AppsService {
             }
 
             let up = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name,
-                       "up", "-d", "--no-build", "--remove-orphans"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "up",
+                    "-d",
+                    "--no-build",
+                    "--remove-orphans",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1827,11 +1986,16 @@ impl AppsService {
             info!("Pulled latest images for compose app '{name}'");
         } else {
             let cname = container_name(name);
-            let info = self.docker()?.inspect_container(&cname, None).await
+            let info = self
+                .docker()?
+                .inspect_container(&cname, None)
+                .await
                 .map_err(|_| AppsError::AppNotFound(name.to_string()))?;
             let image = info.config.and_then(|c| c.image).unwrap_or_default();
             if image.is_empty() {
-                return Err(AppsError::DockerFailed("container has no image".to_string()));
+                return Err(AppsError::DockerFailed(
+                    "container has no image".to_string(),
+                ));
             }
 
             // Pull latest
@@ -1839,13 +2003,28 @@ impl AppsService {
 
             // Recreate container with same config but new image
             // Stop + remove + start from the pulled image
-            let _ = self.docker()?.stop_container(&cname, Some(StopContainerOptions { t: Some(10), signal: None })).await;
+            let _ = self
+                .docker()?
+                .stop_container(
+                    &cname,
+                    Some(StopContainerOptions {
+                        t: Some(10),
+                        signal: None,
+                    }),
+                )
+                .await;
             // We need the full config to recreate — get_config then re-install
             let config = self.get_config(name).await?;
-            let _ = self.docker()?.remove_container(&cname, Some(RemoveContainerOptions {
-                force: true,
-                ..Default::default()
-            })).await;
+            let _ = self
+                .docker()?
+                .remove_container(
+                    &cname,
+                    Some(RemoveContainerOptions {
+                        force: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
 
             let req = InstallAppRequest {
                 name: name.to_string(),
@@ -1868,14 +2047,23 @@ impl AppsService {
     pub async fn prune(&self) -> Result<PruneResult, AppsError> {
         self.require_ready().await?;
 
-        let result = self.docker()?.prune_images(None::<bollard::query_parameters::PruneImagesOptions>).await?;
+        let result = self
+            .docker()?
+            .prune_images(None::<bollard::query_parameters::PruneImagesOptions>)
+            .await?;
         let images_removed = result.images_deleted.map(|v| v.len()).unwrap_or(0);
         let space_reclaimed = result.space_reclaimed.unwrap_or(0) as u64;
 
         // Also prune volumes
-        let _ = self.docker()?.prune_volumes(None::<bollard::query_parameters::PruneVolumesOptions>).await;
+        let _ = self
+            .docker()?
+            .prune_volumes(None::<bollard::query_parameters::PruneVolumesOptions>)
+            .await;
 
-        info!("Pruned {images_removed} images, reclaimed {} bytes", space_reclaimed);
+        info!(
+            "Pruned {images_removed} images, reclaimed {} bytes",
+            space_reclaimed
+        );
         Ok(PruneResult {
             images_removed,
             space_reclaimed_bytes: space_reclaimed,
@@ -1893,7 +2081,9 @@ impl AppsService {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(AppsError::DockerFailed(format!("invalid compose file: {stderr}")));
+            return Err(AppsError::DockerFailed(format!(
+                "invalid compose file: {stderr}"
+            )));
         }
         Ok(())
     }
@@ -1907,7 +2097,15 @@ impl AppsService {
         let container = if Path::new(&compose_file).exists() {
             // Look up the first running container in the compose project
             let output = Command::new("docker")
-                .args(["compose", "-f", &compose_file, "--project-name", name, "ps", "-q"])
+                .args([
+                    "compose",
+                    "-f",
+                    &compose_file,
+                    "--project-name",
+                    name,
+                    "ps",
+                    "-q",
+                ])
                 .output()
                 .await
                 .map_err(|e| AppsError::CommandFailed(e.to_string()))?;
@@ -1918,7 +2116,9 @@ impl AppsService {
                 .trim()
                 .to_string();
             if id.is_empty() {
-                return Err(AppsError::DockerFailed("no running containers in this app".to_string()));
+                return Err(AppsError::DockerFailed(
+                    "no running containers in this app".to_string(),
+                ));
             }
             id
         } else {
@@ -1985,14 +2185,14 @@ async fn find_container_shell(container: &str) -> Option<&'static str> {
             .args(["exec", container, "test", "-x", shell])
             .output()
             .await;
-        if let Ok(output) = result {
-            if output.status.success() {
-                return Some(match shell {
-                    "/bin/bash" => "/bin/bash",
-                    "/bin/ash" => "/bin/ash",
-                    _ => "/bin/sh",
-                });
-            }
+        if let Ok(output) = result
+            && output.status.success()
+        {
+            return Some(match shell {
+                "/bin/bash" => "/bin/bash",
+                "/bin/ash" => "/bin/ash",
+                _ => "/bin/sh",
+            });
         }
     }
     None
@@ -2032,11 +2232,7 @@ async fn system_listeners() -> Result<Vec<(u16, String)>, AppsError> {
 
         // Extract process name from users:(("name",...))
         let process = if let Some(users) = fields.get(5) {
-            users
-                .split('"')
-                .nth(1)
-                .unwrap_or("unknown")
-                .to_string()
+            users.split('"').nth(1).unwrap_or("unknown").to_string()
         } else {
             "unknown".to_string()
         };
@@ -2085,7 +2281,7 @@ fn parse_memory_limit(s: &str) -> Option<i64> {
 
 /// Format bytes as a human-readable memory limit.
 fn format_memory_limit(bytes: u64) -> String {
-    if bytes >= 1024 * 1024 * 1024 && bytes % (1024 * 1024 * 1024) == 0 {
+    if bytes >= 1024 * 1024 * 1024 && bytes.is_multiple_of(1024 * 1024 * 1024) {
         format!("{}g", bytes / (1024 * 1024 * 1024))
     } else if bytes >= 1024 * 1024 {
         format!("{}m", bytes / (1024 * 1024))
@@ -2102,9 +2298,13 @@ fn extract_ports(c: &bollard::models::ContainerSummary) -> Vec<MappedPort> {
         for port in p {
             if let (Some(public), Some(_)) = (port.public_port, Some(port.private_port)) {
                 ports.push(MappedPort {
-                    host_port: public as u16,
-                    container_port: port.private_port as u16,
-                    protocol: port.typ.as_ref().map(|t| format!("{:?}", t).to_lowercase()).unwrap_or_else(|| "tcp".to_string()),
+                    host_port: public,
+                    container_port: port.private_port,
+                    protocol: port
+                        .typ
+                        .as_ref()
+                        .map(|t| format!("{:?}", t).to_lowercase())
+                        .unwrap_or_else(|| "tcp".to_string()),
                 });
             }
         }
@@ -2150,12 +2350,7 @@ async fn setup_apps_storage(filesystem: Option<&str>) -> Option<String> {
 
         let mut found = None;
         while let Ok(Some(entry)) = entries.next_entry().await {
-            if entry
-                .file_type()
-                .await
-                .map(|t| t.is_dir())
-                .unwrap_or(false)
-            {
+            if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
                 found = Some(entry.file_name().to_string_lossy().to_string());
                 break;
             }
@@ -2197,7 +2392,8 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
         name.to_string()
     } else {
         let fs_base = Path::new("/fs");
-        let mut entries = tokio::fs::read_dir(fs_base).await
+        let mut entries = tokio::fs::read_dir(fs_base)
+            .await
             .map_err(|e| AppsError::CommandFailed(format!("cannot read /fs: {e}")))?;
         let mut found = None;
         while let Ok(Some(entry)) = entries.next_entry().await {
@@ -2212,23 +2408,25 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
     // Ensure the apps subvolume exists first
     let apps_path = format!("/fs/{fs_name}/apps");
     if !Path::new(&apps_path).exists() {
-        run_cmd("bcachefs", &["subvolume", "create", &apps_path]).await
+        run_cmd("bcachefs", &["subvolume", "create", &apps_path])
+            .await
             .map_err(|e| AppsError::CommandFailed(format!("create apps subvolume: {e}")))?;
         info!("Created apps subvolume at {apps_path}");
     }
 
     let docker_data = format!("{apps_path}/docker");
-    tokio::fs::create_dir_all(&docker_data).await
+    tokio::fs::create_dir_all(&docker_data)
+        .await
         .map_err(|e| AppsError::CommandFailed(format!("create {docker_data}: {e}")))?;
 
     let docker_lib = Path::new("/var/lib/docker");
 
     // If /var/lib/docker is already a symlink to the right place, nothing to do
-    if let Ok(target) = tokio::fs::read_link(docker_lib).await {
-        if target.to_string_lossy() == docker_data {
-            info!("Docker data symlink already points to {docker_data}");
-            return Ok(());
-        }
+    if let Ok(target) = tokio::fs::read_link(docker_lib).await
+        && target.to_string_lossy() == docker_data
+    {
+        info!("Docker data symlink already points to {docker_data}");
+        return Ok(());
     }
 
     // Stop Docker if running (we need to move/replace its data dir)
@@ -2237,17 +2435,22 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
     // Remove existing /var/lib/docker (empty default dir or old data)
     if docker_lib.exists() {
         if docker_lib.is_symlink() {
-            tokio::fs::remove_file(docker_lib).await
+            tokio::fs::remove_file(docker_lib)
+                .await
                 .map_err(|e| AppsError::CommandFailed(format!("remove old symlink: {e}")))?;
         } else {
-            tokio::fs::remove_dir_all(docker_lib).await
+            tokio::fs::remove_dir_all(docker_lib)
+                .await
                 .map_err(|e| AppsError::CommandFailed(format!("remove /var/lib/docker: {e}")))?;
         }
     }
 
     // Create symlink
-    tokio::fs::symlink(&docker_data, docker_lib).await
-        .map_err(|e| AppsError::CommandFailed(format!("symlink {docker_data} -> /var/lib/docker: {e}")))?;
+    tokio::fs::symlink(&docker_data, docker_lib)
+        .await
+        .map_err(|e| {
+            AppsError::CommandFailed(format!("symlink {docker_data} -> /var/lib/docker: {e}"))
+        })?;
 
     info!("Symlinked /var/lib/docker -> {docker_data}");
     Ok(())
@@ -2349,24 +2552,24 @@ async fn inspect_image_ports(image: &str) -> Result<Vec<AppPort>, String> {
     if let Some(exposed_ports) = exposed {
         for (key, _) in exposed_ports {
             let parts: Vec<&str> = key.split('/').collect();
-            if let Some(port_str) = parts.first() {
-                if let Ok(port) = port_str.parse::<u16>() {
-                    let protocol = parts
-                        .get(1)
-                        .map(|p| p.to_uppercase())
-                        .unwrap_or_else(|| "TCP".to_string());
-                    let name = if ports.is_empty() {
-                        "http".to_string()
-                    } else {
-                        format!("port-{}", ports.len())
-                    };
-                    ports.push(AppPort {
-                        name,
-                        container_port: port,
-                        host_port: None,
-                        protocol,
-                    });
-                }
+            if let Some(port_str) = parts.first()
+                && let Ok(port) = port_str.parse::<u16>()
+            {
+                let protocol = parts
+                    .get(1)
+                    .map(|p| p.to_uppercase())
+                    .unwrap_or_else(|| "TCP".to_string());
+                let name = if ports.is_empty() {
+                    "http".to_string()
+                } else {
+                    format!("port-{}", ports.len())
+                };
+                ports.push(AppPort {
+                    name,
+                    container_port: port,
+                    host_port: None,
+                    protocol,
+                });
             }
         }
     }
@@ -2377,7 +2580,7 @@ async fn inspect_image_ports(image: &str) -> Result<Vec<AppPort>, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_simple_volumes, AppVolume};
+    use super::{AppVolume, validate_simple_volumes};
 
     fn vol(host_path: &str) -> AppVolume {
         AppVolume {
@@ -2395,32 +2598,43 @@ mod tests {
 
     #[test]
     fn strict_allows_app_data_dir_and_fs() {
-        validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[
-            vol("/var/lib/nasty/apps-data/myapp/cfg"),
-            vol("/fs/photos"),
-        ], false).unwrap();
+        validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/var/lib/nasty/apps-data/myapp/cfg"), vol("/fs/photos")],
+            false,
+        )
+        .unwrap();
     }
 
     #[test]
     fn strict_rejects_outside_allowlist() {
-        let e = validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[vol("/home/user/data")], false)
-            .unwrap_err()
-            .to_string();
+        let e = validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/home/user/data")],
+            false,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(e.contains("/home/user/data"), "{e}");
     }
 
     #[test]
     fn strict_rejects_etc() {
-        validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[vol("/etc")], false).unwrap_err();
+        validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[vol("/etc")], false)
+            .unwrap_err();
     }
 
     #[test]
     fn unsafe_allows_arbitrary_paths() {
-        validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[
-            vol("/etc"),
-            vol("/home/user/data"),
-            vol("/dev/shm"),
-        ], true).unwrap();
+        validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/etc"), vol("/home/user/data"), vol("/dev/shm")],
+            true,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -2433,25 +2647,39 @@ mod tests {
 
     #[test]
     fn unsafe_still_rejects_dotdot() {
-        let e = validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[vol("/var/lib/nasty/apps-data/myapp/../auth.json")], true)
-            .unwrap_err()
-            .to_string();
+        let e = validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/var/lib/nasty/apps-data/myapp/../auth.json")],
+            true,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(e.contains(".."), "{e}");
     }
 
     #[test]
     fn unsafe_still_rejects_engine_state() {
-        let e = validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[vol("/var/lib/nasty/auth.json")], true)
-            .unwrap_err()
-            .to_string();
+        let e = validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/var/lib/nasty/auth.json")],
+            true,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(e.contains("engine state"), "{e}");
     }
 
     #[test]
     fn unsafe_still_allows_app_data_under_engine_state() {
         // app-data dir is /var/lib/nasty/apps-data/<name> and is the deliberate exception.
-        validate_simple_volumes("myapp", "/var/lib/nasty/apps-data", &[
-            vol("/var/lib/nasty/apps-data/myapp/foo"),
-        ], true).unwrap();
+        validate_simple_volumes(
+            "myapp",
+            "/var/lib/nasty/apps-data",
+            &[vol("/var/lib/nasty/apps-data/myapp/foo")],
+            true,
+        )
+        .unwrap();
     }
 }

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -5,10 +5,9 @@
 
 use rustic_backend::BackendOptions;
 use rustic_core::{
+    BackupOptions, CheckOptions, ConfigOptions, Credentials, ForgetGroups, Grouped, KeepOptions,
+    KeyOptions, PathList, Repository, RepositoryOptions, SnapshotGroupCriterion, SnapshotOptions,
     repofile::SnapshotFile,
-    BackupOptions, CheckOptions, ConfigOptions, Credentials, ForgetGroups, Grouped,
-    KeyOptions, KeepOptions, PathList, Repository, RepositoryOptions,
-    SnapshotGroupCriterion, SnapshotOptions,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -39,56 +38,96 @@ pub struct BackupProfile {
     pub last_run: Option<BackupRunResult>,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BackupTarget {
-    Local { path: String },
+    Local {
+        path: String,
+    },
     S3 {
-        endpoint: String, bucket: String,
-        access_key: String, secret_key: String,
-        #[serde(default)] region: Option<String>,
+        endpoint: String,
+        bucket: String,
+        access_key: String,
+        secret_key: String,
+        #[serde(default)]
+        region: Option<String>,
     },
     Sftp {
-        host: String, user: String, path: String,
-        #[serde(default)] port: Option<u16>,
+        host: String,
+        user: String,
+        path: String,
+        #[serde(default)]
+        port: Option<u16>,
     },
-    Rest { url: String },
-    B2 { bucket: String, account_id: String, account_key: String },
+    Rest {
+        url: String,
+    },
+    B2 {
+        bucket: String,
+        account_id: String,
+        account_key: String,
+    },
 }
 
 impl BackupTarget {
     fn to_backend_options(&self) -> BackendOptions {
         match self {
-            BackupTarget::Local { path } => {
-                BackendOptions::default().repository(path)
-            }
-            BackupTarget::S3 { endpoint, bucket, access_key, secret_key, region } => {
+            BackupTarget::Local { path } => BackendOptions::default().repository(path),
+            BackupTarget::S3 {
+                endpoint,
+                bucket,
+                access_key,
+                secret_key,
+                region,
+            } => {
                 let mut opts = BTreeMap::new();
                 opts.insert("bucket".into(), bucket.clone());
                 opts.insert("endpoint".into(), endpoint.clone());
                 opts.insert("access_key_id".into(), access_key.clone());
                 opts.insert("secret_access_key".into(), secret_key.clone());
-                if let Some(r) = region { opts.insert("region".into(), r.clone()); }
-                BackendOptions::default().repository("opendal:s3").options(opts)
+                if let Some(r) = region {
+                    opts.insert("region".into(), r.clone());
+                }
+                BackendOptions::default()
+                    .repository("opendal:s3")
+                    .options(opts)
             }
-            BackupTarget::Sftp { host, user, path, port } => {
+            BackupTarget::Sftp {
+                host,
+                user,
+                path,
+                port,
+            } => {
                 let mut opts = BTreeMap::new();
-                opts.insert("endpoint".into(), format!("{}:{}", host, port.unwrap_or(22)));
+                opts.insert(
+                    "endpoint".into(),
+                    format!("{}:{}", host, port.unwrap_or(22)),
+                );
                 opts.insert("user".into(), user.clone());
                 opts.insert("root".into(), path.clone());
-                BackendOptions::default().repository("opendal:sftp").options(opts)
+                BackendOptions::default()
+                    .repository("opendal:sftp")
+                    .options(opts)
             }
             BackupTarget::Rest { url } => {
-                BackendOptions::default().repository(&format!("rest:{url}"))
+                BackendOptions::default().repository(format!("rest:{url}"))
             }
-            BackupTarget::B2 { bucket, account_id, account_key } => {
+            BackupTarget::B2 {
+                bucket,
+                account_id,
+                account_key,
+            } => {
                 let mut opts = BTreeMap::new();
                 opts.insert("bucket".into(), bucket.clone());
                 opts.insert("account_id".into(), account_id.clone());
                 opts.insert("account_key".into(), account_key.clone());
-                BackendOptions::default().repository("opendal:b2").options(opts)
+                BackendOptions::default()
+                    .repository("opendal:b2")
+                    .options(opts)
             }
         }
     }
@@ -96,11 +135,16 @@ impl BackupTarget {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct RetentionPolicy {
-    #[serde(default)] pub keep_last: Option<u32>,
-    #[serde(default)] pub keep_daily: Option<u32>,
-    #[serde(default)] pub keep_weekly: Option<u32>,
-    #[serde(default)] pub keep_monthly: Option<u32>,
-    #[serde(default)] pub keep_yearly: Option<u32>,
+    #[serde(default)]
+    pub keep_last: Option<u32>,
+    #[serde(default)]
+    pub keep_daily: Option<u32>,
+    #[serde(default)]
+    pub keep_weekly: Option<u32>,
+    #[serde(default)]
+    pub keep_monthly: Option<u32>,
+    #[serde(default)]
+    pub keep_yearly: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -145,18 +189,22 @@ pub enum BackupError {
 }
 
 impl BackupError {
-    pub fn to_rpc_error(&self) -> String { self.to_string() }
+    pub fn to_rpc_error(&self) -> String {
+        self.to_string()
+    }
 }
 
 // ── Repository helpers ────────────────────────────────────────
 
 /// Build a Repository from a profile's target and password.
 fn make_repo(profile: &BackupProfile) -> Result<Repository<()>, BackupError> {
-    let backends = profile.target.to_backend_options().to_backends()
+    let backends = profile
+        .target
+        .to_backend_options()
+        .to_backends()
         .map_err(|e| BackupError::Failed(format!("backend: {e}")))?;
     let repo_opts = RepositoryOptions::default();
-    Repository::new(&repo_opts, &backends)
-        .map_err(|e| BackupError::Failed(format!("repo: {e}")))
+    Repository::new(&repo_opts, &backends).map_err(|e| BackupError::Failed(format!("repo: {e}")))
 }
 
 fn creds(password: &str) -> Credentials {
@@ -170,6 +218,12 @@ pub struct BackupService {
     running: std::sync::Arc<tokio::sync::Mutex<Option<String>>>,
 }
 
+impl Default for BackupService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BackupService {
     pub fn new() -> Self {
         Self {
@@ -179,7 +233,10 @@ impl BackupService {
     }
 
     pub fn clone_for_task(&self) -> Self {
-        Self { profiles: self.profiles.clone(), running: self.running.clone() }
+        Self {
+            profiles: self.profiles.clone(),
+            running: self.running.clone(),
+        }
     }
 
     pub async fn list_profiles(&self) -> Vec<BackupProfile> {
@@ -187,14 +244,24 @@ impl BackupService {
     }
 
     pub async fn get_profile(&self, id: &str) -> Result<BackupProfile, BackupError> {
-        self.profiles.lock().await.iter()
-            .find(|p| p.id == id).cloned()
+        self.profiles
+            .lock()
+            .await
+            .iter()
+            .find(|p| p.id == id)
+            .cloned()
             .ok_or_else(|| BackupError::NotFound(id.into()))
     }
 
-    pub async fn create_profile(&self, mut profile: BackupProfile) -> Result<BackupProfile, BackupError> {
+    pub async fn create_profile(
+        &self,
+        mut profile: BackupProfile,
+    ) -> Result<BackupProfile, BackupError> {
         let mut profiles = self.profiles.lock().await;
-        if profiles.iter().any(|p| p.id == profile.id || p.name == profile.name) {
+        if profiles
+            .iter()
+            .any(|p| p.id == profile.id || p.name == profile.name)
+        {
             return Err(BackupError::AlreadyExists(profile.name));
         }
         if profile.id.is_empty() {
@@ -206,9 +273,15 @@ impl BackupService {
         Ok(profile)
     }
 
-    pub async fn update_profile(&self, id: &str, update: BackupProfile) -> Result<BackupProfile, BackupError> {
+    pub async fn update_profile(
+        &self,
+        id: &str,
+        update: BackupProfile,
+    ) -> Result<BackupProfile, BackupError> {
         let mut profiles = self.profiles.lock().await;
-        let idx = profiles.iter().position(|p| p.id == id)
+        let idx = profiles
+            .iter()
+            .position(|p| p.id == id)
             .ok_or_else(|| BackupError::NotFound(id.into()))?;
         profiles[idx] = update.clone();
         save_profiles(&profiles).await;
@@ -219,7 +292,9 @@ impl BackupService {
         let mut profiles = self.profiles.lock().await;
         let len = profiles.len();
         profiles.retain(|p| p.id != id);
-        if profiles.len() == len { return Err(BackupError::NotFound(id.into())); }
+        if profiles.len() == len {
+            return Err(BackupError::NotFound(id.into()));
+        }
         save_profiles(&profiles).await;
         info!("Deleted backup profile '{id}'");
         Ok(())
@@ -227,17 +302,27 @@ impl BackupService {
 
     pub async fn status(&self) -> BackupStatus {
         let running_id = self.running.lock().await.clone();
-        BackupStatus { running: running_id.is_some(), profile_id: running_id, progress: None }
+        BackupStatus {
+            running: running_id.is_some(),
+            profile_id: running_id,
+            progress: None,
+        }
     }
 
     pub async fn init_repo(&self, id: &str) -> Result<String, BackupError> {
         let profile = self.get_profile(id).await?;
         tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile)?;
-            repo.init(&creds(&profile.password), &KeyOptions::default(), &ConfigOptions::default())
-                .map_err(|e| BackupError::Failed(format!("init: {e}")))?;
+            repo.init(
+                &creds(&profile.password),
+                &KeyOptions::default(),
+                &ConfigOptions::default(),
+            )
+            .map_err(|e| BackupError::Failed(format!("init: {e}")))?;
             Ok::<_, BackupError>(())
-        }).await.map_err(|e| BackupError::Failed(format!("spawn: {e}")))??;
+        })
+        .await
+        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))??;
 
         let mut profiles = self.profiles.lock().await;
         if let Some(p) = profiles.iter_mut().find(|p| p.id == id) {
@@ -253,7 +338,10 @@ impl BackupService {
 
         // Auto-init repo if not yet initialized
         if !profile.repo_initialized {
-            info!("Auto-initializing backup repo for profile '{}'", profile.name);
+            info!(
+                "Auto-initializing backup repo for profile '{}'",
+                profile.name
+            );
             self.init_repo(id).await?;
         }
 
@@ -264,16 +352,20 @@ impl BackupService {
         let sources = profile.sources.clone();
         let backup_result = tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile)?;
-            let repo = repo.open(&creds(&profile.password))
+            let repo = repo
+                .open(&creds(&profile.password))
                 .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
-            let repo = repo.to_indexed_ids()
+            let repo = repo
+                .to_indexed_ids()
                 .map_err(|e| BackupError::Failed(format!("index: {e}")))?;
 
             let source = PathList::from_iter(sources.iter().map(|s| s.as_str()));
-            let snap = SnapshotOptions::default().to_snapshot()
+            let snap = SnapshotOptions::default()
+                .to_snapshot()
                 .map_err(|e| BackupError::Failed(format!("snapshot opts: {e}")))?;
 
-            let result = repo.backup(&BackupOptions::default(), &source, snap)
+            let result = repo
+                .backup(&BackupOptions::default(), &source, snap)
                 .map_err(|e| BackupError::Failed(format!("backup: {e}")))?;
 
             Ok::<_, BackupError>((
@@ -281,7 +373,9 @@ impl BackupService {
                 result.summary.as_ref().map(|s| s.files_new),
                 result.summary.as_ref().map(|s| s.files_changed),
             ))
-        }).await.map_err(|e| BackupError::Failed(format!("spawn: {e}")))?;
+        })
+        .await
+        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?;
 
         *self.running.lock().await = None;
         let duration = start.elapsed().as_secs();
@@ -292,14 +386,18 @@ impl BackupService {
                 success: true,
                 message: "Backup completed successfully".into(),
                 duration_secs: duration,
-                bytes_added, files_new, files_changed,
+                bytes_added,
+                files_new,
+                files_changed,
             },
             Err(e) => BackupRunResult {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 success: false,
                 message: format!("Backup failed: {e}"),
                 duration_secs: duration,
-                bytes_added: None, files_new: None, files_changed: None,
+                bytes_added: None,
+                files_new: None,
+                files_changed: None,
             },
         };
 
@@ -313,7 +411,9 @@ impl BackupService {
 
         if result.success {
             info!("Backup completed in {}s", duration);
-            if let Err(e) = self.prune(id).await { warn!("Auto-prune failed: {e}"); }
+            if let Err(e) = self.prune(id).await {
+                warn!("Auto-prune failed: {e}");
+            }
         } else {
             error!("Backup failed: {}", result.message);
         }
@@ -324,19 +424,26 @@ impl BackupService {
         let profile = self.get_profile(id).await?;
         tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile)?;
-            let repo = repo.open(&creds(&profile.password))
+            let repo = repo
+                .open(&creds(&profile.password))
                 .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
-            let snaps: Vec<SnapshotFile> = repo.get_all_snapshots()
+            let snaps: Vec<SnapshotFile> = repo
+                .get_all_snapshots()
                 .map_err(|e| BackupError::Failed(format!("snapshots: {e}")))?;
 
-            Ok(snaps.into_iter().map(|s| BackupSnapshot {
-                id: s.id.to_hex().to_string(),
-                time: s.time.to_string(),
-                hostname: s.hostname.clone(),
-                paths: s.paths.iter().map(|p| p.to_string()).collect(),
-                tags: s.tags.iter().map(|t| t.to_string()).collect(),
-            }).collect())
-        }).await.map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
+            Ok(snaps
+                .into_iter()
+                .map(|s| BackupSnapshot {
+                    id: s.id.to_hex().to_string(),
+                    time: s.time.to_string(),
+                    hostname: s.hostname.clone(),
+                    paths: s.paths.iter().map(|p| p.to_string()).collect(),
+                    tags: s.tags.iter().map(|t| t.to_string()).collect(),
+                })
+                .collect())
+        })
+        .await
+        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
     }
 
     async fn prune(&self, id: &str) -> Result<(), BackupError> {
@@ -345,18 +452,30 @@ impl BackupService {
 
         tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile)?;
-            let repo = repo.open(&creds(&profile.password))
+            let repo = repo
+                .open(&creds(&profile.password))
                 .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
 
-            let snaps = repo.get_all_snapshots()
+            let snaps = repo
+                .get_all_snapshots()
                 .map_err(|e| BackupError::Failed(format!("get snapshots: {e}")))?;
 
             let mut keep = KeepOptions::default();
-            if let Some(n) = r.keep_last { keep = keep.keep_last(n as i32); }
-            if let Some(n) = r.keep_daily { keep = keep.keep_daily(n as i32); }
-            if let Some(n) = r.keep_weekly { keep = keep.keep_weekly(n as i32); }
-            if let Some(n) = r.keep_monthly { keep = keep.keep_monthly(n as i32); }
-            if let Some(n) = r.keep_yearly { keep = keep.keep_yearly(n as i32); }
+            if let Some(n) = r.keep_last {
+                keep = keep.keep_last(n as i32);
+            }
+            if let Some(n) = r.keep_daily {
+                keep = keep.keep_daily(n as i32);
+            }
+            if let Some(n) = r.keep_weekly {
+                keep = keep.keep_weekly(n as i32);
+            }
+            if let Some(n) = r.keep_monthly {
+                keep = keep.keep_monthly(n as i32);
+            }
+            if let Some(n) = r.keep_yearly {
+                keep = keep.keep_yearly(n as i32);
+            }
 
             let criterion = SnapshotGroupCriterion::default();
             let grouped = Grouped::from_items(snaps, criterion);
@@ -371,7 +490,9 @@ impl BackupService {
                     .map_err(|e| BackupError::Failed(format!("delete: {e}")))?;
             }
             Ok::<_, BackupError>(())
-        }).await.map_err(|e| BackupError::Failed(format!("spawn: {e}")))??;
+        })
+        .await
+        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))??;
         Ok(())
     }
 
@@ -379,12 +500,15 @@ impl BackupService {
         let profile = self.get_profile(id).await?;
         tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile)?;
-            let repo = repo.open(&creds(&profile.password))
+            let repo = repo
+                .open(&creds(&profile.password))
                 .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
             repo.check(CheckOptions::default())
                 .map_err(|e| BackupError::Failed(format!("check: {e}")))?;
             Ok("Repository check passed".to_string())
-        }).await.map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
+        })
+        .await
+        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
     }
 }
 
@@ -405,7 +529,9 @@ async fn save_profiles(profiles: &[BackupProfile]) {
             return;
         }
         // Contains S3/B2/SFTP credentials and the repo passphrase.
-        if let Err(e) = tokio::fs::set_permissions(STATE_PATH, std::fs::Permissions::from_mode(0o600)).await {
+        if let Err(e) =
+            tokio::fs::set_permissions(STATE_PATH, std::fs::Permissions::from_mode(0o600)).await
+        {
             error!("Failed to chmod backup profiles: {e}");
         }
     }

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -2,5 +2,5 @@ pub mod jsonrpc;
 pub mod metrics_types;
 pub mod state;
 
-pub use jsonrpc::{Request, Response, Notification, Error as RpcError, ErrorCode};
+pub use jsonrpc::{Error as RpcError, ErrorCode, Notification, Request, Response};
 pub use state::{HasId, StateDir};

--- a/engine/nasty-common/src/state.rs
+++ b/engine/nasty-common/src/state.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// A directory-based state store where each item is a separate JSON file.
 pub struct StateDir {
@@ -59,8 +59,7 @@ impl StateDir {
     pub async fn save<T: Serialize>(&self, id: &str, item: &T) -> std::io::Result<()> {
         tokio::fs::create_dir_all(&self.dir).await?;
 
-        let json = serde_json::to_string_pretty(item)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let json = serde_json::to_string_pretty(item).map_err(std::io::Error::other)?;
 
         let final_path = self.item_path(id);
         let tmp_path = self.dir.join(format!(".{id}.tmp"));

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -91,8 +91,12 @@ impl DeployMessage {
     }
 }
 
-async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: String, pre_auth_token: Option<String>) {
-
+async fn handle_deploy(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_ip: String,
+    pre_auth_token: Option<String>,
+) {
     // Wait for deploy request (first message must contain params; token is
     // optional now that the upgrade may have carried a session cookie).
     let req: DeployRequest = match socket.recv().await {
@@ -100,7 +104,9 @@ async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
             Ok(r) => r,
             Err(e) => {
                 let _ = socket
-                    .send(Message::Text(DeployMessage::error(&format!("invalid request: {e}")).into()))
+                    .send(Message::Text(
+                        DeployMessage::error(&format!("invalid request: {e}")).into(),
+                    ))
                     .await;
                 return;
             }
@@ -112,7 +118,9 @@ async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
         Some(t) => t,
         None => {
             let _ = socket
-                .send(Message::Text(DeployMessage::error("missing session").into()))
+                .send(Message::Text(
+                    DeployMessage::error("missing session").into(),
+                ))
                 .await;
             return;
         }
@@ -123,9 +131,16 @@ async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
     match state.auth.validate(&token, &client_ip).await {
         Ok(s) if s.role == crate::auth::Role::Admin => {}
         Ok(s) => {
-            crate::auth::audit("app_deploy_denied", &s.username, &client_ip, &format!("role={:?}", s.role));
+            crate::auth::audit(
+                "app_deploy_denied",
+                &s.username,
+                &client_ip,
+                &format!("role={:?}", s.role),
+            );
             let _ = socket
-                .send(Message::Text(DeployMessage::error("forbidden: admin role required").into()))
+                .send(Message::Text(
+                    DeployMessage::error("forbidden: admin role required").into(),
+                ))
                 .await;
             return;
         }
@@ -137,7 +152,10 @@ async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
         }
     }
 
-    info!("Deploy stream started for '{}' (kind: {})", req.name, req.kind);
+    info!(
+        "Deploy stream started for '{}' (kind: {})",
+        req.name, req.kind
+    );
 
     match req.kind.as_str() {
         "simple" => deploy_simple(&mut socket, &state, &req).await,
@@ -145,40 +163,63 @@ async fn handle_deploy(mut socket: WebSocket, state: Arc<AppState>, client_ip: S
         "pull" => deploy_pull(&mut socket, &state, &req).await,
         _ => {
             let _ = socket
-                .send(Message::Text(DeployMessage::error("unknown deploy kind").into()))
+                .send(Message::Text(
+                    DeployMessage::error("unknown deploy kind").into(),
+                ))
                 .await;
         }
     }
 }
 
 async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployRequest) {
-
     let image = match &req.image {
         Some(img) => img.clone(),
         None => {
-            let _ = socket.send(Message::Text(DeployMessage::error("missing image").into())).await;
+            let _ = socket
+                .send(Message::Text(DeployMessage::error("missing image").into()))
+                .await;
             return;
         }
     };
 
     // Step 1: Pull image via bollard with structured progress
-    let _ = socket.send(Message::Text(DeployMessage::log(&format!("Pulling image: {image}")).into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log(&format!("Pulling image: {image}")).into(),
+        ))
+        .await;
 
-    if let Err(e) = pull_image_with_progress(socket, &state, &image).await {
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("pull failed: {e}")).into())).await;
+    if let Err(e) = pull_image_with_progress(socket, state, &image).await {
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("pull failed: {e}")).into(),
+            ))
+            .await;
         return;
     }
 
-    let _ = socket.send(Message::Text(DeployMessage::log("Image pulled successfully").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log("Image pulled successfully").into(),
+        ))
+        .await;
 
     // Step 2: Install via the engine's install method
-    let _ = socket.send(Message::Text(DeployMessage::log("Creating container...").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log("Creating container...").into(),
+        ))
+        .await;
 
     let install_params = req.install_params.clone().unwrap_or(serde_json::json!({}));
     let mut params: nasty_apps::InstallAppRequest = match serde_json::from_value(install_params) {
         Ok(p) => p,
         Err(e) => {
-            let _ = socket.send(Message::Text(DeployMessage::error(&format!("invalid params: {e}")).into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::error(&format!("invalid params: {e}")).into(),
+                ))
+                .await;
             return;
         }
     };
@@ -204,21 +245,32 @@ async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployReq
 
     match state.apps.install(params).await {
         Ok(app) => {
-            let _ = socket.send(Message::Text(DeployMessage::log(&format!("Container '{}' started", app.name)).into())).await;
-            let _ = socket.send(Message::Text(DeployMessage::done("ok").into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::log(&format!("Container '{}' started", app.name)).into(),
+                ))
+                .await;
+            let _ = socket
+                .send(Message::Text(DeployMessage::done("ok").into()))
+                .await;
         }
         Err(e) => {
-            let _ = socket.send(Message::Text(DeployMessage::error(&e.to_string()).into())).await;
+            let _ = socket
+                .send(Message::Text(DeployMessage::error(&e.to_string()).into()))
+                .await;
         }
     }
 }
 
 async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRequest) {
-
     let compose_content = match &req.compose_file {
         Some(c) => c.clone(),
         None => {
-            let _ = socket.send(Message::Text(DeployMessage::error("missing compose_file").into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::error("missing compose_file").into(),
+                ))
+                .await;
             return;
         }
     };
@@ -229,7 +281,11 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
     // secret on the host. allow_unsafe relaxes most checks but never permits
     // bind-mounting the engine's state dir or the host root.
     if let Err(e) = validate_compose(&compose_content, &req.name, req.allow_unsafe) {
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("compose rejected: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("compose rejected: {e}")).into(),
+            ))
+            .await;
         return;
     }
 
@@ -241,9 +297,12 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
             &format!("app={}", req.name),
         );
         let _ = socket
-            .send(Message::Text(DeployMessage::log(
-                "WARNING: deploying with allow_unsafe — container has elevated privileges",
-            ).into()))
+            .send(Message::Text(
+                DeployMessage::log(
+                    "WARNING: deploying with allow_unsafe — container has elevated privileges",
+                )
+                .into(),
+            ))
             .await;
     }
 
@@ -255,17 +314,29 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
 
     // Write compose file
     if let Err(e) = tokio::fs::create_dir_all(&compose_dir).await {
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("failed to create dir: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("failed to create dir: {e}")).into(),
+            ))
+            .await;
         return;
     }
     if let Err(e) = tokio::fs::write(&compose_path, &compose_content).await {
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("failed to write compose file: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("failed to write compose file: {e}")).into(),
+            ))
+            .await;
         return;
     }
     // Persist the unsafe flag next to the compose file so list/get can surface
     // it. Marker is the presence of `allow_unsafe: true` in the JSON file.
     if let Err(e) = write_app_meta(&compose_dir, req.allow_unsafe).await {
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("failed to write app meta: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("failed to write app meta: {e}")).into(),
+            ))
+            .await;
         return;
     }
 
@@ -274,104 +345,201 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
     let _ = tokio::fs::write(format!("{}/.env", compose_dir), &env_content).await;
 
     // Validate
-    let _ = socket.send(Message::Text(DeployMessage::log("Validating compose file...").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log("Validating compose file...").into(),
+        ))
+        .await;
     if let Err(e) = stream_command(
         socket,
         "docker",
         &["compose", "-f", &compose_path, "config", "--quiet"],
-    ).await {
+    )
+    .await
+    {
         if !is_update {
             let _ = tokio::fs::remove_dir_all(&compose_dir).await;
         }
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("invalid compose file: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("invalid compose file: {e}")).into(),
+            ))
+            .await;
         return;
     }
 
     // Pull images via bollard (parse compose YAML for image refs)
-    let _ = socket.send(Message::Text(DeployMessage::log("Pulling images...").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log("Pulling images...").into(),
+        ))
+        .await;
     let images = extract_compose_images(&compose_content);
     if images.is_empty() {
-        let _ = socket.send(Message::Text(DeployMessage::log("No images to pull (all built locally?)").into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log("No images to pull (all built locally?)").into(),
+            ))
+            .await;
     } else {
         for image in &images {
-            let _ = socket.send(Message::Text(DeployMessage::log(&format!("Pulling: {image}")).into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::log(&format!("Pulling: {image}")).into(),
+                ))
+                .await;
             if let Err(e) = pull_image_with_progress(socket, state, image).await {
                 if !is_update {
                     let _ = tokio::fs::remove_dir_all(&compose_dir).await;
                 }
-                let _ = socket.send(Message::Text(DeployMessage::error(&format!("pull failed for {image}: {e}")).into())).await;
+                let _ = socket
+                    .send(Message::Text(
+                        DeployMessage::error(&format!("pull failed for {image}: {e}")).into(),
+                    ))
+                    .await;
                 return;
             }
         }
     }
 
     // Start containers
-    let _ = socket.send(Message::Text(DeployMessage::log("Starting containers...").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log("Starting containers...").into(),
+        ))
+        .await;
     let mut args = vec![
-        "compose", "-f", &compose_path, "--project-name", &req.name,
-        "up", "-d", "--no-build",
+        "compose",
+        "-f",
+        &compose_path,
+        "--project-name",
+        &req.name,
+        "up",
+        "-d",
+        "--no-build",
     ];
     if is_update {
         args.push("--remove-orphans");
     }
     if let Err(e) = stream_command(socket, "docker", &args).await {
         // Clean up partially created containers before removing the compose dir
-        let _ = socket.send(Message::Text(DeployMessage::log("Cleaning up failed deployment...").into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log("Cleaning up failed deployment...").into(),
+            ))
+            .await;
         let _ = Command::new("docker")
-            .args(["compose", "-f", &compose_path, "--project-name", &req.name, "down", "-v", "--remove-orphans"])
+            .args([
+                "compose",
+                "-f",
+                &compose_path,
+                "--project-name",
+                &req.name,
+                "down",
+                "-v",
+                "--remove-orphans",
+            ])
             .output()
             .await;
         if !is_update {
             let _ = tokio::fs::remove_dir_all(&compose_dir).await;
         }
-        let _ = socket.send(Message::Text(DeployMessage::error(&format!("deploy failed: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::error(&format!("deploy failed: {e}")).into(),
+            ))
+            .await;
         return;
     }
 
     // Auto-ingress for first exposed port
-    if let Ok(app) = state.apps.get(&req.name).await {
-        if let Some(first_port) = app.ports.first() {
-            let _ = state.apps.ingress_set(nasty_apps::SetIngressRequest {
+    if let Ok(app) = state.apps.get(&req.name).await
+        && let Some(first_port) = app.ports.first()
+    {
+        let _ = state
+            .apps
+            .ingress_set(nasty_apps::SetIngressRequest {
                 name: req.name.clone(),
                 host_port: first_port.host_port,
-            }).await;
-        }
+            })
+            .await;
     }
 
     let action = if is_update { "updated" } else { "deployed" };
-    let _ = socket.send(Message::Text(DeployMessage::log(&format!("Compose app '{}' {action} successfully", req.name)).into())).await;
-    let _ = socket.send(Message::Text(DeployMessage::done("ok").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log(&format!("Compose app '{}' {action} successfully", req.name)).into(),
+        ))
+        .await;
+    let _ = socket
+        .send(Message::Text(DeployMessage::done("ok").into()))
+        .await;
 }
 
 async fn deploy_pull(socket: &mut WebSocket, state: &AppState, req: &DeployRequest) {
-
     let compose_path = format!("/var/lib/nasty/apps/{}/docker-compose.yml", req.name);
 
     if std::path::Path::new(&compose_path).exists() {
         // Compose app: pull via bollard + recreate
-        let _ = socket.send(Message::Text(DeployMessage::log("Pulling latest images...").into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log("Pulling latest images...").into(),
+            ))
+            .await;
         let compose_content = match tokio::fs::read_to_string(&compose_path).await {
             Ok(c) => c,
             Err(e) => {
-                let _ = socket.send(Message::Text(DeployMessage::error(&format!("read compose file: {e}")).into())).await;
+                let _ = socket
+                    .send(Message::Text(
+                        DeployMessage::error(&format!("read compose file: {e}")).into(),
+                    ))
+                    .await;
                 return;
             }
         };
         for image in extract_compose_images(&compose_content) {
-            let _ = socket.send(Message::Text(DeployMessage::log(&format!("Pulling: {image}")).into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::log(&format!("Pulling: {image}")).into(),
+                ))
+                .await;
             if let Err(e) = pull_image_with_progress(socket, state, &image).await {
-                let _ = socket.send(Message::Text(DeployMessage::error(&format!("pull failed for {image}: {e}")).into())).await;
+                let _ = socket
+                    .send(Message::Text(
+                        DeployMessage::error(&format!("pull failed for {image}: {e}")).into(),
+                    ))
+                    .await;
                 return;
             }
         }
 
-        let _ = socket.send(Message::Text(DeployMessage::log("Recreating containers...").into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log("Recreating containers...").into(),
+            ))
+            .await;
         if let Err(e) = stream_command(
-            socket, "docker",
-            &["compose", "-f", &compose_path, "--project-name", &req.name,
-              "up", "-d", "--no-build", "--remove-orphans"],
-        ).await {
-            let _ = socket.send(Message::Text(DeployMessage::error(&format!("recreate failed: {e}")).into())).await;
+            socket,
+            "docker",
+            &[
+                "compose",
+                "-f",
+                &compose_path,
+                "--project-name",
+                &req.name,
+                "up",
+                "-d",
+                "--no-build",
+                "--remove-orphans",
+            ],
+        )
+        .await
+        {
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::error(&format!("recreate failed: {e}")).into(),
+                ))
+                .await;
             return;
         }
     } else {
@@ -383,42 +551,59 @@ async fn deploy_pull(socket: &mut WebSocket, state: &AppState, req: &DeployReque
                 match state.apps.get_config(&req.name).await {
                     Ok(config) => config.image,
                     Err(e) => {
-                        let _ = socket.send(Message::Text(DeployMessage::error(&e.to_string()).into())).await;
+                        let _ = socket
+                            .send(Message::Text(DeployMessage::error(&e.to_string()).into()))
+                            .await;
                         return;
                     }
                 }
             }
         };
 
-        let _ = socket.send(Message::Text(DeployMessage::log(&format!("Pulling image: {image}")).into())).await;
-        if let Err(e) = pull_image_with_progress(socket, &state, &image).await {
-            let _ = socket.send(Message::Text(DeployMessage::error(&format!("pull failed: {e}")).into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log(&format!("Pulling image: {image}")).into(),
+            ))
+            .await;
+        if let Err(e) = pull_image_with_progress(socket, state, &image).await {
+            let _ = socket
+                .send(Message::Text(
+                    DeployMessage::error(&format!("pull failed: {e}")).into(),
+                ))
+                .await;
             return;
         }
 
         // Recreate container
-        let _ = socket.send(Message::Text(DeployMessage::log("Recreating container...").into())).await;
+        let _ = socket
+            .send(Message::Text(
+                DeployMessage::log("Recreating container...").into(),
+            ))
+            .await;
         match state.apps.pull(&req.name).await {
             Ok(_) => {}
             Err(e) => {
-                let _ = socket.send(Message::Text(DeployMessage::error(&e.to_string()).into())).await;
+                let _ = socket
+                    .send(Message::Text(DeployMessage::error(&e.to_string()).into()))
+                    .await;
                 return;
             }
         }
     }
 
-    let _ = socket.send(Message::Text(DeployMessage::log(&format!("Image update complete for '{}'", req.name)).into())).await;
-    let _ = socket.send(Message::Text(DeployMessage::done("ok").into())).await;
+    let _ = socket
+        .send(Message::Text(
+            DeployMessage::log(&format!("Image update complete for '{}'", req.name)).into(),
+        ))
+        .await;
+    let _ = socket
+        .send(Message::Text(DeployMessage::done("ok").into()))
+        .await;
 }
 
 /// Run a command and stream its combined stdout+stderr line by line over the WebSocket.
 /// Returns Ok(()) if the command exits successfully, Err(message) otherwise.
-async fn stream_command(
-    socket: &mut WebSocket,
-    cmd: &str,
-    args: &[&str],
-) -> Result<(), String> {
-
+async fn stream_command(socket: &mut WebSocket, cmd: &str, args: &[&str]) -> Result<(), String> {
     let mut child = Command::new(cmd)
         .args(args)
         .stdout(std::process::Stdio::piped())
@@ -472,12 +657,16 @@ async fn stream_command(
     let status = child.wait().await.map_err(|e| e.to_string())?;
 
     if !status.success() {
-        let err_lines: Vec<_> = all_lines.iter()
+        let err_lines: Vec<_> = all_lines
+            .iter()
             .filter(|l| l.contains("Error") || l.contains("error") || l.contains("failed"))
             .cloned()
             .collect();
         return Err(if err_lines.is_empty() {
-            all_lines.last().cloned().unwrap_or_else(|| "command failed".to_string())
+            all_lines
+                .last()
+                .cloned()
+                .unwrap_or_else(|| "command failed".to_string())
         } else {
             err_lines.join("\n")
         });
@@ -505,7 +694,9 @@ async fn write_app_meta(app_dir: &str, allow_unsafe: bool) -> Result<(), String>
     }
     let meta = AppMeta { allow_unsafe };
     let json = serde_json::to_string(&meta).map_err(|e| e.to_string())?;
-    tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
+    tokio::fs::write(&path, json)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -517,19 +708,36 @@ async fn write_app_meta(app_dir: &str, allow_unsafe: bool) -> Result<(), String>
 /// CAP_DAC_READ_SEARCH/CAP_DAC_OVERRIDE bypass host filesystem permissions.
 /// CAP_MAC_ADMIN/_OVERRIDE bypass MAC (SELinux/AppArmor).
 const FORBIDDEN_CAPS: &[&str] = &[
-    "ALL", "SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE", "SYS_RAWIO", "SYS_BOOT",
-    "SYS_TIME", "NET_ADMIN", "DAC_READ_SEARCH", "DAC_OVERRIDE",
-    "MAC_ADMIN", "MAC_OVERRIDE", "AUDIT_CONTROL", "AUDIT_WRITE",
+    "ALL",
+    "SYS_ADMIN",
+    "SYS_PTRACE",
+    "SYS_MODULE",
+    "SYS_RAWIO",
+    "SYS_BOOT",
+    "SYS_TIME",
+    "NET_ADMIN",
+    "DAC_READ_SEARCH",
+    "DAC_OVERRIDE",
+    "MAC_ADMIN",
+    "MAC_OVERRIDE",
+    "AUDIT_CONTROL",
+    "AUDIT_WRITE",
 ];
 
 /// security_opt values that disable the default container sandbox layers.
 const FORBIDDEN_SECURITY_OPTS: &[&str] = &[
-    "seccomp=unconfined", "seccomp:unconfined",
-    "apparmor=unconfined", "apparmor:unconfined",
-    "label=disable", "label:disable",
-    "label=type:spc_t", "label:type:spc_t",
-    "no-new-privileges=false", "no-new-privileges:false",
-    "systempaths=unconfined", "systempaths:unconfined",
+    "seccomp=unconfined",
+    "seccomp:unconfined",
+    "apparmor=unconfined",
+    "apparmor:unconfined",
+    "label=disable",
+    "label:disable",
+    "label=type:spc_t",
+    "label:type:spc_t",
+    "no-new-privileges=false",
+    "no-new-privileges:false",
+    "systempaths=unconfined",
+    "systempaths:unconfined",
 ];
 
 /// Reasons a bind-mount source must be rejected outright, regardless of
@@ -548,10 +756,14 @@ enum BindReject {
 
 fn always_forbidden_bind(source: &str) -> Option<BindReject> {
     if source.contains("..") {
-        return Some(BindReject::Hard("'..' traversal is never allowed in bind sources"));
+        return Some(BindReject::Hard(
+            "'..' traversal is never allowed in bind sources",
+        ));
     }
     if source == "/" {
-        return Some(BindReject::Hard("'/' (host root) is never allowed as a bind source"));
+        return Some(BindReject::Hard(
+            "'/' (host root) is never allowed as a bind source",
+        ));
     }
     if source == "/var/lib/nasty" || source.starts_with("/var/lib/nasty/") {
         return Some(BindReject::EngineState);
@@ -573,8 +785,8 @@ fn always_forbidden_bind(source: &str) -> Option<BindReject> {
 /// stays on either way: nothing may bind-mount the engine's state dir, the
 /// root filesystem, or use `..` to escape.
 fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<(), String> {
-    let parsed: serde_json::Value = serde_yaml_ng::from_str(yaml)
-        .map_err(|e| format!("compose YAML failed to parse: {e}"))?;
+    let parsed: serde_json::Value =
+        serde_yaml_ng::from_str(yaml).map_err(|e| format!("compose YAML failed to parse: {e}"))?;
 
     let services = parsed
         .get("services")
@@ -588,7 +800,10 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
 
         if !allow_unsafe {
             if svc.get("privileged").and_then(|v| v.as_bool()) == Some(true) {
-                return Err(format!("{} sets privileged: true (host-root equivalent). Set allow_unsafe to override.", scope("privileged")));
+                return Err(format!(
+                    "{} sets privileged: true (host-root equivalent). Set allow_unsafe to override.",
+                    scope("privileged")
+                ));
             }
 
             for field in ["pid", "ipc", "uts", "userns_mode", "cgroup", "network_mode"] {
@@ -597,15 +812,19 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     if v_lower == "host" || v_lower.starts_with("host:") {
                         return Err(format!(
                             "{} = '{}' shares the host namespace. Set allow_unsafe to override.",
-                            scope(field), v
+                            scope(field),
+                            v
                         ));
                     }
                 }
             }
-            if let Some(v) = svc.get("ipc").and_then(|v| v.as_str()) {
-                if v.eq_ignore_ascii_case("shareable") {
-                    return Err(format!("{} = 'shareable' lets other containers attach. Set allow_unsafe to override.", scope("ipc")));
-                }
+            if let Some(v) = svc.get("ipc").and_then(|v| v.as_str())
+                && v.eq_ignore_ascii_case("shareable")
+            {
+                return Err(format!(
+                    "{} = 'shareable' lets other containers attach. Set allow_unsafe to override.",
+                    scope("ipc")
+                ));
             }
 
             if let Some(caps) = svc.get("cap_add").and_then(|v| v.as_array()) {
@@ -613,7 +832,11 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     if let Some(s) = c.as_str() {
                         let bare = s.strip_prefix("CAP_").unwrap_or(s).to_ascii_uppercase();
                         if FORBIDDEN_CAPS.contains(&bare.as_str()) {
-                            return Err(format!("{} includes '{}' — grants host-equivalent privilege. Set allow_unsafe to override.", scope("cap_add"), s));
+                            return Err(format!(
+                                "{} includes '{}' — grants host-equivalent privilege. Set allow_unsafe to override.",
+                                scope("cap_add"),
+                                s
+                            ));
                         }
                     }
                 }
@@ -624,20 +847,30 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     if let Some(s) = o.as_str() {
                         let normalized = s.replace(' ', "").to_ascii_lowercase();
                         if FORBIDDEN_SECURITY_OPTS.iter().any(|f| normalized == *f) {
-                            return Err(format!("{} includes '{}' — disables container sandbox. Set allow_unsafe to override.", scope("security_opt"), s));
+                            return Err(format!(
+                                "{} includes '{}' — disables container sandbox. Set allow_unsafe to override.",
+                                scope("security_opt"),
+                                s
+                            ));
                         }
                     }
                 }
             }
 
-            if let Some(devices) = svc.get("devices").and_then(|v| v.as_array()) {
-                if !devices.is_empty() {
-                    return Err(format!("{} maps host devices. Set allow_unsafe to override.", scope("devices")));
-                }
+            if let Some(devices) = svc.get("devices").and_then(|v| v.as_array())
+                && !devices.is_empty()
+            {
+                return Err(format!(
+                    "{} maps host devices. Set allow_unsafe to override.",
+                    scope("devices")
+                ));
             }
 
             if svc.get("device_cgroup_rules").is_some() {
-                return Err(format!("{} bypasses the device cgroup. Set allow_unsafe to override.", scope("device_cgroup_rules")));
+                return Err(format!(
+                    "{} bypasses the device cgroup. Set allow_unsafe to override.",
+                    scope("device_cgroup_rules")
+                ));
             }
         }
 
@@ -667,12 +900,13 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 }
 
                 // Named volume short-form ("data:/var/lib/foo") — no host path.
-                if !source.starts_with('/') && !source.starts_with('.') && !source.starts_with('~') {
+                if !source.starts_with('/') && !source.starts_with('.') && !source.starts_with('~')
+                {
                     continue;
                 }
 
-                let in_app_dir = source.starts_with(&format!("{allowed_app_dir}/"))
-                    || source == allowed_app_dir;
+                let in_app_dir =
+                    source.starts_with(&format!("{allowed_app_dir}/")) || source == allowed_app_dir;
 
                 match always_forbidden_bind(&source) {
                     Some(BindReject::Hard(why)) => {
@@ -694,9 +928,7 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 }
 
                 if !allow_unsafe {
-                    let allowed = in_app_dir
-                        || source.starts_with("/fs/")
-                        || source == "/fs";
+                    let allowed = in_app_dir || source.starts_with("/fs/") || source == "/fs";
                     if !allowed {
                         return Err(format!(
                             "{} bind-mounts '{}' — only paths under '{}/' or '/fs/' are allowed. Set allow_unsafe to override.",
@@ -719,7 +951,11 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 None => continue,
             };
             let is_bind = opts.get("type").and_then(|v| v.as_str()) == Some("none")
-                || opts.get("o").and_then(|v| v.as_str()).map(|s| s.contains("bind")).unwrap_or(false);
+                || opts
+                    .get("o")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.contains("bind"))
+                    .unwrap_or(false);
             if !is_bind {
                 continue;
             }
@@ -728,8 +964,8 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 continue;
             }
 
-            let in_app_dir = device.starts_with(&format!("{allowed_app_dir}/"))
-                || device == allowed_app_dir;
+            let in_app_dir =
+                device.starts_with(&format!("{allowed_app_dir}/")) || device == allowed_app_dir;
 
             match always_forbidden_bind(device) {
                 Some(BindReject::Hard(why)) => {
@@ -746,9 +982,7 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
             }
 
             if !allow_unsafe {
-                let allowed = in_app_dir
-                    || device.starts_with("/fs/")
-                    || device == "/fs";
+                let allowed = in_app_dir || device.starts_with("/fs/") || device == "/fs";
                 if !allowed {
                     return Err(format!(
                         "volumes.{vol_name} bind-mounts '{device}' — only paths under '{allowed_app_dir}/' or '/fs/' are allowed. Set allow_unsafe to override."
@@ -773,10 +1007,11 @@ fn extract_compose_images(yaml: &str) -> Vec<String> {
     let mut images = Vec::new();
     if let Some(services) = parsed.get("services").and_then(|s| s.as_object()) {
         for (_name, svc) in services {
-            if let Some(image) = svc.get("image").and_then(|i| i.as_str()) {
-                if !image.is_empty() && svc.get("build").is_none() {
-                    images.push(image.to_string());
-                }
+            if let Some(image) = svc.get("image").and_then(|i| i.as_str())
+                && !image.is_empty()
+                && svc.get("build").is_none()
+            {
+                images.push(image.to_string());
             }
         }
     }
@@ -793,7 +1028,9 @@ async fn pull_image_with_progress(
     state: &AppState,
     image: &str,
 ) -> Result<(), String> {
-    let docker = state.apps.docker_client()
+    let docker = state
+        .apps
+        .docker_client()
         .map_err(|e| format!("Docker not ready: {e}"))?;
 
     let (from_image, tag) = if let Some((img, tag)) = image.rsplit_once(':') {
@@ -858,20 +1095,28 @@ mod tests {
     use super::validate_compose;
 
     fn ok_strict(yaml: &str) {
-        assert!(validate_compose(yaml, "myapp", false).is_ok(), "expected strict ok: {yaml}");
+        assert!(
+            validate_compose(yaml, "myapp", false).is_ok(),
+            "expected strict ok: {yaml}"
+        );
     }
 
     fn err_strict(yaml: &str, needle: &str) {
-        let e = validate_compose(yaml, "myapp", false).expect_err(&format!("expected strict err: {yaml}"));
+        let e = validate_compose(yaml, "myapp", false)
+            .expect_err(&format!("expected strict err: {yaml}"));
         assert!(e.contains(needle), "error '{e}' did not contain '{needle}'");
     }
 
     fn ok_unsafe(yaml: &str) {
-        assert!(validate_compose(yaml, "myapp", true).is_ok(), "expected unsafe ok: {yaml}");
+        assert!(
+            validate_compose(yaml, "myapp", true).is_ok(),
+            "expected unsafe ok: {yaml}"
+        );
     }
 
     fn err_unsafe(yaml: &str, needle: &str) {
-        let e = validate_compose(yaml, "myapp", true).expect_err(&format!("expected unsafe err: {yaml}"));
+        let e = validate_compose(yaml, "myapp", true)
+            .expect_err(&format!("expected unsafe err: {yaml}"));
         assert!(e.contains(needle), "error '{e}' did not contain '{needle}'");
     }
 
@@ -884,22 +1129,46 @@ mod tests {
 
     #[test]
     fn strict_rejects_privileged() {
-        err_strict("services:\n  bad:\n    image: alpine\n    privileged: true\n", "privileged");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    privileged: true\n",
+            "privileged",
+        );
     }
 
     #[test]
     fn strict_rejects_host_namespaces() {
-        err_strict("services:\n  bad:\n    image: alpine\n    pid: host\n", "host");
-        err_strict("services:\n  bad:\n    image: alpine\n    network_mode: host\n", "host");
-        err_strict("services:\n  bad:\n    image: alpine\n    ipc: host\n", "host");
-        err_strict("services:\n  bad:\n    image: alpine\n    userns_mode: host\n", "host");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    pid: host\n",
+            "host",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    network_mode: host\n",
+            "host",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    ipc: host\n",
+            "host",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    userns_mode: host\n",
+            "host",
+        );
     }
 
     #[test]
     fn strict_rejects_dangerous_caps() {
-        err_strict("services:\n  bad:\n    image: alpine\n    cap_add: [SYS_ADMIN]\n", "SYS_ADMIN");
-        err_strict("services:\n  bad:\n    image: alpine\n    cap_add: [\"CAP_SYS_PTRACE\"]\n", "PTRACE");
-        err_strict("services:\n  bad:\n    image: alpine\n    cap_add: [ALL]\n", "ALL");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    cap_add: [SYS_ADMIN]\n",
+            "SYS_ADMIN",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    cap_add: [\"CAP_SYS_PTRACE\"]\n",
+            "PTRACE",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    cap_add: [ALL]\n",
+            "ALL",
+        );
     }
 
     #[test]
@@ -909,24 +1178,41 @@ mod tests {
 
     #[test]
     fn strict_rejects_security_opt_unconfined() {
-        err_strict("services:\n  bad:\n    image: alpine\n    security_opt: [\"seccomp=unconfined\"]\n", "seccomp");
-        err_strict("services:\n  bad:\n    image: alpine\n    security_opt: [\"apparmor=unconfined\"]\n", "apparmor");
-        err_strict("services:\n  bad:\n    image: alpine\n    security_opt: [\"no-new-privileges=false\"]\n", "no-new-privileges");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    security_opt: [\"seccomp=unconfined\"]\n",
+            "seccomp",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    security_opt: [\"apparmor=unconfined\"]\n",
+            "apparmor",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    security_opt: [\"no-new-privileges=false\"]\n",
+            "no-new-privileges",
+        );
     }
 
     #[test]
     fn strict_rejects_devices() {
-        err_strict("services:\n  bad:\n    image: alpine\n    devices: [\"/dev/sda:/dev/sda\"]\n", "devices");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    devices: [\"/dev/sda:/dev/sda\"]\n",
+            "devices",
+        );
     }
 
     #[test]
     fn strict_rejects_etc_bind() {
-        err_strict("services:\n  bad:\n    image: alpine\n    volumes: [\"/etc:/etc\"]\n", "/etc");
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    volumes: [\"/etc:/etc\"]\n",
+            "/etc",
+        );
     }
 
     #[test]
     fn strict_allows_app_dir_and_share_root_binds() {
-        ok_strict("services:\n  ok:\n    image: alpine\n    volumes:\n      - \"/var/lib/nasty/apps/myapp/data:/data\"\n      - \"/fs/photos:/photos:ro\"\n      - \"named-vol:/x\"\n");
+        ok_strict(
+            "services:\n  ok:\n    image: alpine\n    volumes:\n      - \"/var/lib/nasty/apps/myapp/data:/data\"\n      - \"/fs/photos:/photos:ro\"\n      - \"named-vol:/x\"\n",
+        );
     }
 
     #[test]
@@ -966,7 +1252,9 @@ mod tests {
 
     #[test]
     fn unsafe_accepts_arbitrary_bind() {
-        ok_unsafe("services:\n  agent:\n    image: monitor\n    volumes: [\"/etc:/host-etc:ro\"]\n");
+        ok_unsafe(
+            "services:\n  agent:\n    image: monitor\n    volumes: [\"/etc:/host-etc:ro\"]\n",
+        );
         ok_unsafe("services:\n  s:\n    image: x\n    volumes: [\"/home/user/data:/data\"]\n");
     }
 
@@ -974,7 +1262,10 @@ mod tests {
 
     #[test]
     fn unsafe_still_rejects_root_bind() {
-        err_unsafe("services:\n  bad:\n    image: alpine\n    volumes: [\"/:/host\"]\n", "off-limits");
+        err_unsafe(
+            "services:\n  bad:\n    image: alpine\n    volumes: [\"/:/host\"]\n",
+            "off-limits",
+        );
     }
 
     #[test]
@@ -993,7 +1284,9 @@ mod tests {
     fn unsafe_still_allows_app_dir_under_engine_state() {
         // /var/lib/nasty/apps/<name>/ is a deliberate exception — the app
         // owns its own subtree of engine state.
-        ok_unsafe("services:\n  ok:\n    image: alpine\n    volumes: [\"/var/lib/nasty/apps/myapp/data:/data\"]\n");
+        ok_unsafe(
+            "services:\n  ok:\n    image: alpine\n    volumes: [\"/var/lib/nasty/apps/myapp/data:/data\"]\n",
+        );
     }
 
     #[test]

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -158,14 +158,24 @@ impl RateLimitState {
     }
 
     fn user_failures(&self, username: &str, now: u64) -> usize {
-        self.by_user.get(username)
-            .map(|v| v.iter().filter(|&&t| now.saturating_sub(t) < LOCKOUT_WINDOW_SECS).count())
+        self.by_user
+            .get(username)
+            .map(|v| {
+                v.iter()
+                    .filter(|&&t| now.saturating_sub(t) < LOCKOUT_WINDOW_SECS)
+                    .count()
+            })
             .unwrap_or(0)
     }
 
     fn ip_failures(&self, ip: &str, now: u64) -> usize {
-        self.by_ip.get(ip)
-            .map(|v| v.iter().filter(|&&t| now.saturating_sub(t) < IP_LOCKOUT_WINDOW_SECS).count())
+        self.by_ip
+            .get(ip)
+            .map(|v| {
+                v.iter()
+                    .filter(|&&t| now.saturating_sub(t) < IP_LOCKOUT_WINDOW_SECS)
+                    .count()
+            })
             .unwrap_or(0)
     }
 }
@@ -214,7 +224,12 @@ impl AuthService {
     }
 
     /// Authenticate with username/password, returns a session token
-    pub async fn login(&self, username: &str, password: &str, client_ip: &str) -> Result<String, AuthError> {
+    pub async fn login(
+        &self,
+        username: &str,
+        password: &str,
+        client_ip: &str,
+    ) -> Result<String, AuthError> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -232,7 +247,12 @@ impl AuthService {
                 tracing::warn!(
                     "Login blocked from {client_ip}: {ip_fails} failed attempts in the last hour"
                 );
-                audit("login_ip_locked", username, client_ip, &format!("{ip_fails} failed attempts"));
+                audit(
+                    "login_ip_locked",
+                    username,
+                    client_ip,
+                    &format!("{ip_fails} failed attempts"),
+                );
                 return Err(AuthError::AccountLocked);
             }
         }
@@ -259,9 +279,16 @@ impl AuthService {
                 } else {
                     tracing::warn!(
                         "Login blocked for '{}': {} failed attempts in last {} minutes",
-                        username, user_fails, LOCKOUT_WINDOW_SECS / 60
+                        username,
+                        user_fails,
+                        LOCKOUT_WINDOW_SECS / 60
                     );
-                    audit("login_locked", username, client_ip, &format!("{user_fails} failed attempts"));
+                    audit(
+                        "login_locked",
+                        username,
+                        client_ip,
+                        &format!("{user_fails} failed attempts"),
+                    );
                     return Err(AuthError::AccountLocked);
                 }
             }
@@ -287,7 +314,12 @@ impl AuthService {
         let hash = match user.password_hash.as_deref() {
             Some(h) => h,
             None => {
-                audit("login_failed", username, client_ip, "no local password (OIDC-only user)");
+                audit(
+                    "login_failed",
+                    username,
+                    client_ip,
+                    "no local password (OIDC-only user)",
+                );
                 self.record_failed_attempt(username, client_ip, now).await;
                 return Err(AuthError::InvalidCredentials);
             }
@@ -319,7 +351,9 @@ impl AuthService {
         };
 
         // Prune expired sessions while we hold the write lock
-        state.sessions.retain(|s| now - s.created_at <= SESSION_TTL_SECS);
+        state
+            .sessions
+            .retain(|s| now - s.created_at <= SESSION_TTL_SECS);
 
         state.sessions.push(session);
         save_state(&state).await?;
@@ -354,7 +388,10 @@ impl AuthService {
             None => {
                 audit(
                     "oidc_login_denied_no_role",
-                    identity.preferred_username.as_deref().unwrap_or(&identity.subject),
+                    identity
+                        .preferred_username
+                        .as_deref()
+                        .unwrap_or(&identity.subject),
                     client_ip,
                     &format!("issuer={} sub={}", identity.issuer, identity.subject),
                 );
@@ -373,7 +410,10 @@ impl AuthService {
             if !auto_provision {
                 audit(
                     "oidc_login_failed",
-                    identity.preferred_username.as_deref().unwrap_or(&identity.subject),
+                    identity
+                        .preferred_username
+                        .as_deref()
+                        .unwrap_or(&identity.subject),
                     client_ip,
                     "user not provisioned and auto_provision disabled",
                 );
@@ -393,7 +433,10 @@ impl AuthService {
                 "oidc_user_provisioned",
                 &username,
                 client_ip,
-                &format!("issuer={} sub={} role={:?}", identity.issuer, identity.subject, role),
+                &format!(
+                    "issuer={} sub={} role={:?}",
+                    identity.issuer, identity.subject, role
+                ),
             );
         }
 
@@ -422,7 +465,9 @@ impl AuthService {
             client_ip: Some(client_ip.to_string()),
         };
 
-        state.sessions.retain(|s| now - s.created_at <= SESSION_TTL_SECS);
+        state
+            .sessions
+            .retain(|s| now - s.created_at <= SESSION_TTL_SECS);
         state.sessions.push(session);
         save_state(&state).await?;
 
@@ -451,38 +496,54 @@ impl AuthService {
                 return Err(AuthError::TokenExpired);
             }
             // Verify client IP matches the one that created this session
-            if let Some(ref bound_ip) = session.client_ip {
-                if bound_ip != client_ip {
-                    tracing::warn!(
-                        "Session for '{}' rejected: IP mismatch (bound={}, request={})",
-                        session.username, bound_ip, client_ip
-                    );
-                    audit("session_ip_mismatch", &session.username, client_ip, &format!("bound={bound_ip}"));
-                    return Err(AuthError::InvalidToken);
-                }
+            if let Some(ref bound_ip) = session.client_ip
+                && bound_ip != client_ip
+            {
+                tracing::warn!(
+                    "Session for '{}' rejected: IP mismatch (bound={}, request={})",
+                    session.username,
+                    bound_ip,
+                    client_ip
+                );
+                audit(
+                    "session_ip_mismatch",
+                    &session.username,
+                    client_ip,
+                    &format!("bound={bound_ip}"),
+                );
+                return Err(AuthError::InvalidToken);
             }
             return Ok(session.clone());
         }
         // Check long-lived API tokens — SHA-256 comparison (tokens are high-entropy,
         // don't need Argon2's brute-force resistance, and Argon2 is too slow for O(n) scan)
         let incoming_hash = hash_token(token);
-        let t = state.api_tokens.iter()
+        let t = state
+            .api_tokens
+            .iter()
             .find(|t| ct_eq_str(&t.token, &incoming_hash))
             .ok_or(AuthError::InvalidToken)?;
 
-        if let Some(exp) = t.expires_at {
-            if now >= exp {
-                return Err(AuthError::TokenExpired);
-            }
+        if let Some(exp) = t.expires_at
+            && now >= exp
+        {
+            return Err(AuthError::TokenExpired);
         }
 
         // Check IP allowlist if configured
         if !t.allowed_ips.is_empty() && !t.allowed_ips.iter().any(|ip| ip == client_ip) {
             tracing::warn!(
                 "API token '{}' rejected: IP {} not in allowed list {:?}",
-                t.name, client_ip, t.allowed_ips
+                t.name,
+                client_ip,
+                t.allowed_ips
             );
-            audit("token_ip_rejected", &t.name, client_ip, &format!("allowed={:?}", t.allowed_ips));
+            audit(
+                "token_ip_rejected",
+                &t.name,
+                client_ip,
+                &format!("allowed={:?}", t.allowed_ips),
+            );
             return Err(AuthError::InvalidToken);
         }
 
@@ -491,7 +552,11 @@ impl AuthService {
             username: t.name.clone(),
             role: t.role.clone(),
             filesystem: t.filesystem.clone(),
-            owner: if t.role == Role::Operator { Some(t.name.clone()) } else { None },
+            owner: if t.role == Role::Operator {
+                Some(t.name.clone())
+            } else {
+                None
+            },
             created_at: t.created_at,
             must_change_password: false,
             client_ip: None,
@@ -541,7 +606,12 @@ impl AuthService {
         state.api_tokens.push(stored);
         save_state(&state).await?;
 
-        audit("token_created", &session.username, session.client_ip.as_deref().unwrap_or(""), &format!("name={name}"));
+        audit(
+            "token_created",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or(""),
+            &format!("name={name}"),
+        );
         info!("Created API token '{name}'");
 
         // Return the raw token to the caller — shown only once, never stored
@@ -579,11 +649,7 @@ impl AuthService {
     }
 
     /// Delete an API token by ID (admin only)
-    pub async fn delete_api_token(
-        &self,
-        session: &Session,
-        id: &str,
-    ) -> Result<(), AuthError> {
+    pub async fn delete_api_token(&self, session: &Session, id: &str) -> Result<(), AuthError> {
         if session.role != Role::Admin {
             return Err(AuthError::Forbidden);
         }
@@ -596,7 +662,12 @@ impl AuthService {
         }
         save_state(&state).await?;
 
-        audit("token_deleted", &session.username, session.client_ip.as_deref().unwrap_or(""), &format!("id={id}"));
+        audit(
+            "token_deleted",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or(""),
+            &format!("id={id}"),
+        );
         info!("Deleted API token '{id}'");
         Ok(())
     }
@@ -645,7 +716,12 @@ impl AuthService {
 
         save_state(&state).await?;
 
-        audit("password_changed", &session.username, session.client_ip.as_deref().unwrap_or(""), &format!("target={username}"));
+        audit(
+            "password_changed",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or(""),
+            &format!("target={username}"),
+        );
         info!("Password changed for user '{username}'");
         Ok(())
     }
@@ -671,7 +747,12 @@ impl AuthService {
             return Err(AuthError::UserExists);
         }
 
-        audit("user_created", &session.username, session.client_ip.as_deref().unwrap_or(""), &format!("target={username}, role={role:?}"));
+        audit(
+            "user_created",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or(""),
+            &format!("target={username}, role={role:?}"),
+        );
         state.users.push(User {
             username: username.to_string(),
             password_hash: Some(hash_password(password)?),
@@ -687,11 +768,7 @@ impl AuthService {
     }
 
     /// Delete a user (admin only, cannot delete self)
-    pub async fn delete_user(
-        &self,
-        session: &Session,
-        username: &str,
-    ) -> Result<(), AuthError> {
+    pub async fn delete_user(&self, session: &Session, username: &str) -> Result<(), AuthError> {
         if session.role != Role::Admin {
             return Err(AuthError::Forbidden);
         }
@@ -710,7 +787,12 @@ impl AuthService {
         state.sessions.retain(|s| s.username != username);
         save_state(&state).await?;
 
-        audit("user_deleted", &session.username, session.client_ip.as_deref().unwrap_or(""), &format!("target={username}"));
+        audit(
+            "user_deleted",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or(""),
+            &format!("target={username}"),
+        );
         info!("Deleted user '{username}'");
         Ok(())
     }
@@ -850,7 +932,9 @@ pub fn audit(event: &str, user: &str, ip: &str, detail: &str) {
 
 /// Read audit log entries, most recent first.
 pub async fn read_audit_log(limit: usize) -> Vec<serde_json::Value> {
-    let content = tokio::fs::read_to_string(AUDIT_LOG_PATH).await.unwrap_or_default();
+    let content = tokio::fs::read_to_string(AUDIT_LOG_PATH)
+        .await
+        .unwrap_or_default();
     let mut entries: Vec<serde_json::Value> = content
         .lines()
         .filter_map(|line| serde_json::from_str(line).ok())
@@ -864,8 +948,8 @@ fn hash_password(password: &str) -> Result<String, AuthError> {
     // Generate 16 random bytes for salt, encode as base64ct for SaltString
     let mut salt_bytes = [0u8; 16];
     rand::fill(&mut salt_bytes);
-    let salt = SaltString::encode_b64(&salt_bytes)
-        .map_err(|e| AuthError::HashError(e.to_string()))?;
+    let salt =
+        SaltString::encode_b64(&salt_bytes).map_err(|e| AuthError::HashError(e.to_string()))?;
     let argon2 = Argon2::default();
     let hash = argon2
         .hash_password(password.as_bytes(), &salt)
@@ -897,7 +981,7 @@ fn ct_eq_str(a: &str, b: &str) -> bool {
 /// SHA-256 hash for API tokens. Tokens are 32 random bytes — high entropy,
 /// no need for Argon2's brute-force resistance. Instant O(1) comparison.
 fn hash_token(token: &str) -> String {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     format!("sha256:{:x}", hasher.finalize())
@@ -918,7 +1002,11 @@ fn pick_username(existing: &[User], identity: &crate::auth_oidc::OidcIdentity) -
         })
         .unwrap_or_else(|| identity.subject.clone());
     let base = base.trim().to_string();
-    let base = if base.is_empty() { identity.subject.clone() } else { base };
+    let base = if base.is_empty() {
+        identity.subject.clone()
+    } else {
+        base
+    };
     if !existing.iter().any(|u| u.username == base) {
         return base;
     }
@@ -1060,10 +1148,8 @@ mod tests {
             "alice".to_string(),
             vec![now - LOCKOUT_WINDOW_SECS - 100, now - 5],
         );
-        rl.by_user.insert(
-            "bob".to_string(),
-            vec![now - LOCKOUT_WINDOW_SECS - 100],
-        );
+        rl.by_user
+            .insert("bob".to_string(), vec![now - LOCKOUT_WINDOW_SECS - 100]);
         rl.by_ip.insert(
             "1.2.3.4".to_string(),
             vec![now - IP_LOCKOUT_WINDOW_SECS - 1],

--- a/engine/nasty-engine/src/auth_oidc.rs
+++ b/engine/nasty-engine/src/auth_oidc.rs
@@ -169,11 +169,7 @@ impl OidcClient {
     /// Look up a pending flow by the state value the IdP echoed back, exchange
     /// the code, validate the ID token (signature, audience, nonce, expiry),
     /// and return the resolved identity.
-    pub async fn exchange_code(
-        &self,
-        state: &str,
-        code: &str,
-    ) -> Result<OidcIdentity, OidcError> {
+    pub async fn exchange_code(&self, state: &str, code: &str) -> Result<OidcIdentity, OidcError> {
         let pending = {
             let mut p = self.pending.write().await;
             p.remove(state).ok_or(OidcError::StateMismatch)?
@@ -190,9 +186,7 @@ impl OidcClient {
             .await
             .map_err(|e| OidcError::TokenExchange(e.to_string()))?;
 
-        let id_token = token_response
-            .id_token()
-            .ok_or(OidcError::MissingIdToken)?;
+        let id_token = token_response.id_token().ok_or(OidcError::MissingIdToken)?;
         let verifier = self.inner.id_token_verifier();
         let claims = id_token
             .claims(&verifier, &pending.nonce)
@@ -306,24 +300,22 @@ pub fn dry_run_role(
 /// hostnames. Private-network RFC1918 hosts are allowed because a
 /// self-hosted Keycloak on the same LAN is a legitimate setup.
 pub fn validate_issuer_url(s: &str) -> Result<(), OidcError> {
-    let u = url::Url::parse(s)
-        .map_err(|e| OidcError::Config(format!("issuer URL: {e}")))?;
+    let u = url::Url::parse(s).map_err(|e| OidcError::Config(format!("issuer URL: {e}")))?;
 
     if u.scheme() != "https" {
         return Err(OidcError::Config(format!(
-            "issuer URL must use https (got '{}')", u.scheme()
+            "issuer URL must use https (got '{}')",
+            u.scheme()
         )));
     }
 
-    let host_str = u.host_str()
+    let host_str = u
+        .host_str()
         .ok_or_else(|| OidcError::Config("issuer URL missing host".to_string()))?;
 
     // Match well-known metadata hostnames regardless of how DNS resolves them.
     let lower = host_str.to_ascii_lowercase();
-    let metadata_hosts = [
-        "metadata.google.internal",
-        "metadata.goog",
-    ];
+    let metadata_hosts = ["metadata.google.internal", "metadata.goog"];
     if metadata_hosts.iter().any(|h| lower == *h) {
         return Err(OidcError::Config(format!(
             "issuer URL host '{host_str}' is a cloud metadata service"

--- a/engine/nasty-engine/src/log_stream.rs
+++ b/engine/nasty-engine/src/log_stream.rs
@@ -39,7 +39,9 @@ struct LogRequest {
     grep: Option<String>,
 }
 
-fn default_lines() -> u32 { 100 }
+fn default_lines() -> u32 {
+    100
+}
 
 #[derive(Serialize)]
 struct LogMessage {
@@ -50,20 +52,37 @@ struct LogMessage {
 
 impl LogMessage {
     fn line(s: &str) -> String {
-        serde_json::to_string(&Self { msg_type: "line".into(), data: s.to_string() }).unwrap()
+        serde_json::to_string(&Self {
+            msg_type: "line".into(),
+            data: s.to_string(),
+        })
+        .unwrap()
     }
     fn error(s: &str) -> String {
-        serde_json::to_string(&Self { msg_type: "error".into(), data: s.to_string() }).unwrap()
+        serde_json::to_string(&Self {
+            msg_type: "error".into(),
+            data: s.to_string(),
+        })
+        .unwrap()
     }
 }
 
-async fn handle_logs(mut socket: WebSocket, state: Arc<AppState>, client_ip: String, pre_auth_token: Option<String>) {
+async fn handle_logs(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_ip: String,
+    pre_auth_token: Option<String>,
+) {
     // First message: params (token optional now — cookie may have provided it)
     let req: LogRequest = match socket.recv().await {
         Some(Ok(Message::Text(text))) => match serde_json::from_str(&text) {
             Ok(r) => r,
             Err(e) => {
-                let _ = socket.send(Message::Text(LogMessage::error(&format!("invalid request: {e}")).into())).await;
+                let _ = socket
+                    .send(Message::Text(
+                        LogMessage::error(&format!("invalid request: {e}")).into(),
+                    ))
+                    .await;
                 return;
             }
         },
@@ -73,7 +92,9 @@ async fn handle_logs(mut socket: WebSocket, state: Arc<AppState>, client_ip: Str
     let token = match pre_auth_token.or_else(|| req.token.clone()) {
         Some(t) => t,
         None => {
-            let _ = socket.send(Message::Text(LogMessage::error("missing session").into())).await;
+            let _ = socket
+                .send(Message::Text(LogMessage::error("missing session").into()))
+                .await;
             return;
         }
     };
@@ -82,12 +103,23 @@ async fn handle_logs(mut socket: WebSocket, state: Arc<AppState>, client_ip: Str
     match state.auth.validate(&token, &client_ip).await {
         Ok(s) if s.role == crate::auth::Role::Admin => {}
         Ok(s) => {
-            crate::auth::audit("log_stream_denied", &s.username, &client_ip, &format!("role={:?}", s.role));
-            let _ = socket.send(Message::Text(LogMessage::error("forbidden: admin role required").into())).await;
+            crate::auth::audit(
+                "log_stream_denied",
+                &s.username,
+                &client_ip,
+                &format!("role={:?}", s.role),
+            );
+            let _ = socket
+                .send(Message::Text(
+                    LogMessage::error("forbidden: admin role required").into(),
+                ))
+                .await;
             return;
         }
         Err(_) => {
-            let _ = socket.send(Message::Text(LogMessage::error("invalid token").into())).await;
+            let _ = socket
+                .send(Message::Text(LogMessage::error("invalid token").into()))
+                .await;
             return;
         }
     }
@@ -96,17 +128,20 @@ async fn handle_logs(mut socket: WebSocket, state: Arc<AppState>, client_ip: Str
 
     // Build journalctl command
     let mut args = vec![
-        "-u".to_string(), req.unit.clone(),
-        "-n".to_string(), req.lines.to_string(),
+        "-u".to_string(),
+        req.unit.clone(),
+        "-n".to_string(),
+        req.lines.to_string(),
         "-f".to_string(),
         "--no-pager".to_string(),
-        "--output".to_string(), "short-iso".to_string(),
+        "--output".to_string(),
+        "short-iso".to_string(),
     ];
-    if let Some(ref grep) = req.grep {
-        if !grep.is_empty() {
-            args.push("--grep".to_string());
-            args.push(grep.clone());
-        }
+    if let Some(ref grep) = req.grep
+        && !grep.is_empty()
+    {
+        args.push("--grep".to_string());
+        args.push(grep.clone());
     }
 
     let mut child = match tokio::process::Command::new("journalctl")
@@ -117,7 +152,11 @@ async fn handle_logs(mut socket: WebSocket, state: Arc<AppState>, client_ip: Str
     {
         Ok(c) => c,
         Err(e) => {
-            let _ = socket.send(Message::Text(LogMessage::error(&format!("spawn journalctl: {e}")).into())).await;
+            let _ = socket
+                .send(Message::Text(
+                    LogMessage::error(&format!("spawn journalctl: {e}")).into(),
+                ))
+                .await;
             return;
         }
     };

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -16,9 +16,9 @@ use tracing::{error, info};
 use tracing_subscriber::{prelude::*, reload};
 
 mod app_deploy;
-mod log_stream;
 mod auth;
 mod auth_oidc;
+mod log_stream;
 mod router;
 mod telemetry;
 mod terminal;
@@ -146,7 +146,11 @@ async fn main() -> anyhow::Result<()> {
     // 4. Restore NVMe-oF configfs (volatile, needs modules from step 3)
     let mount_failures = state.filesystems.restore_mounts().await;
     if !mount_failures.is_empty() {
-        error!("CRITICAL: {} filesystem(s) failed to mount: {}", mount_failures.len(), mount_failures.join(", "));
+        error!(
+            "CRITICAL: {} filesystem(s) failed to mount: {}",
+            mount_failures.len(),
+            mount_failures.join(", ")
+        );
         *state.mount_failures.lock().await = mount_failures;
     }
     // Re-attach loop devices and get the current name→device mapping.
@@ -181,10 +185,10 @@ async fn main() -> anyhow::Result<()> {
     // Sync NVMe-oF ports with Tailscale IP (if Tailscale reconnected on boot)
     {
         let ts_status = state.tailscale.get().await;
-        if ts_status.connected {
-            if let Some(ref ip) = ts_status.ip {
-                state.nvmeof.ensure_tailscale_ports(ip).await;
-            }
+        if ts_status.connected
+            && let Some(ref ip) = ts_status.ip
+        {
+            state.nvmeof.ensure_tailscale_ports(ip).await;
         }
     }
 
@@ -215,7 +219,10 @@ async fn main() -> anyhow::Result<()> {
             if let Err(e) = state.oidc.rebuild(&oidc_settings).await {
                 tracing::warn!("OIDC client init failed at startup: {e}");
             } else {
-                info!("OIDC client initialized (issuer={:?})", oidc_settings.issuer_url);
+                info!(
+                    "OIDC client initialized (issuer={:?})",
+                    oidc_settings.issuer_url
+                );
             }
         }
     }
@@ -1038,7 +1045,7 @@ async fn files_mkdir_handler(
         Some((p, _)) => p,
         None => "",
     };
-    if safe_path(parent.is_empty().then_some("").unwrap_or(parent)).is_err() && !parent.is_empty() {
+    if safe_path(if parent.is_empty() { "" } else { parent }).is_err() && !parent.is_empty() {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({"error": "Invalid path"})),
@@ -1179,10 +1186,10 @@ async fn files_content_handler(
             // Documents
             "pdf" => "application/pdf",
             // Text
-            "txt" | "log" | "md" | "csv" | "conf" | "cfg" | "ini" | "yml" | "yaml"
-            | "toml" | "json" | "xml" | "html" | "htm" | "css" | "js" | "ts"
-            | "rs" | "py" | "sh" | "bash" | "nix" | "c" | "h" | "cpp" | "go"
-            | "java" | "rb" | "php" | "sql" | "dockerfile" => "text/plain; charset=utf-8",
+            "txt" | "log" | "md" | "csv" | "conf" | "cfg" | "ini" | "yml" | "yaml" | "toml"
+            | "json" | "xml" | "html" | "htm" | "css" | "js" | "ts" | "rs" | "py" | "sh"
+            | "bash" | "nix" | "c" | "h" | "cpp" | "go" | "java" | "rb" | "php" | "sql"
+            | "dockerfile" => "text/plain; charset=utf-8",
             _ => "application/octet-stream",
         })
         .unwrap_or("application/octet-stream");
@@ -1309,7 +1316,12 @@ async fn logout_handler(
         // the browser to drop the cookie below.
         let _ = state.auth.logout(&token).await;
     }
-    (StatusCode::OK, resp_headers, Json(serde_json::json!({"ok": true}))).into_response()
+    (
+        StatusCode::OK,
+        resp_headers,
+        Json(serde_json::json!({"ok": true})),
+    )
+        .into_response()
 }
 
 /// 8h, matches SESSION_TTL_SECS in auth.rs (kept in sync by hand).
@@ -1322,9 +1334,7 @@ fn build_session_cookie(token: &str) -> String {
 }
 
 fn build_session_clear_cookie() -> String {
-    format!(
-        "{SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0"
-    )
+    format!("{SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0")
 }
 
 // ── OIDC SSO ─────────────────────────────────────────────────────
@@ -1333,7 +1343,6 @@ fn build_session_clear_cookie() -> String {
 fn url_encode(s: &str) -> String {
     url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
 }
-
 
 /// Tells the WebUI whether to render the "Sign in with SSO" button.
 /// No auth required — the response only exposes booleans / public config.
@@ -1383,7 +1392,12 @@ async fn oidc_callback_handler(
 
     if let Some(err) = q.error {
         let detail = q.error_description.unwrap_or_default();
-        crate::auth::audit("oidc_login_failed", "anonymous", &client_ip, &format!("{err}: {detail}"));
+        crate::auth::audit(
+            "oidc_login_failed",
+            "anonymous",
+            &client_ip,
+            &format!("{err}: {detail}"),
+        );
         return bounce(format!(
             "oidc_error={}",
             url_encode(&format!("{err}: {detail}"))
@@ -1391,7 +1405,12 @@ async fn oidc_callback_handler(
     }
 
     let (Some(code), Some(state_param)) = (q.code, q.state) else {
-        crate::auth::audit("oidc_login_failed", "anonymous", &client_ip, "missing code or state");
+        crate::auth::audit(
+            "oidc_login_failed",
+            "anonymous",
+            &client_ip,
+            "missing code or state",
+        );
         return bounce("oidc_error=missing+code+or+state".into());
     };
 
@@ -1404,10 +1423,7 @@ async fn oidc_callback_handler(
         Err(e) => {
             tracing::warn!("OIDC token exchange failed: {e}");
             crate::auth::audit("oidc_login_failed", "anonymous", &client_ip, &e.to_string());
-            return bounce(format!(
-                "oidc_error={}",
-                url_encode(&e.to_string())
-            ));
+            return bounce(format!("oidc_error={}", url_encode(&e.to_string())));
         }
     };
 
@@ -1436,16 +1452,9 @@ async fn oidc_callback_handler(
                 axum::http::header::SET_COOKIE,
                 build_session_cookie(&token).parse().unwrap(),
             );
-            (
-                resp_headers,
-                axum::response::Redirect::to("/#oidc=1"),
-            )
-                .into_response()
+            (resp_headers, axum::response::Redirect::to("/#oidc=1")).into_response()
         }
-        Err(e) => bounce(format!(
-            "oidc_error={}",
-            url_encode(&e.to_string())
-        )),
+        Err(e) => bounce(format!("oidc_error={}", url_encode(&e.to_string()))),
     }
 }
 
@@ -1508,7 +1517,12 @@ async fn ws_handler(
     ws.on_upgrade(move |socket| handle_socket(socket, state, client_ip, pre_auth_token))
 }
 
-async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>, client_ip: String, pre_auth_token: Option<String>) {
+async fn handle_socket(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_ip: String,
+    pre_auth_token: Option<String>,
+) {
     use futures_util::{SinkExt, StreamExt};
     use nasty_common::Notification;
 
@@ -1585,9 +1599,7 @@ async fn resolve_session(
             }
             Err(_) => {
                 let _ = socket
-                    .send(Message::Text(
-                        r#"{"error":"invalid session"}"#.into(),
-                    ))
+                    .send(Message::Text(r#"{"error":"invalid session"}"#.into()))
                     .await;
                 let _ = socket.send(Message::Close(None)).await;
                 None
@@ -1669,8 +1681,8 @@ async fn wait_for_auth(
 
 fn spawn_alert_notifier(state: Arc<AppState>) {
     tokio::spawn(async move {
-        use std::collections::HashSet;
         use nasty_system::notifications;
+        use std::collections::HashSet;
 
         let mut previously_active: HashSet<(String, String)> = HashSet::new();
 
@@ -1695,11 +1707,13 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
             }
 
             // Find newly fired alerts (not previously active)
-            let current_keys: HashSet<(String, String)> = active.iter()
+            let current_keys: HashSet<(String, String)> = active
+                .iter()
                 .map(|a| (a.rule_id.clone(), a.source.clone()))
                 .collect();
 
-            let new_alerts: Vec<_> = active.iter()
+            let new_alerts: Vec<_> = active
+                .iter()
                 .filter(|a| !previously_active.contains(&(a.rule_id.clone(), a.source.clone())))
                 .collect();
 
@@ -1712,8 +1726,10 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
                             nasty_system::alerts::AlertSeverity::Critical => "CRITICAL",
                         };
                         let subject = format!("[NASty {sev}] {}", alert.rule_name);
-                        let body = format!("{}\n\nSource: {}\nValue: {:.1}\nThreshold: {:.1}",
-                            alert.message, alert.source, alert.current_value, alert.threshold);
+                        let body = format!(
+                            "{}\n\nSource: {}\nValue: {:.1}\nThreshold: {:.1}",
+                            alert.message, alert.source, alert.current_value, alert.threshold
+                        );
                         notifications::send(&config, &subject, &body).await;
                     }
                 }

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -414,10 +414,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                             );
                             match rebuild {
                                 Ok(()) => ok(req, saved),
-                                Err(e) => err(
-                                    req,
-                                    format!("config saved but client rebuild failed: {e}"),
-                                ),
+                                Err(e) => {
+                                    err(req, format!("config saved but client rebuild failed: {e}"))
+                                }
                             }
                         }
                         Err(e) => err(req, e),
@@ -445,7 +444,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
 
         // ── Audit ──────────────────────────────────────────────
         "audit.list" => {
-            let limit = req.params.as_ref()
+            let limit = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("limit"))
                 .and_then(|v| v.as_u64())
                 .unwrap_or(200) as usize;
@@ -466,21 +467,28 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "system.logs" => {
             let unit = str_param(req, "unit").unwrap_or("nasty-engine");
-            let lines: u32 = req.params.as_ref()
+            let lines: u32 = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("lines"))
                 .and_then(|v| v.as_u64())
                 .unwrap_or(100) as u32;
-            let grep = req.params.as_ref()
+            let grep = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("grep"))
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
             let lines_str = lines.to_string();
             let mut args = vec![
-                "-u", unit,
-                "-n", lines_str.as_str(),
+                "-u",
+                unit,
+                "-n",
+                lines_str.as_str(),
                 "--no-pager",
-                "--output", "short-iso",
+                "--output",
+                "short-iso",
             ];
             if let Some(ref g) = grep {
                 args.push("--grep");
@@ -498,10 +506,19 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "system.logs.units" => {
             // Return list of interesting systemd units
             let units = vec![
-                "nasty-engine", "nasty-metrics", "nginx",
-                "nfs-server", "samba-smbd", "samba-nmbd",
-                "docker", "sshd", "avahi-daemon",
-                "smartd", "nut-driver", "nut-server", "nut-monitor",
+                "nasty-engine",
+                "nasty-metrics",
+                "nginx",
+                "nfs-server",
+                "samba-smbd",
+                "samba-nmbd",
+                "docker",
+                "sshd",
+                "avahi-daemon",
+                "smartd",
+                "nut-driver",
+                "nut-server",
+                "nut-monitor",
             ];
             let mut available = Vec::new();
             for unit in units {
@@ -529,10 +546,13 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 .filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#'))
                 .map(|l| l.to_string())
                 .collect::<Vec<_>>();
-            ok(req, serde_json::json!({
-                "password_auth": password_auth,
-                "keys": keys,
-            }))
+            ok(
+                req,
+                serde_json::json!({
+                    "password_auth": password_auth,
+                    "keys": keys,
+                }),
+            )
         }
         "system.ssh.add_key" => {
             let key = match require_str(req, "key") {
@@ -540,20 +560,33 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Err(r) => return r,
             };
             if !key.starts_with("ssh-") && !key.starts_with("ecdsa-") {
-                return err(req, "Invalid SSH public key — must start with ssh-rsa, ssh-ed25519, etc.");
+                return err(
+                    req,
+                    "Invalid SSH public key — must start with ssh-rsa, ssh-ed25519, etc.",
+                );
             }
             let _ = tokio::fs::create_dir_all("/root/.ssh").await;
-            let mut existing = tokio::fs::read_to_string("/root/.ssh/authorized_keys").await.unwrap_or_default();
+            let mut existing = tokio::fs::read_to_string("/root/.ssh/authorized_keys")
+                .await
+                .unwrap_or_default();
             if !existing.contains(&key) {
-                if !existing.ends_with('\n') && !existing.is_empty() { existing.push('\n'); }
+                if !existing.ends_with('\n') && !existing.is_empty() {
+                    existing.push('\n');
+                }
                 existing.push_str(&key);
                 existing.push('\n');
                 if let Err(e) = tokio::fs::write("/root/.ssh/authorized_keys", &existing).await {
                     return err(req, format!("write authorized_keys: {e}"));
                 }
                 // Set permissions
-                let _ = tokio::process::Command::new("chmod").args(["600", "/root/.ssh/authorized_keys"]).status().await;
-                let _ = tokio::process::Command::new("chmod").args(["700", "/root/.ssh"]).status().await;
+                let _ = tokio::process::Command::new("chmod")
+                    .args(["600", "/root/.ssh/authorized_keys"])
+                    .status()
+                    .await;
+                let _ = tokio::process::Command::new("chmod")
+                    .args(["700", "/root/.ssh"])
+                    .status()
+                    .await;
             }
             ok(req, "Key added")
         }
@@ -562,8 +595,11 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(k) => k.trim().to_string(),
                 Err(r) => return r,
             };
-            let content = tokio::fs::read_to_string("/root/.ssh/authorized_keys").await.unwrap_or_default();
-            let filtered: String = content.lines()
+            let content = tokio::fs::read_to_string("/root/.ssh/authorized_keys")
+                .await
+                .unwrap_or_default();
+            let filtered: String = content
+                .lines()
                 .filter(|l| l.trim() != key)
                 .map(|l| format!("{l}\n"))
                 .collect();
@@ -573,16 +609,26 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             ok(req, "Key removed")
         }
         "system.ssh.set_password_auth" => {
-            let enabled = req.params.as_ref()
+            let enabled = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("enabled"))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
             // Check that at least one key exists before disabling password auth
             if !enabled {
-                let keys = tokio::fs::read_to_string("/root/.ssh/authorized_keys").await.unwrap_or_default();
-                let key_count = keys.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#')).count();
+                let keys = tokio::fs::read_to_string("/root/.ssh/authorized_keys")
+                    .await
+                    .unwrap_or_default();
+                let key_count = keys
+                    .lines()
+                    .filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#'))
+                    .count();
                 if key_count == 0 {
-                    return err(req, "Cannot disable password authentication without at least one SSH key — you would be locked out");
+                    return err(
+                        req,
+                        "Cannot disable password authentication without at least one SSH key — you would be locked out",
+                    );
                 }
             }
             // Write sshd override file and reload — takes effect immediately
@@ -591,13 +637,22 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             if let Err(e) = tokio::fs::write(
                 "/var/lib/nasty/sshd_override.conf",
                 format!("PasswordAuthentication {val}\n"),
-            ).await {
+            )
+            .await
+            {
                 tracing::warn!("Failed to write sshd override: {e}");
             }
             let _ = tokio::process::Command::new("systemctl")
                 .args(["reload", "sshd"])
-                .status().await;
-            ok(req, format!("Password authentication {}", if enabled { "enabled" } else { "disabled" }))
+                .status()
+                .await;
+            ok(
+                req,
+                format!(
+                    "Password authentication {}",
+                    if enabled { "enabled" } else { "disabled" }
+                ),
+            )
         }
         "system.network.get" => ok(req, state.network.get().await),
         "system.network.update" => {
@@ -623,7 +678,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             let kind = str_param(req, "kind").unwrap_or("net");
             let name = str_param(req, "name");
             let range = str_param(req, "range").unwrap_or("5m");
-            let offset = req.params.as_ref()
+            let offset = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("offset"))
                 .and_then(|v| v.as_i64())
                 .unwrap_or(0)
@@ -640,7 +697,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 .get(&url)
                 .send()
                 .await
-                .and_then(|r| Ok(r.error_for_status()?))
+                .and_then(|r| r.error_for_status())
             {
                 Ok(resp) => match resp
                     .json::<Vec<nasty_common::metrics_types::ResourceHistory>>()
@@ -691,12 +748,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             nasty_system::settings::reset_acme_status();
             ok(req, "ok")
         }
-        "system.acme.retry" => {
-            match nasty_system::settings::retry_acme().await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            }
-        }
+        "system.acme.retry" => match nasty_system::settings::retry_acme().await {
+            Ok(()) => ok(req, "ok"),
+            Err(e) => err(req, e),
+        },
 
         // ── Tuning ───────────────────────────────────────────────
         "system.tuning.get" => ok(req, state.tuning.get().await),
@@ -924,7 +979,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                         state.firewall.open(proto).await;
                     }
                     ok(req, v)
-                },
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,
@@ -936,56 +991,75 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                         state.firewall.close(proto).await;
                     }
                     ok(req, v)
-                },
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,
         },
         "service.base_names.get" => {
-            let iqn = tokio::fs::read_to_string("/var/lib/nasty/iscsi-base-iqn").await
+            let iqn = tokio::fs::read_to_string("/var/lib/nasty/iscsi-base-iqn")
+                .await
                 .unwrap_or_else(|_| "iqn.2137-04.storage.nasty".into());
-            let nqn = tokio::fs::read_to_string("/var/lib/nasty/nvmeof-base-nqn").await
+            let nqn = tokio::fs::read_to_string("/var/lib/nasty/nvmeof-base-nqn")
+                .await
                 .unwrap_or_else(|_| "nqn.2137-04.storage.nasty".into());
-            ok(req, serde_json::json!({ "iqn_prefix": iqn.trim(), "nqn_prefix": nqn.trim() }))
+            ok(
+                req,
+                serde_json::json!({ "iqn_prefix": iqn.trim(), "nqn_prefix": nqn.trim() }),
+            )
         }
         "service.base_names.update" => {
-            if let Some(iqn) = req.params.as_ref().and_then(|p| p.get("iqn_prefix")).and_then(|v| v.as_str()) {
+            if let Some(iqn) = req
+                .params
+                .as_ref()
+                .and_then(|p| p.get("iqn_prefix"))
+                .and_then(|v| v.as_str())
+            {
                 let _ = tokio::fs::write("/var/lib/nasty/iscsi-base-iqn", iqn.trim()).await;
             }
-            if let Some(nqn) = req.params.as_ref().and_then(|p| p.get("nqn_prefix")).and_then(|v| v.as_str()) {
+            if let Some(nqn) = req
+                .params
+                .as_ref()
+                .and_then(|p| p.get("nqn_prefix"))
+                .and_then(|v| v.as_str())
+            {
                 let _ = tokio::fs::write("/var/lib/nasty/nvmeof-base-nqn", nqn.trim()).await;
             }
             ok(req, "ok")
         }
         "service.rest_server.config" => {
-            let path = tokio::fs::read_to_string("/var/lib/nasty/rest-server-path").await
+            let path = tokio::fs::read_to_string("/var/lib/nasty/rest-server-path")
+                .await
                 .unwrap_or_else(|_| "/var/lib/nasty/rest-server".into());
             ok(req, serde_json::json!({ "path": path.trim() }))
         }
         "service.rest_server.configure" => {
-            let path = match require_str(req, "path") { Ok(s) => s.to_string(), Err(r) => return r };
+            let path = match require_str(req, "path") {
+                Ok(s) => s.to_string(),
+                Err(r) => return r,
+            };
 
             // Create subvolume if path is under /fs/ and doesn't exist
-            if path.starts_with("/fs/") && !std::path::Path::new(&path).exists() {
-                if let Some(rest) = path.strip_prefix("/fs/") {
-                    if let Some((fs_name, subvol_name)) = rest.split_once('/') {
-                        let create_req = nasty_storage::subvolume::CreateSubvolumeRequest {
-                            filesystem: fs_name.to_string(),
-                            name: subvol_name.to_string(),
-                            subvolume_type: nasty_storage::subvolume::SubvolumeType::Filesystem,
-                            volsize_bytes: None,
-                            compression: None,
-                            comments: Some("Backup Server storage".to_string()),
-                            direct_io: None,
-                            foreground_target: None,
-                            background_target: None,
-                            promote_target: None,
-                            metadata_target: None,
-                            data_replicas: None,
-                        };
-                        let _ = state.subvolumes.create(create_req, None).await;
-                    }
-                }
+            if path.starts_with("/fs/")
+                && !std::path::Path::new(&path).exists()
+                && let Some(rest) = path.strip_prefix("/fs/")
+                && let Some((fs_name, subvol_name)) = rest.split_once('/')
+            {
+                let create_req = nasty_storage::subvolume::CreateSubvolumeRequest {
+                    filesystem: fs_name.to_string(),
+                    name: subvol_name.to_string(),
+                    subvolume_type: nasty_storage::subvolume::SubvolumeType::Filesystem,
+                    volsize_bytes: None,
+                    compression: None,
+                    comments: Some("Backup Server storage".to_string()),
+                    direct_io: None,
+                    foreground_target: None,
+                    background_target: None,
+                    promote_target: None,
+                    metadata_target: None,
+                    data_replicas: None,
+                };
+                let _ = state.subvolumes.create(create_req, None).await;
             }
 
             if let Err(e) = tokio::fs::write("/var/lib/nasty/rest-server-path", &path).await {
@@ -995,7 +1069,8 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             // Restart rest-server to pick up new path
             let _ = tokio::process::Command::new("systemctl")
                 .args(["restart", "nasty-rest-server"])
-                .output().await;
+                .output()
+                .await;
 
             ok(req, "ok")
         }
@@ -1005,23 +1080,31 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(s) => s.to_string(),
                 Err(r) => return r,
             };
-            let sources: Vec<String> = req.params.as_ref()
+            let sources: Vec<String> = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("sources"))
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or_default();
-            let interfaces: Vec<String> = req.params.as_ref()
+            let interfaces: Vec<String> = req
+                .params
+                .as_ref()
                 .and_then(|p| p.get("interfaces"))
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or_default();
-            match state.firewall.set_restriction(&service, sources, interfaces).await {
+            match state
+                .firewall
+                .set_restriction(&service, sources, interfaces)
+                .await
+            {
                 Ok(()) => ok(req, "ok"),
                 Err(e) => err(req, e),
             }
-        },
+        }
 
         // ── Alerts ───────────────────────────────────────────────
         "telemetry.send" => {
-            let sent = crate::telemetry::send_report(&state).await;
+            let sent = crate::telemetry::send_report(state).await;
             ok(req, serde_json::json!({ "sent": sent }))
         }
 
@@ -1032,14 +1115,14 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             // open the first WebUI poll after a minute returns instantly.
             {
                 let cache = state.alerts_cache.lock().await;
-                if let Some((ts, ref cached)) = *cache {
-                    if ts.elapsed() < std::time::Duration::from_secs(20) {
-                        return ok(req, cached.clone());
-                    }
+                if let Some((ts, ref cached)) = *cache
+                    && ts.elapsed() < std::time::Duration::from_secs(20)
+                {
+                    return ok(req, cached.clone());
                 }
             }
 
-            let alerts = evaluate_active_alerts(&state).await;
+            let alerts = evaluate_active_alerts(state).await;
             let value = serde_json::to_value(&alerts).unwrap_or_default();
             *state.alerts_cache.lock().await = Some((std::time::Instant::now(), value));
 
@@ -1072,14 +1155,17 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "notifications.config.get" => {
             ok(req, nasty_system::notifications::NotificationConfig::load())
         }
-        "notifications.config.update" => match parse_params::<nasty_system::notifications::NotificationConfig>(req) {
-            Ok(config) => match config.save().await {
-                Ok(()) => ok(req, "ok"),
+        "notifications.config.update" => {
+            match parse_params::<nasty_system::notifications::NotificationConfig>(req) {
+                Ok(config) => match config.save().await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
                 Err(e) => err(req, e),
-            },
-            Err(e) => err(req, e),
-        },
-        "notifications.test" => match parse_params::<nasty_system::notifications::ChannelType>(req) {
+            }
+        }
+        "notifications.test" => match parse_params::<nasty_system::notifications::ChannelType>(req)
+        {
             Ok(channel) => match nasty_system::notifications::test_channel(&channel).await {
                 Ok(msg) => ok(req, msg),
                 Err(e) => err(req, e),
@@ -1104,7 +1190,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(e) => err(req, e),
         },
         "backup.profile.update" => {
-            let id = match require_str(req, "id") { Ok(s) => s.to_string(), Err(r) => return r };
+            let id = match require_str(req, "id") {
+                Ok(s) => s.to_string(),
+                Err(r) => return r,
+            };
             match parse_params::<nasty_backup::BackupProfile>(req) {
                 Ok(p) => match state.backups.update_profile(&id, p).await {
                     Ok(v) => ok(req, v),
@@ -1129,7 +1218,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(r) => r,
         },
         "backup.run" => {
-            let id = match require_str(req, "id") { Ok(s) => s.to_string(), Err(r) => return r };
+            let id = match require_str(req, "id") {
+                Ok(s) => s.to_string(),
+                Err(r) => return r,
+            };
             // Run in background, return immediately
             let backups = state.backups.clone_for_task();
             tokio::spawn(async move {
@@ -1164,7 +1256,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "fs.get" => match require_str(req, "name") {
             Ok(name) => {
-                if session.filesystem.as_deref().map_or(false, |p| p != name) {
+                if session.filesystem.as_deref().is_some_and(|p| p != name) {
                     err(req, "access denied")
                 } else {
                     match state.filesystems.get(name).await {
@@ -1422,11 +1514,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "subvolume.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
-                if session
-                    .filesystem
-                    .as_deref()
-                    .map_or(false, |p| p != fs_name)
-                {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
                     err(req, "access denied")
                 } else {
                     match state
@@ -1443,11 +1531,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "subvolume.get" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session
-                    .filesystem
-                    .as_deref()
-                    .map_or(false, |p| p != fs_name)
-                {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
                     err(req, "access denied")
                 } else {
                     match state
@@ -1475,7 +1559,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |f| f != p.filesystem)
+                        .is_some_and(|f| f != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1495,7 +1579,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |f| f != p.filesystem)
+                        .is_some_and(|f| f != p.filesystem)
                     {
                         err(req, "access denied")
                     } else if let Some(conflict) =
@@ -1514,11 +1598,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "subvolume.attach" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session
-                    .filesystem
-                    .as_deref()
-                    .map_or(false, |p| p != fs_name)
-                {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
                     err(req, "access denied")
                 } else {
                     match state
@@ -1535,11 +1615,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "subvolume.detach" => match (require_str(req, "filesystem"), require_str(req, "name")) {
             (Ok(fs_name), Ok(name)) => {
-                if session
-                    .filesystem
-                    .as_deref()
-                    .map_or(false, |p| p != fs_name)
-                {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
                     err(req, "access denied")
                 } else {
                     match state
@@ -1561,7 +1637,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |f| f != p.filesystem)
+                        .is_some_and(|f| f != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1581,7 +1657,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |f| f != p.filesystem)
+                        .is_some_and(|f| f != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1601,7 +1677,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |f| f != p.filesystem)
+                        .is_some_and(|f| f != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1625,7 +1701,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |sp| sp != p.filesystem)
+                        .is_some_and(|sp| sp != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1648,7 +1724,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                     if session
                         .filesystem
                         .as_deref()
-                        .map_or(false, |sp| sp != p.filesystem)
+                        .is_some_and(|sp| sp != p.filesystem)
                     {
                         err(req, "access denied")
                     } else {
@@ -1697,11 +1773,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         // ── Snapshots ───────────────────────────────────────────
         "snapshot.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
-                if session
-                    .filesystem
-                    .as_deref()
-                    .map_or(false, |p| p != fs_name)
-                {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
                     err(req, "access denied")
                 } else {
                     match state
@@ -1754,7 +1826,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(r) => r,
         },
         "share.nfs.create" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1766,7 +1840,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nfs.update" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1778,7 +1854,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nfs.delete" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nfs).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1803,7 +1881,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(r) => r,
         },
         "share.smb.create" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1815,7 +1895,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.smb.update" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1827,7 +1909,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.smb.delete" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1845,7 +1929,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(e) => err(req, e),
         },
         "smb.user.create" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             match parse_params::<nasty_sharing::smb::CreateSmbUserRequest>(req) {
@@ -1857,7 +1943,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "smb.user.delete" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             match require_str(req, "username") {
@@ -1869,7 +1957,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "smb.user.set_password" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Smb).await
+            {
                 return r;
             }
             #[derive(Deserialize)]
@@ -1891,27 +1981,26 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
-        "smb.group.create" => {
-            match require_str(req, "name") {
-                Ok(name) => match state.smb.create_group(name).await {
-                    Ok(g) => ok(req, g),
-                    Err(e) => err(req, e),
-                },
-                Err(r) => r,
-            }
-        }
-        "smb.group.delete" => {
-            match require_str(req, "name") {
-                Ok(name) => match state.smb.delete_group(name).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
-                Err(r) => r,
-            }
-        }
+        "smb.group.create" => match require_str(req, "name") {
+            Ok(name) => match state.smb.create_group(name).await {
+                Ok(g) => ok(req, g),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "smb.group.delete" => match require_str(req, "name") {
+            Ok(name) => match state.smb.delete_group(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         "smb.group.add_member" => {
             #[derive(Deserialize)]
-            struct P { group: String, user: String }
+            struct P {
+                group: String,
+                user: String,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.smb.add_group_member(&p.group, &p.user).await {
                     Ok(()) => ok(req, "ok"),
@@ -1922,7 +2011,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
         "smb.group.remove_member" => {
             #[derive(Deserialize)]
-            struct P { group: String, user: String }
+            struct P {
+                group: String,
+                user: String,
+            }
             match parse_params::<P>(req) {
                 Ok(p) => match state.smb.remove_group_member(&p.group, &p.user).await {
                     Ok(()) => ok(req, "ok"),
@@ -1945,17 +2037,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(r) => r,
         },
         "share.iscsi.create" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
                 Ok(p) => {
-                    if let Some(ref dp) = p.device_path {
-                        if let Some(conflict) =
+                    if let Some(ref dp) = p.device_path
+                        && let Some(conflict) =
                             check_block_device_conflict(state, dp, "iscsi").await
-                        {
-                            return err(req, conflict);
-                        }
+                    {
+                        return err(req, conflict);
                     }
                     match state.iscsi.create(p).await {
                         Ok(v) => ok(req, v),
@@ -1966,7 +2059,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.iscsi.delete" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -1978,7 +2073,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.iscsi.add_lun" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params::<nasty_sharing::iscsi::AddLunRequest>(req) {
@@ -1998,7 +2095,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.iscsi.remove_lun" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2010,7 +2109,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.iscsi.add_acl" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2022,7 +2123,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.iscsi.remove_acl" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2047,38 +2150,41 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(r) => r,
         },
         "share.nvmeof.create" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params::<nasty_sharing::nvmeof::CreateSubsystemRequest>(req) {
                 Ok(p) => {
-                    if let Some(ref device_path) = p.device_path {
-                        if let Some(conflict) =
+                    if let Some(ref device_path) = p.device_path
+                        && let Some(conflict) =
                             check_block_device_conflict(state, device_path, "nvmeof").await
-                        {
-                            return err(req, conflict);
-                        }
+                    {
+                        return err(req, conflict);
                     }
                     match state.nvmeof.create(p).await {
                         Ok(v) => {
                             // If Tailscale is connected, add a port for its IP too
                             if !v.ports.is_empty() {
                                 let ts = state.tailscale.get().await;
-                                if ts.connected {
-                                    if let Some(ref ip) = ts.ip {
-                                        let nvmeof = state.nvmeof.clone();
-                                        let id = v.id.clone();
-                                        let ip = ip.clone();
-                                        tokio::spawn(async move {
-                                            let _ = nvmeof.add_port(nasty_sharing::nvmeof::AddPortRequest {
+                                if ts.connected
+                                    && let Some(ref ip) = ts.ip
+                                {
+                                    let nvmeof = state.nvmeof.clone();
+                                    let id = v.id.clone();
+                                    let ip = ip.clone();
+                                    tokio::spawn(async move {
+                                        let _ = nvmeof
+                                            .add_port(nasty_sharing::nvmeof::AddPortRequest {
                                                 subsystem_id: id,
                                                 transport: Some("tcp".to_string()),
                                                 addr: Some(ip),
                                                 service_id: Some(4420),
                                                 addr_family: Some("ipv4".to_string()),
-                                            }).await;
-                                        });
-                                    }
+                                            })
+                                            .await;
+                                    });
                                 }
                             }
                             ok(req, v)
@@ -2090,7 +2196,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.delete" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2102,7 +2210,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.add_namespace" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
@@ -2122,7 +2232,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.remove_namespace" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2134,7 +2246,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.add_port" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2146,7 +2260,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.remove_port" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2158,7 +2274,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.add_host" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2170,7 +2288,9 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
         }
         "share.nvmeof.remove_host" => {
-            if let Some(r) = require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Nvmeof).await
+            {
                 return r;
             }
             match parse_params(req) {
@@ -2183,9 +2303,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         }
 
         // ── Virtual Machines ───────────────────────────────────
-        "vm.capabilities" => match state.vms.capabilities().await {
-            c => ok(req, c),
-        },
+        "vm.capabilities" => ok(req, state.vms.capabilities().await),
         "vm.list" => match state.vms.list().await {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
@@ -2517,6 +2635,7 @@ async fn require_protocol(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn require_str<'a>(req: &'a Request, key: &str) -> Result<&'a str, Response> {
     str_param(req, key).ok_or_else(|| {
         Response::error(
@@ -2552,31 +2671,31 @@ async fn check_block_device_conflict(
     device_path: &str,
     exclude_protocol: &str,
 ) -> Option<String> {
-    if exclude_protocol != "iscsi" {
-        if let Ok(targets) = state.iscsi.list().await {
-            for target in &targets {
-                for lun in &target.luns {
-                    if lun.backstore_path == device_path {
-                        return Some(format!(
-                            "device {} is already exported via iSCSI (target '{}')",
-                            device_path, target.iqn
-                        ));
-                    }
+    if exclude_protocol != "iscsi"
+        && let Ok(targets) = state.iscsi.list().await
+    {
+        for target in &targets {
+            for lun in &target.luns {
+                if lun.backstore_path == device_path {
+                    return Some(format!(
+                        "device {} is already exported via iSCSI (target '{}')",
+                        device_path, target.iqn
+                    ));
                 }
             }
         }
     }
 
-    if exclude_protocol != "nvmeof" {
-        if let Ok(subsystems) = state.nvmeof.list().await {
-            for sub in &subsystems {
-                for ns in &sub.namespaces {
-                    if ns.device_path == device_path {
-                        return Some(format!(
-                            "device {} is already exported via NVMe-oF (subsystem '{}')",
-                            device_path, sub.nqn
-                        ));
-                    }
+    if exclude_protocol != "nvmeof"
+        && let Ok(subsystems) = state.nvmeof.list().await
+    {
+        for sub in &subsystems {
+            for ns in &sub.namespaces {
+                if ns.device_path == device_path {
+                    return Some(format!(
+                        "device {} is already exported via NVMe-oF (subsystem '{}')",
+                        device_path, sub.nqn
+                    ));
                 }
             }
         }
@@ -2669,10 +2788,13 @@ async fn ensure_images_subvolume(state: &AppState, filesystem: &str) -> Result<S
 
     // Migrate legacy path
     if !std::path::Path::new(&images_path).exists() && std::path::Path::new(&legacy_path).exists() {
-        tokio::fs::create_dir_all(format!("{mount_point}/vms")).await
+        tokio::fs::create_dir_all(format!("{mount_point}/vms"))
+            .await
             .map_err(|e| format!("failed to create vms dir: {e}"))?;
         if let Err(e) = tokio::fs::rename(&legacy_path, &images_path).await {
-            tracing::warn!("Failed to migrate VM images from {legacy_path}: {e}, using legacy path");
+            tracing::warn!(
+                "Failed to migrate VM images from {legacy_path}: {e}, using legacy path"
+            );
             return Ok(legacy_path);
         }
         tracing::info!("Migrated VM images from {legacy_path} to {images_path}");
@@ -2797,13 +2919,13 @@ async fn check_filesystem_in_use(state: &AppState, name: &str) -> Option<String>
     // Check if apps runtime uses this filesystem
     if state.apps.is_enabled() {
         let config = nasty_apps::AppsService::load_config();
-        if let Some(ref path) = config.storage_path {
-            if path.starts_with(&format!("/fs/{name}/")) {
-                return Some(format!(
-                    "filesystem '{}' cannot be destroyed: apps runtime storage is on this filesystem. Disable Apps first.",
-                    name
-                ));
-            }
+        if let Some(ref path) = config.storage_path
+            && path.starts_with(&format!("/fs/{name}/"))
+        {
+            return Some(format!(
+                "filesystem '{}' cannot be destroyed: apps runtime storage is on this filesystem. Disable Apps first.",
+                name
+            ));
         }
     }
 
@@ -2826,15 +2948,15 @@ async fn resolve_vm_disks(
     let mut resolved = Vec::new();
     for disk in &vm.disks {
         for sv in &all_subvols {
-            if let Some(ref bd) = sv.block_device {
-                if bd == &disk.path {
-                    resolved.push(nasty_vm::VmDiskSubvolume {
-                        filesystem: sv.filesystem.clone(),
-                        subvolume: sv.name.clone(),
-                        device: disk.path.clone(),
-                    });
-                    break;
-                }
+            if let Some(ref bd) = sv.block_device
+                && bd == &disk.path
+            {
+                resolved.push(nasty_vm::VmDiskSubvolume {
+                    filesystem: sv.filesystem.clone(),
+                    subvolume: sv.name.clone(),
+                    device: disk.path.clone(),
+                });
+                break;
             }
         }
     }
@@ -2974,24 +3096,24 @@ async fn vm_clone(
 /// Errors fetching individual signals are swallowed and the corresponding
 /// alert family is treated as "no data" so a metrics-service blip doesn't
 /// silence everything else.
-pub(crate) async fn evaluate_active_alerts(state: &AppState) -> Vec<nasty_system::alerts::ActiveAlert> {
+pub(crate) async fn evaluate_active_alerts(
+    state: &AppState,
+) -> Vec<nasty_system::alerts::ActiveAlert> {
     use nasty_system::alerts;
 
     // System stats — required for CPU/memory/temp rules. If the metrics
     // service is down, evaluating those rules without data is meaningless;
     // return an empty alert set rather than fabricating false positives.
-    let stats = match fetch_metrics_json::<nasty_system::SystemStats>(
-        &state.metrics_client,
-        "/api/stats",
-    )
-    .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!("alert evaluation: stats fetch failed: {e}");
-            return Vec::new();
-        }
-    };
+    let stats =
+        match fetch_metrics_json::<nasty_system::SystemStats>(&state.metrics_client, "/api/stats")
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("alert evaluation: stats fetch failed: {e}");
+                return Vec::new();
+            }
+        };
 
     let filesystems = state.filesystems.list().await.unwrap_or_default();
     let disk_health: Vec<nasty_system::DiskHealth> = if state
@@ -3037,10 +3159,7 @@ pub(crate) async fn evaluate_active_alerts(state: &AppState) -> Vec<nasty_system
                 .map(|d| alerts::BcachefsDeviceHealth {
                     path: d.path.clone(),
                     state: d.state.clone().unwrap_or_else(|| "rw".into()),
-                    has_errors: d
-                        .has_data
-                        .as_deref()
-                        .map_or(false, |s| s.contains("error")),
+                    has_errors: d.has_data.as_deref().is_some_and(|s| s.contains("error")),
                 })
                 .collect();
 
@@ -3141,10 +3260,10 @@ async fn read_bcachefs_error_count(uuid: &str) -> u64 {
     let mut total = 0u64;
     for name in ["io_read_errors", "io_write_errors", "io_checksum_errors"] {
         let path = format!("{counters_dir}/{name}");
-        if let Ok(val) = tokio::fs::read_to_string(&path).await {
-            if let Ok(n) = val.trim().parse::<u64>() {
-                total += n;
-            }
+        if let Ok(val) = tokio::fs::read_to_string(&path).await
+            && let Ok(n) = val.trim().parse::<u64>()
+        {
+            total += n;
         }
     }
     total

--- a/engine/nasty-engine/src/terminal.rs
+++ b/engine/nasty-engine/src/terminal.rs
@@ -59,7 +59,12 @@ struct ControlMessage {
     rows: u16,
 }
 
-async fn handle_terminal(mut socket: WebSocket, state: Arc<AppState>, client_ip: String, pre_auth_token: Option<String>) {
+async fn handle_terminal(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_ip: String,
+    pre_auth_token: Option<String>,
+) {
     // Phase 1: authenticate and get terminal size
     let auth = match wait_for_terminal_auth(&mut socket, &state, &client_ip, pre_auth_token).await {
         Some(a) => a,
@@ -167,8 +172,8 @@ async fn handle_terminal(mut socket: WebSocket, state: Arc<AppState>, client_ip:
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         // Check if it's a control message (resize)
-                        if let Ok(ctrl) = serde_json::from_str::<ControlMessage>(&text) {
-                            if ctrl.msg_type == "resize" {
+                        if let Ok(ctrl) = serde_json::from_str::<ControlMessage>(&text)
+                            && ctrl.msg_type == "resize" {
                                 let _ = master.resize(PtySize {
                                     rows: ctrl.rows,
                                     cols: ctrl.cols,
@@ -177,7 +182,6 @@ async fn handle_terminal(mut socket: WebSocket, state: Arc<AppState>, client_ip:
                                 });
                                 continue;
                             }
-                        }
                         // Regular input — write to PTY
                         let writer = writer.clone();
                         let data: Vec<u8> = text.bytes().collect();
@@ -274,10 +278,20 @@ async fn wait_for_terminal_auth(
             })
         }
         Ok(session) => {
-            warn!("Terminal access denied for '{}': role={:?}", session.username, session.role);
-            crate::auth::audit("terminal_denied", &session.username, client_ip, &format!("role={:?}", session.role));
+            warn!(
+                "Terminal access denied for '{}': role={:?}",
+                session.username, session.role
+            );
+            crate::auth::audit(
+                "terminal_denied",
+                &session.username,
+                client_ip,
+                &format!("role={:?}", session.role),
+            );
             let _ = socket
-                .send(Message::Text(r#"{"error":"forbidden: admin role required"}"#.into()))
+                .send(Message::Text(
+                    r#"{"error":"forbidden: admin role required"}"#.into(),
+                ))
                 .await;
             let _ = socket.send(Message::Close(None)).await;
             None

--- a/engine/nasty-engine/src/vm_console.rs
+++ b/engine/nasty-engine/src/vm_console.rs
@@ -73,6 +73,8 @@ fn extract_client_ip(headers: &axum::http::HeaderMap) -> String {
 ///
 /// For VNC: binary frames are forwarded as-is (noVNC speaks raw RFB).
 /// For serial: text frames are forwarded as bytes.
+// Suggested guards use `.await`, which isn't stable in match guards.
+#[allow(clippy::collapsible_match)]
 async fn proxy_unix_socket(
     mut ws: WebSocket,
     socket_path: String,

--- a/engine/nasty-engine/src/vm_console.rs
+++ b/engine/nasty-engine/src/vm_console.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use axum::extract::{
-    Path,
-    State,
+    Path, State,
     ws::{Message, WebSocket, WebSocketUpgrade},
 };
 use axum::response::IntoResponse;
@@ -27,7 +26,17 @@ pub async fn vnc_handler(
 ) -> impl IntoResponse {
     let client_ip = extract_client_ip(&headers);
     let pre_auth_token = crate::token_from_headers(&headers);
-    ws.on_upgrade(move |socket| proxy_unix_socket(socket, format!("{QMP_DIR}/{vm_id}.vnc"), "vnc", vm_id, state, client_ip, pre_auth_token))
+    ws.on_upgrade(move |socket| {
+        proxy_unix_socket(
+            socket,
+            format!("{QMP_DIR}/{vm_id}.vnc"),
+            "vnc",
+            vm_id,
+            state,
+            client_ip,
+            pre_auth_token,
+        )
+    })
 }
 
 /// WebSocket handler for serial console (text frames → serial unix socket).
@@ -39,7 +48,17 @@ pub async fn serial_handler(
 ) -> impl IntoResponse {
     let client_ip = extract_client_ip(&headers);
     let pre_auth_token = crate::token_from_headers(&headers);
-    ws.on_upgrade(move |socket| proxy_unix_socket(socket, format!("{QMP_DIR}/{vm_id}.serial"), "serial", vm_id, state, client_ip, pre_auth_token))
+    ws.on_upgrade(move |socket| {
+        proxy_unix_socket(
+            socket,
+            format!("{QMP_DIR}/{vm_id}.serial"),
+            "serial",
+            vm_id,
+            state,
+            client_ip,
+            pre_auth_token,
+        )
+    })
 }
 
 fn extract_client_ip(headers: &axum::http::HeaderMap) -> String {
@@ -71,7 +90,11 @@ async fn proxy_unix_socket(
             Some(Ok(Message::Text(text))) => {
                 let parsed: Result<serde_json::Value, _> = serde_json::from_str(&text);
                 match parsed {
-                    Ok(v) => v.get("token").and_then(|t| t.as_str()).unwrap_or("").to_string(),
+                    Ok(v) => v
+                        .get("token")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string(),
                     Err(_) => text.to_string(),
                 }
             }
@@ -83,7 +106,12 @@ async fn proxy_unix_socket(
     match state.auth.validate(&token, &client_ip).await {
         Ok(s) if s.role == crate::auth::Role::Admin || s.role == crate::auth::Role::Operator => {}
         Ok(s) => {
-            crate::auth::audit("vm_console_denied", &s.username, &client_ip, &format!("role={:?} vm={}", s.role, vm_id));
+            crate::auth::audit(
+                "vm_console_denied",
+                &s.username,
+                &client_ip,
+                &format!("role={:?} vm={}", s.role, vm_id),
+            );
             let _ = ws.send(Message::Text("forbidden".into())).await;
             return;
         }

--- a/engine/nasty-metrics/src/collect_bcachefs.rs
+++ b/engine/nasty-metrics/src/collect_bcachefs.rs
@@ -367,7 +367,7 @@ pub fn read_space(mount_point: &str) -> SpaceUsage {
     unsafe {
         let mut stat: libc::statvfs = std::mem::zeroed();
         if libc::statvfs(path.as_ptr(), &mut stat) == 0 {
-            let block_size = stat.f_frsize as u64;
+            let block_size = stat.f_frsize;
             let total = stat.f_blocks as u64 * block_size;
             let available = stat.f_bavail as u64 * block_size;
             let used = total.saturating_sub(stat.f_bfree as u64 * block_size);

--- a/engine/nasty-metrics/src/collect_kernel.rs
+++ b/engine/nasty-metrics/src/collect_kernel.rs
@@ -142,7 +142,10 @@ impl KernelErrorCollector {
         let lines = match output {
             Ok(o) if o.status.success() => {
                 let reader = BufReader::new(&o.stdout[..]);
-                reader.lines().collect::<Result<Vec<_>, _>>().unwrap_or_default()
+                reader
+                    .lines()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap_or_default()
             }
             _ => return self.build_summary(),
         };

--- a/engine/nasty-metrics/src/collect_system.rs
+++ b/engine/nasty-metrics/src/collect_system.rs
@@ -24,7 +24,15 @@ pub fn cpu_stats() -> CpuStats {
     let temp_c = read_cpu_temperature();
     let (freq_mhz, governor) = read_cpu_frequency();
 
-    CpuStats { count, load_1, load_5, load_15, temp_c, freq_mhz, governor }
+    CpuStats {
+        count,
+        load_1,
+        load_5,
+        load_15,
+        temp_c,
+        freq_mhz,
+        governor,
+    }
 }
 
 /// Read CPU package temperature from hwmon sysfs (coretemp / k10temp).
@@ -37,18 +45,18 @@ fn read_cpu_temperature() -> Option<i32> {
         // coretemp (Intel), k10temp (AMD), zenpower (AMD alt)
         if matches!(name, "coretemp" | "k10temp" | "zenpower") {
             // temp1_input is typically the package/Tdie temperature
-            if let Ok(val) = std::fs::read_to_string(path.join("temp1_input")) {
-                if let Ok(millideg) = val.trim().parse::<i64>() {
-                    return Some((millideg / 1000) as i32);
-                }
+            if let Ok(val) = std::fs::read_to_string(path.join("temp1_input"))
+                && let Ok(millideg) = val.trim().parse::<i64>()
+            {
+                return Some((millideg / 1000) as i32);
             }
         }
     }
     // Fallback: first thermal zone
-    if let Ok(val) = std::fs::read_to_string("/sys/class/thermal/thermal_zone0/temp") {
-        if let Ok(millideg) = val.trim().parse::<i64>() {
-            return Some((millideg / 1000) as i32);
-        }
+    if let Ok(val) = std::fs::read_to_string("/sys/class/thermal/thermal_zone0/temp")
+        && let Ok(millideg) = val.trim().parse::<i64>()
+    {
+        return Some((millideg / 1000) as i32);
     }
     None
 }
@@ -67,22 +75,23 @@ fn read_cpu_frequency() -> (Option<u32>, Option<String>) {
     for entry in cpus.flatten() {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if !name.starts_with("cpu") || !name[3..].chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        if !name.starts_with("cpu") || !name[3..].chars().next().is_some_and(|c| c.is_ascii_digit())
+        {
             continue;
         }
         let cpufreq = entry.path().join("cpufreq");
-        if let Ok(val) = std::fs::read_to_string(cpufreq.join("scaling_cur_freq")) {
-            if let Ok(khz) = val.trim().parse::<u64>() {
-                total_khz += khz;
-                count += 1;
-            }
+        if let Ok(val) = std::fs::read_to_string(cpufreq.join("scaling_cur_freq"))
+            && let Ok(khz) = val.trim().parse::<u64>()
+        {
+            total_khz += khz;
+            count += 1;
         }
-        if governor.is_none() {
-            if let Ok(val) = std::fs::read_to_string(cpufreq.join("scaling_governor")) {
-                let g = val.trim().to_string();
-                if !g.is_empty() {
-                    governor = Some(g);
-                }
+        if governor.is_none()
+            && let Ok(val) = std::fs::read_to_string(cpufreq.join("scaling_governor"))
+        {
+            let g = val.trim().to_string();
+            if !g.is_empty() {
+                governor = Some(g);
             }
         }
     }
@@ -132,14 +141,19 @@ pub fn memory_stats() -> MemoryStats {
 
 fn interface_addresses() -> std::collections::HashMap<String, Vec<String>> {
     let mut map = std::collections::HashMap::new();
-    let Ok(output) = std::process::Command::new("ip").args(["-j", "addr", "show"]).output() else {
+    let Ok(output) = std::process::Command::new("ip")
+        .args(["-j", "addr", "show"])
+        .output()
+    else {
         return map;
     };
     let Ok(json): Result<Vec<serde_json::Value>, _> = serde_json::from_slice(&output.stdout) else {
         return map;
     };
     for iface in json {
-        let Some(name) = iface["ifname"].as_str() else { continue };
+        let Some(name) = iface["ifname"].as_str() else {
+            continue;
+        };
         let mut addrs = Vec::new();
         if let Some(addr_info) = iface["addr_info"].as_array() {
             for ai in addr_info {
@@ -161,7 +175,9 @@ pub fn network_stats() -> Vec<NetIfStats> {
 
     for line in content.lines().skip(2) {
         let line = line.trim();
-        let Some((name, rest)) = line.split_once(':') else { continue };
+        let Some((name, rest)) = line.split_once(':') else {
+            continue;
+        };
         let name = name.trim();
 
         if name == "lo" {
@@ -379,7 +395,11 @@ async fn query_smartctl(device: &str) -> Option<DiskHealth> {
 
     let json: SmartctlJson = serde_json::from_slice(&output.stdout).ok()?;
 
-    let health_passed = json.smart_status.as_ref().map(|s| s.passed).unwrap_or(false);
+    let health_passed = json
+        .smart_status
+        .as_ref()
+        .map(|s| s.passed)
+        .unwrap_or(false);
 
     let attributes: Vec<SmartAttribute> = json
         .ata_smart_attributes
@@ -452,7 +472,11 @@ fn resolve_device_path(dev_name: &str) -> (Option<String>, Option<String>) {
         if component.contains(':') && component.contains('.') {
             if let Some(short) = component.strip_prefix("0000:") {
                 pci_addr = Some(short.to_string());
-            } else if component.len() <= 8 && component.chars().all(|c| c.is_ascii_hexdigit() || c == ':' || c == '.') {
+            } else if component.len() <= 8
+                && component
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit() || c == ':' || c == '.')
+            {
                 pci_addr = Some(component.to_string());
             }
         }

--- a/engine/nasty-metrics/src/db.rs
+++ b/engine/nasty-metrics/src/db.rs
@@ -18,8 +18,8 @@ pub struct MetricsDb {
 
 impl MetricsDb {
     pub fn open() -> Result<Self, String> {
-        let conn = Connection::open(DB_PATH)
-            .map_err(|e| format!("failed to open metrics db: {e}"))?;
+        let conn =
+            Connection::open(DB_PATH).map_err(|e| format!("failed to open metrics db: {e}"))?;
 
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
@@ -98,7 +98,9 @@ impl MetricsDb {
         let names: Vec<String> = if let Some(n) = name {
             vec![n.to_string()]
         } else {
-            match conn.prepare("SELECT DISTINCT name FROM io_samples WHERE kind = ?1 AND ts >= ?2 AND ts <= ?3") {
+            match conn.prepare(
+                "SELECT DISTINCT name FROM io_samples WHERE kind = ?1 AND ts >= ?2 AND ts <= ?3",
+            ) {
                 Ok(mut stmt) => stmt
                     .query_map(rusqlite::params![kind, since, until], |row| row.get(0))
                     .map(|rows| rows.filter_map(|r| r.ok()).collect())
@@ -137,7 +139,10 @@ impl MetricsDb {
                     .map(|rows| rows.filter_map(|r| r.ok()).collect())
                     .unwrap_or_default();
 
-                results.push(ResourceHistory { name: n.clone(), samples });
+                results.push(ResourceHistory {
+                    name: n.clone(),
+                    samples,
+                });
             }
         } else {
             let mut stmt = match conn.prepare(
@@ -167,7 +172,10 @@ impl MetricsDb {
                     .map(|rows| rows.filter_map(|r| r.ok()).collect())
                     .unwrap_or_default();
 
-                results.push(ResourceHistory { name: n.clone(), samples });
+                results.push(ResourceHistory {
+                    name: n.clone(),
+                    samples,
+                });
             }
         }
 
@@ -177,11 +185,11 @@ impl MetricsDb {
 
 fn range_to_params(range: &str) -> (i64, i64) {
     match range {
-        "1h"  => (3_600_000,      60_000),
-        "1d"  => (86_400_000,    300_000),
-        "7d"  => (604_800_000, 1_800_000),
+        "1h" => (3_600_000, 60_000),
+        "1d" => (86_400_000, 300_000),
+        "7d" => (604_800_000, 1_800_000),
         "30d" => (2_592_000_000, 7_200_000),
-        _     => (300_000, 0),
+        _ => (300_000, 0),
     }
 }
 

--- a/engine/nasty-metrics/src/main.rs
+++ b/engine/nasty-metrics/src/main.rs
@@ -2,11 +2,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::{
+    Json, Router,
     extract::{Query, State},
     http::{StatusCode, header},
     response::IntoResponse,
     routing::get,
-    Json, Router,
 };
 use serde::Deserialize;
 use tokio::sync::RwLock;
@@ -42,8 +42,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let metrics_db = db::MetricsDb::open()
-        .expect("failed to open metrics database");
+    let metrics_db = db::MetricsDb::open().expect("failed to open metrics database");
 
     let state = Arc::new(AppState {
         db: metrics_db,
@@ -91,7 +90,10 @@ async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoRespons
 
     (
         StatusCode::OK,
-        [(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")],
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
         body,
     )
 }

--- a/engine/nasty-metrics/src/prometheus.rs
+++ b/engine/nasty-metrics/src/prometheus.rs
@@ -32,35 +32,102 @@ pub fn render(stats: &SystemStats, disks: &[DiskHealth], bcachefs: &[BcachefsMet
 // ── System metrics ──────────────────────────────────────────────
 
 fn render_cpu(out: &mut String, cpu: &CpuStats) {
-    gauge(out, "nasty_cpu_count", "Number of logical CPU cores", &[], cpu.count as f64);
-    gauge(out, "nasty_cpu_load", "CPU load average", &[("window", "1m")], cpu.load_1);
+    gauge(
+        out,
+        "nasty_cpu_count",
+        "Number of logical CPU cores",
+        &[],
+        cpu.count as f64,
+    );
+    gauge(
+        out,
+        "nasty_cpu_load",
+        "CPU load average",
+        &[("window", "1m")],
+        cpu.load_1,
+    );
     metric_line(out, "nasty_cpu_load", &[("window", "5m")], cpu.load_5);
     metric_line(out, "nasty_cpu_load", &[("window", "15m")], cpu.load_15);
 }
 
 fn render_memory(out: &mut String, mem: &MemoryStats) {
-    gauge(out, "nasty_memory_total_bytes", "Total installed RAM", &[], mem.total_bytes as f64);
-    gauge(out, "nasty_memory_used_bytes", "RAM in use", &[], mem.used_bytes as f64);
-    gauge(out, "nasty_memory_available_bytes", "RAM available", &[], mem.available_bytes as f64);
-    gauge(out, "nasty_swap_total_bytes", "Total swap space", &[], mem.swap_total_bytes as f64);
-    gauge(out, "nasty_swap_used_bytes", "Swap in use", &[], mem.swap_used_bytes as f64);
+    gauge(
+        out,
+        "nasty_memory_total_bytes",
+        "Total installed RAM",
+        &[],
+        mem.total_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_memory_used_bytes",
+        "RAM in use",
+        &[],
+        mem.used_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_memory_available_bytes",
+        "RAM available",
+        &[],
+        mem.available_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_swap_total_bytes",
+        "Total swap space",
+        &[],
+        mem.swap_total_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_swap_used_bytes",
+        "Swap in use",
+        &[],
+        mem.swap_used_bytes as f64,
+    );
 }
 
 fn render_network(out: &mut String, interfaces: &[NetIfStats]) {
     if interfaces.is_empty() {
         return;
     }
-    header(out, "nasty_net_rx_bytes_total", "counter", "Cumulative bytes received");
+    header(
+        out,
+        "nasty_net_rx_bytes_total",
+        "counter",
+        "Cumulative bytes received",
+    );
     for iface in interfaces {
-        metric_line(out, "nasty_net_rx_bytes_total", &[("interface", &iface.name)], iface.rx_bytes as f64);
+        metric_line(
+            out,
+            "nasty_net_rx_bytes_total",
+            &[("interface", &iface.name)],
+            iface.rx_bytes as f64,
+        );
     }
-    header(out, "nasty_net_tx_bytes_total", "counter", "Cumulative bytes transmitted");
+    header(
+        out,
+        "nasty_net_tx_bytes_total",
+        "counter",
+        "Cumulative bytes transmitted",
+    );
     for iface in interfaces {
-        metric_line(out, "nasty_net_tx_bytes_total", &[("interface", &iface.name)], iface.tx_bytes as f64);
+        metric_line(
+            out,
+            "nasty_net_tx_bytes_total",
+            &[("interface", &iface.name)],
+            iface.tx_bytes as f64,
+        );
     }
     header(out, "nasty_net_up", "gauge", "Whether interface is up");
     for iface in interfaces {
-        metric_line(out, "nasty_net_up", &[("interface", &iface.name)], if iface.up { 1.0 } else { 0.0 });
+        metric_line(
+            out,
+            "nasty_net_up",
+            &[("interface", &iface.name)],
+            if iface.up { 1.0 } else { 0.0 },
+        );
     }
 }
 
@@ -68,17 +135,47 @@ fn render_disk_io(out: &mut String, disks: &[DiskIoStats]) {
     if disks.is_empty() {
         return;
     }
-    header(out, "nasty_disk_read_bytes_total", "counter", "Cumulative bytes read");
+    header(
+        out,
+        "nasty_disk_read_bytes_total",
+        "counter",
+        "Cumulative bytes read",
+    );
     for d in disks {
-        metric_line(out, "nasty_disk_read_bytes_total", &[("device", &d.name)], d.read_bytes as f64);
+        metric_line(
+            out,
+            "nasty_disk_read_bytes_total",
+            &[("device", &d.name)],
+            d.read_bytes as f64,
+        );
     }
-    header(out, "nasty_disk_write_bytes_total", "counter", "Cumulative bytes written");
+    header(
+        out,
+        "nasty_disk_write_bytes_total",
+        "counter",
+        "Cumulative bytes written",
+    );
     for d in disks {
-        metric_line(out, "nasty_disk_write_bytes_total", &[("device", &d.name)], d.write_bytes as f64);
+        metric_line(
+            out,
+            "nasty_disk_write_bytes_total",
+            &[("device", &d.name)],
+            d.write_bytes as f64,
+        );
     }
-    header(out, "nasty_disk_io_in_progress", "gauge", "I/O operations in progress");
+    header(
+        out,
+        "nasty_disk_io_in_progress",
+        "gauge",
+        "I/O operations in progress",
+    );
     for d in disks {
-        metric_line(out, "nasty_disk_io_in_progress", &[("device", &d.name)], d.io_in_progress as f64);
+        metric_line(
+            out,
+            "nasty_disk_io_in_progress",
+            &[("device", &d.name)],
+            d.io_in_progress as f64,
+        );
     }
 }
 
@@ -86,24 +183,50 @@ fn render_smart(out: &mut String, disks: &[DiskHealth]) {
     if disks.is_empty() {
         return;
     }
-    header(out, "nasty_disk_smart_healthy", "gauge", "SMART health status (1=passed, 0=failed)");
+    header(
+        out,
+        "nasty_disk_smart_healthy",
+        "gauge",
+        "SMART health status (1=passed, 0=failed)",
+    );
     for d in disks {
-        metric_line(out, "nasty_disk_smart_healthy",
+        metric_line(
+            out,
+            "nasty_disk_smart_healthy",
             &[("device", &d.device), ("model", &d.model)],
-            if d.health_passed { 1.0 } else { 0.0 });
+            if d.health_passed { 1.0 } else { 0.0 },
+        );
     }
-    header(out, "nasty_disk_temperature_celsius", "gauge", "Drive temperature in Celsius");
+    header(
+        out,
+        "nasty_disk_temperature_celsius",
+        "gauge",
+        "Drive temperature in Celsius",
+    );
     for d in disks {
         if let Some(temp) = d.temperature_c {
-            metric_line(out, "nasty_disk_temperature_celsius",
-                &[("device", &d.device)], temp as f64);
+            metric_line(
+                out,
+                "nasty_disk_temperature_celsius",
+                &[("device", &d.device)],
+                temp as f64,
+            );
         }
     }
-    header(out, "nasty_disk_power_on_hours", "gauge", "Accumulated power-on hours");
+    header(
+        out,
+        "nasty_disk_power_on_hours",
+        "gauge",
+        "Accumulated power-on hours",
+    );
     for d in disks {
         if let Some(hours) = d.power_on_hours {
-            metric_line(out, "nasty_disk_power_on_hours",
-                &[("device", &d.device)], hours as f64);
+            metric_line(
+                out,
+                "nasty_disk_power_on_hours",
+                &[("device", &d.device)],
+                hours as f64,
+            );
         }
     }
 }
@@ -111,23 +234,56 @@ fn render_smart(out: &mut String, disks: &[DiskHealth]) {
 // ── bcachefs metrics ────────────────────────────────────────────
 
 fn render_bcachefs_space(out: &mut String, fs: &BcachefsMetrics) {
-    let labels = [("filesystem", fs.fs_name.as_str()), ("uuid", fs.uuid.as_str())];
-    gauge(out, "nasty_bcachefs_fs_total_bytes", "Total pool capacity", &labels, fs.space.total_bytes as f64);
-    gauge(out, "nasty_bcachefs_fs_used_bytes", "Filesystem bytes in use", &labels, fs.space.used_bytes as f64);
-    gauge(out, "nasty_bcachefs_fs_available_bytes", "Filesystem bytes available", &labels, fs.space.available_bytes as f64);
+    let labels = [
+        ("filesystem", fs.fs_name.as_str()),
+        ("uuid", fs.uuid.as_str()),
+    ];
+    gauge(
+        out,
+        "nasty_bcachefs_fs_total_bytes",
+        "Total pool capacity",
+        &labels,
+        fs.space.total_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_bcachefs_fs_used_bytes",
+        "Filesystem bytes in use",
+        &labels,
+        fs.space.used_bytes as f64,
+    );
+    gauge(
+        out,
+        "nasty_bcachefs_fs_available_bytes",
+        "Filesystem bytes available",
+        &labels,
+        fs.space.available_bytes as f64,
+    );
 }
 
 fn render_bcachefs_counters(out: &mut String, fs: &BcachefsMetrics) {
     if fs.counters.is_empty() {
         return;
     }
-    header(out, "nasty_bcachefs_counter", "counter", "bcachefs persistent counter (since mount)");
+    header(
+        out,
+        "nasty_bcachefs_counter",
+        "counter",
+        "bcachefs persistent counter (since mount)",
+    );
     let mut sorted: Vec<_> = fs.counters.iter().collect();
     sorted.sort_by_key(|(k, _)| k.as_str());
     for (name, value) in sorted {
-        metric_line(out, "nasty_bcachefs_counter",
-            &[("filesystem", fs.fs_name.as_str()), ("uuid", fs.uuid.as_str()), ("counter", name)],
-            *value as f64);
+        metric_line(
+            out,
+            "nasty_bcachefs_counter",
+            &[
+                ("filesystem", fs.fs_name.as_str()),
+                ("uuid", fs.uuid.as_str()),
+                ("counter", name),
+            ],
+            *value as f64,
+        );
     }
 }
 
@@ -138,7 +294,12 @@ fn render_bcachefs_time_stats(out: &mut String, fs: &BcachefsMetrics) {
 
     for suffix in &["mean_ns", "min_ns", "max_ns", "stddev_ns", "count"] {
         let metric_name = format!("nasty_bcachefs_time_stat_{suffix}");
-        header(out, &metric_name, "gauge", &format!("bcachefs time stat {suffix}"));
+        header(
+            out,
+            &metric_name,
+            "gauge",
+            &format!("bcachefs time stat {suffix}"),
+        );
         let mut sorted: Vec<_> = fs.time_stats.iter().collect();
         sorted.sort_by_key(|(k, _)| k.as_str());
         for (name, stat) in &sorted {
@@ -150,9 +311,16 @@ fn render_bcachefs_time_stats(out: &mut String, fs: &BcachefsMetrics) {
                 "count" => stat.count as f64,
                 _ => 0.0,
             };
-            metric_line(out, &metric_name,
-                &[("filesystem", fs.fs_name.as_str()), ("uuid", fs.uuid.as_str()), ("op", name)],
-                val);
+            metric_line(
+                out,
+                &metric_name,
+                &[
+                    ("filesystem", fs.fs_name.as_str()),
+                    ("uuid", fs.uuid.as_str()),
+                    ("op", name),
+                ],
+                val,
+            );
         }
     }
 }
@@ -161,15 +329,36 @@ fn render_bcachefs_devices(out: &mut String, fs: &BcachefsMetrics) {
     if fs.devices.is_empty() {
         return;
     }
-    header(out, "nasty_bcachefs_device_io_latency_ns", "gauge", "Current device I/O latency in nanoseconds");
+    header(
+        out,
+        "nasty_bcachefs_device_io_latency_ns",
+        "gauge",
+        "Current device I/O latency in nanoseconds",
+    );
     for dev in &fs.devices {
         let label_str = dev.label.as_deref().unwrap_or("");
-        metric_line(out, "nasty_bcachefs_device_io_latency_ns",
-            &[("filesystem", fs.fs_name.as_str()), ("device", &dev.name), ("label", label_str), ("direction", "read")],
-            dev.io_latency_read_ns as f64);
-        metric_line(out, "nasty_bcachefs_device_io_latency_ns",
-            &[("filesystem", fs.fs_name.as_str()), ("device", &dev.name), ("label", label_str), ("direction", "write")],
-            dev.io_latency_write_ns as f64);
+        metric_line(
+            out,
+            "nasty_bcachefs_device_io_latency_ns",
+            &[
+                ("filesystem", fs.fs_name.as_str()),
+                ("device", &dev.name),
+                ("label", label_str),
+                ("direction", "read"),
+            ],
+            dev.io_latency_read_ns as f64,
+        );
+        metric_line(
+            out,
+            "nasty_bcachefs_device_io_latency_ns",
+            &[
+                ("filesystem", fs.fs_name.as_str()),
+                ("device", &dev.name),
+                ("label", label_str),
+                ("direction", "write"),
+            ],
+            dev.io_latency_write_ns as f64,
+        );
     }
 }
 
@@ -177,42 +366,106 @@ fn render_bcachefs_compression(out: &mut String, fs: &BcachefsMetrics) {
     if fs.compression.is_empty() {
         return;
     }
-    header(out, "nasty_bcachefs_compressed_bytes", "gauge", "Compressed data size on disk");
+    header(
+        out,
+        "nasty_bcachefs_compressed_bytes",
+        "gauge",
+        "Compressed data size on disk",
+    );
     for c in &fs.compression {
-        metric_line(out, "nasty_bcachefs_compressed_bytes",
-            &[("filesystem", fs.fs_name.as_str()), ("algorithm", &c.algorithm)],
-            c.compressed_bytes as f64);
+        metric_line(
+            out,
+            "nasty_bcachefs_compressed_bytes",
+            &[
+                ("filesystem", fs.fs_name.as_str()),
+                ("algorithm", &c.algorithm),
+            ],
+            c.compressed_bytes as f64,
+        );
     }
-    header(out, "nasty_bcachefs_uncompressed_bytes", "gauge", "Uncompressed (logical) data size");
+    header(
+        out,
+        "nasty_bcachefs_uncompressed_bytes",
+        "gauge",
+        "Uncompressed (logical) data size",
+    );
     for c in &fs.compression {
-        metric_line(out, "nasty_bcachefs_uncompressed_bytes",
-            &[("filesystem", fs.fs_name.as_str()), ("algorithm", &c.algorithm)],
-            c.uncompressed_bytes as f64);
+        metric_line(
+            out,
+            "nasty_bcachefs_uncompressed_bytes",
+            &[
+                ("filesystem", fs.fs_name.as_str()),
+                ("algorithm", &c.algorithm),
+            ],
+            c.uncompressed_bytes as f64,
+        );
     }
 }
 
 fn render_bcachefs_background(out: &mut String, fs: &BcachefsMetrics) {
-    let labels = [("filesystem", fs.fs_name.as_str()), ("uuid", fs.uuid.as_str())];
+    let labels = [
+        ("filesystem", fs.fs_name.as_str()),
+        ("uuid", fs.uuid.as_str()),
+    ];
     if let Some(bytes) = fs.background.btree_cache_size_bytes {
-        gauge(out, "nasty_bcachefs_btree_cache_size_bytes", "Btree cache memory usage", &labels, bytes as f64);
+        gauge(
+            out,
+            "nasty_bcachefs_btree_cache_size_bytes",
+            "Btree cache memory usage",
+            &labels,
+            bytes as f64,
+        );
     }
 }
 
 fn render_bcachefs_info(out: &mut String, fs: &BcachefsMetrics) {
     // Info metric: gauge=1 with labels carrying configuration values.
-    let compression = fs.options.get("compression").map(|s| s.as_str()).unwrap_or("none");
-    let data_replicas = fs.options.get("data_replicas").map(|s| s.as_str()).unwrap_or("1");
-    let metadata_replicas = fs.options.get("metadata_replicas").map(|s| s.as_str()).unwrap_or("1");
-    let data_checksum = fs.options.get("data_checksum").map(|s| s.as_str()).unwrap_or("crc32c");
-    let encrypted = fs.options.get("encrypted").map(|s| s.as_str()).unwrap_or("0");
+    let compression = fs
+        .options
+        .get("compression")
+        .map(|s| s.as_str())
+        .unwrap_or("none");
+    let data_replicas = fs
+        .options
+        .get("data_replicas")
+        .map(|s| s.as_str())
+        .unwrap_or("1");
+    let metadata_replicas = fs
+        .options
+        .get("metadata_replicas")
+        .map(|s| s.as_str())
+        .unwrap_or("1");
+    let data_checksum = fs
+        .options
+        .get("data_checksum")
+        .map(|s| s.as_str())
+        .unwrap_or("crc32c");
+    let encrypted = fs
+        .options
+        .get("encrypted")
+        .map(|s| s.as_str())
+        .unwrap_or("0");
 
-    header(out, "nasty_bcachefs_fs_info", "gauge", "bcachefs pool configuration (labels carry values)");
-    metric_line(out, "nasty_bcachefs_fs_info",
-        &[("filesystem", fs.fs_name.as_str()), ("uuid", fs.uuid.as_str()),
-          ("compression", compression), ("data_replicas", data_replicas),
-          ("metadata_replicas", metadata_replicas), ("data_checksum", data_checksum),
-          ("encrypted", encrypted)],
-        1.0);
+    header(
+        out,
+        "nasty_bcachefs_fs_info",
+        "gauge",
+        "bcachefs pool configuration (labels carry values)",
+    );
+    metric_line(
+        out,
+        "nasty_bcachefs_fs_info",
+        &[
+            ("filesystem", fs.fs_name.as_str()),
+            ("uuid", fs.uuid.as_str()),
+            ("compression", compression),
+            ("data_replicas", data_replicas),
+            ("metadata_replicas", metadata_replicas),
+            ("data_checksum", data_checksum),
+            ("encrypted", encrypted),
+        ],
+        1.0,
+    );
 }
 
 // ── Formatting helpers ──────────────────────────────────────────

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -187,6 +187,12 @@ fn state_dir() -> StateDir {
 
 pub struct IscsiService;
 
+impl Default for IscsiService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IscsiService {
     pub fn new() -> Self {
         Self
@@ -200,7 +206,9 @@ impl IscsiService {
         let mut targets: Vec<IscsiTarget> = state_dir().load_all().await;
         for target in &mut targets {
             let name = target.iqn.rsplit(':').next().unwrap_or("").to_string();
-            let Some(new_dev) = dev_map.get(&name) else { continue };
+            let Some(new_dev) = dev_map.get(&name) else {
+                continue;
+            };
             let mut changed = false;
             for lun in &mut target.luns {
                 if &lun.backstore_path != new_dev {
@@ -283,26 +291,34 @@ impl IscsiService {
         let mut target = target;
         if let Some(device_path) = req.device_path {
             if target.luns.is_empty() {
-                target = self.add_lun(AddLunRequest {
-                    target_id: target.id.clone(),
-                    backstore_path: device_path,
-                    backstore_type: Some("block".to_string()),
-                    size_bytes: None,
-                }).await?;
+                target = self
+                    .add_lun(AddLunRequest {
+                        target_id: target.id.clone(),
+                        backstore_path: device_path,
+                        backstore_type: Some("block".to_string()),
+                        size_bytes: None,
+                    })
+                    .await?;
             } else {
-                info!("iSCSI target {} already has {} LUN(s), skipping", target.iqn, target.luns.len());
+                info!(
+                    "iSCSI target {} already has {} LUN(s), skipping",
+                    target.iqn,
+                    target.luns.len()
+                );
             }
         }
 
         // Optional: add ACLs if provided
         if let Some(acls) = req.acls {
             for acl_entry in acls {
-                target = self.add_acl(AddAclRequest {
-                    target_id: target.id.clone(),
-                    initiator_iqn: acl_entry.initiator_iqn,
-                    userid: acl_entry.userid,
-                    password: acl_entry.password,
-                }).await?;
+                target = self
+                    .add_acl(AddAclRequest {
+                        target_id: target.id.clone(),
+                        initiator_iqn: acl_entry.initiator_iqn,
+                        userid: acl_entry.userid,
+                        password: acl_entry.password,
+                    })
+                    .await?;
             }
         }
 
@@ -358,7 +374,7 @@ impl IscsiService {
         for lun in &target.luns {
             let hba_type = backstore_hba_type(&lun.backstore_type);
             // Find which HBA index this backstore lives under
-            if let Some(hba_idx) = find_backstore_hba(&hba_type, &lun.backstore_name).await {
+            if let Some(hba_idx) = find_backstore_hba(hba_type, &lun.backstore_name).await {
                 let bs_path = format!("{CORE_BASE}/{hba_type}_{hba_idx}/{}", lun.backstore_name);
                 let _ = configfs_write(&format!("{bs_path}/enable"), "0").await;
                 let _ = configfs_rmdir(&bs_path).await;
@@ -403,12 +419,12 @@ impl IscsiService {
                 }
             }
             "fileio" => {
-                if let Some(parent) = Path::new(&req.backstore_path).parent() {
-                    if !parent.exists() {
-                        return Err(IscsiError::BackstoreNotFound(
-                            parent.to_string_lossy().to_string(),
-                        ));
-                    }
+                if let Some(parent) = Path::new(&req.backstore_path).parent()
+                    && !parent.exists()
+                {
+                    return Err(IscsiError::BackstoreNotFound(
+                        parent.to_string_lossy().to_string(),
+                    ));
                 }
             }
             _ => {
@@ -433,7 +449,7 @@ impl IscsiService {
         );
 
         let hba_type = backstore_hba_type(&backstore_type);
-        let hba_idx = next_hba_index(&hba_type).await;
+        let hba_idx = next_hba_index(hba_type).await;
 
         // Create backstore in configfs
         let bs_path = format!("{CORE_BASE}/{hba_type}_{hba_idx}/{backstore_name}");
@@ -444,14 +460,16 @@ impl IscsiService {
                 configfs_write(
                     &format!("{bs_path}/control"),
                     &format!("udev_path={}", req.backstore_path),
-                ).await?;
+                )
+                .await?;
             }
             "fileio" => {
                 let size = req.size_bytes.unwrap_or(1_073_741_824);
                 configfs_write(
                     &format!("{bs_path}/control"),
                     &format!("fd_dev_name={},fd_dev_size={size}", req.backstore_path),
-                ).await?;
+                )
+                .await?;
             }
             _ => unreachable!(),
         }
@@ -459,10 +477,7 @@ impl IscsiService {
         configfs_write(&format!("{bs_path}/enable"), "1").await?;
 
         // Create LUN in TPG and symlink to backstore
-        let lun_path = format!(
-            "{ISCSI_BASE}/{}/tpgt_1/lun/lun_{lun_id}",
-            target.iqn
-        );
+        let lun_path = format!("{ISCSI_BASE}/{}/tpgt_1/lun/lun_{lun_id}", target.iqn);
         configfs_mkdir(&lun_path).await?;
         configfs_symlink(&bs_path, &format!("{lun_path}/{backstore_name}")).await?;
 
@@ -479,7 +494,11 @@ impl IscsiService {
         state_dir().save(&target.id, &target).await?;
         save_lio_config().await;
 
-        info!("Added LUN {} to target '{}'", target.luns.len() - 1, target.iqn);
+        info!(
+            "Added LUN {} to target '{}'",
+            target.luns.len() - 1,
+            target.iqn
+        );
         Ok(target.redacted())
     }
 
@@ -493,23 +512,18 @@ impl IscsiService {
             .luns
             .iter()
             .position(|l| l.lun_id == req.lun_id)
-            .ok_or_else(|| {
-                IscsiError::NotFound(format!("LUN {} not found", req.lun_id))
-            })?;
+            .ok_or_else(|| IscsiError::NotFound(format!("LUN {} not found", req.lun_id)))?;
 
         let lun = &target.luns[lun_idx];
 
         // Remove symlink and LUN dir
-        let lun_path = format!(
-            "{ISCSI_BASE}/{}/tpgt_1/lun/lun_{}",
-            target.iqn, lun.lun_id
-        );
+        let lun_path = format!("{ISCSI_BASE}/{}/tpgt_1/lun/lun_{}", target.iqn, lun.lun_id);
         let _ = configfs_unlink(&format!("{lun_path}/{}", lun.backstore_name)).await;
         let _ = configfs_rmdir(&lun_path).await;
 
         // Remove backstore
         let hba_type = backstore_hba_type(&lun.backstore_type);
-        if let Some(hba_idx) = find_backstore_hba(&hba_type, &lun.backstore_name).await {
+        if let Some(hba_idx) = find_backstore_hba(hba_type, &lun.backstore_name).await {
             let bs_path = format!("{CORE_BASE}/{hba_type}_{hba_idx}/{}", lun.backstore_name);
             let _ = configfs_write(&format!("{bs_path}/enable"), "0").await;
             let _ = configfs_rmdir(&bs_path).await;
@@ -633,10 +647,10 @@ async fn next_hba_index(hba_type: &str) -> u32 {
         while let Ok(Some(entry)) = entries.next_entry().await {
             if let Some(name) = entry.file_name().to_str() {
                 let prefix = format!("{hba_type}_");
-                if let Some(suffix) = name.strip_prefix(&prefix) {
-                    if let Ok(idx) = suffix.parse::<u32>() {
-                        max_idx = Some(max_idx.map_or(idx, |m: u32| m.max(idx)));
-                    }
+                if let Some(suffix) = name.strip_prefix(&prefix)
+                    && let Ok(idx) = suffix.parse::<u32>()
+                {
+                    max_idx = Some(max_idx.map_or(idx, |m: u32| m.max(idx)));
                 }
             }
         }
@@ -650,12 +664,12 @@ async fn find_backstore_hba(hba_type: &str, bs_name: &str) -> Option<u32> {
         while let Ok(Some(entry)) = entries.next_entry().await {
             if let Some(name) = entry.file_name().to_str() {
                 let prefix = format!("{hba_type}_");
-                if let Some(suffix) = name.strip_prefix(&prefix) {
-                    if let Ok(idx) = suffix.parse::<u32>() {
-                        let bs_path = format!("{CORE_BASE}/{name}/{bs_name}");
-                        if Path::new(&bs_path).exists() {
-                            return Some(idx);
-                        }
+                if let Some(suffix) = name.strip_prefix(&prefix)
+                    && let Ok(idx) = suffix.parse::<u32>()
+                {
+                    let bs_path = format!("{CORE_BASE}/{name}/{bs_name}");
+                    if Path::new(&bs_path).exists() {
+                        return Some(idx);
                     }
                 }
             }
@@ -724,30 +738,44 @@ async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
     };
     let mut json: serde_json::Value = match serde_json::from_str(&text) {
         Ok(v) => v,
-        Err(e) => { warn!("Failed to parse {SAVECONFIG}: {e}"); return; }
+        Err(e) => {
+            warn!("Failed to parse {SAVECONFIG}: {e}");
+            return;
+        }
     };
-    let Some(objects) = json.get_mut("storage_objects").and_then(|v| v.as_array_mut()) else {
+    let Some(objects) = json
+        .get_mut("storage_objects")
+        .and_then(|v| v.as_array_mut())
+    else {
         return;
     };
     let mut changed = false;
     for obj in objects.iter_mut() {
-        let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let name = obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         for (subvol_name, new_dev) in dev_map {
             let expected_prefix = format!("nasty_{subvol_name}_");
-            if name.starts_with(&expected_prefix) {
-                if let Some(dev_field) = obj.get("dev").and_then(|v| v.as_str()) {
-                    if dev_field != new_dev {
-                        info!("Patching saveconfig.json backstore '{name}' {} → {new_dev}", dev_field);
-                        obj["dev"] = serde_json::Value::String(new_dev.clone());
-                        changed = true;
-                    }
-                }
+            if name.starts_with(&expected_prefix)
+                && let Some(dev_field) = obj.get("dev").and_then(|v| v.as_str())
+                && dev_field != new_dev
+            {
+                info!(
+                    "Patching saveconfig.json backstore '{name}' {} → {new_dev}",
+                    dev_field
+                );
+                obj["dev"] = serde_json::Value::String(new_dev.clone());
+                changed = true;
             }
         }
     }
     if changed {
         match serde_json::to_string_pretty(&json) {
-            Ok(out) => { let _ = tokio::fs::write(SAVECONFIG, out).await; }
+            Ok(out) => {
+                let _ = tokio::fs::write(SAVECONFIG, out).await;
+            }
             Err(e) => warn!("Failed to serialize patched saveconfig.json: {e}"),
         }
     }

--- a/engine/nasty-sharing/src/lib.rs
+++ b/engine/nasty-sharing/src/lib.rs
@@ -1,11 +1,11 @@
 //! Protocol sharing management: NFS, SMB, iSCSI, NVMe-oF
 
-pub mod nfs;
-pub mod smb;
 pub mod iscsi;
+pub mod nfs;
 pub mod nvmeof;
+pub mod smb;
 
-pub use nfs::NfsService;
-pub use smb::SmbService;
 pub use iscsi::IscsiService;
+pub use nfs::NfsService;
 pub use nvmeof::NvmeofService;
+pub use smb::SmbService;

--- a/engine/nasty-sharing/src/nfs.rs
+++ b/engine/nasty-sharing/src/nfs.rs
@@ -35,7 +35,11 @@ fn validate_nfs_host(host: &str) -> Result<(), NfsError> {
     if host.is_empty() {
         return Err(NfsError::InvalidClient("host is empty".to_string()));
     }
-    if host.chars().any(|c| c.is_whitespace() || c.is_control() || matches!(c, '(' | ')' | '"' | '\'' | ';' | ',' | '\\')) {
+    if host.chars().any(|c| {
+        c.is_whitespace()
+            || c.is_control()
+            || matches!(c, '(' | ')' | '"' | '\'' | ';' | ',' | '\\')
+    }) {
         return Err(NfsError::InvalidClient(format!(
             "host '{host}' contains invalid characters"
         )));
@@ -66,7 +70,10 @@ fn validate_nfs_client(client: &NfsClient) -> Result<(), NfsError> {
 /// Reject any export path containing characters that would let a maliciously-named
 /// directory inject a new line or column into the exports file.
 fn validate_export_path(path: &str) -> Result<(), NfsError> {
-    if path.chars().any(|c| c.is_control() || matches!(c, '\t' | '\n' | '\r' | '"' | '\'' | '\\')) {
+    if path
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '\t' | '\n' | '\r' | '"' | '\'' | '\\'))
+    {
         return Err(NfsError::InvalidClient(format!(
             "path '{path}' contains invalid characters for an exports file"
         )));
@@ -137,6 +144,12 @@ fn state_dir() -> StateDir {
 
 pub struct NfsService;
 
+impl Default for NfsService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NfsService {
     pub fn new() -> Self {
         Self
@@ -144,13 +157,11 @@ impl NfsService {
 
     /// List all NFS shares
     pub async fn list(&self) -> Result<Vec<NfsShare>, NfsError> {
-
         Ok(state_dir().load_all().await)
     }
 
     /// Get a single share by ID
     pub async fn get(&self, id: &str) -> Result<NfsShare, NfsError> {
-
         state_dir()
             .load::<NfsShare>(id)
             .await
@@ -177,7 +188,10 @@ impl NfsService {
         let shares: Vec<NfsShare> = state_dir().load_all().await;
 
         if let Some(existing) = shares.into_iter().find(|s| s.path == req.path) {
-            info!("NFS share for {} already exists, returning existing (idempotent)", req.path);
+            info!(
+                "NFS share for {} already exists, returning existing (idempotent)",
+                req.path
+            );
             return Ok(existing);
         }
 
@@ -199,7 +213,6 @@ impl NfsService {
 
     /// Update an existing NFS share
     pub async fn update(&self, req: UpdateNfsShareRequest) -> Result<NfsShare, NfsError> {
-
         let mut share: NfsShare = state_dir()
             .load(&req.id)
             .await
@@ -228,7 +241,6 @@ impl NfsService {
 
     /// Delete an NFS share
     pub async fn delete(&self, req: DeleteNfsShareRequest) -> Result<(), NfsError> {
-
         let _: NfsShare = state_dir()
             .load(&req.id)
             .await
@@ -294,10 +306,10 @@ async fn write_export_file(share: &NfsShare) -> Result<(), NfsError> {
 /// Remove the export file for a share.
 async fn remove_export_file(id: &str) {
     let path = export_file_path(id);
-    if let Err(e) = tokio::fs::remove_file(&path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            warn!("Failed to remove export file {path}: {e}");
-        }
+    if let Err(e) = tokio::fs::remove_file(&path).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!("Failed to remove export file {path}: {e}");
     }
 }
 

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -169,10 +169,10 @@ async fn next_port_id() -> u16 {
     let mut max_id: u16 = 0;
     if let Ok(mut entries) = tokio::fs::read_dir(&ports_dir).await {
         while let Ok(Some(entry)) = entries.next_entry().await {
-            if let Some(name) = entry.file_name().to_str() {
-                if let Ok(id) = name.parse::<u16>() {
-                    max_id = max_id.max(id);
-                }
+            if let Some(name) = entry.file_name().to_str()
+                && let Ok(id) = name.parse::<u16>()
+            {
+                max_id = max_id.max(id);
             }
         }
     }
@@ -183,6 +183,12 @@ async fn next_port_id() -> u16 {
 
 pub struct NvmeofService;
 
+impl Default for NvmeofService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NvmeofService {
     pub fn new() -> Self {
         Self
@@ -192,11 +198,12 @@ impl NvmeofService {
     /// Called at startup — configfs is volatile and lost on reboot.
     pub async fn restore(&self) {
         // Only restore if the nvmeof protocol is enabled
-        let proto_state: serde_json::Value = tokio::fs::read_to_string("/var/lib/nasty/protocols.json")
-            .await
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default();
+        let proto_state: serde_json::Value =
+            tokio::fs::read_to_string("/var/lib/nasty/protocols.json")
+                .await
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
 
         if proto_state.get("nvmeof").and_then(|v| v.as_bool()) != Some(true) {
             info!("NVMe-oF protocol disabled, skipping restore");
@@ -221,12 +228,16 @@ impl NvmeofService {
             let _ = configfs_write(
                 &format!("{subsys_path}/attr_allow_any_host"),
                 if subsys.allow_any_host { "1" } else { "0" },
-            ).await;
+            )
+            .await;
 
             // Restore namespaces
             for ns in &subsys.namespaces {
                 if !Path::new(&ns.device_path).exists() {
-                    warn!("  Device {} not found, skipping namespace {}", ns.device_path, ns.nsid);
+                    warn!(
+                        "  Device {} not found, skipping namespace {}",
+                        ns.device_path, ns.nsid
+                    );
                     continue;
                 }
                 let ns_path = format!("{subsys_path}/namespaces/{}", ns.nsid);
@@ -253,9 +264,9 @@ impl NvmeofService {
             // Restore ports — reuse existing port if one already binds to the same address
             for port in &subsys.ports {
                 let svc_id: u16 = port.service_id.parse().unwrap_or(4420);
-                let actual_port_id = if let Some(existing) = find_existing_port(
-                    &port.transport, &port.addr, svc_id, &port.addr_family,
-                ).await {
+                let actual_port_id = if let Some(existing) =
+                    find_existing_port(&port.transport, &port.addr, svc_id, &port.addr_family).await
+                {
                     existing
                 } else {
                     let port_path = format!("{NVMET_BASE}/ports/{}", port.port_id);
@@ -263,20 +274,24 @@ impl NvmeofService {
                         warn!("  Failed to create port {}: {e}", port.port_id);
                         continue;
                     }
-                    let _ = configfs_write(&format!("{port_path}/addr_trtype"), &port.transport).await;
+                    let _ =
+                        configfs_write(&format!("{port_path}/addr_trtype"), &port.transport).await;
                     let _ = configfs_write(&format!("{port_path}/addr_traddr"), &port.addr).await;
-                    let _ = configfs_write(&format!("{port_path}/addr_trsvcid"), &port.service_id).await;
-                    let _ = configfs_write(&format!("{port_path}/addr_adrfam"), &port.addr_family).await;
+                    let _ = configfs_write(&format!("{port_path}/addr_trsvcid"), &port.service_id)
+                        .await;
+                    let _ = configfs_write(&format!("{port_path}/addr_adrfam"), &port.addr_family)
+                        .await;
                     port.port_id
                 };
 
                 let port_path = format!("{NVMET_BASE}/ports/{actual_port_id}");
                 let link = format!("{port_path}/subsystems/{}", subsys.nqn);
-                let _ = configfs_symlink(
-                    &format!("{NVMET_BASE}/subsystems/{}", subsys.nqn),
-                    &link,
-                ).await;
-                info!("  Restored port {} ({}:{})", actual_port_id, port.addr, port.service_id);
+                let _ = configfs_symlink(&format!("{NVMET_BASE}/subsystems/{}", subsys.nqn), &link)
+                    .await;
+                info!(
+                    "  Restored port {} ({}:{})",
+                    actual_port_id, port.addr, port.service_id
+                );
             }
         }
 
@@ -290,7 +305,9 @@ impl NvmeofService {
         let mut subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
         for subsys in &mut subsystems {
             let name = subsys.nqn.rsplit(':').next().unwrap_or("").to_string();
-            let Some(new_dev) = dev_map.get(&name) else { continue };
+            let Some(new_dev) = dev_map.get(&name) else {
+                continue;
+            };
             let mut changed = false;
             for ns in &mut subsys.namespaces {
                 if &ns.device_path != new_dev {
@@ -309,12 +326,10 @@ impl NvmeofService {
     }
 
     pub async fn list(&self) -> Result<Vec<NvmeofSubsystem>, NvmeofError> {
-
         Ok(state_dir().load_all().await)
     }
 
     pub async fn get(&self, id: &str) -> Result<NvmeofSubsystem, NvmeofError> {
-
         state_dir()
             .load::<NvmeofSubsystem>(id)
             .await
@@ -325,7 +340,6 @@ impl NvmeofService {
         &self,
         req: CreateSubsystemRequest,
     ) -> Result<NvmeofSubsystem, NvmeofError> {
-
         let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
         let nqn = format!("{DEFAULT_NQN_PREFIX}:{}", req.name);
 
@@ -338,7 +352,11 @@ impl NvmeofService {
 
         let subsys_path = format!("{NVMET_BASE}/subsystems/{nqn}");
         configfs_mkdir(&subsys_path).await?;
-        configfs_write(&format!("{subsys_path}/attr_allow_any_host"), if allow_any { "1" } else { "0" }).await?;
+        configfs_write(
+            &format!("{subsys_path}/attr_allow_any_host"),
+            if allow_any { "1" } else { "0" },
+        )
+        .await?;
 
         let subsystem = NvmeofSubsystem {
             id: Uuid::new_v4().to_string(),
@@ -350,42 +368,58 @@ impl NvmeofService {
             enabled: true,
         };
 
-        state_dir().save(&subsystem.id, &subsystem).await
+        state_dir()
+            .save(&subsystem.id, &subsystem)
+            .await
             .map_err(NvmeofError::Io)?;
 
         // Optional: add namespace if device_path was provided
         let mut subsystem = subsystem;
         if let Some(device_path) = req.device_path {
             if subsystem.namespaces.is_empty() {
-                subsystem = self.add_namespace(AddNamespaceRequest {
-                    subsystem_id: subsystem.id.clone(),
-                    device_path,
-                }).await?;
+                subsystem = self
+                    .add_namespace(AddNamespaceRequest {
+                        subsystem_id: subsystem.id.clone(),
+                        device_path,
+                    })
+                    .await?;
             } else {
-                info!("Subsystem {} already has {} namespace(s), skipping", subsystem.nqn, subsystem.namespaces.len());
+                info!(
+                    "Subsystem {} already has {} namespace(s), skipping",
+                    subsystem.nqn,
+                    subsystem.namespaces.len()
+                );
             }
 
             // Add a port when a namespace was created
             if subsystem.ports.is_empty() {
-                subsystem = self.add_port(AddPortRequest {
-                    subsystem_id: subsystem.id.clone(),
-                    transport: Some("tcp".to_string()),
-                    addr: Some(req.addr.unwrap_or_else(|| "0.0.0.0".to_string())),
-                    service_id: Some(req.port.unwrap_or(4420)),
-                    addr_family: Some("ipv4".to_string()),
-                }).await?;
+                subsystem = self
+                    .add_port(AddPortRequest {
+                        subsystem_id: subsystem.id.clone(),
+                        transport: Some("tcp".to_string()),
+                        addr: Some(req.addr.unwrap_or_else(|| "0.0.0.0".to_string())),
+                        service_id: Some(req.port.unwrap_or(4420)),
+                        addr_family: Some("ipv4".to_string()),
+                    })
+                    .await?;
             } else {
-                info!("Subsystem {} already has {} port(s), skipping", subsystem.nqn, subsystem.ports.len());
+                info!(
+                    "Subsystem {} already has {} port(s), skipping",
+                    subsystem.nqn,
+                    subsystem.ports.len()
+                );
             }
         }
 
         // Optional: add allowed hosts if provided
         if let Some(hosts) = req.allowed_hosts {
             for host_nqn in hosts {
-                subsystem = self.add_host(AddHostRequest {
-                    subsystem_id: subsystem.id.clone(),
-                    host_nqn,
-                }).await?;
+                subsystem = self
+                    .add_host(AddHostRequest {
+                        subsystem_id: subsystem.id.clone(),
+                        host_nqn,
+                    })
+                    .await?;
             }
         }
 
@@ -399,7 +433,6 @@ impl NvmeofService {
     }
 
     pub async fn delete(&self, req: DeleteSubsystemRequest) -> Result<(), NvmeofError> {
-
         let subsys: NvmeofSubsystem = state_dir()
             .load(&req.id)
             .await
@@ -456,8 +489,7 @@ impl NvmeofService {
         let subsys_path = format!("{NVMET_BASE}/subsystems/{}", subsys.nqn);
         configfs_rmdir(&subsys_path).await?;
 
-        state_dir().remove(&req.id).await
-            .map_err(NvmeofError::Io)?;
+        state_dir().remove(&req.id).await.map_err(NvmeofError::Io)?;
 
         info!("Deleted NVMe-oF subsystem '{}'", req.id);
         Ok(())
@@ -470,7 +502,6 @@ impl NvmeofService {
         if !Path::new(&req.device_path).exists() {
             return Err(NvmeofError::DeviceNotFound(req.device_path));
         }
-
 
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
@@ -501,7 +532,9 @@ impl NvmeofService {
             enabled: true,
         });
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
         info!("Added namespace {nsid} to subsystem '{}'", subsys.nqn);
@@ -512,7 +545,6 @@ impl NvmeofService {
         &self,
         req: RemoveNamespaceRequest,
     ) -> Result<NvmeofSubsystem, NvmeofError> {
-
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -532,18 +564,19 @@ impl NvmeofService {
 
         subsys.namespaces.remove(ns_idx);
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
-        info!("Removed namespace {} from subsystem '{}'", req.nsid, subsys.nqn);
+        info!(
+            "Removed namespace {} from subsystem '{}'",
+            req.nsid, subsys.nqn
+        );
         Ok(subsys)
     }
 
-    pub async fn add_port(
-        &self,
-        req: AddPortRequest,
-    ) -> Result<NvmeofSubsystem, NvmeofError> {
-
+    pub async fn add_port(&self, req: AddPortRequest) -> Result<NvmeofSubsystem, NvmeofError> {
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -555,7 +588,9 @@ impl NvmeofService {
             _ => {
                 // NVMe-oF configfs requires a real IP — 0.0.0.0 causes EINVAL
                 // when linking subsystems to ports. Detect the primary IP.
-                detect_primary_ip().await.unwrap_or_else(|| "0.0.0.0".to_string())
+                detect_primary_ip()
+                    .await
+                    .unwrap_or_else(|| "0.0.0.0".to_string())
             }
         };
         let svc_id = req.service_id.unwrap_or(4420);
@@ -563,7 +598,9 @@ impl NvmeofService {
 
         // Check if an existing port already binds to the same address —
         // multiple subsystems can share a single NVMe-oF port.
-        let port_id = if let Some(existing) = find_existing_port(&transport, &addr, svc_id, &addr_family).await {
+        let port_id = if let Some(existing) =
+            find_existing_port(&transport, &addr, svc_id, &addr_family).await
+        {
             info!("Reusing existing port {existing} for {}:{svc_id}", addr);
             existing
         } else {
@@ -597,7 +634,9 @@ impl NvmeofService {
 
         subsys.ports.push(port);
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
         info!("Added port {port_id} to subsystem '{}'", subsys.nqn);
@@ -608,7 +647,6 @@ impl NvmeofService {
         &self,
         req: RemovePortRequest,
     ) -> Result<NvmeofSubsystem, NvmeofError> {
-
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -636,10 +674,15 @@ impl NvmeofService {
 
         subsys.ports.remove(port_idx);
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
-        info!("Removed port {} from subsystem '{}'", req.port_id, subsys.nqn);
+        info!(
+            "Removed port {} from subsystem '{}'",
+            req.port_id, subsys.nqn
+        );
         Ok(subsys)
     }
 
@@ -662,19 +705,24 @@ impl NvmeofService {
             }
 
             // Pick transport/service_id from existing port, or use defaults
-            let (transport, svc_id) = subsys.ports.first()
+            let (transport, svc_id) = subsys
+                .ports
+                .first()
                 .map(|p| (p.transport.clone(), p.service_id.clone()))
                 .unwrap_or_else(|| ("tcp".to_string(), "4420".to_string()));
 
             let svc_port = svc_id.parse::<u16>().unwrap_or(4420);
 
-            match self.add_port(AddPortRequest {
-                subsystem_id: subsys.id.clone(),
-                transport: Some(transport),
-                addr: Some(tailscale_ip.to_string()),
-                service_id: Some(svc_port),
-                addr_family: Some("ipv4".to_string()),
-            }).await {
+            match self
+                .add_port(AddPortRequest {
+                    subsystem_id: subsys.id.clone(),
+                    transport: Some(transport),
+                    addr: Some(tailscale_ip.to_string()),
+                    service_id: Some(svc_port),
+                    addr_family: Some("ipv4".to_string()),
+                })
+                .await
+            {
                 Ok(_) => info!("Added Tailscale port for subsystem '{}'", subsys.nqn),
                 Err(e) => warn!("Failed to add Tailscale port for '{}': {e}", subsys.nqn),
             }
@@ -686,16 +734,21 @@ impl NvmeofService {
         let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
 
         for subsys in &subsystems {
-            let tailscale_ports: Vec<u16> = subsys.ports.iter()
+            let tailscale_ports: Vec<u16> = subsys
+                .ports
+                .iter()
                 .filter(|p| p.addr == ip)
                 .map(|p| p.port_id)
                 .collect();
 
             for port_id in tailscale_ports {
-                match self.remove_port(RemovePortRequest {
-                    subsystem_id: subsys.id.clone(),
-                    port_id,
-                }).await {
+                match self
+                    .remove_port(RemovePortRequest {
+                        subsystem_id: subsys.id.clone(),
+                        port_id,
+                    })
+                    .await
+                {
                     Ok(_) => info!("Removed port {port_id} (IP {ip}) from '{}'", subsys.nqn),
                     Err(e) => warn!("Failed to remove port {port_id} from '{}': {e}", subsys.nqn),
                 }
@@ -703,11 +756,7 @@ impl NvmeofService {
         }
     }
 
-    pub async fn add_host(
-        &self,
-        req: AddHostRequest,
-    ) -> Result<NvmeofSubsystem, NvmeofError> {
-
+    pub async fn add_host(&self, req: AddHostRequest) -> Result<NvmeofSubsystem, NvmeofError> {
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -735,7 +784,9 @@ impl NvmeofService {
             subsys.allowed_hosts.push(req.host_nqn);
         }
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
         info!("Added allowed host to subsystem '{}'", subsys.nqn);
@@ -746,7 +797,6 @@ impl NvmeofService {
         &self,
         req: RemoveHostRequest,
     ) -> Result<NvmeofSubsystem, NvmeofError> {
-
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -760,7 +810,9 @@ impl NvmeofService {
 
         subsys.allowed_hosts.retain(|h| h != &req.host_nqn);
 
-        state_dir().save(&subsys.id, &subsys).await
+        state_dir()
+            .save(&subsys.id, &subsys)
+            .await
             .map_err(NvmeofError::Io)?;
 
         info!("Removed allowed host from subsystem '{}'", subsys.nqn);
@@ -772,8 +824,15 @@ impl NvmeofService {
 
 /// Scan all existing configfs ports for one matching the given transport/addr/service_id.
 /// Returns the port_id if found, so multiple subsystems can share a single listener.
-async fn find_existing_port(transport: &str, addr: &str, svc_id: u16, addr_family: &str) -> Option<u16> {
-    let mut entries = tokio::fs::read_dir(format!("{NVMET_BASE}/ports")).await.ok()?;
+async fn find_existing_port(
+    transport: &str,
+    addr: &str,
+    svc_id: u16,
+    addr_family: &str,
+) -> Option<u16> {
+    let mut entries = tokio::fs::read_dir(format!("{NVMET_BASE}/ports"))
+        .await
+        .ok()?;
     let svc_str = svc_id.to_string();
     while let Ok(Some(entry)) = entries.next_entry().await {
         let name = entry.file_name();
@@ -882,4 +941,3 @@ async fn detect_primary_ip() -> Option<String> {
     }
     None
 }
-

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -115,18 +115,22 @@ fn state_dir() -> StateDir {
 
 pub struct SmbService;
 
+impl Default for SmbService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SmbService {
     pub fn new() -> Self {
         Self
     }
 
     pub async fn list(&self) -> Result<Vec<SmbShare>, SmbError> {
-
         Ok(state_dir().load_all().await)
     }
 
     pub async fn get(&self, id: &str) -> Result<SmbShare, SmbError> {
-
         state_dir()
             .load::<SmbShare>(id)
             .await
@@ -145,11 +149,13 @@ impl SmbService {
             return Err(SmbError::PathNotInFilesystem(req.path));
         }
 
-
         let shares: Vec<SmbShare> = state_dir().load_all().await;
 
         if let Some(existing) = shares.into_iter().find(|s| s.name == req.name) {
-            info!("SMB share '{}' already exists, returning existing (idempotent)", req.name);
+            info!(
+                "SMB share '{}' already exists, returning existing (idempotent)",
+                req.name
+            );
             return Ok(existing);
         }
 
@@ -181,7 +187,6 @@ impl SmbService {
             validate_share_name(new_name)?;
         }
 
-
         let mut share: SmbShare = state_dir()
             .load(&req.id)
             .await
@@ -190,10 +195,7 @@ impl SmbService {
         // Check name uniqueness if changing
         if let Some(ref new_name) = req.name {
             let shares: Vec<SmbShare> = state_dir().load_all().await;
-            if shares
-                .iter()
-                .any(|s| s.name == *new_name && s.id != req.id)
-            {
+            if shares.iter().any(|s| s.name == *new_name && s.id != req.id) {
                 return Err(SmbError::NameExists(new_name.clone()));
             }
         }
@@ -233,7 +235,6 @@ impl SmbService {
     }
 
     pub async fn delete(&self, req: DeleteSmbShareRequest) -> Result<(), SmbError> {
-
         let _: SmbShare = state_dir()
             .load(&req.id)
             .await
@@ -260,7 +261,9 @@ fn sanitize_smb_value(s: &str) -> String {
 fn validate_share_name(name: &str) -> Result<(), SmbError> {
     if name.is_empty()
         || name.len() > 80
-        || name.contains(['/', '\\', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*'])
+        || name.contains([
+            '/', '\\', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*',
+        ])
     {
         return Err(SmbError::InvalidName(
             "Share name must be 1-80 chars without special characters".to_string(),
@@ -310,14 +313,19 @@ async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
         // so writes use that identity regardless of the connecting user.
         // Skip @group entries — they're not user accounts.
         if let Some(first_user) = share.valid_users.iter().find(|u| !u.starts_with('@')) {
-            conf.push_str(&format!("    force user = {}\n", sanitize_smb_value(first_user)));
+            conf.push_str(&format!(
+                "    force user = {}\n",
+                sanitize_smb_value(first_user)
+            ));
         }
         conf.push_str("    create mask = 0664\n");
         conf.push_str("    directory mask = 0775\n");
     }
 
     if !share.valid_users.is_empty() {
-        let sanitized_users: Vec<String> = share.valid_users.iter()
+        let sanitized_users: Vec<String> = share
+            .valid_users
+            .iter()
             .map(|u| sanitize_smb_value(u))
             .collect();
         conf.push_str(&format!(
@@ -329,7 +337,11 @@ async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
     let mut extra: Vec<_> = share.extra_params.iter().collect();
     extra.sort_by_key(|(k, _)| *k);
     for (key, value) in extra {
-        conf.push_str(&format!("    {} = {}\n", sanitize_smb_value(key), sanitize_smb_value(value)));
+        conf.push_str(&format!(
+            "    {} = {}\n",
+            sanitize_smb_value(key),
+            sanitize_smb_value(value)
+        ));
     }
 
     tokio::fs::write(&path, &conf).await?;
@@ -350,10 +362,10 @@ async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
 /// Remove the config file for a share.
 async fn remove_share_conf(id: &str) {
     let path = share_conf_path(id);
-    if let Err(e) = tokio::fs::remove_file(&path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!("Failed to remove share conf {path}: {e}");
-        }
+    if let Err(e) = tokio::fs::remove_file(&path).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!("Failed to remove share conf {path}: {e}");
     }
 }
 
@@ -453,16 +465,24 @@ impl SmbService {
     pub async fn create_user(&self, req: CreateSmbUserRequest) -> Result<SmbUser, SmbError> {
         let username = req.username.trim();
         if username.is_empty() || username.len() > 32 {
-            return Err(SmbError::InvalidName("username must be 1-32 characters".into()));
+            return Err(SmbError::InvalidName(
+                "username must be 1-32 characters".into(),
+            ));
         }
-        if !username.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
-            return Err(SmbError::InvalidName("username must be alphanumeric, hyphens, or underscores".into()));
+        if !username
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SmbError::InvalidName(
+                "username must be alphanumeric, hyphens, or underscores".into(),
+            ));
         }
 
         // Check if user already exists
         let check = tokio::process::Command::new("id")
             .arg(username)
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("id: {e}")))?;
         if check.status.success() {
             return Err(SmbError::NameExists(username.to_string()));
@@ -475,12 +495,15 @@ impl SmbService {
         let output = tokio::process::Command::new("useradd")
             .args([
                 "--system",
-                "--uid", &uid.to_string(),
+                "--uid",
+                &uid.to_string(),
                 "--no-create-home",
-                "--shell", "/usr/sbin/nologin",
+                "--shell",
+                "/usr/sbin/nologin",
                 username,
             ])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("useradd: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -491,7 +514,10 @@ impl SmbService {
         set_smb_password(username, &req.password).await?;
 
         info!("Created SMB user '{username}' (UID {uid})");
-        Ok(SmbUser { username: username.to_string(), uid })
+        Ok(SmbUser {
+            username: username.to_string(),
+            uid,
+        })
     }
 
     /// Delete a Linux system user and remove their Samba password.
@@ -499,12 +525,14 @@ impl SmbService {
         // Remove Samba password
         let _ = tokio::process::Command::new("smbpasswd")
             .args(["-x", username])
-            .output().await;
+            .output()
+            .await;
 
         // Delete system user
         let output = tokio::process::Command::new("userdel")
             .arg(username)
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("userdel: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -527,7 +555,8 @@ impl SmbService {
         // List users from smbpasswd database
         let output = tokio::process::Command::new("pdbedit")
             .args(["-L", "-d", "0"])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("pdbedit: {e}")))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -535,15 +564,14 @@ impl SmbService {
         for line in stdout.lines() {
             // pdbedit -L format: "username:uid:full name"
             let parts: Vec<&str> = line.splitn(3, ':').collect();
-            if parts.len() >= 2 {
-                if let Ok(uid) = parts[1].parse::<u32>() {
-                    if uid >= SMB_USER_UID_MIN {
-                        users.push(SmbUser {
-                            username: parts[0].to_string(),
-                            uid,
-                        });
-                    }
-                }
+            if parts.len() >= 2
+                && let Ok(uid) = parts[1].parse::<u32>()
+                && uid >= SMB_USER_UID_MIN
+            {
+                users.push(SmbUser {
+                    username: parts[0].to_string(),
+                    uid,
+                });
             }
         }
         Ok(users)
@@ -570,16 +598,24 @@ impl SmbService {
     pub async fn create_group(&self, name: &str) -> Result<SmbGroup, SmbError> {
         let name = name.trim();
         if name.is_empty() || name.len() > 32 {
-            return Err(SmbError::InvalidName("group name must be 1-32 characters".into()));
+            return Err(SmbError::InvalidName(
+                "group name must be 1-32 characters".into(),
+            ));
         }
-        if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
-            return Err(SmbError::InvalidName("group name must be alphanumeric, hyphens, or underscores".into()));
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(SmbError::InvalidName(
+                "group name must be alphanumeric, hyphens, or underscores".into(),
+            ));
         }
 
         // Check if group already exists
         let check = tokio::process::Command::new("getent")
             .args(["group", name])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("getent: {e}")))?;
         if check.status.success() {
             return Err(SmbError::NameExists(name.to_string()));
@@ -589,7 +625,8 @@ impl SmbService {
 
         let output = tokio::process::Command::new("groupadd")
             .args(["--gid", &gid.to_string(), name])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("groupadd: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -597,14 +634,19 @@ impl SmbService {
         }
 
         info!("Created SMB group '{name}' (GID {gid})");
-        Ok(SmbGroup { name: name.to_string(), gid, members: vec![] })
+        Ok(SmbGroup {
+            name: name.to_string(),
+            gid,
+            members: vec![],
+        })
     }
 
     /// Delete a Linux system group.
     pub async fn delete_group(&self, name: &str) -> Result<(), SmbError> {
         let output = tokio::process::Command::new("groupdel")
             .arg(name)
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("groupdel: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -616,26 +658,32 @@ impl SmbService {
 
     /// List SMB-managed groups (GIDs in the 3000+ range).
     pub async fn list_groups(&self) -> Result<Vec<SmbGroup>, SmbError> {
-        let content = tokio::fs::read_to_string("/etc/group").await
+        let content = tokio::fs::read_to_string("/etc/group")
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("read /etc/group: {e}")))?;
 
         let mut groups = Vec::new();
         for line in content.lines() {
             // /etc/group format: name:x:gid:member1,member2
             let parts: Vec<&str> = line.splitn(4, ':').collect();
-            if parts.len() >= 3 {
-                if let Ok(gid) = parts[2].parse::<u32>() {
-                    if gid >= SMB_GROUP_GID_MIN && gid < SMB_GROUP_GID_MIN + 1000 {
-                        let members = parts.get(3)
-                            .map(|m| m.split(',').filter(|s| !s.is_empty()).map(|s| s.to_string()).collect())
-                            .unwrap_or_default();
-                        groups.push(SmbGroup {
-                            name: parts[0].to_string(),
-                            gid,
-                            members,
-                        });
-                    }
-                }
+            if parts.len() >= 3
+                && let Ok(gid) = parts[2].parse::<u32>()
+                && (SMB_GROUP_GID_MIN..SMB_GROUP_GID_MIN + 1000).contains(&gid)
+            {
+                let members = parts
+                    .get(3)
+                    .map(|m| {
+                        m.split(',')
+                            .filter(|s| !s.is_empty())
+                            .map(|s| s.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                groups.push(SmbGroup {
+                    name: parts[0].to_string(),
+                    gid,
+                    members,
+                });
             }
         }
         Ok(groups)
@@ -645,7 +693,8 @@ impl SmbService {
     pub async fn add_group_member(&self, group: &str, user: &str) -> Result<(), SmbError> {
         let output = tokio::process::Command::new("usermod")
             .args(["-aG", group, user])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("usermod: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -659,7 +708,8 @@ impl SmbService {
     pub async fn remove_group_member(&self, group: &str, user: &str) -> Result<(), SmbError> {
         let output = tokio::process::Command::new("gpasswd")
             .args(["-d", user, group])
-            .output().await
+            .output()
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("gpasswd: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -675,11 +725,12 @@ async fn next_available_gid() -> u32 {
     for gid in SMB_GROUP_GID_MIN..SMB_GROUP_GID_MIN + 1000 {
         let check = tokio::process::Command::new("getent")
             .args(["group", &gid.to_string()])
-            .output().await;
-        if let Ok(out) = check {
-            if !out.status.success() {
-                return gid;
-            }
+            .output()
+            .await;
+        if let Ok(out) = check
+            && !out.status.success()
+        {
+            return gid;
         }
     }
     SMB_GROUP_GID_MIN
@@ -699,15 +750,21 @@ async fn set_smb_password(username: &str, password: &str) -> Result<(), SmbError
     if let Some(mut stdin) = child.stdin.take() {
         // smbpasswd -s reads password twice from stdin
         let input = format!("{password}\n{password}\n");
-        stdin.write_all(input.as_bytes()).await
+        stdin
+            .write_all(input.as_bytes())
+            .await
             .map_err(|e| SmbError::ReloadFailed(format!("smbpasswd stdin: {e}")))?;
     }
 
-    let output = child.wait_with_output().await
+    let output = child
+        .wait_with_output()
+        .await
         .map_err(|e| SmbError::ReloadFailed(format!("smbpasswd wait: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SmbError::ReloadFailed(format!("smbpasswd failed: {stderr}")));
+        return Err(SmbError::ReloadFailed(format!(
+            "smbpasswd failed: {stderr}"
+        )));
     }
     Ok(())
 }
@@ -717,11 +774,12 @@ async fn next_available_uid() -> u32 {
     for uid in SMB_USER_UID_MIN..SMB_USER_UID_MIN + 1000 {
         let check = tokio::process::Command::new("id")
             .arg(uid.to_string())
-            .output().await;
-        if let Ok(out) = check {
-            if !out.status.success() {
-                return uid;
-            }
+            .output()
+            .await;
+        if let Ok(out) = check
+            && !out.status.success()
+        {
+            return uid;
         }
     }
     SMB_USER_UID_MIN // fallback

--- a/engine/nasty-storage/src/cmd.rs
+++ b/engine/nasty-storage/src/cmd.rs
@@ -29,7 +29,11 @@ pub async fn run_stdin(program: &str, args: &[&str], stdin_data: &[u8]) -> std::
 }
 
 /// Execute a command with stdin, returning stdout on success or stderr on failure.
-pub async fn run_ok_stdin(program: &str, args: &[&str], stdin_data: &[u8]) -> Result<String, String> {
+pub async fn run_ok_stdin(
+    program: &str,
+    args: &[&str],
+    stdin_data: &[u8],
+) -> Result<String, String> {
     let output = run_stdin(program, args, stdin_data)
         .await
         .map_err(|e| format!("failed to execute {program}: {e}"))?;
@@ -52,9 +56,6 @@ pub async fn run_ok(program: &str, args: &[&str]) -> Result<String, String> {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!(
-            "{program} exited with {}: {stderr}",
-            output.status
-        ))
+        Err(format!("{program} exited with {}: {stderr}", output.status))
     }
 }

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -192,8 +192,12 @@ pub struct CreateFilesystemRequest {
     pub io_scheduler: Option<String>,
 }
 
-fn default_replicas() -> u32 { 1 }
-fn default_store_key() -> Option<bool> { Some(true) }
+fn default_replicas() -> u32 {
+    1
+}
+fn default_store_key() -> Option<bool> {
+    Some(true)
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DestroyFilesystemRequest {
@@ -342,9 +346,17 @@ pub struct ReconcileStatus {
 /// How long a cached `list()` result stays valid.
 const FS_LIST_CACHE_TTL: Duration = Duration::from_secs(3);
 
+type ListCache = Arc<Mutex<Option<(Instant, Vec<Filesystem>)>>>;
+
 #[derive(Clone)]
 pub struct FilesystemService {
-    list_cache: Arc<Mutex<Option<(Instant, Vec<Filesystem>)>>>,
+    list_cache: ListCache,
+}
+
+impl Default for FilesystemService {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FilesystemService {
@@ -375,7 +387,8 @@ impl FilesystemService {
         info!("Waiting for block devices to settle...");
         let _ = tokio::process::Command::new("udevadm")
             .args(["settle", "--timeout=30"])
-            .status().await;
+            .status()
+            .await;
 
         let mut failed_names = Vec::new();
 
@@ -391,7 +404,9 @@ impl FilesystemService {
             if !opts.devices.is_empty() {
                 let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
                 loop {
-                    let missing: Vec<&String> = opts.devices.iter()
+                    let missing: Vec<&String> = opts
+                        .devices
+                        .iter()
                         .filter(|d| !std::path::Path::new(d).exists())
                         .collect();
                     if missing.is_empty() {
@@ -400,21 +415,30 @@ impl FilesystemService {
                     if std::time::Instant::now() >= deadline {
                         error!(
                             "Filesystem '{name}': devices still missing after 60s: {}",
-                            missing.iter().map(|d| d.as_str()).collect::<Vec<_>>().join(", ")
+                            missing
+                                .iter()
+                                .map(|d| d.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
                         );
                         break;
                     }
                     info!(
                         "Filesystem '{name}': waiting for {} device(s): {}",
                         missing.len(),
-                        missing.iter().map(|d| d.as_str()).collect::<Vec<_>>().join(", ")
+                        missing
+                            .iter()
+                            .map(|d| d.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     );
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 }
                 // Refresh blkid cache after devices appear
                 let _ = tokio::process::Command::new("blkid")
                     .arg("-g")
-                    .output().await;
+                    .output()
+                    .await;
             }
 
             info!("Mounting filesystem '{name}'...");
@@ -434,10 +458,10 @@ impl FilesystemService {
     pub async fn list(&self) -> Result<Vec<Filesystem>, FilesystemError> {
         {
             let cache = self.list_cache.lock().await;
-            if let Some((ts, ref data)) = *cache {
-                if ts.elapsed() < FS_LIST_CACHE_TTL {
-                    return Ok(data.clone());
-                }
+            if let Some((ts, ref data)) = *cache
+                && ts.elapsed() < FS_LIST_CACHE_TTL
+            {
+                return Ok(data.clone());
             }
         }
 
@@ -547,7 +571,11 @@ impl FilesystemService {
                 name,
                 uuid,
                 devices: fs_devices,
-                mount_point: if has_mount_dir { Some(mount_point) } else { None },
+                mount_point: if has_mount_dir {
+                    Some(mount_point)
+                } else {
+                    None
+                },
                 mounted: false,
                 total_bytes: 0,
                 used_bytes: 0,
@@ -560,15 +588,27 @@ impl FilesystemService {
         let state = load_fs_state().await;
         for fs in &mut filesystems {
             if let Some(opts) = state.get(&fs.name) {
-                if fs.options.version_upgrade.is_none() { fs.options.version_upgrade = opts.version_upgrade.clone(); }
-                if fs.options.degraded.is_none() { fs.options.degraded = opts.degraded; }
-                if fs.options.verbose.is_none() { fs.options.verbose = opts.verbose; }
-                if fs.options.fsck.is_none() { fs.options.fsck = opts.fsck; }
-                if fs.options.journal_flush_disabled.is_none() { fs.options.journal_flush_disabled = opts.journal_flush_disabled; }
+                if fs.options.version_upgrade.is_none() {
+                    fs.options.version_upgrade = opts.version_upgrade.clone();
+                }
+                if fs.options.degraded.is_none() {
+                    fs.options.degraded = opts.degraded;
+                }
+                if fs.options.verbose.is_none() {
+                    fs.options.verbose = opts.verbose;
+                }
+                if fs.options.fsck.is_none() {
+                    fs.options.fsck = opts.fsck;
+                }
+                if fs.options.journal_flush_disabled.is_none() {
+                    fs.options.journal_flush_disabled = opts.journal_flush_disabled;
+                }
 
                 // Encryption state
                 if opts.encrypted == Some(true) {
-                    if fs.options.encrypted.is_none() { fs.options.encrypted = Some(true); }
+                    if fs.options.encrypted.is_none() {
+                        fs.options.encrypted = Some(true);
+                    }
                     let key_path = format!("{KEYS_DIR}/{}.key", fs.name);
                     fs.options.key_stored = Some(Path::new(&key_path).exists());
                     // Locked = encrypted + not mounted
@@ -590,7 +630,10 @@ impl FilesystemService {
     }
 
     /// Create a new bcachefs filesystem: format devices, create mount point, mount
-    pub async fn create(&self, mut req: CreateFilesystemRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn create(
+        &self,
+        mut req: CreateFilesystemRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         if req.devices.is_empty() {
             return Err(FilesystemError::NoDevices);
         }
@@ -662,14 +705,12 @@ impl FilesystemService {
                 ));
             }
             if req.devices.len() < (req.replicas as usize) + 1 {
-                return Err(FilesystemError::InvalidInput(
-                    format!(
-                        "Erasure coding with {} replicas requires at least {} devices (got {})",
-                        req.replicas,
-                        req.replicas + 1,
-                        req.devices.len(),
-                    ),
-                ));
+                return Err(FilesystemError::InvalidInput(format!(
+                    "Erasure coding with {} replicas requires at least {} devices (got {})",
+                    req.replicas,
+                    req.replicas + 1,
+                    req.devices.len(),
+                )));
             }
             args.push("--erasure_code".to_string());
         }
@@ -714,17 +755,26 @@ impl FilesystemService {
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         let dev_paths: Vec<&str> = req.devices.iter().map(|d| d.path.as_str()).collect();
         let is_encrypted = req.encryption == Some(true);
-        info!("Formatting bcachefs filesystem '{}' on {:?}{}", req.name, dev_paths, if is_encrypted { " (encrypted)" } else { "" });
+        info!(
+            "Formatting bcachefs filesystem '{}' on {:?}{}",
+            req.name,
+            dev_paths,
+            if is_encrypted { " (encrypted)" } else { "" }
+        );
 
         if is_encrypted {
             let passphrase = req.passphrase.as_deref().ok_or_else(|| {
-                FilesystemError::CommandFailed("passphrase required for encrypted filesystem".to_string())
+                FilesystemError::CommandFailed(
+                    "passphrase required for encrypted filesystem".to_string(),
+                )
             })?;
             // bcachefs format --encrypted reads passphrase twice from stdin (passphrase + confirm)
             let stdin = format!("{passphrase}\n{passphrase}\n");
             let output = cmd::run_stdin("bcachefs", &arg_refs, stdin.as_bytes())
                 .await
-                .map_err(|e| FilesystemError::CommandFailed(format!("failed to execute bcachefs: {e}")))?;
+                .map_err(|e| {
+                    FilesystemError::CommandFailed(format!("failed to execute bcachefs: {e}"))
+                })?;
 
             if !output.status.success() {
                 // bcachefs format writes superblocks then does a trial open that
@@ -732,11 +782,15 @@ impl FilesystemService {
                 // succeeded.  Check if superblocks were actually written.
                 if !is_device_bcachefs(&req.devices[0].path).await {
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    return Err(FilesystemError::CommandFailed(
-                        format!("bcachefs exited with {}: {stderr}", output.status),
-                    ));
+                    return Err(FilesystemError::CommandFailed(format!(
+                        "bcachefs exited with {}: {stderr}",
+                        output.status
+                    )));
                 }
-                warn!("bcachefs format exited with {} but superblocks are present, continuing", output.status);
+                warn!(
+                    "bcachefs format exited with {} but superblocks are present, continuing",
+                    output.status
+                );
             }
 
             // Store key for auto-unlock (default: yes)
@@ -747,18 +801,22 @@ impl FilesystemService {
                 info!("Encryption key stored at {key_path}");
             }
         } else {
-            let output = cmd::run("bcachefs", &arg_refs)
-                .await
-                .map_err(|e| FilesystemError::CommandFailed(format!("failed to execute bcachefs: {e}")))?;
+            let output = cmd::run("bcachefs", &arg_refs).await.map_err(|e| {
+                FilesystemError::CommandFailed(format!("failed to execute bcachefs: {e}"))
+            })?;
 
             if !output.status.success() {
                 if !is_device_bcachefs(&req.devices[0].path).await {
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    return Err(FilesystemError::CommandFailed(
-                        format!("bcachefs exited with {}: {stderr}", output.status),
-                    ));
+                    return Err(FilesystemError::CommandFailed(format!(
+                        "bcachefs exited with {}: {stderr}",
+                        output.status
+                    )));
                 }
-                warn!("bcachefs format exited with {} but superblocks are present, continuing", output.status);
+                warn!(
+                    "bcachefs format exited with {} but superblocks are present, continuing",
+                    output.status
+                );
             }
         }
 
@@ -776,14 +834,28 @@ impl FilesystemService {
         if is_encrypted {
             let key_path = format!("{KEYS_DIR}/{}.key", req.name);
             if Path::new(&key_path).exists() {
-                cmd::run_ok("bcachefs", &["unlock", "-k", "session", "-f", &key_path, &req.devices[0].path])
-                    .await
-                    .map_err(FilesystemError::CommandFailed)?;
+                cmd::run_ok(
+                    "bcachefs",
+                    &[
+                        "unlock",
+                        "-k",
+                        "session",
+                        "-f",
+                        &key_path,
+                        &req.devices[0].path,
+                    ],
+                )
+                .await
+                .map_err(FilesystemError::CommandFailed)?;
             } else if let Some(ref passphrase) = req.passphrase {
                 let stdin = format!("{passphrase}\n");
-                cmd::run_ok_stdin("bcachefs", &["unlock", "-k", "session", &req.devices[0].path], stdin.as_bytes())
-                    .await
-                    .map_err(FilesystemError::CommandFailed)?;
+                cmd::run_ok_stdin(
+                    "bcachefs",
+                    &["unlock", "-k", "session", &req.devices[0].path],
+                    stdin.as_bytes(),
+                )
+                .await
+                .map_err(FilesystemError::CommandFailed)?;
             }
         }
 
@@ -796,20 +868,35 @@ impl FilesystemService {
             ..FsMountOptions::default()
         };
         let mount_opt_str = build_mount_opts(&mount_opts);
-        info!("Mounting filesystem '{}' at {} with options: {}", req.name, mount_point, mount_opt_str);
-        cmd::run_ok("bcachefs", &["mount", "-o", &mount_opt_str, &device_arg, &mount_point])
-            .await
-            .map_err(FilesystemError::CommandFailed)?;
+        info!(
+            "Mounting filesystem '{}' at {} with options: {}",
+            req.name, mount_point, mount_opt_str
+        );
+        cmd::run_ok(
+            "bcachefs",
+            &["mount", "-o", &mount_opt_str, &device_arg, &mount_point],
+        )
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
 
         // Apply I/O scheduler to member block devices
-        let dev_list: Vec<FilesystemDevice> = req.devices.iter().map(|d| FilesystemDevice {
-            path: d.path.clone(), label: d.label.clone(), durability: d.durability,
-            state: None, data_allowed: None, has_data: None, discard: None,
-        }).collect();
-        if let Some(ref sched) = req.io_scheduler {
-            if let Err(e) = apply_io_scheduler(&dev_list, sched).await {
-                warn!("Failed to set I/O scheduler: {e}");
-            }
+        let dev_list: Vec<FilesystemDevice> = req
+            .devices
+            .iter()
+            .map(|d| FilesystemDevice {
+                path: d.path.clone(),
+                label: d.label.clone(),
+                durability: d.durability,
+                state: None,
+                data_allowed: None,
+                has_data: None,
+                discard: None,
+            })
+            .collect();
+        if let Some(ref sched) = req.io_scheduler
+            && let Err(e) = apply_io_scheduler(&dev_list, sched).await
+        {
+            warn!("Failed to set I/O scheduler: {e}");
         }
 
         // Read back the filesystem info
@@ -862,13 +949,13 @@ impl FilesystemService {
         let fs = self.get(&req.name).await?;
 
         // Unmount if mounted
-        if fs.mounted {
-            if let Some(ref mp) = fs.mount_point {
-                info!("Unmounting filesystem '{}' from {}", req.name, mp);
-                cmd::run_ok("umount", &[mp.as_str()])
-                    .await
-                    .map_err(FilesystemError::CommandFailed)?;
-            }
+        if fs.mounted
+            && let Some(ref mp) = fs.mount_point
+        {
+            info!("Unmounting filesystem '{}' from {}", req.name, mp);
+            cmd::run_ok("umount", &[mp.as_str()])
+                .await
+                .map_err(FilesystemError::CommandFailed)?;
         }
 
         // Also try unmounting by UUID — catches kernel-auto-assembled filesystems
@@ -888,9 +975,9 @@ impl FilesystemService {
             info!("Wiping bcachefs superblock on {}", dev.path);
             cmd::run_ok("wipefs", &["-a", &dev.path])
                 .await
-                .map_err(|e| FilesystemError::CommandFailed(
-                    format!("failed to wipe {}: {e}", dev.path),
-                ))?;
+                .map_err(|e| {
+                    FilesystemError::CommandFailed(format!("failed to wipe {}: {e}", dev.path))
+                })?;
         }
 
         // Flush the kernel's blkid cache so the ghost filesystem disappears
@@ -909,7 +996,11 @@ impl FilesystemService {
     }
 
     /// Mount with explicit mount options
-    async fn mount_with_opts(&self, name: &str, opts: &FsMountOptions) -> Result<Filesystem, FilesystemError> {
+    async fn mount_with_opts(
+        &self,
+        name: &str,
+        opts: &FsMountOptions,
+    ) -> Result<Filesystem, FilesystemError> {
         info!("Mounting filesystem '{}'", name);
         let fs = self.get(name).await?;
         if fs.mounted {
@@ -926,13 +1017,16 @@ impl FilesystemService {
         if opts.encrypted == Some(true) {
             let key_path = format!("{KEYS_DIR}/{name}.key");
             if Path::new(&key_path).exists() {
-                cmd::run_ok("bcachefs", &["unlock", "-k", "session", "-f", &key_path, first_device])
-                    .await
-                    .map_err(FilesystemError::CommandFailed)?;
+                cmd::run_ok(
+                    "bcachefs",
+                    &["unlock", "-k", "session", "-f", &key_path, first_device],
+                )
+                .await
+                .map_err(FilesystemError::CommandFailed)?;
             } else {
-                return Err(FilesystemError::CommandFailed(
-                    format!("encrypted filesystem '{name}' is locked — unlock it first, then mount.")
-                ));
+                return Err(FilesystemError::CommandFailed(format!(
+                    "encrypted filesystem '{name}' is locked — unlock it first, then mount."
+                )));
             }
         }
 
@@ -943,15 +1037,18 @@ impl FilesystemService {
             .collect::<Vec<_>>()
             .join(":");
         let mount_opt_str = build_mount_opts(opts);
-        cmd::run_ok("bcachefs", &["mount", "-o", &mount_opt_str, &device_arg, &mount_point])
-            .await
-            .map_err(FilesystemError::CommandFailed)?;
+        cmd::run_ok(
+            "bcachefs",
+            &["mount", "-o", &mount_opt_str, &device_arg, &mount_point],
+        )
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
 
         // Apply I/O scheduler to member block devices
-        if let Some(ref sched) = opts.io_scheduler {
-            if let Err(e) = apply_io_scheduler(&fs.devices, sched).await {
-                warn!("Failed to set I/O scheduler: {e}");
-            }
+        if let Some(ref sched) = opts.io_scheduler
+            && let Err(e) = apply_io_scheduler(&fs.devices, sched).await
+        {
+            warn!("Failed to set I/O scheduler: {e}");
         }
 
         // Track mount state with identity info for boot reconciliation
@@ -965,17 +1062,27 @@ impl FilesystemService {
     }
 
     /// Unlock an encrypted filesystem with a passphrase (does not mount).
-    pub async fn unlock(&self, name: &str, passphrase: &str) -> Result<Filesystem, FilesystemError> {
+    pub async fn unlock(
+        &self,
+        name: &str,
+        passphrase: &str,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(name).await?;
 
-        let first_device = fs.devices.first()
+        let first_device = fs
+            .devices
+            .first()
             .map(|d| d.path.clone())
             .ok_or_else(|| FilesystemError::CommandFailed("no devices".to_string()))?;
 
         let stdin = format!("{passphrase}\n");
-        cmd::run_ok_stdin("bcachefs", &["unlock", "-k", "session", &first_device], stdin.as_bytes())
-            .await
-            .map_err(FilesystemError::CommandFailed)?;
+        cmd::run_ok_stdin(
+            "bcachefs",
+            &["unlock", "-k", "session", &first_device],
+            stdin.as_bytes(),
+        )
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
 
         info!("Filesystem '{name}' unlocked");
         self.invalidate_list_cache().await;
@@ -985,21 +1092,24 @@ impl FilesystemService {
     /// Export the stored encryption key for a filesystem.
     pub async fn export_key(&self, name: &str) -> Result<String, FilesystemError> {
         let key_path = format!("{KEYS_DIR}/{name}.key");
-        tokio::fs::read_to_string(&key_path)
-            .await
-            .map_err(|_| FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'")))
+        tokio::fs::read_to_string(&key_path).await.map_err(|_| {
+            FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'"))
+        })
     }
 
     /// Delete the stored encryption key (switch to passphrase-only mode).
     pub async fn delete_key(&self, name: &str) -> Result<(), FilesystemError> {
         let key_path = format!("{KEYS_DIR}/{name}.key");
-        tokio::fs::remove_file(&key_path)
-            .await
-            .map_err(|_| FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'")))
+        tokio::fs::remove_file(&key_path).await.map_err(|_| {
+            FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'"))
+        })
     }
 
     /// Update runtime-mutable options on a mounted filesystem via sysfs.
-    pub async fn update_options(&self, req: UpdateFilesystemOptionsRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn update_options(
+        &self,
+        req: UpdateFilesystemOptionsRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(&req.name).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1012,9 +1122,9 @@ impl FilesystemService {
         async fn write_opt(base: &str, name: &str, value: &str) -> Result<(), FilesystemError> {
             let path = format!("{base}/{name}");
             let v = if value.is_empty() { "none" } else { value };
-            tokio::fs::write(&path, v).await.map_err(|e| {
-                FilesystemError::CommandFailed(format!("failed to set {name}: {e}"))
-            })
+            tokio::fs::write(&path, v)
+                .await
+                .map_err(|e| FilesystemError::CommandFailed(format!("failed to set {name}: {e}")))
         }
 
         if let Some(ref v) = req.compression {
@@ -1071,13 +1181,15 @@ impl FilesystemService {
         // Mount options require a remount to take effect — but only if they actually changed.
         let state = load_fs_state().await;
         let current = state.get(&req.name).cloned().unwrap_or_default();
-        let mount_changed =
-            (req.version_upgrade.is_some() && req.version_upgrade != current.version_upgrade)
+        let mount_changed = (req.version_upgrade.is_some()
+            && req.version_upgrade != current.version_upgrade)
             || (req.degraded.is_some() && req.degraded != current.degraded)
             || (req.verbose.is_some() && req.verbose != current.verbose)
             || (req.fsck.is_some() && req.fsck != current.fsck)
-            || (req.journal_flush_disabled.is_some() && req.journal_flush_disabled != current.journal_flush_disabled)
-            || (req.journal_flush_delay.is_some() && req.journal_flush_delay != current.journal_flush_delay);
+            || (req.journal_flush_disabled.is_some()
+                && req.journal_flush_disabled != current.journal_flush_disabled)
+            || (req.journal_flush_delay.is_some()
+                && req.journal_flush_delay != current.journal_flush_delay);
         drop(state);
 
         // Persist state changes (mount opts + io_scheduler)
@@ -1088,13 +1200,27 @@ impl FilesystemService {
             let mut state = load_fs_state().await;
             {
                 let opts = state.entry(req.name.clone()).or_default();
-                if let Some(ref v) = req.version_upgrade { opts.version_upgrade = Some(v.clone()); }
-                if let Some(v) = req.degraded { opts.degraded = Some(v); }
-                if let Some(v) = req.verbose { opts.verbose = Some(v); }
-                if let Some(v) = req.fsck { opts.fsck = Some(v); }
-                if let Some(v) = req.journal_flush_disabled { opts.journal_flush_disabled = Some(v); }
-                if let Some(v) = req.journal_flush_delay { opts.journal_flush_delay = Some(v); }
-                if let Some(ref v) = req.io_scheduler { opts.io_scheduler = Some(v.clone()); }
+                if let Some(ref v) = req.version_upgrade {
+                    opts.version_upgrade = Some(v.clone());
+                }
+                if let Some(v) = req.degraded {
+                    opts.degraded = Some(v);
+                }
+                if let Some(v) = req.verbose {
+                    opts.verbose = Some(v);
+                }
+                if let Some(v) = req.fsck {
+                    opts.fsck = Some(v);
+                }
+                if let Some(v) = req.journal_flush_disabled {
+                    opts.journal_flush_disabled = Some(v);
+                }
+                if let Some(v) = req.journal_flush_delay {
+                    opts.journal_flush_delay = Some(v);
+                }
+                if let Some(ref v) = req.io_scheduler {
+                    opts.io_scheduler = Some(v.clone());
+                }
             }
             let _ = save_fs_state(&state).await;
         }
@@ -1103,10 +1229,14 @@ impl FilesystemService {
             // Remount in-place (no unmount needed, works even when busy)
             let mount_point = format!("{NASTY_MOUNT_BASE}/{}", req.name);
             let state = load_fs_state().await;
-            let mount_opt_str = build_mount_opts(state.get(&req.name).unwrap_or(&FsMountOptions::default()));
-            cmd::run_ok("mount", &["-o", &format!("remount,{mount_opt_str}"), &mount_point])
-                .await
-                .map_err(FilesystemError::CommandFailed)?;
+            let mount_opt_str =
+                build_mount_opts(state.get(&req.name).unwrap_or(&FsMountOptions::default()));
+            cmd::run_ok(
+                "mount",
+                &["-o", &format!("remount,{mount_opt_str}"), &mount_point],
+            )
+            .await
+            .map_err(FilesystemError::CommandFailed)?;
             self.invalidate_list_cache().await;
             return self.get(&req.name).await;
         }
@@ -1170,17 +1300,18 @@ impl FilesystemService {
 
             // Read /proc/mounts to know which devices are *actually* mounted.
             // lsblk's mountpoint field can be stale after bcachefs device removal/wipe.
-            let mounted_devices: std::collections::HashSet<String> = tokio::fs::read_to_string("/proc/mounts")
-                .await
-                .unwrap_or_default()
-                .lines()
-                .flat_map(|line| {
-                    // Each line: "device mountpoint fstype options ..."
-                    // bcachefs uses colon-separated multi-device: "/dev/sdb:/dev/sdc /fs/first ..."
-                    let dev_field = line.split_whitespace().next().unwrap_or("");
-                    dev_field.split(':').map(String::from).collect::<Vec<_>>()
-                })
-                .collect();
+            let mounted_devices: std::collections::HashSet<String> =
+                tokio::fs::read_to_string("/proc/mounts")
+                    .await
+                    .unwrap_or_default()
+                    .lines()
+                    .flat_map(|line| {
+                        // Each line: "device mountpoint fstype options ..."
+                        // bcachefs uses colon-separated multi-device: "/dev/sdb:/dev/sdc /fs/first ..."
+                        let dev_field = line.split_whitespace().next().unwrap_or("");
+                        dev_field.split(':').map(String::from).collect::<Vec<_>>()
+                    })
+                    .collect();
 
             fn collect_devices(
                 devs: &[serde_json::Value],
@@ -1193,11 +1324,18 @@ impl FilesystemService {
                     let dev_type = dev.get("type").and_then(|v| v.as_str()).unwrap_or("");
                     let size = dev
                         .get("size")
-                        .and_then(|v| v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+                        .and_then(|v| {
+                            v.as_u64()
+                                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                        })
                         .unwrap_or(0);
-                    let mountpoint = dev.get("mountpoint").and_then(|v| v.as_str()).map(String::from);
+                    let mountpoint = dev
+                        .get("mountpoint")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
                     let fstype = dev.get("fstype").and_then(|v| v.as_str()).map(String::from);
-                    let rota = dev.get("rota")
+                    let rota = dev
+                        .get("rota")
                         .and_then(|v| {
                             v.as_bool()
                                 .or_else(|| v.as_str().map(|s| s == "1"))
@@ -1231,22 +1369,25 @@ impl FilesystemService {
         }
 
         // Mark parent disks as in_use if any of their partitions are in_use.
-        let in_use_paths: std::collections::HashSet<String> = devices.iter()
+        let in_use_paths: std::collections::HashSet<String> = devices
+            .iter()
             .filter(|d| d.in_use && d.dev_type == "part")
             .map(|d| d.path.clone())
             .collect();
         for dev in &mut devices {
-            if dev.dev_type == "disk" && !dev.in_use {
-                if in_use_paths.iter().any(|p| p.starts_with(&dev.path)) {
-                    dev.in_use = true;
-                }
+            if dev.dev_type == "disk"
+                && !dev.in_use
+                && in_use_paths.iter().any(|p| p.starts_with(&dev.path))
+            {
+                dev.in_use = true;
             }
         }
 
         // Detect unpartitioned free space on disks with existing partitions.
         // Use sgdisk to find the largest free gap; if > 1 GiB, add a virtual "free" entry.
         // Skip boot devices (mmcblk/eMMC) — they should never be offered as storage.
-        let partitioned_disks: Vec<String> = devices.iter()
+        let partitioned_disks: Vec<String> = devices
+            .iter()
             .filter(|d| d.dev_type == "part")
             .filter(|d| !d.path.contains("mmcblk"))
             .filter_map(|d| {
@@ -1254,7 +1395,8 @@ impl FilesystemService {
                 let name = d.path.trim_start_matches("/dev/");
                 // Strip trailing partition number
                 if name.contains("nvme") || name.contains("loop") || name.contains("mmcblk") {
-                    name.rsplit_once('p').map(|(base, _)| format!("/dev/{base}"))
+                    name.rsplit_once('p')
+                        .map(|(base, _)| format!("/dev/{base}"))
                 } else {
                     let base = name.trim_end_matches(|c: char| c.is_ascii_digit());
                     Some(format!("/dev/{base}"))
@@ -1264,7 +1406,11 @@ impl FilesystemService {
             .into_iter()
             .collect();
 
-        info!("Free-space detection: found {} partitioned disks: {:?}", partitioned_disks.len(), partitioned_disks);
+        info!(
+            "Free-space detection: found {} partitioned disks: {:?}",
+            partitioned_disks.len(),
+            partitioned_disks
+        );
         const MIN_FREE_BYTES: u64 = 1_073_741_824; // 1 GiB
         for disk_path in &partitioned_disks {
             match get_disk_free_space(disk_path).await {
@@ -1298,9 +1444,10 @@ impl FilesystemService {
     /// Only allowed if the device is not currently in use by any filesystem.
     pub async fn device_wipe(&self, path: &str) -> Result<(), FilesystemError> {
         let devices = self.list_devices().await?;
-        let dev = devices.iter().find(|d| d.path == path).ok_or_else(|| {
-            FilesystemError::CommandFailed(format!("device not found: {path}"))
-        })?;
+        let dev = devices
+            .iter()
+            .find(|d| d.path == path)
+            .ok_or_else(|| FilesystemError::CommandFailed(format!("device not found: {path}")))?;
         if dev.in_use {
             return Err(FilesystemError::CommandFailed(format!(
                 "device {path} is currently in use"
@@ -1331,7 +1478,10 @@ impl FilesystemService {
 
         // Reject if the device is actively in use (mounted or member of a live filesystem).
         let known_devices = self.list_devices().await?;
-        if known_devices.iter().any(|d| d.path == req.device.path && d.in_use) {
+        if known_devices
+            .iter()
+            .any(|d| d.path == req.device.path && d.in_use)
+        {
             return Err(FilesystemError::DeviceInUse(req.device.path.clone()));
         }
         // Reject if the device has a filesystem signature (including stale bcachefs superblocks
@@ -1354,7 +1504,10 @@ impl FilesystemService {
         args.push(req.device.path.clone());
 
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        info!("Adding device {} to filesystem '{}'", req.device.path, req.filesystem);
+        info!(
+            "Adding device {} to filesystem '{}'",
+            req.device.path, req.filesystem
+        );
         cmd::run_ok("bcachefs", &arg_refs)
             .await
             .map_err(FilesystemError::CommandFailed)?;
@@ -1366,7 +1519,10 @@ impl FilesystemService {
     /// Remove a device from a mounted filesystem.
     /// This evacuates data first, then removes the device.
     /// bcachefs device remove <device> <mountpoint>
-    pub async fn device_remove(&self, req: DeviceActionRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn device_remove(
+        &self,
+        req: DeviceActionRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(&req.filesystem).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1375,7 +1531,10 @@ impl FilesystemService {
         }
         let mount_point = fs.mount_point.as_ref().unwrap();
 
-        info!("Removing device {} from filesystem '{}'", req.device, req.filesystem);
+        info!(
+            "Removing device {} from filesystem '{}'",
+            req.device, req.filesystem
+        );
         cmd::run_ok("bcachefs", &["device", "remove", &req.device, mount_point])
             .await
             .map_err(FilesystemError::CommandFailed)?;
@@ -1397,7 +1556,10 @@ impl FilesystemService {
 
         let device = req.device.clone();
         let fs_name = req.filesystem.clone();
-        info!("Starting evacuation of device {} in filesystem '{}'", device, fs_name);
+        info!(
+            "Starting evacuation of device {} in filesystem '{}'",
+            device, fs_name
+        );
 
         // Spawn evacuation in background — this can take hours for large devices.
         // bcachefs sets the device state to "evacuating" automatically.
@@ -1414,7 +1576,10 @@ impl FilesystemService {
 
     /// Change the persistent state of a device (rw, ro, failed, spare).
     /// bcachefs device set-state <new_state> <device> [path]
-    pub async fn device_set_state(&self, req: DeviceSetStateRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn device_set_state(
+        &self,
+        req: DeviceSetStateRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let valid_states = ["rw", "ro", "failed", "spare"];
         if !valid_states.contains(&req.state.as_str()) {
             return Err(FilesystemError::CommandFailed(format!(
@@ -1447,7 +1612,10 @@ impl FilesystemService {
 
     /// Bring a device online (temporary, no membership change).
     /// bcachefs device online <device>
-    pub async fn device_online(&self, req: DeviceActionRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn device_online(
+        &self,
+        req: DeviceActionRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(&req.filesystem).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1455,7 +1623,10 @@ impl FilesystemService {
             ));
         }
 
-        info!("Onlining device {} in filesystem '{}'", req.device, req.filesystem);
+        info!(
+            "Onlining device {} in filesystem '{}'",
+            req.device, req.filesystem
+        );
         cmd::run_ok("bcachefs", &["device", "online", &req.device])
             .await
             .map_err(FilesystemError::CommandFailed)?;
@@ -1466,14 +1637,20 @@ impl FilesystemService {
 
     /// Take a device offline (temporary, no membership change).
     /// bcachefs device offline <device>
-    pub async fn device_offline(&self, req: DeviceActionRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn device_offline(
+        &self,
+        req: DeviceActionRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(&req.filesystem).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
                 "filesystem must be mounted to offline a device".to_string(),
             ));
         }
-        info!("Offlining device {} in filesystem '{}'", req.device, req.filesystem);
+        info!(
+            "Offlining device {} in filesystem '{}'",
+            req.device, req.filesystem
+        );
         cmd::run_ok("bcachefs", &["device", "offline", &req.device])
             .await
             .map_err(FilesystemError::CommandFailed)?;
@@ -1487,7 +1664,10 @@ impl FilesystemService {
     /// Labels drive tiering target selection (e.g. "ssd.fast", "hdd.archive").
     /// The sysfs entry `/sys/fs/bcachefs/<uuid>/dev-<N>/label` is writable on a
     /// live filesystem; we find the right dev-N by matching the `block` symlink.
-    pub async fn device_set_label(&self, req: DeviceSetLabelRequest) -> Result<Filesystem, FilesystemError> {
+    pub async fn device_set_label(
+        &self,
+        req: DeviceSetLabelRequest,
+    ) -> Result<Filesystem, FilesystemError> {
         let fs = self.get(&req.filesystem).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1498,7 +1678,8 @@ impl FilesystemService {
         // Validate: device must be a member of the filesystem
         if !fs.devices.iter().any(|d| d.path == req.device) {
             return Err(FilesystemError::CommandFailed(format!(
-                "{} is not a member of filesystem '{}'", req.device, req.filesystem
+                "{} is not a member of filesystem '{}'",
+                req.device, req.filesystem
             )));
         }
 
@@ -1517,24 +1698,30 @@ impl FilesystemService {
                 continue;
             }
             let block_link = entry.path().join("block");
-            if let Ok(target) = tokio::fs::read_link(&block_link).await {
-                if target.file_name().map(|n| n == dev_name).unwrap_or(false) {
-                    label_path = Some(entry.path().join("label"));
-                    break;
-                }
+            if let Ok(target) = tokio::fs::read_link(&block_link).await
+                && target.file_name().map(|n| n == dev_name).unwrap_or(false)
+            {
+                label_path = Some(entry.path().join("label"));
+                break;
             }
         }
 
         let label_path = label_path.ok_or_else(|| {
             FilesystemError::CommandFailed(format!(
-                "could not find sysfs entry for {} in filesystem '{}'", req.device, req.filesystem
+                "could not find sysfs entry for {} in filesystem '{}'",
+                req.device, req.filesystem
             ))
         })?;
 
-        info!("Setting label '{}' on {} in filesystem '{}'", req.label, req.device, req.filesystem);
-        tokio::fs::write(&label_path, &req.label).await.map_err(|e| {
-            FilesystemError::CommandFailed(format!("failed to write sysfs label: {e}"))
-        })?;
+        info!(
+            "Setting label '{}' on {} in filesystem '{}'",
+            req.label, req.device, req.filesystem
+        );
+        tokio::fs::write(&label_path, &req.label)
+            .await
+            .map_err(|e| {
+                FilesystemError::CommandFailed(format!("failed to write sysfs label: {e}"))
+            })?;
 
         self.invalidate_list_cache().await;
         self.get(&req.filesystem).await
@@ -1576,17 +1763,18 @@ impl FilesystemService {
                 if let Some(bytes) = extract_first_bytes(trimmed) {
                     data_bytes = bytes; // "Used" is total used (data + metadata)
                 }
-            } else if lower.starts_with("online reserved:") {
-                if let Some(bytes) = extract_first_bytes(trimmed) {
-                    reserved_bytes = bytes;
-                }
+            } else if lower.starts_with("online reserved:")
+                && let Some(bytes) = extract_first_bytes(trimmed)
+            {
+                reserved_bytes = bytes;
             }
 
             // Device table row: "label (device N):  sdb  rw  53264510976  8912896  0%"
-            if trimmed.contains("(device") && trimmed.contains("):") {
-                if let Some(du) = parse_device_table_line(trimmed) {
-                    dev_usages.push(du);
-                }
+            if trimmed.contains("(device")
+                && trimmed.contains("):")
+                && let Some(du) = parse_device_table_line(trimmed)
+            {
+                dev_usages.push(du);
             }
         }
 
@@ -1603,10 +1791,10 @@ impl FilesystemService {
                 if let Some(bytes) = extract_first_bytes(trimmed) {
                     total_btree += bytes;
                 }
-            } else if trimmed.starts_with("user:") {
-                if let Some(bytes) = extract_first_bytes(trimmed) {
-                    total_user += bytes;
-                }
+            } else if trimmed.starts_with("user:")
+                && let Some(bytes) = extract_first_bytes(trimmed)
+            {
+                total_user += bytes;
             }
         }
 
@@ -1659,7 +1847,7 @@ impl FilesystemService {
         }
 
         // Check if a bcachefs scrub process is running for this filesystem
-        let running = cmd::run_ok("pgrep", &["-f", &format!("bcachefs scrub")])
+        let running = cmd::run_ok("pgrep", &["-f", "bcachefs scrub"])
             .await
             .is_ok();
 
@@ -1702,7 +1890,11 @@ impl FilesystemService {
     }
 
     /// Enable or disable reconcile on a mounted filesystem via sysfs.
-    pub async fn set_reconcile_enabled(&self, name: &str, enabled: bool) -> Result<(), FilesystemError> {
+    pub async fn set_reconcile_enabled(
+        &self,
+        name: &str,
+        enabled: bool,
+    ) -> Result<(), FilesystemError> {
         let fs = self.get(name).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1712,9 +1904,9 @@ impl FilesystemService {
         let path = format!("/sys/fs/bcachefs/{}/options/reconcile_enabled", fs.uuid);
         let val = if enabled { "1" } else { "0" };
         info!("Setting reconcile_enabled={val} on filesystem '{name}'");
-        tokio::fs::write(&path, val).await.map_err(|e| {
-            FilesystemError::CommandFailed(format!("failed to write {path}: {e}"))
-        })
+        tokio::fs::write(&path, val)
+            .await
+            .map_err(|e| FilesystemError::CommandFailed(format!("failed to write {path}: {e}")))
     }
 
     /// Raw output of `bcachefs fs usage <mount>` — space breakdown by data type and device.
@@ -1744,7 +1936,11 @@ impl FilesystemService {
         // Capture 2 seconds of output to get at least one full frame
         let raw = cmd::run_ok(
             "script",
-            &["-qc", &format!("timeout 2 bcachefs fs top -h {mount_point}"), "/dev/null"],
+            &[
+                "-qc",
+                &format!("timeout 2 bcachefs fs top -h {mount_point}"),
+                "/dev/null",
+            ],
         )
         .await
         .map_err(FilesystemError::CommandFailed)?;
@@ -1767,7 +1963,10 @@ impl FilesystemService {
         Ok(lines.join("\n"))
     }
 
-    pub async fn bcachefs_timestats(&self, name: &str) -> Result<serde_json::Value, FilesystemError> {
+    pub async fn bcachefs_timestats(
+        &self,
+        name: &str,
+    ) -> Result<serde_json::Value, FilesystemError> {
         let fs = self.get(name).await?;
         if !fs.mounted {
             return Err(FilesystemError::CommandFailed(
@@ -1775,12 +1974,16 @@ impl FilesystemService {
             ));
         }
         let mount_point = fs.mount_point.as_ref().unwrap();
-        let raw = cmd::run_ok("bcachefs", &["fs", "timestats", "--json", "--once", mount_point])
-            .await
-            .map_err(FilesystemError::CommandFailed)?;
-        serde_json::from_str(&raw).map_err(|e| FilesystemError::CommandFailed(format!("failed to parse timestats JSON: {e}")))
+        let raw = cmd::run_ok(
+            "bcachefs",
+            &["fs", "timestats", "--json", "--once", mount_point],
+        )
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
+        serde_json::from_str(&raw).map_err(|e| {
+            FilesystemError::CommandFailed(format!("failed to parse timestats JSON: {e}"))
+        })
     }
-
 }
 
 /// Strip ANSI escape sequences (used for bcachefs raw text output).
@@ -1793,7 +1996,9 @@ fn strip_ansi(s: &str) -> String {
             if chars.peek() == Some(&'[') {
                 chars.next();
                 for next in chars.by_ref() {
-                    if next.is_ascii_alphabetic() { break; }
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
                 }
             }
         } else {
@@ -1903,16 +2108,21 @@ async fn get_disk_free_space(disk_path: &str) -> Result<u64, String> {
             let sectors_str = trimmed
                 .strip_prefix("total free space is ")
                 .and_then(|s| s.split_whitespace().next());
-            if let Some(s) = sectors_str {
-                if let Ok(sectors) = s.parse::<u64>() {
-                    // Sectors are typically 512 bytes; sgdisk uses logical sector size.
-                    // Parse sector size from sgdisk output: "Sector size (logical): NNN bytes"
-                    let sector_size = output.lines()
-                        .find(|l| l.to_lowercase().contains("sector size (logical)"))
-                        .and_then(|l| l.split_whitespace().filter_map(|w| w.parse::<u64>().ok()).last())
-                        .unwrap_or(512);
-                    return Ok(sectors * sector_size);
-                }
+            if let Some(s) = sectors_str
+                && let Ok(sectors) = s.parse::<u64>()
+            {
+                // Sectors are typically 512 bytes; sgdisk uses logical sector size.
+                // Parse sector size from sgdisk output: "Sector size (logical): NNN bytes"
+                let sector_size = output
+                    .lines()
+                    .find(|l| l.to_lowercase().contains("sector size (logical)"))
+                    .and_then(|l| {
+                        l.split_whitespace()
+                            .filter_map(|w| w.parse::<u64>().ok())
+                            .next_back()
+                    })
+                    .unwrap_or(512);
+                return Ok(sectors * sector_size);
             }
         }
     }
@@ -1942,10 +2152,10 @@ pub async fn create_partition_on_free_space(disk_path: &str) -> Result<String, F
         for dev in devs {
             if let Some(children) = dev.get("children").and_then(|v| v.as_array()) {
                 for child in children {
-                    if child.get("type").and_then(|v| v.as_str()) == Some("part") {
-                        if let Some(name) = child.get("name").and_then(|v| v.as_str()) {
-                            last_part = format!("/dev/{name}");
-                        }
+                    if child.get("type").and_then(|v| v.as_str()) == Some("part")
+                        && let Some(name) = child.get("name").and_then(|v| v.as_str())
+                    {
+                        last_part = format!("/dev/{name}");
                     }
                 }
             }
@@ -1953,7 +2163,9 @@ pub async fn create_partition_on_free_space(disk_path: &str) -> Result<String, F
     }
 
     if last_part.is_empty() {
-        return Err(FilesystemError::CommandFailed("failed to find new partition after creation".to_string()));
+        return Err(FilesystemError::CommandFailed(
+            "failed to find new partition after creation".to_string(),
+        ));
     }
 
     // Wipe any stale filesystem signatures inherited from the disk's
@@ -1998,12 +2210,11 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
         let trimmed = line.trim();
         // A new device block starts when a line begins with "Device " followed by a digit.
         if trimmed.starts_with("Device ")
-            && trimmed.chars().nth(7).map_or(false, |c| c.is_ascii_digit())
+            && trimmed.chars().nth(7).is_some_and(|c| c.is_ascii_digit())
+            && !current.is_empty()
         {
-            if !current.is_empty() {
-                blocks.push(current.clone());
-                current.clear();
-            }
+            blocks.push(current.clone());
+            current.clear();
         }
         current.push(line);
     }
@@ -2016,10 +2227,11 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
             let lower = line.to_lowercase();
             if let Some(pos) = lower.find(key) {
                 let rest = &line[pos + key.len()..];
-                let rest = rest.trim_start_matches(|c: char| c == ':' || c == ' ' || c == '\t');
+                let rest = rest.trim_start_matches([':', ' ', '\t']);
                 // Take first token, strip surrounding punctuation
                 if let Some(tok) = rest.split_whitespace().next() {
-                    let tok = tok.trim_matches(|c: char| c == '(' || c == ')' || c == ',' || c == ';');
+                    let tok =
+                        tok.trim_matches(|c: char| c == '(' || c == ')' || c == ',' || c == ';');
                     if !tok.is_empty() && tok != "none" {
                         return Some(tok.to_string());
                     }
@@ -2036,22 +2248,22 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
 
         // Find the block that mentions this device path
         let block = blocks.iter().find(|b| {
-            b.iter().any(|l| l.contains(dev_path.as_str()) || l.contains(dev_short))
+            b.iter()
+                .any(|l| l.contains(dev_path.as_str()) || l.contains(dev_short))
         });
 
-        let (label, durability, state, data_allowed, has_data, discard) =
-            if let Some(block) = block {
-                let label = extract_value(block, "label");
-                let durability =
-                    extract_value(block, "durability").and_then(|s| s.parse().ok());
-                let state = extract_value(block, "state");
-                let data_allowed = extract_value(block, "data allowed");
-                let has_data = extract_value(block, "has data");
-                let discard = extract_value(block, "discard").map(|s| s == "1" || s == "true");
-                (label, durability, state, data_allowed, has_data, discard)
-            } else {
-                (None, None, None, None, None, None)
-            };
+        let (label, durability, state, data_allowed, has_data, discard) = if let Some(block) = block
+        {
+            let label = extract_value(block, "label");
+            let durability = extract_value(block, "durability").and_then(|s| s.parse().ok());
+            let state = extract_value(block, "state");
+            let data_allowed = extract_value(block, "data allowed");
+            let has_data = extract_value(block, "has data");
+            let discard = extract_value(block, "discard").map(|s| s == "1" || s == "true");
+            (label, durability, state, data_allowed, has_data, discard)
+        } else {
+            (None, None, None, None, None, None)
+        };
 
         devices.push(FilesystemDevice {
             path: dev_path.clone(),
@@ -2242,7 +2454,10 @@ async fn get_mount_usage(mount_point: &str) -> Option<(u64, u64, u64)> {
 
     // Skip header line, parse second line
     let line = output.lines().nth(1)?;
-    let nums: Vec<u64> = line.split_whitespace().filter_map(|s| s.parse().ok()).collect();
+    let nums: Vec<u64> = line
+        .split_whitespace()
+        .filter_map(|s| s.parse().ok())
+        .collect();
     if nums.len() == 3 {
         Some((nums[0], nums[1], nums[2]))
     } else {
@@ -2301,7 +2516,9 @@ async fn discover_unmounted_bcachefs(
             continue;
         }
 
-        let entry = results.entry(uuid.clone()).or_insert_with(|| (label.clone(), Vec::new()));
+        let entry = results
+            .entry(uuid.clone())
+            .or_insert_with(|| (label.clone(), Vec::new()));
         if !label.is_empty() && entry.0.is_empty() {
             entry.0 = label;
         }
@@ -2380,15 +2597,24 @@ fn get_fs_mount_options(state: &FsState, name: &str) -> FsMountOptions {
 
 fn build_mount_opts(opts: &FsMountOptions) -> String {
     let mut parts = vec!["prjquota".to_string()];
-    if let Some(ref vu) = opts.version_upgrade {
-        if !vu.is_empty() && vu != "none" {
-            parts.push(format!("version_upgrade={vu}"));
-        }
+    if let Some(ref vu) = opts.version_upgrade
+        && !vu.is_empty()
+        && vu != "none"
+    {
+        parts.push(format!("version_upgrade={vu}"));
     }
-    if opts.degraded == Some(true) { parts.push("degraded".to_string()); }
-    if opts.verbose == Some(true) { parts.push("verbose".to_string()); }
-    if opts.fsck == Some(true) { parts.push("fsck".to_string()); }
-    if opts.journal_flush_disabled == Some(true) { parts.push("journal_flush_disabled".to_string()); }
+    if opts.degraded == Some(true) {
+        parts.push("degraded".to_string());
+    }
+    if opts.verbose == Some(true) {
+        parts.push("verbose".to_string());
+    }
+    if opts.fsck == Some(true) {
+        parts.push("fsck".to_string());
+    }
+    if opts.journal_flush_disabled == Some(true) {
+        parts.push("journal_flush_disabled".to_string());
+    }
     if let Some(delay) = opts.journal_flush_delay {
         parts.push(format!("journal_flush_delay={delay}"));
     }
@@ -2401,9 +2627,14 @@ fn block_dev_name(path: &str) -> Option<&str> {
 }
 
 /// Apply an I/O scheduler to all member block devices of a filesystem.
-async fn apply_io_scheduler(devices: &[FilesystemDevice], scheduler: &str) -> Result<(), FilesystemError> {
+async fn apply_io_scheduler(
+    devices: &[FilesystemDevice],
+    scheduler: &str,
+) -> Result<(), FilesystemError> {
     for dev in devices {
-        let Some(name) = block_dev_name(&dev.path) else { continue };
+        let Some(name) = block_dev_name(&dev.path) else {
+            continue;
+        };
         let sysfs_path = format!("/sys/block/{name}/queue/scheduler");
         if let Err(e) = tokio::fs::write(&sysfs_path, scheduler).await {
             // Not fatal — device may be a partition or missing sysfs entry
@@ -2423,7 +2654,8 @@ async fn read_io_scheduler(devices: &[FilesystemDevice]) -> Option<String> {
     let sysfs_path = format!("/sys/block/{name}/queue/scheduler");
     let content = tokio::fs::read_to_string(&sysfs_path).await.ok()?;
     // Format: "none [mq-deadline] kyber" — extract the bracketed one
-    content.split_whitespace()
+    content
+        .split_whitespace()
         .find(|s| s.starts_with('['))
         .map(|s| s.trim_matches(|c| c == '[' || c == ']').to_string())
 }
@@ -2432,9 +2664,15 @@ async fn is_mountpoint(path: &str) -> bool {
     use std::os::unix::fs::MetadataExt;
     // A path is a mount point when its device ID differs from its parent's,
     // or when it is the filesystem root (path == parent, same inode).
-    let Ok(meta) = tokio::fs::metadata(path).await else { return false; };
-    let parent = std::path::Path::new(path).parent().unwrap_or(std::path::Path::new("/"));
-    let Ok(parent_meta) = tokio::fs::metadata(parent).await else { return false; };
+    let Ok(meta) = tokio::fs::metadata(path).await else {
+        return false;
+    };
+    let parent = std::path::Path::new(path)
+        .parent()
+        .unwrap_or(std::path::Path::new("/"));
+    let Ok(parent_meta) = tokio::fs::metadata(parent).await else {
+        return false;
+    };
     meta.dev() != parent_meta.dev() || meta.ino() == parent_meta.ino()
 }
 

--- a/engine/nasty-storage/src/lib.rs
+++ b/engine/nasty-storage/src/lib.rs
@@ -7,5 +7,5 @@ pub mod cmd;
 pub mod filesystem;
 pub mod subvolume;
 
-pub use filesystem::{FilesystemService, FilesystemError};
+pub use filesystem::{FilesystemError, FilesystemService};
 pub use subvolume::SubvolumeService;

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -25,12 +25,12 @@ fn snap_path(mount_point: &str, subvol: &str, snap: &str) -> String {
 const XATTR_NS: &str = "user.";
 
 /// Reserved xattr keys for NASty-internal subvolume metadata.
-const XATTR_NASTY_TYPE:        &str = "user.nasty.type";
-const XATTR_NASTY_VOLSIZE:     &str = "user.nasty.volsize";
+const XATTR_NASTY_TYPE: &str = "user.nasty.type";
+const XATTR_NASTY_VOLSIZE: &str = "user.nasty.volsize";
 const XATTR_NASTY_COMPRESSION: &str = "user.nasty.compression";
-const XATTR_NASTY_COMMENT:     &str = "user.nasty.comment";
-const XATTR_NASTY_OWNER:       &str = "user.nasty.owner";
-const XATTR_NASTY_DIRECT_IO:   &str = "user.nasty.direct_io";
+const XATTR_NASTY_COMMENT: &str = "user.nasty.comment";
+const XATTR_NASTY_OWNER: &str = "user.nasty.owner";
+const XATTR_NASTY_DIRECT_IO: &str = "user.nasty.direct_io";
 
 /// Logical key prefix that maps to the reserved nasty.* xattrs.
 /// Excluded from the user-visible `properties` map.
@@ -195,7 +195,10 @@ fn read_all_xattrs(path: &Path) -> SubvolumeAttrs {
             compression: meta_raw.remove("nasty.compression"),
             comments: meta_raw.remove("nasty.comment"),
             owner: meta_raw.remove("nasty.owner"),
-            direct_io: meta_raw.get("nasty.direct_io").map(|s| s == "true").unwrap_or(false),
+            direct_io: meta_raw
+                .get("nasty.direct_io")
+                .map(|s| s == "true")
+                .unwrap_or(false),
         },
         properties,
         bcachefs_options,
@@ -458,13 +461,19 @@ impl SubvolumeService {
         for subvol in block_subvols {
             let img_path = format!("{}/{BLOCK_FILE_NAME}", subvol.path);
             if !Path::new(&img_path).exists() {
-                warn!("Block image {img_path} not found for {}/{}", subvol.filesystem, subvol.name);
+                warn!(
+                    "Block image {img_path} not found for {}/{}",
+                    subvol.filesystem, subvol.name
+                );
                 continue;
             }
 
             // Use existing loop device if already attached (engine restart, not reboot)
             let loop_dev = if let Some(existing) = find_loop_device(&img_path).await {
-                info!("Loop device already attached for {}/{}", subvol.filesystem, subvol.name);
+                info!(
+                    "Loop device already attached for {}/{}",
+                    subvol.filesystem, subvol.name
+                );
                 existing
             } else {
                 let mut args = vec!["--find", "--show"];
@@ -475,11 +484,17 @@ impl SubvolumeService {
                 match cmd::run_ok("losetup", &args).await {
                     Ok(dev) => {
                         let dev = dev.trim().to_string();
-                        info!("Attached {} for block subvolume {}/{}", dev, subvol.filesystem, subvol.name);
+                        info!(
+                            "Attached {} for block subvolume {}/{}",
+                            dev, subvol.filesystem, subvol.name
+                        );
                         dev
                     }
                     Err(e) => {
-                        warn!("Failed to attach loop device for {}/{}: {e}", subvol.filesystem, subvol.name);
+                        warn!(
+                            "Failed to attach loop device for {}/{}: {e}",
+                            subvol.filesystem, subvol.name
+                        );
                         continue;
                     }
                 }
@@ -505,7 +520,11 @@ impl SubvolumeService {
 
     /// List subvolumes in a filesystem.
     /// `owner_filter`: if Some, only return subvolumes owned by that token.
-    pub async fn list(&self, fs_name: &str, owner_filter: Option<&str>) -> Result<Vec<Subvolume>, SubvolumeError> {
+    pub async fn list(
+        &self,
+        fs_name: &str,
+        owner_filter: Option<&str>,
+    ) -> Result<Vec<Subvolume>, SubvolumeError> {
         let mount_point = self.fs_mount_point(fs_name).await?;
         let mut subvolumes = Vec::new();
 
@@ -513,13 +532,13 @@ impl SubvolumeService {
         let info = bcachefs_list_all(&mount_point).await;
 
         // Batch queries: run repquota + losetup once instead of du/losetup per subvolume
-        let (project_usages, losetup_map) = tokio::join!(
-            query_project_usages(&mount_point),
-            build_losetup_map()
-        );
+        let (project_usages, losetup_map) =
+            tokio::join!(query_project_usages(&mount_point), build_losetup_map());
 
         // List all subvolumes except snapshots (@) and internal .nasty/* ones.
-        for name in info.subvol_paths.iter().filter(|p| !p.is_empty() && !p.contains('@') && !p.starts_with(".nasty/") && *p != ".nasty") {
+        for name in info.subvol_paths.iter().filter(|p| {
+            !p.is_empty() && !p.contains('@') && !p.starts_with(".nasty/") && *p != ".nasty"
+        }) {
             let path_str = subvol_path(&mount_point, name);
             let path = Path::new(&path_str);
 
@@ -527,10 +546,10 @@ impl SubvolumeService {
             let attrs = read_all_xattrs(path);
 
             // Apply owner filter: operators only see their own subvolumes
-            if let Some(filter) = owner_filter {
-                if attrs.meta.owner.as_deref() != Some(filter) {
-                    continue;
-                }
+            if let Some(filter) = owner_filter
+                && attrs.meta.owner.as_deref() != Some(filter)
+            {
+                continue;
             }
 
             // Build snapshot list from the already-fetched bcachefs data
@@ -598,8 +617,15 @@ impl SubvolumeService {
     /// List subvolumes across all mounted filesystems.
     /// `fs_filter`: if Some, only include that filesystem.
     /// `owner_filter`: if Some, only include subvolumes owned by that token.
-    pub async fn list_all(&self, fs_filter: Option<&str>, owner_filter: Option<&str>) -> Result<Vec<Subvolume>, SubvolumeError> {
-        let all_fs = self.filesystems.list().await
+    pub async fn list_all(
+        &self,
+        fs_filter: Option<&str>,
+        owner_filter: Option<&str>,
+    ) -> Result<Vec<Subvolume>, SubvolumeError> {
+        let all_fs = self
+            .filesystems
+            .list()
+            .await
             .map_err(|e| SubvolumeError::CommandFailed(e.to_string()))?;
 
         let mut all = Vec::new();
@@ -607,10 +633,10 @@ impl SubvolumeService {
             if !fs.mounted {
                 continue;
             }
-            if let Some(filter) = fs_filter {
-                if fs.name != filter {
-                    continue;
-                }
+            if let Some(filter) = fs_filter
+                && fs.name != filter
+            {
+                continue;
             }
             match self.list(&fs.name, owner_filter).await {
                 Ok(mut subvols) => all.append(&mut subvols),
@@ -641,7 +667,11 @@ impl SubvolumeService {
 
     /// Create a new subvolume.
     /// `owner`: if Some, records this token name as the subvolume owner.
-    pub async fn create(&self, req: CreateSubvolumeRequest, owner: Option<String>) -> Result<Subvolume, SubvolumeError> {
+    pub async fn create(
+        &self,
+        req: CreateSubvolumeRequest,
+        owner: Option<String>,
+    ) -> Result<Subvolume, SubvolumeError> {
         if req.name.contains('@') {
             return Err(SubvolumeError::CommandFailed(
                 "subvolume name may not contain '@'".to_string(),
@@ -652,7 +682,10 @@ impl SubvolumeService {
         let subvol_path = subvol_path(&mount_point, &req.name);
 
         if Path::new(&subvol_path).exists() {
-            info!("Subvolume '{}' already exists in filesystem '{}', returning existing (idempotent)", req.name, req.filesystem);
+            info!(
+                "Subvolume '{}' already exists in filesystem '{}', returning existing (idempotent)",
+                req.name, req.filesystem
+            );
             return self.get(&req.filesystem, &req.name, None).await;
         }
 
@@ -661,14 +694,17 @@ impl SubvolumeService {
         }
 
         // Ensure parent directories exist for nested subvolumes (e.g. "projects/web")
-        if let Some(parent) = Path::new(&subvol_path).parent() {
-            if !parent.exists() {
-                tokio::fs::create_dir_all(parent).await?;
-            }
+        if let Some(parent) = Path::new(&subvol_path).parent()
+            && !parent.exists()
+        {
+            tokio::fs::create_dir_all(parent).await?;
         }
 
         // Create the bcachefs subvolume
-        info!("Creating subvolume '{}' in filesystem '{}'", req.name, req.filesystem);
+        info!(
+            "Creating subvolume '{}' in filesystem '{}'",
+            req.name, req.filesystem
+        );
         cmd::run_ok("bcachefs", &["subvolume", "create", &subvol_path])
             .await
             .map_err(SubvolumeError::CommandFailed)?;
@@ -706,7 +742,10 @@ impl SubvolumeService {
 
         // Set data replicas if specified
         if let Some(replicas) = req.data_replicas {
-            info!("Setting data_replicas={} on subvolume '{}'", replicas, req.name);
+            info!(
+                "Setting data_replicas={} on subvolume '{}'",
+                replicas, req.name
+            );
             let _ = cmd::run_ok(
                 "bcachefs",
                 &[
@@ -719,11 +758,11 @@ impl SubvolumeService {
         }
 
         // For filesystem subvolumes: enforce size via bcachefs project quota
-        if req.subvolume_type == SubvolumeType::Filesystem {
-            if let Some(size) = req.volsize_bytes {
-                let projid = project_id_for(&req.filesystem, &req.name);
-                set_project_quota(&mount_point, &subvol_path, projid, size).await;
-            }
+        if req.subvolume_type == SubvolumeType::Filesystem
+            && let Some(size) = req.volsize_bytes
+        {
+            let projid = project_id_for(&req.filesystem, &req.name);
+            set_project_quota(&mount_point, &subvol_path, projid, size).await;
         }
 
         // For block subvolumes: create sparse file and attach loop device
@@ -747,12 +786,17 @@ impl SubvolumeService {
             // at the extent level. On encrypted filesystems this causes reconcile errors
             // (extent_io_opts_not_set) because the checker finds unencrypted extents.
             // See: https://github.com/koverstreet/bcachefs/issues/1112
-            let fs_encrypted = self.filesystems.get(&req.filesystem).await
+            let fs_encrypted = self
+                .filesystems
+                .get(&req.filesystem)
+                .await
                 .map(|fs| fs.options.encrypted == Some(true))
                 .unwrap_or(false);
 
             if fs_encrypted {
-                info!("Skipping nocow on {img_path} — filesystem is encrypted (nocow disables encryption)");
+                info!(
+                    "Skipping nocow on {img_path} — filesystem is encrypted (nocow disables encryption)"
+                );
             } else {
                 match cmd::run_ok("bcachefs", &["set-file-option", "--nocow", &img_path]).await {
                     Ok(_) => info!("Set nocow on {img_path}"),
@@ -786,23 +830,31 @@ impl SubvolumeService {
     }
 
     /// List child subvolumes nested under a given parent.
-    pub async fn list_children(&self, filesystem: &str, name: &str) -> Result<Vec<String>, SubvolumeError> {
+    pub async fn list_children(
+        &self,
+        filesystem: &str,
+        name: &str,
+    ) -> Result<Vec<String>, SubvolumeError> {
         let mount_point = self.fs_mount_point(filesystem).await?;
         Ok(find_child_subvolumes(&mount_point, name).await)
     }
 
     /// Delete a subvolume.
     /// `owner_filter`: if Some, returns `AccessDenied` if the subvolume has a different owner.
-    pub async fn delete(&self, req: DeleteSubvolumeRequest, owner_filter: Option<&str>) -> Result<(), SubvolumeError> {
+    pub async fn delete(
+        &self,
+        req: DeleteSubvolumeRequest,
+        owner_filter: Option<&str>,
+    ) -> Result<(), SubvolumeError> {
         let subvol = self.get(&req.filesystem, &req.name, owner_filter).await?;
 
         // For block subvolumes: detach loop device first
-        if subvol.subvolume_type == SubvolumeType::Block {
-            if let Some(ref loop_dev) = subvol.block_device {
-                info!("Detaching loop device {} for '{}'", loop_dev, req.name);
-                if let Err(e) = cmd::run_ok("losetup", &["-d", loop_dev]).await {
-                    warn!("Failed to detach loop device {loop_dev}: {e}");
-                }
+        if subvol.subvolume_type == SubvolumeType::Block
+            && let Some(ref loop_dev) = subvol.block_device
+        {
+            info!("Detaching loop device {} for '{}'", loop_dev, req.name);
+            if let Err(e) = cmd::run_ok("losetup", &["-d", loop_dev]).await {
+                warn!("Failed to detach loop device {loop_dev}: {e}");
             }
         }
 
@@ -818,13 +870,19 @@ impl SubvolumeService {
         let children = find_child_subvolumes(&mount_point, &req.name).await;
         for child in children.iter().rev() {
             let child_path = format!("{mount_point}/{child}");
-            info!("Deleting child subvolume '{child}' before parent '{}'", req.name);
+            info!(
+                "Deleting child subvolume '{child}' before parent '{}'",
+                req.name
+            );
             if let Err(e) = cmd::run_ok("bcachefs", &["subvolume", "delete", &child_path]).await {
                 warn!("Failed to delete child subvolume '{child}': {e}");
             }
         }
 
-        info!("Deleting subvolume '{}' from filesystem '{}'", req.name, req.filesystem);
+        info!(
+            "Deleting subvolume '{}' from filesystem '{}'",
+            req.name, req.filesystem
+        );
         cmd::run_ok("bcachefs", &["subvolume", "delete", &subvol_path])
             .await
             .map_err(SubvolumeError::CommandFailed)?;
@@ -908,13 +966,19 @@ impl SubvolumeService {
                     "Resizing block subvolume '{}' to {} bytes",
                     req.name, req.volsize_bytes
                 );
-                cmd::run_ok("truncate", &["-s", &req.volsize_bytes.to_string(), &img_path])
-                    .await
-                    .map_err(SubvolumeError::CommandFailed)?;
+                cmd::run_ok(
+                    "truncate",
+                    &["-s", &req.volsize_bytes.to_string(), &img_path],
+                )
+                .await
+                .map_err(SubvolumeError::CommandFailed)?;
 
                 // If loop device is attached, inform the kernel of the new size
                 if let Some(ref loop_dev) = subvol.block_device {
-                    info!("Updating loop device {} capacity for '{}'", loop_dev, req.name);
+                    info!(
+                        "Updating loop device {} capacity for '{}'",
+                        loop_dev, req.name
+                    );
                     cmd::run_ok("losetup", &["--set-capacity", loop_dev])
                         .await
                         .map_err(SubvolumeError::CommandFailed)?;
@@ -931,8 +995,18 @@ impl SubvolumeService {
                 let bytes_str = req.volsize_bytes.to_string();
                 if let Err(e) = cmd::run_ok(
                     "setquota",
-                    &["-P", &proj_name, &bytes_str, &bytes_str, "0", "0", &mount_point],
-                ).await {
+                    &[
+                        "-P",
+                        &proj_name,
+                        &bytes_str,
+                        &bytes_str,
+                        "0",
+                        "0",
+                        &mount_point,
+                    ],
+                )
+                .await
+                {
                     warn!("setquota failed for project {proj_name} on {mount_point}: {e}");
                 }
             }
@@ -940,8 +1014,12 @@ impl SubvolumeService {
 
         // Update volsize xattr
         let path = subvol_path(&self.fs_mount_point(&req.filesystem).await?, &req.name);
-        xattr::set(&path, XATTR_NASTY_VOLSIZE, req.volsize_bytes.to_string().as_bytes())
-            .map_err(|e| SubvolumeError::CommandFailed(format!("setxattr volsize: {e}")))?;
+        xattr::set(
+            &path,
+            XATTR_NASTY_VOLSIZE,
+            req.volsize_bytes.to_string().as_bytes(),
+        )
+        .map_err(|e| SubvolumeError::CommandFailed(format!("setxattr volsize: {e}")))?;
 
         self.get(&req.filesystem, &req.name, owner_filter).await
     }
@@ -961,10 +1039,17 @@ impl SubvolumeService {
             } else {
                 comp.as_str()
             };
-            info!("Setting compression={} on subvolume '{}'", comp_value, req.name);
+            info!(
+                "Setting compression={} on subvolume '{}'",
+                comp_value, req.name
+            );
             cmd::run_ok(
                 "bcachefs",
-                &["set-file-option", &format!("--compression={comp_value}"), path],
+                &[
+                    "set-file-option",
+                    &format!("--compression={comp_value}"),
+                    path,
+                ],
             )
             .await
             .map_err(SubvolumeError::CommandFailed)?;
@@ -972,8 +1057,9 @@ impl SubvolumeService {
             if comp_value == "none" {
                 let _ = xattr::remove(path, XATTR_NASTY_COMPRESSION);
             } else {
-                xattr::set(path, XATTR_NASTY_COMPRESSION, comp_value.as_bytes())
-                    .map_err(|e| SubvolumeError::CommandFailed(format!("setxattr compression: {e}")))?;
+                xattr::set(path, XATTR_NASTY_COMPRESSION, comp_value.as_bytes()).map_err(|e| {
+                    SubvolumeError::CommandFailed(format!("setxattr compression: {e}"))
+                })?;
             }
         }
 
@@ -1006,7 +1092,10 @@ impl SubvolumeService {
 
         // Update data replicas if specified (use 0 to reset to filesystem default)
         if let Some(replicas) = req.data_replicas {
-            info!("Setting data_replicas={} on subvolume '{}'", replicas, req.name);
+            info!(
+                "Setting data_replicas={} on subvolume '{}'",
+                replicas, req.name
+            );
             let flag = if replicas == 0 {
                 "--data_replicas=-".to_string()
             } else {
@@ -1028,7 +1117,8 @@ impl SubvolumeService {
         owner_filter: Option<&str>,
     ) -> Result<Snapshot, SubvolumeError> {
         // Verify ownership of the parent subvolume
-        self.get(&req.filesystem, &req.subvolume, owner_filter).await?;
+        self.get(&req.filesystem, &req.subvolume, owner_filter)
+            .await?;
 
         let mount_point = self.fs_mount_point(&req.filesystem).await?;
         let source_path = subvol_path(&mount_point, &req.subvolume);
@@ -1046,13 +1136,15 @@ impl SubvolumeService {
         // Initiators (iSCSI, NVMe-oF) may have dirty data in their page cache
         // that hasn't been written to the backing loop device yet. A sync ensures
         // the snapshot captures a consistent state.
-        let subvol = self.get(&req.filesystem, &req.subvolume, owner_filter).await?;
-        if subvol.subvolume_type == SubvolumeType::Block {
-            if let Some(ref loop_dev) = subvol.block_device {
-                info!("Flushing block device {} before snapshot", loop_dev);
-                if let Err(e) = cmd::run_ok("blockdev", &["--flushbufs", loop_dev]).await {
-                    warn!("Failed to flush {loop_dev} before snapshot, proceeding anyway: {e}");
-                }
+        let subvol = self
+            .get(&req.filesystem, &req.subvolume, owner_filter)
+            .await?;
+        if subvol.subvolume_type == SubvolumeType::Block
+            && let Some(ref loop_dev) = subvol.block_device
+        {
+            info!("Flushing block device {} before snapshot", loop_dev);
+            if let Err(e) = cmd::run_ok("blockdev", &["--flushbufs", loop_dev]).await {
+                warn!("Failed to flush {loop_dev} before snapshot, proceeding anyway: {e}");
             }
         }
 
@@ -1061,9 +1153,12 @@ impl SubvolumeService {
             req.name, req.filesystem, req.subvolume
         );
         // Snapshots are always read-only; use snapshot.clone for writable copies
-        cmd::run_ok("bcachefs", &["subvolume", "snapshot", "-r", &source_path, &snap_path])
-            .await
-            .map_err(SubvolumeError::CommandFailed)?;
+        cmd::run_ok(
+            "bcachefs",
+            &["subvolume", "snapshot", "-r", &source_path, &snap_path],
+        )
+        .await
+        .map_err(SubvolumeError::CommandFailed)?;
 
         Ok(Snapshot {
             name: req.name,
@@ -1086,7 +1181,10 @@ impl SubvolumeService {
         // Verify ownership if the parent subvolume still exists.
         // The parent may have been deleted (DR scenario) — orphaned snapshots
         // should still be deletable.
-        if let Ok(_parent) = self.get(&req.filesystem, &req.subvolume, owner_filter).await {
+        if let Ok(_parent) = self
+            .get(&req.filesystem, &req.subvolume, owner_filter)
+            .await
+        {
             // Parent exists and ownership verified
         }
 
@@ -1170,13 +1268,15 @@ impl SubvolumeService {
             if rel_path.contains('/') {
                 continue;
             }
-            let Some(at_pos) = rel_path.find('@') else { continue };
+            let Some(at_pos) = rel_path.find('@') else {
+                continue;
+            };
             let subvol_name = rel_path[..at_pos].to_string();
             let snap_name = rel_path[at_pos + 1..].to_string();
-            if let Some(ref set) = owned {
-                if !set.contains(&subvol_name) {
-                    continue;
-                }
+            if let Some(ref set) = owned
+                && !set.contains(&subvol_name)
+            {
+                continue;
             }
             let parent = info.snapshot_parents.get(&rel_path).cloned();
             all_snapshots.push(Snapshot {
@@ -1212,11 +1312,15 @@ impl SubvolumeService {
 
         if !Path::new(&snap_path).exists() {
             return Err(SubvolumeError::NotFound(format!(
-                "snapshot {}@{}", req.subvolume, req.snapshot
+                "snapshot {}@{}",
+                req.subvolume, req.snapshot
             )));
         }
         if Path::new(&new_subvol_path).exists() {
-            info!("Subvolume '{}' already exists in filesystem '{}', returning existing (idempotent)", req.new_name, req.filesystem);
+            info!(
+                "Subvolume '{}' already exists in filesystem '{}', returning existing (idempotent)",
+                req.new_name, req.filesystem
+            );
             return self.get(&req.filesystem, &req.new_name, None).await;
         }
 
@@ -1225,9 +1329,12 @@ impl SubvolumeService {
             req.filesystem, req.subvolume, req.snapshot, req.new_name
         );
         // bcachefs subvolume snapshot without -r creates a writable subvolume from snapshot
-        cmd::run_ok("bcachefs", &["subvolume", "snapshot", &snap_path, &new_subvol_path])
-            .await
-            .map_err(SubvolumeError::CommandFailed)?;
+        cmd::run_ok(
+            "bcachefs",
+            &["subvolume", "snapshot", &snap_path, &new_subvol_path],
+        )
+        .await
+        .map_err(SubvolumeError::CommandFailed)?;
 
         // Read metadata from the snapshot itself — it inherits xattrs from the source.
         // This works even when the parent subvolume has been deleted (DR scenario).
@@ -1243,7 +1350,10 @@ impl SubvolumeService {
         if snap_meta.subvolume_type == SubvolumeType::Block {
             let img_path = format!("{new_subvol_path}/{BLOCK_FILE_NAME}");
             if Path::new(&img_path).exists() {
-                info!("Attaching loop device for restored block subvolume '{}'", req.new_name);
+                info!(
+                    "Attaching loop device for restored block subvolume '{}'",
+                    req.new_name
+                );
                 let mut args = vec!["--find", "--show"];
                 if snap_meta.direct_io {
                     args.push("--direct-io=on");
@@ -1287,12 +1397,12 @@ impl SubvolumeService {
         }
 
         // For block subvolumes, flush pending I/O before cloning
-        if parent.subvolume_type == SubvolumeType::Block {
-            if let Some(ref loop_dev) = parent.block_device {
-                info!("Flushing block device {} before clone", loop_dev);
-                if let Err(e) = cmd::run_ok("blockdev", &["--flushbufs", loop_dev]).await {
-                    warn!("Failed to flush {loop_dev} before clone, proceeding anyway: {e}");
-                }
+        if parent.subvolume_type == SubvolumeType::Block
+            && let Some(ref loop_dev) = parent.block_device
+        {
+            info!("Flushing block device {} before clone", loop_dev);
+            if let Err(e) = cmd::run_ok("blockdev", &["--flushbufs", loop_dev]).await {
+                warn!("Failed to flush {loop_dev} before clone, proceeding anyway: {e}");
             }
         }
 
@@ -1301,9 +1411,12 @@ impl SubvolumeService {
             req.filesystem, req.name, req.new_name
         );
         // Writable snapshot = COW clone
-        cmd::run_ok("bcachefs", &["subvolume", "snapshot", &source_path, &new_subvol_path])
-            .await
-            .map_err(SubvolumeError::CommandFailed)?;
+        cmd::run_ok(
+            "bcachefs",
+            &["subvolume", "snapshot", &source_path, &new_subvol_path],
+        )
+        .await
+        .map_err(SubvolumeError::CommandFailed)?;
 
         write_meta_xattrs(
             &new_subvol_path,
@@ -1320,7 +1433,10 @@ impl SubvolumeService {
         if parent.subvolume_type == SubvolumeType::Block {
             let img_path = format!("{new_subvol_path}/{BLOCK_FILE_NAME}");
             if Path::new(&img_path).exists() {
-                info!("Attaching loop device for cloned block subvolume '{}'", req.new_name);
+                info!(
+                    "Attaching loop device for cloned block subvolume '{}'",
+                    req.new_name
+                );
                 let mut args = vec!["--find", "--show"];
                 if parent.direct_io {
                     args.push("--direct-io=on");
@@ -1345,10 +1461,9 @@ impl SubvolumeService {
 
         for (key, value) in &req.properties {
             let xattr_name = format!("{XATTR_NS}{key}");
-            xattr::set(&subvol.path, &xattr_name, value.as_bytes())
-                .map_err(|e| SubvolumeError::CommandFailed(
-                    format!("setxattr {xattr_name}: {e}")
-                ))?;
+            xattr::set(&subvol.path, &xattr_name, value.as_bytes()).map_err(|e| {
+                SubvolumeError::CommandFailed(format!("setxattr {xattr_name}: {e}"))
+            })?;
         }
 
         self.get(&req.filesystem, &req.name, owner_filter).await
@@ -1367,9 +1482,11 @@ impl SubvolumeService {
             match xattr::remove(&subvol.path, &xattr_name) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(SubvolumeError::CommandFailed(
-                    format!("removexattr {xattr_name}: {e}")
-                )),
+                Err(e) => {
+                    return Err(SubvolumeError::CommandFailed(format!(
+                        "removexattr {xattr_name}: {e}"
+                    )));
+                }
             }
         }
 
@@ -1383,10 +1500,17 @@ impl SubvolumeService {
         req: FindByPropertyRequest,
         owner_filter: Option<&str>,
     ) -> Result<Vec<Subvolume>, SubvolumeError> {
-        let all = self.list_all(req.filesystem.as_deref(), owner_filter).await?;
+        let all = self
+            .list_all(req.filesystem.as_deref(), owner_filter)
+            .await?;
         Ok(all
             .into_iter()
-            .filter(|s| s.properties.get(&req.key).map(|v| v == &req.value).unwrap_or(false))
+            .filter(|s| {
+                s.properties
+                    .get(&req.key)
+                    .map(|v| v == &req.value)
+                    .unwrap_or(false)
+            })
             .collect())
     }
 }
@@ -1445,7 +1569,11 @@ async fn bcachefs_list_all(mount_point: &str) -> BcachefsInfo {
         }
     }
 
-    BcachefsInfo { subvol_paths, snapshot_flags, snapshot_parents }
+    BcachefsInfo {
+        subvol_paths,
+        snapshot_flags,
+        snapshot_parents,
+    }
 }
 
 /// Derive a stable 32-bit project ID from filesystem + subvolume name.
@@ -1486,7 +1614,20 @@ async fn set_project_quota(mount_point: &str, dir_path: &str, projid: u32, bytes
     // setquota -P <name> <soft> <hard> <isoft> <ihard> <mountpoint>
     // soft == hard (no grace period), no inode limits
     let bytes_str = bytes.to_string();
-    match cmd::run_ok("setquota", &["-P", &proj_name, &bytes_str, &bytes_str, "0", "0", mount_point]).await {
+    match cmd::run_ok(
+        "setquota",
+        &[
+            "-P",
+            &proj_name,
+            &bytes_str,
+            &bytes_str,
+            "0",
+            "0",
+            mount_point,
+        ],
+    )
+    .await
+    {
         Ok(_) => info!("set quota {bytes} bytes for project {proj_name} on {mount_point}"),
         Err(e) => warn!("setquota failed for project {proj_name} on {mount_point}: {e}"),
     }
@@ -1502,11 +1643,20 @@ fn register_project(name: &str, projid: u32) {
     // Check by both name and ID to avoid duplicates
     let name_prefix = format!("{name}:");
     let id_suffix = format!(":{projid}");
-    if existing.lines().any(|l| l.starts_with(&name_prefix) || l.ends_with(&id_suffix)) {
+    if existing
+        .lines()
+        .any(|l| l.starts_with(&name_prefix) || l.ends_with(&id_suffix))
+    {
         return;
     }
-    if let Err(e) = std::fs::OpenOptions::new().append(true).create(true).open(path)
-        .and_then(|mut f| { use std::io::Write; f.write_all(entry.as_bytes()) })
+    if let Err(e) = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+        .and_then(|mut f| {
+            use std::io::Write;
+            f.write_all(entry.as_bytes())
+        })
     {
         warn!("register_project: could not write to {path}: {e}");
     }
@@ -1516,7 +1666,9 @@ fn register_project(name: &str, projid: u32) {
 fn unregister_project(projid: u32) {
     let path = "/etc/projid";
     let id_suffix = format!(":{projid}");
-    let Ok(existing) = std::fs::read_to_string(path) else { return };
+    let Ok(existing) = std::fs::read_to_string(path) else {
+        return;
+    };
     let filtered: String = existing
         .lines()
         .filter(|l| !l.ends_with(&id_suffix))
@@ -1608,7 +1760,10 @@ async fn find_loop_device(file_path: &str) -> Option<String> {
 }
 
 /// Look up the loop device for a given file path using a pre-built map.
-fn find_loop_device_from_map(losetup_map: &HashMap<String, String>, file_path: &str) -> Option<String> {
+fn find_loop_device_from_map(
+    losetup_map: &HashMap<String, String>,
+    file_path: &str,
+) -> Option<String> {
     // Canonicalize the target path so symlinks / relative paths don't matter
     let canonical = std::fs::canonicalize(file_path).ok()?;
     let canonical_str = canonical.to_string_lossy().to_string();
@@ -1638,4 +1793,3 @@ async fn find_child_subvolumes(mount_point: &str, parent_name: &str) -> Vec<Stri
     children.sort();
     children
 }
-

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -140,7 +140,11 @@ impl AlertService {
         Ok(rule)
     }
 
-    pub async fn update_rule(&self, id: &str, update: AlertRuleUpdate) -> Result<AlertRule, String> {
+    pub async fn update_rule(
+        &self,
+        id: &str,
+        update: AlertRuleUpdate,
+    ) -> Result<AlertRule, String> {
         let mut state = self.state.write().await;
         let rule = state
             .rules
@@ -311,10 +315,7 @@ impl AlertService {
                                 rule_name: rule.name.clone(),
                                 severity: rule.severity.clone(),
                                 metric: rule.metric.clone(),
-                                message: format!(
-                                    "Disk {} SMART health check FAILED",
-                                    disk.device
-                                ),
+                                message: format!("Disk {} SMART health check FAILED", disk.device),
                                 current_value: 0.0,
                                 threshold: rule.threshold,
                                 source: disk.device.clone(),
@@ -465,22 +466,22 @@ impl AlertService {
                     }
                 }
                 AlertMetric::RootDiskFreeGb => {
-                    if let Some(free_gb) = root_free_gb() {
-                        if check_condition(free_gb, &rule.condition, rule.threshold) {
-                            alerts.push(ActiveAlert {
-                                rule_id: rule.id.clone(),
-                                rule_name: rule.name.clone(),
-                                severity: rule.severity.clone(),
-                                metric: rule.metric.clone(),
-                                message: format!(
-                                    "Root partition has {:.1} GB free (threshold: {:.0} GB)",
-                                    free_gb, rule.threshold
-                                ),
-                                current_value: free_gb,
-                                threshold: rule.threshold,
-                                source: "/".into(),
-                            });
-                        }
+                    if let Some(free_gb) = root_free_gb()
+                        && check_condition(free_gb, &rule.condition, rule.threshold)
+                    {
+                        alerts.push(ActiveAlert {
+                            rule_id: rule.id.clone(),
+                            rule_name: rule.name.clone(),
+                            severity: rule.severity.clone(),
+                            metric: rule.metric.clone(),
+                            message: format!(
+                                "Root partition has {:.1} GB free (threshold: {:.0} GB)",
+                                free_gb, rule.threshold
+                            ),
+                            current_value: free_gb,
+                            threshold: rule.threshold,
+                            source: "/".into(),
+                        });
                     }
                 }
             }
@@ -564,7 +565,9 @@ fn root_free_gb() -> Option<f64> {
     let path = CString::new("/").ok()?;
     let mut buf = MaybeUninit::<libc::statvfs>::uninit();
     let ret = unsafe { libc::statvfs(path.as_ptr(), buf.as_mut_ptr()) };
-    if ret != 0 { return None; }
+    if ret != 0 {
+        return None;
+    }
     let stat = unsafe { buf.assume_init() };
     Some(stat.f_bavail as f64 * stat.f_frsize as f64 / 1_073_741_824.0)
 }
@@ -742,11 +745,22 @@ fn uuid_v4() -> String {
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
     format!(
         "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        bytes[0], bytes[1], bytes[2], bytes[3],
-        bytes[4], bytes[5],
-        bytes[6], bytes[7],
-        bytes[8], bytes[9],
-        bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
     )
 }
 

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -34,9 +34,9 @@ impl FirewallRestrictions {
     }
 
     pub async fn save(&self) -> Result<(), String> {
-        let json = serde_json::to_string_pretty(self)
-            .map_err(|e| format!("serialize: {e}"))?;
-        tokio::fs::write(RESTRICTIONS_PATH, json).await
+        let json = serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {e}"))?;
+        tokio::fs::write(RESTRICTIONS_PATH, json)
+            .await
             .map_err(|e| format!("write {RESTRICTIONS_PATH}: {e}"))
     }
 }
@@ -88,11 +88,21 @@ pub struct FirewallStatus {
 // ── Port mapping ───────────────────────────────────────────────
 
 fn tcp(port: u16) -> PortSpec {
-    PortSpec { port, transport: Transport::Tcp, source: None, iface: None }
+    PortSpec {
+        port,
+        transport: Transport::Tcp,
+        source: None,
+        iface: None,
+    }
 }
 
 fn udp(port: u16) -> PortSpec {
-    PortSpec { port, transport: Transport::Udp, source: None, iface: None }
+    PortSpec {
+        port,
+        transport: Transport::Udp,
+        source: None,
+        iface: None,
+    }
 }
 
 /// Return the ports that should be open for a given protocol.
@@ -122,6 +132,12 @@ pub struct FirewallService {
     restrictions: tokio::sync::Mutex<FirewallRestrictions>,
 }
 
+impl Default for FirewallService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FirewallService {
     pub fn new() -> Self {
         Self {
@@ -137,8 +153,16 @@ impl FirewallService {
         let restrictions = self.restrictions.lock().await;
 
         // WebUI is always open
-        let webui_sources = restrictions.services.get("webui").cloned().unwrap_or_default();
-        let webui_ifaces = restrictions.interfaces.get("webui").cloned().unwrap_or_default();
+        let webui_sources = restrictions
+            .services
+            .get("webui")
+            .cloned()
+            .unwrap_or_default();
+        let webui_ifaces = restrictions
+            .interfaces
+            .get("webui")
+            .cloned()
+            .unwrap_or_default();
         state.rules.push(FirewallRule {
             service: "webui".to_string(),
             ports: apply_restrictions(webui_ports(), &webui_sources, &webui_ifaces),
@@ -151,8 +175,16 @@ impl FirewallService {
             if ports.is_empty() {
                 continue;
             }
-            let sources = restrictions.services.get(proto.name()).cloned().unwrap_or_default();
-            let ifaces = restrictions.interfaces.get(proto.name()).cloned().unwrap_or_default();
+            let sources = restrictions
+                .services
+                .get(proto.name())
+                .cloned()
+                .unwrap_or_default();
+            let ifaces = restrictions
+                .interfaces
+                .get(proto.name())
+                .cloned()
+                .unwrap_or_default();
             ports = apply_restrictions(ports, &sources, &ifaces);
             state.rules.push(FirewallRule {
                 service: proto.name().to_string(),
@@ -226,17 +258,28 @@ impl FirewallService {
 
     /// Set source IP and/or interface restrictions for a service and rebuild firewall.
     pub async fn set_restriction(
-        &self, service: &str,
+        &self,
+        service: &str,
         sources: Vec<String>,
         ifaces: Vec<String>,
     ) -> Result<(), String> {
         // Update persisted restrictions
         {
             let mut restrictions = self.restrictions.lock().await;
-            if sources.is_empty() { restrictions.services.remove(service); }
-            else { restrictions.services.insert(service.to_string(), sources.clone()); }
-            if ifaces.is_empty() { restrictions.interfaces.remove(service); }
-            else { restrictions.interfaces.insert(service.to_string(), ifaces.clone()); }
+            if sources.is_empty() {
+                restrictions.services.remove(service);
+            } else {
+                restrictions
+                    .services
+                    .insert(service.to_string(), sources.clone());
+            }
+            if ifaces.is_empty() {
+                restrictions.interfaces.remove(service);
+            } else {
+                restrictions
+                    .interfaces
+                    .insert(service.to_string(), ifaces.clone());
+            }
             restrictions.save().await?;
         }
 
@@ -265,7 +308,11 @@ impl FirewallService {
 }
 
 /// Apply source and interface restrictions to a set of ports.
-fn apply_restrictions(ports: Vec<PortSpec>, sources: &[String], ifaces: &[String]) -> Vec<PortSpec> {
+fn apply_restrictions(
+    ports: Vec<PortSpec>,
+    sources: &[String],
+    ifaces: &[String],
+) -> Vec<PortSpec> {
     if sources.is_empty() && ifaces.is_empty() {
         return ports;
     }
@@ -343,7 +390,8 @@ async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
             conditions.push(format!("{proto} dport {}", port.port));
             rules.push_str(&format!(
                 "        {} accept # {}\n",
-                conditions.join(" "), rule.service
+                conditions.join(" "),
+                rule.service
             ));
         }
     }
@@ -357,12 +405,12 @@ async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
         .output()
         .await;
     // Ignore flush errors (table may not exist yet)
-    if let Ok(o) = &flush {
-        if !o.status.success() {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            if !stderr.contains("No such file") && !stderr.contains("does not exist") {
-                warn!("nft delete table warning: {stderr}");
-            }
+    if let Ok(o) = &flush
+        && !o.status.success()
+    {
+        let stderr = String::from_utf8_lossy(&o.stderr);
+        if !stderr.contains("No such file") && !stderr.contains("does not exist") {
+            warn!("nft delete table warning: {stderr}");
         }
     }
 
@@ -370,7 +418,8 @@ async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
     // An earlier version tried `nft -f -` with piped stdin but never wrote to
     // the pipe, so nft hung waiting for EOF until the spawn went out of scope.
     let tmp = "/tmp/nasty-firewall.nft";
-    tokio::fs::write(tmp, &rules).await
+    tokio::fs::write(tmp, &rules)
+        .await
         .map_err(|e| format!("write {tmp}: {e}"))?;
 
     let output = Command::new("nft")

--- a/engine/nasty-system/src/firmware.rs
+++ b/engine/nasty-system/src/firmware.rs
@@ -38,6 +38,12 @@ pub struct FirmwareUpdateResult {
 
 pub struct FirmwareService;
 
+impl Default for FirmwareService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FirmwareService {
     pub fn new() -> Self {
         Self
@@ -46,9 +52,7 @@ impl FirmwareService {
     /// Check if firmware management is available.
     /// Disabled on VMs (no real firmware) — detected via systemd-detect-virt.
     pub async fn is_available(&self) -> bool {
-        let output = Command::new("systemd-detect-virt")
-            .output()
-            .await;
+        let output = Command::new("systemd-detect-virt").output().await;
         match output {
             Ok(o) => {
                 // Exit code 0 = virtualized, non-zero = bare metal (or container)
@@ -87,12 +91,11 @@ impl FirmwareService {
             }
         };
 
-        let devices = json["Devices"].as_array()
-            .cloned()
-            .unwrap_or_default();
+        let devices = json["Devices"].as_array().cloned().unwrap_or_default();
 
-        devices.iter().map(|d| {
-            FirmwareDevice {
+        devices
+            .iter()
+            .map(|d| FirmwareDevice {
                 name: d["Name"].as_str().unwrap_or("Unknown").to_string(),
                 device_id: d["DeviceId"].as_str().unwrap_or("").to_string(),
                 version: d["Version"].as_str().unwrap_or("unknown").to_string(),
@@ -100,8 +103,8 @@ impl FirmwareService {
                 update_available: false,
                 update_version: None,
                 update_description: None,
-            }
-        }).collect()
+            })
+            .collect()
     }
 
     /// Check for available firmware updates.
@@ -129,20 +132,18 @@ impl FirmwareService {
         };
 
         if let Some(json) = updates_json {
-            let updates = json["Devices"].as_array()
-                .cloned()
-                .unwrap_or_default();
+            let updates = json["Devices"].as_array().cloned().unwrap_or_default();
 
             for update in &updates {
                 let device_id = update["DeviceId"].as_str().unwrap_or("");
                 if let Some(dev) = devices.iter_mut().find(|d| d.device_id == device_id) {
                     dev.update_available = true;
                     // Releases array — take the first (latest)
-                    if let Some(releases) = update["Releases"].as_array() {
-                        if let Some(release) = releases.first() {
-                            dev.update_version = release["Version"].as_str().map(|s| s.to_string());
-                            dev.update_description = release["Summary"].as_str().map(|s| s.to_string());
-                        }
+                    if let Some(releases) = update["Releases"].as_array()
+                        && let Some(release) = releases.first()
+                    {
+                        dev.update_version = release["Version"].as_str().map(|s| s.to_string());
+                        dev.update_description = release["Summary"].as_str().map(|s| s.to_string());
                     }
                 }
             }
@@ -185,14 +186,12 @@ impl FirmwareService {
                     }
                 }
             }
-            Err(e) => {
-                FirmwareUpdateResult {
-                    device_name: device_id.to_string(),
-                    success: false,
-                    message: format!("fwupdmgr not available: {e}"),
-                    reboot_required: false,
-                }
-            }
+            Err(e) => FirmwareUpdateResult {
+                device_name: device_id.to_string(),
+                success: false,
+                message: format!("fwupdmgr not available: {e}"),
+                reboot_required: false,
+            },
         }
     }
 }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -3,8 +3,8 @@ pub mod firewall;
 pub mod firmware;
 pub mod network;
 pub mod notifications;
-pub mod protocol;
 pub mod nut;
+pub mod protocol;
 pub mod settings;
 pub mod tailscale;
 pub mod tuning;
@@ -110,7 +110,11 @@ pub struct ServiceStatus {
 
 impl SystemService {
     pub fn new(engine_commit: Option<String>, engine_built: Option<String>) -> Self {
-        Self { cached: Arc::new(RwLock::new(None)), engine_commit, engine_built }
+        Self {
+            cached: Arc::new(RwLock::new(None)),
+            engine_commit,
+            engine_built,
+        }
     }
 
     /// Invalidate cached bcachefs info — call after rebuild or reboot.
@@ -126,7 +130,14 @@ impl SystemService {
             }
         }
         // Compute — run subprocess calls in parallel.
-        let (bcachefs_version, bcachefs_commit, (pinned_ref, _), debug_symbols, debug_checks, default_ref) = tokio::join!(
+        let (
+            bcachefs_version,
+            bcachefs_commit,
+            (pinned_ref, _),
+            debug_symbols,
+            debug_checks,
+            default_ref,
+        ) = tokio::join!(
             bcachefs_version(),
             read_bcachefs_commit(),
             crate::update::read_flake_lock_bcachefs_pub(),
@@ -137,7 +148,8 @@ impl SystemService {
         // Running state: compare actual loaded module against default.
         // Strip leading 'v' from default ref for comparison (e.g. "v1.37.2" vs "1.37.2").
         let default_bare = default_ref.strip_prefix('v').unwrap_or(&default_ref);
-        let bcachefs_is_custom_running = bcachefs_version != default_bare && bcachefs_version != "unknown";
+        let bcachefs_is_custom_running =
+            bcachefs_version != default_bare && bcachefs_version != "unknown";
         let info = CachedInfo {
             bcachefs_version,
             bcachefs_commit,
@@ -180,7 +192,8 @@ impl SystemService {
 
     pub async fn health(&self) -> SystemHealth {
         let engine = self_service_status("Engine").await;
-        let metrics = remote_service_status("Metrics", "nasty-metrics", "http://127.0.0.1:2138/health").await;
+        let metrics =
+            remote_service_status("Metrics", "nasty-metrics", "http://127.0.0.1:2138/health").await;
 
         let all_ok = engine.running && metrics.running;
         SystemHealth {
@@ -188,7 +201,6 @@ impl SystemService {
             services: vec![engine, metrics],
         }
     }
-
 }
 
 fn hostname() -> String {
@@ -201,12 +213,7 @@ fn hostname() -> String {
 
 fn kernel_version() -> String {
     std::fs::read_to_string("/proc/version")
-        .map(|s| {
-            s.split_whitespace()
-                .nth(2)
-                .unwrap_or("unknown")
-                .to_string()
-        })
+        .map(|s| s.split_whitespace().nth(2).unwrap_or("unknown").to_string())
         .unwrap_or_else(|_| "unknown".to_string())
 }
 
@@ -220,7 +227,11 @@ async fn bcachefs_version() -> String {
     match output {
         Ok(o) if o.status.success() => {
             let v = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if v.is_empty() { "unknown".to_string() } else { v }
+            if v.is_empty() {
+                "unknown".to_string()
+            } else {
+                v
+            }
         }
         _ => "unknown".to_string(),
     }
@@ -371,11 +382,19 @@ async fn remote_service_status(name: &str, unit: &str, health_url: &str) -> Serv
 /// Get the MainPID of a systemd unit.
 async fn systemd_main_pid(unit: &str) -> Option<u32> {
     let output = tokio::process::Command::new("systemctl")
-        .args(["show", &format!("{unit}.service"), "--property=MainPID", "--value"])
+        .args([
+            "show",
+            &format!("{unit}.service"),
+            "--property=MainPID",
+            "--value",
+        ])
         .output()
         .await
         .ok()?;
-    let pid: u32 = String::from_utf8_lossy(&output.stdout).trim().parse().ok()?;
+    let pid: u32 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .ok()?;
     if pid > 0 { Some(pid) } else { None }
 }
 
@@ -423,7 +442,9 @@ async fn read_proc_stats(pid: u32) -> (u64, f64, u64) {
 
 /// Read the pinned bcachefs-tools commit SHA from flake.lock (12-char short form).
 async fn read_bcachefs_commit() -> Option<String> {
-    let content = tokio::fs::read_to_string("/etc/nixos/flake.lock").await.ok()?;
+    let content = tokio::fs::read_to_string("/etc/nixos/flake.lock")
+        .await
+        .ok()?;
     let v: serde_json::Value = serde_json::from_str(&content).ok()?;
     let rev = v["nodes"]["bcachefs-tools"]["locked"]["rev"].as_str()?;
     Some(rev[..rev.len().min(12)].to_string())

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -14,15 +14,13 @@ const NIX_PATH: &str = "/etc/nixos/networking.nix";
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum IpMethod {
     Dhcp,
     Static,
     Slaac,
+    #[default]
     Disabled,
-}
-
-impl Default for IpMethod {
-    fn default() -> Self { Self::Disabled }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
@@ -48,7 +46,9 @@ pub struct InterfaceConfig {
     pub mtu: Option<u16>,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -133,8 +133,16 @@ pub struct NetworkState {
 
 pub struct NetworkService;
 
+impl Default for NetworkService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NetworkService {
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 
     pub async fn get(&self) -> NetworkState {
         let config = load_config().await;
@@ -166,7 +174,8 @@ impl NetworkService {
         // Persist JSON
         let json = serde_json::to_string_pretty(&config)
             .map_err(|e| format!("serialization error: {e}"))?;
-        tokio::fs::write(JSON_PATH, &json).await
+        tokio::fs::write(JSON_PATH, &json)
+            .await
             .map_err(|e| format!("failed to write {JSON_PATH}: {e}"))?;
 
         // Generate networking.nix
@@ -178,8 +187,12 @@ impl NetworkService {
         // Apply immediately
         apply_config(&config).await?;
 
-        info!("Network config updated ({} interfaces, {} bonds, {} VLANs)",
-            config.interfaces.len(), config.bonds.len(), config.vlans.len());
+        info!(
+            "Network config updated ({} interfaces, {} bonds, {} VLANs)",
+            config.interfaces.len(),
+            config.bonds.len(),
+            config.vlans.len()
+        );
         Ok(())
     }
 
@@ -190,13 +203,10 @@ impl NetworkService {
 }
 
 fn validate_ip_config(ip: &IpConfig, label: &str) -> Result<(), String> {
-    match ip.method {
-        IpMethod::Static => {
-            if ip.addresses.is_empty() {
-                return Err(format!("{label} static mode requires at least one address"));
-            }
-        }
-        _ => {}
+    if let IpMethod::Static = ip.method
+        && ip.addresses.is_empty()
+    {
+        return Err(format!("{label} static mode requires at least one address"));
     }
     Ok(())
 }
@@ -218,19 +228,28 @@ async fn load_config() -> NetworkConfig {
 async fn enumerate_interfaces() -> Vec<LiveInterface> {
     let mut result = Vec::new();
     let sys_net = std::path::Path::new("/sys/class/net");
-    let Ok(entries) = std::fs::read_dir(sys_net) else { return result };
+    let Ok(entries) = std::fs::read_dir(sys_net) else {
+        return result;
+    };
 
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         // Skip loopback and Docker/container interfaces
-        if name == "lo" || name.starts_with("docker") || name.starts_with("veth")
-            || name.starts_with("br-") || name.starts_with("cni") {
+        if name == "lo"
+            || name.starts_with("docker")
+            || name.starts_with("veth")
+            || name.starts_with("br-")
+            || name.starts_with("cni")
+        {
             continue;
         }
 
         let path = entry.path();
         let read_file = |f: &str| -> String {
-            std::fs::read_to_string(path.join(f)).unwrap_or_default().trim().to_string()
+            std::fs::read_to_string(path.join(f))
+                .unwrap_or_default()
+                .trim()
+                .to_string()
         };
 
         let mac = read_file("address");
@@ -239,7 +258,10 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
         let up = operstate == "up" || operstate == "unknown";
         let carrier = read_file("carrier") == "1";
         let mtu: u32 = read_file("mtu").parse().unwrap_or(1500);
-        let speed: Option<u32> = read_file("speed").parse().ok().filter(|&s: &u32| s > 0 && s < 100_000);
+        let speed: Option<u32> = read_file("speed")
+            .parse()
+            .ok()
+            .filter(|&s: &u32| s > 0 && s < 100_000);
 
         // Detect interface type from sysfs
         let tun_flags = read_file("tun_flags");
@@ -247,7 +269,12 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
 
         let kind = if path.join("bonding").is_dir() {
             "bond"
-        } else if !tun_flags.is_empty() || name.starts_with("tun") || name.starts_with("tap") || name.starts_with("tailscale") || name.starts_with("wg") {
+        } else if !tun_flags.is_empty()
+            || name.starts_with("tun")
+            || name.starts_with("tap")
+            || name.starts_with("tailscale")
+            || name.starts_with("wg")
+        {
             "tunnel"
         } else if dev_type == "772" {
             "vlan"
@@ -312,15 +339,25 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
     for bond in &config.bonds {
         // Create bond if it doesn't exist
         if !std::path::Path::new(&format!("/sys/class/net/{}", bond.name)).exists() {
-            run_ip(&["link", "add", &bond.name, "type", "bond", "mode", bond.mode.to_kernel()]).await
-                .map_err(|e| format!("create bond {}: {e}", bond.name))?;
+            run_ip(&[
+                "link",
+                "add",
+                &bond.name,
+                "type",
+                "bond",
+                "mode",
+                bond.mode.to_kernel(),
+            ])
+            .await
+            .map_err(|e| format!("create bond {}: {e}", bond.name))?;
         }
         // Enslave members
         for member in &bond.members {
             let _ = run_ip(&["link", "set", member, "down"]).await;
             let _ = run_ip(&["link", "set", member, "master", &bond.name]).await;
         }
-        run_ip(&["link", "set", &bond.name, "up"]).await
+        run_ip(&["link", "set", &bond.name, "up"])
+            .await
             .map_err(|e| format!("bring up bond {}: {e}", bond.name))?;
         apply_ip_config(&bond.name, &bond.ipv4, false).await?;
         apply_ip_config(&bond.name, &bond.ipv6, true).await?;
@@ -330,11 +367,23 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
     for vlan in &config.vlans {
         let vlan_name = format!("{}.{}", vlan.parent, vlan.vlan_id);
         if !std::path::Path::new(&format!("/sys/class/net/{vlan_name}")).exists() {
-            run_ip(&["link", "add", "link", &vlan.parent, "name", &vlan_name,
-                     "type", "vlan", "id", &vlan.vlan_id.to_string()]).await
-                .map_err(|e| format!("create vlan {vlan_name}: {e}"))?;
+            run_ip(&[
+                "link",
+                "add",
+                "link",
+                &vlan.parent,
+                "name",
+                &vlan_name,
+                "type",
+                "vlan",
+                "id",
+                &vlan.vlan_id.to_string(),
+            ])
+            .await
+            .map_err(|e| format!("create vlan {vlan_name}: {e}"))?;
         }
-        run_ip(&["link", "set", &vlan_name, "up"]).await
+        run_ip(&["link", "set", &vlan_name, "up"])
+            .await
             .map_err(|e| format!("bring up vlan {vlan_name}: {e}"))?;
         apply_ip_config(&vlan_name, &vlan.ipv4, false).await?;
         apply_ip_config(&vlan_name, &vlan.ipv6, true).await?;
@@ -346,7 +395,8 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
             let _ = run_ip(&["link", "set", &iface.name, "down"]).await;
             continue;
         }
-        run_ip(&["link", "set", &iface.name, "up"]).await
+        run_ip(&["link", "set", &iface.name, "up"])
+            .await
             .map_err(|e| format!("bring up {}: {e}", iface.name))?;
         if let Some(mtu) = iface.mtu {
             let _ = run_ip(&["link", "set", &iface.name, "mtu", &mtu.to_string()]).await;
@@ -358,7 +408,9 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
     // Apply DNS via resolvconf (NixOS manages /etc/resolv.conf — writing it
     // directly causes "signature mismatch" errors on the next rebuild).
     if !config.dns.is_empty() {
-        let resolv: String = config.dns.iter()
+        let resolv: String = config
+            .dns
+            .iter()
             .map(|ns| format!("nameserver {ns}\n"))
             .collect();
         use tokio::io::AsyncWriteExt;
@@ -370,10 +422,14 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
             .spawn()
             .map_err(|e| format!("resolvconf: {e}"))?;
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(resolv.as_bytes()).await
+            stdin
+                .write_all(resolv.as_bytes())
+                .await
                 .map_err(|e| format!("resolvconf stdin: {e}"))?;
         }
-        let output = child.wait_with_output().await
+        let output = child
+            .wait_with_output()
+            .await
             .map_err(|e| format!("resolvconf wait: {e}"))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -392,7 +448,8 @@ async fn apply_ip_config(iface: &str, ip: &IpConfig, v6: bool) -> Result<(), Str
                 // Restart DHCP for this interface
                 let _ = tokio::process::Command::new("systemctl")
                     .args(["restart", "dhcpcd"])
-                    .status().await;
+                    .status()
+                    .await;
             }
             // DHCPv6 is typically handled by dhcpcd or systemd-networkd
         }
@@ -401,12 +458,14 @@ async fn apply_ip_config(iface: &str, ip: &IpConfig, v6: bool) -> Result<(), Str
             let _ = run_ip(&[flag, "addr", "flush", "dev", iface]).await;
             // Add configured addresses
             for addr in &ip.addresses {
-                run_ip(&[flag, "addr", "add", addr, "dev", iface]).await
+                run_ip(&[flag, "addr", "add", addr, "dev", iface])
+                    .await
                     .map_err(|e| format!("ip addr add {addr} on {iface}: {e}"))?;
             }
             // Set gateway
             if let Some(ref gw) = ip.gateway {
-                let _ = run_ip(&[flag, "route", "replace", "default", "via", gw, "dev", iface]).await;
+                let _ =
+                    run_ip(&[flag, "route", "replace", "default", "via", gw, "dev", iface]).await;
             }
         }
         IpMethod::Slaac => {
@@ -433,9 +492,8 @@ async fn apply_ip_config(iface: &str, ip: &IpConfig, v6: bool) -> Result<(), Str
 // ── NixOS config generation ────────────────────────────────────
 
 fn generate_nix(config: &NetworkConfig) -> String {
-    let mut out = String::from(
-        "# Managed by NASty — edit via WebUI Settings > Network\n{ ... }:\n{\n",
-    );
+    let mut out =
+        String::from("# Managed by NASty — edit via WebUI Settings > Network\n{ ... }:\n{\n");
 
     out.push_str("  networking.useDHCP = false;\n\n");
 
@@ -471,25 +529,38 @@ fn generate_nix(config: &NetworkConfig) -> String {
     // DNS
     if !config.dns.is_empty() {
         let items: Vec<String> = config.dns.iter().map(|ns| format!("\"{ns}\"")).collect();
-        out.push_str(&format!("  networking.nameservers = [ {} ];\n", items.join(" ")));
+        out.push_str(&format!(
+            "  networking.nameservers = [ {} ];\n",
+            items.join(" ")
+        ));
     }
 
     out.push_str("}\n");
     out
 }
 
-fn generate_iface_nix(out: &mut String, name: &str, ipv4: &IpConfig, ipv6: &IpConfig, mtu: Option<u16>) {
+fn generate_iface_nix(
+    out: &mut String,
+    name: &str,
+    ipv4: &IpConfig,
+    ipv6: &IpConfig,
+    mtu: Option<u16>,
+) {
     match ipv4.method {
         IpMethod::Dhcp => {
             out.push_str(&format!("  networking.interfaces.{name}.useDHCP = true;\n"));
         }
         IpMethod::Static => {
-            let addrs: Vec<String> = ipv4.addresses.iter().map(|a| {
-                let parts: Vec<&str> = a.split('/').collect();
-                let addr = parts[0];
-                let prefix: u8 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(24);
-                format!("{{ address = \"{addr}\"; prefixLength = {prefix}; }}")
-            }).collect();
+            let addrs: Vec<String> = ipv4
+                .addresses
+                .iter()
+                .map(|a| {
+                    let parts: Vec<&str> = a.split('/').collect();
+                    let addr = parts[0];
+                    let prefix: u8 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(24);
+                    format!("{{ address = \"{addr}\"; prefixLength = {prefix}; }}")
+                })
+                .collect();
             out.push_str(&format!(
                 "  networking.interfaces.{name}.ipv4.addresses = [ {} ];\n",
                 addrs.join(" ")
@@ -506,12 +577,16 @@ fn generate_iface_nix(out: &mut String, name: &str, ipv4: &IpConfig, ipv6: &IpCo
             // NixOS enables SLAAC by default when IPv6 is not disabled
         }
         IpMethod::Static => {
-            let addrs: Vec<String> = ipv6.addresses.iter().map(|a| {
-                let parts: Vec<&str> = a.split('/').collect();
-                let addr = parts[0];
-                let prefix: u8 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(64);
-                format!("{{ address = \"{addr}\"; prefixLength = {prefix}; }}")
-            }).collect();
+            let addrs: Vec<String> = ipv6
+                .addresses
+                .iter()
+                .map(|a| {
+                    let parts: Vec<&str> = a.split('/').collect();
+                    let addr = parts[0];
+                    let prefix: u8 = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(64);
+                    format!("{{ address = \"{addr}\"; prefixLength = {prefix}; }}")
+                })
+                .collect();
             out.push_str(&format!(
                 "  networking.interfaces.{name}.ipv6.addresses = [ {} ];\n",
                 addrs.join(" ")
@@ -521,7 +596,9 @@ fn generate_iface_nix(out: &mut String, name: &str, ipv4: &IpConfig, ipv6: &IpCo
             }
         }
         IpMethod::Disabled => {
-            out.push_str(&format!("  networking.interfaces.{name}.ipv6.addresses = [];\n"));
+            out.push_str(&format!(
+                "  networking.interfaces.{name}.ipv6.addresses = [];\n"
+            ));
         }
         _ => {}
     }
@@ -536,7 +613,11 @@ fn generate_iface_nix(out: &mut String, name: &str, ipv4: &IpConfig, ipv6: &IpCo
 pub async fn detect_primary_interface() -> Option<String> {
     // Try IPv4 first, then IPv6
     for flag in &["-4", "-6"] {
-        let target = if *flag == "-4" { "1.1.1.1" } else { "2001:4860:4860::8888" };
+        let target = if *flag == "-4" {
+            "1.1.1.1"
+        } else {
+            "2001:4860:4860::8888"
+        };
         let output = tokio::process::Command::new("ip")
             .args([flag, "route", "get", target])
             .output()

--- a/engine/nasty-system/src/notifications.rs
+++ b/engine/nasty-system/src/notifications.rs
@@ -67,8 +67,7 @@ impl NotificationConfig {
 
     pub async fn save(&self) -> Result<(), String> {
         use std::os::unix::fs::PermissionsExt;
-        let json = serde_json::to_string_pretty(self)
-            .map_err(|e| format!("serialize: {e}"))?;
+        let json = serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {e}"))?;
         tokio::fs::write(CONFIG_PATH, json)
             .await
             .map_err(|e| format!("write {CONFIG_PATH}: {e}"))?;
@@ -97,47 +96,65 @@ pub async fn send(config: &NotificationConfig, subject: &str, body: &str) {
 
 /// Test a specific channel by sending a test message.
 pub async fn test_channel(channel: &ChannelType) -> Result<String, String> {
-    send_to_channel(channel, "NASty Test", "This is a test notification from NASty.").await?;
+    send_to_channel(
+        channel,
+        "NASty Test",
+        "This is a test notification from NASty.",
+    )
+    .await?;
     Ok("Test notification sent successfully".to_string())
 }
 
 async fn send_to_channel(channel: &ChannelType, subject: &str, body: &str) -> Result<(), String> {
     match channel {
-        ChannelType::Smtp { host, port, username, password, from, to } => {
-            send_smtp(host, *port, username, password, from, to, subject, body).await
-        }
+        ChannelType::Smtp {
+            host,
+            port,
+            username,
+            password,
+            from,
+            to,
+        } => send_smtp(host, *port, username, password, from, to, subject, body).await,
         ChannelType::Telegram { bot_token, chat_id } => {
             send_telegram(bot_token, chat_id, subject, body).await
         }
-        ChannelType::Webhook { url, headers } => {
-            send_webhook(url, headers, subject, body).await
-        }
-        ChannelType::Ntfy { server_url, topic, token } => {
-            send_ntfy(server_url, topic, token.as_deref(), subject, body).await
-        }
-        ChannelType::Signal { api_url, from_number, to_number } => {
-            send_signal(api_url, from_number, to_number, subject, body).await
-        }
+        ChannelType::Webhook { url, headers } => send_webhook(url, headers, subject, body).await,
+        ChannelType::Ntfy {
+            server_url,
+            topic,
+            token,
+        } => send_ntfy(server_url, topic, token.as_deref(), subject, body).await,
+        ChannelType::Signal {
+            api_url,
+            from_number,
+            to_number,
+        } => send_signal(api_url, from_number, to_number, subject, body).await,
     }
 }
 
 // ── SMTP ───────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn send_smtp(
-    host: &str, port: u16, username: &str, password: &str,
-    from: &str, to: &str,
-    subject: &str, body: &str,
+    host: &str,
+    port: u16,
+    username: &str,
+    password: &str,
+    from: &str,
+    to: &str,
+    subject: &str,
+    body: &str,
 ) -> Result<(), String> {
     use lettre::{
         AsyncSmtpTransport, AsyncTransport, Tokio1Executor,
-        message::{header::ContentType, Mailbox},
+        message::{Mailbox, header::ContentType},
         transport::smtp::authentication::Credentials,
     };
 
-    let from_mbox: Mailbox = from.parse()
+    let from_mbox: Mailbox = from
+        .parse()
         .map_err(|e| format!("invalid from address: {e}"))?;
-    let to_mbox: Mailbox = to.parse()
-        .map_err(|e| format!("invalid to address: {e}"))?;
+    let to_mbox: Mailbox = to.parse().map_err(|e| format!("invalid to address: {e}"))?;
 
     let email = lettre::Message::builder()
         .from(from_mbox)
@@ -161,7 +178,9 @@ async fn send_smtp(
     .credentials(creds)
     .build();
 
-    transport.send(email).await
+    transport
+        .send(email)
+        .await
         .map_err(|e| format!("smtp send: {e}"))?;
 
     Ok(())
@@ -169,12 +188,18 @@ async fn send_smtp(
 
 // ── Telegram ───────────────────────────────────────────────────
 
-async fn send_telegram(bot_token: &str, chat_id: &str, subject: &str, body: &str) -> Result<(), String> {
+async fn send_telegram(
+    bot_token: &str,
+    chat_id: &str,
+    subject: &str,
+    body: &str,
+) -> Result<(), String> {
     let text = format!("*{subject}*\n\n{body}");
     let url = format!("https://api.telegram.org/bot{bot_token}/sendMessage");
 
     let client = reqwest::Client::new();
-    let resp = client.post(&url)
+    let resp = client
+        .post(&url)
         .json(&serde_json::json!({
             "chat_id": chat_id,
             "text": text,
@@ -201,19 +226,20 @@ async fn send_webhook(
     body: &str,
 ) -> Result<(), String> {
     let client = reqwest::Client::new();
-    let mut req = client.post(url)
-        .json(&serde_json::json!({
-            "subject": subject,
-            "body": body,
-            "source": "nasty",
-            "timestamp": chrono::Utc::now().to_rfc3339(),
-        }));
+    let mut req = client.post(url).json(&serde_json::json!({
+        "subject": subject,
+        "body": body,
+        "source": "nasty",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }));
 
     for (k, v) in headers {
         req = req.header(k, v);
     }
 
-    let resp = req.send().await
+    let resp = req
+        .send()
+        .await
         .map_err(|e| format!("webhook request: {e}"))?;
 
     if !resp.status().is_success() {
@@ -228,13 +254,16 @@ async fn send_webhook(
 // ── ntfy ───────────────────────────────────────────────────────
 
 async fn send_ntfy(
-    server_url: &str, topic: &str,
+    server_url: &str,
+    topic: &str,
     token: Option<&str>,
-    subject: &str, body: &str,
+    subject: &str,
+    body: &str,
 ) -> Result<(), String> {
     let url = format!("{}/{}", server_url.trim_end_matches('/'), topic);
     let client = reqwest::Client::new();
-    let mut req = client.post(&url)
+    let mut req = client
+        .post(&url)
         .header("Title", subject)
         .header("Priority", "high")
         .header("Tags", "warning")
@@ -244,8 +273,7 @@ async fn send_ntfy(
         req = req.header("Authorization", format!("Bearer {t}"));
     }
 
-    let resp = req.send().await
-        .map_err(|e| format!("ntfy request: {e}"))?;
+    let resp = req.send().await.map_err(|e| format!("ntfy request: {e}"))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -259,14 +287,18 @@ async fn send_ntfy(
 // ── Signal ─────────────────────────────────────────────────────
 
 async fn send_signal(
-    api_url: &str, from_number: &str, to_number: &str,
-    subject: &str, body: &str,
+    api_url: &str,
+    from_number: &str,
+    to_number: &str,
+    subject: &str,
+    body: &str,
 ) -> Result<(), String> {
     let message = format!("{subject}\n\n{body}");
     let url = format!("{}/v2/send", api_url.trim_end_matches('/'));
 
     let client = reqwest::Client::new();
-    let resp = client.post(&url)
+    let resp = client
+        .post(&url)
         .json(&serde_json::json!({
             "message": message,
             "number": from_number,

--- a/engine/nasty-system/src/nut.rs
+++ b/engine/nasty-system/src/nut.rs
@@ -36,11 +36,21 @@ pub struct NutConfig {
     pub shutdown_command: String,
 }
 
-fn default_driver() -> String { "usbhid-ups".into() }
-fn default_port() -> String { "auto".into() }
-fn default_ups_name() -> String { "ups".into() }
-fn default_shutdown_percent() -> u32 { 20 }
-fn default_shutdown_seconds() -> u32 { 120 }
+fn default_driver() -> String {
+    "usbhid-ups".into()
+}
+fn default_port() -> String {
+    "auto".into()
+}
+fn default_ups_name() -> String {
+    "ups".into()
+}
+fn default_shutdown_percent() -> u32 {
+    20
+}
+fn default_shutdown_seconds() -> u32 {
+    120
+}
 fn default_shutdown_command() -> String {
     "/run/current-system/sw/bin/systemctl poweroff".into()
 }
@@ -117,21 +127,33 @@ impl NutService {
     pub async fn update_config(&self, update: NutConfigUpdate) -> Result<NutConfig, String> {
         let mut config = self.state.write().await;
 
-        if let Some(v) = update.driver { config.driver = v; }
-        if let Some(v) = update.port { config.port = v; }
+        if let Some(v) = update.driver {
+            config.driver = v;
+        }
+        if let Some(v) = update.port {
+            config.port = v;
+        }
         if let Some(v) = update.ups_name {
-            if v.is_empty() { return Err("ups_name cannot be empty".into()); }
+            if v.is_empty() {
+                return Err("ups_name cannot be empty".into());
+            }
             config.ups_name = v;
         }
-        if let Some(v) = update.description { config.description = v; }
+        if let Some(v) = update.description {
+            config.description = v;
+        }
         if let Some(v) = update.shutdown_on_battery_percent {
-            if v > 100 { return Err("shutdown_on_battery_percent must be 0-100".into()); }
+            if v > 100 {
+                return Err("shutdown_on_battery_percent must be 0-100".into());
+            }
             config.shutdown_on_battery_percent = v;
         }
         if let Some(v) = update.shutdown_on_battery_seconds {
             config.shutdown_on_battery_seconds = v;
         }
-        if let Some(v) = update.shutdown_command { config.shutdown_command = v; }
+        if let Some(v) = update.shutdown_command {
+            config.shutdown_command = v;
+        }
 
         save(&config).await.map_err(|e| e.to_string())?;
 
@@ -165,7 +187,8 @@ impl NutService {
 // ── Config file generation ───────────────────────────────────
 
 pub async fn write_config_files(config: &NutConfig) -> Result<(), String> {
-    tokio::fs::create_dir_all(NUT_CONF_DIR).await
+    tokio::fs::create_dir_all(NUT_CONF_DIR)
+        .await
         .map_err(|e| format!("failed to create {NUT_CONF_DIR}: {e}"))?;
 
     // ups.conf
@@ -212,12 +235,14 @@ async fn write_file(name: &str, content: &str) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
 
     let path = format!("{NUT_CONF_DIR}/{name}");
-    tokio::fs::write(&path, content).await
+    tokio::fs::write(&path, content)
+        .await
         .map_err(|e| format!("failed to write {path}: {e}"))?;
 
     // upsd.users contains credentials — restrict to owner-only
     if name == "upsd.users" {
-        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).await
+        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640))
+            .await
             .map_err(|e| format!("failed to set permissions on {path}: {e}"))?;
     }
 
@@ -261,12 +286,13 @@ async fn read_ups_status(ups_name: &str) -> UpsStatus {
 
     let get_f64 = |key: &str| -> Option<f64> { raw.get(key).and_then(|v| v.parse().ok()) };
     let get_u64 = |key: &str| -> Option<u64> { raw.get(key).and_then(|v| v.parse().ok()) };
-    let get_str = |key: &str| -> Option<String> {
-        raw.get(key).filter(|v| !v.is_empty()).cloned()
-    };
+    let get_str = |key: &str| -> Option<String> { raw.get(key).filter(|v| !v.is_empty()).cloned() };
 
     UpsStatus {
-        status: raw.get("ups.status").cloned().unwrap_or_else(|| "UNKNOWN".into()),
+        status: raw
+            .get("ups.status")
+            .cloned()
+            .unwrap_or_else(|| "UNKNOWN".into()),
         battery_charge: get_f64("battery.charge"),
         battery_runtime: get_u64("battery.runtime"),
         input_voltage: get_f64("input.voltage"),
@@ -292,7 +318,11 @@ async fn is_nut_running() -> bool {
 
 async fn restart_nut_services() {
     info!("Restarting NUT services after config change");
-    for svc in &["nut-monitor.service", "nut-server.service", "nut-driver.service"] {
+    for svc in &[
+        "nut-monitor.service",
+        "nut-server.service",
+        "nut-driver.service",
+    ] {
         let _ = tokio::process::Command::new("systemctl")
             .args(["restart", svc])
             .output()

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -38,7 +38,14 @@ impl Protocol {
     ];
 
     pub fn is_system_service(&self) -> bool {
-        matches!(self, Protocol::Nut | Protocol::Ssh | Protocol::Avahi | Protocol::Smart | Protocol::RestServer)
+        matches!(
+            self,
+            Protocol::Nut
+                | Protocol::Ssh
+                | Protocol::Avahi
+                | Protocol::Smart
+                | Protocol::RestServer
+        )
     }
 
     pub fn name(&self) -> &'static str {
@@ -76,7 +83,11 @@ impl Protocol {
             Protocol::Smb => &["samba-smbd.service", "samba-nmbd.service"],
             Protocol::Iscsi => &["target.service"],
             Protocol::Nvmeof => &[], // configfs-based, no daemon
-            Protocol::Nut => &["nut-driver.service", "nut-server.service", "nut-monitor.service"],
+            Protocol::Nut => &[
+                "nut-driver.service",
+                "nut-server.service",
+                "nut-monitor.service",
+            ],
             Protocol::Ssh => &["sshd.service"],
             Protocol::Avahi => &["avahi-daemon.service"],
             Protocol::Smart => &["smartd.service"],
@@ -136,7 +147,9 @@ struct ProtocolState {
     rest_server: bool,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 impl Default for ProtocolState {
     fn default() -> Self {
@@ -186,6 +199,12 @@ impl ProtocolState {
 
 pub struct ProtocolService;
 
+impl Default for ProtocolService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ProtocolService {
     pub fn new() -> Self {
         Self
@@ -232,7 +251,10 @@ impl ProtocolService {
                 }
             }
             if failed {
-                warn!("Auto-disabling {} — service units not available", proto.display_name());
+                warn!(
+                    "Auto-disabling {} — service units not available",
+                    proto.display_name()
+                );
                 let mut state = load_state().await;
                 state.set(proto, false);
                 let _ = save_state(&state).await;
@@ -265,8 +287,7 @@ impl ProtocolService {
 
     /// Enable a protocol: start its services and persist state
     pub async fn enable(&self, name: &str) -> Result<ProtocolStatus, String> {
-        let proto = Protocol::from_name(name)
-            .ok_or_else(|| format!("unknown protocol: {name}"))?;
+        let proto = Protocol::from_name(name).ok_or_else(|| format!("unknown protocol: {name}"))?;
 
         let mut state = load_state().await;
         state.set(proto, true);
@@ -294,7 +315,10 @@ impl ProtocolService {
         let services = proto.services();
         let mut started: Vec<&str> = Vec::new();
         for svc in services {
-            info!("Starting service {svc} for protocol {}", proto.display_name());
+            info!(
+                "Starting service {svc} for protocol {}",
+                proto.display_name()
+            );
             if let Err(e) = systemctl("start", svc).await {
                 warn!("Failed to start {svc}: {e}");
                 // Roll back: stop any services we already started
@@ -321,8 +345,7 @@ impl ProtocolService {
 
     /// Disable a protocol: stop its services and persist state
     pub async fn disable(&self, name: &str) -> Result<ProtocolStatus, String> {
-        let proto = Protocol::from_name(name)
-            .ok_or_else(|| format!("unknown protocol: {name}"))?;
+        let proto = Protocol::from_name(name).ok_or_else(|| format!("unknown protocol: {name}"))?;
 
         let mut state = load_state().await;
         state.set(proto, false);
@@ -330,7 +353,10 @@ impl ProtocolService {
 
         // Stop associated services
         for svc in proto.services() {
-            info!("Stopping service {svc} for protocol {}", proto.display_name());
+            info!(
+                "Stopping service {svc} for protocol {}",
+                proto.display_name()
+            );
             if let Err(e) = systemctl("stop", svc).await {
                 warn!("Failed to stop {svc}: {e}");
             }

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -29,7 +29,15 @@ pub struct AcmeStatus {
 
 impl Default for AcmeStatus {
     fn default() -> Self {
-        Self { state: "idle".into(), message: String::new(), domain: None, expires: None, issued: None, issuer: None, last_attempt: None }
+        Self {
+            state: "idle".into(),
+            message: String::new(),
+            domain: None,
+            expires: None,
+            issued: None,
+            issuer: None,
+            last_attempt: None,
+        }
     }
 }
 
@@ -42,7 +50,9 @@ fn set_acme_status(state: &str, message: &str, domain: Option<&str>) {
     if let Ok(mut s) = status.lock() {
         s.state = state.to_string();
         s.message = message.to_string();
-        if let Some(d) = domain { s.domain = Some(d.to_string()); }
+        if let Some(d) = domain {
+            s.domain = Some(d.to_string());
+        }
         s.last_attempt = Some(now);
     }
 }
@@ -200,7 +210,12 @@ pub fn redact_oidc_secret(mut s: OidcSettings) -> OidcSettings {
 }
 
 fn default_oidc_scopes() -> Vec<String> {
-    vec!["openid".into(), "profile".into(), "email".into(), "groups".into()]
+    vec![
+        "openid".into(),
+        "profile".into(),
+        "email".into(),
+        "groups".into(),
+    ]
 }
 
 fn default_oidc_groups_claim() -> String {
@@ -288,13 +303,13 @@ impl SettingsService {
         // Seed hostname from the running system if not yet persisted.
         // This picks up whatever the installer configured (networking.hostName)
         // so the settings page shows the real hostname from day one.
-        if settings.hostname.is_none() {
-            if let Ok(name) = tokio::fs::read_to_string("/proc/sys/kernel/hostname").await {
-                let name = name.trim().to_string();
-                if !name.is_empty() {
-                    settings.hostname = Some(name);
-                    let _ = save(&settings).await;
-                }
+        if settings.hostname.is_none()
+            && let Ok(name) = tokio::fs::read_to_string("/proc/sys/kernel/hostname").await
+        {
+            let name = name.trim().to_string();
+            if !name.is_empty() {
+                settings.hostname = Some(name);
+                let _ = save(&settings).await;
             }
         }
         Self {
@@ -336,81 +351,99 @@ impl SettingsService {
         }
         let mut tls_changed = false;
         if let Some(domain) = update.tls_domain {
-            let domain = if domain.trim().is_empty() { None } else { Some(domain.trim().to_string()) };
+            let domain = if domain.trim().is_empty() {
+                None
+            } else {
+                Some(domain.trim().to_string())
+            };
             if settings.tls_domain != domain {
                 settings.tls_domain = domain;
                 tls_changed = true;
             }
         }
         if let Some(email) = update.tls_acme_email {
-            let email = if email.trim().is_empty() { None } else { Some(email.trim().to_string()) };
+            let email = if email.trim().is_empty() {
+                None
+            } else {
+                Some(email.trim().to_string())
+            };
             if settings.tls_acme_email != email {
                 settings.tls_acme_email = email;
                 tls_changed = true;
             }
         }
-        if let Some(enabled) = update.tls_acme_enabled {
-            if settings.tls_acme_enabled != enabled {
-                settings.tls_acme_enabled = enabled;
-                tls_changed = true;
-            }
+        if let Some(enabled) = update.tls_acme_enabled
+            && settings.tls_acme_enabled != enabled
+        {
+            settings.tls_acme_enabled = enabled;
+            tls_changed = true;
         }
-        if let Some(ct) = update.tls_challenge_type {
-            if settings.tls_challenge_type != ct {
-                settings.tls_challenge_type = ct;
-                tls_changed = true;
-            }
+        if let Some(ct) = update.tls_challenge_type
+            && settings.tls_challenge_type != ct
+        {
+            settings.tls_challenge_type = ct;
+            tls_changed = true;
         }
         if let Some(provider) = update.tls_dns_provider {
-            let provider = if provider.trim().is_empty() { None } else { Some(provider.trim().to_string()) };
+            let provider = if provider.trim().is_empty() {
+                None
+            } else {
+                Some(provider.trim().to_string())
+            };
             if settings.tls_dns_provider != provider {
                 settings.tls_dns_provider = provider;
                 tls_changed = true;
             }
         }
         if let Some(creds) = update.tls_dns_credentials {
-            let creds = if creds.trim().is_empty() { None } else { Some(creds.trim().to_string()) };
+            let creds = if creds.trim().is_empty() {
+                None
+            } else {
+                Some(creds.trim().to_string())
+            };
             if settings.tls_dns_credentials != creds {
                 settings.tls_dns_credentials = creds;
                 tls_changed = true;
             }
         }
-        if let Some(staging) = update.tls_acme_staging {
-            if settings.tls_acme_staging != staging {
-                settings.tls_acme_staging = staging;
-                tls_changed = true;
-            }
+        if let Some(staging) = update.tls_acme_staging
+            && settings.tls_acme_staging != staging
+        {
+            settings.tls_acme_staging = staging;
+            tls_changed = true;
         }
-        if let Some(resolver) = update.tls_dns_resolver {
-            if settings.tls_dns_resolver != Some(resolver.clone()) {
-                settings.tls_dns_resolver = if resolver.is_empty() { None } else { Some(resolver) };
-                tls_changed = true;
-            }
+        if let Some(resolver) = update.tls_dns_resolver
+            && settings.tls_dns_resolver != Some(resolver.clone())
+        {
+            settings.tls_dns_resolver = if resolver.is_empty() {
+                None
+            } else {
+                Some(resolver)
+            };
+            tls_changed = true;
         }
-        if let Some(wait) = update.tls_dns_propagation_wait {
-            if settings.tls_dns_propagation_wait != Some(wait) {
-                settings.tls_dns_propagation_wait = Some(wait);
-                tls_changed = true;
-            }
+        if let Some(wait) = update.tls_dns_propagation_wait
+            && settings.tls_dns_propagation_wait != Some(wait)
+        {
+            settings.tls_dns_propagation_wait = Some(wait);
+            tls_changed = true;
         }
         if let Some(telemetry) = update.telemetry_enabled {
             settings.telemetry_enabled = telemetry;
         }
         save(&settings).await.map_err(|e| e.to_string())?;
-        if tls_changed {
-            if settings.tls_acme_enabled {
-                if settings.tls_challenge_type == "dns" {
-                    write_dns_credentials(&settings).await;
-                }
-                // Run ACME cert provisioning in the background
-                let s = settings.clone();
-                tokio::spawn(async move {
-                    match run_lego(&s).await {
-                        Ok(()) => info!("ACME certificate provisioned successfully"),
-                        Err(e) => warn!("ACME certificate provisioning failed: {e}"),
-                    }
-                });
+        if tls_changed && settings.tls_acme_enabled {
+            if settings.tls_challenge_type == "dns" {
+                write_dns_credentials(&settings).await;
             }
+            // Run ACME cert provisioning in the background
+            let s = settings.clone();
+            tokio::spawn(async move {
+                match run_lego(&s).await {
+                    Ok(()) => info!("ACME certificate provisioned successfully"),
+                    Err(e) => warn!("ACME certificate provisioning failed: {e}"),
+                }
+            });
         }
         Ok(settings.clone())
     }
@@ -469,12 +502,17 @@ const DNS_CREDS_PATH: &str = "/var/lib/nasty/acme-dns-credentials";
 /// Run lego ACME client to obtain or renew a certificate.
 /// Writes cert and key to /var/lib/nasty/tls/ and reloads nginx.
 async fn run_lego(settings: &Settings) -> Result<(), String> {
-    let domain = settings.tls_domain.as_deref()
-        .ok_or("TLS domain not set")?;
-    let email = settings.tls_acme_email.as_deref()
+    let domain = settings.tls_domain.as_deref().ok_or("TLS domain not set")?;
+    let email = settings
+        .tls_acme_email
+        .as_deref()
         .ok_or("ACME email not set")?;
 
-    set_acme_status("running", &format!("Preparing certificate for {domain}..."), Some(domain));
+    set_acme_status(
+        "running",
+        &format!("Preparing certificate for {domain}..."),
+        Some(domain),
+    );
 
     // Create lego data directory
     // Use separate lego directories per ACME server so staging/production data coexist
@@ -495,9 +533,12 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
 
     let mut args = vec![
         "--accept-tos".to_string(),
-        "--email".to_string(), email.to_string(),
-        "--domains".to_string(), domain.to_string(),
-        "--path".to_string(), lego_dir.clone(),
+        "--email".to_string(),
+        email.to_string(),
+        "--domains".to_string(),
+        domain.to_string(),
+        "--path".to_string(),
+        lego_dir.clone(),
     ];
 
     if settings.tls_acme_staging {
@@ -512,7 +553,9 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             args.push(provider.clone());
             // Custom resolver for propagation checks (default: 1.1.1.1 to avoid
             // issues with local DNS not seeing public ACME TXT records).
-            let resolver = settings.tls_dns_resolver.as_deref()
+            let resolver = settings
+                .tls_dns_resolver
+                .as_deref()
                 .filter(|s| !s.is_empty())
                 .unwrap_or("1.1.1.1:53");
             args.push("--dns.resolvers".to_string());
@@ -536,21 +579,39 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
 
     args.push(action.to_string());
 
-    info!("Running lego {action} for {domain} (challenge: {})", settings.tls_challenge_type);
+    info!(
+        "Running lego {action} for {domain} (challenge: {})",
+        settings.tls_challenge_type
+    );
 
     // For TLS-ALPN challenge, stop nginx briefly so lego can bind to :443
     let need_nginx_stop = settings.tls_challenge_type != "dns";
     if need_nginx_stop {
-        set_acme_status("running", "Stopping web server for TLS challenge...", Some(domain));
+        set_acme_status(
+            "running",
+            "Stopping web server for TLS challenge...",
+            Some(domain),
+        );
         let _ = tokio::process::Command::new("systemctl")
             .args(["stop", "nginx"])
-            .output().await;
+            .output()
+            .await;
     }
 
     if settings.tls_challenge_type == "dns" {
-        set_acme_status("running", &format!("Running ACME {action} — creating DNS records and waiting for propagation (this can take 1-2 minutes)..."), Some(domain));
+        set_acme_status(
+            "running",
+            &format!(
+                "Running ACME {action} — creating DNS records and waiting for propagation (this can take 1-2 minutes)..."
+            ),
+            Some(domain),
+        );
     } else {
-        set_acme_status("running", &format!("Running ACME {action} — waiting for Let's Encrypt verification..."), Some(domain));
+        set_acme_status(
+            "running",
+            &format!("Running ACME {action} — waiting for Let's Encrypt verification..."),
+            Some(domain),
+        );
     }
 
     // Run lego — stream stderr to status updates, ensure nginx is ALWAYS restarted
@@ -574,7 +635,8 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             }
         }
 
-        let mut child = cmd.spawn()
+        let mut child = cmd
+            .spawn()
             .map_err(|e| format!("failed to run lego: {e}"))?;
 
         // Stream stderr lines to ACME status so the UI shows real-time progress
@@ -598,8 +660,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             None
         };
 
-        let status = child.wait().await
-            .map_err(|e| format!("lego wait: {e}"))?;
+        let status = child.wait().await.map_err(|e| format!("lego wait: {e}"))?;
 
         let stderr_lines = if let Some(h) = stderr_handle {
             h.await.unwrap_or_default()
@@ -608,14 +669,16 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
         };
 
         Ok::<_, String>((status, stderr_lines))
-    }.await;
+    }
+    .await;
 
     // ALWAYS restart nginx, regardless of lego success/failure
     if need_nginx_stop {
         set_acme_status("running", "Restarting web server...", Some(domain));
         let _ = tokio::process::Command::new("systemctl")
             .args(["start", "nginx"])
-            .output().await;
+            .output()
+            .await;
     }
 
     let (exit_status, stderr_lines) = lego_result?;
@@ -633,10 +696,20 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     let lego_cert = format!("{lego_dir}/certificates/{domain}.crt");
     let lego_key = format!("{lego_dir}/certificates/{domain}.key");
 
-    tokio::fs::copy(&lego_cert, TLS_CERT_PATH).await
-        .map_err(|e| { let m = format!("failed to copy cert: {e}"); set_acme_status("error", &m, Some(domain)); m })?;
-    tokio::fs::copy(&lego_key, TLS_KEY_PATH).await
-        .map_err(|e| { let m = format!("failed to copy key: {e}"); set_acme_status("error", &m, Some(domain)); m })?;
+    tokio::fs::copy(&lego_cert, TLS_CERT_PATH)
+        .await
+        .map_err(|e| {
+            let m = format!("failed to copy cert: {e}");
+            set_acme_status("error", &m, Some(domain));
+            m
+        })?;
+    tokio::fs::copy(&lego_key, TLS_KEY_PATH)
+        .await
+        .map_err(|e| {
+            let m = format!("failed to copy key: {e}");
+            set_acme_status("error", &m, Some(domain));
+            m
+        })?;
 
     // Set permissions so nginx (running as nginx user) can read the cert
     let _ = tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await;
@@ -644,12 +717,14 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     // Set key group to nginx so it can read it
     let _ = tokio::process::Command::new("chown")
         .args(["root:nginx", TLS_KEY_PATH])
-        .output().await;
+        .output()
+        .await;
 
     // Reload nginx to pick up the new certificate
     let reload = tokio::process::Command::new("systemctl")
         .args(["reload", "nginx"])
-        .output().await;
+        .output()
+        .await;
     match reload {
         Ok(r) if r.status.success() => info!("nginx reloaded with new certificate"),
         Ok(r) => {
@@ -674,7 +749,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_secs().to_string())
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
             );
         }
     }
@@ -690,7 +765,11 @@ struct CertInfo {
 
 /// Read certificate details from a PEM file.
 async fn read_cert_info(cert_path: &str) -> CertInfo {
-    let mut info = CertInfo { expires: None, issued: None, issuer: None };
+    let mut info = CertInfo {
+        expires: None,
+        issued: None,
+        issuer: None,
+    };
     let pem_data = match tokio::fs::read(cert_path).await {
         Ok(d) => d,
         Err(_) => return info,
@@ -704,8 +783,18 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
         Err(_) => return info,
     };
     let validity = cert.validity();
-    info.issued = Some(validity.not_before.to_rfc2822().unwrap_or_else(|_| validity.not_before.to_string()));
-    info.expires = Some(validity.not_after.to_rfc2822().unwrap_or_else(|_| validity.not_after.to_string()));
+    info.issued = Some(
+        validity
+            .not_before
+            .to_rfc2822()
+            .unwrap_or_else(|_| validity.not_before.to_string()),
+    );
+    info.expires = Some(
+        validity
+            .not_after
+            .to_rfc2822()
+            .unwrap_or_else(|_| validity.not_after.to_string()),
+    );
     // Extract CN or O from issuer
     for rdn in cert.issuer().iter() {
         for attr in rdn.iter() {
@@ -715,7 +804,9 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
             if *oid == x509_parser::oid_registry::OID_X509_COMMON_NAME {
                 info.issuer = Some(val.to_string());
                 break;
-            } else if *oid == x509_parser::oid_registry::OID_X509_ORGANIZATION_NAME && info.issuer.is_none() {
+            } else if *oid == x509_parser::oid_registry::OID_X509_ORGANIZATION_NAME
+                && info.issuer.is_none()
+            {
                 info.issuer = Some(val.to_string());
             }
         }
@@ -730,10 +821,8 @@ async fn write_dns_credentials(settings: &Settings) {
             warn!("Failed to write DNS credentials: {e}");
             return;
         }
-        let _ = tokio::fs::set_permissions(
-            DNS_CREDS_PATH,
-            std::fs::Permissions::from_mode(0o600),
-        ).await;
+        let _ = tokio::fs::set_permissions(DNS_CREDS_PATH, std::fs::Permissions::from_mode(0o600))
+            .await;
     }
 }
 
@@ -763,9 +852,15 @@ pub async fn check_acme_renewal() {
     }
 
     // Check if cert exists and is near expiry (within 30 days)
-    let lego_subdir = if settings.tls_acme_staging { "staging" } else { "production" };
-    let cert_path = format!("{LEGO_DATA_DIR}/{lego_subdir}/certificates/{}.crt",
-        settings.tls_domain.as_deref().unwrap_or(""));
+    let lego_subdir = if settings.tls_acme_staging {
+        "staging"
+    } else {
+        "production"
+    };
+    let cert_path = format!(
+        "{LEGO_DATA_DIR}/{lego_subdir}/certificates/{}.crt",
+        settings.tls_domain.as_deref().unwrap_or("")
+    );
     if !std::path::Path::new(&cert_path).exists() {
         info!("No ACME cert found, running initial provisioning...");
         if let Err(e) = run_lego(&settings).await {

--- a/engine/nasty-system/src/tailscale.rs
+++ b/engine/nasty-system/src/tailscale.rs
@@ -10,22 +10,13 @@ const SYSTEMD_UNIT: &str = "nasty-tailscale";
 const TAILSCALE_SOCKET: &str = "/run/tailscale/tailscaled.sock";
 
 /// Persisted Tailscale configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct TailscaleConfig {
     /// Whether Tailscale should be enabled.
     pub enabled: bool,
     /// Tailscale auth key for `tailscale up --authkey`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_key: Option<String>,
-}
-
-impl Default for TailscaleConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            auth_key: None,
-        }
-    }
 }
 
 /// Connect request — requires an auth key.
@@ -108,7 +99,10 @@ impl TailscaleService {
         let mut config = self.config.write().await;
 
         let key = if req.auth_key.is_empty() {
-            config.auth_key.clone().ok_or_else(|| "Auth key is required".to_string())?
+            config
+                .auth_key
+                .clone()
+                .ok_or_else(|| "Auth key is required".to_string())?
         } else {
             req.auth_key
         };
@@ -117,7 +111,9 @@ impl TailscaleService {
         start_tailscale(Some(key.as_str())).await?;
         config.enabled = true;
         config.auth_key = Some(key);
-        save_config(&config).await.map_err(|e| format!("Failed to save config: {e}"))?;
+        save_config(&config)
+            .await
+            .map_err(|e| format!("Failed to save config: {e}"))?;
         drop(config);
 
         Ok(self.get().await)
@@ -129,7 +125,9 @@ impl TailscaleService {
         info!("Disconnecting from Tailscale");
         stop_tailscale().await?;
         config.enabled = false;
-        save_config(&config).await.map_err(|e| format!("Failed to save config: {e}"))?;
+        save_config(&config)
+            .await
+            .map_err(|e| format!("Failed to save config: {e}"))?;
         drop(config);
 
         Ok(self.get().await)
@@ -170,8 +168,12 @@ async fn start_tailscale(auth_key: Option<&str>) -> Result<(), String> {
     // Use a timeout to prevent hanging if auth key is invalid or network is unreachable
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(30),
-        run_cmd("tailscale", &[&socket_arg, "up", "--accept-routes", &authkey_arg]),
-    ).await;
+        run_cmd(
+            "tailscale",
+            &[&socket_arg, "up", "--accept-routes", &authkey_arg],
+        ),
+    )
+    .await;
 
     match result {
         Ok(Ok(stdout)) => {
@@ -239,14 +241,10 @@ async fn query_status() -> (bool, Option<String>, Option<String>, Option<String>
         .map(|s| s.to_string());
 
     // Hostname from Self.HostName
-    let hostname = json["Self"]["HostName"]
-        .as_str()
-        .map(|s| s.to_string());
+    let hostname = json["Self"]["HostName"].as_str().map(|s| s.to_string());
 
     // Version from Version
-    let version = json["Version"]
-        .as_str()
-        .map(|s| s.to_string());
+    let version = json["Version"].as_str().map(|s| s.to_string());
 
     (connected, ip, hostname, version)
 }
@@ -264,8 +262,7 @@ async fn save_config(config: &TailscaleConfig) -> Result<(), std::io::Error> {
     use std::os::unix::fs::PermissionsExt;
     let dir = std::path::Path::new(STATE_PATH).parent().unwrap();
     tokio::fs::create_dir_all(dir).await?;
-    let json = serde_json::to_string_pretty(config)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let json = serde_json::to_string_pretty(config).map_err(std::io::Error::other)?;
     tokio::fs::write(STATE_PATH, json).await?;
     // Contains the Tailscale auth key (reusable).
     tokio::fs::set_permissions(STATE_PATH, std::fs::Permissions::from_mode(0o600)).await

--- a/engine/nasty-system/src/tuning.rs
+++ b/engine/nasty-system/src/tuning.rs
@@ -58,15 +58,33 @@ pub struct TuningConfig {
     pub vm_dirty_writeback_centisecs: u32,
 }
 
-fn default_nfs_threads() -> u32 { 8 }
-fn default_nfs_lease_time() -> u32 { 90 }
-fn default_nfs_grace_time() -> u32 { 90 }
-fn default_iscsi_cmdsn_depth() -> u32 { 64 }
-fn default_iscsi_login_timeout() -> u32 { 15 }
-fn default_vm_dirty_ratio() -> u32 { 20 }
-fn default_vm_dirty_background_ratio() -> u32 { 10 }
-fn default_vm_dirty_expire_centisecs() -> u32 { 3000 }
-fn default_vm_dirty_writeback_centisecs() -> u32 { 500 }
+fn default_nfs_threads() -> u32 {
+    8
+}
+fn default_nfs_lease_time() -> u32 {
+    90
+}
+fn default_nfs_grace_time() -> u32 {
+    90
+}
+fn default_iscsi_cmdsn_depth() -> u32 {
+    64
+}
+fn default_iscsi_login_timeout() -> u32 {
+    15
+}
+fn default_vm_dirty_ratio() -> u32 {
+    20
+}
+fn default_vm_dirty_background_ratio() -> u32 {
+    10
+}
+fn default_vm_dirty_expire_centisecs() -> u32 {
+    3000
+}
+fn default_vm_dirty_writeback_centisecs() -> u32 {
+    500
+}
 
 impl Default for TuningConfig {
     fn default() -> Self {
@@ -129,14 +147,18 @@ impl TuningService {
 
         // ── NFS ──
         if let Some(v) = update.nfs_threads {
-            if v == 0 { return Err("nfs_threads must be > 0".into()); }
+            if v == 0 {
+                return Err("nfs_threads must be > 0".into());
+            }
             if v != config.nfs_threads {
                 apply_nfs_threads(v).await?;
                 config.nfs_threads = v;
             }
         }
         if let Some(v) = update.nfs_lease_time {
-            if v == 0 { return Err("nfs_lease_time must be > 0".into()); }
+            if v == 0 {
+                return Err("nfs_lease_time must be > 0".into());
+            }
             if v != config.nfs_lease_time {
                 // nfsv4leasetime returns EBUSY when clients hold active leases.
                 // This is expected — the new value takes effect after existing leases expire.
@@ -148,11 +170,15 @@ impl TuningService {
             }
         }
         if let Some(v) = update.nfs_grace_time {
-            if v == 0 { return Err("nfs_grace_time must be > 0".into()); }
+            if v == 0 {
+                return Err("nfs_grace_time must be > 0".into());
+            }
             if v != config.nfs_grace_time {
                 if let Err(e) = apply_proc_value("/proc/fs/nfsd/nfsv4gracetime", v).await {
                     warn!("Cannot set NFS grace time: {e}");
-                    return Err("NFS grace time cannot be changed while the server is active.".into());
+                    return Err(
+                        "NFS grace time cannot be changed while the server is active.".into(),
+                    );
                 }
                 config.nfs_grace_time = v;
             }
@@ -160,59 +186,72 @@ impl TuningService {
 
         // ── SMB ──
         let mut smb_changed = false;
-        if let Some(v) = update.smb_max_connections {
-            if v != config.smb_max_connections { config.smb_max_connections = v; smb_changed = true; }
+        if let Some(v) = update.smb_max_connections
+            && v != config.smb_max_connections
+        {
+            config.smb_max_connections = v;
+            smb_changed = true;
         }
-        if let Some(v) = update.smb_deadtime {
-            if v != config.smb_deadtime { config.smb_deadtime = v; smb_changed = true; }
+        if let Some(v) = update.smb_deadtime
+            && v != config.smb_deadtime
+        {
+            config.smb_deadtime = v;
+            smb_changed = true;
         }
-        if let Some(v) = update.smb_socket_options {
-            if v != config.smb_socket_options { config.smb_socket_options = v; smb_changed = true; }
+        if let Some(v) = update.smb_socket_options
+            && v != config.smb_socket_options
+        {
+            config.smb_socket_options = v;
+            smb_changed = true;
         }
         if smb_changed {
             apply_smb_tuning(&config).await?;
         }
 
         // ── iSCSI ──
-        if let Some(v) = update.iscsi_default_cmdsn_depth {
-            if v != config.iscsi_default_cmdsn_depth {
-                apply_iscsi_cmdsn_depth(v).await?;
-                config.iscsi_default_cmdsn_depth = v;
-            }
+        if let Some(v) = update.iscsi_default_cmdsn_depth
+            && v != config.iscsi_default_cmdsn_depth
+        {
+            apply_iscsi_cmdsn_depth(v).await?;
+            config.iscsi_default_cmdsn_depth = v;
         }
-        if let Some(v) = update.iscsi_login_timeout {
-            if v != config.iscsi_login_timeout {
-                apply_iscsi_login_timeout(v).await?;
-                config.iscsi_login_timeout = v;
-            }
+        if let Some(v) = update.iscsi_login_timeout
+            && v != config.iscsi_login_timeout
+        {
+            apply_iscsi_login_timeout(v).await?;
+            config.iscsi_login_timeout = v;
         }
 
         // ── VM writeback ──
         if let Some(v) = update.vm_dirty_ratio {
-            if v > 100 { return Err("vm_dirty_ratio must be 0-100".into()); }
+            if v > 100 {
+                return Err("vm_dirty_ratio must be 0-100".into());
+            }
             if v != config.vm_dirty_ratio {
                 apply_sysctl("vm.dirty_ratio", v).await?;
                 config.vm_dirty_ratio = v;
             }
         }
         if let Some(v) = update.vm_dirty_background_ratio {
-            if v > 100 { return Err("vm_dirty_background_ratio must be 0-100".into()); }
+            if v > 100 {
+                return Err("vm_dirty_background_ratio must be 0-100".into());
+            }
             if v != config.vm_dirty_background_ratio {
                 apply_sysctl("vm.dirty_background_ratio", v).await?;
                 config.vm_dirty_background_ratio = v;
             }
         }
-        if let Some(v) = update.vm_dirty_expire_centisecs {
-            if v != config.vm_dirty_expire_centisecs {
-                apply_sysctl("vm.dirty_expire_centisecs", v).await?;
-                config.vm_dirty_expire_centisecs = v;
-            }
+        if let Some(v) = update.vm_dirty_expire_centisecs
+            && v != config.vm_dirty_expire_centisecs
+        {
+            apply_sysctl("vm.dirty_expire_centisecs", v).await?;
+            config.vm_dirty_expire_centisecs = v;
         }
-        if let Some(v) = update.vm_dirty_writeback_centisecs {
-            if v != config.vm_dirty_writeback_centisecs {
-                apply_sysctl("vm.dirty_writeback_centisecs", v).await?;
-                config.vm_dirty_writeback_centisecs = v;
-            }
+        if let Some(v) = update.vm_dirty_writeback_centisecs
+            && v != config.vm_dirty_writeback_centisecs
+        {
+            apply_sysctl("vm.dirty_writeback_centisecs", v).await?;
+            config.vm_dirty_writeback_centisecs = v;
         }
 
         save(&config).await.map_err(|e| e.to_string())?;
@@ -229,10 +268,14 @@ impl TuningService {
             if let Err(e) = apply_nfs_threads(config.nfs_threads).await {
                 warn!("Failed to apply nfs_threads: {e}");
             }
-            if let Err(e) = apply_proc_value("/proc/fs/nfsd/nfsv4leasetime", config.nfs_lease_time).await {
+            if let Err(e) =
+                apply_proc_value("/proc/fs/nfsd/nfsv4leasetime", config.nfs_lease_time).await
+            {
                 warn!("Failed to apply nfs_lease_time: {e}");
             }
-            if let Err(e) = apply_proc_value("/proc/fs/nfsd/nfsv4gracetime", config.nfs_grace_time).await {
+            if let Err(e) =
+                apply_proc_value("/proc/fs/nfsd/nfsv4gracetime", config.nfs_grace_time).await
+            {
                 warn!("Failed to apply nfs_grace_time: {e}");
             }
         } else {
@@ -250,13 +293,28 @@ impl TuningService {
         if let Err(e) = apply_sysctl("vm.dirty_ratio", config.vm_dirty_ratio).await {
             warn!("Failed to apply vm.dirty_ratio: {e}");
         }
-        if let Err(e) = apply_sysctl("vm.dirty_background_ratio", config.vm_dirty_background_ratio).await {
+        if let Err(e) = apply_sysctl(
+            "vm.dirty_background_ratio",
+            config.vm_dirty_background_ratio,
+        )
+        .await
+        {
             warn!("Failed to apply vm.dirty_background_ratio: {e}");
         }
-        if let Err(e) = apply_sysctl("vm.dirty_expire_centisecs", config.vm_dirty_expire_centisecs).await {
+        if let Err(e) = apply_sysctl(
+            "vm.dirty_expire_centisecs",
+            config.vm_dirty_expire_centisecs,
+        )
+        .await
+        {
             warn!("Failed to apply vm.dirty_expire_centisecs: {e}");
         }
-        if let Err(e) = apply_sysctl("vm.dirty_writeback_centisecs", config.vm_dirty_writeback_centisecs).await {
+        if let Err(e) = apply_sysctl(
+            "vm.dirty_writeback_centisecs",
+            config.vm_dirty_writeback_centisecs,
+        )
+        .await
+        {
             warn!("Failed to apply vm.dirty_writeback_centisecs: {e}");
         }
         info!("Tuning configuration applied");
@@ -297,7 +355,10 @@ async fn apply_smb_tuning(config: &TuningConfig) -> Result<(), String> {
     // Build a Samba config fragment with tuning parameters
     let mut lines = vec!["[global]".to_string()];
     if config.smb_max_connections > 0 {
-        lines.push(format!("   max connections = {}", config.smb_max_connections));
+        lines.push(format!(
+            "   max connections = {}",
+            config.smb_max_connections
+        ));
     }
     if config.smb_deadtime > 0 {
         lines.push(format!("   deadtime = {}", config.smb_deadtime));
@@ -332,15 +393,21 @@ async fn apply_iscsi_cmdsn_depth(depth: u32) -> Result<(), String> {
     let mut entries = entries;
     while let Ok(Some(entry)) = entries.next_entry().await {
         let iqn_path = entry.path();
-        if !iqn_path.is_dir() { continue; }
+        if !iqn_path.is_dir() {
+            continue;
+        }
         let iqn_name = entry.file_name().to_string_lossy().to_string();
-        if !iqn_name.starts_with("iqn.") { continue; }
+        if !iqn_name.starts_with("iqn.") {
+            continue;
+        }
 
         // Iterate TPGs within this IQN
         if let Ok(mut tpg_entries) = tokio::fs::read_dir(&iqn_path).await {
             while let Ok(Some(tpg)) = tpg_entries.next_entry().await {
                 let tpg_name = tpg.file_name().to_string_lossy().to_string();
-                if !tpg_name.starts_with("tpgt_") { continue; }
+                if !tpg_name.starts_with("tpgt_") {
+                    continue;
+                }
                 let attr_path = tpg.path().join("attrib/default_cmdsn_depth");
                 if attr_path.exists() {
                     let _ = tokio::fs::write(&attr_path, depth.to_string()).await;
@@ -361,14 +428,20 @@ async fn apply_iscsi_login_timeout(timeout: u32) -> Result<(), String> {
     let mut entries = entries;
     while let Ok(Some(entry)) = entries.next_entry().await {
         let iqn_path = entry.path();
-        if !iqn_path.is_dir() { continue; }
+        if !iqn_path.is_dir() {
+            continue;
+        }
         let iqn_name = entry.file_name().to_string_lossy().to_string();
-        if !iqn_name.starts_with("iqn.") { continue; }
+        if !iqn_name.starts_with("iqn.") {
+            continue;
+        }
 
         if let Ok(mut tpg_entries) = tokio::fs::read_dir(&iqn_path).await {
             while let Ok(Some(tpg)) = tpg_entries.next_entry().await {
                 let tpg_name = tpg.file_name().to_string_lossy().to_string();
-                if !tpg_name.starts_with("tpgt_") { continue; }
+                if !tpg_name.starts_with("tpgt_") {
+                    continue;
+                }
                 let attr_path = tpg.path().join("param/login_timeout");
                 if attr_path.exists() {
                     let _ = tokio::fs::write(&attr_path, timeout.to_string()).await;

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1820,7 +1820,7 @@ fn rewrite_flake_input_urls(
         ));
     }
 
-    edits.sort_by(|a, b| b.0.cmp(&a.0));
+    edits.sort_by_key(|b| std::cmp::Reverse(b.0));
     let mut rewritten = content.to_string();
     for (start, end, replacement) in edits {
         rewritten.replace_range(start..end, &replacement);

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -113,7 +113,6 @@ async fn write_channel(channel: ReleaseChannel) -> Result<(), std::io::Error> {
     tokio::fs::write(RELEASE_CHANNEL_PATH, channel.to_string()).await
 }
 
-
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct VersionInputInfo {
     /// Flake input name (e.g. `nixpkgs`).
@@ -265,6 +264,12 @@ struct NixosGeneration {
 
 pub struct UpdateService;
 
+impl Default for UpdateService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UpdateService {
     pub fn new() -> Self {
         Self
@@ -331,7 +336,6 @@ impl UpdateService {
             return Err(UpdateError::AlreadyRunning);
         }
 
-
         let release_status = self.version_tagged_release_status().await?;
         if release_status.current_is_latest_standard_url {
             return Err(UpdateError::CommandFailed(
@@ -350,9 +354,9 @@ impl UpdateService {
         )
         .await?;
         let current_flake_path = format!("{NIXOS_FLAKE_DIR}/flake.nix");
-        let current_flake = tokio::fs::read_to_string(&current_flake_path).await.map_err(|e| {
-            UpdateError::CommandFailed(format!("read {current_flake_path}: {e}"))
-        })?;
+        let current_flake = tokio::fs::read_to_string(&current_flake_path)
+            .await
+            .map_err(|e| UpdateError::CommandFailed(format!("read {current_flake_path}: {e}")))?;
         let next_flake = if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
             render_system_flake_template(&template, &release_status.latest_tag, &local_system)?
         } else {
@@ -696,7 +700,6 @@ echo "==> Update complete!"
             return Err(UpdateError::AlreadyRunning);
         }
 
-
         let current_urls = read_flake_input_urls().await?;
         let mut seen = HashSet::new();
         let mut requested = HashMap::new();
@@ -766,64 +769,63 @@ echo "==> Update complete!"
             .get("nasty")
             .map(|input| input.url.clone())
             .ok_or_else(|| UpdateError::CommandFailed("missing request entry for nasty".into()))?;
-        let rewritten_flake = if let Some(target_tag) =
-            parse_official_nasty_release_tag(&requested_nasty_url)
-        {
-            let token = read_github_token().await;
-            let template = fetch_github_text_file(
-                token.as_deref(),
-                DEFAULT_NASTY_OWNER,
-                DEFAULT_NASTY_REPO,
-                SYSTEM_FLAKE_TEMPLATE_PATH,
-                &target_tag,
-            )
-            .await?;
+        let rewritten_flake =
+            if let Some(target_tag) = parse_official_nasty_release_tag(&requested_nasty_url) {
+                let token = read_github_token().await;
+                let template = fetch_github_text_file(
+                    token.as_deref(),
+                    DEFAULT_NASTY_OWNER,
+                    DEFAULT_NASTY_REPO,
+                    SYSTEM_FLAKE_TEMPLATE_PATH,
+                    &target_tag,
+                )
+                .await?;
 
-            if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
-                let local_system = detect_local_system().await?;
-                let bootstrapped_flake =
-                    render_system_flake_template(&template, &target_tag, &local_system)?;
-                let preserved_urls = HashMap::from([
-                    (
-                        String::from("nixpkgs"),
-                        requested
-                            .get("nixpkgs")
-                            .ok_or_else(|| {
-                                UpdateError::CommandFailed(
-                                    "missing request entry for nixpkgs".into(),
-                                )
-                            })?
-                            .url
-                            .clone(),
-                    ),
-                    (
-                        String::from("bcachefs-tools"),
-                        requested
-                            .get("bcachefs-tools")
-                            .ok_or_else(|| {
-                                UpdateError::CommandFailed(
-                                    "missing request entry for bcachefs-tools".into(),
-                                )
-                            })?
-                            .url
-                            .clone(),
-                    ),
-                ]);
-                rewrite_flake_input_urls(&bootstrapped_flake, &preserved_urls)?
+                if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
+                    let local_system = detect_local_system().await?;
+                    let bootstrapped_flake =
+                        render_system_flake_template(&template, &target_tag, &local_system)?;
+                    let preserved_urls = HashMap::from([
+                        (
+                            String::from("nixpkgs"),
+                            requested
+                                .get("nixpkgs")
+                                .ok_or_else(|| {
+                                    UpdateError::CommandFailed(
+                                        "missing request entry for nixpkgs".into(),
+                                    )
+                                })?
+                                .url
+                                .clone(),
+                        ),
+                        (
+                            String::from("bcachefs-tools"),
+                            requested
+                                .get("bcachefs-tools")
+                                .ok_or_else(|| {
+                                    UpdateError::CommandFailed(
+                                        "missing request entry for bcachefs-tools".into(),
+                                    )
+                                })?
+                                .url
+                                .clone(),
+                        ),
+                    ]);
+                    rewrite_flake_input_urls(&bootstrapped_flake, &preserved_urls)?
+                } else {
+                    let flake_replacements = url_changes
+                        .iter()
+                        .map(|(name, url)| (name.clone(), url.clone()))
+                        .collect::<HashMap<_, _>>();
+                    rewrite_flake_input_urls(&current_flake, &flake_replacements)?
+                }
             } else {
                 let flake_replacements = url_changes
                     .iter()
                     .map(|(name, url)| (name.clone(), url.clone()))
                     .collect::<HashMap<_, _>>();
                 rewrite_flake_input_urls(&current_flake, &flake_replacements)?
-            }
-        } else {
-            let flake_replacements = url_changes
-                .iter()
-                .map(|(name, url)| (name.clone(), url.clone()))
-                .collect::<HashMap<_, _>>();
-            rewrite_flake_input_urls(&current_flake, &flake_replacements)?
-        };
+            };
         let flake_temp_path = "/tmp/nasty-version-flake.nix";
         tokio::fs::write(flake_temp_path, &rewritten_flake)
             .await
@@ -1190,12 +1192,12 @@ echo "==> Switch to generation {gen_id} complete!"
         }
 
         // Check if it's the booted generation
-        if let Ok(booted) = tokio::fs::read_link("/run/booted-system").await {
-            if gen_target == booted {
-                return Err(UpdateError::CommandFailed(
-                    "cannot delete the booted generation".into(),
-                ));
-            }
+        if let Ok(booted) = tokio::fs::read_link("/run/booted-system").await
+            && gen_target == booted
+        {
+            return Err(UpdateError::CommandFailed(
+                "cannot delete the booted generation".into(),
+            ));
         }
 
         // Remove the profile link
@@ -1304,7 +1306,6 @@ echo "==> Switch to generation {gen_id} complete!"
             webui_changed,
         }
     }
-
 }
 
 ///
@@ -1636,10 +1637,10 @@ async fn is_reboot_required() -> bool {
     for (booted_path, current_path) in paths {
         let booted = tokio::fs::read_link(booted_path).await;
         let current = tokio::fs::read_link(current_path).await;
-        if let (Ok(b), Ok(c)) = (booted, current) {
-            if b != c {
-                return true;
-            }
+        if let (Ok(b), Ok(c)) = (booted, current)
+            && b != c
+        {
+            return true;
         }
     }
     false
@@ -2042,9 +2043,7 @@ mod tests {
   };
 }
 "#;
-        assert!(read_wrapper_flake_version(flake)
-            .expect("parsed")
-            .is_some());
+        assert!(read_wrapper_flake_version(flake).expect("parsed").is_some());
     }
 
     #[test]
@@ -2083,8 +2082,10 @@ mod tests {
   };
 }
 "#;
-        assert!(should_rebootstrap_wrapper_flake(local_without_version, upstream_new)
-            .expect("comparison"));
+        assert!(
+            should_rebootstrap_wrapper_flake(local_without_version, upstream_new)
+                .expect("comparison")
+        );
         assert!(should_rebootstrap_wrapper_flake(local_old, upstream_new).expect("comparison"));
         assert!(!should_rebootstrap_wrapper_flake(upstream_new, local_old).expect("comparison"));
         assert!(
@@ -2104,12 +2105,8 @@ outputs = { nixpkgs, nasty, ... }: {
   nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "@LOCAL_SYSTEM@"; };
 };
 "#;
-        let rendered = super::render_system_flake_template(
-            &template,
-            "0.0.3",
-            "x86_64-linux",
-        )
-        .expect("rendered");
+        let rendered = super::render_system_flake_template(&template, "0.0.3", "x86_64-linux")
+            .expect("rendered");
         assert!(rendered.contains("github:nasty-project/nasty/v0.0.3"));
         assert!(rendered.contains("\"x86_64-linux\""));
     }

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::process::Command;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 const STATE_DIR: &str = "/var/lib/nasty/vms";
@@ -103,8 +103,12 @@ pub struct VmConfig {
     pub extra_args: Option<Vec<String>>,
 }
 
-fn default_boot_order() -> String { "disk".to_string() }
-fn default_true() -> bool { true }
+fn default_boot_order() -> String {
+    "disk".to_string()
+}
+fn default_true() -> bool {
+    true
+}
 
 impl HasId for VmConfig {
     fn id(&self) -> &str {
@@ -139,7 +143,9 @@ pub struct VmDisk {
     pub iops_wr: Option<u64>,
 }
 
-fn default_disk_interface() -> String { "virtio".to_string() }
+fn default_disk_interface() -> String {
+    "virtio".to_string()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct VmNetwork {
@@ -154,7 +160,9 @@ pub struct VmNetwork {
     pub mac: Option<String>,
 }
 
-fn default_net_mode() -> String { "user".to_string() }
+fn default_net_mode() -> String {
+    "user".to_string()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PassthroughDevice {
@@ -313,12 +321,14 @@ fn state_dir() -> StateDir {
 /// Validate that a VM disk/ISO path resolves to an allowed location.
 /// After symlink resolution, the path must be under `/fs/` or be a `/dev/` block device.
 fn validate_vm_path(path: &str) -> Result<(), VmError> {
-    let canonical = std::fs::canonicalize(path)
-        .map_err(|_| VmError::InvalidDiskPath(format!("{} does not exist or cannot be resolved", path)))?;
+    let canonical = std::fs::canonicalize(path).map_err(|_| {
+        VmError::InvalidDiskPath(format!("{} does not exist or cannot be resolved", path))
+    })?;
     let canonical_str = canonical.to_string_lossy();
     if !canonical_str.starts_with("/fs/") && !canonical_str.starts_with("/dev/") {
         return Err(VmError::InvalidDiskPath(format!(
-            "{} resolves to {} which is not under /fs/ or /dev/", path, canonical_str
+            "{} resolves to {} which is not under /fs/ or /dev/",
+            path, canonical_str
         )));
     }
     Ok(())
@@ -345,6 +355,12 @@ fn ovmf_vars_path(vm_id: &str) -> String {
 }
 
 pub struct VmService;
+
+impl Default for VmService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl VmService {
     pub fn new() -> Self {
@@ -380,7 +396,11 @@ impl VmService {
         let mut result = Vec::with_capacity(configs.len());
         for config in configs {
             let running = self.is_running(&config.id).await;
-            let pid = if running { self.get_pid(&config.id).await } else { None };
+            let pid = if running {
+                self.get_pid(&config.id).await
+            } else {
+                None
+            };
             result.push(VmStatus {
                 config,
                 running,
@@ -398,7 +418,11 @@ impl VmService {
             .ok_or_else(|| VmError::NotFound(id.to_string()))?;
 
         let running = self.is_running(id).await;
-        let pid = if running { self.get_pid(id).await } else { None };
+        let pid = if running {
+            self.get_pid(id).await
+        } else {
+            None
+        };
 
         Ok(VmStatus {
             config,
@@ -424,7 +448,8 @@ impl VmService {
             for disk in disks {
                 if !Path::new(&disk.path).exists() {
                     return Err(VmError::InvalidDiskPath(format!(
-                        "disk path {} does not exist", disk.path
+                        "disk path {} does not exist",
+                        disk.path
                     )));
                 }
                 validate_vm_path(&disk.path)?;
@@ -433,7 +458,8 @@ impl VmService {
         if let Some(ref iso) = req.boot_iso {
             if !Path::new(iso).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
-                    "boot ISO {} does not exist", iso
+                    "boot ISO {} does not exist",
+                    iso
                 )));
             }
             validate_vm_path(iso)?;
@@ -447,11 +473,13 @@ impl VmService {
             cpus: req.cpus.unwrap_or(1),
             memory_mib: req.memory_mib.unwrap_or(1024),
             disks: req.disks.unwrap_or_default(),
-            networks: req.networks.unwrap_or_else(|| vec![VmNetwork {
-                mode: "user".to_string(),
-                bridge: None,
-                mac: None,
-            }]),
+            networks: req.networks.unwrap_or_else(|| {
+                vec![VmNetwork {
+                    mode: "user".to_string(),
+                    bridge: None,
+                    mac: None,
+                }]
+            }),
             passthrough_devices: req.passthrough_devices.unwrap_or_default(),
             boot_iso: req.boot_iso,
             boot_order: req.boot_order.unwrap_or_else(|| "disk".to_string()),
@@ -479,37 +507,76 @@ impl VmService {
         // Don't allow updates while running (except autostart/description)
         let running = self.is_running(&req.id).await;
 
-        if let Some(name) = req.name { config.name = name; }
-        if let Some(desc) = req.description { config.description = Some(desc); }
-        if let Some(auto) = req.autostart { config.autostart = auto; }
+        if let Some(name) = req.name {
+            config.name = name;
+        }
+        if let Some(desc) = req.description {
+            config.description = Some(desc);
+        }
+        if let Some(auto) = req.autostart {
+            config.autostart = auto;
+        }
 
         // Hardware changes require VM to be stopped
         if running {
-            if req.cpus.is_some() || req.memory_mib.is_some() || req.disks.is_some()
-                || req.networks.is_some() || req.passthrough_devices.is_some()
-                || req.boot_iso.is_some() || req.boot_order.is_some() || req.uefi.is_some()
-                || req.cpu_model.is_some() || req.machine_type.is_some()
-                || req.vga.is_some() || req.extra_args.is_some()
+            if req.cpus.is_some()
+                || req.memory_mib.is_some()
+                || req.disks.is_some()
+                || req.networks.is_some()
+                || req.passthrough_devices.is_some()
+                || req.boot_iso.is_some()
+                || req.boot_order.is_some()
+                || req.uefi.is_some()
+                || req.cpu_model.is_some()
+                || req.machine_type.is_some()
+                || req.vga.is_some()
+                || req.extra_args.is_some()
             {
                 return Err(VmError::AlreadyRunning(
                     "stop the VM before changing hardware settings".to_string(),
                 ));
             }
         } else {
-            if let Some(cpus) = req.cpus { config.cpus = cpus; }
-            if let Some(mem) = req.memory_mib { config.memory_mib = mem; }
-            if let Some(disks) = req.disks { config.disks = disks; }
-            if let Some(nets) = req.networks { config.networks = nets; }
-            if let Some(pt) = req.passthrough_devices { config.passthrough_devices = pt; }
-            if let Some(ref iso) = req.boot_iso {
-                config.boot_iso = if iso.is_empty() { None } else { Some(iso.clone()) };
+            if let Some(cpus) = req.cpus {
+                config.cpus = cpus;
             }
-            if let Some(bo) = req.boot_order { config.boot_order = bo; }
-            if let Some(uefi) = req.uefi { config.uefi = uefi; }
-            if req.cpu_model.is_some() { config.cpu_model = req.cpu_model; }
-            if req.machine_type.is_some() { config.machine_type = req.machine_type; }
-            if req.vga.is_some() { config.vga = req.vga; }
-            if req.extra_args.is_some() { config.extra_args = req.extra_args; }
+            if let Some(mem) = req.memory_mib {
+                config.memory_mib = mem;
+            }
+            if let Some(disks) = req.disks {
+                config.disks = disks;
+            }
+            if let Some(nets) = req.networks {
+                config.networks = nets;
+            }
+            if let Some(pt) = req.passthrough_devices {
+                config.passthrough_devices = pt;
+            }
+            if let Some(ref iso) = req.boot_iso {
+                config.boot_iso = if iso.is_empty() {
+                    None
+                } else {
+                    Some(iso.clone())
+                };
+            }
+            if let Some(bo) = req.boot_order {
+                config.boot_order = bo;
+            }
+            if let Some(uefi) = req.uefi {
+                config.uefi = uefi;
+            }
+            if req.cpu_model.is_some() {
+                config.cpu_model = req.cpu_model;
+            }
+            if req.machine_type.is_some() {
+                config.machine_type = req.machine_type;
+            }
+            if req.vga.is_some() {
+                config.vga = req.vga;
+            }
+            if req.extra_args.is_some() {
+                config.extra_args = req.extra_args;
+            }
         }
 
         state_dir().save(&config.id, &config).await?;
@@ -558,7 +625,8 @@ impl VmService {
         for disk in &config.disks {
             if !Path::new(&disk.path).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
-                    "disk path {} does not exist", disk.path
+                    "disk path {} does not exist",
+                    disk.path
                 )));
             }
             validate_vm_path(&disk.path)?;
@@ -566,7 +634,8 @@ impl VmService {
         if let Some(ref iso) = config.boot_iso {
             if !Path::new(iso).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
-                    "boot ISO {} does not exist", iso
+                    "boot ISO {} does not exist",
+                    iso
                 )));
             }
             validate_vm_path(iso)?;
@@ -577,16 +646,17 @@ impl VmService {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = tokio::fs::set_permissions(QMP_DIR, std::fs::Permissions::from_mode(0o700)).await;
+            let _ =
+                tokio::fs::set_permissions(QMP_DIR, std::fs::Permissions::from_mode(0o700)).await;
         }
 
         // Copy OVMF_VARS template for this VM if it doesn't exist yet
         if config.uefi {
             let vars = ovmf_vars_path(id);
             if !Path::new(&vars).exists() {
-                tokio::fs::copy(OVMF_VARS_TEMPLATE, &vars).await.map_err(|e| {
-                    VmError::QemuFailed(format!("failed to copy OVMF_VARS: {e}"))
-                })?;
+                tokio::fs::copy(OVMF_VARS_TEMPLATE, &vars)
+                    .await
+                    .map_err(|e| VmError::QemuFailed(format!("failed to copy OVMF_VARS: {e}")))?;
             }
         }
 
@@ -598,8 +668,12 @@ impl VmService {
         }
 
         let args = build_qemu_args(&config);
-        info!("Starting VM '{}': qemu-system-{} {}", config.name, std::env::consts::ARCH,
-              args.join(" "));
+        info!(
+            "Starting VM '{}': qemu-system-{} {}",
+            config.name,
+            std::env::consts::ARCH,
+            args.join(" ")
+        );
 
         let qemu_bin = format!("qemu-system-{}", std::env::consts::ARCH);
         let child = Command::new(&qemu_bin)
@@ -620,7 +694,10 @@ impl VmService {
         // Negotiate QMP handshake
         let qmp_path = qmp_socket_path(id);
         if let Err(e) = qmp::negotiate(&qmp_path).await {
-            warn!("QMP handshake failed for '{}': {e} (VM may still be starting)", config.name);
+            warn!(
+                "QMP handshake failed for '{}': {e} (VM may still be starting)",
+                config.name
+            );
         }
 
         Ok(VmStatus {
@@ -643,7 +720,8 @@ impl VmService {
         }
 
         let qmp_path = qmp_socket_path(id);
-        qmp::execute(&qmp_path, "system_powerdown", None).await
+        qmp::execute(&qmp_path, "system_powerdown", None)
+            .await
             .map_err(|e| VmError::Qmp(format!("system_powerdown: {e}")))?;
 
         info!("Sent shutdown signal to VM '{}'", config.name);
@@ -730,8 +808,10 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
 
     // CPU and memory
     args.extend_from_slice(&[
-        "-smp".to_string(), config.cpus.to_string(),
-        "-m".to_string(), format!("{}M", config.memory_mib),
+        "-smp".to_string(),
+        config.cpus.to_string(),
+        "-m".to_string(),
+        format!("{}M", config.memory_mib),
     ]);
 
     // UEFI firmware
@@ -752,15 +832,38 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
             _ => "none", // virtio uses -device virtio-blk-pci
         };
         let ro = if disk.readonly { ",readonly=on" } else { "" };
-        let cache = disk.cache.as_deref().map(|c| format!(",cache={c}")).unwrap_or_default();
-        let aio = disk.aio.as_deref().map(|a| format!(",aio={a}")).unwrap_or_default();
-        let discard = disk.discard.as_deref().map(|d| format!(",discard={d}")).unwrap_or_default();
+        let cache = disk
+            .cache
+            .as_deref()
+            .map(|c| format!(",cache={c}"))
+            .unwrap_or_default();
+        let aio = disk
+            .aio
+            .as_deref()
+            .map(|a| format!(",aio={a}"))
+            .unwrap_or_default();
+        let discard = disk
+            .discard
+            .as_deref()
+            .map(|d| format!(",discard={d}"))
+            .unwrap_or_default();
         let mut throttle = String::new();
-        if let Some(v) = disk.iops_rd { if v > 0 { throttle.push_str(&format!(",throttling.iops-read={v}")); } }
-        if let Some(v) = disk.iops_wr { if v > 0 { throttle.push_str(&format!(",throttling.iops-write={v}")); } }
+        if let Some(v) = disk.iops_rd
+            && v > 0
+        {
+            throttle.push_str(&format!(",throttling.iops-read={v}"));
+        }
+        if let Some(v) = disk.iops_wr
+            && v > 0
+        {
+            throttle.push_str(&format!(",throttling.iops-write={v}"));
+        }
         args.extend_from_slice(&[
             "-drive".to_string(),
-            format!("file={},format=raw,if={iface},id=drive{i}{ro}{cache}{aio}{discard}{throttle}", disk.path),
+            format!(
+                "file={},format=raw,if={iface},id=drive{i}{ro}{cache}{aio}{discard}{throttle}",
+                disk.path
+            ),
         ]);
         // Add virtio-blk-pci device for virtio disks
         if disk.interface == "virtio" || disk.interface.is_empty() {
@@ -773,10 +876,7 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
 
     // Boot ISO (as a CDROM)
     if let Some(ref iso) = config.boot_iso {
-        args.extend_from_slice(&[
-            "-cdrom".to_string(),
-            iso.clone(),
-        ]);
+        args.extend_from_slice(&["-cdrom".to_string(), iso.clone()]);
     }
 
     // Boot order
@@ -789,7 +889,9 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
 
     // Network interfaces
     for (i, net) in config.networks.iter().enumerate() {
-        let mac_opt = net.mac.as_deref()
+        let mac_opt = net
+            .mac
+            .as_deref()
             .map(|m| format!(",mac={m}"))
             .unwrap_or_default();
 
@@ -866,15 +968,18 @@ async fn bind_vfio(pci_addr: &str) -> Result<(), String> {
     // Unbind from current driver
     let driver_path = format!("/sys/bus/pci/devices/{pci_addr}/driver/unbind");
     if Path::new(&driver_path).exists() {
-        tokio::fs::write(&driver_path, pci_addr).await
+        tokio::fs::write(&driver_path, pci_addr)
+            .await
             .map_err(|e| format!("unbind {pci_addr}: {e}"))?;
     }
 
     // Get vendor:device ID
     let vendor = tokio::fs::read_to_string(format!("/sys/bus/pci/devices/{pci_addr}/vendor"))
-        .await.map_err(|e| format!("read vendor: {e}"))?;
+        .await
+        .map_err(|e| format!("read vendor: {e}"))?;
     let device = tokio::fs::read_to_string(format!("/sys/bus/pci/devices/{pci_addr}/device"))
-        .await.map_err(|e| format!("read device: {e}"))?;
+        .await
+        .map_err(|e| format!("read device: {e}"))?;
 
     let vendor_device = format!("{} {}", vendor.trim(), device.trim());
 
@@ -888,10 +993,7 @@ async fn bind_vfio(pci_addr: &str) -> Result<(), String> {
 
 /// List PCI devices available for passthrough.
 async fn list_pci_devices() -> Vec<PciDevice> {
-    let output = Command::new("lspci")
-        .args(["-Dnn"])
-        .output()
-        .await;
+    let output = Command::new("lspci").args(["-Dnn"]).output().await;
 
     let output = match output {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
@@ -902,27 +1004,29 @@ async fn list_pci_devices() -> Vec<PciDevice> {
     for line in output.lines() {
         // Format: "0000:03:00.0 VGA compatible controller [0300]: NVIDIA ... [10de:2206] (rev a1)"
         let parts: Vec<&str> = line.splitn(2, ' ').collect();
-        if parts.len() < 2 { continue; }
+        if parts.len() < 2 {
+            continue;
+        }
         let address = parts[0].to_string();
         let description = parts[1].to_string();
 
         // Extract vendor:device from brackets
-        let vendor_device = line.rfind('[')
-            .and_then(|start| line.rfind(']').map(|end| &line[start+1..end]))
+        let vendor_device = line
+            .rfind('[')
+            .and_then(|start| line.rfind(']').map(|end| &line[start + 1..end]))
             .unwrap_or("")
             .to_string();
 
         // Find IOMMU group
-        let iommu_group = tokio::fs::read_link(
-            format!("/sys/bus/pci/devices/{address}/iommu_group")
-        ).await
-            .ok()
-            .and_then(|p| p.file_name()?.to_str()?.parse::<u32>().ok())
-            .unwrap_or(0);
+        let iommu_group =
+            tokio::fs::read_link(format!("/sys/bus/pci/devices/{address}/iommu_group"))
+                .await
+                .ok()
+                .and_then(|p| p.file_name()?.to_str()?.parse::<u32>().ok())
+                .unwrap_or(0);
 
-        let bound_to_vfio = tokio::fs::read_link(
-            format!("/sys/bus/pci/devices/{address}/driver")
-        ).await
+        let bound_to_vfio = tokio::fs::read_link(format!("/sys/bus/pci/devices/{address}/driver"))
+            .await
             .ok()
             .and_then(|p| Some(p.file_name()?.to_str()? == "vfio-pci"))
             .unwrap_or(false);

--- a/engine/nasty-vm/src/qmp.rs
+++ b/engine/nasty-vm/src/qmp.rs
@@ -4,34 +4,40 @@
 //! machine control. Every QMP session starts with a greeting from QEMU,
 //! after which the client must send `qmp_capabilities` to enter command mode.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 /// Perform the QMP handshake (read greeting, send qmp_capabilities).
 pub async fn negotiate(socket_path: &str) -> Result<(), String> {
-    let stream = UnixStream::connect(socket_path).await
+    let stream = UnixStream::connect(socket_path)
+        .await
         .map_err(|e| format!("connect {socket_path}: {e}"))?;
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
 
     // Read greeting
     let mut line = String::new();
-    reader.read_line(&mut line).await
+    reader
+        .read_line(&mut line)
+        .await
         .map_err(|e| format!("read greeting: {e}"))?;
 
     // Send qmp_capabilities
     let cmd = json!({"execute": "qmp_capabilities"}).to_string() + "\n";
-    writer.write_all(cmd.as_bytes()).await
+    writer
+        .write_all(cmd.as_bytes())
+        .await
         .map_err(|e| format!("write qmp_capabilities: {e}"))?;
 
     // Read response
     line.clear();
-    reader.read_line(&mut line).await
+    reader
+        .read_line(&mut line)
+        .await
         .map_err(|e| format!("read capabilities response: {e}"))?;
 
-    let resp: Value = serde_json::from_str(&line)
-        .map_err(|e| format!("parse response: {e}"))?;
+    let resp: Value = serde_json::from_str(&line).map_err(|e| format!("parse response: {e}"))?;
 
     if resp.get("return").is_some() {
         Ok(())
@@ -41,25 +47,36 @@ pub async fn negotiate(socket_path: &str) -> Result<(), String> {
 }
 
 /// Execute a QMP command and return the result.
-pub async fn execute(socket_path: &str, command: &str, arguments: Option<Value>) -> Result<Value, String> {
-    let stream = UnixStream::connect(socket_path).await
+pub async fn execute(
+    socket_path: &str,
+    command: &str,
+    arguments: Option<Value>,
+) -> Result<Value, String> {
+    let stream = UnixStream::connect(socket_path)
+        .await
         .map_err(|e| format!("connect {socket_path}: {e}"))?;
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
 
     // Read greeting
     let mut line = String::new();
-    reader.read_line(&mut line).await
+    reader
+        .read_line(&mut line)
+        .await
         .map_err(|e| format!("read greeting: {e}"))?;
 
     // Send qmp_capabilities
     let cap_cmd = json!({"execute": "qmp_capabilities"}).to_string() + "\n";
-    writer.write_all(cap_cmd.as_bytes()).await
+    writer
+        .write_all(cap_cmd.as_bytes())
+        .await
         .map_err(|e| format!("write qmp_capabilities: {e}"))?;
 
     // Read capabilities response
     line.clear();
-    reader.read_line(&mut line).await
+    reader
+        .read_line(&mut line)
+        .await
         .map_err(|e| format!("read cap response: {e}"))?;
 
     // Send the actual command
@@ -68,21 +85,24 @@ pub async fn execute(socket_path: &str, command: &str, arguments: Option<Value>)
         cmd_obj["arguments"] = args;
     }
     let cmd_str = cmd_obj.to_string() + "\n";
-    writer.write_all(cmd_str.as_bytes()).await
+    writer
+        .write_all(cmd_str.as_bytes())
+        .await
         .map_err(|e| format!("write command: {e}"))?;
 
     // Read response — skip any async events (they have "event" key)
     loop {
         line.clear();
-        reader.read_line(&mut line).await
+        reader
+            .read_line(&mut line)
+            .await
             .map_err(|e| format!("read response: {e}"))?;
 
         if line.trim().is_empty() {
             return Err("connection closed".to_string());
         }
 
-        let resp: Value = serde_json::from_str(&line)
-            .map_err(|e| format!("parse: {e}"))?;
+        let resp: Value = serde_json::from_str(&line).map_err(|e| format!("parse: {e}"))?;
 
         if resp.get("event").is_some() {
             continue; // Skip async events
@@ -102,7 +122,8 @@ pub async fn execute(socket_path: &str, command: &str, arguments: Option<Value>)
 
 /// Ping the QMP socket — just connect and read greeting.
 pub async fn ping(socket_path: &str) -> Result<(), String> {
-    let stream = UnixStream::connect(socket_path).await
+    let stream = UnixStream::connect(socket_path)
+        .await
         .map_err(|e| format!("connect: {e}"))?;
     let (reader, _) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -111,9 +132,10 @@ pub async fn ping(socket_path: &str) -> Result<(), String> {
     tokio::time::timeout(
         std::time::Duration::from_secs(2),
         reader.read_line(&mut line),
-    ).await
-        .map_err(|_| "timeout".to_string())?
-        .map_err(|e| format!("read: {e}"))?;
+    )
+    .await
+    .map_err(|_| "timeout".to_string())?
+    .map_err(|e| format!("read: {e}"))?;
 
     if line.contains("QMP") {
         Ok(())


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two parallel jobs:
  - **engine**: `cargo fmt --check` → `cargo clippy --workspace --all-targets -- -D warnings` → `cargo test --workspace`
  - **webui**: `npm ci` → `npm run check` → `npm run build`
- Reformats the engine workspace (`cargo fmt --all`) and applies `cargo clippy --fix` so the strict gate passes from day one
- 9 manual fixes for non-auto-fixable lints; `#[allow]` on `send_smtp` (8 SMTP args) and `require_str` (large `Err` variant) where the principled fix would be a real refactor

## Test plan
- [ ] Engine job goes green (fmt, clippy `-D warnings`, tests)
- [ ] WebUI job goes green (svelte-check, vite build)
- [ ] Workflow cancels superseded runs on the same ref (push twice quickly to verify)
- [ ] Re-run the CI workflow and confirm the rust-cache hit shaves time off the second run

## Follow-ups (not in this PR)
- Add `.git-blame-ignore-revs` containing the fmt commit SHA so `git blame` skips the noisy reformat
- Cover the cheapest big-win parsers (`parse_device_table_line`, `parse_human_bytes`, sharing-config generators) — the gate is meaningless without unit tests on the riskiest untested code