### PR TITLE
webui: fix stale countdown on first frame of rollback banner

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -192,22 +192,32 @@
 	// Network rollback countdown — ticks once per second while a rollback is
 	// pending so the banner can show "Xs left to keep changes". Auto-clears
 	// the local store at deadline; the engine has already reverted by then.
-	let nowSec = $state(Math.floor(Date.now() / 1000));
+	//
+	// `tick` is just a re-run trigger for the $derived; the actual time is
+	// read from Date.now() at derivation time so the very first frame after
+	// `pending` appears is correct. (Storing a `nowSec` $state initialized
+	// at layout mount made the first render show seconds-remaining computed
+	// against page-load time — visible as a brief "429s"-style flash before
+	// the first interval tick corrected it.)
+	let tick = $state(0);
 	$effect(() => {
 		if (!rollbackState.pending) return;
 		const handle = setInterval(() => {
-			nowSec = Math.floor(Date.now() / 1000);
-			if (rollbackState.pending && nowSec >= rollbackState.pending.revertAtUnix) {
+			tick++;
+			if (
+				rollbackState.pending &&
+				Math.floor(Date.now() / 1000) >= rollbackState.pending.revertAtUnix
+			) {
 				rollbackState.clear();
 			}
 		}, 1000);
 		return () => clearInterval(handle);
 	});
-	let rollbackSecondsLeft = $derived(
-		rollbackState.pending
-			? Math.max(0, rollbackState.pending.revertAtUnix - nowSec)
-			: 0,
-	);
+	let rollbackSecondsLeft = $derived.by(() => {
+		void tick;
+		if (!rollbackState.pending) return 0;
+		return Math.max(0, rollbackState.pending.revertAtUnix - Math.floor(Date.now() / 1000));
+	});
 
 	$effect(() => {
 		const _r = sysInfoRefresh.count; // track refresh triggers


### PR DESCRIPTION
## Bug

The rollback banner's seconds-remaining counter briefly showed wildly wrong numbers when it first appeared — e.g. \`429s\` for one tick, then snapping to \`29\` and counting down normally. Reproduced on a page that had been open ~7 minutes before triggering a network change.

## Cause

In \`+layout.svelte\`, \`nowSec\` was a \`\$state(Math.floor(Date.now() / 1000))\` initialized **once at root-layout mount**. The \`setInterval\` inside the \`\$effect\` only refreshes it once per second, and the interval doesn't even start until \`rollbackState.pending\` becomes non-null. Between the apply RPC returning and the first interval tick (~1s later), the derived \`rollbackSecondsLeft = revertAtUnix - nowSec\` was computed using the mount-time \`nowSec\` — so a page open for N seconds rendered \`30 + N\` seconds remaining for one frame.

## Fix

Replace \`nowSec\` with a \`tick\` counter that's purely a re-run trigger, and read \`Date.now()\` inside \`\$derived.by\` so every derivation (including the first one when \`pending\` flips on) sees the current wall clock. Self-corrects against any clock drift between ticks too.

## Test plan

- [x] \`npm --prefix webui run check\` — 4835 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 75 passing (no test changes; this is presentational and there's no existing harness for the layout component)
- [ ] **Manual**: leave page open ~5 minutes, trigger an MTU change on the mgmt iface, confirm banner opens at \"30s\" and counts down monotonically without any flash of a larger number.