### PR TITLE
test: drive JSON-RPC over /ws in appliance smoke

### DIFF
--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -43,19 +43,27 @@ let
         me = call("auth.me", 1)
         assert me["username"] == "admin", f"auth.me wrong: {me!r}"
 
-        health = call("system.health", 2)
+        # First login of the default admin/admin sets must_change_password,
+        # which gates most RPC methods until cleared. Change it so the rest
+        # of the smoke can call system.health / fs.list.
+        call("auth.change_password", 2, {
+            "username": "admin",
+            "new_password": "password-changed-by-smoke-test",
+        })
+
+        health = call("system.health", 3)
         print("system.health:", health, file=sys.stderr)
 
-        fs_list = call("fs.list", 3)
+        fs_list = call("fs.list", 4)
         assert isinstance(fs_list, list), f"fs.list not a list: {fs_list!r}"
         # Fresh appliance with no virtual disks => empty list.
         assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
 
         # Unknown method must come back as a JSON-RPC error envelope, not a
         # silent drop.
-        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 4}))
+        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 5}))
         bad = json.loads(ws.recv())
-        assert bad.get("id") == 4, f"id mismatch: {bad!r}"
+        assert bad.get("id") == 5, f"id mismatch: {bad!r}"
         assert bad.get("error"), f"unknown method should error: {bad!r}"
         print("unknown method error:", bad["error"], file=sys.stderr)
     finally:

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -16,6 +16,10 @@
 pkgs.testers.runNixOSTest {
   name = "appliance-smoke";
 
+  # websocket-client lets the testScript drive the JSON-RPC dispatch over
+  # the same /ws endpoint the WebUI uses.
+  extraPythonPackages = ps: [ ps.websocket-client ];
+
   nodes.machine = { lib, ... }: {
     imports = [
       ../modules/bcachefs.nix
@@ -98,5 +102,63 @@ pkgs.testers.runNixOSTest {
 
     # Same endpoint without a cookie should be rejected.
     machine.fail("curl -fsS http://127.0.0.1:2137/api/auth/check")
+
+    # ── JSON-RPC over /ws ──────────────────────────────────────────
+    # Drive the same dispatch path the WebUI uses: open a WebSocket,
+    # auth with the token from /api/login, send a few requests, and
+    # check the responses come back correlated by id. This exercises
+    # router.rs end-to-end — the part the unit tests deliberately
+    # don't reach.
+    import shlex
+    rpc_script = '''
+import json
+import sys
+import websocket
+
+token = sys.argv[1]
+
+ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=10)
+try:
+    ws.send(json.dumps({"token": token}))
+    auth = json.loads(ws.recv())
+    assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
+    assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
+
+    def call(method, request_id, params=None):
+        req = {"jsonrpc": "2.0", "method": method, "id": request_id}
+        if params is not None:
+            req["params"] = params
+        ws.send(json.dumps(req))
+        resp = json.loads(ws.recv())
+        assert resp.get("id") == request_id, (
+            f"id mismatch: req={request_id} resp={resp!r}"
+        )
+        assert "error" not in resp, f"{method} returned error: {resp!r}"
+        return resp["result"]
+
+    me = call("auth.me", 1)
+    assert me["username"] == "admin", f"auth.me wrong: {me!r}"
+
+    health = call("system.health", 2)
+    print("system.health:", health, file=sys.stderr)
+
+    fs_list = call("fs.list", 3)
+    assert isinstance(fs_list, list), f"fs.list not a list: {fs_list!r}"
+    # Fresh appliance with no virtual disks => empty list.
+    assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
+
+    # Unknown method must come back as a JSON-RPC error envelope, not a
+    # silent drop.
+    ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 4}))
+    bad = json.loads(ws.recv())
+    assert bad.get("id") == 4, f"id mismatch: {bad!r}"
+    assert bad.get("error"), f"unknown method should error: {bad!r}"
+    print("unknown method error:", bad["error"], file=sys.stderr)
+finally:
+    ws.close()
+'''
+    machine.succeed(
+        f"python3 -c {shlex.quote(rpc_script)} {shlex.quote(login_obj['token'])}"
+    )
   '';
 }

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -1,24 +1,72 @@
 # Boots the full NASty appliance (engine + nginx + supporting services) in a
-# QEMU VM, waits for the engine to come up, and exercises the HTTP surface:
-#   - /health responds before any auth
-#   - /api/login with admin/admin succeeds and returns a session token
-#   - /api/login with a bad password returns 401
-#   - /api/auth/check with the cookie reports authenticated=true
+# QEMU VM, waits for the engine to come up, and exercises both halves of the
+# WebUI ↔ engine boundary that unit tests can't reach:
+#   - HTTP: /health, /api/login (good + bad creds), /api/auth/check
+#   - JSON-RPC over /ws: auth.me, system.health, fs.list, unknown-method
 #
-# This is the engine ↔ WebUI boundary that unit tests can't reach: real
-# systemd unit start, real auth manager (argon2 + lockout DB), real HTTP
-# routing, real cookie handshake. Pairs with the JSON-RPC framing tests
-# (#29) and the WebSocket client tests (#32) which cover the wire shape on
-# either side of this boundary.
+# Pairs with the JSON-RPC framing tests (#29) and the WebSocket client tests
+# (#32) which cover the wire shape on either side of this boundary; this
+# proves the engine actually wires up to honour both.
 
 { pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
 
+let
+  # Self-contained Python script run inside the guest. Putting it in its own
+  # file avoids nesting a triple-quoted Python string inside a Nix `''`
+  # string, which mangles indentation under the testScript type-checker.
+  rpcSmoke = pkgs.writeText "rpc-smoke.py" ''
+    import json
+    import sys
+    import websocket
+
+    token = sys.argv[1]
+
+    ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=10)
+    try:
+        ws.send(json.dumps({"token": token}))
+        auth = json.loads(ws.recv())
+        assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
+        assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
+
+        def call(method, request_id, params=None):
+            req = {"jsonrpc": "2.0", "method": method, "id": request_id}
+            if params is not None:
+                req["params"] = params
+            ws.send(json.dumps(req))
+            resp = json.loads(ws.recv())
+            assert resp.get("id") == request_id, (
+                f"id mismatch: req={request_id} resp={resp!r}"
+            )
+            assert "error" not in resp, f"{method} returned error: {resp!r}"
+            return resp["result"]
+
+        me = call("auth.me", 1)
+        assert me["username"] == "admin", f"auth.me wrong: {me!r}"
+
+        health = call("system.health", 2)
+        print("system.health:", health, file=sys.stderr)
+
+        fs_list = call("fs.list", 3)
+        assert isinstance(fs_list, list), f"fs.list not a list: {fs_list!r}"
+        # Fresh appliance with no virtual disks => empty list.
+        assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
+
+        # Unknown method must come back as a JSON-RPC error envelope, not a
+        # silent drop.
+        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 4}))
+        bad = json.loads(ws.recv())
+        assert bad.get("id") == 4, f"id mismatch: {bad!r}"
+        assert bad.get("error"), f"unknown method should error: {bad!r}"
+        print("unknown method error:", bad["error"], file=sys.stderr)
+    finally:
+        ws.close()
+  '';
+
+  pythonWithWs = pkgs.python3.withPackages (ps: [ ps.websocket-client ]);
+in
+
 pkgs.testers.runNixOSTest {
   name = "appliance-smoke";
-
-  # websocket-client lets the testScript drive the JSON-RPC dispatch over
-  # the same /ws endpoint the WebUI uses.
-  extraPythonPackages = ps: [ ps.websocket-client ];
 
   nodes.machine = { lib, ... }: {
     imports = [
@@ -49,11 +97,15 @@ pkgs.testers.runNixOSTest {
     # transient test VM.
     services.timesyncd.enable = lib.mkForce false;
 
+    # The rpc-smoke script needs websocket-client at runtime in the guest.
+    environment.systemPackages = [ pythonWithWs ];
+
     virtualisation.memorySize = 2048;
   };
 
   testScript = ''
     import json
+    import shlex
 
     machine.start()
     machine.wait_for_unit("nasty-engine.service")
@@ -105,60 +157,11 @@ pkgs.testers.runNixOSTest {
 
     # ── JSON-RPC over /ws ──────────────────────────────────────────
     # Drive the same dispatch path the WebUI uses: open a WebSocket,
-    # auth with the token from /api/login, send a few requests, and
-    # check the responses come back correlated by id. This exercises
-    # router.rs end-to-end — the part the unit tests deliberately
-    # don't reach.
-    import shlex
-    rpc_script = '''
-import json
-import sys
-import websocket
-
-token = sys.argv[1]
-
-ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=10)
-try:
-    ws.send(json.dumps({"token": token}))
-    auth = json.loads(ws.recv())
-    assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
-    assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
-
-    def call(method, request_id, params=None):
-        req = {"jsonrpc": "2.0", "method": method, "id": request_id}
-        if params is not None:
-            req["params"] = params
-        ws.send(json.dumps(req))
-        resp = json.loads(ws.recv())
-        assert resp.get("id") == request_id, (
-            f"id mismatch: req={request_id} resp={resp!r}"
-        )
-        assert "error" not in resp, f"{method} returned error: {resp!r}"
-        return resp["result"]
-
-    me = call("auth.me", 1)
-    assert me["username"] == "admin", f"auth.me wrong: {me!r}"
-
-    health = call("system.health", 2)
-    print("system.health:", health, file=sys.stderr)
-
-    fs_list = call("fs.list", 3)
-    assert isinstance(fs_list, list), f"fs.list not a list: {fs_list!r}"
-    # Fresh appliance with no virtual disks => empty list.
-    assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
-
-    # Unknown method must come back as a JSON-RPC error envelope, not a
-    # silent drop.
-    ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 4}))
-    bad = json.loads(ws.recv())
-    assert bad.get("id") == 4, f"id mismatch: {bad!r}"
-    assert bad.get("error"), f"unknown method should error: {bad!r}"
-    print("unknown method error:", bad["error"], file=sys.stderr)
-finally:
-    ws.close()
-'''
+    # auth with the token from /api/login, send a few requests, check
+    # responses come back correlated by id. Exercises router.rs
+    # end-to-end — the part unit tests deliberately don't reach.
     machine.succeed(
-        f"python3 -c {shlex.quote(rpc_script)} {shlex.quote(login_obj['token'])}"
+        f"${pythonWithWs}/bin/python3 ${rpcSmoke} {shlex.quote(login_obj['token'])}"
     )
   '';
 }

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -17,53 +17,77 @@ let
   rpcSmoke = pkgs.writeText "rpc-smoke.py" ''
     import json
     import sys
+    import urllib.request
     import websocket
 
-    token = sys.argv[1]
+    initial_token = sys.argv[1]
+    NEW_PW = "password-changed-by-smoke-test"
 
-    ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=10)
-    try:
+
+    def ws_auth(token):
+        ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=10)
         ws.send(json.dumps({"token": token}))
         auth = json.loads(ws.recv())
         assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
         assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
+        return ws
 
-        def call(method, request_id, params=None):
-            req = {"jsonrpc": "2.0", "method": method, "id": request_id}
-            if params is not None:
-                req["params"] = params
-            ws.send(json.dumps(req))
-            resp = json.loads(ws.recv())
-            assert resp.get("id") == request_id, (
-                f"id mismatch: req={request_id} resp={resp!r}"
-            )
-            assert "error" not in resp, f"{method} returned error: {resp!r}"
-            return resp["result"]
 
-        me = call("auth.me", 1)
+    def call(ws, method, request_id, params=None):
+        req = {"jsonrpc": "2.0", "method": method, "id": request_id}
+        if params is not None:
+            req["params"] = params
+        ws.send(json.dumps(req))
+        resp = json.loads(ws.recv())
+        assert resp.get("id") == request_id, (
+            f"id mismatch: req={request_id} resp={resp!r}"
+        )
+        assert "error" not in resp, f"{method} returned error: {resp!r}"
+        return resp["result"]
+
+
+    def http_login(password):
+        req = urllib.request.Request(
+            "http://127.0.0.1:2137/api/login",
+            data=json.dumps({"username": "admin", "password": password}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())["token"]
+
+
+    # ── Session 1: change the default admin password ──────────────
+    # Default admin/admin has must_change_password set, which gates
+    # most RPC methods. Change it, then re-login so subsequent calls
+    # hit a session that doesn't carry the gate.
+    ws = ws_auth(initial_token)
+    try:
+        me = call(ws, "auth.me", 1)
         assert me["username"] == "admin", f"auth.me wrong: {me!r}"
-
-        # First login of the default admin/admin sets must_change_password,
-        # which gates most RPC methods until cleared. Change it so the rest
-        # of the smoke can call system.health / fs.list.
-        call("auth.change_password", 2, {
+        call(ws, "auth.change_password", 2, {
             "username": "admin",
-            "new_password": "password-changed-by-smoke-test",
+            "new_password": NEW_PW,
         })
+    finally:
+        ws.close()
 
-        health = call("system.health", 3)
+    # ── Session 2: drive a few representative RPCs ────────────────
+    new_token = http_login(NEW_PW)
+    ws = ws_auth(new_token)
+    try:
+        health = call(ws, "system.health", 1)
         print("system.health:", health, file=sys.stderr)
 
-        fs_list = call("fs.list", 4)
+        fs_list = call(ws, "fs.list", 2)
         assert isinstance(fs_list, list), f"fs.list not a list: {fs_list!r}"
         # Fresh appliance with no virtual disks => empty list.
         assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
 
-        # Unknown method must come back as a JSON-RPC error envelope, not a
-        # silent drop.
-        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 5}))
+        # Unknown method must come back as a JSON-RPC error envelope,
+        # not a silent drop.
+        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 3}))
         bad = json.loads(ws.recv())
