### PR TITLE
network: server-authoritative pending rollback recovery

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -688,6 +688,12 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Err(e) => invalid(req, e),
             }
         }
+        // Snapshot of pending rollback txns. WebUI calls this on
+        // connect so a session that didn't initiate the change can
+        // still recover the Confirm banner — fixes the "can't change
+        // mgmt-iface IP" UX hole where the original session loses
+        // connectivity at apply time.
+        "system.network.pending" => ok(req, state.network.pending().await),
         // Phase 3a: read-only NM preview. Connects to NetworkManager
         // via DBus, diffs the persisted desired config against the
         // current `nasty-*` connections in NM, returns the change set.

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -252,15 +252,26 @@ pub struct NetworkService {
 }
 
 struct PendingTxn {
-    /// When the rollback will fire if not confirmed. Currently unread but
-    /// kept so a future `system.network.transactions` RPC can surface it.
-    #[allow(dead_code)]
+    /// When the rollback will fire if not confirmed. Surfaced via
+    /// `system.network.pending` so a fresh WebUI session (e.g. after
+    /// the user reconnects on a new IP they just configured) can find
+    /// out about pending rollbacks and offer the Confirm button.
     revert_at_unix: u64,
     /// Why the server scheduled this rollback (human-readable). Same
     /// rationale as `revert_at_unix`.
-    #[allow(dead_code)]
     risk_reason: String,
     cancel: tokio::sync::oneshot::Sender<()>,
+}
+
+/// Snapshot of one pending rollback, returned by
+/// `system.network.pending`. Intended for the WebUI to recover the
+/// rollback banner after a reconnect (or first connect from a new IP)
+/// — see `network.rs:PendingTxn` for storage.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct NetworkPendingTxn {
+    pub txn_id: String,
+    pub revert_at_unix: u64,
+    pub risk_reason: String,
 }
 
 impl Default for NetworkService {
@@ -395,6 +406,24 @@ impl NetworkService {
 
             Ok(UpdateResponse::default())
         }
+    }
+
+    /// Snapshot of all currently-pending rollback transactions. The
+    /// WebUI calls this on connect so a session that didn't initiate
+    /// the change (e.g. the user just reconnected on a new IP they
+    /// configured 5 seconds ago) can still see the Confirm banner.
+    /// Order is unspecified; the table rarely has more than one entry.
+    pub async fn pending(&self) -> Vec<NetworkPendingTxn> {
+        self.transactions
+            .lock()
+            .await
+            .iter()
+            .map(|(id, txn)| NetworkPendingTxn {
+                txn_id: id.clone(),
+                revert_at_unix: txn.revert_at_unix,
+                risk_reason: txn.risk_reason.clone(),
+            })
+            .collect()
     }
 
     /// Confirm a pending rollback transaction — cancel its timer and remove
