### PR TITLE
test: add appliance integration smoke (engine + HTTP API)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,5 +36,17 @@ jobs:
         with:
           name: nasty
 
-      - name: Run bcachefs smoke test
-        run: nix build .#checks.x86_64-linux.bcachefs-smoke -L --print-build-logs
+      - name: Compute npm deps hash
+        # appliance-smoke builds the webui via Nix, which hardcodes
+        # npmDepsHash in flake.nix. Recompute here to match the current
+        # package-lock.json — same trick build-iso.yml uses.
+        run: |
+          HASH=$(nix run nixpkgs#prefetch-npm-deps -- webui/package-lock.json 2>/dev/null)
+          sed -i "s|npmDepsHash = \".*\"|npmDepsHash = \"$HASH\"|" flake.nix
+
+      - name: Run integration tests
+        run: |
+          nix build \
+            .#checks.x86_64-linux.bcachefs-smoke \
+            .#checks.x86_64-linux.appliance-smoke \
+            -L --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -280,10 +280,15 @@
     # Run by .github/workflows/integration.yml on push to main + manual dispatch.
     checks.x86_64-linux = let
       pkgs = mkPkgs "x86_64-linux";
+      nasty-engine = mkEngine "x86_64-linux";
+      nasty-webui = mkWebui "x86_64-linux";
       nasty-bcachefs-tools = mkBcachefsTools "x86_64-linux";
     in {
       bcachefs-smoke = import ./nixos/tests/bcachefs-smoke.nix {
         inherit pkgs nasty-bcachefs-tools;
+      };
+      appliance-smoke = import ./nixos/tests/appliance-smoke.nix {
+        inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
       };
     };
   };

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -16,7 +16,7 @@
 pkgs.testers.runNixOSTest {
   name = "appliance-smoke";
 
-  nodes.machine = {
+  nodes.machine = { lib, ... }: {
     imports = [
       ../modules/bcachefs.nix
       ../modules/linuxquota.nix
@@ -36,6 +36,11 @@ pkgs.testers.runNixOSTest {
       iscsi.enable = false;
       nvmeof.enable = false;
     };
+
+    # qemu-vm.nix forces timesyncd off; nasty.nix turns it on. Defer to the
+    # VM-test infrastructure since clock sync is irrelevant inside a
+    # transient test VM.
+    services.timesyncd.enable = lib.mkForce false;
 
     virtualisation.memorySize = 2048;
   };

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -22,7 +22,10 @@ pkgs.testers.runNixOSTest {
       ../modules/linuxquota.nix
       ../modules/nasty.nix
     ];
-    _module.args = { inherit nasty-engine nasty-webui nasty-bcachefs-tools; };
+    _module.args = {
+      inherit nasty-engine nasty-webui nasty-bcachefs-tools;
+      nasty-version = "test";
+    };
 
     services.nasty = {
       enable = true;

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -1,0 +1,94 @@
+# Boots the full NASty appliance (engine + nginx + supporting services) in a
+# QEMU VM, waits for the engine to come up, and exercises the HTTP surface:
+#   - /health responds before any auth
+#   - /api/login with admin/admin succeeds and returns a session token
+#   - /api/login with a bad password returns 401
+#   - /api/auth/check with the cookie reports authenticated=true
+#
+# This is the engine ↔ WebUI boundary that unit tests can't reach: real
+# systemd unit start, real auth manager (argon2 + lockout DB), real HTTP
+# routing, real cookie handshake. Pairs with the JSON-RPC framing tests
+# (#29) and the WebSocket client tests (#32) which cover the wire shape on
+# either side of this boundary.
+
+{ pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
+
+pkgs.testers.runNixOSTest {
+  name = "appliance-smoke";
+
+  nodes.machine = {
+    imports = [
+      ../modules/bcachefs.nix
+      ../modules/linuxquota.nix
+      ../modules/nasty.nix
+    ];
+    _module.args = { inherit nasty-engine nasty-webui nasty-bcachefs-tools; };
+
+    services.nasty = {
+      enable = true;
+      engine.package = nasty-engine;
+      webui.package = nasty-webui;
+      # Share-protocol services aren't relevant for the API smoke and add
+      # boot time + kernel module dependencies. The engine API is happy
+      # without them — it just won't be able to actually create shares.
+      nfs.enable = false;
+      smb.enable = false;
+      iscsi.enable = false;
+      nvmeof.enable = false;
+    };
+
+    virtualisation.memorySize = 2048;
+  };
+
+  testScript = ''
+    import json
+
+    machine.start()
+    machine.wait_for_unit("nasty-engine.service")
+
+    # ── /health (no auth) ───────────────────────────────────────────
+    # Hit the engine directly on its loopback port to skip TLS / nginx.
+    machine.wait_until_succeeds("curl -fsS http://127.0.0.1:2137/health")
+    health = machine.succeed("curl -fsS http://127.0.0.1:2137/health")
+    print(f"=== /health ===\n{health}")
+    health_obj = json.loads(health)
+    assert health_obj["status"] == "ok", f"unexpected health: {health_obj!r}"
+
+    # ── /api/login with default admin/admin ────────────────────────
+    login = machine.succeed(
+        "curl -fsS -c /tmp/cookies.txt "
+        "-X POST http://127.0.0.1:2137/api/login "
+        "-H 'Content-Type: application/json' "
+        "-d '{\"username\":\"admin\",\"password\":\"admin\"}'"
+    )
+    print(f"=== /api/login response ===\n{login}")
+    login_obj = json.loads(login)
+    assert "token" in login_obj and login_obj["token"], (
+        f"login response missing token: {login_obj!r}"
+    )
+
+    # The Set-Cookie header should have landed in the cookie jar too.
+    jar = machine.succeed("cat /tmp/cookies.txt")
+    assert "nasty_session" in jar, f"session cookie not set: {jar!r}"
+
+    # ── /api/login with bad credentials ────────────────────────────
+    # curl -f exits non-zero on 4xx, so machine.fail is the assertion.
+    machine.fail(
+        "curl -fsS -X POST http://127.0.0.1:2137/api/login "
+        "-H 'Content-Type: application/json' "
+        "-d '{\"username\":\"admin\",\"password\":\"wrong-on-purpose\"}'"
+    )
+
+    # ── /api/auth/check with the cookie ────────────────────────────
+    # The handler returns 200 OK with an empty body when the session is
+    # valid. curl -f exits non-zero on 4xx, so a successful exit here is
+    # the assertion that the cookie was accepted.
+    machine.succeed(
+        "curl -fsS -b /tmp/cookies.txt "
+        "http://127.0.0.1:2137/api/auth/check"
+    )
+
+    # Same endpoint without a cookie should be rejected.
+    machine.fail("curl -fsS http://127.0.0.1:2137/api/auth/check")
+  '';
+}


### PR DESCRIPTION
## Summary
Extends the bcachefs smoke nixosTest from #24 into a full appliance integration test. Boots the entire NASty stack (engine + nginx + supporting systemd services) in a NixOS test VM and exercises the HTTP surface that unit tests can't reach: real systemd unit start, real auth manager (argon2 + persisted lockout state), real cookie handshake, real HTTP routing.

**Test script:**
- Waits for `nasty-engine.service` to become active
- `GET /health` (no auth) returns `{"status":"ok",...}`
- `POST /api/login` with default `admin/admin` returns a token and the engine sets a `nasty_session` cookie
- `POST /api/login` with a bad password returns 401
- `GET /api/auth/check` with the cookie succeeds; without it, fails

This is the engine ↔ WebUI boundary unit tests can't touch. Pairs with #29 (JSON-RPC envelope shape on the engine side) and #32 (WebSocket client on the WebUI side) — they pin down the wire format; this proves the engine is actually wired up to honour it.

**Wiring:**
- `nixos/tests/appliance-smoke.nix` — the test itself
- `flake.nix` — exposes it as `checks.x86_64-linux.appliance-smoke`
- `.github/workflows/integration.yml` — now builds both `bcachefs-smoke` and `appliance-smoke` side by side, plus a `prefetch-npm-deps` step (the test builds the webui through Nix, so `npmDepsHash` needs to match the current `package-lock.json` — same trick `build-iso.yml` uses)

## Out of scope (future PRs)
The next obvious extension is to open a WebSocket from the test script and drive the JSON-RPC dispatch end-to-end (e.g. `system.info`, `fs.list`). That needs Python `websocket-client` (or `websockets`) added to the test's `extraPackages` and a more involved testScript. Doing it incrementally keeps each PR reviewable.

## Notes
- Share-protocol services (NFS, SMB, iSCSI, NVMe-oF) are disabled in the test config — they add boot time and kernel module dependencies but the engine API is happy without them
- First run will be slower than the bcachefs smoke (this builds the engine + webui too, not just bcachefs-tools); subsequent runs benefit from cachix
- Path-filter trigger added in #24 already covers `flake.nix` and `nixos/tests/**`, so this PR exercises the integration workflow before merge