### PR TITLE
webui: tests for toast queue and IO history buffer

### DIFF
--- a/webui/src/lib/history.svelte.test.ts
+++ b/webui/src/lib/history.svelte.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { createIoHistory } from './history.svelte';
+
+const t = (s: number) => new Date(2026, 0, 1, 0, 0, s);
+
+describe('createIoHistory', () => {
+	test('push adds samples to the named resource', () => {
+		const h = createIoHistory();
+		h.push('sda', t(1), 100, 50);
+		h.push('sda', t(2), 200, 100);
+		const samples = h.getSamples('sda');
+		expect(samples).toHaveLength(2);
+		expect(samples[0]).toEqual({ time: t(1), in: 100, out: 50 });
+		expect(samples[1]).toEqual({ time: t(2), in: 200, out: 100 });
+	});
+
+	test('separate resources keep separate buffers', () => {
+		const h = createIoHistory();
+		h.push('sda', t(1), 1, 1);
+		h.push('sdb', t(1), 2, 2);
+		h.push('sda', t(2), 3, 3);
+		expect(h.getSamples('sda')).toHaveLength(2);
+		expect(h.getSamples('sdb')).toHaveLength(1);
+	});
+
+	test('getSamples for an unknown resource returns an empty array', () => {
+		const h = createIoHistory();
+		expect(h.getSamples('missing')).toEqual([]);
+	});
+
+	test('buffer truncates oldest samples once it exceeds 400 entries', () => {
+		const h = createIoHistory();
+		for (let i = 0; i < 500; i++) {
+			h.push('sda', t(i), i, i);
+		}
+		const samples = h.getSamples('sda');
+		// Cap is 400; we pushed 500 → oldest 100 dropped, newest 400 kept.
+		expect(samples).toHaveLength(400);
+		expect(samples[0].in).toBe(100); // sample #100 is now the oldest
+		expect(samples[399].in).toBe(499); // newest is the last one we pushed
+	});
+
+	test('clear empties every resource', () => {
+		const h = createIoHistory();
+		h.push('sda', t(1), 1, 1);
+		h.push('sdb', t(1), 2, 2);
+		h.clear();
+		expect(h.getSamples('sda')).toEqual([]);
+		expect(h.getSamples('sdb')).toEqual([]);
+		expect(h.resources.size).toBe(0);
+	});
+});

