### PR TITLE
filesystems: show drive model/serial/vendor/transport in create wizard

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1275,9 +1275,15 @@ impl FilesystemService {
             .flat_map(|f| f.devices.iter().map(|d| d.path.clone()))
             .collect();
 
-        let output = cmd::run_ok("lsblk", &["-Jbno", "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,ROTA"])
-            .await
-            .map_err(FilesystemError::CommandFailed)?;
+        let output = cmd::run_ok(
+            "lsblk",
+            &[
+                "-Jbno",
+                "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,ROTA,MODEL,SERIAL,VENDOR,TRAN",
+            ],
+        )
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
 
         let parsed: serde_json::Value =
             serde_json::from_str(&output).unwrap_or(serde_json::Value::Null);
@@ -1344,6 +1350,21 @@ impl FilesystemService {
                         .unwrap_or(false);
                     let (rotational, device_class) = classify(name, rota);
 
+                    // lsblk surfaces these only on whole disks; on partitions
+                    // they're empty/null. Treat empty-after-trim as None so
+                    // the WebUI can hide the field entirely instead of
+                    // rendering blanks.
+                    let pick = |key: &str| -> Option<String> {
+                        dev.get(key)
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                    };
+                    let model = pick("model");
+                    let serial = pick("serial");
+                    let vendor = pick("vendor");
+                    let transport = pick("tran");
+
                     if dev_type == "disk" || dev_type == "part" {
                         let path = format!("/dev/{name}");
                         let in_fs = fs_devices.contains(&path);
@@ -1357,6 +1378,10 @@ impl FilesystemService {
                             in_use: in_fs || actually_mounted,
                             rotational,
                             device_class,
+                            model,
+                            serial,
+                            vendor,
+                            transport,
                         });
                     }
 
@@ -1418,9 +1443,18 @@ impl FilesystemService {
                     info!("Free space on {disk_path}: {free_bytes} bytes");
                     if free_bytes >= MIN_FREE_BYTES {
                         let disk = devices.iter().find(|d| &d.path == disk_path);
-                        let (rotational, device_class) = disk
-                            .map(|d| (d.rotational, d.device_class.clone()))
-                            .unwrap_or((false, "ssd".to_string()));
+                        let (rotational, device_class, model, serial, vendor, transport) = disk
+                            .map(|d| {
+                                (
+                                    d.rotational,
+                                    d.device_class.clone(),
+                                    d.model.clone(),
+                                    d.serial.clone(),
+                                    d.vendor.clone(),
+                                    d.transport.clone(),
+                                )
+                            })
+                            .unwrap_or((false, "ssd".to_string(), None, None, None, None));
                         devices.push(BlockDevice {
                             path: format!("{disk_path}:free"),
                             size_bytes: free_bytes,
@@ -1430,6 +1464,10 @@ impl FilesystemService {
                             in_use: false,
                             rotational,
                             device_class,
+                            model,
+                            serial,
+                            vendor,
+                            transport,
                         });
                     }
                 }
@@ -2089,6 +2127,19 @@ pub struct BlockDevice {
     pub rotational: bool,
     /// Device speed class: "nvme", "ssd", or "hdd".
     pub device_class: String,
+    /// Drive model from lsblk (e.g. "Samsung SSD 970 EVO Plus 1TB"). None
+    /// for partitions and for virtual disks that don't expose a model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Drive serial from lsblk. None for partitions and virtual disks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial: Option<String>,
+    /// Drive vendor from lsblk (e.g. "ATA", "NVMe").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
+    /// Transport bus from lsblk (e.g. "sata", "nvme", "usb").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
 }
 
 /// Get the largest contiguous free space on a partitioned disk using sgdisk.

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -119,6 +119,14 @@ export interface BlockDevice {
 	rotational: boolean;
 	/** "nvme" | "ssd" | "hdd" */
 	device_class: string;
+	/** Drive model from lsblk; missing on partitions and many virtual disks. */
+	model?: string;
+	/** Drive serial from lsblk; same caveat. */
+	serial?: string;
+	/** Drive vendor from lsblk (e.g. "ATA", "NVMe"). */
+	vendor?: string;
+	/** Transport bus from lsblk (e.g. "sata", "nvme", "usb"). */
+	transport?: string;
 }
 
 export type TieringProfileId = 'single' | 'write_cache' | 'full_tiering' | 'none' | 'manual';

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -743,14 +743,24 @@
 									{@const diskPath = dev.path.replace(':free', '')}
 									{@const existingParts = devices.filter(d => d.dev_type === 'part' && d.path.startsWith(diskPath))}
 									<div class="rounded-lg border border-border overflow-hidden">
-										<label class="flex cursor-pointer items-center gap-3 px-3 py-2 text-sm
+										<label class="flex cursor-pointer flex-col gap-1 px-3 py-2 text-sm
 											{selectedPaths.includes(dev.path) ? 'border-primary bg-primary/5' : 'hover:bg-secondary/50'}">
-											<input type="checkbox" checked={selectedPaths.includes(dev.path)}
-												onchange={() => toggleDevice(dev.path)} class="h-4 w-4 shrink-0" />
-											<span class="font-mono text-xs shrink-0">{diskPath}</span>
-											<span class="rounded bg-green-900 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-green-300">free space</span>
-											<span class="text-muted-foreground">{formatBytes(dev.size_bytes)}</span>
-											<span class="text-xs text-muted-foreground">(new partition will be created)</span>
+											<div class="flex items-center gap-3">
+												<input type="checkbox" checked={selectedPaths.includes(dev.path)}
+													onchange={() => toggleDevice(dev.path)} class="h-4 w-4 shrink-0" />
+												<span class="font-mono text-xs shrink-0">{diskPath}</span>
+												<span class="rounded bg-green-900 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-green-300">free space</span>
+												<span class="text-muted-foreground">{formatBytes(dev.size_bytes)}</span>
+												<span class="text-xs text-muted-foreground">(new partition will be created)</span>
+											</div>
+											{#if dev.model || dev.vendor || dev.transport || dev.serial}
+												<div class="ml-7 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground/80">
+													{#if dev.model}<span>{dev.model}</span>{/if}
+													{#if dev.vendor && dev.vendor !== dev.model}<span class="opacity-70">{dev.vendor}</span>{/if}
+													{#if dev.transport}<span class="uppercase opacity-70">{dev.transport}</span>{/if}
+													{#if dev.serial}<span class="font-mono opacity-70">SN: {dev.serial}</span>{/if}
+												</div>
+											{/if}
 										</label>
 										{#if existingParts.length > 0}
 											<div class="border-t border-border bg-muted/20 px-3 py-1.5">
@@ -767,17 +777,27 @@
 										{/if}
 									</div>
 								{:else}
-									<label class="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-3 py-2 text-sm
+									<label class="flex cursor-pointer flex-col gap-1 rounded-lg border border-border px-3 py-2 text-sm
 										{selectedPaths.includes(dev.path) ? 'border-primary bg-primary/5' : 'hover:bg-secondary/50'}">
-										<input type="checkbox" checked={selectedPaths.includes(dev.path)}
-											onchange={() => toggleDevice(dev.path)} class="h-4 w-4 shrink-0" />
-										<span class="font-mono text-xs shrink-0">{dev.path}</span>
-										<span class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase {classColor(dev.device_class)}">
-											{dev.device_class}
-										</span>
-										<span class="text-muted-foreground">{formatBytes(dev.size_bytes)}</span>
-										{#if dev.fs_type}
-											<span class="rounded border border-amber-700 px-1.5 py-0.5 text-[10px] text-amber-400">has signatures · wipe first</span>
+										<div class="flex items-center gap-3">
+											<input type="checkbox" checked={selectedPaths.includes(dev.path)}
+												onchange={() => toggleDevice(dev.path)} class="h-4 w-4 shrink-0" />
+											<span class="font-mono text-xs shrink-0">{dev.path}</span>
+											<span class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase {classColor(dev.device_class)}">
+												{dev.device_class}
+											</span>
+											<span class="text-muted-foreground">{formatBytes(dev.size_bytes)}</span>
+											{#if dev.fs_type}
+												<span class="rounded border border-amber-700 px-1.5 py-0.5 text-[10px] text-amber-400">has signatures · wipe first</span>
+											{/if}
+										</div>
+										{#if dev.model || dev.vendor || dev.transport || dev.serial}
+											<div class="ml-7 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground/80">
+												{#if dev.model}<span>{dev.model}</span>{/if}
+												{#if dev.vendor && dev.vendor !== dev.model}<span class="opacity-70">{dev.vendor}</span>{/if}
+												{#if dev.transport}<span class="uppercase opacity-70">{dev.transport}</span>{/if}
+												{#if dev.serial}<span class="font-mono opacity-70">SN: {dev.serial}</span>{/if}
+											</div>
 										{/if}
 									</label>
 								{/if}


### PR DESCRIPTION
## Summary
Closes #18 — the Create Filesystem wizard previously showed only `/dev/sdX`, the size, and the device class (nvme/ssd/hdd). Now it also shows model, vendor, transport, and serial of the underlying drive so the user knows which physical disk they're picking from a list of identical-looking \`sda/sdb/sdc\`.

## Changes
**Engine** (\`nasty-storage::BlockDevice\`):
- Adds optional \`model\`, \`serial\`, \`vendor\`, \`transport\` fields populated from the lsblk JSON. lsblk command extended from \`NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,ROTA\` to also include \`MODEL,SERIAL,VENDOR,TRAN\`
- lsblk only fills these on whole disks; partitions and many virtual drives (QEMU \`vd*\`) leave them blank, so empty-after-trim becomes \`None\`. Fields are \`#[serde(skip_serializing_if = "Option::is_none")]\` so the wire stays clean
- Synthetic \`:free\` entries inherit the parent disk's metadata so the user still sees what drive they're carving out of

**WebUI** (\`filesystems/+page.svelte\`):
- Each device row in the wizard now has a second descriptor line under the path/class/size: \`<model> · <vendor> · <transport> · SN: <serial>\`
- Each field is rendered only when populated; the whole second line is suppressed when the disk exposes none of them (e.g., on the user's QEMU appliance — \`vd*\` disks won't have any of this and the rendering looks identical to today)
- Same treatment for both the disk and \`:free\` branches of the wizard

## Test plan
- [ ] Engine + WebUI CI green (svelte-check 0/0, vitest still 60/60, clippy/fmt clean)
- [ ] On a bare-metal appliance: Create Filesystem wizard now shows e.g. \`Samsung SSD 990 PRO 2TB · NVMe · NVME · SN: S7XXNXXXXXX\` under each disk
- [ ] On a VM: rows render exactly as before (no second line, no blank dots)