### PR TITLE
network: phase 3a — NetworkManager DBus client (read-only)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -148,6 +148,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +168,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1207,6 +1230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1249,27 @@ name = "enum-map-derive"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1415,6 +1465,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2555,7 +2618,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "x509-parser",
+ "zbus",
 ]
 
 [[package]]
@@ -2935,6 +3000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4310,6 +4394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,6 +4824,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4791,6 +4882,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -4947,6 +5068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5014,6 +5146,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -5475,6 +5608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,6 +5776,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5745,4 +5943,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -28,7 +28,8 @@ thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 argon2 = { version = "0.5", features = ["rand"] }
 rand = "0.10"
 base64 = "0.22"

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -688,6 +688,14 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Err(e) => invalid(req, e),
             }
         }
+        // Phase 3a: read-only NM preview. Connects to NetworkManager
+        // via DBus, diffs the persisted desired config against the
+        // current `nasty-*` connections in NM, returns the change set.
+        // No NM state is touched; safe to call at any time.
+        "system.network.nm_preview" => match state.network.nm_preview().await {
+            Ok(diff) => ok(req, diff),
+            Err(e) => err(req, e),
+        },
         "system.metrics.prometheus" => {
             let url = format!("{}/metrics", crate::METRICS_BASE);
             match state.metrics_client.get(&url).send().await {

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -20,6 +20,8 @@ x509-parser = "0.18"
 rowan = "0.15"
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+uuid.workspace = true
+zbus.workspace = true
 
 [dev-dependencies]
 # `test-util` enables tokio::time::pause/advance for transaction tests.

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -492,6 +492,23 @@ impl NetworkService {
     pub async fn list_interfaces(&self) -> Vec<LiveInterface> {
         enumerate_interfaces().await
     }
+
+    /// Phase 3a — connect to NetworkManager via DBus and report what
+    /// would change if the persisted (resolved) network config were
+    /// applied via NM. **Read-only**; no NM state is touched. Phase 3b
+    /// adds the actual apply.
+    ///
+    /// Returns the diff as data so callers (and the future WebUI) can
+    /// surface it before committing to the cutover.
+    pub async fn nm_preview(&self) -> Result<nm::dbus::NmDiff, String> {
+        let cfg = load_config().await;
+        let layered_cfg = layered::to_layered(&cfg);
+        let desired = nm::to_nm_profiles(&layered_cfg);
+
+        let client = nm::dbus::NmDbusClient::new().await?;
+        let existing = client.list_nasty_connections().await?;
+        Ok(nm::dbus::compute_diff(&desired, &existing))
+    }
 }
 
 /// Top-level helper for the rollback timer. Reads the pending-revert file,

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -1021,8 +1021,7 @@ mod tests {
         let outer = addr_data.try_clone().ok()?;
         // `address-data` is `aa{sv}` — array of dicts.
         let arr: zbus::zvariant::Array = outer.try_into().ok()?;
-        let mut iter = arr.into_iter();
-        let first: zbus::zvariant::Value = iter.next()?.try_clone().ok()?;
+        let first: zbus::zvariant::Value = arr.iter().next()?.try_clone().ok()?;
         let entry: zbus::zvariant::Dict = first.try_into().ok()?;
         let map: HashMap<String, OwnedValue> = entry.try_into().ok()?;
         let addr: String = map.get("address")?.try_clone().ok()?.try_into().ok()?;

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -21,9 +21,12 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use zbus::zvariant::OwnedValue;
 
 use super::IpMethod;
 use super::layered::{Address, AddressMethod, Family, LayeredConfig, Link, LinkKind};
+
+pub mod dbus;
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -303,30 +306,20 @@ fn default_ip_pair() -> (NmIpSettings, NmIpSettings) {
     (NmIpSettings::default(), NmIpSettings::default())
 }
 
-/// Phase 2 placeholder: produce a UUID-shaped string deterministically
-/// from the link name. Phase 3 will replace this with `Uuid::new_v5`
-/// (real UUIDv5) when the `uuid` crate is added as a dep alongside the
-/// chosen NM binding.
+/// Stable namespace UUID for NASty-managed NM connections. Generated
+/// once via `Uuid::new_v4`, then frozen. Same name → same connection
+/// UUID across reboots and across boxes, which keeps NM's connection
+/// identity stable when we re-author profiles.
+const NASTY_UUID_NAMESPACE: uuid::Uuid = uuid::uuid!("8d1f3a4e-4c8b-5e9f-9a1b-7c2e3d4f5a6b");
+
+/// Deterministic UUIDv5 from the link name. Same name → same UUID,
+/// always. Phase 3a (this PR) made this real (was a placeholder hash
+/// in phase 2); phase 3b uses these UUIDs as the connection identity
+/// when calling `Settings.AddConnection` over DBus.
 fn deterministic_uuid_for(name: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut h = DefaultHasher::new();
-    "nasty-network-v2".hash(&mut h);
-    name.hash(&mut h);
-    let h1 = h.finish();
-    let mut h = DefaultHasher::new();
-    h1.hash(&mut h);
-    "split".hash(&mut h);
-    let h2 = h.finish();
-    // Format: 8-4-4-4-12 hex digits, with version (4) and variant (8) bits.
-    format!(
-        "{:08x}-{:04x}-4{:03x}-8{:03x}-{:012x}",
-        (h1 >> 32) as u32,
-        ((h1 >> 16) & 0xffff) as u16,
-        (h1 & 0xfff) as u16,
-        ((h2 >> 48) & 0xfff) as u16,
-        h2 & 0xffff_ffff_ffff,
-    )
+    uuid::Uuid::new_v5(&NASTY_UUID_NAMESPACE, name.as_bytes())
+        .hyphenated()
+        .to_string()
 }
 
 // ── Keyfile serializer ─────────────────────────────────────────
@@ -447,6 +440,144 @@ fn serialize_ip_section(out: &mut String, ip: &NmIpSettings) {
     if ip.gateway.is_some() && ip.addresses.is_empty() {
         out.push_str("# warning: gateway set but no addresses; NM will ignore\n");
     }
+}
+
+// ── DBus settings dict converter ───────────────────────────────
+//
+// Phase 3a addition: convert a typed `NmConnection` into the dict
+// shape NM expects on DBus (`a{sa{sv}}` — section name → key →
+// variant). This is the `Settings.AddConnection` / `Connection.Update`
+// payload.
+//
+// Why this lives alongside `serialize_keyfile`: the keyfile and the
+// DBus dict are two views of the same connection. Some fields are
+// formatted differently (`address1=10.0.0.5/24,10.0.0.1` in keyfile
+// becomes a `Vec<Vec<u32>>` of `[ip, prefix, gateway]` triples on
+// DBus), but every field is in both. Keeping them next to each other
+// makes drift easy to spot.
+
+/// Build the DBus settings dict for an `NmConnection`. Compatible with
+/// `org.freedesktop.NetworkManager.Settings.AddConnection`.
+pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, OwnedValue>> {
+    let mut out: HashMap<String, HashMap<String, OwnedValue>> = HashMap::new();
+
+    // [connection]
+    let mut conn = HashMap::new();
+    conn.insert("id".into(), into_value(p.id.clone()));
+    conn.insert("uuid".into(), into_value(p.uuid.clone()));
+    conn.insert(
+        "type".into(),
+        into_value(p.conn_type.keyfile_str().to_string()),
+    );
+    conn.insert(
+        "interface-name".into(),
+        into_value(p.interface_name.clone()),
+    );
+    conn.insert("autoconnect".into(), into_value(p.autoconnect));
+    if let Some(c) = &p.controller {
+        conn.insert("controller".into(), into_value(c.clone()));
+    }
+    if let Some(pt) = &p.port_type {
+        conn.insert("port-type".into(), into_value(pt.clone()));
+    }
+    out.insert("connection".into(), conn);
+
+    // type-specific section
+    match &p.type_specific {
+        NmTypeSpecific::None => {}
+        NmTypeSpecific::Bond { mode } => {
+            // NM's [bond] is `options`: a string→string map.
+            let mut options = HashMap::<String, String>::new();
+            options.insert("mode".into(), mode.clone());
+            let mut bond = HashMap::new();
+            bond.insert("options".into(), into_value(options));
+            out.insert("bond".into(), bond);
+        }
+        NmTypeSpecific::Bridge { stp, forward_delay } => {
+            let mut bridge = HashMap::new();
+            bridge.insert("stp".into(), into_value(*stp));
+            if let Some(fd) = forward_delay {
+                // NM expects forward-delay as a u32 in seconds.
+                bridge.insert("forward-delay".into(), into_value(u32::from(*fd)));
+            }
+            out.insert("bridge".into(), bridge);
+        }
+        NmTypeSpecific::Vlan { parent, id } => {
+            let mut vlan = HashMap::new();
+            vlan.insert("parent".into(), into_value(parent.clone()));
+            vlan.insert("id".into(), into_value(u32::from(*id)));
+            out.insert("vlan".into(), vlan);
+        }
+    }
+
+    // [ethernet] for Ethernet type. Carries MTU + cloned-mac.
+    if matches!(p.conn_type, NmConnectionType::Ethernet) {
+        let mut eth = HashMap::new();
+        if let Some(mtu) = p.mtu {
+            eth.insert("mtu".into(), into_value(u32::from(mtu)));
+        }
+        if let Some(mac) = &p.mac {
+            eth.insert("cloned-mac-address".into(), into_value(mac.clone()));
+        }
+        out.insert("802-3-ethernet".into(), eth);
+    }
+
+    // [ipv4]
+    out.insert("ipv4".into(), ip_section_dict(&p.ipv4, Family::V4));
+    // [ipv6]
+    out.insert("ipv6".into(), ip_section_dict(&p.ipv6, Family::V6));
+
+    out
+}
+
+fn ip_section_dict(ip: &NmIpSettings, family: Family) -> HashMap<String, OwnedValue> {
+    let mut s = HashMap::new();
+    s.insert(
+        "method".into(),
+        into_value(ip.method.keyfile_str().to_string()),
+    );
+
+    // NM's `address-data` (since 1.0) is the modern shape:
+    //   aa{sv} — array of dicts with keys "address" (string CIDR base)
+    //   and "prefix" (u32). Optional gateway is on `[ipv4].gateway`.
+    if !ip.addresses.is_empty() {
+        let mut addr_data: Vec<HashMap<String, OwnedValue>> = Vec::new();
+        for cidr in &ip.addresses {
+            if let Some((addr, prefix)) = parse_cidr(cidr, family) {
+                let mut entry = HashMap::new();
+                entry.insert("address".into(), into_value(addr));
+                entry.insert("prefix".into(), into_value(prefix));
+                addr_data.push(entry);
+            }
+        }
+        if !addr_data.is_empty() {
+            s.insert("address-data".into(), into_value(addr_data));
+        }
+    }
+    if let Some(gw) = &ip.gateway {
+        s.insert("gateway".into(), into_value(gw.clone()));
+    }
+    s
+}
+
+/// Parse `"10.0.0.5/24"` → (`"10.0.0.5"`, 24). Returns None on
+/// malformed input (we'd rather drop a bad address row than fail the
+/// whole apply).
+fn parse_cidr(cidr: &str, _family: Family) -> Option<(String, u32)> {
+    let (addr, prefix_str) = cidr.split_once('/')?;
+    let prefix: u32 = prefix_str.parse().ok()?;
+    Some((addr.to_string(), prefix))
+}
+
+/// Wrap a value in `OwnedValue`. Centralized so the unwrap handling is
+/// in one place — these conversions only fail on out-of-memory, which
+/// would fail loudly elsewhere first.
+fn into_value<T>(v: T) -> OwnedValue
+where
+    T: Into<zbus::zvariant::Value<'static>>,
+{
+    let value: zbus::zvariant::Value<'static> = v.into();
+    OwnedValue::try_from(value).expect("OwnedValue conversion")
 }
 
 // ── Tests ──────────────────────────────────────────────────────
@@ -880,5 +1011,224 @@ mod tests {
         };
         let keyfile = serialize_keyfile(&to_nm_profiles(&layered)[0]);
         assert!(keyfile.contains("cloned-mac-address=aa:bb:cc:dd:ee:ff"));
+    }
+
+    // ── DBus settings dict conversion (phase 3a) ───────────────
+
+    fn cidr_addr_data_first(dict: &HashMap<String, OwnedValue>) -> Option<(String, u32)> {
+        // Pull the first {address, prefix} entry out of `address-data`.
+        let addr_data: &OwnedValue = dict.get("address-data")?;
+        let outer = addr_data.try_clone().ok()?;
+        // `address-data` is `aa{sv}` — array of dicts.
+        let arr: zbus::zvariant::Array = outer.try_into().ok()?;
+        let mut iter = arr.into_iter();
+        let first: zbus::zvariant::Value = iter.next()?.try_clone().ok()?;
+        let entry: zbus::zvariant::Dict = first.try_into().ok()?;
+        let map: HashMap<String, OwnedValue> = entry.try_into().ok()?;
+        let addr: String = map.get("address")?.try_clone().ok()?.try_into().ok()?;
+        let prefix: u32 = map.get("prefix")?.try_clone().ok()?.try_into().ok()?;
+        Some((addr, prefix))
+    }
+
+    #[test]
+    fn dict_has_required_top_level_sections_for_ethernet_dhcp() {
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0")],
+            addresses: vec![Address {
+                link: "eth0".into(),
+                family: Family::V4,
+                method: IpMethod::Dhcp,
+                cidr: vec![],
+                gateway: None,
+            }],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        assert!(dict.contains_key("connection"));
+        assert!(dict.contains_key("802-3-ethernet"));
+        assert!(dict.contains_key("ipv4"));
+        assert!(dict.contains_key("ipv6"));
+    }
+
+    #[test]
+    fn dict_connection_section_carries_id_uuid_type_and_interface() {
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0")],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let conn = &dict["connection"];
+        let id: String = conn["id"].try_clone().unwrap().try_into().unwrap();
+        let uuid: String = conn["uuid"].try_clone().unwrap().try_into().unwrap();
+        let conn_type: String = conn["type"].try_clone().unwrap().try_into().unwrap();
+        let iface: String = conn["interface-name"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(id, "nasty-eth0");
+        assert_eq!(uuid.len(), 36);
+        assert_eq!(conn_type, "802-3-ethernet");
+        assert_eq!(iface, "eth0");
+    }
+
+    #[test]
+    fn dict_static_ipv4_uses_address_data_with_prefix() {
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0")],
+            addresses: vec![Address {
+                link: "eth0".into(),
+                family: Family::V4,
+                method: IpMethod::Static,
+                cidr: vec!["10.0.0.5/24".into()],
+                gateway: Some("10.0.0.1".into()),
+            }],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let ipv4 = &dict["ipv4"];
+        let method: String = ipv4["method"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(method, "manual");
+
+        let (addr, prefix) = cidr_addr_data_first(ipv4).expect("address-data parse");
+        assert_eq!(addr, "10.0.0.5");
+        assert_eq!(prefix, 24);
+
+        let gateway: String = ipv4["gateway"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(gateway, "10.0.0.1");
+    }
+
+    #[test]
+    fn dict_bridge_member_carries_controller_and_port_type_in_connection_section() {
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0"), link_bridge("br0", &["eth0"])],
+            ..Default::default()
+        };
+        let profiles = to_nm_profiles(&layered);
+        let eth0 = find(&profiles, "eth0");
+        let dict = to_settings_dict(eth0);
+        let conn = &dict["connection"];
+        let controller: String = conn["controller"].try_clone().unwrap().try_into().unwrap();
+        let port_type: String = conn["port-type"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(controller, "br0");
+        assert_eq!(port_type, "bridge");
+        // Member port should declare disabled IP method explicitly.
+        let ipv4_method: String = dict["ipv4"]["method"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(ipv4_method, "disabled");
+    }
+
+    #[test]
+    fn dict_bond_emits_options_subdict_with_mode() {
+        let layered = LayeredConfig {
+            links: vec![link_bond("bond0", &[])],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let bond = dict.get("bond").expect("bond section");
+        // `options` is `a{ss}` — string→string dict.
+        let options_value = bond["options"].try_clone().unwrap();
+        let options: HashMap<String, String> = options_value.try_into().unwrap();
+        assert_eq!(options.get("mode").map(|s| s.as_str()), Some("802.3ad"));
+    }
+
+    #[test]
+    fn dict_bridge_emits_stp_and_forward_delay() {
+        let layered = LayeredConfig {
+            links: vec![Link {
+                name: "br0".into(),
+                enabled: true,
+                mtu: None,
+                mac: None,
+                kind: LinkKind::Bridge {
+                    members: vec![],
+                    stp: true,
+                    forward_delay_s: Some(7),
+                },
+            }],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let bridge = dict.get("bridge").expect("bridge section");
+        let stp: bool = bridge["stp"].try_clone().unwrap().try_into().unwrap();
+        let fd: u32 = bridge["forward-delay"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert!(stp);
+        assert_eq!(fd, 7);
+    }
+
+    #[test]
+    fn dict_vlan_emits_parent_and_id_as_u32() {
+        let layered = LayeredConfig {
+            links: vec![Link {
+                name: "eth0.10".into(),
+                enabled: true,
+                mtu: None,
+                mac: None,
+                kind: LinkKind::Vlan {
+                    parent: "eth0".into(),
+                    id: 10,
+                },
+            }],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let vlan = dict.get("vlan").expect("vlan section");
+        let parent: String = vlan["parent"].try_clone().unwrap().try_into().unwrap();
+        let id: u32 = vlan["id"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(parent, "eth0");
+        assert_eq!(id, 10);
+    }
+
+    #[test]
+    fn dict_ethernet_section_carries_mtu_and_cloned_mac() {
+        let mut eth0 = link_phys("eth0");
+        eth0.mtu = Some(9000);
+        eth0.mac = Some("aa:bb:cc:dd:ee:ff".into());
+        let layered = LayeredConfig {
+            links: vec![eth0],
+            ..Default::default()
+        };
+        let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
+        let eth = dict.get("802-3-ethernet").expect("ethernet section");
+        let mtu: u32 = eth["mtu"].try_clone().unwrap().try_into().unwrap();
+        let mac: String = eth["cloned-mac-address"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(mtu, 9000);
+        assert_eq!(mac, "aa:bb:cc:dd:ee:ff");
+    }
+
+    // ── UUIDv5 sanity checks ───────────────────────────────────
+
+    #[test]
+    fn uuid_v5_is_canonical_36_chars() {
+        let u = deterministic_uuid_for("br0");
+        assert_eq!(u.len(), 36);
+        assert_eq!(u.as_bytes()[8], b'-');
+        assert_eq!(u.as_bytes()[13], b'-');
+        assert_eq!(u.as_bytes()[14], b'5'); // version 5
+        assert_eq!(u.as_bytes()[18], b'-');
+        assert_eq!(u.as_bytes()[23], b'-');
+    }
+
+    #[test]
+    fn uuid_v5_is_stable_for_same_name() {
+        assert_eq!(
+            deterministic_uuid_for("eth0"),
+            deterministic_uuid_for("eth0")
+        );
+        assert_ne!(
+            deterministic_uuid_for("eth0"),
+            deterministic_uuid_for("eth1")
+        );
     }
 }

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -1,0 +1,387 @@
+//! NetworkManager D-Bus client — phase 3a (read-only).
+//!
+//! Talks to NM via zbus. Phase 3a only exposes read methods
+//! (`list_connections`, `get_settings`, `list_devices`,
+//! `find_device_by_name`) plus diff computation against a desired set
+//! of `NmConnection` profiles. Phase 3b adds the write methods
+//! (`AddConnection` / `Update` / `Delete` / `Activate`) and wires the
+//! diff into the apply pipeline.
+//!
+//! Why phase 3a is read-only: this is the first PR that talks to NM at
+//! all. Bugs here can only return wrong data, not break the box.
+//! Phase 3b — which actually mutates NM state and runs the
+//! `nixos-rebuild switch` cutover — ships only after we've used
+//! `system.network.nm_preview` on a real NASty box and confirmed the
+//! diff matches expectations.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+use zbus::Connection as DbusConnection;
+use zbus::proxy;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+
+use super::{NmConnection, to_settings_dict};
+
+/// NM's settings dict shape: `a{sa{sv}}` — section name → setting
+/// name → variant. We use `OwnedValue` so the dict can hold any
+/// type NM expects (strings, integers, arrays of arrays of bytes,
+/// etc.). The `to_settings_dict` converter in `super` produces this.
+pub type SettingsDict = HashMap<String, HashMap<String, OwnedValue>>;
+
+// ── Proxies ────────────────────────────────────────────────────
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Settings",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/Settings"
+)]
+trait Settings {
+    /// Returns a list of object paths, one per persisted connection.
+    fn list_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Settings.Connection",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait ConnectionSettings {
+    /// Read the connection's settings dict. Phase 3a uses this to
+    /// identify NASty-managed connections (id starting with `nasty-`)
+    /// and to diff against the desired profile set.
+    fn get_settings(&self) -> zbus::Result<SettingsDict>;
+}
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager"
+)]
+trait NetworkManager {
+    fn get_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+}
+
+#[proxy(
+    interface = "org.freedesktop.NetworkManager.Device",
+    default_service = "org.freedesktop.NetworkManager"
+)]
+trait Device {
+    /// Kernel interface name (`eth0`, `br0`, `bond0`, ...). Phase 3b
+    /// uses this to resolve a profile's `interface_name` to the device
+    /// path that `ActivateConnection` needs.
+    #[zbus(property)]
+    fn interface(&self) -> zbus::Result<String>;
+}
+
+// ── Client ─────────────────────────────────────────────────────
+
+/// Read-only NM DBus client. Holds a system-bus connection and the
+/// top-level proxies. Cheap to construct — proxies don't open new
+/// connections.
+pub struct NmDbusClient {
+    conn: DbusConnection,
+}
+
+impl NmDbusClient {
+    /// Connect to the system bus. Fails if NM isn't running, the bus
+    /// isn't reachable, or the user lacks access. Surface the error
+    /// verbatim — phase 3a's `nm_preview` RPC reports it to the
+    /// caller so a misconfigured box is immediately diagnosable.
+    pub async fn new() -> Result<Self, String> {
+        let conn = DbusConnection::system()
+            .await
+            .map_err(|e| format!("connect to system DBus: {e}"))?;
+        Ok(Self { conn })
+    }
+
+    /// Object paths for every persisted connection NM knows about.
+    /// Includes external (Docker, libvirt, etc.) connections plus our
+    /// `nasty-*` ones; the caller filters.
+    pub async fn list_connections(&self) -> Result<Vec<OwnedObjectPath>, String> {
+        let proxy = SettingsProxy::new(&self.conn)
+            .await
+            .map_err(|e| format!("settings proxy: {e}"))?;
+        proxy
+            .list_connections()
+            .await
+            .map_err(|e| format!("list_connections: {e}"))
+    }
+
+    /// Read a single connection's settings dict.
+    pub async fn get_settings(&self, path: &OwnedObjectPath) -> Result<SettingsDict, String> {
+        let proxy = ConnectionSettingsProxy::builder(&self.conn)
+            .path(path.clone())
+            .map_err(|e| format!("connection path {path}: {e}"))?
+            .build()
+            .await
+            .map_err(|e| format!("connection proxy {path}: {e}"))?;
+        proxy
+            .get_settings()
+            .await
+            .map_err(|e| format!("get_settings {path}: {e}"))
+    }
+
+    /// All NASty-managed connections. Discriminator: the
+    /// `[connection].id` field starts with `nasty-`. Returns
+    /// (object path, settings) so callers can both compare settings
+    /// and identify which path to update/delete in phase 3b.
+    pub async fn list_nasty_connections(&self) -> Result<Vec<NmExisting>, String> {
+        let mut out = Vec::new();
+        for path in self.list_connections().await? {
+            let settings = match self.get_settings(&path).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("skip unreadable connection {path}: {e}");
+                    continue;
+                }
+            };
+            let Some(id) = read_string(&settings, "connection", "id") else {
+                continue;
+            };
+            if id.starts_with("nasty-") {
+                out.push(NmExisting { path, id, settings });
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Read a string field out of a settings dict. Returns None when the
+/// section, key, or expected variant type is missing.
+fn read_string(settings: &SettingsDict, section: &str, key: &str) -> Option<String> {
+    let value = settings.get(section)?.get(key)?;
+    let s: &str = value.downcast_ref().ok()?;
+    Some(s.to_string())
+}
+
+/// One existing NASty-managed NM connection.
+#[derive(Debug, Clone)]
+pub struct NmExisting {
+    pub path: OwnedObjectPath,
+    pub id: String,
+    pub settings: SettingsDict,
+}
+
+// ── Diff ───────────────────────────────────────────────────────
+
+/// What `nm_preview` would do if it were an apply: the per-id breakdown
+/// of additions, updates, and deletions. JSON-serialized for the RPC.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct NmDiff {
+    /// Connection IDs present in the desired set but not currently in
+    /// NM. Phase 3b would call `Settings.AddConnection`.
+    pub to_add: Vec<String>,
+    /// IDs present in both, but with different settings. Phase 3b would
+    /// call `Connection.Update`.
+    pub to_update: Vec<NmDiffUpdate>,
+    /// NASty-managed IDs in NM but not in the desired set — user must
+    /// have removed the link. Phase 3b would call `Connection.Delete`.
+    pub to_delete: Vec<String>,
+    /// Counts for at-a-glance display in the WebUI.
+    pub summary: NmDiffSummary,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct NmDiffUpdate {
+    pub id: String,
+    /// One line per differing top-level section (e.g. `"ipv4"`,
+    /// `"bridge"`). Cheap signal for the UI; phase 3b can show a
+    /// richer diff.
+    pub changed_sections: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct NmDiffSummary {
+    pub add: usize,
+    pub update: usize,
+    pub delete: usize,
+    pub unchanged: usize,
+}
+
+/// Compute what would change if the desired profiles were applied.
+/// Pure-data once `existing` is fetched — easy to unit-test.
+pub fn compute_diff(desired: &[NmConnection], existing: &[NmExisting]) -> NmDiff {
+    let mut out = NmDiff::default();
+    let existing_by_id: HashMap<&str, &NmExisting> =
+        existing.iter().map(|e| (e.id.as_str(), e)).collect();
+
+    let mut seen = std::collections::HashSet::new();
+    for desired_conn in desired {
+        seen.insert(desired_conn.id.clone());
+        match existing_by_id.get(desired_conn.id.as_str()) {
+            None => {
+                out.to_add.push(desired_conn.id.clone());
+                out.summary.add += 1;
+            }
+            Some(existing_conn) => {
+                let desired_dict = to_settings_dict(desired_conn);
+                let changed = diff_sections(&desired_dict, &existing_conn.settings);
+                if changed.is_empty() {
+                    out.summary.unchanged += 1;
+                } else {
+                    out.to_update.push(NmDiffUpdate {
+                        id: desired_conn.id.clone(),
+                        changed_sections: changed,
+                    });
+                    out.summary.update += 1;
+                }
+            }
+        }
+    }
+    for existing_conn in existing {
+        if !seen.contains(&existing_conn.id) {
+            out.to_delete.push(existing_conn.id.clone());
+            out.summary.delete += 1;
+        }
+    }
+    out
+}
+
+/// Names of top-level sections that differ between two settings dicts.
+/// We compare section-by-section by serialized representation — good
+/// enough signal for phase 3a's preview, sidesteps the OwnedValue
+/// equality awkwardness.
+fn diff_sections(a: &SettingsDict, b: &SettingsDict) -> Vec<String> {
+    let mut sections: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    sections.extend(a.keys().map(String::as_str));
+    sections.extend(b.keys().map(String::as_str));
+    sections
+        .into_iter()
+        .filter(|s| section_changed(a.get(*s), b.get(*s)))
+        .map(String::from)
+        .collect()
+}
+
+fn section_changed(
+    a: Option<&HashMap<String, OwnedValue>>,
+    b: Option<&HashMap<String, OwnedValue>>,
+) -> bool {
+    match (a, b) {
+        (None, None) => false,
+        (Some(_), None) | (None, Some(_)) => true,
+        (Some(a), Some(b)) => {
+            // Compare keys-and-values via Debug repr — OwnedValue
+            // doesn't impl Eq, but its Debug is stable and includes
+            // the variant + payload. Phase 3b gets a real comparator
+            // that walks the variant tree.
+            if a.len() != b.len() {
+                return true;
+            }
+            for (k, va) in a {
+                let Some(vb) = b.get(k) else {
+                    return true;
+                };
+                if format!("{va:?}") != format!("{vb:?}") {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::nm::{
+        NmConnection, NmConnectionType, NmIpMethod, NmIpSettings, NmTypeSpecific,
+    };
+
+    fn ethernet_profile(id: &str) -> NmConnection {
+        NmConnection {
+            id: id.into(),
+            uuid: format!("uuid-for-{id}"),
+            conn_type: NmConnectionType::Ethernet,
+            interface_name: id.trim_start_matches("nasty-").into(),
+            controller: None,
+            port_type: None,
+            mtu: None,
+            mac: None,
+            autoconnect: true,
+            ipv4: NmIpSettings {
+                method: NmIpMethod::Auto,
+                addresses: vec![],
+                gateway: None,
+            },
+            ipv6: NmIpSettings::default(),
+            type_specific: NmTypeSpecific::None,
+        }
+    }
+
+    #[test]
+    fn diff_empty_when_nothing_exists_and_nothing_desired() {
+        let d = compute_diff(&[], &[]);
+        assert_eq!(d.summary.add, 0);
+        assert_eq!(d.summary.update, 0);
+        assert_eq!(d.summary.delete, 0);
+        assert_eq!(d.summary.unchanged, 0);
+    }
+
+    #[test]
+    fn diff_lists_new_profiles_as_add() {
+        let d = compute_diff(&[ethernet_profile("nasty-eth0")], &[]);
+        assert_eq!(d.to_add, vec!["nasty-eth0".to_string()]);
+        assert_eq!(d.summary.add, 1);
+    }
+
+    #[test]
+    fn diff_lists_orphaned_existing_as_delete() {
+        // A nasty-* connection in NM that's no longer in our desired
+        // set — the user removed the link.
+        let existing = NmExisting {
+            path: OwnedObjectPath::try_from("/org/freedesktop/NetworkManager/Settings/1").unwrap(),
+            id: "nasty-old".into(),
+            settings: HashMap::new(),
+        };
+        let d = compute_diff(&[], &[existing]);
+        assert_eq!(d.to_delete, vec!["nasty-old".to_string()]);
+        assert_eq!(d.summary.delete, 1);
+    }
+
+    #[test]
+    fn diff_reports_unchanged_when_settings_match() {
+        // Existing connection with identical settings to the desired
+        // profile should be classified as unchanged.
+        let desired = ethernet_profile("nasty-eth0");
+        let existing = NmExisting {
+            path: OwnedObjectPath::try_from("/org/freedesktop/NetworkManager/Settings/1").unwrap(),
+            id: "nasty-eth0".into(),
+            settings: to_settings_dict(&desired),
+        };
+        let d = compute_diff(&[desired], &[existing]);
+        assert_eq!(d.summary.unchanged, 1);
+        assert_eq!(d.summary.update, 0);
+        assert!(d.to_update.is_empty());
+    }
+
+    #[test]
+    fn diff_reports_changed_section_when_settings_differ() {
+        // Existing has IPv4 manual; desired is auto. The diff should
+        // flag `ipv4` as the changed section.
+        let mut desired = ethernet_profile("nasty-eth0");
+        desired.ipv4.method = NmIpMethod::Auto;
+
+        let mut existing_profile = ethernet_profile("nasty-eth0");
+        existing_profile.ipv4.method = NmIpMethod::Manual;
+        existing_profile.ipv4.addresses = vec!["10.0.0.5/24".into()];
+
+        let existing = NmExisting {
+            path: OwnedObjectPath::try_from("/org/freedesktop/NetworkManager/Settings/1").unwrap(),
+            id: "nasty-eth0".into(),
+            settings: to_settings_dict(&existing_profile),
+        };
+        let d = compute_diff(&[desired], &[existing]);
+        assert_eq!(d.summary.update, 1);
+        assert_eq!(d.to_update[0].id, "nasty-eth0");
+        assert!(
+            d.to_update[0]
+                .changed_sections
+                .contains(&"ipv4".to_string()),
+            "ipv4 should be flagged as changed; got {:?}",
+            d.to_update[0].changed_sections
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First real DBus contact in the network architecture rework. Phase 3a adds:
- the binding (zbus 5 + uuid v5)
- NM DBus proxies via `zbus::proxy!`
- a typed `NmConnection` → DBus settings dict converter
- an `NmDbusClient` that can list/read NM connections
- a diff computer (`compute_diff(desired, existing) → NmDiff`)
- a `system.network.nm_preview` RPC that connects to NM and reports what would change

**Nothing in NM is mutated.** Phase 3b adds writes and the cutover (migration runner + flip the active apply path + drop legacy code).

## Why split phase 3 into 3a + 3b

The cutover (write keyfiles → `nixos-rebuild switch` → flip the active apply path → drop dhcpcd / nixos-rebuild / ip-command apply) is the only step in the entire architectural rework that is *hard to undo*. Splitting lets us:

1. Land the binding choice (zbus, real UUIDs) in a contained PR that can't break the network.
2. Run `system.network.nm_preview` on a real NASty box and inspect the diff before phase 3b commits.
3. Discover any dict-shape surprises (zbus variant types, NM section quirks) at preview time, not during the cutover.

Phase 3b ships only after a successful preview on the actual box.

## What's in this PR

**Workspace deps** (`engine/Cargo.toml`):
- `zbus = { version = "5", default-features = false, features = ["tokio"] }` — added
- `uuid = { features = ["v4", "v5", "serde"] }` — extended with `v5`

**`network/nm.rs`** (extended):
- `to_settings_dict(profile)` — `NmConnection` → NM's `a{sa{sv}}` dict for `AddConnection` / `Update`. Mirrors `serialize_keyfile` (each field is in both views; keeping them adjacent makes drift easy to spot).
- `deterministic_uuid_for` — replaced placeholder hash with `uuid::Uuid::new_v5` against a frozen `NASTY_UUID_NAMESPACE`. Same name → same UUID across reboots and across boxes; keeps NM connection identity stable.

**`network/nm/dbus.rs`** (new):
- `zbus::proxy!` definitions for `Settings`, `Settings.Connection`, `NetworkManager`, `NetworkManager.Device`.
- `NmDbusClient` with read-only methods: `list_connections`, `get_settings`, `list_nasty_connections` (filters on the `nasty-` prefix — the ownership boundary).
- `NmDiff { to_add, to_update, to_delete, summary }` and `compute_diff(desired, existing)` — pure data, easy to test.
- `section_changed` compares per-section via `Debug` repr for now; phase 3b gets a real `OwnedValue` walker.

**Wiring**:
- `NetworkService::nm_preview()` — load resolved config → `to_layered` → `to_nm_profiles` → connect to NM → list `nasty-*` → diff. Returns `NmDiff` for the RPC.
- `system.network.nm_preview` RPC — wired into `router.rs`.

## Test plan

- [x] `cargo test -p nasty-system` — 136 passing (was 121, +15)
  - 8 dict-converter tests: ethernet (id/uuid/type/iface), static IPv4 with address-data + prefix + gateway, member port (controller + port-type in `[connection]`, disabled IP), bond (`options` sub-dict with `mode`), bridge (`stp` + `forward-delay`), vlan (`parent` + `id` as u32), ethernet section (`mtu` + `cloned-mac-address`)
  - 2 UUIDv5 sanity: canonical 36-char shape with version byte `5`; deterministic across calls
  - 5 diff-computer tests: empty, add new, delete orphan, unchanged when settings match, update when section differs
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `npm run check` (svelte-check): 4833 files, 0 errors (no UI changes)
- [ ] **Manual on a NASty box (the real test):** call `curl -X POST -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"system.network.nm_preview\"}' …`. Expect:
  - On a box where NM isn't running yet: clear error message about DBus connection failing
  - On a box where NM *is* running but has no `nasty-*` connections: response is `{ to_add: [<one per link>], to_update: [], to_delete: [], summary: { add: N, update: 0, delete: 0, unchanged: 0 } }`
  - On a box mid-cutover: diff matches what's actually been applied so far

## Out of scope (phase 3b)

- **Writes to NM** — `AddConnection` / `Update` / `Delete` / `Activate` proxies + an `apply_via_nm()` function.
- **Migration runner** — write keyfiles into `/etc/NetworkManager/system-connections/`, configure `unmanaged-devices` for Docker / libvirt / wg / ts, run `nixos-rebuild switch`.
- **Cutover** — switch the active apply path from `Plan/Op` ip-commands to NM DBus calls.
- **Drop legacy code** — `dhcp::start/stop` (dhcpcd module), `spawn_nixos_rebuild_boot`, the kernel-imperative `Op` executor, `apply_dns` (NM owns DNS).
- **Flip layered validation from warn to error.**
- **NixOS module changes** — `networking.networkmanager.enable = true`, `lib.mkForce {}` on `networking.bridges/bonds/vlans/interfaces`, drop dhcpcd config.
- **WebUI** — surface nm_preview as a button before phase 3b commits.