### PR TITLE
apps: render Services link as a button in Maintenance card

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -780,7 +780,7 @@
 						<h4 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Maintenance</h4>
 						<div class="flex flex-col gap-2">
 							<Button size="sm" variant="outline" onclick={pruneDocker}>Cleanup Unused Images</Button>
-							<a href="/services" class="text-xs text-muted-foreground hover:text-foreground">On/off is managed in Services →</a>
+							<Button size="sm" variant="outline" onclick={() => goto('/services')}>Manage in Services →</Button>
 						</div>
 					</CardContent>
 				</Card>


### PR DESCRIPTION
The "On/off is managed in Services →" link in the Maintenance card was a plain `<a>` styled as muted text, sitting right under a real button. Looked like a sentence, not a control. Switched it to the same `Button size="sm" variant="outline"` shape as Cleanup Unused Images directly above it and the Install App button on the action bar.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Manual: Maintenance card shows two same-shape buttons stacked