### PR TITLE
protocol: persist fresh-install state so VM detect doesn't loop

### DIFF
--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -470,10 +470,17 @@ async fn load_state() -> ProtocolState {
         Err(_) => {
             // Fresh install: disable SMART by default on VMs since smartd
             // cannot find SMART-capable drives in virtual environments.
+            // Persist immediately — this function is called on every
+            // protocol-status refresh, so without persistence the file
+            // never appears, and the VM detection (plus its info!) runs
+            // forever every minute.
             let mut state = ProtocolState::default();
             if is_virtual_machine().await {
                 info!("Virtual machine detected — disabling SMART by default");
                 state.smart = false;
+            }
+            if let Err(e) = save_state(&state).await {
+                warn!("Failed to persist initial protocol state: {e}");
             }
             state
         }


### PR DESCRIPTION
## What you're seeing
\`\`\`
nasty-engine[207065]: Virtual machine detected — disabling SMART by default
nasty-engine[247116]: kvm
nasty-engine[247158]: kvm   (a minute later)
nasty-engine[247200]: kvm   (and so on)
\`\`\`

## Why
\`load_state()\` in \`nasty-system::protocol\` looks up \`/var/lib/nasty/protocols.json\`. When the file is missing, it computes "fresh install" defaults — and as part of that runs \`systemd-detect-virt --vm\` to decide whether to disable SMART by default on VMs:

\`\`\`rust
Err(_) => {
    let mut state = ProtocolState::default();
    if is_virtual_machine().await {
        info!("Virtual machine detected — disabling SMART by default");
        state.smart = false;
    }
    state   // ← never persisted!
}
\`\`\`

The function returns those defaults but **doesn't save them**. So on a fresh appliance where the user hasn't toggled any protocol yet, every subsequent call to \`load_state()\` (driven by the WebUI's per-minute status refresh via \`ProtocolService::list()\`) finds the file still missing and re-runs the whole song and dance:
- spawns \`systemd-detect-virt\` (the bare \`kvm\` log lines are its stdout — it prints the virt name in addition to its exit code)
- re-logs \`Virtual machine detected — disabling SMART by default\`
- returns the same defaults

## Fix
Persist immediately after computing the defaults, so the file exists on the next call and the Ok branch wins. One-liner-ish change in \`load_state()\`:

\`\`\`rust
if let Err(e) = save_state(&state).await {
    warn!("Failed to persist initial protocol state: {e}");
}
\`\`\`

Also adds the explanation in a code comment so the next person who looks at this knows why the persist is load-bearing.

## Test plan
- [ ] Engine CI green
- [ ] On a real fresh appliance: rm \`/var/lib/nasty/protocols.json\`, restart engine, watch logs — VM detect log appears **once** (during \`load_state()\`'s first miss), file appears, no further \`kvm\` / "Virtual machine detected" lines on subsequent status refreshes