### PR TITLE
smb: announce on mDNS + WSDD so file managers see NASty (#70)

### DIFF
--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -109,7 +109,9 @@ fn udp(port: u16) -> PortSpec {
 pub fn ports_for_protocol(proto: Protocol) -> Vec<PortSpec> {
     match proto {
         Protocol::Nfs => vec![tcp(2049)],
-        Protocol::Smb => vec![tcp(445), tcp(139)],
+        // 445/139: Samba serving. 3702/udp: WSDD announcements for
+        // Windows 10/11 Explorer discovery (samba-wsdd.service).
+        Protocol::Smb => vec![tcp(445), tcp(139), udp(3702)],
         Protocol::Iscsi => vec![tcp(3260)],
         Protocol::Nvmeof => vec![tcp(4420)],
         Protocol::Nut => vec![tcp(3493)],
@@ -436,4 +438,34 @@ async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smb_opens_serving_and_wsdd_discovery_ports() {
+        // 445 + 139 are Samba's serving ports; 3702/udp is WSDD's
+        // multicast WS-Discovery port — without it Windows 10/11
+        // Explorer can't browse the host. Pin them so a refactor
+        // doesn't silently drop discovery and turn NASty invisible
+        // to Windows file managers again (issue #70).
+        let ports = ports_for_protocol(Protocol::Smb);
+        assert!(
+            ports
+                .iter()
+                .any(|p| p.port == 445 && p.transport == Transport::Tcp)
+        );
+        assert!(
+            ports
+                .iter()
+                .any(|p| p.port == 139 && p.transport == Transport::Tcp)
+        );
+        assert!(
+            ports
+                .iter()
+                .any(|p| p.port == 3702 && p.transport == Transport::Udp)
+        );
+    }
 }

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -80,7 +80,16 @@ impl Protocol {
     fn services(&self) -> &[&str] {
         match self {
             Protocol::Nfs => &["nfs-server.service"],
-            Protocol::Smb => &["samba-smbd.service", "samba-nmbd.service"],
+            Protocol::Smb => &[
+                "samba-smbd.service",
+                "samba-nmbd.service",
+                // wsdd advertises SMB shares to Windows 10/11 file
+                // managers via WS-Discovery (Win dropped NetBIOS
+                // browsing). Started/stopped alongside Samba so
+                // toggling the SMB protocol consistently affects all
+                // discovery surfaces.
+                "samba-wsdd.service",
+            ],
             Protocol::Iscsi => &["target.service"],
             Protocol::Nvmeof => &[], // configfs-based, no daemon
             Protocol::Nut => &[
@@ -493,4 +502,22 @@ async fn save_state(state: &ProtocolState) -> Result<(), String> {
     tokio::fs::write(STATE_PATH, json)
         .await
         .map_err(|e| format!("failed to write protocol state: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smb_protocol_includes_wsdd_in_its_service_set() {
+        // Toggling SMB in the WebUI must start/stop the WSDD daemon
+        // alongside Samba — otherwise the host stays invisible to
+        // Windows 10/11 Explorer (issue #70). Pin the membership so
+        // a future refactor of `services()` doesn't silently break
+        // discovery.
+        let svcs = Protocol::Smb.services();
+        assert!(svcs.contains(&"samba-smbd.service"));
+        assert!(svcs.contains(&"samba-nmbd.service"));
+        assert!(svcs.contains(&"samba-wsdd.service"));
+    }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1043,6 +1043,55 @@ in {
     # on demand when the user enables the protocol.
     systemd.targets.samba.wantedBy = mkIf cfg.smb.enable (lib.mkForce []);
 
+    # ── SMB network discovery ──────────────────────────────────
+    # NASty was invisible to file-manager network browsers — TrueNAS,
+    # Synology et al. show up because they advertise SMB over multiple
+    # discovery surfaces. Cover the three that matter for modern OSes:
+    #
+    # - mDNS `_smb._tcp` via Avahi  → macOS Finder, GNOME Files, KDE
+    # - mDNS `_device-info._tcp`    → Finder shows the rack-server icon
+    # - WS-Discovery (UDP 3702)     → Windows 10/11 Explorer
+    #
+    # All gated on the build-time SMB switch. The engine starts/stops
+    # samba-wsdd alongside samba-smbd/nmbd via the protocol service
+    # list (see engine/nasty-system/src/protocol.rs::Protocol::Smb).
+    services.avahi.extraServiceFiles = mkIf cfg.smb.enable {
+      smb = ''
+        <?xml version="1.0" standalone='no'?>
+        <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+        <service-group>
+          <name replace-wildcards="yes">%h</name>
+          <service>
+            <type>_smb._tcp</type>
+            <port>445</port>
+          </service>
+        </service-group>
+      '';
+      # `model=Xserve` is the rack-mount NAS icon Finder uses for
+      # TrueNAS, Synology, etc. `port=0` because this entry is just
+      # metadata — there's no service on the other end.
+      device-info = ''
+        <?xml version="1.0" standalone='no'?>
+        <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+        <service-group>
+          <name replace-wildcards="yes">%h</name>
+          <service>
+            <type>_device-info._tcp</type>
+            <port>0</port>
+            <txt-record>model=Xserve</txt-record>
+          </service>
+        </service-group>
+      '';
+    };
+
+    # WSDD daemon (Web Services Dynamic Discovery) for Windows 10/11
+    # Explorer browsing — Win dropped NetBIOS/SMB1 browse master in
+    # favour of WS-Discovery, which TrueNAS et al. ship by default.
+    # NixOS upstream enables the unit at boot via `wantedBy`; override
+    # so it follows the SMB protocol toggle managed by the engine.
+    services.samba-wsdd.enable = mkIf cfg.smb.enable true;
+    systemd.services.samba-wsdd.wantedBy = mkIf cfg.smb.enable (lib.mkForce []);
+
     # ── iSCSI / LIO ───────────────────────────────────────────
     # target.service: restore LIO config from /etc/target/saveconfig.json.
     # Not started at boot — the nasty-engine starts it on demand after


### PR DESCRIPTION
Closes #70.

## Bug

Mac Finder, Windows Explorer, and Linux file-manager network sidebars all skipped past NASty even with SMB enabled. TrueNAS and Synology show up because they advertise on multiple discovery surfaces; NASty's Avahi config only published \`_workstation._tcp\`, which a few Linux tools pick up but Finder ignores.

## Fix

Cover the three surfaces that matter for modern OSes:

| Surface | Used by | Implementation |
|---|---|---|
| \`_smb._tcp\` mDNS | macOS Finder, GNOME Files, KDE | New \`services.avahi.extraServiceFiles.smb\` |
| \`_device-info._tcp\` mDNS, model=Xserve | Finder icon (rack-server, not generic computer) | New \`services.avahi.extraServiceFiles.device-info\` |
| WSDD (UDP 3702) | Windows 10/11 Explorer | \`services.samba-wsdd.enable\` |

All gated on \`cfg.smb.enable\` (the build-time SMB switch, defaults to on).

## Engine integration

\`samba-wsdd.service\` is added to \`Protocol::Smb\`'s service list (\`engine/nasty-system/src/protocol.rs\`), so toggling SMB in the WebUI starts/stops WSDD alongside \`samba-smbd\` and \`samba-nmbd\`. Otherwise WSDD would run indefinitely after one boot. The upstream \`wantedBy = multi-user.target\` is overridden to \`[]\` for the same reason — engine controls the lifecycle.

\`udp(3702)\` is added to the SMB protocol's port list (\`firewall.rs\`), so the engine's nftables firewall opens the WSDD multicast port when SMB is enabled. Otherwise wsdd would broadcast but nobody could reach it.

## Tradeoff to know

The mDNS announcements fire whenever the **NixOS module** has SMB enabled, regardless of whether the **engine** has the protocol currently running. Means: if a user disables SMB at runtime, the host still appears in Finder but clicking gives connection-refused. This matches TrueNAS/Synology behaviour (they advertise even when stopped) and is much better than \"completely invisible\". A tighter fix where the engine drops/recreates \`/etc/avahi/services/smb.service\` on protocol toggle is a possible follow-up if it bothers anyone — out of scope here.

WSDD itself is engine-managed (it's in the protocol service list), so the Windows side does follow the runtime toggle.

## What I deliberately skipped

- Per-protocol mDNS for iSCSI / NVMe-oF (\`_iscsi._tcp\` etc.). Niche; very few clients browse those; would just clutter Finder.
- AFP (\`_afpovertcp._tcp\`). Apple deprecated it years ago and modern Macs use SMB.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 142 passing (2 new):
  - \`smb_protocol_includes_wsdd_in_its_service_set\` pins membership of the systemd service set
  - \`smb_opens_serving_and_wsdd_discovery_ports\` pins 445/tcp + 139/tcp + 3702/udp in the firewall map
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [ ] **Manual on a real LAN**:
  1. \`avahi-browse -a -t\` from another machine should list NASty under both \`_smb._tcp\` and \`_device-info._tcp\`.
  2. macOS Finder → Network sidebar shows NASty with the rack-server icon (not generic computer).
  3. Windows 11 Explorer → Network shows NASty under Computers.
  4. Disabling SMB in the WebUI stops \`samba-wsdd.service\` and closes UDP 3702. (mDNS announcements stay; documented above.)