### PR TITLE
test: add bcachefs smoke nixosTest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,33 @@
+name: Integration
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bcachefs-smoke:
+    name: bcachefs smoke (NixOS test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Read-only — cache.yml owns pushes to the binary cache.
+      - uses: cachix/cachix-action@v17
+        with:
+          name: nasty
+
+      - name: Run bcachefs smoke test
+        run: nix build .#checks.x86_64-linux.bcachefs-smoke -L --print-build-logs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/integration.yml'
+      - 'nixos/tests/**'
+      - 'nixos/modules/bcachefs.nix'
+      - 'flake.nix'
+      - 'flake.lock'
 
 permissions:
   contents: read

--- a/flake.nix
+++ b/flake.nix
@@ -275,5 +275,16 @@
         "nasty-cloud-aarch64" = configs.nasty-cloud;
       }
     );
+
+    # Integration tests built via `nix build .#checks.x86_64-linux.<name>`.
+    # Run by .github/workflows/integration.yml on push to main + manual dispatch.
+    checks.x86_64-linux = let
+      pkgs = mkPkgs "x86_64-linux";
+      nasty-bcachefs-tools = mkBcachefsTools "x86_64-linux";
+    in {
+      bcachefs-smoke = import ./nixos/tests/bcachefs-smoke.nix {
+        inherit pkgs nasty-bcachefs-tools;
+      };
+    };
   };
 }

--- a/nixos/tests/bcachefs-smoke.nix
+++ b/nixos/tests/bcachefs-smoke.nix
@@ -1,0 +1,39 @@
+# Boots a minimal NixOS VM with our bcachefs DKMS module, formats a
+# virtual disk, mounts it, and prints the raw output of `bcachefs fs usage`
+# and `bcachefs show-super` so the test log captures real fixtures we can
+# paste into nasty-storage parser tests.
+
+{ pkgs, nasty-bcachefs-tools }:
+
+pkgs.testers.runNixOSTest {
+  name = "bcachefs-smoke";
+
+  nodes.machine = {
+    imports = [ ../modules/bcachefs.nix ];
+    _module.args = { inherit nasty-bcachefs-tools; };
+
+    virtualisation.emptyDiskImages = [ 1024 ];
+    virtualisation.memorySize = 1024;
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    # Format the empty 1 GiB disk and mount it.
+    machine.succeed("bcachefs format /dev/vdb")
+    machine.succeed("mkdir -p /mnt/test")
+    machine.succeed("mount -t bcachefs /dev/vdb /mnt/test")
+
+    # Capture raw outputs to the test log. These are the fixtures
+    # nasty-storage parsers (parse_device_table_line, parse_human_bytes,
+    # parse_bcachefs_opt) need to be tested against.
+    fs_usage = machine.succeed("bcachefs fs usage /mnt/test")
+    show_super = machine.succeed("bcachefs show-super /dev/vdb")
+
+    print("=== bcachefs fs usage /mnt/test ===")
+    print(fs_usage)
+    print("=== bcachefs show-super /dev/vdb ===")
+    print(show_super)
+  '';
+}


### PR DESCRIPTION
## Summary
- Adds `nixos/tests/bcachefs-smoke.nix` — a `pkgs.testers.runNixOSTest` that boots a 1 GiB NixOS VM with our bcachefs DKMS module, formats a virtual disk, mounts it, and prints raw output of `bcachefs fs usage` and `bcachefs show-super` to the build log
- Wires the test into the flake as `checks.x86_64-linux.bcachefs-smoke`
- Adds `.github/workflows/integration.yml` — separate workflow, runs on push to `main` + manual dispatch, doesn't slow the existing fast PR gate

## Why
The first unit-test target in the testing roadmap is the `nasty-storage` output parsers (`parse_device_table_line`, `parse_human_bytes`, `parse_bcachefs_opt`). Those parsers eat real `bcachefs` command output, and we want test fixtures captured from a real run rather than ones I synthesize from reading the parser code. This test produces those fixtures in a green CI run, and stays around as a format-drift detector when bcachefs upstream changes its output.

## Test plan
- [ ] Manually dispatch the Integration workflow against this branch and confirm green
- [ ] Read the captured `fs usage` / `show-super` output in the run log to confirm it's the real format (not stub/error text)
- [ ] Once green: copy the captured output into nasty-storage parser tests as fixtures (follow-up PR)

## Notes
- The workflow won't run automatically on this PR (it's filtered to `main`); I'll trigger it manually with `gh workflow run integration.yml --ref bcachefs-smoke-test`
- First run will be slow (~5–15 min uncached) — building bcachefs DKMS kernel module + booting NixOS in QEMU. Cached subsequent runs should be much faster
- Cachix integration is read-only here; pushes still happen from `cache.yml` on merge to main