### PR TITLE
webui: tidy banner buttons and make SSH "Manage" actually navigate

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -889,25 +889,15 @@
 					</div>
 				{/if}
 				{#if sshPasswordAuth}
-					<div class="mb-4 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
-						<a href="/services" class="flex-1 no-underline text-amber-400 hover:text-amber-300">
-							SSH password authentication is enabled — disable it for better security.
-						</a>
-						<button onclick={async () => {
-							try {
-								await getClient().call('system.ssh.set_password_auth', { enabled: false });
-								sshPasswordAuth = false;
-							} catch (e) {
-								// Likely no keys — need to add one first
-							}
-						}} class="text-xs font-medium text-amber-400 hover:text-amber-300 shrink-0">Disable now</button>
+					<div class="mb-4 flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
+						<span class="flex-1">SSH password authentication is enabled — disable it for better security.</span>
+						<Button size="sm" onclick={() => goto('/services?configure=ssh')}>Manage SSH</Button>
 					</div>
 				{/if}
 				{#if configBackupMissing}
-					<div class="mb-4 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
+					<div class="mb-4 flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
 						<span class="flex-1">NASty configuration is not backed up.</span>
-						<a href="/backups?create=config" class="text-xs font-medium text-amber-400 hover:text-amber-300 shrink-0 no-underline">Create backup</a>
-						<span class="text-amber-400/30">|</span>
+						<Button size="sm" onclick={() => goto('/backups?create=config')}>Create Backup</Button>
 						<button onclick={dismissConfigBackup} class="text-xs text-amber-400/60 hover:text-amber-400 shrink-0">dismiss</button>
 					</div>
 				{/if}

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -780,7 +780,10 @@
 						<h4 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Maintenance</h4>
 						<div class="flex flex-col gap-2">
 							<Button size="sm" variant="outline" onclick={pruneDocker}>Cleanup Unused Images</Button>
-							<Button size="sm" variant="outline" onclick={() => goto('/services')}>Manage in Services →</Button>
+							<div class="flex items-center gap-2 text-sm text-muted-foreground">
+								<span>Manage in</span>
+								<Button size="sm" onclick={() => goto('/services')}>Services</Button>
+							</div>
 						</div>
 					</CardContent>
 				</Card>

--- a/webui/src/routes/services/+page.svelte
+++ b/webui/src/routes/services/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
+	import { page } from '$app/stores';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import type { ProtocolStatus, AppsStatus, Filesystem, TuningConfig, NutConfig, UpsStatus } from '$lib/types';
@@ -203,6 +204,10 @@
 		client.onEvent(handleEvent);
 		await refresh();
 		loading = false;
+		// Deep-link: /services?configure=<name> opens that service's config panel.
+		// Used by the SSH "Manage SSH" banner button (and any future banners).
+		const target = $page.url.searchParams.get('configure');
+		if (target) toggleConfig(target);
 	});
 
 	onDestroy(() => client.offEvent(handleEvent));


### PR DESCRIPTION
Three small UX issues collected from a screenshot review:

## Apps page maintenance card
**Before**: two stacked outline buttons — "Cleanup Unused Images" and "Manage in Services →".
**After**: same Cleanup button on top; "Manage in Services" becomes inline prose ("Manage in") with a small Services button — different affordance for what is fundamentally a destination, not an in-place action.

## Backups banner ("NASty configuration is not backed up")
**Before**: amber-styled `<a href="/backups?create=config">Create backup</a>` sitting next to a "dismiss" button — mixed link/button styles in the same banner.
**After**: real `<Button size="sm">Create Backup</Button>`, matching the page-level "Create Backup" button on the Backups page.

## SSH banner "Disable now" was broken
**Before**: tried `system.ssh.set_password_auth({ enabled: false })` inline. The engine refuses if no keys are configured (correctly — that would lock the user out), but the catch block swallowed the error silently, so the button just looked dead. Reproduced exactly per the user report: removed all SSH keys, enabled password auth, "Disable now" stops doing anything.
**After**: button replaced with **"Manage SSH"** that deep-links to `/services?configure=ssh`. From there the user can add a key and then disable password auth deliberately, which is what they should be doing.

## Services page deep-link support
`/services?configure=<name>` now opens that service's config panel on mount, using the existing `toggleConfig` path. Currently used by the SSH banner; other banners can use the same pattern.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Manual: Apps maintenance card shows "Cleanup Unused Images" outline + "Manage in [Services]" inline pattern
- [ ] Manual: Backups page banner — "Create Backup" renders as a button
- [ ] Manual: with password auth on and no keys, "Manage SSH" navigates to /services and the SSH config panel is open