### PR TITLE
webui: promote orphaned members when removing a bond/bridge

### DIFF
--- a/webui/src/lib/network.test.ts
+++ b/webui/src/lib/network.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { promoteOrphanedMembers } from './network';
+import type { BondConfig, BridgeConfig, InterfaceConfig, NetworkConfig } from './types';
+
+function iface(name: string): InterfaceConfig {
+	return {
+		name,
+		enabled: true,
+		ipv4: { method: 'static', addresses: ['192.0.2.1/24'], gateway: null },
+		ipv6: { method: 'disabled', addresses: [], gateway: null },
+		mtu: null,
+	};
+}
+
+function bridge(name: string, members: string[]): BridgeConfig {
+	return {
+		name,
+		members,
+		ipv4: { method: 'inherit', addresses: [], gateway: null },
+		ipv6: { method: 'inherit', addresses: [], gateway: null },
+		mtu: null,
+	};
+}
+
+function bond(name: string, members: string[]): BondConfig {
+	return {
+		name,
+		members,
+		mode: 'lacp',
+		ipv4: { method: 'dhcp', addresses: [], gateway: null },
+		ipv6: { method: 'slaac', addresses: [], gateway: null },
+		mtu: null,
+	};
+}
+
+function emptyNet(over: Partial<NetworkConfig> = {}): NetworkConfig {
+	return { interfaces: [], dns: [], bonds: [], vlans: [], bridges: [], ...over };
+}
+
+describe('promoteOrphanedMembers', () => {
+	it('promotes a sole bridge member that has no standalone entry', () => {
+		// The headline case: br0 has ens18 as a member, ens18 isn't in
+		// interfaces[] (it was only known as a bridge port). When br0
+		// is removed, ens18 must be promoted or it drops out of config
+		// entirely and the engine has no profile to emit for it.
+		const net = emptyNet({ bridges: [bridge('br0', ['ens18'])] });
+		const result = promoteOrphanedMembers(net, { kind: 'bridge', name: 'br0' }, ['ens18']);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			name: 'ens18',
+			enabled: true,
+			ipv4: { method: 'dhcp' },
+			ipv6: { method: 'slaac' },
+		});
+	});
+
+	it('does not duplicate a member that is already in interfaces', () => {
+		// Some setups have the iface listed both as a standalone entry
+		// (carrying its own L3 from a prior topology) and as a bridge
+		// member. Removing the bridge mustn't add a second entry.
+		const net = emptyNet({
+			interfaces: [iface('ens18')],
+			bridges: [bridge('br0', ['ens18'])],
+		});
+		const result = promoteOrphanedMembers(net, { kind: 'bridge', name: 'br0' }, ['ens18']);
+		expect(result).toHaveLength(1);
+		// The pre-existing entry is preserved untouched (incl. its
+		// static IP — we don't overwrite user config).
+		expect(result[0].ipv4.method).toBe('static');
+	});
+
+	it('does not promote a member still claimed by another bridge', () => {
+		// Edge case: shared-port topology where eth0 is a member of
+		// both br0 and br1 (unusual but representable in our schema).
+		// Removing br0 leaves eth0 still under br1, so don't promote.
+		const net = emptyNet({
+			bridges: [bridge('br0', ['eth0']), bridge('br1', ['eth0'])],
+		});
+		const result = promoteOrphanedMembers(net, { kind: 'bridge', name: 'br0' }, ['eth0']);
+		expect(result).toHaveLength(0);
+	});
+
+	it('does not promote a member still claimed by a bond', () => {
+		// eth0 is in both bridge br0 and bond bond0. Removing the
+		// bridge keeps it inside the bond — no promotion.
+		const net = emptyNet({
+			bridges: [bridge('br0', ['eth0'])],
+			bonds: [bond('bond0', ['eth0'])],
+		});
+		const result = promoteOrphanedMembers(net, { kind: 'bridge', name: 'br0' }, ['eth0']);
+		expect(result).toHaveLength(0);
+	});
+
+	it('ignores the master being removed when scanning for other claims', () => {
+		// The function is given the master's identity so it can ignore
+		// it when checking "is this iface still mastered elsewhere".
+		// Without this filter, the function would see eth0 still
+		// listed under br0 and skip the promotion.
+		const net = emptyNet({ bridges: [bridge('br0', ['eth0'])] });
+		const result = promoteOrphanedMembers(net, { kind: 'bridge', name: 'br0' }, ['eth0']);
+		expect(result.map((i) => i.name)).toEqual(['eth0']);
+	});
+
+	it('promotes multiple orphans from one master', () => {
+		const net = emptyNet({ bonds: [bond('bond0', ['eth0', 'eth1', 'eth2'])] });
+		const result = promoteOrphanedMembers(
+			net,
+			{ kind: 'bond', name: 'bond0' },
+			['eth0', 'eth1', 'eth2'],
+		);
+		expect(result.map((i) => i.name)).toEqual(['eth0', 'eth1', 'eth2']);
+		// All get the same DHCP defaults — we don't pick a "primary".
+		expect(result.every((i) => i.ipv4.method === 'dhcp')).toBe(true);
+	});
+
+	it('handles bond removal symmetrically to bridge removal', () => {
+		const net = emptyNet({ bonds: [bond('bond0', ['eth0'])] });
+		const result = promoteOrphanedMembers(net, { kind: 'bond', name: 'bond0' }, ['eth0']);
+		expect(result.map((i) => i.name)).toEqual(['eth0']);
+	});
+});

