### PR TITLE
hostname: alias nixosConfigurations.<hostname> after WebUI rename (#95)

### DIFF
--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -481,12 +481,62 @@ pub async fn list_timezones() -> Result<Vec<String>, String> {
 }
 
 async fn apply_hostname(name: &str) -> Result<(), String> {
-    // NixOS has /etc as read-only — set hostname via kernel proc only.
-    // Persistence is via /var/lib/nasty/settings.json, read at boot.
+    // NixOS has /etc as read-only — set the kernel hostname via /proc.
+    // Persistence is via /var/lib/nasty/settings.json, read at boot by
+    // nasty-apply-hostname.service.
     tokio::fs::write("/proc/sys/kernel/hostname", name.as_bytes())
         .await
         .map_err(|e| format!("failed to set kernel hostname: {e}"))?;
+
+    // Also expose the name to the wrapper flake so `nixos-rebuild
+    // switch` (which defaults to looking up `nixosConfigurations.<kernel-hostname>`)
+    // resolves to our system. The flake at /etc/nixos/flake.nix imports
+    // ./hostname.nix when present and falls back to "nasty" otherwise,
+    // so writing this file is best-effort — failures are logged but
+    // don't fail the apply (e.g. fresh installs before rebootstrap, or
+    // if /etc/nixos isn't writable for some reason).
+    write_hostname_nix(name).await;
+
     Ok(())
+}
+
+/// Write `/etc/nixos/hostname.nix` with the current hostname as a Nix
+/// string literal. Read by the wrapper flake to alias
+/// `nixosConfigurations.<hostname>` to the same system attr as `nasty`.
+async fn write_hostname_nix(name: &str) {
+    let nixos_dir = std::path::Path::new("/etc/nixos");
+    if !nixos_dir.exists() {
+        // Fresh install before rebootstrap, or running outside a normal
+        // NixOS layout (tests). Nothing to do.
+        return;
+    }
+    let path = nixos_dir.join("hostname.nix");
+    let content = format!("{}\n", to_nix_string(name));
+    if let Err(e) = tokio::fs::write(&path, content).await {
+        warn!("could not write {}: {e}", path.display());
+    }
+}
+
+/// Render a Rust string as a Nix double-quoted string literal, escaping
+/// the characters that have special meaning inside `"..."`. The hostname
+/// has been validated upstream (RFC1123-ish), but escape defensively so
+/// any future relaxation can't smuggle Nix syntax into the flake.
+fn to_nix_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '$' => out.push_str("\\$"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 async fn apply_timezone(tz: &str) -> Result<(), String> {
@@ -894,5 +944,42 @@ pub async fn check_acme_renewal() {
     info!("Checking ACME certificate renewal...");
     if let Err(e) = run_lego(&settings).await {
         warn!("ACME renewal check failed: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_nix_string;
+
+    #[test]
+    fn nix_string_renders_a_plain_hostname_unchanged() {
+        // The common case: a normal hostname has no special characters,
+        // so the output is just `"name"`.
+        assert_eq!(to_nix_string("nasty"), "\"nasty\"");
+    }
+
+    #[test]
+    fn nix_string_renders_an_fqdn_unchanged() {
+        // The motivating case from issue #95: user set hostname to
+        // a dot-separated FQDN. Dots have no Nix-string semantics so
+        // they just pass through.
+        assert_eq!(to_nix_string("nasty.domain.xyz"), "\"nasty.domain.xyz\"",);
+    }
+
+    #[test]
+    fn nix_string_escapes_quotes_backslashes_and_dollar() {
+        // Defensive — hostnames have been validated upstream, but if
+        // anything ever sneaks past validation we don't want it
+        // smuggling Nix syntax into the flake. `${...}` interpolation
+        // is the most dangerous: escaping the leading `$` is enough.
+        assert_eq!(to_nix_string("a\"b"), r#""a\"b""#);
+        assert_eq!(to_nix_string("a\\b"), r#""a\\b""#);
+        assert_eq!(to_nix_string("a${x}b"), r#""a\${x}b""#);
+    }
+
+    #[test]
+    fn nix_string_escapes_whitespace_control_chars() {
+        assert_eq!(to_nix_string("a\nb"), r#""a\nb""#);
+        assert_eq!(to_nix_string("a\tb"), r#""a\tb""#);
     }
 }

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -50,9 +50,29 @@
           ];
         };
     in {
-      wrapperFlakeVersion = "v0.1";
-      nixosConfigurations = {
-        nasty = mkSystem "@LOCAL_SYSTEM@";
-      };
+      wrapperFlakeVersion = "v0.2";
+      nixosConfigurations =
+        let
+          sys = mkSystem "@LOCAL_SYSTEM@";
+          # `nixos-rebuild switch` defaults to looking up
+          # `nixosConfigurations.<kernel-hostname>`. The engine writes the
+          # user's chosen hostname to /proc/sys/kernel/hostname (and
+          # re-applies it on boot via nasty-apply-hostname.service), so
+          # after a WebUI rename the lookup would fail without an alias.
+          # The engine also writes the hostname into a sibling
+          # `hostname.nix` file (alongside this flake.nix) on every
+          # apply — read it here and expose it as an alias of `nasty`.
+          # `nasty` itself stays as a stable fallback so
+          # `nixos-rebuild switch --flake /etc/nixos#nasty` always works.
+          # Pure-eval-safe: relative path inside the flake source tree.
+          hostName =
+            if builtins.pathExists ./hostname.nix
+            then nixpkgs.lib.strings.removeSuffix "\n" (builtins.readFile ./hostname.nix)
+            else "nasty";
+        in
+        { nasty = sys; }
+        // nixpkgs.lib.optionalAttrs (hostName != "" && hostName != "nasty") {
+          "${hostName}" = sys;
+        };
     };
 }


### PR DESCRIPTION
Closes #95.

## The bug

After renaming the host via Settings → General (e.g. \`nasty\` → \`nasty.domain.xyz\`), \`nixos-rebuild switch\` fails:

\`\`\`
error: flake 'path:/etc/nixos' does not provide attribute
'nixosConfigurations.\"nasty.domain.xyz\".config.system.build.nixos-rebuild', ...
\`\`\`

\`nixos-rebuild\` defaults to looking up \`nixosConfigurations.<kernel-hostname>\`, but the wrapper flake template (\`nixos/system-flake/flake.nix.template\`) hardcodes only \`nasty = mkSystem ...\`. The engine writes the new name to \`/proc/sys/kernel/hostname\` and persists it in \`settings.json\`, so the live hostname diverges from what the flake exposes.

## Fix

Make the flake expose \`nixosConfigurations.<currentHostname>\` as an alias of \`nasty\`, **without breaking pure-eval mode**.

The naive fix — \`builtins.readFile /proc/sys/kernel/hostname\` — is rejected by pure flake eval (which is what \`nixos-rebuild\` runs by default): pure mode forbids absolute paths outside the flake source tree.

Instead: the engine maintains a \`/etc/nixos/hostname.nix\` sibling file containing the hostname as a Nix string literal. The flake imports it via the relative path \`./hostname.nix\` (inside the flake source tree → pure-eval-safe). When the file is absent (fresh install pre-rebootstrap), it falls back to \`\"nasty\"\`.

\`nasty\` itself stays as a stable key so \`nixos-rebuild switch --flake /etc/nixos#nasty\` always works, regardless of hostname state.

## Where it ships

\`wrapperFlakeVersion\` bumped from \`v0.1\` → \`v0.2\`. Existing installs re-bootstrap their \`/etc/nixos/flake.nix\` from the new template on their next NASty update (existing mechanism — see \`should_rebootstrap_wrapper_flake\` in \`update.rs\`). Fresh installs get it directly.

The fallback to \`\"nasty\"\` in the template means the v0.2 rebootstrap is safe even before the engine has written \`hostname.nix\`. The next hostname change writes it; nothing breaks in between.

## Engine changes

- \`apply_hostname\` now also best-effort writes \`/etc/nixos/hostname.nix\`. Failures are logged but don't fail the apply (e.g. when running outside a NixOS layout in tests).
- New \`to_nix_string\` helper escapes \`\\\`, \`\"\`, \`\$\`, and whitespace controls. Hostnames are validated upstream, but escaping defensively means a future validation-relaxation bug can't smuggle Nix syntax into the flake.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 140 passing (4 new \`nix_string_*\`):
  - plain hostname unchanged
  - FQDN (\`nasty.domain.xyz\`) unchanged — the motivating case
  - escapes \`\"\`, \`\\\`, \`\$\` (the dangerous Nix-string interp)
  - escapes \\n, \\t
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [ ] **Manual on a real box**:
  1. Rename via WebUI \`nasty\` → \`mynas\` → \`nixos-rebuild switch\` works (no \`--flake\` flag needed).
  2. Rename to FQDN \`mynas.lab.example.com\` → same.
  3. \`--flake /etc/nixos#nasty\` keeps working as a stable fallback regardless of current hostname.
  4. Inspect \`/etc/nixos/hostname.nix\` after each rename — should contain \`\"<name>\"\\n\`.