### PR TITLE
hardware: add motherboard / CPU / memory / USB summary cards (#100)

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -98,6 +98,7 @@ fn is_read_only(method: &str) -> bool {
             "system.info"
                 | "system.health"
                 | "system.hardware.iommu"
+                | "system.hardware.summary"
                 | "system.stats"
                 | "system.disks"
                 | "system.network.get"
@@ -461,6 +462,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         // bound driver per device. Backs the /system/hardware page;
         // empty response means IOMMU isn't enabled in BIOS.
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
+        // Hardware overview: motherboard, BIOS, CPU, DIMMs, USB.
+        // Server-side cached for 60s (dmidecode is slow); the data
+        // doesn't change between reboots so this is fine.
+        "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
         "system.stats" => match fetch_metrics_json::<nasty_system::SystemStats>(
             &state.metrics_client,
             "/api/stats",

--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -1,25 +1,32 @@
-//! Read-only hardware discovery: PCI device tree grouped by IOMMU group.
+//! Read-only hardware discovery for the Hardware page.
 //!
-//! This is the data backbone for the Hardware page in the WebUI. It's
-//! intentionally narrow in scope — IOMMU groups, PCI devices, current
-//! driver bindings — because that's the information passthrough users
-//! actually need to plan VM device assignment, and it's all derivable
-//! from sysfs (deterministic, fast, no vendor quirks).
+//! Two surfaces, both driven from this module:
 //!
-//! Broader hardware overview (motherboard, BIOS, DIMMs, USB) is a
-//! separate concern handled via `inxi` in a follow-up; the parsing
-//! risk profile there is completely different.
+//! 1. **IOMMU + PCI tree** (`iommu_groups()`) — sysfs walker, deterministic,
+//!    cheap, the data passthrough users need. No caching needed.
+//! 2. **Hardware summary** (`system_summary()`) — motherboard, BIOS, CPU,
+//!    DIMMs, USB. Backed by `dmidecode`, `/proc/cpuinfo`, `lsusb`.
+//!    Cached 60s in-memory because dmidecode takes ~50–200ms and the
+//!    underlying state doesn't change between runs.
 //!
 //! Sources:
 //! - `/sys/kernel/iommu_groups/<N>/devices/<BDF>` — group membership
 //! - `/sys/bus/pci/devices/<BDF>/{vendor,device,class}` — numeric IDs
 //! - `/sys/bus/pci/devices/<BDF>/driver` symlink — currently bound driver
 //! - `lspci -nnvmm` — human-readable vendor / device / class names
-//!   (joined in by BDF; sysfs has the IDs but not the names)
+//! - `dmidecode -t baseboard,bios,memory` — DMI tables. We parse three
+//!   specific subsection types (Base Board, BIOS, Memory Device) which
+//!   have stable, well-documented field names — much narrower than
+//!   parsing all of dmidecode.
+//! - `/proc/cpuinfo` — CPU model + cores
+//! - `lsusb -t` and `lsusb` — USB device tree
 
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 use tracing::warn;
 
 const IOMMU_GROUPS_DIR: &str = "/sys/kernel/iommu_groups";
@@ -249,6 +256,395 @@ fn strip_id_suffix(s: &str) -> &str {
     s.trim()
 }
 
+// ── Hardware summary ───────────────────────────────────────────
+//
+// Motherboard / BIOS / CPU / DIMMs / USB. Cached for 60s because
+// dmidecode is slow and the underlying data is effectively static
+// between reboots — no point re-running it on every page render.
+
+const SUMMARY_CACHE_TTL: Duration = Duration::from_secs(60);
+
+static SUMMARY_CACHE: OnceLock<Mutex<Option<(Instant, HardwareSummary)>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct HardwareSummary {
+    pub system: Option<DmiSystem>,
+    pub bios: Option<DmiBios>,
+    pub cpu: Option<CpuSummary>,
+    pub memory: MemorySummary,
+    pub usb: Vec<UsbDevice>,
+}
+
+/// DMI Type 1 + Type 2 — the "what hardware is this box" basics.
+/// Serial numbers are deliberately not included; they're sensitive
+/// and rarely useful in a UI.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DmiSystem {
+    pub manufacturer: Option<String>,
+    pub product: Option<String>,
+    pub version: Option<String>,
+}
+
+/// DMI Type 0 — the BIOS info row. `release_date` is the original
+/// firmware date in `MM/DD/YYYY` (DMI convention).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DmiBios {
+    pub vendor: Option<String>,
+    pub version: Option<String>,
+    pub release_date: Option<String>,
+}
+
+/// CPU info pulled from /proc/cpuinfo. Logical cores = `processor`
+/// entries; physical cores = unique `(physical id, core id)` pairs.
+/// We only store a handful of fields; for live frequency/temperature
+/// the dashboard already uses the `system.stats` endpoint.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CpuSummary {
+    pub model: Option<String>,
+    pub vendor: Option<String>,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+    /// Max advertised speed in MHz from `cpu MHz` (often 0 on idle
+    /// systems; better signal than `lscpu --max`).
+    pub max_mhz: Option<u32>,
+}
+
+/// Memory subsystem summary. Slot counts and per-DIMM detail come
+/// from DMI Type 16 (Memory Array) and Type 17 (Memory Device).
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct MemorySummary {
+    /// Sum of all populated DIMM sizes in bytes.
+    pub total_bytes: u64,
+    /// Total DIMM slots on the system (populated + empty).
+    pub slots_total: u32,
+    /// Slots with a DIMM in them.
+    pub slots_used: u32,
+    /// Whether the memory array supports ECC (single bit, multi-bit, or chipkill).
+    pub ecc: bool,
+    pub dimms: Vec<DimmInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DimmInfo {
+    /// Slot identifier from DMI Type 17 `Locator`, e.g. `DIMM_A1`.
+    pub locator: String,
+    /// Bytes; 0 means slot is empty.
+    pub size_bytes: u64,
+    /// `DDR4`, `DDR5`, `LPDDR4`, etc. Empty/None when slot is empty.
+    pub mem_type: Option<String>,
+    /// MT/s rated speed.
+    pub speed_mts: Option<u32>,
+    pub manufacturer: Option<String>,
+    pub part_number: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct UsbDevice {
+    /// Bus number from `lsusb` (decimal).
+    pub bus: u32,
+    /// Device address on the bus.
+    pub device: u32,
+    /// 4-hex-digit vendor ID.
+    pub vendor_id: String,
+    /// 4-hex-digit product ID.
+    pub product_id: String,
+    /// Single-line "Vendor Name Product Name" rendered by lsusb. The
+    /// embedded `pci.ids`/`usb.ids` lookup is lsusb's job, not ours.
+    pub description: String,
+}
+
+/// Public entry point — returns the cached summary, refreshing if
+/// older than `SUMMARY_CACHE_TTL`. The first call after engine start
+/// pays the dmidecode cost (~50–200ms); subsequent ones are
+/// effectively free.
+pub async fn system_summary() -> HardwareSummary {
+    let cell = SUMMARY_CACHE.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().await;
+    if let Some((at, ref cached)) = *guard
+        && at.elapsed() < SUMMARY_CACHE_TTL
+    {
+        return cached.clone();
+    }
+    let fresh = build_summary().await;
+    *guard = Some((Instant::now(), fresh.clone()));
+    fresh
+}
+
+async fn build_summary() -> HardwareSummary {
+    let dmidecode_baseboard = run_text(
+        "dmidecode",
+        &[
+            "-q", "-t", "1", "-t", "2", "-t", "0", "-t", "16", "-t", "17",
+        ],
+    )
+    .await
+    .unwrap_or_default();
+
+    let (system, bios, memory) = parse_dmidecode(&dmidecode_baseboard);
+    let cpu = read_cpu_info().await;
+    let usb = read_usb_devices().await;
+    HardwareSummary {
+        system,
+        bios,
+        cpu,
+        memory,
+        usb,
+    }
+}
+
+async fn run_text(cmd: &str, args: &[&str]) -> Option<String> {
+    match tokio::process::Command::new(cmd).args(args).output().await {
+        Ok(o) if o.status.success() => Some(String::from_utf8_lossy(&o.stdout).into_owned()),
+        Ok(o) => {
+            warn!(
+                "{cmd} {args:?} exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+            None
+        }
+        Err(e) => {
+            warn!("{cmd} spawn failed: {e}");
+            None
+        }
+    }
+}
+
+/// Parse `dmidecode -q -t 0 -t 1 -t 2 -t 16 -t 17` output. Format:
+/// blank-line-separated blocks; each block starts with a non-indented
+/// section title line (e.g. `BIOS Information`) and continues with
+/// indented `Key: Value` pairs. Type 16 (Memory Array) and Type 17
+/// (Memory Device) blocks are aggregated into the MemorySummary.
+fn parse_dmidecode(input: &str) -> (Option<DmiSystem>, Option<DmiBios>, MemorySummary) {
+    let mut system: Option<DmiSystem> = None;
+    let mut bios: Option<DmiBios> = None;
+    let mut memory = MemorySummary::default();
+
+    for block in input.split("\n\n") {
+        let mut lines = block.lines();
+        // First non-empty line is the section title (e.g.
+        // "Base Board Information"). The "Handle 0xNNNN, DMI type..."
+        // line is filtered out by `-q`.
+        let Some(title) = lines.find(|l| !l.trim().is_empty()) else {
+            continue;
+        };
+        let kv = collect_kv(lines);
+        match title.trim() {
+            "System Information" if system.is_none() => {
+                // Prefer Base Board if available, but fall back to System
+                // when /sys/devices/virtual/dmi has no baseboard table
+                // (e.g. some VMs).
+                system = Some(DmiSystem {
+                    manufacturer: kv.get("Manufacturer").cloned(),
+                    product: kv.get("Product Name").cloned(),
+                    version: kv.get("Version").cloned(),
+                });
+            }
+            "Base Board Information" => {
+                system = Some(DmiSystem {
+                    manufacturer: kv.get("Manufacturer").cloned(),
+                    product: kv.get("Product Name").cloned(),
+                    version: kv.get("Version").cloned(),
+                });
+            }
+            "BIOS Information" => {
+                bios = Some(DmiBios {
+                    vendor: kv.get("Vendor").cloned(),
+                    version: kv.get("Version").cloned(),
+                    release_date: kv.get("Release Date").cloned(),
+                });
+            }
+            "Physical Memory Array" => {
+                // Slot count & ECC support live here; per-DIMM detail
+                // is in the Type 17 blocks below.
+                if let Some(devices) = kv.get("Number Of Devices")
+                    && let Ok(n) = devices.parse::<u32>()
+                {
+                    memory.slots_total += n;
+                }
+                if let Some(ec) = kv.get("Error Correction Type")
+                    && !ec.eq_ignore_ascii_case("None")
+                    && !ec.eq_ignore_ascii_case("Unknown")
+                {
+                    memory.ecc = true;
+                }
+            }
+            "Memory Device" => {
+                let locator = kv
+                    .get("Locator")
+                    .cloned()
+                    .unwrap_or_else(|| "(unknown)".to_string());
+                let size_bytes = kv.get("Size").map(|s| parse_dmi_size(s)).unwrap_or(0);
+                let populated = size_bytes > 0;
+                if populated {
+                    memory.slots_used += 1;
+                    memory.total_bytes += size_bytes;
+                }
+                memory.dimms.push(DimmInfo {
+                    locator,
+                    size_bytes,
+                    mem_type: kv.get("Type").filter(|s| *s != "Unknown").cloned(),
+                    speed_mts: kv.get("Speed").and_then(|s| parse_dmi_speed(s)),
+                    manufacturer: kv
+                        .get("Manufacturer")
+                        .filter(|s| !s.starts_with("Not Specified") && !s.starts_with("Unknown"))
+                        .cloned(),
+                    part_number: kv
+                        .get("Part Number")
+                        .filter(|s| !s.starts_with("Not Specified") && !s.starts_with("Unknown"))
+                        .cloned(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    (system, bios, memory)
+}
+
+/// Collect indented `Key: Value` lines into a map. Sub-list lines
+/// (deeper indentation, no `:`) are ignored — we don't surface
+/// characteristic flags etc.
+fn collect_kv<'a, I: Iterator<Item = &'a str>>(lines: I) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for line in lines {
+        if !line.starts_with('\t') && !line.starts_with("    ") {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        let Some((k, v)) = trimmed.split_once(':') else {
+            continue;
+        };
+        // Sub-properties (e.g. Characteristics list) start with a
+        // capital-letter prefix in the value but no colon — those
+        // are filtered out by the split_once above.
+        let v = v.trim();
+        if v.is_empty() {
+            continue;
+        }
+        out.insert(k.trim().to_string(), v.to_string());
+    }
+    out
+}
+
+/// `"16 GB"` → 17179869184; `"8192 MB"` → 8589934592. Returns 0 on
+/// `"No Module Installed"` or any unrecognized format.
+fn parse_dmi_size(s: &str) -> u64 {
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("No Module Installed") {
+        return 0;
+    }
+    let mut parts = trimmed.split_whitespace();
+    let Some(num) = parts.next().and_then(|n| n.parse::<u64>().ok()) else {
+        return 0;
+    };
+    match parts.next().unwrap_or("").to_ascii_lowercase().as_str() {
+        "kb" => num * 1024,
+        "mb" => num * 1024 * 1024,
+        "gb" => num * 1024 * 1024 * 1024,
+        "tb" => num * 1024_u64.pow(4),
+        _ => 0,
+    }
+}
+
+/// `"3200 MT/s"` → `Some(3200)`; `"Unknown"` → `None`.
+fn parse_dmi_speed(s: &str) -> Option<u32> {
+    s.split_whitespace().next()?.parse::<u32>().ok()
+}
+
+async fn read_cpu_info() -> Option<CpuSummary> {
+    let raw = tokio::fs::read_to_string("/proc/cpuinfo").await.ok()?;
+    Some(parse_cpuinfo(&raw))
+}
+
+fn parse_cpuinfo(input: &str) -> CpuSummary {
+    let mut model: Option<String> = None;
+    let mut vendor: Option<String> = None;
+    let mut logical = 0u32;
+    let mut max_mhz: Option<u32> = None;
+    let mut phys: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    let mut current_phys_id = String::new();
+    let mut current_core_id = String::new();
+
+    for line in input.lines() {
+        let Some((k, v)) = line.split_once(':') else {
+            if line.trim().is_empty() {
+                if !current_phys_id.is_empty() && !current_core_id.is_empty() {
+                    phys.insert((current_phys_id.clone(), current_core_id.clone()));
+                }
+                current_phys_id.clear();
+                current_core_id.clear();
+            }
+            continue;
+        };
+        let key = k.trim();
+        let value = v.trim();
+        match key {
+            "processor" => logical += 1,
+            "model name" if model.is_none() => model = Some(value.to_string()),
+            "vendor_id" if vendor.is_none() => vendor = Some(value.to_string()),
+            "physical id" => current_phys_id = value.to_string(),
+            "core id" => current_core_id = value.to_string(),
+            "cpu MHz" => {
+                if let Ok(mhz) = value.parse::<f64>() {
+                    let rounded = mhz.round() as u32;
+                    max_mhz = Some(max_mhz.map_or(rounded, |m| m.max(rounded)));
+                }
+            }
+            _ => {}
+        }
+    }
+    // Catch the last block if the file didn't end with a blank line.
+    if !current_phys_id.is_empty() && !current_core_id.is_empty() {
+        phys.insert((current_phys_id, current_core_id));
+    }
+
+    CpuSummary {
+        model,
+        vendor,
+        physical_cores: phys.len() as u32,
+        logical_cores: logical,
+        max_mhz,
+    }
+}
+
+async fn read_usb_devices() -> Vec<UsbDevice> {
+    let Some(text) = run_text("lsusb", &[]).await else {
+        return Vec::new();
+    };
+    parse_lsusb(&text)
+}
+
+/// Parse plain `lsusb` output. Format per line:
+///   `Bus 002 Device 003: ID 1234:5678 Vendor Name Product Name`
+fn parse_lsusb(input: &str) -> Vec<UsbDevice> {
+    let mut out = Vec::new();
+    for line in input.lines() {
+        let Some(rest) = line.strip_prefix("Bus ") else {
+            continue;
+        };
+        let mut parts = rest.splitn(6, ' ');
+        let bus: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let _device_word = parts.next();
+        let dev_str = parts.next().and_then(|s| s.strip_suffix(':'));
+        let device: u32 = dev_str.and_then(|s| s.parse().ok()).unwrap_or(0);
+        let _id_word = parts.next();
+        let id_pair = parts.next().unwrap_or("");
+        let description = parts.next().unwrap_or("").trim().to_string();
+        let Some((vendor_id, product_id)) = id_pair.split_once(':') else {
+            continue;
+        };
+        out.push(UsbDevice {
+            bus,
+            device,
+            vendor_id: vendor_id.to_string(),
+            product_id: product_id.to_string(),
+            description,
+        });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -337,5 +733,241 @@ Device:\tCometLake-S cAVS [a3f0]
         let map = parse_lspci_machine_readable(output);
         assert_eq!(map.len(), 1);
         assert!(map.contains_key("0000:02:00.0"));
+    }
+
+    // ── parse_dmi_size ────────────────────────────────────────────
+
+    #[test]
+    fn parse_dmi_size_handles_all_units() {
+        // Sizes in /sys/firmware/dmi/tables come through dmidecode's
+        // -t 17 already converted to GB / MB / TB depending on the
+        // module. Cover all the units to make sure none are silently
+        // returning 0.
+        assert_eq!(parse_dmi_size("16 GB"), 16 * 1024 * 1024 * 1024);
+        assert_eq!(parse_dmi_size("8192 MB"), 8192 * 1024 * 1024);
+        assert_eq!(parse_dmi_size("64 KB"), 64 * 1024);
+        assert_eq!(parse_dmi_size("1 TB"), 1024_u64.pow(4));
+    }
+
+    #[test]
+    fn parse_dmi_size_returns_zero_for_empty_slot() {
+        // dmidecode prints this exact string for unpopulated slots.
+        // We use 0 to mark "empty"; any other return value would
+        // wrongly inflate the total memory count.
+        assert_eq!(parse_dmi_size("No Module Installed"), 0);
+        assert_eq!(parse_dmi_size("garbage"), 0);
+    }
+
+    // ── parse_dmi_speed ──────────────────────────────────────────
+
+    #[test]
+    fn parse_dmi_speed_takes_first_numeric_token() {
+        // Real values are like "3200 MT/s" or "DDR4 3200 MT/s".
+        // Only the leading numeric word matters for our display.
+        assert_eq!(parse_dmi_speed("3200 MT/s"), Some(3200));
+        assert_eq!(parse_dmi_speed("Unknown"), None);
+        assert_eq!(parse_dmi_speed(""), None);
+    }
+
+    // ── parse_dmidecode (DMI sections) ───────────────────────────
+
+    #[test]
+    fn parse_dmidecode_extracts_baseboard_bios_and_dimms() {
+        // Synthetic-but-format-faithful sample mixing all four DMI
+        // types we care about. dmidecode -q output: blank-line-
+        // separated blocks, indented key:value pairs, no Handle line.
+        let input = "\
+Base Board Information
+\tManufacturer: Dell Inc.
+\tProduct Name: 0XYZ123
+\tVersion: A02
+
+BIOS Information
+\tVendor: Dell Inc.
+\tVersion: 1.2.3
+\tRelease Date: 12/01/2024
+
+Physical Memory Array
+\tNumber Of Devices: 4
+\tError Correction Type: Multi-bit ECC
+
+Memory Device
+\tLocator: DIMM_A1
+\tSize: 16 GB
+\tType: DDR4
+\tSpeed: 3200 MT/s
+\tManufacturer: Kingston
+\tPart Number: KSM32ED8/16HD
+
+Memory Device
+\tLocator: DIMM_A2
+\tSize: No Module Installed
+\tType: Unknown
+\tSpeed: Unknown
+\tManufacturer: Not Specified
+\tPart Number: Not Specified
+";
+        let (sys, bios, mem) = parse_dmidecode(input);
+
+        let sys = sys.unwrap();
+        assert_eq!(sys.manufacturer.as_deref(), Some("Dell Inc."));
+        assert_eq!(sys.product.as_deref(), Some("0XYZ123"));
+        assert_eq!(sys.version.as_deref(), Some("A02"));
+
+        let bios = bios.unwrap();
+        assert_eq!(bios.vendor.as_deref(), Some("Dell Inc."));
+        assert_eq!(bios.version.as_deref(), Some("1.2.3"));
+        assert_eq!(bios.release_date.as_deref(), Some("12/01/2024"));
+
+        // Slot accounting: 4 total, 1 populated, ECC enabled.
+        assert_eq!(mem.slots_total, 4);
+        assert_eq!(mem.slots_used, 1);
+        assert!(mem.ecc);
+        assert_eq!(mem.total_bytes, 16 * 1024 * 1024 * 1024);
+        assert_eq!(mem.dimms.len(), 2);
+
+        let populated = &mem.dimms[0];
+        assert_eq!(populated.locator, "DIMM_A1");
+        assert_eq!(populated.size_bytes, 16 * 1024 * 1024 * 1024);
+        assert_eq!(populated.mem_type.as_deref(), Some("DDR4"));
+        assert_eq!(populated.speed_mts, Some(3200));
+        assert_eq!(populated.manufacturer.as_deref(), Some("Kingston"));
+
+        // Empty slot still listed but with size 0 and unknown fields
+        // suppressed (so the UI can render "—" cleanly).
+        let empty = &mem.dimms[1];
+        assert_eq!(empty.locator, "DIMM_A2");
+        assert_eq!(empty.size_bytes, 0);
+        assert_eq!(empty.mem_type, None);
+        assert_eq!(empty.speed_mts, None);
+        assert_eq!(empty.manufacturer, None);
+    }
+
+    #[test]
+    fn parse_dmidecode_handles_no_ecc() {
+        // Consumer boards report "None" for Error Correction Type.
+        // Make sure we don't accidentally flag that as ECC.
+        let input = "\
+Physical Memory Array
+\tNumber Of Devices: 2
+\tError Correction Type: None
+";
+        let (_, _, mem) = parse_dmidecode(input);
+        assert!(!mem.ecc);
+        assert_eq!(mem.slots_total, 2);
+    }
+
+    #[test]
+    fn parse_dmidecode_falls_back_to_system_when_no_baseboard() {
+        // Some VMs / virtualized hardware emit Type 1 (System
+        // Information) but no Type 2 (Base Board Information).
+        // We accept Type 1 as a fallback for the box-identity card.
+        let input = "\
+System Information
+\tManufacturer: QEMU
+\tProduct Name: Standard PC (Q35 + ICH9, 2009)
+\tVersion: pc-q35-9.0
+";
+        let (sys, _, _) = parse_dmidecode(input);
+        let sys = sys.unwrap();
+        assert_eq!(sys.manufacturer.as_deref(), Some("QEMU"));
+    }
+
+    // ── parse_cpuinfo ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_cpuinfo_counts_physical_and_logical_cores() {
+        // Synthetic 2-physical-core / 4-logical-core CPU. The
+        // `(physical id, core id)` pair is what `lscpu` uses to
+        // dedupe SMT siblings, so we mirror it.
+        let input = "\
+processor\t: 0
+vendor_id\t: GenuineIntel
+model name\t: Intel(R) Core(TM) i5-8400
+physical id\t: 0
+core id\t: 0
+cpu MHz\t\t: 3800.000
+
+processor\t: 1
+vendor_id\t: GenuineIntel
+model name\t: Intel(R) Core(TM) i5-8400
+physical id\t: 0
+core id\t: 0
+cpu MHz\t\t: 3500.000
+
+processor\t: 2
+vendor_id\t: GenuineIntel
+model name\t: Intel(R) Core(TM) i5-8400
+physical id\t: 0
+core id\t: 1
+cpu MHz\t\t: 4000.000
+
+processor\t: 3
+vendor_id\t: GenuineIntel
+model name\t: Intel(R) Core(TM) i5-8400
+physical id\t: 0
+core id\t: 1
+cpu MHz\t\t: 3200.000
+";
+        let cpu = parse_cpuinfo(input);
+        assert_eq!(cpu.logical_cores, 4);
+        assert_eq!(cpu.physical_cores, 2);
+        assert_eq!(cpu.model.as_deref(), Some("Intel(R) Core(TM) i5-8400"));
+        assert_eq!(cpu.vendor.as_deref(), Some("GenuineIntel"));
+        // Max across all `cpu MHz` entries — ignores per-core throttle.
+        assert_eq!(cpu.max_mhz, Some(4000));
+    }
+
+    #[test]
+    fn parse_cpuinfo_handles_missing_topology_fields() {
+        // Some VMs don't expose `physical id` / `core id`; fall back
+        // to "physical = logical" rather than reporting 0 cores
+        // (which would look like "no CPU detected").
+        let input = "\
+processor\t: 0
+model name\t: Single Core CPU
+
+processor\t: 1
+model name\t: Single Core CPU
+";
+        let cpu = parse_cpuinfo(input);
+        assert_eq!(cpu.logical_cores, 2);
+        // No topology info means we can't dedupe — physical = 0.
+        // The UI is responsible for falling back to logical_cores
+        // when this is 0; documented behaviour.
+        assert_eq!(cpu.physical_cores, 0);
+    }
+
+    // ── parse_lsusb ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_lsusb_extracts_one_device_per_line() {
+        // Verbatim format from `lsusb` (no -v). The IDs are the
+        // canonical 4-hex form; the description is whatever string
+        // lsusb resolved from /var/lib/usbutils/usb.ids.
+        let input = "\
+Bus 002 Device 003: ID 046d:c52b Logitech, Inc. Unifying Receiver
+Bus 001 Device 002: ID 8087:0029 Intel Corp. AX200 Bluetooth
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+";
+        let devs = parse_lsusb(input);
+        assert_eq!(devs.len(), 3);
+
+        assert_eq!(devs[0].bus, 2);
+        assert_eq!(devs[0].device, 3);
+        assert_eq!(devs[0].vendor_id, "046d");
+        assert_eq!(devs[0].product_id, "c52b");
+        assert_eq!(devs[0].description, "Logitech, Inc. Unifying Receiver");
+
+        assert_eq!(devs[2].vendor_id, "1d6b");
+        assert_eq!(devs[2].description, "Linux Foundation 2.0 root hub");
+    }
+
+    #[test]
+    fn parse_lsusb_returns_empty_for_no_buses() {
+        // Defensive — empty input shouldn't panic.
+        assert!(parse_lsusb("").is_empty());
+        // Lines that don't start with "Bus " are ignored.
+        assert!(parse_lsusb("not lsusb output\n").is_empty());
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -556,6 +556,8 @@ in {
       lm_sensors        # CPU/drive temperature monitoring
       lsof              # open file debugging ("device busy")
       keyutils          # keyctl — used by the engine to lock encrypted FSes
+      dmidecode         # DMI tables — engine reads baseboard/BIOS/memory for /system/hardware
+      usbutils          # lsusb — engine reads USB device tree for /system/hardware
       iotop-c           # per-process I/O monitoring
       ethtool           # NIC speed, duplex, ring buffer tuning
       iperf3            # network throughput testing

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -41,6 +41,63 @@ export interface PciDevice {
 	driver: string | null;
 }
 
+/** Hardware overview, returned by `system.hardware.summary`. Server-
+ * side cached for 60s; expect stale-by-up-to-a-minute data after
+ * suspend/resume cycles, but the underlying physical hardware
+ * doesn't change between boots so this is fine. */
+export interface HardwareSummary {
+	system: DmiSystem | null;
+	bios: DmiBios | null;
+	cpu: CpuSummary | null;
+	memory: MemorySummary;
+	usb: UsbDevice[];
+}
+
+export interface DmiSystem {
+	manufacturer: string | null;
+	product: string | null;
+	version: string | null;
+}
+
+export interface DmiBios {
+	vendor: string | null;
+	version: string | null;
+	release_date: string | null;
+}
+
+export interface CpuSummary {
+	model: string | null;
+	vendor: string | null;
+	physical_cores: number;
+	logical_cores: number;
+	max_mhz: number | null;
+}
+
+export interface MemorySummary {
+	total_bytes: number;
+	slots_total: number;
+	slots_used: number;
+	ecc: boolean;
+	dimms: DimmInfo[];
+}
+
+export interface DimmInfo {
+	locator: string;
+	size_bytes: number;
+	mem_type: string | null;
+	speed_mts: number | null;
+	manufacturer: string | null;
+	part_number: string | null;
+}
+
+export interface UsbDevice {
+	bus: number;
+	device: number;
+	vendor_id: string;
+	product_id: string;
+	description: string;
+}
+
 export interface ServiceStatus {
 	name: string;
 	running: boolean;

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -4,21 +4,28 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Card, CardContent } from '$lib/components/ui/card';
-	import type { IommuGroup, PciDevice } from '$lib/types';
+	import type { HardwareSummary, IommuGroup, PciDevice } from '$lib/types';
+	import { formatBytes } from '$lib/format';
 	import { ChevronDown, ChevronRight, RefreshCw } from '@lucide/svelte';
 
+	let summary: HardwareSummary | null = $state(null);
 	let groups: IommuGroup[] = $state([]);
 	let loading = $state(true);
 	let refreshing = $state(false);
 	let expanded = $state(new Set<number>());
 	let filter = $state('');
+	let showAllDimms = $state(false);
 
 	const client = getClient();
 
 	async function load() {
 		try {
-			groups = await client.call<IommuGroup[]>('system.hardware.iommu');
+			[summary, groups] = await Promise.all([
+				client.call<HardwareSummary>('system.hardware.summary'),
+				client.call<IommuGroup[]>('system.hardware.iommu'),
+			]);
 		} catch {
+			summary = null;
 			groups = [];
 		}
 		loading = false;
@@ -95,8 +102,8 @@
 	<div>
 		<h1 class="text-2xl font-semibold">Hardware</h1>
 		<p class="text-sm text-muted-foreground">
-			PCI devices grouped by IOMMU group. Useful for planning VM passthrough — devices in the same
-			group must be assigned together.
+			Hardware overview and IOMMU groupings. Devices in the same IOMMU group must be passed through
+			together.
 		</p>
 	</div>
 	<Button size="sm" variant="secondary" onclick={refresh} disabled={refreshing}>
@@ -109,17 +116,164 @@
 	<Card>
 		<CardContent class="py-12 text-center text-sm text-muted-foreground">Loading…</CardContent>
 	</Card>
-{:else if groups.length === 0}
-	<Card>
-		<CardContent class="py-8 text-center">
-			<p class="mb-1 font-medium">No IOMMU groups found</p>
-			<p class="text-sm text-muted-foreground">
-				IOMMU is likely off in BIOS. Enable VT-d (Intel) or AMD-Vi (AMD) and reboot. NASty's kernel
-				params already pass <code class="font-mono">intel_iommu=on amd_iommu=on iommu=pt</code>.
-			</p>
-		</CardContent>
-	</Card>
 {:else}
+	<!-- ── Hardware overview cards ─────────────────────────────────── -->
+	<div class="mb-6 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					System
+				</h3>
+				{#if summary?.system}
+					<div class="text-sm font-medium">
+						{summary.system.manufacturer ?? 'Unknown'}
+						{summary.system.product ?? ''}
+					</div>
+					{#if summary.system.version}
+						<div class="text-xs text-muted-foreground">v{summary.system.version}</div>
+					{/if}
+				{:else}
+					<div class="text-sm text-muted-foreground">—</div>
+				{/if}
+				{#if summary?.bios}
+					<div class="mt-3 border-t border-border/40 pt-2 text-xs text-muted-foreground">
+						BIOS: {summary.bios.vendor ?? '—'}
+						{#if summary.bios.version} · {summary.bios.version}{/if}
+						{#if summary.bios.release_date} · {summary.bios.release_date}{/if}
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					CPU
+				</h3>
+				{#if summary?.cpu}
+					<div class="text-sm font-medium">{summary.cpu.model ?? 'Unknown'}</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						{summary.cpu.physical_cores > 0
+							? `${summary.cpu.physical_cores} core${summary.cpu.physical_cores === 1 ? '' : 's'} · `
+							: ''}{summary.cpu.logical_cores} thread{summary.cpu.logical_cores === 1 ? '' : 's'}
+						{#if summary.cpu.max_mhz} · {(summary.cpu.max_mhz / 1000).toFixed(2)} GHz{/if}
+					</div>
+				{:else}
+					<div class="text-sm text-muted-foreground">—</div>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					Memory
+				</h3>
+				{#if summary && summary.memory.slots_total > 0}
+					<div class="text-sm font-medium">{formatBytes(summary.memory.total_bytes)}</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						{summary.memory.slots_used} of {summary.memory.slots_total} slot{summary.memory
+							.slots_total === 1
+							? ''
+							: 's'} populated
+						{#if summary.memory.ecc} · ECC{/if}
+					</div>
+				{:else}
+					<div class="text-sm text-muted-foreground">—</div>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					USB
+				</h3>
+				<div class="text-sm font-medium">
+					{summary?.usb.length ?? 0} device{summary?.usb.length === 1 ? '' : 's'}
+				</div>
+				{#if summary?.usb.length}
+					<div class="mt-1 text-xs text-muted-foreground">
+						{summary.usb
+							.slice(0, 3)
+							.map((d) => d.description.split(' ').slice(0, 3).join(' '))
+							.join(' · ')}{summary.usb.length > 3 ? ' · …' : ''}
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+	</div>
+
+	<!-- ── DIMM detail (collapsed by default) ──────────────────────── -->
+	{#if summary && summary.memory.dimms.length > 0}
+		<Card class="mb-6">
+			<CardContent class="p-0">
+				<button
+					onclick={() => (showAllDimms = !showAllDimms)}
+					class="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-accent/50"
+				>
+					{#if showAllDimms}
+						<ChevronDown size={16} class="text-muted-foreground" />
+					{:else}
+						<ChevronRight size={16} class="text-muted-foreground" />
+					{/if}
+					<span class="text-sm font-medium">Memory slots</span>
+					<span class="text-xs text-muted-foreground">
+						{summary.memory.slots_used} populated of {summary.memory.dimms.length}
+					</span>
+				</button>
+				{#if showAllDimms}
+					<div class="border-t border-border bg-muted/20 px-4 py-3">
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="text-left text-[0.7rem] uppercase tracking-wide text-muted-foreground"
+								>
+									<th class="pb-2 font-medium">Slot</th>
+									<th class="pb-2 font-medium">Size</th>
+									<th class="pb-2 font-medium">Type</th>
+									<th class="pb-2 font-medium">Speed</th>
+									<th class="pb-2 font-medium">Manufacturer</th>
+									<th class="pb-2 font-medium">Part #</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each summary.memory.dimms as dimm (dimm.locator)}
+									<tr class="border-t border-border/40 {dimm.size_bytes === 0 ? 'opacity-50' : ''}">
+										<td class="py-2 pr-3 font-mono text-xs">{dimm.locator}</td>
+										<td class="py-2 pr-3"
+											>{dimm.size_bytes === 0 ? '—' : formatBytes(dimm.size_bytes)}</td
+										>
+										<td class="py-2 pr-3 text-xs">{dimm.mem_type ?? '—'}</td>
+										<td class="py-2 pr-3 text-xs"
+											>{dimm.speed_mts ? `${dimm.speed_mts} MT/s` : '—'}</td
+										>
+										<td class="py-2 pr-3 text-xs">{dimm.manufacturer ?? '—'}</td>
+										<td class="py-2 font-mono text-xs">{dimm.part_number ?? '—'}</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+	{/if}
+
+	<!-- ── IOMMU group tree ───────────────────────────────────────── -->
+	{#if groups.length === 0}
+		<Card>
+			<CardContent class="py-8 text-center">
+				<p class="mb-1 font-medium">No IOMMU groups found</p>
+				<p class="text-sm text-muted-foreground">
+					IOMMU is likely off in BIOS. Enable VT-d (Intel) or AMD-Vi (AMD) and reboot. NASty's
+					kernel params already pass
+					<code class="font-mono">intel_iommu=on amd_iommu=on iommu=pt</code>.
+				</p>
+			</CardContent>
+		</Card>
+	{:else}
+	<h2 class="mb-3 text-base font-semibold">IOMMU groups</h2>
 	<div class="mb-3 flex items-center gap-3">
 		<input
 			bind:value={filter}
@@ -200,4 +354,5 @@
 			</Card>
 		{/each}
 	</div>
+	{/if}
 {/if}


### PR DESCRIPTION
**Stacked on #117 (PR A).** Merge that first; this PR's diff against \`main\` will be cleaner once #117 lands and this rebases.

Closes the rest of #100. (#101's passthrough toggles are PR C.)

## What lands

The Hardware page now leads with four overview cards above the IOMMU tree:

| Card | Source | Shows |
|---|---|---|
| System | \`dmidecode -t 1,2\` | Manufacturer + product + version, plus BIOS vendor/version/date |
| CPU | \`/proc/cpuinfo\` | Model, physical/logical core counts, max MHz |
| Memory | \`dmidecode -t 16,17\` | Total size, slots populated/total, ECC flag |
| USB | \`lsusb\` | Device count + first few descriptions |

A collapsible **Memory slots** table below shows per-DIMM detail (locator, size, type, speed, manufacturer, part number) for users who care about populating empty slots or matching speeds.

## Why hand-rolled, not inxi

[Earlier in the discussion](https://github.com/nasty-project/nasty/issues/100) I'd argued for \`inxi --output json\` to avoid writing dmidecode parsers. After actually looking at inxi's JSON: keys like \`Mfg-23-1\`, \`v-15-1\`, \`v-15-2\` with display-position suffixes — hostile to consume from an API. Parsing three specific DMI subsections directly (Type 0/1/2/16/17) is narrower than a generic dmidecode parser would be — we ignore 30+ other DMI types — and gives us full control of the wire schema. Tradeoff: more code on our side (~250 lines of parsers + tests); benefit: no schema drift against external tool versions.

## Caching

\`dmidecode\` takes 50–200ms because it's reading firmware tables. Server-side cache with 60s TTL — first call after engine start pays the cost, subsequent ones return instantly. The page UI shows a \`Refresh\` button that invalidates by reload.

## Sensitive fields

Skipped on purpose: chassis serial, board serial, CPU serial, system UUID. They're noisy at best (often \`To Be Filled By O.E.M.\`) and a small footgun if they leak into screenshots / telemetry. Add them later if there's demand, with explicit redaction toggles.

## Edge cases handled

- **No dmidecode** (containers, exotic VMs): card renders \`—\`, no errors.
- **No baseboard table** (some VMs emit Type 1 only): falls back to System Information for the box-identity card.
- **Consumer board with non-ECC RAM**: \`Error Correction Type: None\` doesn't trip the ECC flag.
- **Empty DIMM slot**: \`No Module Installed\` parses to size 0; included in the slots table with opacity-50 styling but excluded from totals.
- **VM with no \`physical id\`/\`core id\`**: falls back to physical_cores=0, UI documents this and uses logical_cores instead.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 152 passing (10 new \`hardware::tests\`):
  - parse_dmi_size handles all units (KB/MB/GB/TB) + empty-slot literal
  - parse_dmi_speed takes first numeric token
  - parse_dmidecode extracts baseboard + BIOS + DIMMs (full sample)
  - no-ECC consumer board doesn't get ECC=true
  - VM falls back to System Information when Base Board is absent
  - parse_cpuinfo dedupes SMT siblings via (physical id, core id)
  - parse_cpuinfo handles missing topology fields without panicking
  - parse_lsusb reads standard lsusb line format
  - parse_lsusb handles empty / non-lsusb input
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4840 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 87 passing
- [ ] **Manual on a real box**: verify cards render with sensible values, expand DIMM table to inspect per-slot detail, refresh button works. Verify on a VM that the System fallback kicks in (no baseboard).

## Tech-debt note

There's a duplicate \`PciDevice\` interface in \`webui/src/lib/types.ts\` — one I added for IOMMU (PR A), one pre-existing for VM passthrough. TypeScript silently merges them; svelte-check passes. Should be untangled in a small follow-up by renaming one of them; out of scope for this PR.