### PR TITLE
nasty-sharing: render extraction + tests for NFS/SMB config

### DIFF
--- a/engine/nasty-sharing/src/nfs.rs
+++ b/engine/nasty-sharing/src/nfs.rs
@@ -256,20 +256,11 @@ impl NfsService {
 }
 
 /// Write a single export file for one share: /etc/exports.d/nasty-{id}.exports
-async fn write_export_file(share: &NfsShare) -> Result<(), NfsError> {
-    tokio::fs::create_dir_all(NASTY_EXPORTS_DIR).await?;
-
-    let path = export_file_path(&share.id);
-
-    if !share.enabled || !Path::new(&share.path).exists() {
-        // Disabled or stale — remove the file if it exists
-        let _ = tokio::fs::remove_file(&path).await;
-        return Ok(());
-    }
-
-    // Belt-and-braces: every value that lands in /etc/exports.d gets re-validated
-    // here, regardless of which RPC produced the share. Anything containing a
-    // newline or unbalanced quoting could otherwise inject a new export line.
+/// Render the contents of an `/etc/exports.d/nasty-<id>.exports` file for
+/// a single share. Pure: no I/O. Re-validates path and clients so anything
+/// landing on disk has gone through the same belt-and-braces checks
+/// regardless of which RPC produced the share.
+fn render_export_file(share: &NfsShare) -> Result<String, NfsError> {
     validate_export_path(&share.path)?;
     for client in &share.clients {
         validate_nfs_client(client)?;
@@ -292,13 +283,26 @@ async fn write_export_file(share: &NfsShare) -> Result<(), NfsError> {
         })
         .collect();
 
-    let content = format!(
+    Ok(format!(
         "# NASty share {}\n{}\t{}\n",
         share.id,
         share.path,
         clients.join(" ")
-    );
+    ))
+}
 
+async fn write_export_file(share: &NfsShare) -> Result<(), NfsError> {
+    tokio::fs::create_dir_all(NASTY_EXPORTS_DIR).await?;
+
+    let path = export_file_path(&share.id);
+
+    if !share.enabled || !Path::new(&share.path).exists() {
+        // Disabled or stale — remove the file if it exists
+        let _ = tokio::fs::remove_file(&path).await;
+        return Ok(());
+    }
+
+    let content = render_export_file(share)?;
     tokio::fs::write(&path, &content).await?;
     Ok(())
 }
@@ -349,4 +353,129 @@ async fn reload_exports() -> Result<(), NfsError> {
 
     info!("NFS exports reloaded");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn share_with(clients: Vec<NfsClient>) -> NfsShare {
+        NfsShare {
+            id: "abc".to_string(),
+            path: "/fs/p/data".to_string(),
+            comment: None,
+            clients,
+            enabled: true,
+        }
+    }
+
+    fn client(host: &str, options: &str) -> NfsClient {
+        NfsClient {
+            host: host.to_string(),
+            options: options.to_string(),
+        }
+    }
+
+    // ── validators ─────────────────────────────────────────────────
+
+    #[test]
+    fn validate_nfs_host_accepts_valid_forms() {
+        assert!(validate_nfs_host("192.168.1.5").is_ok());
+        assert!(validate_nfs_host("192.168.1.0/24").is_ok());
+        assert!(validate_nfs_host("fd00::1/64").is_ok());
+        assert!(validate_nfs_host("client.example.com").is_ok());
+        assert!(validate_nfs_host("*").is_ok());
+    }
+
+    #[test]
+    fn validate_nfs_host_rejects_injection() {
+        assert!(validate_nfs_host("").is_err());
+        assert!(validate_nfs_host("host with space").is_err());
+        assert!(validate_nfs_host("host\nnewline").is_err());
+        assert!(validate_nfs_host("host(opts)").is_err());
+        assert!(validate_nfs_host("host;evil").is_err());
+        assert!(validate_nfs_host("host\"quoted").is_err());
+    }
+
+    #[test]
+    fn validate_nfs_options_accepts_standard_grammar() {
+        assert!(validate_nfs_options("rw,sync,no_subtree_check,no_root_squash").is_ok());
+        assert!(validate_nfs_options("ro,fsid=42,sec=sys:krb5").is_ok());
+        assert!(validate_nfs_options("").is_ok());
+    }
+
+    #[test]
+    fn validate_nfs_options_rejects_injection() {
+        assert!(validate_nfs_options("rw\nsync").is_err());
+        assert!(validate_nfs_options("rw sync").is_err());
+        assert!(validate_nfs_options("rw;evil").is_err());
+        assert!(validate_nfs_options("rw,(opts)").is_err());
+    }
+
+    #[test]
+    fn validate_export_path_rejects_dangerous_chars() {
+        assert!(validate_export_path("/fs/p/data").is_ok());
+        assert!(validate_export_path("/fs/p/data with spaces").is_ok()); // spaces allowed
+        assert!(validate_export_path("/fs/p\nlinejection").is_err());
+        assert!(validate_export_path("/fs/p\"quoted").is_err());
+        assert!(validate_export_path("/fs/p\\back").is_err());
+    }
+
+    // ── render_export_file ─────────────────────────────────────────
+
+    #[test]
+    fn render_export_file_single_client_auto_injects_fsid_and_insecure() {
+        let share = share_with(vec![client("192.168.1.0/24", "rw,sync")]);
+        let out = render_export_file(&share).unwrap();
+        let fsid = stable_fsid("abc");
+        assert_eq!(
+            out,
+            format!(
+                "# NASty share abc\n/fs/p/data\t192.168.1.0/24(rw,sync,fsid={fsid},insecure)\n"
+            )
+        );
+    }
+
+    #[test]
+    fn render_export_file_multiple_clients_space_separated() {
+        let share = share_with(vec![client("10.0.0.1", "rw"), client("10.0.0.2", "ro")]);
+        let out = render_export_file(&share).unwrap();
+        let fsid = stable_fsid("abc");
+        assert_eq!(
+            out,
+            format!(
+                "# NASty share abc\n/fs/p/data\t10.0.0.1(rw,fsid={fsid},insecure) 10.0.0.2(ro,fsid={fsid},insecure)\n"
+            )
+        );
+    }
+
+    #[test]
+    fn render_export_file_preserves_explicit_fsid() {
+        let share = share_with(vec![client("10.0.0.1", "rw,fsid=0")]);
+        let out = render_export_file(&share).unwrap();
+        // Caller-supplied fsid wins; we don't append a second one.
+        assert!(out.contains("fsid=0"));
+        assert_eq!(out.matches("fsid=").count(), 1);
+    }
+
+    #[test]
+    fn render_export_file_preserves_explicit_secure_skips_insecure_default() {
+        let share = share_with(vec![client("10.0.0.1", "rw,secure")]);
+        let out = render_export_file(&share).unwrap();
+        // Caller asked for secure — don't add the insecure default.
+        assert!(!out.contains("insecure"));
+    }
+
+    #[test]
+    fn render_export_file_rejects_bad_path() {
+        let mut share = share_with(vec![client("10.0.0.1", "rw")]);
+        share.path = "/fs/p\ninjection".to_string();
+        assert!(render_export_file(&share).is_err());
+    }
+
+    #[test]
+    fn render_export_file_rejects_bad_client_options() {
+        let share = share_with(vec![client("10.0.0.1", "rw;evil")]);
+        assert!(render_export_file(&share).is_err());
+    }
 }

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -272,17 +272,8 @@ fn validate_share_name(name: &str) -> Result<(), SmbError> {
     Ok(())
 }
 
-/// Write a single share config file: /etc/samba/nasty.d/{id}.conf
-async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
-    tokio::fs::create_dir_all(NASTY_SMB_SHARE_DIR).await?;
-
-    let path = share_conf_path(&share.id);
-
-    if !share.enabled {
-        let _ = tokio::fs::remove_file(&path).await;
-        return Ok(());
-    }
-
+/// Render a single share config section. Pure: no I/O.
+fn render_share_conf(share: &SmbShare) -> String {
     let mut conf = format!("[{}]\n", sanitize_smb_value(&share.name));
     conf.push_str(&format!("    path = {}\n", share.path));
 
@@ -344,6 +335,21 @@ async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
         ));
     }
 
