### PR TITLE
webui: make Apps internal port editable + surface inspect failures

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -233,6 +233,9 @@
 	let composeAllowUnsafe = $state(false);
 	let inspecting = $state(false);
 	let lastInspectedImage = '';
+	/** Inline status from the last apps.inspect_image call so the user sees
+	 *  why ports weren't auto-detected (image unreachable, no EXPOSE, etc.). */
+	let inspectMsg: string | null = $state(null);
 
 	// Port conflict state
 	let portConflicts = $state<{ port: number; used_by: string }[]>([]);
@@ -254,6 +257,7 @@
 		if (!image || image === lastInspectedImage) return;
 		lastInspectedImage = image;
 		inspecting = true;
+		inspectMsg = null;
 		try {
 			const result = await client.call<ImageInspectResult>('apps.inspect_image', { image });
 			if (result.ports.length > 0) {
@@ -263,9 +267,16 @@
 					host_port: '',
 					protocol: p.protocol,
 				}));
+			} else {
+				// Image declares no EXPOSE — let the user know they need to
+				// set the internal port manually below.
+				inspectMsg = 'Image declares no exposed ports — set the internal port manually.';
 			}
-		} catch {
-			// Inspection failed — keep whatever ports the user has
+		} catch (e) {
+			// Registry unreachable / image not found / private without auth.
+			// Surface inline so the user knows to fall back to manual entry.
+			const msg = e instanceof Error ? e.message : typeof e === 'object' && e !== null && 'message' in e ? String((e as { message: unknown }).message) : String(e);
+			inspectMsg = `Could not inspect image (${msg}) — set ports manually.`;
 		}
 		inspecting = false;
 		checkPortConflicts();
@@ -855,6 +866,8 @@
 					<Input id="app-image" bind:value={newImage} placeholder="traefik/whoami:latest" class="mt-1" onblur={inspectImage} />
 					{#if inspecting}
 						<span class="mt-1 block text-xs text-muted-foreground">Detecting exposed ports...</span>
+					{:else if inspectMsg}
+						<span class="mt-1 block text-xs text-amber-500">{inspectMsg}</span>
 					{/if}
 				</div>
 
@@ -877,7 +890,7 @@
 						{@const hasConflict = portConflicts.some(c => c.port === (parseInt(port.host_port) || port.container_port))}
 						<div class="grid grid-cols-[1fr_80px_90px_60px_auto] gap-2 mt-1 items-center">
 							<Input bind:value={port.name} placeholder="e.g. http" class="h-8 text-xs" />
-							<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 text-xs" disabled />
+							<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 text-xs" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 							<Input bind:value={port.host_port} placeholder={String(port.container_port)} class="h-8 text-xs {hasConflict ? 'border-amber-500 ring-1 ring-amber-500/50' : ''}" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 							<select bind:value={port.protocol} class="h-8 rounded-md border border-input bg-transparent px-1 text-xs">
 								<option>TCP</option>


### PR DESCRIPTION
## Summary
Closes #19. Two related fixes to the Install / Edit App form on the Apps page.

**1. The Internal port input was hard-disabled.**

Auto-detection from the image's `EXPOSE` works for many images but not all — private registries, no `EXPOSE` declared, registry unreachable, or simply images where the user wants a different internal port for some reason. The user reported this against `jellyfin/jellyfin` (which listens on 8096): even when they typed the right exposed port, the internal stayed stuck at the default 80.

Fix: drop `disabled` on the container_port input and wire `checkPortConflicts` to its `oninput` so editing it re-runs conflict detection like the host port does.

**2. `apps.inspect_image` failures were swallowed silently.**

The form started with a default `container_port: 80`, called inspect on `onblur` of the image field, and on any failure quietly fell back to that default. Users with a problematic image saw "80" appear and had no clue why auto-detection didn't fire.

Fix: track an `inspectMsg` state and surface it inline under the image input:
- `Image declares no exposed ports — set the internal port manually.` when inspect succeeded with an empty ports list
- `Could not inspect image (<error>) — set ports manually.` when the RPC itself failed

The message is amber (warning, not error) and clears as soon as the next inspect runs.

## Test plan
- [ ] Engine + WebUI CI green (svelte-check 0/0, vitest 60 tests still pass)
- [ ] On a real appliance: install a Jellyfin app, verify Internal port can be typed manually and Exposed maps onto it correctly
- [ ] Type a bogus image like `does-not-exist:latest` and confirm the amber inline message appears
- [ ] Type an image with no `EXPOSE` (e.g. some `alpine` tag) and confirm the "no exposed ports" message