### PR TITLE
network: persist via nixos-rebuild + treat live DHCP as Dhcp on inherit

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -373,6 +373,11 @@ impl NetworkService {
                 config.vlans.len()
             );
 
+            // Safe (non-rollback) change: persist to NixOS now so the next
+            // reboot uses our generated networking.nix instead of the
+            // last-built generation. Risky changes defer this to confirm().
+            spawn_nixos_rebuild_boot("apply");
+
             Ok(UpdateResponse::default())
         }
     }
@@ -390,6 +395,11 @@ impl NetworkService {
                 let _ = txn.cancel.send(());
                 let _ = tokio::fs::remove_file(PENDING_REVERT_PATH).await;
                 info!("Network txn {txn_id} confirmed");
+                // Now that the user has acknowledged the change, persist it
+                // to NixOS so a reboot uses it. Deferred to confirm() (not
+                // run at apply time) so we don't pay the rebuild cost for
+                // changes that get rolled back.
+                spawn_nixos_rebuild_boot(&format!("confirm {txn_id}"));
                 Ok(())
             }
             None => Err(format!("unknown or already-completed txn_id {txn_id}")),
@@ -499,6 +509,46 @@ async fn perform_rollback(txn_id: &str) {
     }
     let _ = tokio::fs::remove_file(PENDING_REVERT_PATH).await;
     warn!("rollback {txn_id}: completed; previous config restored");
+}
+
+/// Spawn `nixos-rebuild boot --flake /etc/nixos` in the background so the
+/// generated `/etc/nixos/networking.nix` is realized into a built system
+/// generation. `boot` (not `switch`) updates the bootloader entry without
+/// disrupting the running system — the runtime change is already in place
+/// via `ip` commands, this just makes it stick across reboot.
+///
+/// Returns immediately; the rebuild runs to completion in the background
+/// and logs success or stderr on failure. Multiple concurrent invocations
+/// serialize on `nixos-rebuild`'s own lock (the Nix store DB lock); cheap
+/// enough that we don't add our own mutex.
+///
+/// `cause` is logged for traceability — typically `"apply"` or
+/// `"confirm <txn_id>"` so journal grep is straightforward.
+fn spawn_nixos_rebuild_boot(cause: &str) {
+    let cause = cause.to_string();
+    tokio::spawn(async move {
+        info!("nixos-rebuild boot starting ({cause})");
+        let output = tokio::process::Command::new("nixos-rebuild")
+            .args(["boot", "--flake", "/etc/nixos"])
+            .output()
+            .await;
+        match output {
+            Ok(out) if out.status.success() => {
+                info!("nixos-rebuild boot completed ({cause}); change persists across reboot");
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let stderr = stderr.trim();
+                warn!(
+                    "nixos-rebuild boot failed ({cause}, status {}): {stderr}",
+                    out.status
+                );
+            }
+            Err(e) => {
+                warn!("nixos-rebuild boot failed to spawn ({cause}): {e}");
+            }
+        }
+    });
 }
 
 fn new_txn_id() -> String {
@@ -925,7 +975,26 @@ fn resolve_inherit_one(
                 _ => {}
             }
         }
-        // Fall back to whatever the kernel currently shows for this member.
+        // No prior config for this member. The fallback is to look at live
+        // kernel state — but with one important exception: if the member's
+        // address came from dhcpcd (the kernel route table marks the route
+        // `proto: dhcp`), the live address is a *lease*, not a static
+        // configuration. Baking that lease into the bridge as Static would
+        // cause two real bugs:
+        //   1) On reboot, the bridge claims the leased address even though
+        //      the DHCP server may have re-issued it elsewhere.
+        //   2) The bridge stops doing DHCP renewals — when the lease
+        //      expires the address is still claimed but no longer valid.
+        // So treat DHCP-managed members as `Dhcp` (let the bridge get its
+        // own lease), and only bake live addrs as Static when the route
+        // table says they're statically configured.
+        if !v6 && live.is_dhcp_managed_v4(member) {
+            return IpConfig {
+                method: IpMethod::Dhcp,
+                addresses: Vec::new(),
+                gateway: None,
+            };
+        }
         let live_addrs = live.addrs(member, v6);
         if !live_addrs.is_empty() {
             return IpConfig {
@@ -969,6 +1038,11 @@ struct LiveTopology {
     default_via_v4: std::collections::HashMap<String, String>,
     /// Egress iface → IPv6 default gateway.
     default_via_v6: std::collections::HashMap<String, String>,
+    /// Ifaces whose IPv4 addresses were installed by dhcpcd (any route on
+    /// the iface with `proto: dhcp`). Used by `resolve_inherit` so the
+    /// live lease address isn't baked into the bridge config as Static —
+    /// the bridge inherits DHCP semantics, not the specific address.
+    dhcp_managed_v4: std::collections::HashSet<String>,
 }
 
 impl LiveTopology {
@@ -991,12 +1065,16 @@ impl LiveTopology {
         let default_via_v6 =
             parse_default_via(&run_ip_json(&["-j", "-6", "route", "show", "default"]).await)
                 .unwrap_or_default();
+        let dhcp_managed_v4 =
+            parse_dhcp_managed(&run_ip_json(&["-j", "-4", "route", "show"]).await)
+                .unwrap_or_default();
         Self {
             links,
             addrs_v4,
             addrs_v6,
             default_via_v4,
             default_via_v6,
+            dhcp_managed_v4,
         }
     }
 
@@ -1016,6 +1094,10 @@ impl LiveTopology {
             &self.default_via_v4
         };
         map.get(iface).map(|s| s.as_str())
+    }
+
+    fn is_dhcp_managed_v4(&self, iface: &str) -> bool {
+        self.dhcp_managed_v4.contains(iface)
     }
 }
 
@@ -1066,6 +1148,11 @@ struct IpRouteLine {
     dst: String,
     gateway: Option<String>,
     dev: Option<String>,
+    /// Routing protocol id — `"dhcp"` when dhcpcd installed the route.
+    /// Used to distinguish a DHCP lease from a static address that
+    /// happens to be the same value.
+    #[serde(default)]
+    protocol: String,
 }
 
 fn parse_default_via(json: &str) -> Option<std::collections::HashMap<String, String>> {
@@ -1078,6 +1165,19 @@ fn parse_default_via(json: &str) -> Option<std::collections::HashMap<String, Str
                 (Some(dev), Some(gw)) => Some((dev, gw)),
                 _ => None,
             })