--- a/webui/src/lib/network.ts
+++ b/webui/src/lib/network.ts
@@ -1,0 +1,61 @@
+import type { InterfaceConfig, NetworkConfig } from './types';
+
+/** A standalone interface entry with default DHCP / SLAAC L3.
+ * Used when a bond/bridge member becomes orphaned by its master's
+ * removal — DHCP is the right default because most homelab boxes
+ * are on DHCP, and it matches what NM's auto-default would do anyway
+ * if we left the iface unconfigured. The user can edit to static
+ * after the apply if needed. */
+function defaultStandaloneIface(name: string): InterfaceConfig {
+	return {
+		name,
+		enabled: true,
+		ipv4: { method: 'dhcp', addresses: [], gateway: null },
+		ipv6: { method: 'slaac', addresses: [], gateway: null },
+		mtu: null,
+	};
+}
+
+/** When a bond or bridge is removed, its members lose their master and
+ * would otherwise drop out of the config entirely (they were only
+ * referenced via `master.members`). Promote each orphaned member to a
+ * standalone `InterfaceConfig` with DHCP defaults — unless it's already
+ * a standalone interface, or still a member of another master.
+ *
+ * `removedMaster` is the (kind, name) of the bond/bridge being deleted;
+ * we ignore references to it when checking whether a member is still
+ * mastered, since the caller is *about* to apply a payload that no
+ * longer contains it.
+ *
+ * Returns the new `interfaces` array. Existing entries are preserved
+ * (and not duplicated). VLANs aren't considered — they have a `parent`,
+ * not `members`, so they don't orphan anything when removed. */
+export function promoteOrphanedMembers(
+	network: NetworkConfig,
+	removedMaster: { kind: 'bond' | 'bridge'; name: string },
+	members: string[],
+): InterfaceConfig[] {
+	const existing = new Set((network.interfaces ?? []).map((i) => i.name));
+	const stillMastered = (iface: string) => {
+		const inBond = (network.bonds ?? []).some(
+			(b) =>
+				!(removedMaster.kind === 'bond' && b.name === removedMaster.name) &&
+				b.members.includes(iface),
+		);
+		const inBridge = (network.bridges ?? []).some(
+			(b) =>
+				!(removedMaster.kind === 'bridge' && b.name === removedMaster.name) &&
+				b.members.includes(iface),
+		);
+		return inBond || inBridge;
+	};
+
+	const promoted: InterfaceConfig[] = [];
+	for (const m of members) {
+		if (existing.has(m)) continue;
+		if (stillMastered(m)) continue;
+		promoted.push(defaultStandaloneIface(m));
+		existing.add(m);
+	}
+	return [...(network.interfaces ?? []), ...promoted];
+}

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { promoteOrphanedMembers } from '$lib/network';
+	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -477,7 +478,7 @@
 
 	async function deleteBond(name: string) {
 		if (!network) return;
-		if (!confirm(`Remove bond ${name}? Members will return to standalone interfaces.`)) return;
+		if (!await confirm(`Remove bond ${name}?`, 'Members will return to standalone interfaces.', { confirmLabel: 'Remove' })) return;
 		const removed = (network.bonds || []).find(b => b.name === name);
 		const payload: NetworkConfig = {
 			interfaces: removed
@@ -494,7 +495,7 @@
 
 	async function deleteBridge(name: string) {
 		if (!network) return;
-		if (!confirm(`Remove bridge ${name}? Members will return to standalone interfaces.`)) return;
+		if (!await confirm(`Remove bridge ${name}?`, 'Members will return to standalone interfaces.', { confirmLabel: 'Remove' })) return;
 		const removed = (network.bridges || []).find(b => b.name === name);
 		const payload: NetworkConfig = {
 			interfaces: removed
@@ -511,7 +512,7 @@
 
 	async function deleteVlan(parent: string, vlan_id: number) {
 		if (!network) return;
-		if (!confirm(`Remove VLAN ${parent}.${vlan_id}?`)) return;
+		if (!await confirm(`Remove VLAN ${parent}.${vlan_id}?`, undefined, { confirmLabel: 'Remove' })) return;
 		const payload: NetworkConfig = {
 			interfaces: network.interfaces || [],
 			dns: network.dns || [],

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -3,6 +3,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
+	import { promoteOrphanedMembers } from '$lib/network';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -477,8 +478,11 @@
 	async function deleteBond(name: string) {
 		if (!network) return;
 		if (!confirm(`Remove bond ${name}? Members will return to standalone interfaces.`)) return;
+		const removed = (network.bonds || []).find(b => b.name === name);
 		const payload: NetworkConfig = {
-			interfaces: network.interfaces || [],
+			interfaces: removed
+				? promoteOrphanedMembers(network, { kind: 'bond', name }, removed.members)
+				: network.interfaces || [],
 			dns: network.dns || [],
 			bonds: (network.bonds || []).filter(b => b.name !== name),
 			vlans: network.vlans || [],
@@ -491,8 +495,11 @@
 	async function deleteBridge(name: string) {
 		if (!network) return;
 		if (!confirm(`Remove bridge ${name}? Members will return to standalone interfaces.`)) return;
+		const removed = (network.bridges || []).find(b => b.name === name);
 		const payload: NetworkConfig = {
-			interfaces: network.interfaces || [],
+			interfaces: removed
+				? promoteOrphanedMembers(network, { kind: 'bridge', name }, removed.members)
+				: network.interfaces || [],
 			dns: network.dns || [],
 			bonds: network.bonds || [],
 			vlans: network.vlans || [],


### PR DESCRIPTION
## Background

Caught while debugging the broken state on my own box after PR #107. Removing \`br0\` via the new WebUI button (PR #105) silently dropped \`ens18\` from the config: it only existed as \`bridges[0].members[0]\`, and \`interfaces[]\` was passed through unchanged in \`deleteBridge\`'s payload. The engine then had no \`Link::Physical\` for it, so \`to_nm_profiles\` emitted no \`nasty-ens18\` profile — leaving NM's auto-default \`Wired connection 1\` as the only thing keeping the iface alive, and that auto-default is exactly what fights every later config push.

Same gap exists symmetrically in \`deleteBond\`. \`deleteVlan\` is fine — VLANs have a \`parent\`, not \`members\`.

## Fix

New pure helper in \`$lib/network.ts\`:

\`\`\`ts
promoteOrphanedMembers(network, { kind, name }, members): InterfaceConfig[]
\`\`\`

Returns the new \`interfaces[]\` array with each orphaned member added as a standalone \`InterfaceConfig\` set to DHCP/SLAAC. Skips:
- Members already present in \`interfaces[]\` (no duplicates; existing entries are preserved untouched, including any static IP).
- Members still claimed by another bridge/bond (shared-port topologies).

The master being removed is passed as \`{kind, name}\` so the \"still claimed elsewhere\" check correctly ignores it (it's about to be filtered out of the payload).

Wired into \`deleteBond\` and \`deleteBridge\`.

## Why DHCP/SLAAC and not the master's L3?

The master may have multiple members. Picking a \"primary\" to inherit the L3 introduces a rule the user can't see — and can't override — at click time. DHCP/SLAAC is what NM's auto-default would assign anyway; it matches the most common homelab case; and it leaves a clean state the user can edit to static after the apply.

## Test plan

- [x] \`npm --prefix webui run check\` — 4835 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 75 passing (7 new for \`promoteOrphanedMembers\`):
  - sole bridge member promoted
  - existing standalone entry not duplicated (and not overwritten)
  - member still claimed by another bridge / bond → no promotion
  - master being removed is correctly excluded from \"still mastered\" check
  - multiple orphans from one master → all promoted with DHCP defaults
  - bond removal symmetric to bridge removal
- [ ] **Manual on my box**: remove br0 (members=[ens18]) via WebUI → \`networking.json\` should have \`interfaces:[{name:\"ens18\", ipv4.method:\"dhcp\", ...}]\`, no bridges, and the engine should emit \`nasty-ens18\` on next apply.