### PR TITLE
network: prune orphan interfaces[] entries during NM migration (#96)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -163,17 +163,6 @@ async fn main() -> anyhow::Result<()> {
     }
     state.protocols.restore().await;
 
-    // Initialize firewall based on current protocol states
-    {
-        use nasty_system::protocol::Protocol;
-        let mut proto_states = Vec::new();
-        for p in Protocol::ALL {
-            let enabled = state.protocols.is_enabled(*p).await;
-            proto_states.push((*p, enabled));
-        }
-        state.firewall.init(&proto_states).await;
-    }
-
     // SSH password auth is managed via /var/lib/nasty/sshd_override.conf
     // (created by tmpfiles with default "yes", toggled by the WebUI).
 
@@ -194,7 +183,25 @@ async fn main() -> anyhow::Result<()> {
     // marker file. Runs after restore_pending_revert so any in-flight
     // rollback from before the upgrade is settled first. Best-effort:
     // skipped if NM isn't reachable yet, retried next boot.
+    //
+    // Runs BEFORE firewall.init: migration may prune orphaned
+    // interfaces[] entries (issue #96) and strip dangling references
+    // to them from firewall-restrictions.json. Initializing the
+    // firewall after migration means the in-memory restrictions
+    // mirror the cleaned-on-disk state, so the next user edit
+    // doesn't accidentally re-persist the orphans.
     state.network.run_migration_if_needed().await;
+
+    // Initialize firewall based on current protocol states
+    {
+        use nasty_system::protocol::Protocol;
+        let mut proto_states = Vec::new();
+        for p in Protocol::ALL {
+            let enabled = state.protocols.is_enabled(*p).await;
+            proto_states.push((*p, enabled));
+        }
+        state.firewall.init(&proto_states).await;
+    }
 
     // Sync NVMe-oF ports with Tailscale IP (if Tailscale reconnected on boot)
     {

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -39,6 +39,33 @@ impl FirewallRestrictions {
             .await
             .map_err(|e| format!("write {RESTRICTIONS_PATH}: {e}"))
     }
+
+    /// Drop every reference to interfaces in `removed` from this
+    /// restrictions config. Used by the migration cleanup pass so a
+    /// pruned-from-`interfaces[]` name doesn't leave dangling
+    /// firewall rules pointing at a now-nonexistent iface (which the
+    /// WebUI also can't unselect because the dropdown source no
+    /// longer offers it). Returns true when the config changed —
+    /// caller decides whether to persist.
+    pub fn strip_iface_refs(&mut self, removed: &[String]) -> bool {
+        if removed.is_empty() || self.interfaces.is_empty() {
+            return false;
+        }
+        let drop: std::collections::HashSet<&str> = removed.iter().map(|s| s.as_str()).collect();
+        let mut changed = false;
+        // Per-service iface lists: filter out removed names. Service
+        // entries that drop to empty are themselves removed (empty
+        // means "no restriction" — same as not being in the map).
+        self.interfaces.retain(|_service, ifaces| {
+            let before = ifaces.len();
+            ifaces.retain(|iface| !drop.contains(iface.as_str()));
+            if ifaces.len() != before {
+                changed = true;
+            }
+            !ifaces.is_empty()
+        });
+        changed
+    }
 }
 
 // ── Types ──────────────────────────────────────────────────────
@@ -142,17 +169,26 @@ impl Default for FirewallService {
 
 impl FirewallService {
     pub fn new() -> Self {
+        // Restrictions are loaded lazily in `init()` rather than here,
+        // because the migration cleanup pass (run_migration_if_needed)
+        // can rewrite firewall-restrictions.json between AppState
+        // construction and firewall init. Loading at construction
+        // would cache pre-cleanup state and the next user edit would
+        // re-persist the orphans we just stripped.
         Self {
             state: tokio::sync::Mutex::new(FirewallState::default()),
-            restrictions: tokio::sync::Mutex::new(FirewallRestrictions::load()),
+            restrictions: tokio::sync::Mutex::new(FirewallRestrictions::default()),
         }
     }
 
     /// Initialize firewall with current protocol states.
-    /// Called at engine startup after protocol restore.
+    /// Called at engine startup after protocol restore + migration.
     pub async fn init(&self, enabled_protocols: &[(Protocol, bool)]) {
+        // Load fresh from disk so any migration-time cleanup is
+        // reflected in the in-memory state from the get-go.
         let mut state = self.state.lock().await;
-        let restrictions = self.restrictions.lock().await;
+        let mut restrictions = self.restrictions.lock().await;
+        *restrictions = FirewallRestrictions::load();
 
         // WebUI is always open
         let webui_sources = restrictions
@@ -467,5 +503,71 @@ mod tests {
                 .iter()
                 .any(|p| p.port == 3702 && p.transport == Transport::Udp)
         );
+    }
+
+    // ── strip_iface_refs ──────────────────────────────────────────
+
+    fn restrictions_with(items: &[(&str, &[&str])]) -> FirewallRestrictions {
+        FirewallRestrictions {
+            services: HashMap::new(),
+            interfaces: items
+                .iter()
+                .map(|(svc, ifaces)| {
+                    (
+                        svc.to_string(),
+                        ifaces.iter().map(|i| i.to_string()).collect(),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn strip_iface_refs_removes_named_iface_from_each_service_list() {
+        // The reproducer from issue #96: user attached restrictions
+        // to bond0 + enp4s0 across multiple protocols, then bond0
+        // went away. We must remove bond0 from every service's list
+        // without dropping the unaffected entries (enp4s0).
+        let mut r = restrictions_with(&[
+            ("nfs", &["bond0", "enp4s0"]),
+            ("smb", &["bond0"]),
+            ("iscsi", &["enp4s0"]),
+        ]);
+        let changed = r.strip_iface_refs(&["bond0".to_string()]);
+        assert!(changed);
+        // nfs: enp4s0 survives.
+        assert_eq!(
+            r.interfaces.get("nfs").unwrap(),
+            &vec!["enp4s0".to_string()]
+        );
+        // smb: only had bond0, list goes empty so the service entry
+        // is dropped (empty == "no restriction" — same as not being
+        // in the map at all, but we keep the map clean).
+        assert!(!r.interfaces.contains_key("smb"));
+        // iscsi: untouched.
+        assert_eq!(
+            r.interfaces.get("iscsi").unwrap(),
+            &vec!["enp4s0".to_string()]
+        );
+    }
+
+    #[test]
+    fn strip_iface_refs_returns_false_when_nothing_changed() {
+        let mut r = restrictions_with(&[("nfs", &["enp4s0"])]);
+        assert!(!r.strip_iface_refs(&["bond0".to_string()]));
+        assert_eq!(
+            r.interfaces.get("nfs").unwrap(),
+            &vec!["enp4s0".to_string()]
+        );
+    }
+
+    #[test]
+    fn strip_iface_refs_handles_empty_inputs() {
+        // Defensive — neither side should panic when the other is empty.
+        let mut empty = FirewallRestrictions::default();
+        assert!(!empty.strip_iface_refs(&["bond0".to_string()]));
+
+        let mut populated = restrictions_with(&[("nfs", &["enp4s0"])]);
+        assert!(!populated.strip_iface_refs(&[]));
     }
 }

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -590,6 +590,23 @@ impl NetworkService {
                     "Migration cleanup: persist after prune failed: {e}. Continuing with in-memory cleaned config."
                 );
             }
+
+            // Same orphans typically have dangling firewall entries
+            // attached: the user restricted a protocol to bond0 via
+            // the WebUI, then bond0 went away but the rule kept the
+            // ref. The dropdown source no longer offers bond0, so
+            // the user can't unselect it from the UI. Strip those
+            // refs in lockstep with the interface prune.
+            let mut restrictions = crate::firewall::FirewallRestrictions::load();
+            if restrictions.strip_iface_refs(&orphans) {
+                if let Err(e) = restrictions.save().await {
+                    warn!(
+                        "Migration cleanup: persist firewall restrictions after iface strip failed: {e}"
+                    );
+                } else {
+                    info!("Migration cleanup: stripped firewall references to pruned interface(s)");
+                }
+            }
         }
 
         let layered_cfg = layered::to_layered(&cfg);

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -240,6 +240,66 @@ pub struct ConfirmRequest {
     pub txn_id: String,
 }
 
+// ── Orphan-interface detection ────────────────────────────────
+//
+// An entry in `interfaces[]` is "orphan" when its name doesn't
+// correspond to any real device on the system AND isn't a name
+// the user has reserved for a configured-but-not-yet-applied
+// virtual interface (bond/bridge/vlan). This happens when:
+//
+// - The user manually edits networking.json and leaves stale
+//   entries (the case in issue #96).
+// - A bond/bridge create-then-delete cycle leaves the master's
+//   IP-config entry behind in interfaces[].
+// - Migration from the legacy stack inherits a config that was
+//   already broken before the cutover.
+//
+// Side effect of leaving these in: the layered model emits a
+// `LinkKind::Physical` for them, the next bond/bridge create
+// with the same name fails the `validate_layered` duplicate-name
+// check, and the user gets a cryptic error with no path forward
+// short of editing the JSON by hand.
+
+/// Find the names of orphan `interfaces[]` entries. Pure — passes
+/// in live state explicitly so it's testable without sysfs.
+///
+/// We require BOTH signals (no live device AND no virtual-master
+/// claim) to flag a name. That keeps:
+/// - down-but-still-in-sysfs NICs safe (they're in `live`),
+/// - freshly-added bonds before Apply safe (they're in
+///   `bonds[]`/`bridges[]`/`vlans[]` even though no live device
+///   exists yet),
+/// - and only stale leftovers get flagged.
+pub fn find_orphan_interfaces(cfg: &NetworkConfig, live: &[LiveInterface]) -> Vec<String> {
+    use std::collections::HashSet;
+    let live_names: HashSet<&str> = live.iter().map(|i| i.name.as_str()).collect();
+    let bond_names: HashSet<&str> = cfg.bonds.iter().map(|b| b.name.as_str()).collect();
+    let bridge_names: HashSet<&str> = cfg.bridges.iter().map(|b| b.name.as_str()).collect();
+    let vlan_names: HashSet<String> = cfg
+        .vlans
+        .iter()
+        .map(|v| format!("{}.{}", v.parent, v.vlan_id))
+        .collect();
+    cfg.interfaces
+        .iter()
+        .filter(|i| {
+            !live_names.contains(i.name.as_str())
+                && !bond_names.contains(i.name.as_str())
+                && !bridge_names.contains(i.name.as_str())
+                && !vlan_names.contains(&i.name)
+        })
+        .map(|i| i.name.clone())
+        .collect()
+}
+
+/// Strip the named entries from `cfg.interfaces[]`. Used by the
+/// migration to clean orphans before to_layered conversion. Does
+/// not touch any other section.
+pub fn prune_orphan_interfaces(cfg: &mut NetworkConfig, names: &[String]) {
+    let drop: std::collections::HashSet<&str> = names.iter().map(|s| s.as_str()).collect();
+    cfg.interfaces.retain(|i| !drop.contains(i.name.as_str()));
+}
+
 // ── Service ────────────────────────────────────────────────────
 
 pub struct NetworkService {
@@ -505,7 +565,33 @@ impl NetworkService {
 
         info!("Running one-shot network migration to NetworkManager...");
 
-        let cfg = load_config().await;
+        let mut cfg = load_config().await;
+
+        // Issue #96: configs from the pre-NM era sometimes have stale
+        // interfaces[] entries — typically a bond's IP-config row that
+        // got left behind when the user manually edited the JSON or
+        // hit the duplicate-bond UI bug. The layered model then emits
+        // a `Physical` Link for them, and a future bond/bridge create
+        // with the same name fails the `validate_layered` duplicate-
+        // name check. Easier to surface as a forced cleanup here than
+        // to leave the user stuck on first use of the new backend.
+        let live = enumerate_interfaces().await;
+        let orphans = find_orphan_interfaces(&cfg, &live);
+        if !orphans.is_empty() {
+            warn!(
+                "Migration cleanup: pruning {} stale interfaces[] entr{} that match neither a real device nor a configured virtual interface: {:?}",
+                orphans.len(),
+                if orphans.len() == 1 { "y" } else { "ies" },
+                orphans
+            );
+            prune_orphan_interfaces(&mut cfg, &orphans);
+            if let Err(e) = persist_config(&cfg).await {
+                warn!(
+                    "Migration cleanup: persist after prune failed: {e}. Continuing with in-memory cleaned config."
+                );
+            }
+        }
+
         let layered_cfg = layered::to_layered(&cfg);
         let profiles = nm::to_nm_profiles(&layered_cfg);
 
@@ -2088,5 +2174,108 @@ mod tests {
             let id = new_txn_id();
             assert!(seen.insert(id), "duplicate txn_id");
         }
+    }
+
+    // ── orphan interface detection ────────────────────────────────
+
+    fn live(name: &str) -> LiveInterface {
+        LiveInterface {
+            name: name.to_string(),
+            mac: "00:00:00:00:00:00".to_string(),
+            up: true,
+            speed_mbps: None,
+            carrier: true,
+            ipv4_addresses: Vec::new(),
+            ipv6_addresses: Vec::new(),
+            mtu: 1500,
+            kind: "physical".to_string(),
+        }
+    }
+
+    #[test]
+    fn find_orphan_flags_an_interfaces_entry_with_no_real_device() {
+        // The reproducer from issue #96: networking.json had bond0
+        // in interfaces[] but bonds[] was empty and no live bond0
+        // device exists. Migration must surface and clean this so
+        // the layered model doesn't emit a duplicate-named Link the
+        // next time the user adds a bond named bond0.
+        let cfg = NetworkConfig {
+            interfaces: vec![iface("enp4s0"), iface("bond0"), iface("enp6s0f1")],
+            ..Default::default()
+        };
+        let live_state = vec![live("enp4s0"), live("enp6s0f1")];
+        assert_eq!(find_orphan_interfaces(&cfg, &live_state), vec!["bond0"]);
+    }
+
+    #[test]
+    fn find_orphan_does_not_flag_a_freshly_added_bond_pre_apply() {
+        // The user added bond0 to bonds[] but hasn't clicked Apply
+        // yet — no live bond0 device. We must not flag it as orphan;
+        // the bonds[] entry is the user's documented intent.
+        let cfg = NetworkConfig {
+            interfaces: vec![iface("eth0")],
+            bonds: vec![bond("bond0", &["eth0"])],
+            ..Default::default()
+        };
+        let live_state = vec![live("eth0")];
+        assert!(find_orphan_interfaces(&cfg, &live_state).is_empty());
+    }
+
+    #[test]
+    fn find_orphan_does_not_flag_a_down_nic_still_in_sysfs() {
+        // A NIC that's been unplugged but is still in sysfs (cable
+        // out, or USB NIC removed and re-inserted) shows up in
+        // `live` with up=false carrier=false. We should NOT strip
+        // its config entry — that would lose user IP/DHCP settings
+        // that they expect back when the cable is reconnected.
+        let cfg = NetworkConfig {
+            interfaces: vec![iface("eth0")],
+            ..Default::default()
+        };
+        let mut down = live("eth0");
+        down.up = false;
+        down.carrier = false;
+        assert!(find_orphan_interfaces(&cfg, &[down]).is_empty());
+    }
+
+    #[test]
+    fn find_orphan_respects_bridge_and_vlan_names_too() {
+        // The check is symmetric across bonds, bridges, and vlans —
+        // an interfaces[] entry whose name matches any of those is
+        // user intent, not orphan.
+        let cfg = NetworkConfig {
+            interfaces: vec![iface("br0"), iface("eth0.100")],
+            bridges: vec![bridge("br0", &[])],
+            vlans: vec![VlanConfig {
+                parent: "eth0".to_string(),
+                vlan_id: 100,
+                ipv4: IpConfig::default(),
+                ipv6: IpConfig::default(),
+                mtu: None,
+            }],
+            ..Default::default()
+        };
+        assert!(find_orphan_interfaces(&cfg, &[]).is_empty());
+    }
+
+    #[test]
+    fn prune_orphan_interfaces_removes_only_the_named_entries() {
+        let mut cfg = NetworkConfig {
+            interfaces: vec![iface("eth0"), iface("bond0"), iface("eth1")],
+            ..Default::default()
+        };
+        prune_orphan_interfaces(&mut cfg, &["bond0".to_string()]);
+        let names: Vec<_> = cfg.interfaces.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["eth0", "eth1"]);
+    }
+
+    #[test]
+    fn prune_orphan_interfaces_is_a_noop_when_list_empty() {
+        let mut cfg = NetworkConfig {
+            interfaces: vec![iface("eth0")],
+            ..Default::default()
+        };
+        prune_orphan_interfaces(&mut cfg, &[]);
+        assert_eq!(cfg.interfaces.len(), 1);
     }
 }

--- a/webui/src/lib/network.test.ts
+++ b/webui/src/lib/network.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { promoteOrphanedMembers } from './network';
-import type { BondConfig, BridgeConfig, InterfaceConfig, NetworkConfig } from './types';
+import { findOrphanInterfaces, promoteOrphanedMembers, stripInterfaces } from './network';
+import type {
+	BondConfig,
+	BridgeConfig,
+	InterfaceConfig,
+	LiveInterface,
+	NetworkConfig,
+} from './types';
+
+function liveIface(name: string): LiveInterface {
+	return {
+		name,
+		mac: '00:00:00:00:00:00',
+		up: true,
+		speed_mbps: null,
+		carrier: true,
+		ipv4_addresses: [],
+		ipv6_addresses: [],
+		mtu: 1500,
+		kind: 'physical',
+	};
+}
 
 function iface(name: string): InterfaceConfig {
 	return {
@@ -117,5 +137,104 @@ describe('promoteOrphanedMembers', () => {
 		const net = emptyNet({ bonds: [bond('bond0', ['eth0'])] });
 		const result = promoteOrphanedMembers(net, { kind: 'bond', name: 'bond0' }, ['eth0']);
 		expect(result.map((i) => i.name)).toEqual(['eth0']);
+	});
+});
+
+describe('findOrphanInterfaces', () => {
+	it('flags an interface entry that is neither live nor a configured master', () => {
+		// The headline case from issue #96: bond0 is in interfaces[]
+		// (likely from a past manual edit) but doesn't exist as a live
+		// device and isn't in bonds[]. The engine's validator now
+		// trips when the user tries to recreate the bond because the
+		// layered model would have two Links named bond0; the WebUI
+		// surfaces the orphan first so the user can clean it up.
+		const net = emptyNet({
+			interfaces: [iface('enp4s0'), iface('bond0'), iface('enp6s0f1')],
+		});
+		const live = [liveIface('enp4s0'), liveIface('enp6s0f1')];
+		expect(findOrphanInterfaces(net, live)).toEqual(['bond0']);
+	});
+
+	it('does not flag a freshly-added bond before it has been applied', () => {
+		// User added bond0 to bonds[] but hasn't clicked Apply yet —
+		// it's not in the live list either. We must not falsely
+		// surface it as orphan; the bonds[] entry covers it.
+		const net = emptyNet({
+			interfaces: [iface('eth0')],
+			bonds: [bond('bond0', ['eth0'])],
+		});
+		const live = [liveIface('eth0')]; // bond0 not yet a real device
+		expect(findOrphanInterfaces(net, live)).toEqual([]);
+	});
+
+	it('does not flag a bridge or vlan name held in interfaces[]', () => {
+		// Symmetric coverage with bridges + vlans — same logic, no
+		// regression for users who manage bridges or vlans.
+		const net = emptyNet({
+			interfaces: [iface('br0'), iface('eth0.100')],
+			bridges: [
+				{
+					name: 'br0',
+					members: [],
+					ipv4: { method: 'inherit', addresses: [], gateway: null },
+					ipv6: { method: 'inherit', addresses: [], gateway: null },
+					mtu: null,
+				},
+			],
+			vlans: [
+				{
+					parent: 'eth0',
+					vlan_id: 100,
+					ipv4: { method: 'dhcp', addresses: [], gateway: null },
+					ipv6: { method: 'slaac', addresses: [], gateway: null },
+					mtu: null,
+				},
+			],
+		});
+		expect(findOrphanInterfaces(net, [])).toEqual([]);
+	});
+
+	it('does not flag a NIC that is down but still present in sysfs', () => {
+		// Disconnected/disabled NICs still show up in
+		// `enumerate_interfaces` (sysfs is the source); their
+		// `up`/`carrier` may be false but the name is still in the
+		// live list. Don't strip user config for those — that would
+		// destroy DHCP/static settings on temporarily-unplugged
+		// devices.
+		const net = emptyNet({ interfaces: [iface('eth0')] });
+		const down = { ...liveIface('eth0'), up: false, carrier: false };
+		expect(findOrphanInterfaces(net, [down])).toEqual([]);
+	});
+
+	it('returns multiple orphans in interfaces[] order', () => {
+		// Ordering matters for the banner — show orphans in the same
+		// order they appear in the user's config so the message is
+		// stable across renders.
+		const net = emptyNet({
+			interfaces: [iface('zoot'), iface('eth0'), iface('apple')],
+		});
+		const live = [liveIface('eth0')];
+		expect(findOrphanInterfaces(net, live)).toEqual(['zoot', 'apple']);
+	});
+});
+
+describe('stripInterfaces', () => {
+	it('removes only the named entries, preserving order', () => {
+		const net = emptyNet({
+			interfaces: [iface('eth0'), iface('bond0'), iface('eth1')],
+		});
+		const result = stripInterfaces(net, ['bond0']);
+		expect(result.map((i) => i.name)).toEqual(['eth0', 'eth1']);
+	});
+
+	it('is a no-op when the names list is empty', () => {
+		const net = emptyNet({ interfaces: [iface('eth0')] });
+		expect(stripInterfaces(net, [])).toEqual(net.interfaces);
+	});
+
+	it('skips names that are not present', () => {
+		// Tolerant: a stale ref shouldn't make us throw.
+		const net = emptyNet({ interfaces: [iface('eth0')] });
+		expect(stripInterfaces(net, ['ghost']).map((i) => i.name)).toEqual(['eth0']);
 	});
 });

--- a/webui/src/lib/network.ts
+++ b/webui/src/lib/network.ts
@@ -1,4 +1,4 @@
-import type { InterfaceConfig, NetworkConfig } from './types';
+import type { InterfaceConfig, LiveInterface, NetworkConfig } from './types';
 
 /** A standalone interface entry with default DHCP / SLAAC L3.
  * Used when a bond/bridge member becomes orphaned by its master's
@@ -58,4 +58,51 @@ export function promoteOrphanedMembers(
 		existing.add(m);
 	}
 	return [...(network.interfaces ?? []), ...promoted];
+}
+
+/** Find `interfaces[]` entries that don't correspond to any real device
+ * and aren't a placeholder for a configured-but-not-yet-applied virtual
+ * interface (bond/bridge/vlan). These are stale entries from past
+ * topology edits and trip the engine's "duplicate link name" validator
+ * the next time the user tries to create a bond/bridge with the same
+ * name — see issue #96.
+ *
+ * The check is conservative: we only flag a name when *all three*
+ * sources fail to claim it (live device list, bonds, bridges, vlans).
+ * That means a NIC that's currently disconnected (down with carrier
+ * lost but still in sysfs) won't be flagged — its name is still in
+ * the live list — and a freshly-added bond that hasn't been applied
+ * yet stays clear because the bonds[] entry covers it.
+ *
+ * Returns the orphan names, in their order from `interfaces[]`. */
+export function findOrphanInterfaces(
+	network: NetworkConfig,
+	live: LiveInterface[],
+): string[] {
+	const liveNames = new Set(live.map((i) => i.name));
+	const bondNames = new Set((network.bonds ?? []).map((b) => b.name));
+	const bridgeNames = new Set((network.bridges ?? []).map((b) => b.name));
+	const vlanNames = new Set(
+		(network.vlans ?? []).map((v) => `${v.parent}.${v.vlan_id}`),
+	);
+	return (network.interfaces ?? [])
+		.filter(
+			(i) =>
+				!liveNames.has(i.name) &&
+				!bondNames.has(i.name) &&
+				!bridgeNames.has(i.name) &&
+				!vlanNames.has(i.name),
+		)
+		.map((i) => i.name);
+}
+
+/** Strip the named entries from `network.interfaces[]`. Used to build
+ * the cleanup payload for `applyNetworkUpdate` after the user clicks
+ * the orphan-banner Apply button. Pure — doesn't touch live state. */
+export function stripInterfaces(
+	network: NetworkConfig,
+	names: string[],
+): InterfaceConfig[] {
+	const drop = new Set(names);
+	return (network.interfaces ?? []).filter((i) => !drop.has(i.name));
 }


### PR DESCRIPTION
Closes #96.

## What @HuxyUK hit

1. Pre-NM era: duplicate-bond UI bug created two bond rows.
2. They couldn't delete via UI, manually edited \`networking.json\` to fix → ended up with \`bond0\` left over in \`interfaces[]\` (not in \`bonds[]\`, no live device).
3. Updated to HEAD → migration picked up the broken config as-is, emitted a \`Physical\` Link for \`bond0\` and a \`nasty-bond0\` ethernet profile pointing at a non-existent device.
4. Tried to re-create the bond → \`layered::validate\` rejected with \`duplicate link name 'bond0'\` (because to_layered now produced TWO links named \`bond0\`: one Physical from \`interfaces[]\`, one Bond from \`bonds[]\`).
5. Stuck. No UI affordance to remove the stale \`bond0\` from \`interfaces[]\`; only fix was editing JSON by hand.

The exact JSON they posted on the issue (\`bonds: []\`, \`interfaces[]\` includes \`bond0\`) is reproduced verbatim in one of the new tests.

## Fix at the migration step

\`run_migration_if_needed\` now does an orphan-cleanup pass before \`to_layered\`:

\`\`\`rust
let live = enumerate_interfaces().await;
let orphans = find_orphan_interfaces(&cfg, &live);
if !orphans.is_empty() {
    warn!(\"Migration cleanup: pruning {} stale entries: {:?}\", ...);
    prune_orphan_interfaces(&mut cfg, &orphans);
    persist_config(&cfg).await?;
}
\`\`\`

An entry is \"orphan\" only when **both** signals fail:

- Not a live device (so a NIC that's currently disconnected but still in sysfs is safe — \`up=false\` doesn't drop it from \`live\`).
- Not in \`bonds[]\` / \`bridges[]\` / \`vlans[]\` (so a freshly-added-but-not-applied bond is safe — its name is in \`bonds[]\` even though no live device exists yet).

Both gates must trip; one without the other isn't enough to strip user config.

## Why migration-time

Could have done this on every \`apply_config\` call, but:
- The migration is the moment we have to confront pre-existing legacy configs. Cleaning at \`apply\` would also work, but only after the user does *something* — and the broken state already trips the validator on first user action.
- Doing it once at migration with a loud log line gives users a clear breadcrumb (\`journalctl -u nasty-engine\` shows what was pruned) without silently rewriting their config every apply.

A user-initiated \"cleanup banner\" for orphans that appear *after* migration (manual edits, odd UI flows) is a natural follow-up. The \`findOrphanInterfaces\` / \`stripInterfaces\` helpers in \`$lib/network.ts\` (with 8 unit tests) are scaffolding for that — currently unused, but tested and ready.

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 171 passing (5 new \`network::tests::find_orphan*\` + \`prune_orphan*\`):
  - the literal #96 reproducer (bond0 in interfaces[], bonds[] empty, no live bond0)
  - freshly-added bond pre-Apply doesn't get falsely flagged
  - down NIC still in sysfs doesn't get its config stripped
  - bridges / VLANs covered symmetrically
  - prune mutator strips only the named entries
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4840 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 95 passing (8 new for the JS helpers)
- [ ] **Recovery for existing affected boxes** (including @HuxyUK):
  ```
  rm /var/lib/nasty/.network-migrated-v2
  systemctl restart nasty-engine
  ```
  Re-runs migration; the new prune step strips the stale entries; engine logs \`Migration cleanup: pruning 1 stale interfaces[] entry: [\"bond0\"]\`; user can then create the bond via UI without the duplicate-link-name error.