### PR TITLE
fs: fix /proc/keys parsing and locked-fs boot alert (#87)

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -3293,19 +3293,47 @@ pub(crate) async fn evaluate_active_alerts(
         )
         .await;
 
-    // Mount failures recorded at boot stay live until the engine is restarted.
+    // Mount failures recorded at boot stay live until the engine is
+    // restarted. Enrich the alert with current state: a locked
+    // encrypted FS gets a "unlock to mount" message instead of the
+    // generic "check disk connectivity" hint, since the user can
+    // recover from this through the WebUI without touching cables
+    // or logs (issue #87). Filesystems that have since been mounted
+    // by the user drop out entirely.
     let mount_failures = state.mount_failures.lock().await;
-    for name in mount_failures.iter() {
-        active.push(alerts::ActiveAlert {
-            rule_id: "mount-failure".into(),
-            rule_name: "Filesystem failed to mount".into(),
-            severity: alerts::AlertSeverity::Critical,
-            metric: alerts::AlertMetric::BcachefsDegraded,
-            message: format!("Filesystem \"{name}\" failed to mount after boot. Check disk connectivity and logs."),
-            current_value: 1.0,
-            threshold: 0.0,
-            source: name.clone(),
-        });
+    if !mount_failures.is_empty() {
+        let current_fses = state.filesystems.list().await.unwrap_or_default();
+        for name in mount_failures.iter() {
+            let fs = current_fses.iter().find(|f| &f.name == name);
+            // Already mounted (user fixed it via UI) — drop the alert.
+            if fs.is_some_and(|f| f.mounted) {
+                continue;
+            }
+            let (rule_name, severity, message) = match fs {
+                Some(f) if f.options.encrypted == Some(true) => (
+                    "Encrypted filesystem locked",
+                    alerts::AlertSeverity::Warning,
+                    format!("Filesystem \"{name}\" is encrypted and locked — unlock it to mount."),
+                ),
+                _ => (
+                    "Filesystem failed to mount",
+                    alerts::AlertSeverity::Critical,
+                    format!(
+                        "Filesystem \"{name}\" failed to mount after boot. Check disk connectivity and logs."
+                    ),
+                ),
+            };
+            active.push(alerts::ActiveAlert {
+                rule_id: "mount-failure".into(),
+                rule_name: rule_name.into(),
+                severity,
+                metric: alerts::AlertMetric::BcachefsDegraded,
+                message,
+                current_value: 1.0,
+                threshold: 0.0,
+                source: name.clone(),
+            });
+        }
     }
 
     active

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -17,18 +17,34 @@ const KEYS_DIR: &str = "/var/lib/nasty/keys";
 const PROC_KEYS_PATH: &str = "/proc/keys";
 
 /// Parse /proc/keys output and return true if the session keyring (or any
-/// keyring visible to this process) holds a `bcachefs:<uuid>` logon key.
+/// keyring visible to this process) holds a `bcachefs:<uuid>` key.
 /// `bcachefs unlock -k session` lands the FS encryption key here; the kernel
 /// reads it from there at mount time. So "key present" === "FS unlocked",
 /// regardless of whether it's currently mounted.
 fn proc_keys_has_bcachefs_uuid(contents: &str, uuid: &str) -> bool {
     let needle = format!("bcachefs:{uuid}");
-    contents.lines().any(|line| {
-        // Each /proc/keys line ends with `<type>  <description>`. We only care
-        // about logon-type entries whose description is exactly our needle —
-        // belt-and-braces against future bcachefs key naming changes by also
-        // accepting the description as a token anywhere on the line.
-        line.split_whitespace().any(|tok| tok == needle)
+    contents
+        .lines()
+        .any(|line| line_has_key_description(line, &needle))
+}
+
+/// Token-level membership check against a `/proc/keys` line.
+///
+/// The format on a real running kernel is:
+///   `<id-hex> <flags> <uses> <perm> <uid> <gid> <type> <description>: <data>`
+///
+/// e.g. `1de1938e I--Q--- 1 perm 3f010000 0 0 user bcachefs:<uuid>: 32`
+///
+/// — the description column ends with `:` followed by a type-specific
+/// data column. A naive `tok == needle` fails because the token in the
+/// real output is `bcachefs:<uuid>:`, not `bcachefs:<uuid>`. Strip the
+/// trailing colon before comparing. (This bug was masked in earlier
+/// tests that hand-wrote /proc/keys content without the trailing colon
+/// — those tests were wrong about the kernel format.)
+fn line_has_key_description(line: &str, needle: &str) -> bool {
+    line.split_whitespace().any(|tok| {
+        let stripped = tok.strip_suffix(':').unwrap_or(tok);
+        stripped == needle
     })
 }
 
@@ -41,7 +57,7 @@ async fn is_bcachefs_key_loaded(uuid: &str) -> bool {
 }
 
 /// Parse `/proc/keys` and return the decimal key id of the
-/// `bcachefs:<uuid>` logon key, or `None` if it isn't loaded. The id
+/// `bcachefs:<uuid>` key, or `None` if it isn't loaded. The id
 /// is what `keyctl unlink <id> @s` expects to revoke the key from
 /// the engine's session keyring.
 ///
@@ -49,13 +65,10 @@ async fn is_bcachefs_key_loaded(uuid: &str) -> bool {
 fn parse_bcachefs_key_id(contents: &str, uuid: &str) -> Option<String> {
     let needle = format!("bcachefs:{uuid}");
     contents.lines().find_map(|line| {
-        let mut toks = line.split_whitespace();
-        let id_hex = toks.next()?;
-        // Same token-equality check as `proc_keys_has_bcachefs_uuid` —
-        // belt-and-braces against partial-uuid matches.
-        if !line.split_whitespace().any(|tok| tok == needle) {
+        if !line_has_key_description(line, &needle) {
             return None;
         }
+        let id_hex = line.split_whitespace().next()?;
         // /proc/keys writes ids as 8-hex-digit zero-padded; keyctl
         // accepts decimal — stick with decimal so the command line
         // is unambiguous regardless of leading-zero handling.
@@ -2946,12 +2959,35 @@ mod tests {
 
     // ── proc_keys_has_bcachefs_uuid ────────────────────────────────
 
+    // Real /proc/keys lines have format:
+    //   `<id-hex> <flags> <uses> perm <perm-hex> <uid> <gid> <type>  <description>: <data>`
+    // i.e. the description column ends with `:` followed by a type-specific
+    // data column (for `user`/`logon` keys: data length in bytes). Earlier
+    // tests handcrafted lines without that trailing `:`, which masked a
+    // real bug in the parser — see `line_has_key_description`.
+
+    #[test]
+    fn proc_keys_finds_bcachefs_user_key() {
+        // Verbatim from a running NASty after `bcachefs unlock -k session`
+        // (issue: filesystem 'first' showed Locked despite successful unlock,
+        // because the parser's `tok == needle` check missed the trailing colon).
+        let contents = "\
+1de1938e I--Q---     1 perm 3f010000     0     0 user      bcachefs:a56458ab-a24c-45b6-9052-299ae1e3da43: 32
+";
+        assert!(proc_keys_has_bcachefs_uuid(
+            contents,
+            "a56458ab-a24c-45b6-9052-299ae1e3da43",
+        ));
+    }
+
     #[test]
     fn proc_keys_finds_bcachefs_logon_key() {
-        // Lines lifted from a real /proc/keys after `bcachefs unlock -k session`.
+        // bcachefs has shipped variants that use the `logon` keytype too —
+        // make sure the parser doesn't over-fit to one keytype. The trailing
+        // `:` and data column are still present.
         let contents = "\
 2c93e9b4 I--Q---     1 perm 3f010000     0     0 keyring   _ses: 1
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-1111-2222-3333-444455556666
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-1111-2222-3333-444455556666: 32
 ";
         assert!(proc_keys_has_bcachefs_uuid(
             contents,
@@ -2963,7 +2999,7 @@ mod tests {
     fn proc_keys_misses_when_uuid_absent() {
         let contents = "\
 2c93e9b4 I--Q---     1 perm 3f010000     0     0 keyring   _ses: 1
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:other-uuid-here
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:other-uuid-here: 32
 ";
         assert!(!proc_keys_has_bcachefs_uuid(
             contents,
@@ -2981,7 +3017,7 @@ mod tests {
         // A UUID that's a *prefix* of an entry must not match — bcachefs UUIDs
         // are full strings, not prefixes.
         let contents = "\
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra-suffix
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra-suffix: 32
 ";
         assert!(!proc_keys_has_bcachefs_uuid(contents, "abcd1234"));
     }
@@ -2989,12 +3025,23 @@ mod tests {
     // ── parse_bcachefs_key_id ─────────────────────────────────────
 
     #[test]
+    fn parse_key_id_returns_decimal_id_for_real_kernel_format() {
+        // Verbatim live-box format including the trailing `:` and `<data>`
+        // column. 1de1938e hex == 501322638 decimal — that's what
+        // `keyctl unlink` needs to revoke the key.
+        let contents = "\
+1de1938e I--Q---     1 perm 3f010000     0     0 user      bcachefs:a56458ab-a24c-45b6-9052-299ae1e3da43: 32
+";
+        let id = parse_bcachefs_key_id(contents, "a56458ab-a24c-45b6-9052-299ae1e3da43");
+        assert_eq!(id.as_deref(), Some("501322638"));
+    }
+
+    #[test]
     fn parse_key_id_returns_decimal_id_for_matching_uuid() {
-        // `keyctl unlink` takes a decimal id; /proc/keys writes hex.
-        // 3a821c8e hex == 981605518 decimal.
+        // Synthetic but format-faithful: 3a821c8e hex == 981605518 decimal.
         let contents = "\
 2c93e9b4 I--Q---     1 perm 3f010000     0     0 keyring   _ses: 1
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-1111-2222-3333-444455556666
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-1111-2222-3333-444455556666: 32
 ";
         let id = parse_bcachefs_key_id(contents, "abcd1234-1111-2222-3333-444455556666");
         assert_eq!(id.as_deref(), Some("981605518"));
@@ -3003,7 +3050,7 @@ mod tests {
     #[test]
     fn parse_key_id_returns_none_when_uuid_absent() {
         let contents = "\
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:other-uuid
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:other-uuid: 32
 ";
         assert!(parse_bcachefs_key_id(contents, "abcd1234-1111-2222-3333-444455556666").is_none());
     }
@@ -3019,7 +3066,7 @@ mod tests {
         // unlink someone else's key just because the uuids share a
         // common prefix.
         let contents = "\
-3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra
+3a821c8e I------     1 perm 3f010000     0     0 logon     bcachefs:abcd1234-extra: 32
 ";
         assert!(parse_bcachefs_key_id(contents, "abcd1234").is_none());
     }
@@ -3031,8 +3078,8 @@ mod tests {
         // interrupted. Take the first id; if unlink fails on it, the
         // operator can re-run.
         let contents = "\
-00000010 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid
-00000020 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid
+00000010 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid: 32
+00000020 I------     1 perm 3f010000     0     0 logon     bcachefs:dup-uuid: 32
 ";
         let id = parse_bcachefs_key_id(contents, "dup-uuid");
         assert_eq!(id.as_deref(), Some("16")); // 0x10


### PR DESCRIPTION
Two related bugs touching encrypted-FS UX, both confirmed live by SSHing into a NASty (\`10.10.10.61\`) and replaying the failure.

## Bug 1 — Unlock appeared to do nothing

The reproducer in your screenshot: click **Unlock** → green \"Filesystem first unlocked\" toast → FS still shows **Locked**, devices empty, Mount stays disabled.

The unlock *did* work — \`/proc/keys\` had the key the moment after clicking:

\`\`\`
1de1938e I--Q---  1 perm 3f010000  0 0 user  bcachefs:a56458ab-...-da43: 32
\`\`\`

But the engine reported \`locked: true\` regardless. Reason: the description column in real \`/proc/keys\` ends with \`:\` followed by a data column (byte length). Whitespace-tokenizing produces \`bcachefs:<uuid>:\`, but \`proc_keys_has_bcachefs_uuid\` compared against \`bcachefs:<uuid>\` (no trailing colon). Always missed.

The bug was hidden by tests that hand-wrote \`/proc/keys\` content **without** the trailing colon, pinning the wrong format. **My PR #112** (\`fs.lock\`) inherited the same parser pattern, which means **\`fs.lock\` silently no-ops the keyctl unlink in production** — it can't find the id to revoke and just exits successful. Locking is broken, currently shipped.

### Fix

Single \`line_has_key_description\` helper that strips the trailing colon before comparing tokens. Both \`proc_keys_has_bcachefs_uuid\` and \`parse_bcachefs_key_id\` route through it. Existing tests updated to use real kernel format (with the trailing \`:\` and data column), plus a new test pinned to the verbatim line from \`10.10.10.61\` so future regressions trip immediately.

## Bug 2 — Misleading boot alert for locked encrypted FS (#87)

When a user reboots with an encrypted FS that has no stored auto-unlock key, mount fails (correctly — engine has no way to unlock) and the alert says:

> *Filesystem \"foo\" failed to mount after boot. Check disk connectivity and logs.*

Sends the user chasing cables when the actual fix is one click in the WebUI. Worse: the alert stays live even after the user unlocks and mounts the FS — never cleared until engine restart.

### Fix

In \`mount_failure_alert\` (router.rs), look up current FS state at alert generation time:

- FS is now mounted (user fixed it): **drop** the alert entirely.
- FS is encrypted: **Warning-level** \"\\\"foo\\\" is encrypted and locked — unlock it to mount.\", rule name \"Encrypted filesystem locked\".
- Otherwise: keep the original Critical \"check disk connectivity\" message.

## Test plan

- [x] \`cargo test -p nasty-storage --lib\` — 21 passing (existing 5 \`parse_key_id_*\` updated to real kernel format, +1 verbatim live-box test).
- [x] \`cargo test -p nasty-system --lib\` — 140 passing.
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean.
- [ ] **Manual on \`10.10.10.61\`** (after merge + redeploy):
  1. Click Unlock with passphrase → \`Locked\` badge clears, devices show their data, **Mount becomes clickable**, \`bcachefs:<uuid>\` is in \`/proc/keys\` and the engine sees it.
  2. Click **Lock** on a mounted encrypted FS → unmount + \`keyctl unlink\` actually run (verify: \`bcachefs:<uuid>\` gone from \`/proc/keys\`). Pre-fix this command was a no-op; this PR makes it work.
  3. Reboot box with stored-key checkbox unchecked → boot alert shows \"Encrypted filesystem locked — unlock to mount\" (Warning, not Critical), and disappears after the user unlocks + mounts.