--- a/webui/src/lib/toast.svelte.test.ts
+++ b/webui/src/lib/toast.svelte.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { dismiss, error, getToasts, info, isBusy, success, withToast } from './toast.svelte';
+
+// Toast state is module-scoped, so each test must start from an empty queue.
+function clearAllToasts() {
+	for (const t of [...getToasts()]) dismiss(t.id);
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	clearAllToasts();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('toast queue', () => {
+	test('success / error / info push toasts of the right type', () => {
+		success('saved');
+		error('boom');
+		info('heads up');
+		const toasts = getToasts();
+		expect(toasts).toHaveLength(3);
+		expect(toasts[0]).toMatchObject({ type: 'success', message: 'saved' });
+		expect(toasts[1]).toMatchObject({ type: 'error', message: 'boom' });
+		expect(toasts[2]).toMatchObject({ type: 'info', message: 'heads up' });
+	});
+
+	test('every toast gets a unique numeric id', () => {
+		success('a');
+		success('b');
+		success('c');
+		const ids = getToasts().map((t) => t.id);
+		expect(new Set(ids).size).toBe(3);
+	});
+
+	test('dismiss removes only the matching toast', () => {
+		success('keep');
+		success('drop');
+		const dropId = getToasts().find((t) => t.message === 'drop')!.id;
+		dismiss(dropId);
+		expect(getToasts().map((t) => t.message)).toEqual(['keep']);
+	});
+
+	test('success/info auto-dismiss after 5 seconds', () => {
+		success('saved');
+		expect(getToasts()).toHaveLength(1);
+		vi.advanceTimersByTime(4999);
+		expect(getToasts()).toHaveLength(1);
+		vi.advanceTimersByTime(1);
+		expect(getToasts()).toHaveLength(0);
+	});
+
+	test('error toasts stay longer (8 seconds) than success/info', () => {
+		error('boom');
+		vi.advanceTimersByTime(5000);
+		expect(getToasts()).toHaveLength(1); // would have been gone if 5s
+		vi.advanceTimersByTime(3000);
+		expect(getToasts()).toHaveLength(0);
+	});
+});
+
+describe('withToast', () => {
+	test('returns the wrapped function\'s result', async () => {
+		const result = await withToast(async () => 42);
+		expect(result).toBe(42);
+	});
+
+	test('shows a success toast when successMsg is provided', async () => {
+		await withToast(async () => 'ok', 'Saved!');
+		expect(getToasts()).toMatchObject([{ type: 'success', message: 'Saved!' }]);
+	});
+
+	test('catches Error instances and surfaces .message in an error toast', async () => {
+		const result = await withToast(async () => {
+			throw new Error('disk full');
+		});
+		expect(result).toBeUndefined();
+		expect(getToasts()).toMatchObject([{ type: 'error', message: 'disk full' }]);
+	});
+
+	test('catches JSON-RPC error envelopes ({ code, message }) and surfaces message', async () => {
+		// rpc.ts's call() rejects with the raw server error object on JSON-RPC
+		// failures — that's not an Error instance.
+		const result = await withToast(async () => {
+			throw { code: -32601, message: 'no such filesystem' };
+		});
+		expect(result).toBeUndefined();
+		expect(getToasts()).toMatchObject([
+			{ type: 'error', message: 'no such filesystem' }
+		]);
+	});
+
+	test('falls back to String(e) for primitives and unrecognised shapes', async () => {
+		const result = await withToast(async () => {
+			throw 'plain string';
+		});
+		expect(result).toBeUndefined();
+		expect(getToasts()).toMatchObject([{ type: 'error', message: 'plain string' }]);
+	});
+
+	test('isBusy is true while in flight and false again after', async () => {
+		expect(isBusy()).toBe(false);
+		let releaseInner!: () => void;
+		const inner = new Promise<void>((res) => {
+			releaseInner = res;
+		});
+		const op = withToast(async () => {
+			await inner;
+		});
+		expect(isBusy()).toBe(true);
+		releaseInner();
+		await op;
+		expect(isBusy()).toBe(false);
+	});
+
+	test('isBusy stays true while any concurrent op is in flight', async () => {
+		let releaseA!: () => void;
+		let releaseB!: () => void;
+		const a = new Promise<void>((res) => {
+			releaseA = res;
+		});
+		const b = new Promise<void>((res) => {
+			releaseB = res;
+		});
+		const opA = withToast(async () => {
+			await a;
+		});
+		const opB = withToast(async () => {
+			await b;
+		});
+		expect(isBusy()).toBe(true);
+		releaseA();
+		await opA;
+		expect(isBusy()).toBe(true); // b still running
+		releaseB();
+		await opB;
+		expect(isBusy()).toBe(false);
+	});
+});

--- a/webui/vitest.config.ts
+++ b/webui/vitest.config.ts
@@ -1,8 +1,12 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
 
 // Kept separate from vite.config.ts so vitest's bundled vite copy doesn't
 // clash with the SvelteKit plugin's plugin types under svelte-check.
+// We bring in just the Svelte plugin (not full SvelteKit) so vitest can
+// compile *.svelte.ts files that use $state and other runes.
 export default defineConfig({
+	plugins: [svelte()],
 	test: {
 		include: ['src/**/*.{test,spec}.ts'],
 		setupFiles: ['./vitest.setup.ts']


### PR DESCRIPTION
## Summary
17 new tests for the two `*.svelte.ts` files with non-trivial logic. Wires `@sveltejs/vite-plugin-svelte` into `vitest.config.ts` so vitest can compile Svelte 5 rune files (`$state`, etc.).

**`toast.svelte.ts` (12 tests):**
- `success`/`error`/`info` push toasts with the correct type and unique ids
- `dismiss` removes only the matching toast
- Auto-dismiss timing: success/info disappear at 5 s, error stays for 8 s (verified with `vi.useFakeTimers`)
- `withToast`: returns the wrapped fn's result; shows `successMsg` toast on success; catches `Error` instances; catches **JSON-RPC error envelopes** (`{ code, message }` — the shape rpc.ts rejects with on server errors); catches primitive throws via `String(e)`
- `isBusy` tracks in-flight ops, including concurrent ones

**`history.svelte.ts` (5 tests):**
- `push` adds samples to the named resource
- Separate resources keep separate buffers
- `getSamples` for unknown resource returns `[]`
- Ring buffer truncates oldest when exceeding 400 samples
- `clear` empties everything

WebUI total goes from 27 tests (#31 + #32) to 44 across 4 files.

## Test plan
- [ ] webui CI job goes green; vitest counts 4 files × 44 tests
- [ ] `svelte-check` still 0/0 errors
- [ ] vite build still succeeds