### PR TITLE
installer: bump system-flake template to bcachefs-tools v1.38.2 + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,35 @@ jobs:
             exit 1
           fi
           echo "npmDepsHash matches package-lock.json: $ACTUAL"
+
+  installer-flake-template:
+    # The installer's system-flake template must reference the same
+    # bcachefs-tools input as the project's flake.nix. The ISO build copies
+    # all transitive nodes from flake.lock into the system flake's lock; if
+    # the template's bcachefs-tools.url drifts from flake.nix, the lock will
+    # hold a different ref than the rendered flake.nix asks for and
+    # nixos-install will bail out with a NAR hash mismatch on first boot.
+    name: Installer template bcachefs-tools URL matches flake.nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare URLs
+        run: |
+          PROJECT=$(grep -oE 'bcachefs-tools\.url = "[^"]+"' flake.nix | head -1)
+          TEMPLATE=$(grep -oE 'bcachefs-tools\.url = "[^"]+"' nixos/system-flake/flake.nix.template | head -1)
+          if [ -z "$PROJECT" ] || [ -z "$TEMPLATE" ]; then
+            echo "::error::could not extract bcachefs-tools.url from one of the files"
+            echo "  flake.nix:                             $PROJECT"
+            echo "  nixos/system-flake/flake.nix.template: $TEMPLATE"
+            exit 1
+          fi
+          if [ "$PROJECT" != "$TEMPLATE" ]; then
+            echo "::error::installer template bcachefs-tools URL is stale"
+            echo "  flake.nix:                             $PROJECT"
+            echo "  nixos/system-flake/flake.nix.template: $TEMPLATE"
+            echo
+            echo "When bumping bcachefs-tools, update both files together."
+            exit 1
+          fi
+          echo "Installer template matches flake.nix: $PROJECT"

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.0";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.2";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # Installer payload template. Bootstrap substitutes the tagged release


### PR DESCRIPTION
## What broke

Pre-release ISO bombs out at `==> Installing NASty...` with:

```
warning: updating lock file "/mnt/etc/nixos/flake.lock":
• Updated input 'bcachefs-tools':
    'github:koverstreet/bcachefs-tools/bba7b97...' (2026-05-02)
  → 'github:koverstreet/bcachefs-tools/44ea2cc...' (2026-04-19)
error: NAR hash mismatch in input 'path:/mnt/etc/nixos?...&narHash=sha256-eQmUii...',
  expected 'sha256-SQFf...' but got 'sha256-eQmUii...'
```

## Root cause

When `1e6d047` ("flake: bump bcachefs-tools to v1.38.2") landed, only `flake.nix` and `flake.lock` were bumped. The installer's system-flake template at `nixos/system-flake/flake.nix.template` was overlooked and still pinned `v1.38.0`.

The ISO build:
1. Renders `flake.nix.template` into the system flake's `flake.nix` — references `v1.38.0`.
2. Synthesises the system flake's `flake.lock` by copying every non-root node from the project's `flake.lock` (so bcachefs-tools is locked at `v1.38.2`/`bba7b97`) and adding a custom `nasty` node.

On first boot `nixos-install` sees flake.nix asks for `v1.38.0` but the lock says `v1.38.2`, decides to "update" the lock back to `v1.38.0` (the older `44ea2cc`), and the cascading lock rewrite trips the NAR hash check on the root `path:/mnt/etc/nixos` input.

## Fix

- `nixos/system-flake/flake.nix.template`: bump `bcachefs-tools.url` to `v1.38.2` to match `flake.nix`.
- `.github/workflows/ci.yml`: add an `installer-flake-template` job that greps the `bcachefs-tools.url` line out of both files and fails CI if they differ. Same shape as the existing `npm-deps-hash` gate.

## Test plan
- [x] Local sanity check: gate logic matches before and after the bump.
- [ ] CI green on this PR (the gate runs against the fixed tree).
- [ ] After merge: rebuild the pre-release ISO and verify the install completes.