+    conf
+}
+
+/// Write a single share config file: /etc/samba/nasty.d/{id}.conf
+async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
+    tokio::fs::create_dir_all(NASTY_SMB_SHARE_DIR).await?;
+
+    let path = share_conf_path(&share.id);
+
+    if !share.enabled {
+        let _ = tokio::fs::remove_file(&path).await;
+        return Ok(());
+    }
+
+    let conf = render_share_conf(share);
     tokio::fs::write(&path, &conf).await?;
 
     // Make the directory writable by any authenticated user.
@@ -783,4 +789,132 @@ async fn next_available_uid() -> u32 {
         }
     }
     SMB_USER_UID_MIN // fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_share() -> SmbShare {
+        SmbShare {
+            id: "id-1".to_string(),
+            name: "share1".to_string(),
+            path: "/fs/p/data".to_string(),
+            comment: None,
+            read_only: false,
+            browseable: true,
+            guest_ok: false,
+            valid_users: vec![],
+            extra_params: HashMap::new(),
+            enabled: true,
+        }
+    }
+
+    // ── validators / sanitizers ────────────────────────────────────
+
+    #[test]
+    fn sanitize_smb_value_strips_injection_chars() {
+        assert_eq!(sanitize_smb_value("hello"), "hello");
+        assert_eq!(sanitize_smb_value("a;b\nc\rd"), "abcd");
+        assert_eq!(
+            sanitize_smb_value("name\twith\x01control"),
+            "namewithcontrol"
+        );
+    }
+
+    #[test]
+    fn validate_share_name_accepts_normal_names() {
+        assert!(validate_share_name("docs").is_ok());
+        assert!(validate_share_name("My Share 2024").is_ok());
+    }
+
+    #[test]
+    fn validate_share_name_rejects_invalid() {
+        assert!(validate_share_name("").is_err());
+        assert!(validate_share_name(&"x".repeat(81)).is_err());
+        for bad in ["a/b", "a\\b", "a[b", "a]b", "a:b", "a|b", "a;b"] {
+            assert!(validate_share_name(bad).is_err(), "should reject '{bad}'");
+        }
+    }
+
+    // ── render_share_conf ──────────────────────────────────────────
+
+    #[test]
+    fn render_share_conf_minimal() {
+        let out = render_share_conf(&minimal_share());
+        assert_eq!(
+            out,
+            "[share1]\n    \
+             path = /fs/p/data\n    \
+             read only = no\n    \
+             browseable = yes\n    \
+             guest ok = no\n"
+        );
+    }
+
+    #[test]
+    fn render_share_conf_with_comment() {
+        let mut share = minimal_share();
+        share.comment = Some("Family photos".to_string());
+        let out = render_share_conf(&share);
+        assert!(out.contains("    comment = Family photos\n"));
+    }
+
+    #[test]
+    fn render_share_conf_guest_ok_emits_nobody_block() {
+        let mut share = minimal_share();
+        share.guest_ok = true;
+        let out = render_share_conf(&share);
+        assert!(out.contains("    guest ok = yes\n"));
+        assert!(out.contains("    force user = nobody\n"));
+        assert!(out.contains("    force group = nogroup\n"));
+        assert!(out.contains("    create mask = 0666\n"));
+        assert!(out.contains("    directory mask = 0777\n"));
+    }
+
+    #[test]
+    fn render_share_conf_authenticated_force_user_picks_first_non_group() {
+        let mut share = minimal_share();
+        share.valid_users = vec![
+            "@admins".to_string(),
+            "alice".to_string(),
+            "bob".to_string(),
+        ];
+        let out = render_share_conf(&share);
+        assert!(out.contains("    force user = alice\n"));
+        assert!(out.contains("    valid users = @admins alice bob\n"));
+        assert!(out.contains("    create mask = 0664\n"));
+        assert!(out.contains("    directory mask = 0775\n"));
+    }
+
+    #[test]
+    fn render_share_conf_authenticated_all_groups_omits_force_user() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["@admins".to_string(), "@users".to_string()];
+        let out = render_share_conf(&share);
+        assert!(!out.contains("force user"));
+        assert!(out.contains("    valid users = @admins @users\n"));
+    }
+
+    #[test]
+    fn render_share_conf_extra_params_sorted_and_sanitized() {
+        let mut share = minimal_share();
+        share
+            .extra_params
+            .insert("zeta".to_string(), "1".to_string());
+        share
+            .extra_params
+            .insert("alpha".to_string(), "two".to_string());
+        share
+            .extra_params
+            .insert("middle".to_string(), "v;injected\nx".to_string());
+        let out = render_share_conf(&share);
+        // Sorted by key: alpha, middle, zeta.
+        let alpha_pos = out.find("alpha = two").unwrap();
+        let middle_pos = out.find("middle = ").unwrap();
+        let zeta_pos = out.find("zeta = 1").unwrap();
+        assert!(alpha_pos < middle_pos && middle_pos < zeta_pos);
+        // Injection chars in the value got stripped.
+        assert!(out.contains("    middle = vinjectedx\n"));
+    }
 }


