### PR TITLE
webui: rename SSH banner button to "Configure SSH" + add dismiss

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -126,13 +126,22 @@
 	let helpOpen = $state(false);
 
 	// SSH password auth warning
+	const SSH_DISMISSED_KEY = 'nasty:ssh_password_auth_dismissed';
 	let sshPasswordAuth = $state(false);
+	let sshPasswordAuthDismissed = $state(
+		typeof localStorage !== 'undefined' && localStorage.getItem(SSH_DISMISSED_KEY) === '1'
+	);
 	async function checkSshStatus() {
-		if (!connected) return;
+		if (!connected || sshPasswordAuthDismissed) return;
 		try {
 			const result = await getClient().call<{ password_auth: boolean; keys: string[] }>('system.ssh.status');
 			sshPasswordAuth = result.password_auth;
 		} catch { /* ignore */ }
+	}
+	function dismissSshPasswordAuth() {
+		sshPasswordAuthDismissed = true;
+		sshPasswordAuth = false;
+		localStorage.setItem(SSH_DISMISSED_KEY, '1');
 	}
 
 	// Config backup warning
@@ -891,7 +900,8 @@
 				{#if sshPasswordAuth}
 					<div class="mb-4 flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
 						<span class="flex-1">SSH password authentication is enabled — disable it for better security.</span>
-						<Button size="sm" onclick={() => goto('/services?configure=ssh')}>Manage SSH</Button>
+						<Button size="sm" onclick={() => goto('/services?configure=ssh')}>Configure SSH</Button>
+						<button onclick={dismissSshPasswordAuth} class="text-xs text-amber-400/60 hover:text-amber-400 shrink-0">dismiss</button>
 					</div>
 				{/if}
 				{#if configBackupMissing}


### PR DESCRIPTION
- Rename **Manage SSH** → **Configure SSH** to match the existing "Configure" verb used on the Services page rows.
- Add a **dismiss** link to the SSH password-auth banner, mirroring the pattern already in use on the config-backup banner: localStorage-backed (\`nasty:ssh_password_auth_dismissed\`), survives reloads. \`checkSshStatus\` short-circuits when dismissed, so the banner doesn't reappear unless the user clears the key.

## Test plan
- [x] \`npm run check\` — 0 errors
- [x] \`npm run build\` — succeeds
- [ ] Manual: enable password auth → banner appears with "Configure SSH" + "dismiss"; dismiss → gone; reload → still gone