### PR TITLE
flake: bump nixpkgs (kernel 6.18.24 → 6.18.26)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps the pinned nixpkgs from 2026-04-27 (`1c3fe55a`) to 2026-05-05 (`549bd84d`) — about 8 days newer. Brings the kernel from `linux-6.18.24` to `6.18.26` so CI (and the appliance-smoke nixosTest) runs against the same kernel users running `nix flake update` already have on their live appliances.

**Single-file diff**: `flake.lock` only. `npmDepsHash` is content-addressable from `package-lock.json` (verified by re-running `prefetch-npm-deps` — same hash) so `flake.nix` doesn't need a follow-up.

## Test plan
- [ ] CI engine + webui jobs go green on the newer nixpkgs
- [ ] `npm-deps-hash` job (added in #37) confirms hash is still in sync
- [ ] Integration workflow runs both nixosTests against 6.18.26 and stays green
- [ ] After merge: bcachefs DKMS module still builds against the new kernel headers (the integration smoke covers this transitively)

## Note
Fairly small bump — could become a recurring "weekly nixpkgs refresh" PR if you want tests to track upstream more tightly. Otherwise treat as one-off.