@@ -1998,6 +2027,50 @@ mod tests {
         let res = svc.confirm("does-not-exist").await;
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("does-not-exist"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_returns_empty_when_no_active_txns() {
+        let svc = NetworkService::new();
+        assert!(svc.pending().await.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_surfaces_active_txn_metadata() {
+        // Reproduces the IP-change recovery scenario: an apply has
+        // scheduled a rollback, the original WebUI session lost
+        // connectivity, and a fresh session calls `pending()` to
+        // recover the banner. The metadata returned must be enough
+        // for the WebUI to render the banner verbatim — txn_id (for
+        // confirm), revert deadline (for the countdown), risk reason
+        // (for the tooltip).
+        let svc = NetworkService::new();
+        let revert_at = unix_now() + 30;
+        svc.schedule_rollback(
+            "txn-abc".into(),
+            30,
+            revert_at,
+            "IP config of management iface eth0 is changing".into(),
+        )
+        .await;
+        let pending = svc.pending().await;
+        assert_eq!(pending.len(), 1);
+        let p = &pending[0];
+        assert_eq!(p.txn_id, "txn-abc");
+        assert_eq!(p.revert_at_unix, revert_at);
+        assert!(p.risk_reason.contains("IP config"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_drops_confirmed_txn() {
+        // Once a txn is confirmed, it must not appear in pending —
+        // otherwise a fresh WebUI session would re-show a banner for
+        // a change the user already accepted.
+        let svc = NetworkService::new();
+        svc.schedule_rollback("txn-abc".into(), 30, unix_now() + 30, "test".into())
+            .await;
+        svc.confirm("txn-abc").await.unwrap();
+        assert!(svc.pending().await.is_empty());
     }
 
     // The timeout-fires-rollback path isn't unit-tested here — exercising

--- a/webui/src/lib/rollbackState.svelte.test.ts
+++ b/webui/src/lib/rollbackState.svelte.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub the underlying RPC client so we can drive `loadPendingRollback`
+// deterministically — no real WebSocket needed for these tests.
+const callMock = vi.fn();
+vi.mock('./client', () => ({
+	getClient: () => ({ call: callMock }),
+}));
+vi.mock('./toast.svelte', () => ({
+	withToast: async (fn: () => Promise<unknown>) => fn(),
+}));
+
+import { loadPendingRollback, rollbackState } from './rollbackState.svelte';
+
+beforeEach(() => {
+	callMock.mockReset();
+	rollbackState.clear();
+});
+
+describe('loadPendingRollback', () => {
+	it('populates the store from a single pending txn', async () => {
+		// The headline case: user changed the mgmt iface IP, original
+		// session got dropped, fresh session connects on the new IP and
+		// pulls the pending txn so the banner reappears.
+		callMock.mockResolvedValueOnce([
+			{
+				txn_id: 'txn-abc',
+				revert_at_unix: 1234567890,
+				risk_reason: 'IP config of management iface eth0 is changing',
+			},
+		]);
+		await loadPendingRollback();
+		expect(rollbackState.pending).toEqual({
+			txnId: 'txn-abc',
+			revertAtUnix: 1234567890,
+			riskReason: 'IP config of management iface eth0 is changing',
+		});
+	});
+
+	it('clears local state when the server reports nothing pending', async () => {
+		// On reconnect after the rollback already fired (or after the
+		// user confirmed in another tab), the local store may still
+		// hold a stale entry. The server's empty response is the
+		// authoritative "nothing pending" signal.
+		rollbackState.set({ txnId: 'stale', revertAtUnix: 1, riskReason: null });
+		callMock.mockResolvedValueOnce([]);
+		await loadPendingRollback();
+		expect(rollbackState.pending).toBeNull();
+	});
+
+	it('picks the soonest-expiring txn when multiple are pending', async () => {
+		// Pathological case (the server table almost never has more
+		// than one entry), but if it does we'd rather show the user
+		// the most-urgent one — they need to make a decision sooner.
+		callMock.mockResolvedValueOnce([
+			{ txn_id: 'later', revert_at_unix: 2000, risk_reason: 'a' },
+			{ txn_id: 'sooner', revert_at_unix: 1500, risk_reason: 'b' },
+			{ txn_id: 'middle', revert_at_unix: 1700, risk_reason: 'c' },
+		]);
+		await loadPendingRollback();
+		expect(rollbackState.pending?.txnId).toBe('sooner');
+	});
+
+	it('leaves local state alone if the RPC fails', async () => {
+		// An older engine (pre-this-PR) doesn't have the RPC, so
+		// the call rejects with method-not-found. We must not
+		// clobber whatever pending state we have locally — the user
+		// might have just gotten it from `applyNetworkUpdate`.
+		rollbackState.set({ txnId: 'local', revertAtUnix: 999, riskReason: null });
+		callMock.mockRejectedValueOnce(new Error('method not found'));
+		await loadPendingRollback();
+		expect(rollbackState.pending?.txnId).toBe('local');
+	});
+
+	it('maps empty risk_reason string to null', async () => {
+		// Server-side risk_reason is non-Optional (always a string,
+		// possibly empty). The local PendingRollback shape uses
+		// `string | null` because the banner code treats null as
+		// "no tooltip". Empty string would render as an empty tooltip.
+		callMock.mockResolvedValueOnce([
+			{ txn_id: 'txn-1', revert_at_unix: 1, risk_reason: '' },
+		]);
+		await loadPendingRollback();
+		expect(rollbackState.pending?.riskReason).toBeNull();
+	});
+});

--- a/webui/src/lib/rollbackState.svelte.ts
+++ b/webui/src/lib/rollbackState.svelte.ts
@@ -10,7 +10,7 @@
 
 import { getClient } from './client';
 import { withToast } from './toast.svelte';
-import type { NetworkUpdateRequest, NetworkUpdateResponse } from './types';
+import type { NetworkPendingTxn, NetworkUpdateRequest, NetworkUpdateResponse } from './types';
 
 export interface PendingRollback {
 	txnId: string;
@@ -58,6 +58,38 @@ export async function applyNetworkUpdate(
 		};
 	}
 	return res;
+}
+
+/** Query the server for any active rollback transactions and populate the
+ * local store. Called on every (re)connect so a fresh session can recover
+ * the banner — important when the user just changed the management iface
+ * IP and reconnected on the new address: the txn is still pending on the
+ * server, but the *original* browser session that initiated it is gone.
+ *
+ * Best-effort: if the RPC fails (older engine, transient error), we leave
+ * the local state alone. Picks the soonest-expiring txn if multiple are
+ * pending — pathological in practice (the in-memory table rarely has more
+ * than one entry) but we want stable behavior. */
+export async function loadPendingRollback(): Promise<void> {
+	const client = getClient();
+	let txns: NetworkPendingTxn[];
+	try {
+		txns = await client.call<NetworkPendingTxn[]>('system.network.pending');
+	} catch {
+		return;
+	}
+	if (txns.length === 0) {
+		// Server says nothing pending — clear local in case we'd been
+		// holding a stale entry from a prior session.
+		_pending = null;
+		return;
+	}
+	const soonest = txns.reduce((a, b) => (a.revert_at_unix <= b.revert_at_unix ? a : b));
+	_pending = {
+		txnId: soonest.txn_id,
+		revertAtUnix: soonest.revert_at_unix,
+		riskReason: soonest.risk_reason || null,
+	};
 }
 
 /** Confirm a pending rollback — keeps the change. Clears the local store

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -575,6 +575,16 @@ export interface NetworkUpdateResponse {
 	risk_reason?: string | null;
 }
 
+/** One pending rollback transaction, as returned by `system.network.pending`.
+ * Used by the WebUI to recover the rollback banner after a reconnect — the
+ * original session that initiated the change may have lost connectivity
+ * (e.g. on an IP change), but the new session can pick the txn back up. */
+export interface NetworkPendingTxn {
+	txn_id: string;
+	revert_at_unix: number;
+	risk_reason: string;
+}
+
 export interface FirewallRule {
 	service: string;
 	ports: { port: number; transport: 'tcp' | 'udp'; source: string | null; iface: string | null }[];

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -63,7 +63,7 @@
 	import { goto } from '$app/navigation';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
-	import { rollbackState, confirmRollback } from '$lib/rollbackState.svelte';
+	import { rollbackState, confirmRollback, loadPendingRollback } from '$lib/rollbackState.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
@@ -249,6 +249,15 @@
 
 	$effect(() => {
 		if (connected) checkRebootRequired();
+	});
+
+	// Recover any pending rollback the server is tracking — covers the
+	// "user changed mgmt-iface IP and reconnected on the new address"
+	// case, where the original session that initiated the change has
+	// already been torn down. The txn is still alive server-side; this
+	// fetch puts the banner back so the user can confirm.
+	$effect(() => {
+		if (connected) loadPendingRollback();
 	});
 
 	// Clock


### PR DESCRIPTION
## Two related bugs, one fix

The \"Keep changes\" rollback banner lived only in the initiating session's browser memory. Two cases this broke:

**1. Can't change the management iface IP via the WebUI.** Apply succeeds → rollback timer arms → new IP comes up → original session loses connectivity at the worst possible moment → can't reach the box on the old IP to click Confirm. A fresh session on the new IP has no idea a txn is pending. 30s elapses → auto-revert. **You're locked out of changing the management IP through the UI.**

**2. Reloading the page kills the banner.** Reported just now: a common reflex during the 30s window is to refresh the page to verify connectivity — and the banner disappears, removing the only UI for keeping the change. Same root cause: \`rollbackState.pending\` is a \`\$state\` initialized to \`null\` on every page load.

## Fix

Make the server authoritative.

- **Engine**: new \`system.network.pending\` RPC. Returns a snapshot of the in-memory transactions table as a \`Vec<NetworkPendingTxn>\` (\`txn_id\`, \`revert_at_unix\`, \`risk_reason\`). The fields were already there on \`PendingTxn\` with a \`#[allow(dead_code)]\` and a comment anticipating exactly this RPC.
- **WebUI**: \`loadPendingRollback()\` calls the RPC and rehydrates \`rollbackState\` from whatever the server reports. Wired into a \`\$effect\` in \`+layout.svelte\` that fires whenever \`connected\` flips true — initial connect, reconnect after a network blip, fresh load on a new IP, page reload on the same IP.

Empty server response clears local state (authoritative \"nothing pending\"). RPC errors leave local state alone (so an older engine doesn't clobber an in-flight txn the same session just initiated). Picks the soonest-expiring txn if multiple are pending.

## Test plan

- [x] \`cargo test --workspace --lib\` — 136 passing (3 new \`pending_*\` tests on the engine):
  - empty when no active txns
  - surfaces full metadata for a scheduled txn
  - drops a confirmed txn
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4836 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 80 passing (5 new \`loadPendingRollback\` tests):
  - populates store from a single pending txn
  - clears local on empty server response
  - picks soonest-expiring when multiple
  - leaves local alone on RPC error (old-engine compat)
  - maps empty risk_reason to null
- [ ] **Manual #1 (page reload)**: trigger an MTU change → banner appears with 30s countdown → reload page → **banner reappears with remaining seconds intact**. Click Keep → change persists.
- [ ] **Manual #2 (IP change)**: change ens18's IP via WebUI to a known-reachable static address → original session loses connectivity → navigate to new IP within 30s → banner appears → click Keep. (Console-accessible test only, please.)

## Out of scope

- Extending the rollback window for IP changes (mentioned earlier as an option). Probably worth doing once we have telemetry on how long reconnects actually take, but not needed for this UX hole.