### PR TITLE
hardware: System → Hardware page with IOMMU group view (#100)

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -97,6 +97,7 @@ fn is_read_only(method: &str) -> bool {
             method,
             "system.info"
                 | "system.health"
+                | "system.hardware.iommu"
                 | "system.stats"
                 | "system.disks"
                 | "system.network.get"
@@ -456,6 +457,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         // ── System ──────────────────────────────────────────────
         "system.info" => ok(req, state.system.info().await),
         "system.health" => ok(req, state.system.health().await),
+        // PCI device tree grouped by IOMMU group, with the currently
+        // bound driver per device. Backs the /system/hardware page;
+        // empty response means IOMMU isn't enabled in BIOS.
+        "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.stats" => match fetch_metrics_json::<nasty_system::SystemStats>(
             &state.metrics_client,
             "/api/stats",

--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -1,0 +1,341 @@
+//! Read-only hardware discovery: PCI device tree grouped by IOMMU group.
+//!
+//! This is the data backbone for the Hardware page in the WebUI. It's
+//! intentionally narrow in scope — IOMMU groups, PCI devices, current
+//! driver bindings — because that's the information passthrough users
+//! actually need to plan VM device assignment, and it's all derivable
+//! from sysfs (deterministic, fast, no vendor quirks).
+//!
+//! Broader hardware overview (motherboard, BIOS, DIMMs, USB) is a
+//! separate concern handled via `inxi` in a follow-up; the parsing
+//! risk profile there is completely different.
+//!
+//! Sources:
+//! - `/sys/kernel/iommu_groups/<N>/devices/<BDF>` — group membership
+//! - `/sys/bus/pci/devices/<BDF>/{vendor,device,class}` — numeric IDs
+//! - `/sys/bus/pci/devices/<BDF>/driver` symlink — currently bound driver
+//! - `lspci -nnvmm` — human-readable vendor / device / class names
+//!   (joined in by BDF; sysfs has the IDs but not the names)
+
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::collections::HashMap;
+use tracing::warn;
+
+const IOMMU_GROUPS_DIR: &str = "/sys/kernel/iommu_groups";
+const PCI_DEVICES_DIR: &str = "/sys/bus/pci/devices";
+
+/// One IOMMU group with its constituent PCI devices. Groups are the
+/// unit of passthrough — assigning any device in a group to a VM
+/// effectively claims the whole group, so this view is what users
+/// need to make passthrough decisions.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct IommuGroup {
+    pub id: u32,
+    pub devices: Vec<PciDevice>,
+}
+
+/// One PCI device. Numeric IDs come from sysfs; human-readable names
+/// come from `lspci -nnvmm` (when available) and may be `None` if
+/// `lspci` isn't installed or the device is too new for the local
+/// `pci.ids` database.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PciDevice {
+    /// Bus:Device.Function in canonical sysfs form, e.g. `0000:01:00.0`.
+    pub bdf: String,
+    /// 4-hex-digit vendor ID, e.g. `10de` (NVIDIA).
+    pub vendor_id: String,
+    /// 4-hex-digit device ID, e.g. `2204` (RTX 3080).
+    pub device_id: String,
+    /// 4-hex-digit class code, e.g. `0300` (VGA controller).
+    pub class_id: String,
+    /// Human-readable vendor name (from pci.ids), if available.
+    pub vendor_name: Option<String>,
+    /// Human-readable device name (from pci.ids), if available.
+    pub device_name: Option<String>,
+    /// Human-readable class name (from pci.ids), if available.
+    pub class_name: Option<String>,
+    /// Currently bound kernel driver, e.g. `vfio-pci`, `nvidia`,
+    /// `e1000e`. `None` if no driver is bound (rare — usually means
+    /// the device is reserved for explicit binding).
+    pub driver: Option<String>,
+}
+
+/// Walk `/sys/kernel/iommu_groups/` and build the full grouping. The
+/// returned vec is sorted by group id (ascending) with devices inside
+/// each group sorted by BDF — stable order so the UI doesn't shuffle
+/// between refreshes.
+///
+/// Returns an empty vec if IOMMU isn't enabled at the kernel level
+/// (`iommu_groups` directory absent). Caller surfaces that as
+/// "IOMMU off" rather than as an error.
+pub async fn iommu_groups() -> Vec<IommuGroup> {
+    let raw = match read_iommu_membership().await {
+        Ok(m) => m,
+        Err(e) => {
+            warn!("iommu_groups: read failed ({e}); IOMMU likely off in BIOS");
+            return Vec::new();
+        }
+    };
+    if raw.is_empty() {
+        return Vec::new();
+    }
+
+    let lspci_names = lspci_name_map().await;
+
+    let mut groups: Vec<IommuGroup> = raw
+        .into_iter()
+        .map(|(id, bdfs)| {
+            let mut devices: Vec<PciDevice> = bdfs
+                .into_iter()
+                .filter_map(|bdf| read_pci_device(&bdf, &lspci_names))
+                .collect();
+            devices.sort_by(|a, b| a.bdf.cmp(&b.bdf));
+            IommuGroup { id, devices }
+        })
+        .collect();
+    groups.sort_by_key(|g| g.id);
+    groups
+}
+
+/// Map of `iommu_group_id → [bdf]` from sysfs. Pulled out so the
+/// gathering step is testable against a fake fs in the future if
+/// needed; for now we exercise the scalar parsers below.
+async fn read_iommu_membership() -> std::io::Result<HashMap<u32, Vec<String>>> {
+    let mut entries = tokio::fs::read_dir(IOMMU_GROUPS_DIR).await?;
+    let mut out: HashMap<u32, Vec<String>> = HashMap::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let Some(group_id) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let devices_dir = entry.path().join("devices");
+        let Ok(mut devs) = tokio::fs::read_dir(&devices_dir).await else {
+            continue;
+        };
+        while let Some(d) = devs.next_entry().await? {
+            if let Some(bdf) = d.file_name().to_str() {
+                out.entry(group_id).or_default().push(bdf.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read a single PCI device's sysfs entry. Returns `None` if the
+/// device disappears between the iommu_groups walk and our read
+/// (unlikely; race with hot-unplug).
+fn read_pci_device(bdf: &str, lspci_names: &HashMap<String, LspciNames>) -> Option<PciDevice> {
+    let dev_dir = format!("{PCI_DEVICES_DIR}/{bdf}");
+    let vendor_id = read_pci_id_field(&dev_dir, "vendor")?;
+    let device_id = read_pci_id_field(&dev_dir, "device")?;
+    let class_id = read_pci_id_field(&dev_dir, "class")?;
+    let driver = read_driver(&dev_dir);
+    let names = lspci_names.get(bdf).cloned().unwrap_or_default();
+    Some(PciDevice {
+        bdf: bdf.to_string(),
+        vendor_id,
+        device_id,
+        class_id,
+        vendor_name: names.vendor,
+        device_name: names.device,
+        class_name: names.class,
+        driver,
+    })
+}
+
+/// `/sys/bus/pci/devices/<BDF>/{vendor,device}` are 6-char strings of
+/// the form `0xVVVV` for vendor/device, or `0xCCSSPP` for class
+/// (class+subclass+programming-interface). Strip the `0x` and any
+/// trailing newline. Returns the raw hex string for downstream
+/// rendering — we don't care about numeric value.
+fn read_pci_id_field(dev_dir: &str, field: &str) -> Option<String> {
+    let raw = std::fs::read_to_string(format!("{dev_dir}/{field}")).ok()?;
+    let trimmed = raw.trim();
+    Some(trimmed.strip_prefix("0x").unwrap_or(trimmed).to_string())
+}
+
+/// Resolve the basename of the `driver` symlink. Sysfs uses a
+/// symlink at `/sys/bus/pci/devices/<BDF>/driver` pointing into
+/// `/sys/bus/pci/drivers/<name>`; absent if no driver is bound.
+fn read_driver(dev_dir: &str) -> Option<String> {
+    let link = std::fs::read_link(format!("{dev_dir}/driver")).ok()?;
+    Some(link.file_name()?.to_string_lossy().into_owned())
+}
+
+/// Cached lookup table built by parsing one `lspci -nnvmm` invocation.
+#[derive(Debug, Clone, Default)]
+struct LspciNames {
+    vendor: Option<String>,
+    device: Option<String>,
+    class: Option<String>,
+}
+
+/// Run `lspci -nnvmm` once and parse it into a BDF→names map. This is
+/// the only slow operation in the walker (~10ms on a typical box);
+/// caller invokes it once per `iommu_groups()` call and joins by BDF.
+async fn lspci_name_map() -> HashMap<String, LspciNames> {
+    let output = match tokio::process::Command::new("lspci")
+        .args(["-nnvmm", "-D"])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => o.stdout,
+        Ok(o) => {
+            warn!(
+                "lspci -nnvmm exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr)
+            );
+            return HashMap::new();
+        }
+        Err(e) => {
+            warn!("lspci -nnvmm spawn failed: {e} — vendor/device names unavailable");
+            return HashMap::new();
+        }
+    };
+    parse_lspci_machine_readable(&String::from_utf8_lossy(&output))
+}
+
+/// Parse `lspci -nnvmm -D` output. Format: blocks separated by blank
+/// lines, each block is `Key:\tValue` lines. Relevant keys for us:
+///
+/// ```text
+/// Slot:    0000:01:00.0
+/// Class:   VGA compatible controller [0300]
+/// Vendor:  NVIDIA Corporation [10de]
+/// Device:  GA102 [GeForce RTX 3080] [2204]
+/// ```
+///
+/// Trailing `[<id>]` brackets are vendor/device IDs we already have
+/// from sysfs — strip them out so the user sees just the name.
+fn parse_lspci_machine_readable(output: &str) -> HashMap<String, LspciNames> {
+    let mut out = HashMap::new();
+    for block in output.split("\n\n") {
+        let mut slot: Option<String> = None;
+        let mut names = LspciNames::default();
+        for line in block.lines() {
+            let Some((key, value)) = line.split_once(':') else {
+                continue;
+            };
+            let value = value.trim();
+            match key.trim() {
+                "Slot" => slot = Some(value.to_string()),
+                "Class" => names.class = Some(strip_id_suffix(value).to_string()),
+                "Vendor" => names.vendor = Some(strip_id_suffix(value).to_string()),
+                "Device" => names.device = Some(strip_id_suffix(value).to_string()),
+                _ => {}
+            }
+        }
+        if let Some(s) = slot {
+            out.insert(s, names);
+        }
+    }
+    out
+}
+
+/// `"NVIDIA Corporation [10de]"` → `"NVIDIA Corporation"`. The id in
+/// brackets is what `-nn` adds; we strip it because the JSON already
+/// surfaces the id separately.
+fn strip_id_suffix(s: &str) -> &str {
+    if let Some(idx) = s.rfind(" [")
+        && s.ends_with(']')
+    {
+        return s[..idx].trim();
+    }
+    s.trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_id_suffix_removes_trailing_bracketed_id() {
+        assert_eq!(
+            strip_id_suffix("NVIDIA Corporation [10de]"),
+            "NVIDIA Corporation"
+        );
+        assert_eq!(
+            strip_id_suffix("VGA compatible controller [0300]"),
+            "VGA compatible controller"
+        );
+    }
+
+    #[test]
+    fn strip_id_suffix_leaves_text_with_internal_brackets_alone() {
+        // Some device names embed brackets (e.g. "AMD/ATI [Vega 10]")
+        // — we only strip the trailing suffix, not internal brackets.
+        assert_eq!(
+            strip_id_suffix("AMD/ATI [Vega 10] [10de]"),
+            "AMD/ATI [Vega 10]"
+        );
+    }
+
+    #[test]
+    fn strip_id_suffix_passes_through_when_no_bracket() {
+        assert_eq!(strip_id_suffix("Some Device"), "Some Device");
+        assert_eq!(strip_id_suffix(""), "");
+    }
+
+    #[test]
+    fn parse_lspci_extracts_slot_class_vendor_device_per_block() {
+        // Real `lspci -nnvmm -D` output: blocks separated by blank
+        // lines. Includes lines we don't care about (Rev, ProgIf,
+        // SVendor, SDevice, PhySlot, NUMANode) — they should be
+        // ignored without breaking parsing.
+        let output = "\
+Slot:\t0000:00:00.0
+Class:\tHost bridge [0600]
+Vendor:\tIntel Corporation [8086]
+Device:\t12th Gen Core Host Bridge [4660]
+Rev:\t02
+
+Slot:\t0000:01:00.0
+Class:\tVGA compatible controller [0300]
+Vendor:\tNVIDIA Corporation [10de]
+Device:\tGA102 [GeForce RTX 3080] [2204]
+SVendor:\tASUSTeK Computer Inc. [1043]
+SDevice:\tROG STRIX RTX 3080 [8678]
+Rev:\ta1
+";
+        let map = parse_lspci_machine_readable(output);
+        assert_eq!(map.len(), 2);
+
+        let host = map.get("0000:00:00.0").unwrap();
+        assert_eq!(host.vendor.as_deref(), Some("Intel Corporation"));
+        assert_eq!(host.device.as_deref(), Some("12th Gen Core Host Bridge"));
+        assert_eq!(host.class.as_deref(), Some("Host bridge"));
+
+        let gpu = map.get("0000:01:00.0").unwrap();
+        assert_eq!(gpu.vendor.as_deref(), Some("NVIDIA Corporation"));
+        assert_eq!(gpu.device.as_deref(), Some("GA102 [GeForce RTX 3080]"));
+        assert_eq!(gpu.class.as_deref(), Some("VGA compatible controller"));
+    }
+
+    #[test]
+    fn parse_lspci_handles_empty_input() {
+        assert!(parse_lspci_machine_readable("").is_empty());
+    }
+
+    #[test]
+    fn parse_lspci_skips_blocks_without_a_slot() {
+        // Defensive: malformed block (no Slot:) shouldn't poison the
+        // map by inserting under a previous block's key.
+        let output = "\
+Class:\tOrphan Class [0000]
+Vendor:\tNobody [0000]
+
+Slot:\t0000:02:00.0
+Class:\tAudio device [0403]
+Vendor:\tIntel Corporation [8086]
+Device:\tCometLake-S cAVS [a3f0]
+";
+        let map = parse_lspci_machine_readable(output);
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("0000:02:00.0"));
+    }
+}

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod alerts;
 pub mod firewall;
 pub mod firmware;
+pub mod hardware;
 pub mod network;
 pub mod notifications;
 pub mod nut;

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -18,6 +18,29 @@ export interface SystemHealth {
 	services: ServiceStatus[];
 }
 
+/** One IOMMU group with its constituent PCI devices, returned by
+ * `system.hardware.iommu`. The id is the kernel's group number;
+ * devices are sorted by BDF. Empty list = IOMMU is off in BIOS. */
+export interface IommuGroup {
+	id: number;
+	devices: PciDevice[];
+}
+
+/** One PCI device. Numeric IDs are 4-hex-digit strings. Names come
+ * from `pci.ids` via `lspci` and may be null on bleeding-edge or
+ * exotic hardware. `driver` is the currently bound kernel module
+ * (`vfio-pci` = ready for passthrough). */
+export interface PciDevice {
+	bdf: string;
+	vendor_id: string;
+	device_id: string;
+	class_id: string;
+	vendor_name: string | null;
+	device_name: string | null;
+	class_name: string | null;
+	driver: string | null;
+}
+
 export interface ServiceStatus {
 	name: string;
 	running: boolean;

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -54,6 +54,7 @@
 		Zap,
 		Globe,
 		Cpu,
+		CircuitBoard,
 		Server,
 		Wrench,
 		ScrollText,
@@ -446,6 +447,7 @@
 			{ href: '/terminal', label: 'Terminal', icon: Terminal },
 			{ label: 'System', icon: Wrench, children: [
 				{ href: '/services', label: 'Services',       icon: Server },
+				{ href: '/hardware', label: 'Hardware',       icon: CircuitBoard },
 				{ href: '/logs',     label: 'Logs',           icon: ScrollText },
 				{ href: '/update',   label: 'Update',         icon: RefreshCw },
 				{ href: '/users',    label: 'Access Control', icon: ShieldCheck },
@@ -513,6 +515,7 @@
 		{ href: '/apps', label: 'Apps', keywords: ['app', 'docker', 'container', 'compose', 'install', 'image', 'port'] },
 		{ href: '/terminal', label: 'Terminal', keywords: ['terminal', 'shell', 'ssh', 'console', 'command', 'bash'] },
 		{ href: '/services', label: 'Services', keywords: ['service', 'protocol', 'nfs', 'smb', 'iscsi', 'smart', 'avahi', 'mdns', 'enable', 'disable', 'rest server', 'docker', 'container', 'runtime', 'ups', 'nut', 'battery', 'power', 'shutdown', 'uninterruptible'] },
+		{ href: '/hardware', label: 'Hardware', keywords: ['hardware', 'pci', 'iommu', 'group', 'passthrough', 'vfio', 'gpu', 'device', 'driver', 'lspci'] },
 		{ href: '/logs', label: 'Logs', keywords: ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream'] },
 		{ href: '/update', label: 'Update', keywords: ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation'] },
 		{ href: '/users', label: 'Access Control', keywords: ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login'] },

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getClient } from '$lib/client';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import type { IommuGroup, PciDevice } from '$lib/types';
+	import { ChevronDown, ChevronRight, RefreshCw } from '@lucide/svelte';
+
+	let groups: IommuGroup[] = $state([]);
+	let loading = $state(true);
+	let refreshing = $state(false);
+	let expanded = $state(new Set<number>());
+	let filter = $state('');
+
+	const client = getClient();
+
+	async function load() {
+		try {
+			groups = await client.call<IommuGroup[]>('system.hardware.iommu');
+		} catch {
+			groups = [];
+		}
+		loading = false;
+	}
+
+	async function refresh() {
+		refreshing = true;
+		await load();
+		refreshing = false;
+	}
+
+	function toggle(id: number) {
+		if (expanded.has(id)) expanded.delete(id);
+		else expanded.add(id);
+		expanded = new Set(expanded);
+	}
+
+	function expandAll() {
+		expanded = new Set(filteredGroups.map((g) => g.id));
+	}
+
+	function collapseAll() {
+		expanded = new Set();
+	}
+
+	/** Single-line description for a device. Falls back through human
+	 * names → numeric IDs so the user always sees something useful even
+	 * on bleeding-edge hardware where pci.ids has no entry. */
+	function describe(d: PciDevice): string {
+		const vendor = d.vendor_name ?? d.vendor_id;
+		const device = d.device_name ?? d.device_id;
+		return `${vendor} ${device}`;
+	}
+
+	/** Group is "active for passthrough" if any device in it is bound to
+	 * vfio-pci. We highlight these so users can see at a glance which
+	 * groups are currently claimed for VMs. */
+	function isPassthroughGroup(g: IommuGroup): boolean {
+		return g.devices.some((d) => d.driver === 'vfio-pci');
+	}
+
+	function driverBadgeVariant(driver: string | null): 'default' | 'secondary' | 'outline' {
+		if (!driver) return 'outline';
+		if (driver === 'vfio-pci') return 'default';
+		return 'secondary';
+	}
+
+	let filteredGroups = $derived.by(() => {
+		const q = filter.trim().toLowerCase();
+		if (!q) return groups;
+		return groups.filter((g) =>
+			g.devices.some((d) => {
+				const haystack = [
+					d.bdf,
+					d.vendor_id,
+					d.device_id,
+					d.vendor_name,
+					d.device_name,
+					d.class_name,
+					d.driver,
+				]
+					.filter(Boolean)
+					.join(' ')
+					.toLowerCase();
+				return haystack.includes(q);
+			}),
+		);
+	});
+
+	onMount(load);
+</script>
+
+<div class="mb-4 flex items-center justify-between">
+	<div>
+		<h1 class="text-2xl font-semibold">Hardware</h1>
+		<p class="text-sm text-muted-foreground">
+			PCI devices grouped by IOMMU group. Useful for planning VM passthrough — devices in the same
+			group must be assigned together.
+		</p>
+	</div>
+	<Button size="sm" variant="secondary" onclick={refresh} disabled={refreshing}>
+		<RefreshCw class={refreshing ? 'animate-spin' : ''} size={14} />
+		Refresh
+	</Button>
+</div>
+
+{#if loading}
+	<Card>
+		<CardContent class="py-12 text-center text-sm text-muted-foreground">Loading…</CardContent>
+	</Card>
+{:else if groups.length === 0}
+	<Card>
+		<CardContent class="py-8 text-center">
+			<p class="mb-1 font-medium">No IOMMU groups found</p>
+			<p class="text-sm text-muted-foreground">
+				IOMMU is likely off in BIOS. Enable VT-d (Intel) or AMD-Vi (AMD) and reboot. NASty's kernel
+				params already pass <code class="font-mono">intel_iommu=on amd_iommu=on iommu=pt</code>.
+			</p>
+		</CardContent>
+	</Card>
+{:else}
+	<div class="mb-3 flex items-center gap-3">
+		<input
+			bind:value={filter}
+			placeholder="Filter by BDF, vendor, device, or driver…"
+			class="h-9 flex-1 max-w-md rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+		/>
+		<Button size="xs" variant="ghost" onclick={expandAll}>Expand all</Button>
+		<Button size="xs" variant="ghost" onclick={collapseAll}>Collapse all</Button>
+		<span class="ml-auto text-xs text-muted-foreground">
+			{filteredGroups.length} of {groups.length} groups
+		</span>
+	</div>
+
+	<div class="space-y-2">
+		{#each filteredGroups as group (group.id)}
+			{@const passthrough = isPassthroughGroup(group)}
+			<Card>
+				<CardContent class="p-0">
+					<button
+						onclick={() => toggle(group.id)}
+						class="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-accent/50"
+					>
+						{#if expanded.has(group.id)}
+							<ChevronDown size={16} class="text-muted-foreground" />
+						{:else}
+							<ChevronRight size={16} class="text-muted-foreground" />
+						{/if}
+						<span class="font-mono text-sm">Group {group.id}</span>
+						<span class="text-xs text-muted-foreground"
+							>{group.devices.length} device{group.devices.length === 1 ? '' : 's'}</span
+						>
+						{#if passthrough}
+							<Badge variant="default" class="ml-1 text-[0.6rem]">Passthrough</Badge>
+						{/if}
+						<span class="ml-auto truncate text-xs text-muted-foreground">
+							{group.devices
+								.map((d) => d.device_name ?? d.device_id)
+								.slice(0, 2)
+								.join(' · ')}{group.devices.length > 2 ? ' · …' : ''}
+						</span>
+					</button>
+
+					{#if expanded.has(group.id)}
+						<div class="border-t border-border bg-muted/20 px-4 py-3">
+							<table class="w-full text-sm">
+								<thead>
+									<tr class="text-left text-[0.7rem] uppercase tracking-wide text-muted-foreground">
+										<th class="pb-2 font-medium">BDF</th>
+										<th class="pb-2 font-medium">Class</th>
+										<th class="pb-2 font-medium">Device</th>
+										<th class="pb-2 font-medium">IDs</th>
+										<th class="pb-2 font-medium">Driver</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each group.devices as device (device.bdf)}
+										<tr class="border-t border-border/40">
+											<td class="py-2 pr-3 font-mono text-xs">{device.bdf}</td>
+											<td class="py-2 pr-3 text-xs text-muted-foreground"
+												>{device.class_name ?? device.class_id}</td
+											>
+											<td class="py-2 pr-3">{describe(device)}</td>
+											<td class="py-2 pr-3 font-mono text-xs text-muted-foreground"
+												>{device.vendor_id}:{device.device_id}</td
+											>
+											<td class="py-2">
+												<Badge variant={driverBadgeVariant(device.driver)} class="text-[0.65rem]">
+													{device.driver ?? 'unbound'}
+												</Badge>
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					{/if}
+				</CardContent>
+			</Card>
+		{/each}
+	</div>
+{/if}


### PR DESCRIPTION
First of three planned PRs from #100/#101 (see [discussion](https://github.com/nasty-project/nasty/issues/100#issuecomment-...)). Read-only, deliberately scoped to IOMMU + PCI tree.

## What it shows

A new **System → Hardware** page lists every PCI device on the box, grouped by IOMMU group. Per device:

- BDF (`0000:01:00.0`)
- Class (\"VGA compatible controller\")
- Vendor + device name (\"NVIDIA Corporation GA102 [GeForce RTX 3080]\")
- Numeric IDs (\`10de:2204\`) for users who need them verbatim
- Currently bound driver, with **\`vfio-pci\` highlighted** as the passthrough indicator. Groups containing any \`vfio-pci\`-bound device get a \"Passthrough\" badge for at-a-glance scanning.

Filter box, expand/collapse all, refresh button. When IOMMU is off in BIOS the page shows a helpful explanation pointing at the relevant kernel params (which NASty already passes — \`intel_iommu=on amd_iommu=on iommu=pt\`).

## How it gets the data

\`engine/nasty-system/src/hardware.rs\` walks:

- \`/sys/kernel/iommu_groups/<N>/devices/<BDF>\` for membership
- \`/sys/bus/pci/devices/<BDF>/{vendor,device,class}\` for numeric IDs
- \`/sys/bus/pci/devices/<BDF>/driver\` symlink for the bound driver
- one \`lspci -nnvmm -D\` invocation, parsed into a BDF→names map for human-readable strings (joined by BDF)

Total cost is ~10-30ms on a typical desktop. No caching yet — easy to add if it ever shows up in profiles.

## Why hand-rolled (and not \`ls-iommu\`)

The IOMMU walker is ~50 lines of straightforward sysfs reading. Wrapping \`ls-iommu\` would be the same amount of code (shell-out, parse text, handle errors), plus a new dep that's not in nixpkgs and ships with no JSON output. The cost/benefit only flips when external tooling replaces hundreds of lines (which is why **PR B will lean on \`inxi\`** for motherboard/BIOS/DIMM data — the parsing risk profile there is completely different).

## What this PR is not

- **Not yet** a \"Mark for passthrough\" toggle — that's PR C, which will use the data model this PR establishes (vendor:device IDs and IOMMU group membership) and write \`/etc/nixos/passthrough.nix\` for the kernel-param injection. PR C also needs a safety classifier (refuse if device's IOMMU group contains the boot disk's controller, or the management network adapter) which doesn't exist yet.
- **Not yet** motherboard / CPU / memory / USB cards — PR B via \`inxi\`.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 148 passing (6 new \`hardware::tests\`):
  - lspci -nnvmm parser extracts Slot/Class/Vendor/Device per block
  - trailing \`[id]\` suffix stripping (so the UI shows \"NVIDIA Corporation\" not \"NVIDIA Corporation [10de]\")
  - text with internal brackets preserved (e.g. \"AMD/ATI [Vega 10]\")
  - empty input → empty map
  - blocks without a Slot field skipped (defensive)
- [x] \`cargo test --workspace --lib\` — full pass
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4840 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 87 passing
- [ ] **Manual on a real box**: navigate to /hardware, verify groups + devices match \`for d in /sys/kernel/iommu_groups/*/devices/*; do echo \"Group $(basename $(dirname $(dirname $d))): $(basename $d)\"; done\`. With a passthrough VM running, the group containing the assigned device shows \"Passthrough\" badge and \`vfio-pci\` driver. With IOMMU off in BIOS, the empty-state card appears.