### PR TITLE
ci: pin Rust toolchain to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Version must match rust-toolchain.toml at the repo root.
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- Adds `rust-toolchain.toml` at the repo root pinning the workspace to Rust **1.95.0** with `rustfmt` and `clippy` components
- Updates `.github/workflows/ci.yml` to use `dtolnay/rust-toolchain@1.95.0` (was `@stable`)

## Why
PR #22 hit two failures from clippy lints that were added to the toolchain after my local install (`unnecessary_sort_by`, `collapsible_match`). Without a pin, every Rust release can break CI overnight even with no code changes. The toml also auto-installs the matching toolchain for local devs on first `cargo` invocation, so CI and dev stay in lockstep.

## Tradeoff
Lint *fixes* and bug fixes in newer Rust don't reach the project until the pin is bumped. Bumping is a single-line change in two files (`rust-toolchain.toml` and the workflow) that we run once every release or two.

## Test plan
- [ ] CI runs on this PR and goes green
- [ ] `cargo fmt --check` and `cargo clippy ... -D warnings` pass with the pinned toolchain