### PR TITLE
webui: tests for theme + confirm dialogs

### DIFF
--- a/webui/src/lib/confirm-dangerous.svelte.test.ts
+++ b/webui/src/lib/confirm-dangerous.svelte.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+	confirmDangerous,
+	confirmDangerousRespond,
+	confirmDangerousState
+} from './confirm-dangerous.svelte';
+
+afterEach(() => {
+	confirmDangerousState.open = false;
+	confirmDangerousState.resolve = null;
+});
+
+describe('confirmDangerous', () => {
+	test('opens the dialog and populates title, message, and expectedValue', () => {
+		void confirmDangerous('Delete tank?', 'Type "tank" to confirm', 'tank');
+		expect(confirmDangerousState.open).toBe(true);
+		expect(confirmDangerousState.title).toBe('Delete tank?');
+		expect(confirmDangerousState.message).toBe('Type "tank" to confirm');
+		expect(confirmDangerousState.expectedValue).toBe('tank');
+	});
+
+	test('confirmDangerousRespond(true) resolves with true and closes', async () => {
+		const p = confirmDangerous('x', 'y', 'z');
+		confirmDangerousRespond(true);
+		await expect(p).resolves.toBe(true);
+		expect(confirmDangerousState.open).toBe(false);
+	});
+
+	test('confirmDangerousRespond(false) resolves with false', async () => {
+		const p = confirmDangerous('x', 'y', 'z');
+		confirmDangerousRespond(false);
+		await expect(p).resolves.toBe(false);
+	});
+
+	test('a second response after the promise resolves is a no-op', () => {
+		void confirmDangerous('x', 'y', 'z');
+		confirmDangerousRespond(true);
+		expect(() => confirmDangerousRespond(true)).not.toThrow();
+	});
+});

--- a/webui/src/lib/confirm.svelte.test.ts
+++ b/webui/src/lib/confirm.svelte.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { confirm, confirmRespond, confirmState } from './confirm.svelte';
+
+afterEach(() => {
+	// The dialog is module-singleton state; reset between tests so a leftover
+	// open=true from one test doesn't affect the next.
+	confirmState.open = false;
+	confirmState.resolve = null;
+});
+
+describe('confirm', () => {
+	test('opens the dialog and populates title and message', () => {
+		void confirm('Delete share?', 'This cannot be undone.');
+		expect(confirmState.open).toBe(true);
+		expect(confirmState.title).toBe('Delete share?');
+		expect(confirmState.message).toBe('This cannot be undone.');
+	});
+
+	test('uses default Confirm/Cancel labels when options are omitted', () => {
+		void confirm('Title');
+		expect(confirmState.confirmLabel).toBe('Confirm');
+		expect(confirmState.cancelLabel).toBe('Cancel');
+	});
+
+	test('honours custom labels passed via options', () => {
+		void confirm('Reboot?', 'Are you sure?', {
+			confirmLabel: 'Reboot now',
+			cancelLabel: 'Wait'
+		});
+		expect(confirmState.confirmLabel).toBe('Reboot now');
+		expect(confirmState.cancelLabel).toBe('Wait');
+	});
+
+	test('omitted message defaults to the empty string', () => {
+		void confirm('Just title');
+		expect(confirmState.message).toBe('');
+	});
+
+	test('confirmRespond(true) resolves the promise with true and closes the dialog', async () => {
+		const p = confirm('x', 'y');
+		confirmRespond(true);
+		await expect(p).resolves.toBe(true);
+		expect(confirmState.open).toBe(false);
+	});
+
+	test('confirmRespond(false) resolves with false', async () => {
+		const p = confirm('x', 'y');
+		confirmRespond(false);
+		await expect(p).resolves.toBe(false);
+	});
+
+	test('confirmRespond clears resolve so a stray second call does not throw', () => {
+		void confirm('x', 'y');
+		confirmRespond(true);
+		// Second response after the promise already resolved must be a no-op,
+		// not an error — guards against double-click on the confirm button.
+		expect(() => confirmRespond(true)).not.toThrow();
+	});
+});

