### PR TITLE
filesystems: estimate usable capacity in wizard + fs list (closes #16)

### DIFF
--- a/webui/src/lib/format.test.ts
+++ b/webui/src/lib/format.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'vitest';
-import { formatBytes, formatPercent, formatUptime, makeBytesFormatter } from './format';
+import {
+	estimateUsableBytes,
+	formatBytes,
+	formatPercent,
+	formatUptime,
+	makeBytesFormatter
+} from './format';
+
+const GIB = 1024 ** 3;
 
 describe('formatBytes', () => {
 	test('zero is the literal "0 B" — not "0.0 B" or "0 KiB"', () => {
@@ -61,6 +69,53 @@ describe('formatUptime', () => {
 		expect(formatUptime(86400)).toBe('1d 0h 0m');
 		expect(formatUptime(86400 + 3600 + 60)).toBe('1d 1h 1m');
 		expect(formatUptime(7 * 86400 + 12 * 3600 + 30 * 60)).toBe('7d 12h 30m');
+	});
+});
+
+describe('estimateUsableBytes', () => {
+	test('mirror divides raw by replicas — the issue #16 case', () => {
+		// 2 × 480 GiB mirror should report ~480 GiB usable (raw is 960).
+		const usable = estimateUsableBytes(960 * GIB, 2, 2, false);
+		expect(usable).toBe(480 * GIB);
+	});
+
+	test('replicas=1 with no EC is identity', () => {
+		expect(estimateUsableBytes(500 * GIB, 1, 1, false)).toBe(500 * GIB);
+	});
+
+	test('mirror with replicas=3 is rawTotal / 3', () => {
+		const usable = estimateUsableBytes(900 * GIB, 3, 3, false);
+		expect(usable).toBe(300 * GIB);
+	});
+
+	test('erasure code RAID-5 (replicas=2) keeps (n-1)/n of raw', () => {
+		// 4 × 480 GiB with RAID-5 → 3/4 × 1920 = 1440 GiB usable.
+		const raw = 4 * 480 * GIB;
+		expect(estimateUsableBytes(raw, 4, 2, true)).toBe(1440 * GIB);
+	});
+
+	test('erasure code RAID-6 (replicas=3) keeps (n-2)/n of raw', () => {
+		// 5 × 480 GiB with RAID-6 → 3/5 × 2400 = 1440 GiB usable.
+		const raw = 5 * 480 * GIB;
+		expect(estimateUsableBytes(raw, 5, 3, true)).toBe(1440 * GIB);
+	});
+
+	test('zero / negative inputs return 0 (no NaN, no surprises)', () => {
+		expect(estimateUsableBytes(0, 2, 2, false)).toBe(0);
+		expect(estimateUsableBytes(-1, 2, 2, false)).toBe(0);
+		expect(estimateUsableBytes(100, 0, 2, false)).toBe(0);
+		expect(estimateUsableBytes(100, 2, 0, false)).toBe(0);
+	});
+
+	test('EC with too few devices to satisfy parity returns 0', () => {
+		// RAID-5 needs at least 2 devices (1 data + 1 parity); 1 device → 0.
+		expect(estimateUsableBytes(100, 1, 2, true)).toBe(0);
+		// RAID-6 needs 3+ (1 data + 2 parity); 2 devices → 0.
+		expect(estimateUsableBytes(100, 2, 3, true)).toBe(0);
+	});
+
+	test('EC with replicas=1 returns 0 (no parity, EC nonsense)', () => {
+		expect(estimateUsableBytes(100, 5, 1, true)).toBe(0);
 	});
 });
 

--- a/webui/src/lib/format.ts
+++ b/webui/src/lib/format.ts
@@ -29,3 +29,36 @@ export function formatPercent(used: number, total: number): string {
 	if (total === 0) return '0%';
 	return `${((used / total) * 100).toFixed(1)}%`;
 }
+
+/**
+ * Estimate user-facing usable bytes given a raw byte total, a device count,
+ * a replica count, and whether erasure coding is on. The math:
+ *
+ *   - Mirror (no EC): usable ≈ rawTotal / replicas
+ *   - Erasure code (RAID-5 if replicas=2, RAID-6 if replicas=3):
+ *       parity = replicas - 1
+ *       usable ≈ rawTotal × (deviceCount - parity) / deviceCount
+ *
+ * Returns 0 for nonsensical inputs (no devices, EC with too few devices, etc.).
+ *
+ * Caveat baked into the doc and the UI tooltip: bcachefs lets subvolumes
+ * override replica counts and apply different durability per file, so this
+ * is an approximation for the simple-case configuration.
+ */
+export function estimateUsableBytes(
+	rawTotal: number,
+	deviceCount: number,
+	replicas: number,
+	erasureCode: boolean
+): number {
+	if (rawTotal <= 0 || deviceCount <= 0 || replicas <= 0) return 0;
+	let factor: number;
+	if (erasureCode) {
+		const parity = replicas - 1;
+		if (parity <= 0 || deviceCount <= parity) return 0;
+		factor = (deviceCount - parity) / deviceCount;
+	} else {
+		factor = 1 / replicas;
+	}
+	return Math.floor(rawTotal * factor);
+}

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { getClient } from '$lib/client';
-	import { formatBytes, formatPercent } from '$lib/format';
+	import { estimateUsableBytes, formatBytes, formatPercent } from '$lib/format';
 	import { withToast } from '$lib/toast.svelte';
 
 	let pageTab = $state<'manage' | 'diagnostics'>(
@@ -1031,6 +1031,44 @@
 				</div>
 				{/if}
 
+				{#if selectedPaths.length > 0}
+					{@const rawTotal = selectedDeviceObjects().reduce(
+						(sum, d) => sum + d.size_bytes,
+						0
+					)}
+					{@const usable = estimateUsableBytes(
+						rawTotal,
+						selectedPaths.length,
+						replicas,
+						erasureCode
+					)}
+					<div class="mb-5 rounded-lg border border-border bg-secondary/20 p-4 text-sm">
+						<div class="mb-2 flex items-center gap-2">
+							<span class="font-medium">Storage estimate</span>
+							<span class="text-xs text-muted-foreground">approximate</span>
+						</div>
+						<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+							<span class="text-muted-foreground">Raw selected</span>
+							<span class="font-mono">{formatBytes(rawTotal)} across {selectedPaths.length} device{selectedPaths.length === 1 ? '' : 's'}</span>
+							<span class="text-muted-foreground">Layout</span>
+							<span>
+								{#if erasureCode}
+									Erasure code · {replicas === 2 ? 'RAID-5' : 'RAID-6'} ({replicas - 1} parity per stripe)
+								{:else if replicas === 1}
+									No redundancy
+								{:else}
+									{replicas}× mirror
+								{/if}
+							</span>
+							<span class="text-muted-foreground">Estimated usable</span>
+							<span class="font-mono font-semibold">~{formatBytes(usable)}</span>
+						</div>
+						<p class="mt-2 text-[11px] text-muted-foreground/80">
+							bcachefs lets subvolumes override replica counts and apply different durability per file, so this is a rough number for the simple-case configuration.
+						</p>
+					</div>
+				{/if}
+
 				<!-- Encryption -->
 				<div class="mb-5 rounded-lg border border-border p-4">
 					<label class="flex cursor-pointer items-center gap-2 text-sm font-medium">
@@ -1241,13 +1279,20 @@
 				</div>
 
 				{#if fs.total_bytes > 0}
+					{@const fsReplicas = fs.options.data_replicas ?? 1}
+					{@const fsEc = fs.options.erasure_code ?? false}
+					{@const showUsable = fsReplicas > 1 || fsEc}
+					{@const fsUsable = showUsable
+						? estimateUsableBytes(fs.total_bytes, fs.devices.length, fsReplicas, fsEc)
+						: fs.total_bytes}
 					<div class="mt-3">
 						<div class="mb-1 h-1.5 overflow-hidden rounded-full bg-secondary">
 							<div class="h-full rounded-full bg-primary" style="width: {(fs.used_bytes / fs.total_bytes) * 100}%"></div>
 						</div>
 						<span class="text-xs text-muted-foreground">
 							{formatBytes(fs.used_bytes)} / {formatBytes(fs.total_bytes)} ({formatPercent(fs.used_bytes, fs.total_bytes)})
-							{#if fs.options.data_replicas && fs.options.data_replicas > 1} · {fs.options.data_replicas} replicas{/if}
+							{#if showUsable} · <span title="Estimate. bcachefs reports raw capacity; this is total ÷ replicas (or × (n-parity)/n with EC). Subvolumes can override replica counts.">~{formatBytes(fsUsable)} usable</span>{/if}
+							{#if fsReplicas > 1} · {fsReplicas} replicas{/if}
 							{#if fs.options.compression} · {fs.options.compression}{/if}
 						</span>
 					</div>


### PR DESCRIPTION
## Summary
Closes #16. The reporter saw \`bcachefs fs usage\` raw capacity (815.7 GB across two 480 GB SSDs in a mirror) and expected ~480 GB usable, like ZFS / mdraid. Bcachefs's number is correct but counter-intuitive — it doesn't account for replicas because subvolumes can override the replica count per file.

The owner already explained the constraint in the thread; this PR adds the **estimated usable** number alongside the raw one in two places, with tooltip text that names the simple-case assumption explicitly.

## Math (tested helper)
\`estimateUsableBytes(rawTotal, deviceCount, replicas, erasureCode)\` in \`$lib/format\`:
- Mirror: \`usable ≈ rawTotal / replicas\`
- EC:     \`usable ≈ rawTotal × (deviceCount - parity) / deviceCount\` with \`parity = replicas - 1\` (RAID-5 at replicas=2, RAID-6 at replicas=3)
- Returns 0 for nonsensical inputs (no devices, EC requested with too few devices, replicas=1 + EC)

8 new vitest cases including the issue #16 scenario verbatim (\`960 GB, 2 devices, replicas=2, no EC → 480 GB\`).

## UI changes
**Create Filesystem wizard, Review step** — new "Storage estimate" block, updates live as the user toggles replicas / EC:
\`\`\`
Storage estimate                                     approximate
  Raw selected     960 GiB across 2 devices
  Layout           2× mirror
  Estimated usable ~480 GiB

bcachefs lets subvolumes override replica counts and apply
different durability per file, so this is a rough number for
the simple-case configuration.
\`\`\`

**Filesystems list** — existing usage line gains a \`~{usable} usable\` suffix when replicas > 1 or EC is on, with the same tooltip explanation on hover:
\`\`\`
2.1 GiB / 815.7 GiB (0.3%)  ·  ~407.8 GiB usable  ·  2 replicas  ·  zstd
\`\`\`

For replicas=1 + no EC the suffix is omitted (would just duplicate the existing total).

## Test plan
- [ ] WebUI CI green (svelte-check 0/0, vitest now 68 tests)
- [ ] On an appliance: create a 2-device mirror, Review step shows the right estimate and the FS list shows the suffix after creation
- [ ] Toggle EC in the wizard, see the layout description and estimate update accordingly