### PR DESCRIPTION
## Summary
Roadmap item #6: tests for the sharing-config generators.

**Refactor (no behavior change):**
- Extract `render_export_file(share) -> Result<String, NfsError>` from `write_export_file` so the contents that land in `/etc/exports.d/nasty-<id>.exports` are testable without touching disk
- Extract `render_share_conf(share) -> String` from `write_share_conf` so the contents that land in `/etc/samba/nasty.d/<id>.conf` are testable without touching disk
- Both async writers shrink to a clear "validate, render, write" sequence

**Tests (20 new):**
- NFS validators (`validate_nfs_host`, `validate_nfs_options`, `validate_export_path`) — accept and reject cases, including injection attempts via newlines, semicolons, parens, quotes
- `render_export_file` — single client, multiple clients, preservation of explicit `fsid=` (no double-injection), preservation of explicit `secure` (skips `insecure` default), rejection of bad path / bad client options
- SMB `sanitize_smb_value` and `validate_share_name` — injection char stripping, length and special-char rules
- `render_share_conf` — minimal, with comment, `guest_ok` block (forces nobody/nogroup + masks), authenticated force-user logic (picks first non-`@group` entry, omits force-user when all are groups), `extra_params` sorted alphabetically and value-sanitized

## Why this matters
iSCSI and NVMe-oF write directly to configfs (no string artifact to test), but NFS exports and Samba share confs are text files generated from share specs. Silent regressions there look like "share stops working after upgrade" — these tests catch them at PR time.

## Test plan
- [ ] Engine job goes green; new tests counted in `cargo test --workspace`
- [ ] No clippy/fmt drift
- [ ] No production behavior change — refactor is mechanical extraction of content building from disk-writers