### PR TITLE
filesystems: show device count, EC, encryption in fs summary

### DIFF
--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -1305,6 +1305,7 @@
 					{@const fsUsable = showUsable
 						? estimateUsableBytes(fs.total_bytes, fs.devices.length, fsReplicas, fsEc)
 						: fs.total_bytes}
+					{@const deviceCount = fs.devices.length}
 					<div class="mt-3">
 						<div class="mb-1 h-1.5 overflow-hidden rounded-full bg-secondary">
 							<div class="h-full rounded-full bg-primary" style="width: {(fs.used_bytes / fs.total_bytes) * 100}%"></div>
@@ -1312,7 +1313,10 @@
 						<span class="text-xs text-muted-foreground">
 							{formatBytes(fs.used_bytes)} / {formatBytes(fs.total_bytes)} ({formatPercent(fs.used_bytes, fs.total_bytes)})
 							{#if showUsable} · <span title="Estimate. bcachefs reports raw capacity; this is total ÷ replicas (or × (n-parity)/n with EC). Subvolumes can override replica counts.">~{formatBytes(fsUsable)} usable</span>{/if}
+							· {deviceCount} {deviceCount === 1 ? 'device' : 'devices'}
 							{#if fsReplicas > 1} · {fsReplicas} replicas{/if}
+							{#if fsEc} · <span title="Erasure coding (Reed-Solomon parity). At {fsReplicas} replicas this is a {fsReplicas === 2 ? 'RAID-5' : 'RAID-6'}-style layout.">erasure code</span>{/if}
+							{#if fs.options.encrypted} · <span title={fs.options.locked ? 'Encrypted, currently locked — unlock to mount.' : 'Encrypted.'}>encrypted{fs.options.locked ? ' · locked' : ''}</span>{/if}
 							{#if fs.options.compression} · {fs.options.compression}{/if}
 						</span>
 					</div>


### PR DESCRIPTION
## Summary
Addresses the WebUI half of #15. The reporter has a 16-disk, 3-replica, EC array on heterogeneous drives and was confused about what the displayed total represented. The summary line under each filesystem in the list hid information that's useful to see at a glance.

**Before** (after #43 merged):
\`\`\`
2.1 GiB / 815.7 GiB (0.3%) · ~407.8 GiB usable · 2 replicas · zstd
\`\`\`

**After:**
\`\`\`
2.1 GiB / 815.7 GiB (0.3%) · ~407.8 GiB usable · 16 devices · 3 replicas · erasure code · encrypted · zstd
\`\`\`

Adds:
- **\`N devices\`** — always shown; surfaces array width without expanding the FS card
- **\`erasure code\`** — hover reveals "At {N} replicas this is a RAID-{5|6}-style layout"
- **\`encrypted\`** (and \`encrypted · locked\` if applicable) — surfaces encryption state and whether the user needs to unlock before mounting

## Out of scope
The robocopy hangs / dmesg errors part of #15 is a kernel-level bcachefs runtime issue — not actionable from the WebUI. The owner is already asking the reporter for dmesg output in the issue thread.

## Test plan
- [x] svelte-check 0/0
- [x] vitest 68/68
- [x] vite build green
- [ ] On a real appliance: filesystem summary line shows the new fields when applicable; ones with no replicas / no EC / no encryption render unchanged