### PR TITLE
auth: include must_change_password in cookie-path WS auth response

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1590,6 +1590,7 @@ async fn resolve_session(
                             "authenticated": true,
                             "username": session.username,
                             "role": session.role,
+                            "must_change_password": session.must_change_password,
                         })
                         .to_string()
                         .into(),

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -30,7 +30,20 @@ let
         auth = json.loads(ws.recv())
         assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
         assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
-        return ws
+        return ws, auth
+
+
+    def ws_auth_cookie(token):
+        # Browser path: session cookie on the upgrade request, no auth message.
+        ws = websocket.create_connection(
+            "ws://127.0.0.1:2137/ws",
+            timeout=10,
+            cookie=f"nasty_session={token}",
+        )
+        auth = json.loads(ws.recv())
+        assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
+        assert auth.get("username") == "admin", f"unexpected user: {auth!r}"
+        return ws, auth
 
 
     def call(ws, method, request_id, params=None):
@@ -60,7 +73,20 @@ let
     # Default admin/admin has must_change_password set, which gates
     # most RPC methods. Change it, then re-login so subsequent calls
     # hit a session that doesn't carry the gate.
-    ws = ws_auth(initial_token)
+    #
+    # Both auth paths (token-in-message for non-browsers, cookie-on-upgrade
+    # for browsers) must surface must_change_password on the auth response —
+    # otherwise the WebUI lands on the dashboard instead of the change-
+    # password screen and just silently fails every subsequent RPC.
+    ws, auth = ws_auth(initial_token)
+    assert auth.get("must_change_password") is True, (
+        f"token-path auth missing must_change_password: {auth!r}"
+    )
+    cookie_ws, cookie_auth = ws_auth_cookie(initial_token)
+    cookie_ws.close()
+    assert cookie_auth.get("must_change_password") is True, (
+        f"cookie-path auth missing must_change_password: {cookie_auth!r}"
+    )
     try:
         me = call(ws, "auth.me", 1)
         assert me["username"] == "admin", f"auth.me wrong: {me!r}"
@@ -73,7 +99,10 @@ let
 
     # ── Session 2: drive a few representative RPCs ────────────────
     new_token = http_login(NEW_PW)
-    ws = ws_auth(new_token)
+    ws, auth = ws_auth(new_token)
+    assert auth.get("must_change_password") is False, (
+        f"after change_password, flag should be cleared: {auth!r}"
+    )
     try:
         health = call(ws, "system.health", 1)
         print("system.health:", health, file=sys.stderr)


### PR DESCRIPTION
## What broke

Fresh install, log in with `admin`/`admin`, and you land on the dashboard. The only feedback is a small "Password change required" toast in the bottom-right corner; every panel just shows "Loading…" forever. There's no way to actually change the password from the UI.

## Root cause

\`7d323cd auth: move browser session to httpOnly cookie\` introduced a cookie-on-upgrade auth path in the WS handler. The two paths now look like this:

| path | who uses it | auth ack carries |
|------|-------------|------------------|
| token-in-first-message | kubectl, CSI driver, smoke tests | `username`, `role`, **`must_change_password`** |
| cookie-on-upgrade | the browser | `username`, `role` |

The browser-side layout reads \`authInfo.must_change_password\` to decide whether to render the change-password screen instead of the dashboard. With the cookie path returning \`undefined\` it's always falsy, so the password gate never engages on the WebUI; the engine still rejects RPCs with "Password change required", which is the toast.

## Fix

One field added to the cookie-path response in \`engine/nasty-engine/src/main.rs:resolve_session\`. The Session struct already carries the value.

## Regression coverage

The appliance smoke test only exercised the token path (which already worked), so the cookie-path drop went unnoticed. Extended the test to:

1. Open a second WS using the cookie-on-upgrade path and assert `must_change_password=true` on default admin/admin.
2. Keep the existing token-path assertion explicit.
3. After `auth.change_password`, re-login and assert the flag flips to `false`.

## Test plan
- [x] `cargo check` clean
- [ ] CI green (engine fmt/clippy/test, appliance integration smoke)
- [ ] Manual: rebuild + reinstall, log in as admin/admin, change-password screen appears