### PR TITLE
flake: refresh stale npmDepsHash + add CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,35 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  npm-deps-hash:
+    # Verifies the npmDepsHash hardcoded in flake.nix matches the current
+    # webui/package-lock.json. Without this gate, adding an npm dep silently
+    # breaks every NASty appliance pulling main: CI jobs that build the
+    # webui auto-recompute the hash before building (see build-iso.yml,
+    # cache.yml), but end users build with the value committed in flake.nix.
+    name: npmDepsHash freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify hash
+        run: |
+          EXPECTED=$(nix run nixpkgs#prefetch-npm-deps -- webui/package-lock.json 2>/dev/null)
+          ACTUAL=$(grep -oE 'npmDepsHash = "[^"]*"' flake.nix | sed 's/.*"\(.*\)"/\1/')
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::npmDepsHash in flake.nix is stale"
+            echo "  expected: $EXPECTED"
+            echo "  in tree:  $ACTUAL"
+            echo
+            echo "Run:"
+            echo "  nix run nixpkgs#prefetch-npm-deps -- webui/package-lock.json"
+            echo "and replace the npmDepsHash value in flake.nix."
+            exit 1
+          fi
+          echo "npmDepsHash matches package-lock.json: $ACTUAL"

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-zfP1VnpsfF9Nvb/JapjndyqJIQ5/cAuZDl++W3CE2RE=";
+      npmDepsHash = "sha256-vUJYh4udXDfKZ9ZFCfsIjWpG6qg26C9TxV+wB+emp/M=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare


### PR DESCRIPTION
## Summary
**Fixes a real regression** I introduced: every NASty appliance pulling `main` since #31 fails to update with `npmDepsHash is out of date` when Nix tries to fetch the webui's npm dependencies.

PR #31 added vitest as a dev dependency, which changed `webui/package-lock.json`. The `npmDepsHash` hardcoded in `flake.nix` wasn't updated to match. CI was green because both `build-iso.yml` and `cache.yml` run `prefetch-npm-deps` to recompute the hash *before* building — but end users building from source use the value committed in `flake.nix`, so they hit the mismatch.

## Changes
- **`flake.nix`**: `npmDepsHash` updated from `sha256-zfP1Vnp...` to `sha256-vUJYh4u...` (matches current `package-lock.json`)
- **`.github/workflows/ci.yml`**: new `npm-deps-hash` job that installs Nix, runs `prefetch-npm-deps webui/package-lock.json`, and fails the PR if the result differs from what's in `flake.nix`. Cheap gate (~30 s) that catches this class of regression at PR time

## Apology
This was on me — I noted in the #31 PR body that "Nix builds auto-recompute npmDepsHash from `package-lock.json`" and concluded "no manual hash update needed". That was wrong: the auto-recompute only happens in CI, not in end-user builds. Should have updated the in-tree hash whenever the lock file changed, or added the CI gate at the time. The gate this PR adds prevents a repeat.

## Test plan
- [ ] CI job `npm-deps-hash` goes green (proves the new value matches)
- [ ] Engine and webui jobs still green
- [ ] After merge: `nix build .#nixosConfigurations.nasty.config.system.build.toplevel` from a NASty appliance succeeds (the user's failing flow)