-        assert bad.get("id") == 5, f"id mismatch: {bad!r}"
+        assert bad.get("id") == 3, f"id mismatch: {bad!r}"
         assert bad.get("error"), f"unknown method should error: {bad!r}"
         print("unknown method error:", bad["error"], file=sys.stderr)
     finally:


### PR DESCRIPTION
## Summary
Extends the appliance integration test from #35 with a WebSocket leg that exercises the engine's JSON-RPC dispatch end-to-end — the part of `router.rs` (3151 lines) the unit tests deliberately skip because it would need stubbed `AppState` plumbing. Now `router.rs` has real coverage without any refactor.

**Adds:**
- `python3Packages.websocket-client` via `extraPythonPackages` so the testScript can speak WebSocket
- A small inline Python script that:
  - Opens `ws://127.0.0.1:2137/ws` and authenticates with the token from `/api/login`
  - Calls `auth.me` and asserts `username == admin`
  - Calls `system.health` and logs the result
  - Calls `fs.list` and asserts the empty list (no virtual disks attached to the test VM)
  - Sends a bogus method name and asserts a JSON-RPC error envelope comes back with the right `id` — exercises the unknown-method path

**Token handling:** passed via `sys.argv` with `shlex.quote` so a session ID containing shell-special chars can't break the command line.

## Why this is useful
Together with #29 (engine-side JSON-RPC framing) and #32 (WebUI-side WebSocket client), this PR closes the loop:
- `Response::success` / `Response::error` envelope shape ✅ #29
- `NastyClient` request/response correlation, reconnect, etc. ✅ #32
- `router.rs` actually dispatches methods correctly and produces the right envelope shape on a real engine ✅ this PR

Future PRs can extend with more methods (e.g. attach a virtual disk and exercise `fs.create` / `subvolume.create`) without re-inventing the harness.

## Test plan
- [ ] Integration workflow goes green on this PR
- [ ] WS auth handshake completes
- [ ] `auth.me`, `system.health`, `fs.list` all return well-formed responses
- [ ] Unknown method comes back as a JSON-RPC error envelope (not a connection drop)