### PR TITLE
settings: add Celsius/Fahrenheit display unit (#79)

### DIFF
--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -90,6 +90,16 @@ const TLS_CERT_PATH: &str = "/var/lib/nasty/tls/cert.pem";
 const TLS_KEY_PATH: &str = "/var/lib/nasty/tls/key.pem";
 const LEGO_DATA_DIR: &str = "/var/lib/nasty/lego";
 
+/// Display unit for temperatures rendered in the WebUI. Internal storage
+/// and alert thresholds are always in Celsius; this is presentational only.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TempUnit {
+    #[default]
+    Celsius,
+    Fahrenheit,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Settings {
     /// IANA timezone string applied to the system (e.g. `UTC`, `America/New_York`).
@@ -100,6 +110,11 @@ pub struct Settings {
     /// Whether to display clocks in 24-hour format.
     #[serde(default = "default_clock_24h")]
     pub clock_24h: bool,
+    /// Unit for displayed temperatures (CPU, disks, alert thresholds).
+    /// Storage and alert evaluation always use Celsius internally — this
+    /// only affects rendering in the WebUI.
+    #[serde(default)]
+    pub temp_unit: TempUnit,
     /// Domain name for Let's Encrypt TLS (e.g. "nasty.example.com"). Empty = self-signed.
     #[serde(default)]
     pub tls_domain: Option<String>,
@@ -248,6 +263,7 @@ impl Default for Settings {
             timezone: default_timezone(),
             hostname: None,
             clock_24h: default_clock_24h(),
+            temp_unit: TempUnit::default(),
             tls_domain: None,
             tls_acme_email: None,
             tls_acme_enabled: false,
@@ -271,6 +287,8 @@ pub struct SettingsUpdate {
     pub hostname: Option<String>,
     /// Whether to use 24-hour clock display (optional).
     pub clock_24h: Option<bool>,
+    /// Display unit for temperatures (optional).
+    pub temp_unit: Option<TempUnit>,
     /// Domain name for Let's Encrypt TLS (set to empty string to disable).
     pub tls_domain: Option<String>,
     /// Email address for ACME notifications.
@@ -348,6 +366,9 @@ impl SettingsService {
         }
         if let Some(h24) = update.clock_24h {
             settings.clock_24h = h24;
+        }
+        if let Some(unit) = update.temp_unit {
+            settings.temp_unit = unit;
         }
         let mut tls_changed = false;
         if let Some(domain) = update.tls_domain {

--- a/webui/src/lib/temperature.svelte.test.ts
+++ b/webui/src/lib/temperature.svelte.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { cToF, formatTemp, tempUnitLabel } from './temperature.svelte';
+
+describe('cToF', () => {
+	it('converts the canonical reference points', () => {
+		// Sanity — verifies the formula isn't reversed.
+		expect(cToF(0)).toBe(32);
+		expect(cToF(100)).toBe(212);
+		expect(cToF(-40)).toBe(-40);
+	});
+
+	it('handles non-integer inputs', () => {
+		expect(cToF(36.6)).toBeCloseTo(97.88, 2);
+	});
+});
+
+describe('formatTemp', () => {
+	it('renders Celsius with the degree symbol when unit is celsius', () => {
+		expect(formatTemp(45, 'celsius')).toBe('45°C');
+	});
+
+	it('rounds and converts to Fahrenheit when unit is fahrenheit', () => {
+		// 55°C ≈ 131°F. The disks page uses 55°C as the red threshold —
+		// the user should see "131°F" there if they switched units.
+		expect(formatTemp(55, 'fahrenheit')).toBe('131°F');
+	});
+
+	it('rounds rather than truncating', () => {
+		// 45.6°C → 114.08°F → "114°F" (round to nearest, not floor).
+		expect(formatTemp(45.6, 'fahrenheit')).toBe('114°F');
+	});
+
+	it('returns null for null inputs so callers can render their own placeholder', () => {
+		expect(formatTemp(null, 'celsius')).toBeNull();
+		expect(formatTemp(null, 'fahrenheit')).toBeNull();
+	});
+});
+
+describe('tempUnitLabel', () => {
+	it('returns the bare degree label for headers/metric names', () => {
+		expect(tempUnitLabel('celsius')).toBe('°C');
+		expect(tempUnitLabel('fahrenheit')).toBe('°F');
+	});
+});

--- a/webui/src/lib/temperature.svelte.ts
+++ b/webui/src/lib/temperature.svelte.ts
@@ -1,0 +1,35 @@
+/** Temperature display helper. Internal storage and alert thresholds are
+ * always Celsius — this module only converts at render time so a user
+ * preference for Fahrenheit never leaks into stored data. */
+
+import type { TempUnit } from './types';
+
+let _unit = $state<TempUnit>('celsius');
+
+export const tempUnit = {
+	get current(): TempUnit {
+		return _unit;
+	},
+	set(unit: TempUnit) {
+		_unit = unit;
+	},
+};
+
+export function cToF(c: number): number {
+	return c * 9 / 5 + 32;
+}
+
+/** Render a Celsius value in the active unit, with the degree symbol.
+ * Pass `null` for missing readings — caller decides whether to render
+ * "—" or hide the row entirely. */
+export function formatTemp(c: number | null, unit: TempUnit = _unit): string | null {
+	if (c == null) return null;
+	if (unit === 'fahrenheit') return `${Math.round(cToF(c))}°F`;
+	return `${Math.round(c)}°C`;
+}
+
+/** Just the unit's degree label, without a value — for column headers
+ * and metric labels like "Disk Temperature (°C)". */
+export function tempUnitLabel(unit: TempUnit = _unit): string {
+	return unit === 'fahrenheit' ? '°F' : '°C';
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -433,10 +433,13 @@ export interface ProtocolStatus {
 	system_service: boolean;
 }
 
+export type TempUnit = 'celsius' | 'fahrenheit';
+
 export interface Settings {
 	timezone: string;
 	hostname: string | null;
 	clock_24h: boolean;
+	temp_unit: TempUnit;
 	tls_domain: string | null;
 	tls_acme_email: string | null;
 	tls_acme_enabled: boolean;

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -64,6 +64,7 @@
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
 	import { rollbackState, confirmRollback, loadPendingRollback } from '$lib/rollbackState.svelte';
+	import { tempUnit } from '$lib/temperature.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
@@ -223,7 +224,10 @@
 		const _r = sysInfoRefresh.count; // track refresh triggers
 		if (connected) {
 			getClient().call('system.info').then((info: any) => { sysInfo = info; }).catch(() => {});
-			getClient().call('system.settings.get').then((s: any) => { clock24h = s.clock_24h ?? true; }).catch(() => {});
+			getClient().call('system.settings.get').then((s: any) => {
+				clock24h = s.clock_24h ?? true;
+				tempUnit.set(s.temp_unit ?? 'celsius');
+			}).catch(() => {});
 		}
 	});
 

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { formatBytes, formatUptime, formatPercent } from '$lib/format';
+	import { formatTemp } from '$lib/temperature.svelte';
 	import { withToast } from '$lib/toast.svelte';
 	import type { SystemInfo, SystemHealth, SystemStats, Filesystem, DiskHealth, DiskIoStats, NetIfStats, ActiveAlert, Settings, ResourceHistory } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -432,7 +433,7 @@
 			<CardContent class="pt-4 pb-3">
 				<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU Temp</div>
 				<div class="mt-1 flex items-baseline gap-2">
-					<span class="text-2xl font-bold">{stats.cpu.temp_c != null ? stats.cpu.temp_c + '°C' : '—'}</span>
+					<span class="text-2xl font-bold">{formatTemp(stats.cpu.temp_c) ?? '—'}</span>
 				</div>
 				<div class="mt-2 text-xs text-muted-foreground">
 					{#if stats.cpu.freq_mhz != null}

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -3,6 +3,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { tempUnit, cToF, tempUnitLabel } from '$lib/temperature.svelte';
 	import type { AlertRule, ActiveAlert, AlertMetric, AlertCondition, AlertSeverity } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -23,11 +24,15 @@
 
 	const client = getClient();
 
-	const metricLabels: Record<AlertMetric, string> = {
+	// Disk temperature label tracks the user's display-unit preference;
+	// thresholds remain Celsius internally (so an existing rule keeps its
+	// alerting semantics if the user toggles units), but we convert at
+	// the input/display boundary in `createRule` and the rules table.
+	const metricLabels: Record<AlertMetric, string> = $derived({
 		fs_usage_percent: 'Filesystem Usage (%)',
 		cpu_load_percent: 'CPU Load (%)',
 		memory_usage_percent: 'Memory Usage (%)',
-		disk_temperature: 'Disk Temperature (°C)',
+		disk_temperature: `Disk Temperature (${tempUnitLabel(tempUnit.current)})`,
 		smart_health: 'SMART Health Failure',
 		swap_usage_percent: 'Swap Usage (%)',
 		bcachefs_degraded: 'bcachefs Degraded Mode',
@@ -37,7 +42,7 @@
 		bcachefs_scrub_errors: 'bcachefs Scrub Corruption',
 		bcachefs_reconcile_stalled: 'bcachefs Reconcile Stalled',
 		kernel_errors: 'Kernel Errors',
-	};
+	});
 
 	const conditionLabels: Record<AlertCondition, string> = {
 		above: 'Above',
@@ -69,6 +74,13 @@
 
 	async function createRule() {
 		if (!newName) return;
+		// disk_temperature thresholds are stored in Celsius. If the user is
+		// viewing Fahrenheit, the value typed in the input is in °F — convert
+		// before sending so the alert evaluator sees the canonical unit.
+		const stored =
+			newMetric === 'disk_temperature' && tempUnit.current === 'fahrenheit'
+				? Math.round(((newThreshold - 32) * 5) / 9)
+				: newThreshold;
 		const ok = await withToast(
 			() => client.call('alert.rules.create', {
 				id: '',
@@ -76,7 +88,7 @@
 				enabled: true,
 				metric: newMetric,
 				condition: newCondition,
-				threshold: newThreshold,
+				threshold: stored,
 				severity: newSeverity,
 			}),
 			'Alert rule created'
@@ -198,7 +210,12 @@
 				<tr class="border-b border-border {!rule.enabled ? 'opacity-50' : ''}">
 					<td class="p-3"><strong>{rule.name}</strong></td>
 					<td class="p-3">{metricLabels[rule.metric] ?? rule.metric}</td>
-					<td class="p-3">{conditionLabels[rule.condition] ?? rule.condition} {rule.threshold}</td>
+					<td class="p-3">
+						{conditionLabels[rule.condition] ?? rule.condition}
+						{rule.metric === 'disk_temperature' && tempUnit.current === 'fahrenheit'
+							? Math.round(cToF(rule.threshold))
+							: rule.threshold}
+					</td>
 					<td class="p-3">
 						<span class="rounded px-1.5 py-0.5 text-[0.7rem] font-semibold uppercase {
 							rule.severity === 'critical' ? 'bg-red-950 text-red-200' : 'bg-amber-950 text-amber-200'

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { formatBytes } from '$lib/format';
+	import { formatTemp } from '$lib/temperature.svelte';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { BlockDevice, DiskHealth, ProtocolStatus } from '$lib/types';
@@ -255,7 +256,7 @@
 								<div class="flex flex-col">
 									<span class="text-[0.7rem] uppercase text-muted-foreground">Temperature</span>
 									<span class="text-sm font-semibold {disk.temperature_c > 55 ? 'text-red-400' : disk.temperature_c > 45 ? 'text-amber-500' : ''}">
-										{disk.temperature_c}°C
+										{formatTemp(disk.temperature_c)}
 									</span>
 								</div>
 							{/if}
@@ -344,7 +345,7 @@
 									<td class="p-3 font-mono text-xs text-muted-foreground">{disk.serial}</td>
 									<td class="p-3 text-sm">{formatBytes(disk.capacity_bytes)}</td>
 									<td class="p-3 text-sm {disk.temperature_c != null && disk.temperature_c > 55 ? 'text-red-400' : disk.temperature_c != null && disk.temperature_c > 45 ? 'text-amber-500' : ''}">
-										{disk.temperature_c != null ? `${disk.temperature_c}°C` : '—'}
+										{formatTemp(disk.temperature_c) ?? '—'}
 									</td>
 									<td class="p-3">
 										<span class="rounded px-2 py-0.5 text-xs font-bold {disk.health_passed ? 'bg-green-950 text-green-400' : 'bg-red-950 text-red-400'}">

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -3,6 +3,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
+	import { tempUnit } from '$lib/temperature.svelte';
 	import { promoteOrphanedMembers } from '$lib/network';
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
@@ -228,6 +229,16 @@
 		await withToast(
 			() => client.call('system.settings.update', { clock_24h: val }),
 			val ? '24-hour clock enabled' : '12-hour clock enabled'
+		);
+	}
+
+	async function saveTempUnit(val: 'celsius' | 'fahrenheit') {
+		if (!settings) return;
+		settings.temp_unit = val;
+		tempUnit.set(val);
+		await withToast(
+			() => client.call('system.settings.update', { temp_unit: val }),
+			val === 'fahrenheit' ? 'Temperature unit: Fahrenheit' : 'Temperature unit: Celsius'
 		);
 	}
 
@@ -743,6 +754,20 @@
 								onclick={() => saveClock24h(false)}
 								class="rounded-r-md px-3 py-1 font-medium transition-colors {!settings.clock_24h ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
 							>AM/PM</button>
+						</div>
+					</div>
+
+					<div class="mb-4 flex items-center justify-between">
+						<span class="text-sm text-muted-foreground">Temperature Unit</span>
+						<div class="flex rounded-md border border-border text-xs">
+							<button
+								onclick={() => saveTempUnit('celsius')}
+								class="rounded-l-md px-3 py-1 font-medium transition-colors {settings.temp_unit !== 'fahrenheit' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+							>°C</button>
+							<button
+								onclick={() => saveTempUnit('fahrenheit')}
+								class="rounded-r-md px-3 py-1 font-medium transition-colors {settings.temp_unit === 'fahrenheit' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+							>°F</button>
 						</div>
 					</div>
 


### PR DESCRIPTION
Closes #79.

## What

Adds a **Temperature Unit** toggle to Settings → General, sitting next to Clock Format. Switches between °C and °F display across the WebUI:

- Dashboard CPU temp
- Disks page — both the per-disk card and the SMART table
- Alerts page — \`disk_temperature\` metric label adapts (\`Disk Temperature (°C)\` vs \`(°F)\`); threshold input accepts and table displays the active unit

## Storage stays Celsius

The unit is presentational only. The engine stores temperatures and evaluates alert thresholds in °C. When the user authors a \`disk_temperature\` rule with the unit set to °F:

1. WebUI converts \`°F → °C\` before \`alert.rules.create\`.
2. Engine evaluates against the live °C reading.
3. WebUI converts \`°C → °F\` for display.

This means **toggling the unit doesn't change the alerting semantics of existing rules** — a 55°C threshold stays 55°C internally even when shown as 131°F.

## Why server-side

Same admin reaches the box from multiple browsers. Putting the preference in the per-user-but-shared \`Settings\` table (next to \`clock_24h\`) gives consistent display everywhere; localStorage would diverge per browser.

## Files

- **Engine** — \`engine/nasty-system/src/settings.rs\`: new \`TempUnit\` enum (lowercase serde), \`Settings.temp_unit\` field with default Celsius, matching \`SettingsUpdate.temp_unit\`, apply path.
- **WebUI** — \`webui/src/lib/temperature.svelte.ts\`: small reactive \`tempUnit\` store + \`formatTemp\` / \`cToF\` / \`tempUnitLabel\`. Loaded on connect from \`system.settings.get\`.
- Display sites updated in dashboard, disks, alerts.

## Test plan

- [x] \`cargo test --workspace --lib\` — 136 passing
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4838 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 87 passing (7 new for \`formatTemp\` / \`cToF\` / \`tempUnitLabel\`):
  - canonical reference points (0°C → 32°F, 100°C → 212°F, -40 invariant)
  - non-integer inputs (36.6°C ≈ 97.88°F)
  - rounds (45.6°C → 114°F, not 113)
  - null in → null out (callers render their own placeholder)
  - bare unit label for headers
- [ ] **Manual**: toggle to °F → CPU/disks/alerts display all in °F, including existing rules' thresholds. Toggle back → all °C. Create a new rule under °F (\"Above 130°F\") → server stores 54°C → triggers correctly when a disk hits 55°C.