### PR TITLE
network: add bridge interfaces (closes #27)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - '.github/workflows/integration.yml'
       - 'nixos/tests/**'
-      - 'nixos/modules/bcachefs.nix'
+      - 'nixos/modules/**'
       - 'flake.nix'
       - 'flake.lock'
 

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -95,6 +95,21 @@ pub struct VlanConfig {
     pub ipv6: IpConfig,
 }
 
+/// A Linux bridge (e.g. `br0`) used as a virtual switch — typically for VMs
+/// to share the host's network. Members can be empty (a host-internal bridge
+/// that VMs attach to via veth pairs at runtime) or one or more physical /
+/// bond interfaces (bridge to the LAN).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BridgeConfig {
+    pub name: String,
+    #[serde(default)]
+    pub members: Vec<String>,
+    #[serde(default)]
+    pub ipv4: IpConfig,
+    #[serde(default)]
+    pub ipv6: IpConfig,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct NetworkConfig {
     #[serde(default)]
@@ -105,6 +120,8 @@ pub struct NetworkConfig {
     pub bonds: Vec<BondConfig>,
     #[serde(default)]
     pub vlans: Vec<VlanConfig>,
+    #[serde(default)]
+    pub bridges: Vec<BridgeConfig>,
 }
 
 /// Live interface state — read-only, populated at query time.
@@ -170,6 +187,13 @@ impl NetworkService {
             validate_ip_config(&vlan.ipv4, "IPv4")?;
             validate_ip_config(&vlan.ipv6, "IPv6")?;
         }
+        for bridge in &config.bridges {
+            if bridge.name.is_empty() {
+                return Err("Bridge name is required".to_string());
+            }
+            validate_ip_config(&bridge.ipv4, "IPv4")?;
+            validate_ip_config(&bridge.ipv6, "IPv6")?;
+        }
 
         // Persist JSON
         let json = serde_json::to_string_pretty(&config)
@@ -188,9 +212,10 @@ impl NetworkService {
         apply_config(&config).await?;
 
         info!(
-            "Network config updated ({} interfaces, {} bonds, {} VLANs)",
+            "Network config updated ({} interfaces, {} bonds, {} bridges, {} VLANs)",
             config.interfaces.len(),
             config.bonds.len(),
+            config.bridges.len(),
             config.vlans.len()
         );
         Ok(())
@@ -363,6 +388,26 @@ async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
         apply_ip_config(&bond.name, &bond.ipv6, true).await?;
     }
 
+    // Apply bridges (after bonds so bonds can be members; before VLANs so
+    // VLANs can sit on top of a bridge).
+    for bridge in &config.bridges {
+        if !std::path::Path::new(&format!("/sys/class/net/{}", bridge.name)).exists() {
+            run_ip(&["link", "add", &bridge.name, "type", "bridge"])
+                .await
+                .map_err(|e| format!("create bridge {}: {e}", bridge.name))?;
+        }
+        for member in &bridge.members {
+            let _ = run_ip(&["link", "set", member, "down"]).await;
+            let _ = run_ip(&["link", "set", member, "master", &bridge.name]).await;
+            let _ = run_ip(&["link", "set", member, "up"]).await;
+        }
+        run_ip(&["link", "set", &bridge.name, "up"])
+            .await
+            .map_err(|e| format!("bring up bridge {}: {e}", bridge.name))?;
+        apply_ip_config(&bridge.name, &bridge.ipv4, false).await?;
+        apply_ip_config(&bridge.name, &bridge.ipv6, true).await?;
+    }
+
     // Apply VLANs
     for vlan in &config.vlans {
         let vlan_name = format!("{}.{}", vlan.parent, vlan.vlan_id);
@@ -513,6 +558,17 @@ fn generate_nix(config: &NetworkConfig) -> String {
             bond.name, members.join(" "), bond.mode.to_nix()
         ));
         generate_iface_nix(&mut out, &bond.name, &bond.ipv4, &bond.ipv6, None);
+    }
+
+    // Bridges
+    for bridge in &config.bridges {
+        let members: Vec<String> = bridge.members.iter().map(|m| format!("\"{m}\"")).collect();
+        out.push_str(&format!(
+            "  networking.bridges.{} = {{ interfaces = [ {} ]; }};\n",
+            bridge.name,
+            members.join(" ")
+        ));
+        generate_iface_nix(&mut out, &bridge.name, &bridge.ipv4, &bridge.ipv6, None);
     }
 
     // VLANs

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -898,9 +898,12 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
         match net.mode.as_str() {
             "bridge" => {
                 let br = net.bridge.as_deref().unwrap_or("br0");
+                // QEMU's default helper path is the package's libexec, which
+                // doesn't have CAP_NET_ADMIN. Point at the NixOS wrapper that
+                // does (configured in nasty.nix: security.wrappers.qemu-bridge-helper).
                 args.extend_from_slice(&[
                     "-netdev".to_string(),
-                    format!("bridge,id=net{i},br={br}"),
+                    format!("bridge,id=net{i},br={br},helper=/run/wrappers/bin/qemu-bridge-helper"),
                     "-device".to_string(),
                     format!("virtio-net-pci,netdev=net{i}{mac_opt}"),
                 ]);

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -222,6 +222,22 @@ in {
     environment.etc."nasty/ovmf/OVMF_CODE.fd".source = "${pkgs.OVMF.fd}/FV/OVMF_CODE.fd";
     environment.etc."nasty/ovmf/OVMF_VARS.fd".source = "${pkgs.OVMF.fd}/FV/OVMF_VARS.fd";
 
+    # qemu-bridge-helper attaches a VM's tap to a bridge (e.g. br0) — needs
+    # CAP_NET_ADMIN, which NixOS does not give it by default. Without this
+    # wrapper, `qemu-system-* -netdev bridge,br=...` fails for VMs configured
+    # in bridge mode. The allow-list is `allow all` because the only user
+    # that ever invokes the helper on a NASty appliance is nasty-engine
+    # itself (running as root via the systemd unit) — so a static config
+    # avoids having the engine rewrite /etc/qemu/bridge.conf on every
+    # bridge change in the WebUI.
+    security.wrappers.qemu-bridge-helper = {
+      source = "${pkgs.qemu}/libexec/qemu-bridge-helper";
+      capabilities = "cap_net_admin+ep";
+      owner = "root";
+      group = "root";
+    };
+    environment.etc."qemu/bridge.conf".text = "allow all\n";
+
     # Keep a generation-owned copy of the managed wrapper flake in /etc so the
     # exact flake used to build the active generation is readable from
     # /run/current-system/etc/nasty-system-flake and can be restored on boot.

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -511,11 +511,19 @@ export interface VlanConfig {
 	ipv6: IpConfig;
 }
 
+export interface BridgeConfig {
+	name: string;
+	members: string[];
+	ipv4: IpConfig;
+	ipv6: IpConfig;
+}
+
 export interface NetworkConfig {
 	interfaces: InterfaceConfig[];
 	dns: string[];
 	bonds: BondConfig[];
 	vlans: VlanConfig[];
+	bridges: BridgeConfig[];
 }
 
 export interface LiveInterface {

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -46,6 +46,10 @@
 	let showVlanForm = $state(false);
 	let vlanParent = $state('');
 	let vlanId = $state(100);
+	// Bridge form
+	let showBridgeForm = $state(false);
+	let bridgeName = $state('br0');
+	let bridgeMembers: string[] = $state([]);
 	// ── General tab state ───────────────────────────────────
 	let settings: Settings | null = $state(null);
 	let info: SystemInfo | null = $state(null);
@@ -271,6 +275,7 @@
 			dns: nameservers,
 			bonds: network?.bonds ?? [],
 			vlans: network?.vlans ?? [],
+			bridges: network?.bridges ?? [],
 		};
 
 		await withToast(
@@ -366,7 +371,7 @@
 		const entry = { name: selectedIface, enabled: true, ipv4, ipv6, mtu: null };
 		if (idx >= 0) ifaces[idx] = entry; else ifaces.push(entry);
 
-		const payload = { interfaces: ifaces, dns: nameservers, bonds: network.bonds || [], vlans: network.vlans || [] };
+		const payload = { interfaces: ifaces, dns: nameservers, bonds: network.bonds || [], vlans: network.vlans || [], bridges: network.bridges || [] };
 		await withToast(() => client.call('system.network.update', payload), 'Network configuration applied');
 		networkState = await client.call<NetworkState>('system.network.get');
 		netChanged = false;
@@ -380,6 +385,7 @@
 			dns: network.dns || [],
 			bonds: [...(network.bonds || []), { name: bondName, members: bondMembers, mode: bondMode, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null } }],
 			vlans: network.vlans || [],
+			bridges: network.bridges || [],
 		};
 		await withToast(() => client.call('system.network.update', payload), `Bond ${bondName} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
@@ -393,10 +399,25 @@
 			dns: network.dns || [],
 			bonds: network.bonds || [],
 			vlans: [...(network.vlans || []), { parent: vlanParent, vlan_id: vlanId, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null } }],
+			bridges: network.bridges || [],
 		};
 		await withToast(() => client.call('system.network.update', payload), `VLAN ${vlanParent}.${vlanId} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
 		showVlanForm = false; vlanParent = ''; vlanId = 100;
+	}
+
+	async function createBridge() {
+		if (!bridgeName || !network) return;
+		const payload = {
+			interfaces: network.interfaces || [],
+			dns: network.dns || [],
+			bonds: network.bonds || [],
+			vlans: network.vlans || [],
+			bridges: [...(network.bridges || []), { name: bridgeName, members: bridgeMembers, ipv4: { method: 'dhcp' as const, addresses: [], gateway: null }, ipv6: { method: 'slaac' as const, addresses: [], gateway: null } }],
+		};
+		await withToast(() => client.call('system.network.update', payload), `Bridge ${bridgeName} created`);
+		networkState = await client.call<NetworkState>('system.network.get');
+		showBridgeForm = false; bridgeName = 'br0'; bridgeMembers = [];
 	}
 
 	async function loadNotifications() {
@@ -825,12 +846,13 @@
 			{/if}
 		</section>
 
-		<!-- Bond / VLAN creation -->
+		<!-- Bond / Bridge / VLAN creation -->
 		<section class="rounded-lg border border-border p-5">
 			<div class="flex items-center gap-3 mb-4">
 				<h2 class="text-base font-semibold">Advanced</h2>
-				<Button size="xs" variant="secondary" onclick={() => { showBondForm = !showBondForm; showVlanForm = false; }}>{showBondForm ? 'Cancel' : '+ Bond'}</Button>
-				<Button size="xs" variant="secondary" onclick={() => { showVlanForm = !showVlanForm; showBondForm = false; }}>{showVlanForm ? 'Cancel' : '+ VLAN'}</Button>
+				<Button size="xs" variant="secondary" onclick={() => { showBondForm = !showBondForm; showVlanForm = false; showBridgeForm = false; }}>{showBondForm ? 'Cancel' : '+ Bond'}</Button>
+				<Button size="xs" variant="secondary" onclick={() => { showBridgeForm = !showBridgeForm; showBondForm = false; showVlanForm = false; }}>{showBridgeForm ? 'Cancel' : '+ Bridge'}</Button>
+				<Button size="xs" variant="secondary" onclick={() => { showVlanForm = !showVlanForm; showBondForm = false; showBridgeForm = false; }}>{showVlanForm ? 'Cancel' : '+ VLAN'}</Button>
 			</div>
 
 			{#if showBondForm}
@@ -870,6 +892,32 @@
 				</div>
 			{/if}
 
+			{#if showBridgeForm}
+				<div class="rounded-lg border border-border bg-secondary/20 p-4 space-y-3">
+					<div class="text-sm font-medium">Create Bridge Interface</div>
+					<p class="text-xs text-muted-foreground">A virtual switch for VMs to share the host's network. Members are optional — leave empty for a host-internal bridge that VMs attach to via veth pairs, or add a physical interface to bridge VMs onto the LAN.</p>
+					<div>
+						<label for="bridge-name" class="text-xs text-muted-foreground">Name</label>
+						<input id="bridge-name" bind:value={bridgeName} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
+					</div>
+					<div>
+						<div class="text-xs text-muted-foreground mb-1">Members (optional)</div>
+						{#if networkState}
+							<div class="flex flex-wrap gap-2">
+								{#each networkState.interfaces.filter(i => i.kind === 'physical' || i.kind === 'bond') as iface}
+									<label class="flex items-center gap-1.5 text-sm">
+										<input type="checkbox" checked={bridgeMembers.includes(iface.name)}
+											onchange={() => { bridgeMembers = bridgeMembers.includes(iface.name) ? bridgeMembers.filter(m => m !== iface.name) : [...bridgeMembers, iface.name]; }} />
+										{iface.name}
+									</label>
+								{/each}
+							</div>
+						{/if}
+					</div>
+					<Button size="sm" onclick={createBridge} disabled={!bridgeName}>Create Bridge</Button>
+				</div>
+			{/if}
+
 			{#if showVlanForm}
 				<div class="rounded-lg border border-border bg-secondary/20 p-4 space-y-3">
 					<div class="text-sm font-medium">Create VLAN Interface</div>
@@ -895,14 +943,21 @@
 				</div>
 			{/if}
 
-			{#if !showBondForm && !showVlanForm}
-				{#if network && (network.bonds?.length > 0 || network.vlans?.length > 0)}
+			{#if !showBondForm && !showBridgeForm && !showVlanForm}
+				{#if network && (network.bonds?.length > 0 || network.bridges?.length > 0 || network.vlans?.length > 0)}
 					<div class="space-y-1 text-sm">
 						{#each network.bonds as bond}
 							<div class="flex items-center gap-2 rounded px-2 py-1">
 								<Badge variant="outline" class="text-[0.6rem]">bond</Badge>
 								<span class="font-mono">{bond.name}</span>
 								<span class="text-xs text-muted-foreground">{bond.mode} · {bond.members.join(', ')}</span>
+							</div>
+						{/each}
+						{#each network.bridges ?? [] as bridge}
+							<div class="flex items-center gap-2 rounded px-2 py-1">
+								<Badge variant="outline" class="text-[0.6rem]">bridge</Badge>
+								<span class="font-mono">{bridge.name}</span>
+								<span class="text-xs text-muted-foreground">{bridge.members.length === 0 ? 'no members' : bridge.members.join(', ')}</span>
 							</div>
 						{/each}
 						{#each network.vlans as vlan}
@@ -913,7 +968,7 @@
 						{/each}
 					</div>
 				{:else}
-					<p class="text-xs text-muted-foreground">No bonds or VLANs configured.</p>
+					<p class="text-xs text-muted-foreground">No bonds, bridges, or VLANs configured.</p>
 				{/if}
 			{/if}
 		</section>


### PR DESCRIPTION
## Summary
Closes #27. Adds first-class support for Linux bridges in the network model — and fixes the latent issue that even **with** a bridge, VMs in bridge mode were unable to attach.

## Two pieces

**(a) Create / manage bridges from the WebUI**
- `BridgeConfig` in `nasty-system::network` (`name`, optional `members`, `ipv4`, `ipv6`) mirroring `BondConfig`
- `NetworkConfig.bridges` with `#[serde(default)]` so existing `/var/lib/nasty/networking.json` files stay valid
- `update()` validates bridges and applies them **after bonds** (so bonds can be enslaved) and **before VLANs** (so VLANs can sit on top of a bridge)
- NixOS generation emits `networking.bridges.<name> = { interfaces = [ ... ]; };`
- Settings → Network → Advanced gains a `+ Bridge` button mirroring the bond/VLAN forms. Members are optional — leave empty for a host-internal vSwitch that VMs attach to via veth pairs, or pick a physical/bond interface to bridge VMs onto the LAN

**(b) Make VM bridge attachment actually work**
Today, `mode: "bridge"` on a VM literally cannot work because:
1. `qemu-bridge-helper` needs `CAP_NET_ADMIN` to attach a tap to a bridge — NixOS doesn't grant that by default
2. `qemu-bridge-helper` consults `/etc/qemu/bridge.conf` for an allow-list — that file doesn't exist either

Fixes:
- `nasty.nix`: `security.wrappers.qemu-bridge-helper` with `cap_net_admin+ep`, plus `environment.etc."qemu/bridge.conf".text = "allow all\n"`. The static `allow all` is fine because the only user that ever invokes the helper on a NASty appliance is `nasty-engine` (running as root via the systemd unit) — saves having the engine rewrite `/etc/qemu/bridge.conf` on every bridge change in the WebUI
- `nasty-vm`: `-netdev bridge,...,helper=/run/wrappers/bin/qemu-bridge-helper` so QEMU finds the wrapped binary instead of its package's libexec copy

VMs already accept any bridge name via `VmNetwork.bridge` (defaulting to `"br0"`), so once a bridge exists in the network config, existing VM configs work unchanged.

## Test plan
- [ ] Engine + WebUI CI green (no clippy/fmt drift, svelte-check 0/0)
- [ ] Integration smoke still green on the new nasty.nix
- [ ] On a real appliance: create `br0` from Settings → Network → + Bridge with no members → matches the host-internal vSwitch case
- [ ] Create a VM with `mode: "bridge"`, `bridge: "br0"` → VM successfully attaches its tap to br0 (was previously a runtime failure)
- [ ] Delete bridge from JSON / restart → `ip link show br0` gone, VMs in bridge mode fail loudly (expected)

## Notes
- `allow all` in `/etc/qemu/bridge.conf` is a static `nasty.nix` choice. If you'd rather have the engine generate the allow-list from configured bridges, that's a small follow-up — happy to swap if preferred
- Bridge ordering of apply: `bonds → bridges → vlans → interfaces` so each layer can reference the previous (a bridge can include a bond; a VLAN can sit on a bridge)