+            .collect(),
+    )
+}
+
+/// Set of ifaces with at least one route installed by dhcpcd. Parsed from
+/// `ip -j -4 route show` (no filter — we want default *and* link routes).
+fn parse_dhcp_managed(json: &str) -> Option<std::collections::HashSet<String>> {
+    let parsed: Vec<IpRouteLine> = serde_json::from_str(json).ok()?;
+    Some(
+        parsed
+            .into_iter()
+            .filter(|r| r.protocol == "dhcp")
+            .filter_map(|r| r.dev)
             .collect(),
     )
 }
@@ -2175,9 +2275,10 @@ mod tests {
     }
 
     #[test]
-    fn inherit_falls_back_to_live_addrs() {
-        // No prior config for eth0, but the kernel currently shows a lease
-        // address — adopt it as static so the bridge keeps connectivity.
+    fn inherit_falls_back_to_live_addrs_as_static_when_not_dhcp_managed() {
+        // No prior config for eth0; live shows an address that wasn't
+        // installed by dhcpcd (proto != dhcp). Adopt it as Static — it's
+        // a manually-configured address that should follow the bridge.
         let prev = NetworkConfig::default();
         let mut br = bridge("br0", &["eth0"]);
         br.ipv4 = inherit_ip();
@@ -2196,6 +2297,29 @@ mod tests {
             resolved.bridges[0].ipv4.gateway,
             Some("10.0.0.1".to_string())
         );
+    }
+
+    #[test]
+    fn inherit_resolves_to_dhcp_when_live_route_is_dhcp_managed() {
+        // No prior config, but the kernel route table marks the iface's
+        // route as `proto: dhcp` — the live address is a lease, not a
+        // static configuration. The bridge must inherit DHCP semantics
+        // (so it does its own renewals) rather than baking the leased
+        // address as Static, which would break on reboot if the DHCP
+        // server hands the address to someone else.
+        let prev = NetworkConfig::default();
+        let mut br = bridge("br0", &["eth0"]);
+        br.ipv4 = inherit_ip();
+        let next = NetworkConfig {
+            bridges: vec![br],
+            ..Default::default()
+        };
+        let mut live = live_for("eth0", &["10.0.0.5/24"], Some("10.0.0.1"));
+        live.dhcp_managed_v4.insert("eth0".to_string());
+        let resolved = resolve_inherit(next, &prev, &live);
+        assert_eq!(resolved.bridges[0].ipv4.method, IpMethod::Dhcp);
+        assert!(resolved.bridges[0].ipv4.addresses.is_empty());
+        assert!(resolved.bridges[0].ipv4.gateway.is_none());
     }
 
     #[test]
@@ -2299,7 +2423,32 @@ mod tests {
     fn parse_handles_empty_or_malformed_json() {
         assert!(parse_ip_addrs("[]", false).unwrap().is_empty());
         assert!(parse_default_via("[]").unwrap().is_empty());
+        assert!(parse_dhcp_managed("[]").unwrap().is_empty());
         assert!(parse_ip_addrs("not json", false).is_none());
+    }
+
+    #[test]
+    fn parse_dhcp_managed_picks_up_proto_dhcp_routes() {
+        // Real `ip -j -4 route show` output from a DHCP-managed iface:
+        // both the default route and the link-scope route are tagged
+        // proto: dhcp because dhcpcd installed them.
+        let json = r#"[
+          {"dst":"default","gateway":"10.10.10.1","dev":"ens18","protocol":"dhcp"},
+          {"dst":"10.10.10.0/24","dev":"ens18","protocol":"dhcp"},
+          {"dst":"172.17.0.0/16","dev":"docker0","protocol":"kernel"}
+        ]"#;
+        let parsed = parse_dhcp_managed(json).unwrap();
+        assert!(parsed.contains("ens18"));
+        assert!(!parsed.contains("docker0"));
+    }
+
+    #[test]
+    fn parse_dhcp_managed_ignores_static_routes() {
+        let json = r#"[
+          {"dst":"default","gateway":"10.0.0.1","dev":"eth0","protocol":"static"},
+          {"dst":"10.0.0.0/24","dev":"eth0","protocol":"kernel"}
+        ]"#;
+        assert!(parse_dhcp_managed(json).unwrap().is_empty());
     }
 
     // ── BridgeConfig deserialization defaults ──────────────────