--- a/webui/src/lib/theme.svelte.test.ts
+++ b/webui/src/lib/theme.svelte.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { theme } from './theme.svelte';
+
+beforeEach(() => {
+	// Each test starts from a known state. theme is a module-level singleton,
+	// so we explicitly set it rather than reload the module.
+	theme.set('dark');
+	localStorage.removeItem('nasty-theme');
+});
+
+describe('theme', () => {
+	test('set("light") updates current and isDark', () => {
+		theme.set('light');
+		expect(theme.current).toBe('light');
+		expect(theme.isDark).toBe(false);
+	});
+
+	test('set("dark") updates current and isDark', () => {
+		theme.set('light');
+		theme.set('dark');
+		expect(theme.current).toBe('dark');
+		expect(theme.isDark).toBe(true);
+	});
+
+	test('toggle flips dark → light → dark', () => {
+		theme.set('dark');
+		theme.toggle();
+		expect(theme.current).toBe('light');
+		theme.toggle();
+		expect(theme.current).toBe('dark');
+	});
+
+	test('set persists to localStorage', () => {
+		theme.set('light');
+		expect(localStorage.getItem('nasty-theme')).toBe('light');
+		theme.set('dark');
+		expect(localStorage.getItem('nasty-theme')).toBe('dark');
+	});
+
+	test('toggle persists the new value to localStorage', () => {
+		theme.set('dark');
+		theme.toggle();
+		expect(localStorage.getItem('nasty-theme')).toBe('light');
+	});
+});

--- a/webui/vitest.setup.ts
+++ b/webui/vitest.setup.ts
@@ -1,13 +1,23 @@
 // Browser-globals stubs for vitest's node environment.
 //
-// rpc.ts has `static debug = ... localStorage.getItem(...)` which evaluates
-// at module-import time. Vitest's node env provides a partial localStorage
-// without getItem; without a stub the import throws before any test runs.
+// rpc.ts and theme.svelte.ts both touch `localStorage` at module-import time.
+// Vitest's node env provides a partial localStorage without getItem, so the
+// import would throw before any test runs. We back it with a real Map so
+// theme tests can verify persistence too.
+const store = new Map<string, string>();
 globalThis.localStorage = {
-	getItem: () => null,
-	setItem: () => {},
-	removeItem: () => {},
-	clear: () => {},
-	key: () => null,
-	length: 0
+	getItem: (k: string) => store.get(k) ?? null,
+	setItem: (k: string, v: string) => {
+		store.set(k, v);
+	},
+	removeItem: (k: string) => {
+		store.delete(k);
+	},
+	clear: () => {
+		store.clear();
+	},
+	key: (i: number) => Array.from(store.keys())[i] ?? null,
+	get length() {
+		return store.size;
+	}
 };


### PR DESCRIPTION
## Summary
16 tests covering the three remaining `lib/*.svelte.ts` files:

**`theme.svelte.ts` (5 tests):**
- `set('light'|'dark')` updates `current` and `isDark`
- `toggle` flips dark ↔ light
- `set` and `toggle` both persist to `localStorage` under `nasty-theme`

**`confirm.svelte.ts` (7 tests):**
- `confirm()` opens the dialog with the given title/message
- Default `Confirm` / `Cancel` labels when options are omitted
- Custom labels honoured via the options arg
- Omitted message defaults to `''`
- `confirmRespond(true|false)` resolves the promise with the right value and closes the dialog
- Second response after the promise resolves is a no-op (guards against a double-click on the confirm button)

**`confirm-dangerous.svelte.ts` (4 tests):**
- `confirmDangerous()` populates `title`, `message`, and `expectedValue`
- `confirmDangerousRespond(true|false)` resolves and closes
- Second response is a no-op

**Setup change**: `vitest.setup.ts` now backs `localStorage` with a real `Map` instead of a no-op stub, so theme persistence is testable end-to-end rather than just shape-checked. The earlier rpc/format tests don't depend on the stub returning anything specific, so they're unaffected.

WebUI total: 60 tests across 7 files (was 44).

## Note (out of scope)
Running the Svelte plugin under vitest surfaces a benign `state_referenced_locally` warning at `theme.svelte.ts:19` — the `apply(current)` call at module-load captures the initial value rather than tracking it reactively. That call only runs once at load (toggle/set call `apply` themselves with the new value), so behaviour is correct; the warning is pre-existing in the production code, not introduced here.

## Test plan
- [ ] webui CI job goes green (vitest: 7 files / 60 tests)
- [ ] svelte-check still 0/0
- [ ] vite build succeeds