### PR TITLE
webui: fix MTU input crash on Apply

### DIFF
--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -372,10 +372,11 @@
 		netChanged = false;
 	}
 
-	function parseMtu(v: string): number | null {
-		const t = v.trim();
-		if (!t) return null;
-		const n = parseInt(t, 10);
+	// Svelte coerces bind:value on <input type="number"> to a number (or '' / null
+	// when the field is empty), so accept anything and normalise.
+	function parseMtu(v: unknown): number | null {
+		if (v === null || v === undefined || v === '') return null;
+		const n = typeof v === 'number' ? v : parseInt(String(v), 10);
 		return Number.isFinite(n) && n > 0 ? n : null;
 	}
 


### PR DESCRIPTION
## Summary
With `<input type=\"number\">`, Svelte coerces `bind:value` to a `number` (or `''` / `null` when empty). The MTU state vars were declared `let netMtu = $state('')` etc., but at runtime they hold numbers — so `parseMtu`'s `v.trim()` threw `TypeError: e.trim is not a function` synchronously inside `saveInterfaceConfig` (and the bond / bridge / VLAN create paths). The throw aborted before `client.call` ever ran, leaving `savingNetwork=true` and the **Apply** button stuck on "Applying…" forever — exactly the symptom reported on a freshly-installed v0.0.6 box.

`parseMtu` now accepts `unknown` and normalises:
- `null` / `undefined` / `''` → `null`
- `number` → returned as-is (after `> 0` / finite check)
- anything else → `parseInt(String(v), 10)`

No `.trim()` needed; `parseInt` already tolerates whitespace and bad input (returns `NaN`, which the finite check rejects).

Reproducer (pre-fix): edit a physical interface, type `1496` in MTU, click Apply → button stays on "Applying…", DevTools shows `Uncaught (in promise) TypeError: e.trim is not a function`.

## Test plan
- [ ] On a freshly-built ISO, edit a physical interface, set MTU `1496`, click Apply — button returns and `ip link show <iface>` reports MTU 1496.
- [ ] Same with `9000` on a bond.
- [ ] Clear the MTU field and Apply — interface returns to default 1500.
- [ ] Create a new bond with MTU populated in the create form.