### PR TITLE
network: phase 3b-alpha — NM writes (CRUD), no activation

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -696,6 +696,18 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Ok(diff) => ok(req, diff),
             Err(e) => err(req, e),
         },
+        // Phase 3b-alpha: write the current desired config into NM
+        // (Settings.AddConnection / Update / Delete). **Persists
+        // profiles to /etc/NetworkManager/system-connections/; does
+        // NOT activate them.** The active apply path is still the
+        // legacy ip+nixos-rebuild flow — this is for explicit
+        // testing on a box that has NM installed alongside.
+        // Phase 3b-beta makes invocation automatic as part of the
+        // cutover migration.
+        "system.network.nm_apply" => match state.network.nm_apply().await {
+            Ok(outcome) => ok(req, outcome),
+            Err(e) => err(req, e),
+        },
         "system.metrics.prometheus" => {
             let url = format!("{}/metrics", crate::METRICS_BASE);
             match state.metrics_client.get(&url).send().await {

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -509,6 +509,25 @@ impl NetworkService {
         let existing = client.list_nasty_connections().await?;
         Ok(nm::dbus::compute_diff(&desired, &existing))
     }
+
+    /// Phase 3b-alpha — push the current desired config into NM via
+    /// DBus. **Persists profiles to disk; does not activate them.**
+    ///
+    /// Intended for explicit invocation (curl + `nm_apply` RPC) on a
+    /// box that has NM installed alongside the legacy stack. Phase
+    /// 3b-beta replaces this with automatic invocation as part of
+    /// the cutover migration.
+    ///
+    /// Calling this on a box without NM installed errors out at the
+    /// DBus connect step; safe.
+    pub async fn nm_apply(&self) -> Result<nm::dbus::NmApplyOutcome, String> {
+        let cfg = load_config().await;
+        let layered_cfg = layered::to_layered(&cfg);
+        let desired = nm::to_nm_profiles(&layered_cfg);
+
+        let client = nm::dbus::NmDbusClient::new().await?;
+        nm::dbus::apply_profiles(&client, &desired).await
+    }
 }
 
 /// Top-level helper for the rollback timer. Reads the pending-revert file,

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -1,18 +1,21 @@
-//! NetworkManager D-Bus client — phase 3a (read-only).
+//! NetworkManager D-Bus client.
 //!
-//! Talks to NM via zbus. Phase 3a only exposes read methods
-//! (`list_connections`, `get_settings`, `list_devices`,
-//! `find_device_by_name`) plus diff computation against a desired set
-//! of `NmConnection` profiles. Phase 3b adds the write methods
-//! (`AddConnection` / `Update` / `Delete` / `Activate`) and wires the
-//! diff into the apply pipeline.
+//! Talks to NM via zbus. Read methods (`list_connections`,
+//! `get_settings`) plus diff computation arrived in phase 3a; write
+//! methods (`AddConnection` / `Update` / `Delete`) and `apply_profiles`
+//! arrived in phase 3b-alpha. **No activation yet** — `apply_profiles`
+//! persists keyfiles into NM but doesn't bring connections up. That
+//! lets the writes ship before the migration cutover, since persisted
+//! keyfiles don't affect the running system until something explicitly
+//! activates them.
 //!
-//! Why phase 3a is read-only: this is the first PR that talks to NM at
-//! all. Bugs here can only return wrong data, not break the box.
-//! Phase 3b — which actually mutates NM state and runs the
-//! `nixos-rebuild switch` cutover — ships only after we've used
-//! `system.network.nm_preview` on a real NASty box and confirmed the
-//! diff matches expectations.
+//! Phase 3b-beta — which adds activation, runs the
+//! `nixos-rebuild switch` cutover, and switches the active apply path
+//! away from the legacy ip-command flow — ships separately, once the
+//! migration story (idempotent runner with snapshot+rollback) is
+//! built. By then the write code here is already in the field via
+//! the explicit `system.network.nm_apply` RPC; bugs surface as failed
+//! preview/apply on inspection rather than as broken connectivity.
 
 use std::collections::HashMap;
 
@@ -40,6 +43,10 @@ pub type SettingsDict = HashMap<String, HashMap<String, OwnedValue>>;
 trait Settings {
     /// Returns a list of object paths, one per persisted connection.
     fn list_connections(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+    /// Persist a new connection profile. NM writes the keyfile to
+    /// `/etc/NetworkManager/system-connections/` and returns the
+    /// object path of the new `Connection`. Does not activate.
+    fn add_connection(&self, connection: SettingsDict) -> zbus::Result<OwnedObjectPath>;
 }
 
 #[proxy(
@@ -51,6 +58,14 @@ trait ConnectionSettings {
     /// identify NASty-managed connections (id starting with `nasty-`)
     /// and to diff against the desired profile set.
     fn get_settings(&self) -> zbus::Result<SettingsDict>;
+    /// Replace the connection's settings dict in place. Profile
+    /// identity (UUID, object path) is preserved. Does not re-activate;
+    /// running connections need an explicit `nmcli connection up` to
+    /// reload the new settings.
+    fn update(&self, settings: SettingsDict) -> zbus::Result<()>;
+    /// Remove the connection from NM. Deletes the on-disk keyfile.
+    /// If the connection was active, NM deactivates it first.
+    fn delete(&self) -> zbus::Result<()>;
 }
 
 #[proxy(
@@ -144,6 +159,52 @@ impl NmDbusClient {
             }
         }
         Ok(out)
+    }
+
+    /// Persist a new NASty-managed connection. Returns the object path
+    /// of the new `Connection` for follow-up calls (Update, Delete).
+    /// Does not activate.
+    pub async fn add_connection(&self, settings: SettingsDict) -> Result<OwnedObjectPath, String> {
+        let proxy = SettingsProxy::new(&self.conn)
+            .await
+            .map_err(|e| format!("settings proxy: {e}"))?;
+        proxy
+            .add_connection(settings)
+            .await
+            .map_err(|e| format!("add_connection: {e}"))
+    }
+
+    /// Replace an existing connection's settings dict in place.
+    pub async fn update_connection(
+        &self,
+        path: &OwnedObjectPath,
+        settings: SettingsDict,
+    ) -> Result<(), String> {
+        let proxy = ConnectionSettingsProxy::builder(&self.conn)
+            .path(path.clone())
+            .map_err(|e| format!("connection path {path}: {e}"))?
+            .build()
+            .await
+            .map_err(|e| format!("connection proxy {path}: {e}"))?;
+        proxy
+            .update(settings)
+            .await
+            .map_err(|e| format!("update {path}: {e}"))
+    }
+
+    /// Delete a connection. NM removes the on-disk keyfile and (if
+    /// active) deactivates it.
+    pub async fn delete_connection(&self, path: &OwnedObjectPath) -> Result<(), String> {
+        let proxy = ConnectionSettingsProxy::builder(&self.conn)
+            .path(path.clone())
+            .map_err(|e| format!("connection path {path}: {e}"))?
+            .build()
+            .await
+            .map_err(|e| format!("connection proxy {path}: {e}"))?;
+        proxy
+            .delete()
+            .await
+            .map_err(|e| format!("delete {path}: {e}"))
     }
 }
 
