### PR TITLE
apps: enable Docker inline from the Apps page (#72)

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -734,9 +734,30 @@
 		<CardContent class="py-8 text-center">
 			<p class="mb-1 font-medium">Apps are disabled</p>
 			<p class="mb-4 text-sm text-muted-foreground">
-				Container apps run on a Docker daemon NASty manages as a service. Enable the Apps service to install and manage them.
+				Container apps run on a Docker daemon NASty manages as a service. Pick a filesystem for Docker's data, then enable the runtime — no need to leave this page.
 			</p>
-			<Button onclick={() => goto('/services')}>Manage in Services →</Button>
+			{#if filesystems.length === 0}
+				<p class="mb-4 text-sm text-amber-400">You need at least one mounted filesystem before enabling Apps.</p>
+				<Button variant="secondary" onclick={() => goto('/filesystems')}>Go to Filesystems →</Button>
+			{:else}
+				<div class="mb-4 inline-flex items-center gap-2 text-sm">
+					{#if filesystems.length > 1}
+						<label for="apps-fs" class="text-muted-foreground">Storage filesystem:</label>
+						<select id="apps-fs" bind:value={selectedFs} class="h-8 rounded-md border border-input bg-transparent px-2 text-sm">
+							{#each filesystems as fs}
+								<option value={fs.name}>{fs.name}</option>
+							{/each}
+						</select>
+					{:else}
+						<span class="text-muted-foreground">Storage filesystem: <code class="font-mono">{selectedFs}</code></span>
+					{/if}
+				</div>
+				<div>
+					<Button onclick={enableApps} disabled={enabling || !selectedFs}>
+						{enabling ? 'Enabling…' : 'Enable Apps'}
+					</Button>
+				</div>
+			{/if}
 		</CardContent>
 	</Card>
 {:else}


### PR DESCRIPTION
Closes #72.

## Before / after

**Before** — Apps page when Docker is disabled dead-ends here:

> *Apps are disabled*
> *Container apps run on a Docker daemon NASty manages as a service. Enable the Apps service to install and manage them.*
> *[ Manage in Services → ]*

Click the button, you're sent to Services with no breadcrumb back, no instruction about which row to flip, and no obvious tie-in to the filesystem picker. Issue #72 in one sentence.

**After** — same card now has the storage picker and an Enable button right there. No round trip to Services. After clicking Enable, the page seamlessly transitions to the existing \"Starting app runtime\" spinner card while Docker spins up, and lands on the normal Apps view when ready.

## What was already there

- \`apps.enable\` RPC accepts \`{ filesystem }\` payload.
- \`enableApps()\` handler already wired (was used elsewhere).
- \`onMount\` calls \`loadFilesystems()\` so the picker is pre-populated regardless of Docker state.
- The startup-spinner card and post-enable polling already handle the transition.

This PR is just the missing UI.

## Edge cases handled

- **Multiple mounted filesystems**: dropdown, default to first.
- **One mounted filesystem**: show its name as text, no dropdown.
- **Zero mounted filesystems**: amber warning + link to /filesystems. (Prerequisite, not a UI dead-end — Docker needs somewhere to put its data.)

## Test plan

- [x] \`npm --prefix webui run check\` — 4838 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 87 passing
- [ ] **Manual on a real box**:
  1. Disable Docker → land on /apps → see the new card with picker + Enable button.
  2. Click Enable → toast, spinner card, then Apps installs view, all without leaving /apps.
  3. With multiple FSes → dropdown lets the user pick a non-default. Verify Docker storage path matches choice.
  4. With zero mounted FSes → amber message + Filesystems link.