### PR TITLE
fs: lock encrypted filesystems from the WebUI (#86)

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -1368,6 +1368,13 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             }
             Err(e) => invalid(req, e),
         },
+        "fs.lock" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.lock(name).await {
+                Ok(fs) => ok(req, fs),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         "fs.key.export" => match require_str(req, "name") {
             Ok(name) => match state.filesystems.export_key(name).await {
                 Ok(key) => ok(req, key),

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -40,6 +40,34 @@ async fn is_bcachefs_key_loaded(uuid: &str) -> bool {
     proc_keys_has_bcachefs_uuid(&contents, uuid)
 }
 
+/// Parse `/proc/keys` and return the decimal key id of the
+/// `bcachefs:<uuid>` logon key, or `None` if it isn't loaded. The id
+/// is what `keyctl unlink <id> @s` expects to revoke the key from
+/// the engine's session keyring.
+///
+/// Pure function — `find_bcachefs_key_id` is the async I/O wrapper.
+fn parse_bcachefs_key_id(contents: &str, uuid: &str) -> Option<String> {
+    let needle = format!("bcachefs:{uuid}");
+    contents.lines().find_map(|line| {
+        let mut toks = line.split_whitespace();
+        let id_hex = toks.next()?;
+        // Same token-equality check as `proc_keys_has_bcachefs_uuid` —
+        // belt-and-braces against partial-uuid matches.
+        if !line.split_whitespace().any(|tok| tok == needle) {
+            return None;
+        }
+        // /proc/keys writes ids as 8-hex-digit zero-padded; keyctl
+        // accepts decimal — stick with decimal so the command line
+        // is unambiguous regardless of leading-zero handling.
+        u32::from_str_radix(id_hex, 16).ok().map(|n| n.to_string())
+    })
+}
+
+async fn find_bcachefs_key_id(uuid: &str) -> Option<String> {
+    let contents = tokio::fs::read_to_string(PROC_KEYS_PATH).await.ok()?;
+    parse_bcachefs_key_id(&contents, uuid)
+}
+
 #[derive(Debug, Error)]
 pub enum FilesystemError {
     #[error("bcachefs command failed: {0}")]
@@ -1114,6 +1142,41 @@ impl FilesystemService {
         .map_err(FilesystemError::CommandFailed)?;
 
         info!("Filesystem '{name}' unlocked");
+        self.invalidate_list_cache().await;
+        self.get(name).await
+    }
+
+    /// Lock an encrypted filesystem: unmount it (if mounted) and revoke
+    /// its key from the kernel keyring. Mirror of `unlock`. After this,
+    /// remounting requires re-entering the passphrase via `unlock`
+    /// (or the stored auto-unlock key, if one is on disk — those two
+    /// concepts are independent; "lock" doesn't delete the stored key,
+    /// `delete_key` does).
+    ///
+    /// No-op (success) if the FS is already locked. Errors out if the
+    /// FS isn't encrypted at all — calling lock on a plain FS is a
+    /// programming bug worth surfacing.
+    pub async fn lock(&self, name: &str) -> Result<Filesystem, FilesystemError> {
+        let fs = self.get(name).await?;
+        if fs.options.encrypted != Some(true) {
+            return Err(FilesystemError::InvalidInput(format!(
+                "filesystem '{name}' is not encrypted"
+            )));
+        }
+        if fs.mounted {
+            self.unmount(name).await?;
+        }
+        match find_bcachefs_key_id(&fs.uuid).await {
+            Some(key_id) => {
+                cmd::run_ok("keyctl", &["unlink", &key_id, "@s"])
+                    .await
+                    .map_err(FilesystemError::CommandFailed)?;
+                info!("Filesystem '{name}' locked (key {key_id} unlinked from session keyring)");
+            }
+            None => {
+                info!("Filesystem '{name}' was already locked (no key in keyring)");
+            }
+        }
         self.invalidate_list_cache().await;
         self.get(name).await
     }
@@ -2921,5 +2984,57 @@ mod tests {
 3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra-suffix
 ";
         assert!(!proc_keys_has_bcachefs_uuid(contents, "abcd1234"));
+    }
+
+    // ── parse_bcachefs_key_id ─────────────────────────────────────
+
+    #[test]
+    fn parse_key_id_returns_decimal_id_for_matching_uuid() {
+        // `keyctl unlink` takes a decimal id; /proc/keys writes hex.
+        // 3a821c8e hex == 981605518 decimal.
+        let contents = "\
+2c93e9b4 I--Q---     1 perm 3f010000     0     0 keyring   _ses: 1
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-1111-2222-3333-444455556666
+";
+        let id = parse_bcachefs_key_id(contents, "abcd1234-1111-2222-3333-444455556666");
+        assert_eq!(id.as_deref(), Some("981605518"));
+    }
+
+    #[test]
+    fn parse_key_id_returns_none_when_uuid_absent() {
+        let contents = "\
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:other-uuid
+";
+        assert!(parse_bcachefs_key_id(contents, "abcd1234-1111-2222-3333-444455556666").is_none());
+    }
+
+    #[test]
+    fn parse_key_id_returns_none_for_empty_keyring() {
+        assert!(parse_bcachefs_key_id("", "any-uuid").is_none());
+    }
+
+    #[test]
+    fn parse_key_id_does_not_match_uuid_prefix() {
+        // Same prefix-safety as proc_keys_has_bcachefs_uuid — don't
+        // unlink someone else's key just because the uuids share a
+        // common prefix.
+        let contents = "\
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra
+";
+        assert!(parse_bcachefs_key_id(contents, "abcd1234").is_none());
+    }
+
+    #[test]
+    fn parse_key_id_picks_first_matching_line() {
+        // Defensive: a stale revoked key + a fresh one with the same
+        // uuid would be unusual but possible if a previous lock was
+        // interrupted. Take the first id; if unlink fails on it, the
+        // operator can re-run.
+        let contents = "\
+00000010 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid
+00000020 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid
+";
+        let id = parse_bcachefs_key_id(contents, "dup-uuid");
+        assert_eq!(id.as_deref(), Some("16")); // 0x10
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -555,6 +555,7 @@ in {
       hdparm            # HDD spin-down, drive parameters
       lm_sensors        # CPU/drive temperature monitoring
       lsof              # open file debugging ("device busy")
+      keyutils          # keyctl — used by the engine to lock encrypted FSes
       iotop-c           # per-process I/O monitoring
       ethtool           # NIC speed, duplex, ring buffer tuning
       iperf3            # network throughput testing

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -554,6 +554,20 @@
 		editIoScheduler = fs.options.io_scheduler ?? '';
 	}
 
+	async function lockFs(fs: Filesystem) {
+		const ok = await confirm(
+			`Lock Filesystem "${fs.name}"`,
+			`This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.`,
+			{ confirmLabel: 'Lock' },
+		);
+		if (!ok) return;
+		await withToast(
+			() => client.call('fs.lock', { name: fs.name }, 120000),
+			`Filesystem "${fs.name}" locked`,
+		);
+		await refresh();
+	}
+
 	async function doUnlock() {
 		if (!unlockFs || !unlockPassphrase) return;
 		const name = unlockFs;
@@ -1286,6 +1300,10 @@
 						{#if fs.options.encrypted && fs.options.locked}
 							<Button variant="default" size="xs" onclick={() => { unlockFs = fs.name; unlockPassphrase = ''; }}>
 								Unlock
+							</Button>
+						{:else if fs.options.encrypted}
+							<Button variant="secondary" size="xs" onclick={() => lockFs(fs)}>
+								Lock
 							</Button>
 						{/if}
 						<Button variant="secondary" size="xs" onclick={() => toggleMount(fs)}


### PR DESCRIPTION
Closes #86.

## What

Adds a **Lock** button next to Unmount/Options on encrypted filesystems. Mirror of the existing Unlock — unmounts (if mounted) and revokes the encryption key from the kernel keyring. Subsequent mount attempts require the passphrase again.

Confirm dialog text explicitly warns about the blast radius (per review comment):

> *This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.*

## How

- **Engine** — \`FilesystemService::lock(name)\`:
  1. Refuse if the FS isn't encrypted (programming bug, surface it).
  2. \`unmount(name)\` if currently mounted (cascades through shares the same way the existing toggle does).
  3. Walk \`/proc/keys\`, find the line whose token equals \`bcachefs:<uuid>\`, extract the hex id from column one.
  4. \`keyctl unlink <decimal-id> @s\` to remove the key from the engine's session keyring (where \`bcachefs unlock -k session\` deposits it).
  5. No-op (success) if the key isn't there — already locked.
- **Router**: new \`fs.lock\` arm. Same shape as \`fs.unlock\` minus the passphrase.
- **NixOS module**: \`keyutils\` added to \`environment.systemPackages\` so \`keyctl\` is on PATH.
- **WebUI**: Lock button on encrypted FS rows, gated on \`encrypted && !locked\`.

## Lock vs. delete-stored-key (intentionally separate)

\`fs.lock\` is transient: it removes the key from the kernel keyring but **doesn't delete the stored auto-unlock key file** at \`/var/lib/nasty/keys/<name>.key\`. So:
- Without a stored key: lock → unlock requires passphrase. Reboot keeps it locked.
- With a stored key: lock → can re-unlock without passphrase via the same Unlock dialog (key is still on disk). Reboot **does** auto-unlock.

The persistent \"forget passphrase\" action is the existing \`fs.key.delete\` (\"Forget Stored Key\" button). Mixing the two would surprise users who lock just to revoke *runtime* access without losing their auto-unlock convenience.

## Test plan

- [x] \`cargo test -p nasty-storage --lib\` — 19 passing (5 new \`parse_key_id_*\` tests):
  - decimal id for matching uuid (3a821c8e → 981605518)
  - none when uuid absent
  - none for empty keyring
  - prefix-safety (uuid \`abcd1234\` doesn't match \`abcd1234-extra\`)
  - duplicate lines: picks first id
- [x] \`cargo test --workspace --lib\` — full pass
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4838 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 87 passing
- [ ] **Manual on a real box** with an encrypted bcachefs FS:
  - Click Lock on a mounted, unlocked FS → confirm dialog → unmounted, key gone from \`/proc/keys\`, status flips to Locked.
  - Click Lock on an unlocked-but-unmounted FS → key gone, no spurious unmount call.
  - Click Lock on a plain (non-encrypted) FS shouldn't even render the button. (Server-side check would error if invoked anyway.)
  - Click Lock on a FS with active services → unmount fails with EBUSY → toast shows the error → FS stays mounted+unlocked. (Existing unmount behavior; lock just inherits it.)