### PR DESCRIPTION
## Summary

Two related fixes for the bug surfaced after #85: bridging the management iface worked at runtime and through the confirm-or-rollback flow, but after reboot the box came up on a different IP **without the bridge**. Diagnosis on the affected box (10.10.10.61):

```
nixos-rebuild switch    →  06:37:43  (built generation 32, no bridge)
networking.nix written  →  06:40:58  (bridge added — only on disk)
booted system           →  generation 32, the pre-bridge build
live state              →  br0 doesn't exist; ens18 has 10.10.10.61 via DHCP
                          (was 10.10.10.52 at apply time, but the bridge
                           config baked the lease as Static)
```

So two underlying issues, both fixed here.

## 1. `nixos-rebuild boot` after apply / confirm

The engine writes `/etc/nixos/networking.nix` on every successful update, but until now **nothing ever turned that file into a built system generation**. The runtime change was correct (via `ip` commands); reboot used the previously-built generation, which still reflected the pre-change config. Net effect: changes never survived a reboot.

**Fix:** spawn `nixos-rebuild boot --flake /etc/nixos` in the background after:
- a successful apply for **non-risky** changes (no rollback timer was scheduled)
- a successful **confirm** for risky changes (so we don't pay the rebuild cost for changes that get rolled back)

Why `boot` (not `switch`):
- `boot` only updates the bootloader entry — the running system is left alone
- the runtime change is already in place via `ip` commands
- no risk of the rebuild itself disrupting the SSH session that submitted the change

Multiple concurrent rebuilds serialize on Nix's own DB lock; cheap enough to not need our own mutex. Failure is logged via `tracing::warn!` (visible in journalctl) and doesn't block apply.

## 2. `resolve_inherit` treats live-DHCP addresses as Dhcp, not Static

When a member iface has no prior top-level config (the typical case — most people don't explicitly configure their default-DHCP iface via the WebUI), PR3's fallback was \"live state has an address, bake it as Static.\" That meant a box DHCPing at `.61` ended up with the bridge configured Static `.61`. Two real bugs followed:

- On reboot, the bridge would claim `.61` even if the DHCP server had re-issued it elsewhere — silent address conflict.
- The bridge stopped doing DHCP renewals; if the lease expired, the address remained claimed but was no longer valid.

**Fix:** the kernel route table tells us the truth — dhcpcd-installed routes are tagged `proto: dhcp`. New `LiveTopology.dhcp_managed_v4` set, populated from `ip -j -4 route show` and a new `parse_dhcp_managed` parser. `resolve_inherit_one` now short-circuits to `IpMethod::Dhcp` for DHCP-managed members instead of falling through to Static. Genuinely static live addresses (proto: `static` or `kernel`) still resolve to Static, which is correct for manually-configured addresses that should follow the bridge.

## What this does *not* change

- The runtime apply path. `ip` commands still apply changes immediately so the WebUI feels responsive; the rebuild just realizes the persistence layer.
- IPv6 inheritance. Only IPv4 has the dhcpcd-vs-static distinction here; IPv6 keeps SLAAC / Static / Disabled semantics.
- The Nix rebuild URL — hardcoded as `/etc/nixos`. Matches the path used by `update.rs` already; if a future install puts the flake elsewhere, this needs to grow a config knob.

## Test plan

- [x] `cargo test -p nasty-system`: 81 passed (was 78). Three new tests:
  - `inherit_resolves_to_dhcp_when_live_route_is_dhcp_managed`
  - `inherit_falls_back_to_live_addrs_as_static_when_not_dhcp_managed` (renamed; non-DHCP semantics preserved)
  - `parse_dhcp_managed_picks_up_proto_dhcp_routes` / `parse_dhcp_managed_ignores_static_routes`
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `npm run check` (svelte-check): 0 errors (no UI changes)
- [ ] **Manual on a NASty box (10.10.10.61, the one that surfaced this):** I already manually fixed up the persisted config + ran `nixos-rebuild boot` to recover from the original incident. After this PR lands and is deployed, the proper test is:
  1. Tear down the bridge from the WebUI.
  2. Re-create it over the management iface.
  3. Confirm the change in the WebUI banner.
  4. Verify `journalctl -u nasty-engine | grep nixos-rebuild` shows a successful build.
  5. Verify `nix-env --list-generations -p /nix/var/nix/profiles/system` shows a new generation as the boot target.
  6. Reboot. Bridge should come back DHCPing on ens18's MAC.