### PR TITLE
ci: build-iso always creates new GitHub Releases as prereleases

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -75,14 +75,17 @@ jobs:
         run: |
           TAG="${{ env.version }}"
           if gh release view "$TAG" &>/dev/null; then
+            # Existing release — only upload the asset. Don't touch the
+            # prerelease flag so manually-promoted releases stay promoted
+            # if the workflow is re-run for the same tag.
             gh release upload "$TAG" "${{ env.iso_dest }}" --clobber
           else
-            PRERELEASE=""
-            if [[ "$TAG" != v* ]]; then
-              PRERELEASE="--prerelease"
-            fi
+            # All freshly-created releases start as prereleases — including
+            # tagged v* releases. The maintainer downloads the ISO, tests
+            # it, writes release notes, and then flips "Set as latest" in
+            # the GitHub Releases UI to promote it.
             gh release create "$TAG" "${{ env.iso_dest }}" \
               --title "NASty $TAG" \
               --notes "NASty ISO build — $(git rev-parse --short HEAD)" \
-              $PRERELEASE
+              --prerelease
           fi


### PR DESCRIPTION
Tagged \`v*\` releases used to be marked as "Latest" the moment \`build-iso.yml\` finished, which gave no window to test the ISO or write release notes before users saw the new version on the Releases page.

Change: every newly-created release — tagged or \`dev-*\` — is created with \`--prerelease\`. Re-running the workflow against an already-existing release only uploads/clobbers the asset and never touches the prerelease flag, so a manually-promoted release stays promoted.

## New release flow
1. Bump \`engine/Cargo.toml\` and tag \`v0.0.x\`.
2. Trigger \`build-iso.yml\` (workflow_dispatch). It creates a **prerelease** with the ISO assets.
3. Download the ISO, test the install, write release notes.
4. In the GitHub Releases UI, edit the release: paste notes, click **Set as latest**.

## Test plan
- [x] YAML still valid (single string change in a heredoc-style block)
- [ ] Next \`v*\` release: confirm the release lands as "Pre-release" on the Releases page until manually promoted
- [ ] Re-running the workflow for an existing release: confirm the prerelease flag isn't touched