### PR TITLE
filesystems: align wizard estimate with fs list + fix svelte-check warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-0WO5CZzbTpYwmuvMmxDllds/+nWP4NsHWJWuZP+M9dE=";
+      npmDepsHash = "sha256-GAMBqkVUnO9EDLy7tZK1k/+SMjezPHGf9DMm/syRAPc=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -28,6 +28,7 @@
 				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
 				"@tailwindcss/vite": "^4.2.4",
+				"@types/node": "^25.6.1",
 				"bits-ui": "^2.18.0",
 				"clsx": "^2.1.1",
 				"layerchart": "2.0.0-next.46",
@@ -1157,6 +1158,16 @@
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.1.tgz",
+			"integrity": "sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -2890,6 +2901,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "8.0.11",

--- a/webui/package.json
+++ b/webui/package.json
@@ -21,6 +21,7 @@
 		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.4",
+		"@types/node": "^25.6.1",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"layerchart": "2.0.0-next.46",

--- a/webui/src/lib/format.ts
+++ b/webui/src/lib/format.ts
@@ -31,6 +31,17 @@ export function formatPercent(used: number, total: number): string {
 }
 
 /**
+ * Fraction of the sum of physical disk sizes that bcachefs actually reports
+ * as filesystem capacity after format. The rest is reserved for metadata,
+ * journal, btree, and gc_reserve_percent (which defaults to 8). 0.91 is
+ * what we observe for fresh single-tier mirrors against bcachefs 1.38 — it
+ * varies a couple of points up or down depending on filesystem size and
+ * bcachefs version, so anything that uses it is labelled "approximate" in
+ * the UI.
+ */
+export const BCACHEFS_FS_OVERHEAD = 0.91;
+
+/**
  * Estimate user-facing usable bytes given a raw byte total, a device count,
  * a replica count, and whether erasure coding is on. The math:
  *

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -2,7 +2,12 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { getClient } from '$lib/client';
-	import { estimateUsableBytes, formatBytes, formatPercent } from '$lib/format';
+	import {
+		BCACHEFS_FS_OVERHEAD,
+		estimateUsableBytes,
+		formatBytes,
+		formatPercent
+	} from '$lib/format';
 	import { withToast } from '$lib/toast.svelte';
 
 	let pageTab = $state<'manage' | 'diagnostics'>(
@@ -1056,8 +1061,9 @@
 						(sum, d) => sum + d.size_bytes,
 						0
 					)}
+					{@const fsCapacity = Math.floor(rawTotal * BCACHEFS_FS_OVERHEAD)}
 					{@const usable = estimateUsableBytes(
-						rawTotal,
+						fsCapacity,
 						selectedPaths.length,
 						replicas,
 						erasureCode
@@ -1070,6 +1076,8 @@
 						<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
 							<span class="text-muted-foreground">Raw selected</span>
 							<span class="font-mono">{formatBytes(rawTotal)} across {selectedPaths.length} device{selectedPaths.length === 1 ? '' : 's'}</span>
+							<span class="text-muted-foreground">After bcachefs overhead</span>
+							<span class="font-mono">~{formatBytes(fsCapacity)} <span class="text-muted-foreground">(metadata, journal, gc reserve)</span></span>
 							<span class="text-muted-foreground">Layout</span>
 							<span>
 								{#if erasureCode}
@@ -1084,7 +1092,7 @@
 							<span class="font-mono font-semibold">~{formatBytes(usable)}</span>
 						</div>
 						<p class="mt-2 text-[11px] text-muted-foreground/80">
-							bcachefs lets subvolumes override replica counts and apply different durability per file, so this is a rough number for the simple-case configuration.
+							Overhead varies a couple of points by filesystem size and bcachefs version. Subvolumes can also override replica counts per file, so this is a rough number for the simple-case configuration.
 						</p>
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary
You spotted that the Create Filesystem wizard's estimated-usable number doesn't match what the same array reports in the filesystem list after format:

- Wizard: 3× 50 GiB at replicas=2 → \"~75 GiB usable\" (i.e., raw / 2)
- FS list (after format): \"~68 GiB usable\" (i.e., bcachefs's 136.8 GiB total / 2)

The wizard was using raw disk sums; the list was using bcachefs's already-reduced \`total_bytes\` from \`df\`. Both \"correct\" given their inputs but inconsistent in what the user sees.

## Fix
Fold bcachefs's metadata/journal/gc reserve into the wizard math via a shared \`BCACHEFS_FS_OVERHEAD = 0.91\` constant in \`format.ts\`. The wizard now also shows the intermediate step explicitly so users see how the chain works:

\`\`\`
Storage estimate                  approximate
  Raw selected            150 GiB across 3 devices
  After bcachefs overhead ~136 GiB (metadata, journal, gc reserve)
  Layout                  2× mirror
  Estimated usable        ~68 GiB
\`\`\`

That ~68 GiB matches what the filesystem list will show post-format.

The 0.91 factor is what we measured for fresh single-tier mirrors against bcachefs 1.38; it varies a couple of points by filesystem size and bcachefs version, so the section is still labelled \"approximate\".

## Drive-by: svelte-check warning
Long-standing warning that's been showing all session:

\`\`\`
Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
\`\`\`

Generated \`.svelte-kit/tsconfig.json\` declares \`types: [\"node\"]\` but \`@types/node\` wasn't a dep. Adding it makes svelte-check go cleanly to 0 errors / 0 warnings / 0 files.

\`flake.nix\` \`npmDepsHash\` refreshed to match the new lockfile.

## Test plan
- [x] svelte-check now 0/0/0 (no warning)
- [x] vitest 68/68
- [x] vite build green
- [ ] On a real appliance: wizard's \"Estimated usable\" matches what the FS list shows after format