@@ -279,6 +340,104 @@ fn section_changed(
             false
         }
     }
+}
+
+// ── Apply ──────────────────────────────────────────────────────
+//
+// Phase 3b-alpha: writes the diff to NM. **Does not activate**
+// connections — profiles are persisted to
+// `/etc/NetworkManager/system-connections/` but not brought up. A
+// caller wanting to test a profile end-to-end can do
+// `nmcli connection up nasty-<iface>` manually after `apply_profiles`
+// returns. Phase 3b-beta will add automatic activation as part of the
+// cutover.
+//
+// Why no activation here: activation deactivates whatever was holding
+// the iface previously. On a box still running the legacy ip-command
+// apply path, that's the live network config — auto-activating an NM
+// profile would drop connectivity. Keeping `apply_profiles` to
+// "persist only" makes phase 3b-alpha safe to invoke at any time on
+// any box that has NM installed.
+
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct NmApplyOutcome {
+    pub added: Vec<String>,
+    pub updated: Vec<String>,
+    pub deleted: Vec<String>,
+    pub unchanged: Vec<String>,
+    /// Per-id error map. Empty on full success. The apply is best-
+    /// effort — one failed connection doesn't abort the rest.
+    pub errors: HashMap<String, String>,
+}
+
+/// Apply a desired profile set to NM. Computes the diff against the
+/// current `nasty-*` connections, then issues `AddConnection` /
+/// `Update` / `Delete` calls. Persists everything to disk via NM;
+/// does not activate.
+pub async fn apply_profiles(
+    client: &NmDbusClient,
+    desired: &[NmConnection],
+) -> Result<NmApplyOutcome, String> {
+    let existing = client.list_nasty_connections().await?;
+    let existing_by_id: HashMap<&str, &NmExisting> =
+        existing.iter().map(|e| (e.id.as_str(), e)).collect();
+    let desired_ids: std::collections::HashSet<&str> =
+        desired.iter().map(|d| d.id.as_str()).collect();
+
+    let mut outcome = NmApplyOutcome::default();
+
+    // Adds first: a new bridge profile may be a controller for a port
+    // we're about to add; NM resolves controller-by-name lazily, so
+    // the order doesn't matter for correctness, but adding masters
+    // first matches operator intuition when watching journalctl.
+    for d in desired {
+        match existing_by_id.get(d.id.as_str()) {
+            None => {
+                let dict = super::to_settings_dict(d);
+                match client.add_connection(dict).await {
+                    Ok(_path) => outcome.added.push(d.id.clone()),
+                    Err(e) => {
+                        outcome.errors.insert(d.id.clone(), e);
+                    }
+                }
+            }
+            Some(existing_conn) => {
+                let dict = super::to_settings_dict(d);
+                if section_changed_any(&dict, &existing_conn.settings) {
+                    match client.update_connection(&existing_conn.path, dict).await {
+                        Ok(()) => outcome.updated.push(d.id.clone()),
+                        Err(e) => {
+                            outcome.errors.insert(d.id.clone(), e);
+                        }
+                    }
+                } else {
+                    outcome.unchanged.push(d.id.clone());
+                }
+            }
+        }
+    }
+
+    // Deletes: any existing nasty-* not in desired.
+    for e in &existing {
+        if !desired_ids.contains(e.id.as_str()) {
+            match client.delete_connection(&e.path).await {
+                Ok(()) => outcome.deleted.push(e.id.clone()),
+                Err(err) => {
+                    outcome.errors.insert(e.id.clone(), err);
+                }
+            }
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Quick "any section differs" check, mirroring `diff_sections`. Returns
+/// true if either dict has a section the other lacks, or any shared
+/// section disagrees on contents (compared via Debug repr — same
+/// caveat as `compute_diff`).
+fn section_changed_any(a: &SettingsDict, b: &SettingsDict) -> bool {
+    !diff_sections(a, b).is_empty()
 }
 
 // ── Tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the NetworkManager write methods (`AddConnection` / `Update` / `Delete`) and an `apply_profiles` function that diffs a desired profile set against existing `nasty-*` connections and applies the changes. **Persists profiles to `/etc/NetworkManager/system-connections/` but does NOT activate them** — the legacy ip-command apply path is still live; auto-activating an NM profile would deactivate it.

Exposed as opt-in `system.network.nm_apply` RPC for explicit testing on a box that has NM installed alongside the legacy stack. Nothing in the apply pipeline calls this automatically. Phase 3b-beta is where activation + automatic invocation + the `nixos-rebuild switch` cutover land.

## Why split phase 3b further

Two reasons. First, phase 3b-beta is the cutover that runs automatically on every user's box at upgrade time — the migration runner (snapshot → validate → rebuild → validate → rollback on failure) deserves more design + implementation care than fitting alongside the writes in one PR. Second, shipping the writes ahead of the migration means the dict converter and write proxies get exercised in the field via the explicit RPC; bugs surface as failed preview/apply on inspection rather than as broken connectivity.

Activation deliberately stays out of this PR. On a box where the legacy ip-command apply path is still authoritative, activating an NM profile would compete with the live connection. Keeping `apply_profiles` to "persist only" makes the PR safe to invoke at any time on any box that has NM running.

## What's in here

- `network/nm/dbus.rs`:
  - Extended `zbus::proxy!` traits with `AddConnection`, `Update`, `Delete`
  - New client methods: `add_connection`, `update_connection`, `delete_connection`
  - `apply_profiles(client, desired)` — computes the diff, issues Add/Update/Delete in order, collects per-id errors. Best-effort: one failed connection doesn't abort the rest. Returns `NmApplyOutcome { added, updated, deleted, unchanged, errors }`.
  - Doc comment updated (was still claiming \"phase 3a, read-only\")
- `NetworkService::nm_apply()` — load_config → to_layered → to_nm_profiles → apply_profiles
- `system.network.nm_apply` RPC handler with a loud opt-in comment

## Test plan

- [x] `cargo test -p nasty-system` — 136 passing (no count change; `apply_profiles` is exercise-only without a live DBus)
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` clean (uses `--all-targets` to match CI this time)
- [x] `cargo fmt --all --check` clean
- [x] `npm run check` (svelte-check): 4833 files, 0 errors (no UI changes)
- [ ] **Manual on a box with NM installed alongside the legacy stack:**
  - `system.network.nm_preview` → see what would change
  - `system.network.nm_apply` → keyfiles appear in `/etc/NetworkManager/system-connections/`, `nmcli connection show` lists them as inactive
  - Pick one (e.g. a host-internal VM bridge that won't conflict with anything live) and `nmcli connection up nasty-vmbr0` to confirm it activates correctly
  - `system.network.nm_apply` again → outcome reports the connection as `unchanged`

## Out of scope (phase 3b-beta)

- **Connection activation** (`NetworkManager.ActivateConnection`)
- **Migration runner** — write keyfiles + `nixos-rebuild switch`, with snapshot+rollback around the whole flow
- **Automatic invocation** from `apply_config`
- **Drop legacy code** — `dhcp::start/stop` (dhcpcd module), `spawn_nixos_rebuild_boot`, the kernel-imperative `Op` executor, `apply_dns`, `networking.nix` generation
- **NixOS module changes** — `networking.networkmanager.enable = true`, `lib.mkForce {}` on legacy networking modules
- **Layered validation flip** from warn to error
- **WebUI buttons** for nm_preview / nm_apply