### PR TITLE
network: purge NM auto-default profiles before migration apply

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -491,6 +491,27 @@ impl NetworkService {
             }
         };
 
+        // Preempt NM's auto-default profiles. NM starts before nasty-
+        // engine on cutover boot, sees unmanaged ethernet devices, and
+        // creates "Wired connection 1"-style profiles that grab the
+        // DHCP lease. apply_profiles only diffs `nasty-*` connections,
+        // so those auto-defaults are invisible to it and end up
+        // winning the activation race for the iface. Delete them
+        // before we add ours.
+        match nm::dbus::purge_conflicting_connections(&client, &profiles).await {
+            Ok(deleted) if !deleted.is_empty() => {
+                info!(
+                    "migration: purged {} conflicting NM auto-profile(s): {:?}",
+                    deleted.len(),
+                    deleted
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!("migration: purge step failed ({e}). Continuing with apply.");
+            }
+        }
+
         match nm::dbus::apply_profiles(&client, &profiles).await {
             Ok(outcome) => {
                 info!(

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -429,10 +429,7 @@ fn should_purge_for_migration(
     // Only the connection types our profiles emit. Wi-Fi, VPN, tun,
     // etc. stay — they're either user-managed or configured outside
     // the WebUI's scope.
-    if !matches!(
-        conn_type,
-        "802-3-ethernet" | "bond" | "bridge" | "vlan"
-    ) {
+    if !matches!(conn_type, "802-3-ethernet" | "bond" | "bridge" | "vlan") {
         return false;
     }
     let Some(iface) = interface_name else {
@@ -840,8 +837,23 @@ mod tests {
         // The race isn't ethernet-only. Any of our managed types,
         // bound to one of our target ifaces, is a candidate.
         let targets = ifset(&["bond0", "br0", "eth0.100"]);
-        assert!(should_purge_for_migration("auto", "bond", Some("bond0"), &targets));
-        assert!(should_purge_for_migration("auto", "bridge", Some("br0"), &targets));
-        assert!(should_purge_for_migration("auto", "vlan", Some("eth0.100"), &targets));
+        assert!(should_purge_for_migration(
+            "auto",
+            "bond",
+            Some("bond0"),
+            &targets
+        ));
+        assert!(should_purge_for_migration(
+            "auto",
+            "bridge",
+            Some("br0"),
+            &targets
+        ));
+        assert!(should_purge_for_migration(
+            "auto",
+            "vlan",
+            Some("eth0.100"),
+            &targets
+        ));
     }
 }

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -394,6 +394,105 @@ fn section_changed(
     }
 }
 
+// ── Migration preempt ──────────────────────────────────────────
+//
+// On first boot under the cutover, NM starts before nasty-engine and
+// auto-creates default ethernet profiles ("Wired connection 1") for
+// any unmanaged ethernet device. Those profiles bind by interface-
+// name and grab the DHCP lease before the engine's migration runs.
+//
+// `apply_profiles` then can't take the device away cleanly — its
+// diff only sees `nasty-*` connections, so the auto-default is
+// invisible to it, and its activation step often fails or no-ops
+// because the device already has an active connection.
+//
+// `purge_conflicting_connections` scans every NM connection and
+// deletes the ones we'd compete with: not-already-nasty, of a type
+// we manage (ethernet/bond/bridge/vlan), bound to one of the
+// interfaces in our desired set. Called from migration only; normal
+// post-cutover applies don't need it because by then there are no
+// auto-defaults left to fight.
+
+/// Decide whether an existing NM connection should be purged before
+/// migration applies our profiles. Pure logic, easy to unit-test;
+/// the DBus walker in `purge_conflicting_connections` is the I/O
+/// layer that feeds this.
+fn should_purge_for_migration(
+    id: &str,
+    conn_type: &str,
+    interface_name: Option<&str>,
+    target_ifaces: &std::collections::HashSet<&str>,
+) -> bool {
+    if id.starts_with("nasty-") {
+        return false;
+    }
+    // Only the connection types our profiles emit. Wi-Fi, VPN, tun,
+    // etc. stay — they're either user-managed or configured outside
+    // the WebUI's scope.
+    if !matches!(
+        conn_type,
+        "802-3-ethernet" | "bond" | "bridge" | "vlan"
+    ) {
+        return false;
+    }
+    let Some(iface) = interface_name else {
+        // Auto-defaults bind by `connection.interface-name` on
+        // recent NM (≥1.40). If a connection has no iface binding,
+        // we can't tell whether it's ours to purge — leave alone.
+        return false;
+    };
+    target_ifaces.contains(iface)
+}
+
+/// Delete every non-nasty NM connection that conflicts with the
+/// desired migration set. See module-level comment above.
+///
+/// Returns the IDs of the connections deleted, for log surfacing.
+/// Errors during the per-connection read or delete are logged and
+/// the loop continues — one bad apple doesn't abort migration.
+pub async fn purge_conflicting_connections(
+    client: &NmDbusClient,
+    desired: &[NmConnection],
+) -> Result<Vec<String>, String> {
+    let target_ifaces: std::collections::HashSet<&str> =
+        desired.iter().map(|d| d.interface_name.as_str()).collect();
+    let mut deleted = Vec::new();
+
+    for path in client.list_connections().await? {
+        let settings = match client.get_settings(&path).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("purge: skip unreadable conn {path}: {e}");
+                continue;
+            }
+        };
+        let Some(id) = read_string(&settings, "connection", "id") else {
+            continue;
+        };
+        let Some(conn_type) = read_string(&settings, "connection", "type") else {
+            continue;
+        };
+        let iface = read_string(&settings, "connection", "interface-name");
+        if !should_purge_for_migration(&id, &conn_type, iface.as_deref(), &target_ifaces) {
+            continue;
+        }
+        match client.delete_connection(&path).await {
+            Ok(()) => {
+                tracing::info!(
+                    "migration purge: deleted conflicting NM conn '{id}' on {}",
+                    iface.as_deref().unwrap_or("<unknown>"),
+                );
+                deleted.push(id);
+            }
+            Err(e) => {
+                tracing::warn!("migration purge: delete '{id}' failed: {e}");
+            }
+        }
+    }
+
+    Ok(deleted)
+}
+
 // ── Apply ──────────────────────────────────────────────────────
 //
 // Phase 3b-alpha: writes the diff to NM. **Does not activate**
@@ -656,5 +755,93 @@ mod tests {
             "ipv4 should be flagged as changed; got {:?}",
             d.to_update[0].changed_sections
         );
+    }
+
+    // ── should_purge_for_migration ────────────────────────────
+
+    fn ifset(items: &[&'static str]) -> std::collections::HashSet<&'static str> {
+        items.iter().copied().collect()
+    }
+
+    #[test]
+    fn purge_targets_nm_auto_default_on_managed_iface() {
+        // The reproducer: NM auto-created "Wired connection 1" bound
+        // to ens18, and our migration is about to add `nasty-ens18`.
+        // The auto-default must be purged.
+        let targets = ifset(&["ens18"]);
+        assert!(should_purge_for_migration(
+            "Wired connection 1",
+            "802-3-ethernet",
+            Some("ens18"),
+            &targets,
+        ));
+    }
+
+    #[test]
+    fn purge_skips_nasty_owned_connections() {
+        // Our own profiles must never be purged — apply_profiles
+        // updates them, doesn't delete-then-re-add.
+        let targets = ifset(&["ens18"]);
+        assert!(!should_purge_for_migration(
+            "nasty-ens18",
+            "802-3-ethernet",
+            Some("ens18"),
+            &targets,
+        ));
+    }
+
+    #[test]
+    fn purge_skips_unrelated_iface() {
+        // A non-nasty conn on an iface we're not managing stays. The
+        // user might have wired a separate profile on eth1 that the
+        // WebUI hasn't been told about yet.
+        let targets = ifset(&["ens18"]);
+        assert!(!should_purge_for_migration(
+            "Wired connection 2",
+            "802-3-ethernet",
+            Some("eth1"),
+            &targets,
+        ));
+    }
+
+    #[test]
+    fn purge_skips_non_managed_types() {
+        // Wi-Fi, VPN, tun, etc. are out of nasty's scope. Even if they
+        // happened to bind to one of our target ifaces (rare edge —
+        // a user-created PPPoE on top of ens18, say), we don't own
+        // them and shouldn't delete them.
+        let targets = ifset(&["ens18"]);
+        for t in ["802-11-wireless", "vpn", "tun", "wireguard", "gsm"] {
+            assert!(
+                !should_purge_for_migration("user-thing", t, Some("ens18"), &targets),
+                "type {t} should not be purged"
+            );
+        }
+    }
+
+    #[test]
+    fn purge_skips_when_iface_binding_missing() {
+        // Older NM auto-defaults bind by MAC instead of interface-
+        // name. We can't tell whether such a profile would land on
+        // one of our ifaces from the dict alone — leave it alone
+        // and let activation deal with the conflict (worst case the
+        // engine logs the activation failure on next apply).
+        let targets = ifset(&["ens18"]);
+        assert!(!should_purge_for_migration(
+            "Wired connection 1",
+            "802-3-ethernet",
+            None,
+            &targets,
+        ));
+    }
+
+    #[test]
+    fn purge_targets_bond_bridge_vlan_too() {
+        // The race isn't ethernet-only. Any of our managed types,
+        // bound to one of our target ifaces, is a candidate.
+        let targets = ifset(&["bond0", "br0", "eth0.100"]);
+        assert!(should_purge_for_migration("auto", "bond", Some("bond0"), &targets));
+        assert!(should_purge_for_migration("auto", "bridge", Some("br0"), &targets));
+        assert!(should_purge_for_migration("auto", "vlan", Some("eth0.100"), &targets));
     }
 }


### PR DESCRIPTION
## Background

PR #104's migration lost a startup race I hit on my own NASty during testing.

NM starts before \`nasty-engine.service\` and auto-creates default ethernet profiles (\`Wired connection 1\`) for unmanaged ethernet devices, binding by \`connection.interface-name\` and grabbing the DHCP lease. By the time the engine runs \`run_migration_if_needed\`, those auto-defaults are already active.

\`apply_profiles\` only diffs \`nasty-*\` connections via \`list_nasty_connections\`, so the auto-default is invisible to it. NM keeps the auto-default winning, the engine's profile (if it gets created at all — sometimes the management iface isn't even in the layered profile set) sits dormant. The migration marker still gets written because no errors propagated, so we never retry.

When the user later deletes the bridge that was the engine's only profile, all that's left is NM's auto-default — and there's no engine-managed counterpart anywhere.

## Fix

Add \`purge_conflicting_connections\` in \`network/nm/dbus.rs\`. Walks every NM connection and deletes the ones that are:

1. Not already nasty-owned (id doesn't start with \`nasty-\`).
2. Of a type we manage (\`802-3-ethernet\` / \`bond\` / \`bridge\` / \`vlan\`).
3. Bound to one of our target interfaces (\`connection.interface-name\` ∈ desired iface set).

Called from \`run_migration_if_needed\` before \`apply_profiles\`. Normal post-cutover applies don't run it.

## Why migration-only

Running this on every apply would delete user-created NM connections that exist outside the WebUI. The migration is the only place where we know we're transitioning *from* a clean-slate semantic (legacy stack with no NM connections) *to* nasty as the authoritative source — so it's the only place we can safely assume everything non-nasty is a leftover.

## What's explicitly skipped

- Wi-Fi, VPN, tun, wireguard, gsm, etc. — outside nasty's scope even if they bind to a target iface.
- Connections that bind by MAC instead of \`interface-name\` (NM <1.40). Recent NM sets \`interface-name\` on auto-defaults, so this covers the realistic case. We log + leave alone if we can't classify.
- Per-connection delete failures don't abort the loop — best-effort, mirrors the rest of \`apply_profiles\`.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 133 passing (6 new for \`should_purge_for_migration\`)
- [x] \`cargo clippy -p nasty-system --lib --tests -- -D warnings\` — clean
- [ ] **Manual**: on a NASty where the migration marker exists but NM still has \`Wired connection 1\` (the broken-state reproducer): \`rm /var/lib/nasty/.network-migrated-v2 && systemctl restart nasty-engine\`. Verify: \`Wired connection 1\` is gone, \`nasty-<iface>\` is the active profile, IP is back. (Don't run this on a remote box without console access.)
- [ ] **Fresh install / first cutover**: smoke test on a non-production box that hasn't migrated yet. Verify the migration runs cleanly with no \`Wired connection 1\` ever appearing in \`nmcli con show\`.

## Out of scope

- A way to re-run the migration on demand (delete-marker RPC). Boxes already in the broken state still need manual recovery; this PR only fixes future migrations.
- Handling connections that bind by MAC. Could add — walk \`Devices\`, match HW address — but the realistic blast radius for now is small and the code stays simpler.