### PR TITLE
webui: rollback countdown banner + bridge mgmt-iface warning

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -654,7 +654,13 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 ),
             )
         }
-        "system.network.get" => ok(req, state.network.get().await),
+        "system.network.get" => {
+            let mgmt = match session.client_ip.as_deref() {
+                Some(peer) => nasty_system::network::mgmt_iface_for_peer(peer).await,
+                None => None,
+            };
+            ok(req, state.network.get(mgmt).await)
+        }
         "system.network.update" => {
             match parse_params::<nasty_system::network::UpdateRequest>(req) {
                 Ok(p) => {

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -179,6 +179,13 @@ pub struct LiveInterface {
 pub struct NetworkState {
     pub config: NetworkConfig,
     pub interfaces: Vec<LiveInterface>,
+    /// The interface the calling client is currently reaching the engine
+    /// through (resolved by `mgmt_iface_for_peer` from `session.client_ip`).
+    /// Surfaced so the WebUI can warn before submitting a change that would
+    /// disconnect the user — e.g. enslaving this iface into a new bridge.
+    /// `None` if we couldn't resolve it (no peer info, route lookup failed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mgmt_iface: Option<String>,
 }
 
 /// Request shape for `system.network.update`. The `NetworkConfig` fields
@@ -256,10 +263,14 @@ impl NetworkService {
         }
     }
 
-    pub async fn get(&self) -> NetworkState {
+    pub async fn get(&self, mgmt_iface: Option<String>) -> NetworkState {
         let config = load_config().await;
         let interfaces = enumerate_interfaces().await;
-        NetworkState { config, interfaces }
+        NetworkState {
+            config,
+            interfaces,
+            mgmt_iface,
+        }
     }
 
     pub async fn update(

--- a/webui/src/lib/rollbackState.svelte.ts
+++ b/webui/src/lib/rollbackState.svelte.ts
@@ -1,0 +1,79 @@
+/** Pending network rollback state.
+ *
+ * After `system.network.update` returns a `txn_id`, the engine has scheduled
+ * an automatic rollback to the prior config at `revert_at_unix`. The user
+ * has to call `system.network.confirm` before then to keep the change.
+ *
+ * This store is the global single source of truth so a banner can be
+ * rendered persistently in the root layout — the user might navigate away
+ * from the settings page during the confirm window. */
+
+import { getClient } from './client';
+import { withToast } from './toast.svelte';
+import type { NetworkUpdateRequest, NetworkUpdateResponse } from './types';
+
+export interface PendingRollback {
+	txnId: string;
+	revertAtUnix: number;
+	riskReason: string | null;
+}
+
+let _pending = $state<PendingRollback | null>(null);
+
+export const rollbackState = {
+	get pending(): PendingRollback | null {
+		return _pending;
+	},
+	set(p: PendingRollback) {
+		_pending = p;
+	},
+	clear() {
+		_pending = null;
+	},
+	/** Compute remaining seconds until the server-side rollback fires. */
+	secondsRemaining(): number {
+		if (!_pending) return 0;
+		const now = Math.floor(Date.now() / 1000);
+		return Math.max(0, _pending.revertAtUnix - now);
+	},
+};
+
+/** Submit a network config change. Captures the response and, if the server
+ * scheduled a rollback, populates the global store so the layout banner
+ * shows up. Always shows a toast on success/error. */
+export async function applyNetworkUpdate(
+	payload: NetworkUpdateRequest,
+	successMsg: string,
+): Promise<NetworkUpdateResponse | undefined> {
+	const client = getClient();
+	const res = await withToast(
+		() => client.call<NetworkUpdateResponse>('system.network.update', payload),
+		successMsg,
+	);
+	if (res?.txn_id && res.revert_at_unix) {
+		_pending = {
+			txnId: res.txn_id,
+			revertAtUnix: res.revert_at_unix,
+			riskReason: res.risk_reason ?? null,
+		};
+	}
+	return res;
+}
+
+/** Confirm a pending rollback — keeps the change. Clears the local store
+ * even if the RPC fails (the server may have already reverted, in which
+ * case the banner should disappear regardless). */
+export async function confirmRollback(): Promise<void> {
+	const txn = _pending;
+	if (!txn) return;
+	const client = getClient();
+	try {
+		await client.call('system.network.confirm', { txn_id: txn.txnId });
+	} finally {
+		// Clear regardless: if the server didn't know the txn, the rollback
+		// already fired and the banner is stale.
+		if (_pending?.txnId === txn.txnId) {
+			_pending = null;
+		}
+	}
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -486,7 +486,7 @@ export interface TuningConfig {
 
 // ── Networking ─────────────────────────────────────────────
 
-export type IpMethod = 'dhcp' | 'static' | 'slaac' | 'disabled';
+export type IpMethod = 'dhcp' | 'static' | 'slaac' | 'inherit' | 'disabled';
 
 export interface IpConfig {
 	method: IpMethod;
@@ -527,6 +527,8 @@ export interface BridgeConfig {
 	ipv4: IpConfig;
 	ipv6: IpConfig;
 	mtu: number | null;
+	stp?: boolean;
+	forward_delay_s?: number | null;
 }
 
 export interface NetworkConfig {
@@ -552,6 +554,25 @@ export interface LiveInterface {
 export interface NetworkState {
 	config: NetworkConfig;
 	interfaces: LiveInterface[];
+	/** Iface the WebUI is currently reaching the engine through. Used to
+	 * warn before submitting a change that would disconnect the user. */
+	mgmt_iface?: string | null;
+}
+
+/** Optional fields the WebUI can include when submitting a network update.
+ * Server-side flatten means a bare NetworkConfig is also accepted. */
+export interface NetworkUpdateRequest extends NetworkConfig {
+	/** Seconds the user has to confirm the change before it auto-rolls back.
+	 * Omit to let the server pick (30s for risky changes, none for safe). */
+	confirm_within_secs?: number;
+}
+
+/** Returned by `system.network.update`. Fields are populated only when the
+ * server scheduled a rollback. */
+export interface NetworkUpdateResponse {
+	txn_id?: string | null;
+	revert_at_unix?: number | null;
+	risk_reason?: string | null;
 }
 
 export interface FirewallRule {

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -58,10 +58,12 @@
 		Wrench,
 		ScrollText,
 		Search,
+		AlertTriangle,
 	} from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
+	import { rollbackState, confirmRollback } from '$lib/rollbackState.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
@@ -186,6 +188,26 @@
 	// Version info (loaded once after connect)
 	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
 	let clock24h = $state(true);
+
+	// Network rollback countdown — ticks once per second while a rollback is
+	// pending so the banner can show "Xs left to keep changes". Auto-clears
+	// the local store at deadline; the engine has already reverted by then.
+	let nowSec = $state(Math.floor(Date.now() / 1000));
+	$effect(() => {
+		if (!rollbackState.pending) return;
+		const handle = setInterval(() => {
+			nowSec = Math.floor(Date.now() / 1000);
+			if (rollbackState.pending && nowSec >= rollbackState.pending.revertAtUnix) {
+				rollbackState.clear();
+			}
+		}, 1000);
+		return () => clearInterval(handle);
+	});
+	let rollbackSecondsLeft = $derived(
+		rollbackState.pending
+			? Math.max(0, rollbackState.pending.revertAtUnix - nowSec)
+			: 0,
+	);
 
 	$effect(() => {
 		const _r = sysInfoRefresh.count; // track refresh triggers
@@ -759,6 +781,28 @@
 								<span title="Debug checks"><Bug size={14} class={sysInfo.bcachefs_debug_checks ? 'text-blue-400' : 'text-muted-foreground/30'} /></span>
 							</span>
 						</a>
+					{/if}
+					{#if rollbackState.pending}
+						<!-- Pending network rollback. Sticky on every page so the
+						     user can confirm even after navigating away from
+						     /settings. The engine reverts at revertAtUnix; this
+						     banner auto-clears when the countdown hits zero. -->
+						<div
+							class="flex items-center gap-3 rounded-md border-2 border-amber-500/70 px-3 py-1.5 text-sm text-amber-400 animate-pulse hover:animate-none"
+							role="status"
+							title={rollbackState.pending.riskReason ?? ''}
+						>
+							<AlertTriangle size={15} />
+							<span class="font-medium">
+								{rollbackSecondsLeft}s to keep network change
+							</span>
+							<button
+								onclick={() => confirmRollback()}
+								class="rounded border border-amber-400/50 px-2 py-0.5 text-xs hover:bg-amber-500/10 hover:border-amber-400 active:bg-amber-500/20"
+							>
+								Keep changes
+							</button>
+						</div>
 					{/if}
 				</div>
 

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
+	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -283,10 +284,7 @@
 			bridges: network?.bridges ?? [],
 		};
 
-		await withToast(
-			() => client.call('system.network.update', payload),
-			'Network configuration applied'
-		);
+		await applyNetworkUpdate(payload, 'Network configuration applied');
 		networkState = await client.call<NetworkState>('system.network.get');
 		syncNetworkForm();
 		savingNetwork = false;
@@ -420,7 +418,7 @@
 			if (idx >= 0) payload.interfaces[idx] = entry; else payload.interfaces.push(entry);
 		}
 
-		await withToast(() => client.call('system.network.update', payload), 'Network configuration applied');
+		await applyNetworkUpdate(payload, 'Network configuration applied');
 		networkState = await client.call<NetworkState>('system.network.get');
 		netChanged = false;
 		savingNetwork = false;
@@ -436,7 +434,7 @@
 			vlans: network.vlans || [],
 			bridges: network.bridges || [],
 		};
-		await withToast(() => client.call('system.network.update', payload), `Bond ${bondName} created`);
+		await applyNetworkUpdate(payload, `Bond ${bondName} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
 		showBondForm = false; bondName = 'bond0'; bondMembers = []; bondMtu = '';
 	}
@@ -451,7 +449,7 @@
 			vlans: [...(network.vlans || []), { parent: vlanParent, vlan_id: vlanId, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null }, mtu }],
 			bridges: network.bridges || [],
 		};
-		await withToast(() => client.call('system.network.update', payload), `VLAN ${vlanParent}.${vlanId} created`);
+		await applyNetworkUpdate(payload, `VLAN ${vlanParent}.${vlanId} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
 		showVlanForm = false; vlanParent = ''; vlanId = 100; vlanMtu = '';
 	}
@@ -464,9 +462,14 @@
 			dns: network.dns || [],
 			bonds: network.bonds || [],
 			vlans: network.vlans || [],
-			bridges: [...(network.bridges || []), { name: bridgeName, members: bridgeMembers, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null }, mtu }],
+			// `inherit` = adopt the primary member's L3 (DHCP lease, static
+			// addrs, default route). The server resolves it to a concrete
+			// Static/Dhcp before persisting so reboot reapplies the same L3.
+			// For host-internal bridges (no members), inherit resolves to
+			// Disabled — the bridge is L2-only, which is what VMs want.
+			bridges: [...(network.bridges || []), { name: bridgeName, members: bridgeMembers, ipv4: { method: 'inherit', addresses: [], gateway: null }, ipv6: { method: 'inherit', addresses: [], gateway: null }, mtu }],
 		};
-		await withToast(() => client.call('system.network.update', payload), `Bridge ${bridgeName} created`);
+		await applyNetworkUpdate(payload, `Bridge ${bridgeName} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
 		showBridgeForm = false; bridgeName = 'br0'; bridgeMembers = []; bridgeMtu = '';
 	}
@@ -980,6 +983,12 @@
 						<label for="bridge-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
 						<input id="bridge-mtu" type="number" min="68" max="65535" bind:value={bridgeMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
 					</div>
+					{#if networkState?.mgmt_iface && bridgeMembers.includes(networkState.mgmt_iface)}
+						<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300">
+							<div class="font-medium mb-1">Heads up — this bridges your management interface</div>
+							<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. The bridge will adopt its IP and route, but you may briefly see the page reconnect. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
+						</div>
+					{/if}
 					<Button size="sm" onclick={createBridge} disabled={!bridgeName}>Create Bridge</Button>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary

Surfaces the confirm-or-rollback safety net from #80 in the WebUI so a risky network change is visible and one-click confirmable instead of silently auto-reverting after 30s. Also adds a pre-submit warning in the bridge form when the user is about to bridge their own management interface.

This is the UX layer the comprehensive #74 fix was missing — without a banner, a user submitting a risky change just sees the change \"undo itself\" 30s later with no explanation. Now they get a countdown and a Keep changes button.

## Backend touch

`system.network.get` now returns `mgmt_iface: Option<String>` — the iface the WebUI is currently reaching the engine through, resolved by walking from `session.client_ip` through `ip route get` + the sysfs master chain. Used by the bridge form to warn before submitting a change that would disconnect the user.

## WebUI

- **New `lib/rollbackState.svelte.ts` global store.**
  - `applyNetworkUpdate(payload, msg)` wraps `system.network.update`, shows toasts the same way `withToast` does, and populates the store when the response carries a `txn_id`.
  - `confirmRollback()` posts `system.network.confirm` and clears the store. Clears optimistically even if the RPC fails (server may have already reverted, in which case the banner should disappear regardless).
- **Sticky banner in `+layout.svelte`.** Shows `{Xs} to keep network change` plus a Keep changes button while `rollbackState.pending` is set. Renders in the centered banners area on every page so confirms work even after navigating away from /settings. Auto-clears at deadline (engine has reverted by then). Hovering shows `risk_reason` as a tooltip.
- **All five `system.network.update` call sites** in `settings/+page.svelte` go through `applyNetworkUpdate` so any update can trigger the banner — not just the bridge form. Other endpoints keep using `withToast` directly.
- **Bridge form pre-submit warning.** When the user has the management iface checked as a member, a destructive-amber callout appears explaining the bridge will adopt that iface's L3, the page may briefly reconnect, and there's a 30s rollback window. Reactive — toggles as they check/uncheck.
- **Bridge defaults updated.** Bridge creation now sends `ipv4: { method: 'inherit' }` / `ipv6: { method: 'inherit' }` instead of `'dhcp'`, matching PR3's server-side default. For host-internal bridges with no members, the server resolves Inherit to Disabled — the right L2-only default for VM-attach bridges.
- **Types.** `IpMethod` adds `'inherit'`; `BridgeConfig` gets optional `stp` / `forward_delay_s`; `NetworkState` gets `mgmt_iface`; new `NetworkUpdateRequest` / `NetworkUpdateResponse`.

## Verified

- [x] `npm run check` (svelte-check): 0 errors, 0 warnings, 4833 files
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test -p nasty-system`: 78 passed (no test changes; backend diff is data-only)
- [ ] **Manual end-to-end on a NASty box** — I haven't done this; verifying a Svelte 5 `$effect` countdown + WebSocket roundtrip + real `ip route get` lookup needs the actual box. What to check:
  - Open WebUI, go to Settings → Network, click + Bridge, select the iface that's in `mgmt_iface` — destructive-amber warning appears
  - Submit — banner shows `30s to keep network change` with countdown
  - Hover the banner — tooltip shows `risk_reason`
  - Click Keep changes — banner disappears, change persists
  - Repeat without confirming — at 0s the banner clears, refreshing the page shows the original config (server reverted)
  - Navigate away to /vms during the countdown — banner stays visible
  - Reload the WebUI mid-countdown — banner is lost (it's in-memory only); the engine still rolls back at deadline. Acceptable; `system.network.transactions` follow-up would let us re-hydrate.

## Out of scope (deliberate)

- **Auto-confirm on healthy roundtrip.** A user proving connectivity post-apply could reasonably be auto-confirmed, but it's opinionated — they might want time to verify a config manually first. Banner-only is simpler and the user can still wait it out.
- **`system.network.transactions` RPC.** Would let the WebUI re-hydrate the banner after a page reload. Easy follow-up.
- **History UI** (PR1's `/var/lib/nasty/networking.history/` snapshots). Audit trail today, restore-by-click later.
- **STP / forward-delay form fields** — backend is plumbed, just need WebUI inputs. Cosmetic, separate PR.

## Closing the comprehensive #74 plan

This is the last of the five PRs in the architectural plan that started with #74:

1. #75 — atomic config write, history snapshots, per-iface DHCP
2. #76 — `Plan` / `Op` refactor (pure-data, testable apply pipeline)
3. #77 — bridge L3 inheritance (functional fix for #74)
4. #80 — confirm-or-rollback transaction layer (safety net for the *class* of bug)
5. #81 (this PR) — WebUI banner + bridge form risk warning

After this lands, creating a bridge over the management iface from the WebUI is a normal-looking operation: the user sees a warning before submitting, the page may briefly reconnect, a banner appears with a 30s countdown, and one click keeps the change.