### PR TITLE
fs: mount uses keyring-already-loaded key, not just stored key file

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1083,7 +1083,19 @@ impl FilesystemService {
 
         let first_device = fs.devices.first().map(|d| d.path.as_str()).unwrap_or("");
 
-        // Unlock encrypted filesystem if key is stored
+        // Unlock encrypted filesystem before mounting. Three paths:
+        // 1. Stored key file exists (auto-unlock-on-boot setup) → use
+        //    it to load the key into the session keyring.
+        // 2. No stored key file BUT the keyring already has the key
+        //    (user clicked Unlock with a passphrase earlier this
+        //    session) → nothing to do, kernel will use the loaded
+        //    key when we call `bcachefs mount`.
+        // 3. Neither → genuinely locked, ask user to unlock first.
+        //
+        // Path 2 was missing before — a passphrase-unlocked FS would
+        // hit the else-error even though the keyring was ready, and
+        // the UI would show the FS as Unmounted (correctly: the
+        // `locked` flag is keyring-aware) but Mount would fail.
         if opts.encrypted == Some(true) {
             let key_path = format!("{KEYS_DIR}/{name}.key");
             if Path::new(&key_path).exists() {
@@ -1093,7 +1105,7 @@ impl FilesystemService {
                 )
                 .await
                 .map_err(FilesystemError::CommandFailed)?;
-            } else {
+            } else if !is_bcachefs_key_loaded(&fs.uuid).await {
                 return Err(FilesystemError::CommandFailed(format!(
                     "encrypted filesystem '{name}' is locked — unlock it first, then mount."
                 )));


### PR DESCRIPTION
Reproducer caught live on 10.10.10.61:

1. Encrypted FS \`first\`, no auto-unlock-on-boot (no stored key file).
2. After reboot the FS shows in the UI as Unmounted (correct — the \`locked\` flag is keyring-aware) but actually fails the engine-level mount.
3. User clicks **Unlock**, enters passphrase. \`/proc/keys\` now has \`bcachefs:<uuid>\`. UI still shows \"Unmounted\" — also correct, since the \`locked\` flag now reports false.
4. User clicks **Mount**. Toast: *\"bcachefs command failed: encrypted filesystem 'first' is locked — unlock it first, then mount.\"*

UI and engine disagreed. The \`locked\` flag is computed from the keyring (PR #115 fixed its parser). But \`mount_with_opts\` ignores the keyring entirely — it only checks for a stored key file at \`/var/lib/nasty/keys/<name>.key\`, and if that file's missing it errors with \"is locked\" regardless of what's actually in the keyring.

## Fix

In \`mount_with_opts\`, between the stored-key-file path and the error path, add a keyring check using the existing \`is_bcachefs_key_loaded(uuid)\` helper:

\`\`\`rust
if opts.encrypted == Some(true) {
    let key_path = format!(\"{KEYS_DIR}/{name}.key\");
    if Path::new(&key_path).exists() {
        // Path 1: auto-unlock with stored key file.
        cmd::run_ok(\"bcachefs\", &[\"unlock\", \"-k\", \"session\", \"-f\", &key_path, first_device]).await?;
    } else if !is_bcachefs_key_loaded(&fs.uuid).await {
        // Path 3: genuinely locked — user needs to unlock first.
        return Err(\"encrypted filesystem '{name}' is locked — unlock it first, then mount.\");
    }
    // Path 2 (newly handled): key is already in the keyring from an
    // earlier explicit unlock. Kernel will use it during `bcachefs mount`.
}
\`\`\`

Three named paths now (was two with no fallthrough for path 2), comment block in the diff explains.

## Why this matches PR #115's spirit

PR #115 fixed \`proc_keys_has_bcachefs_uuid\` and \`parse_bcachefs_key_id\` for the \`locked\` flag and the Lock button. After that fix, the UI correctly reports the FS as unlocked once the keyring has the key. This PR makes \`mount\` agree.

## Test plan

- [x] \`cargo test -p nasty-storage --lib\` — 21 passing
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [ ] **Manual on 10.10.10.61** (after merge + redeploy):
  - Reboot box → FS shows Unmounted with Lock badge (since at boot the keyring is empty).
  - Click Unlock, enter passphrase → FS shows Unmounted (no Lock badge), Mount button enabled.
  - Click Mount → mount succeeds. Pre-fix: same click produced the toast in the screenshot.
  - With \"Store key for auto-unlock on boot\" enabled: behaviour unchanged — stored-key path still preferred.

## Separately — boot alert (the second thing you flagged)

I checked the engine log on the box: the FS *was* recorded in \`mount_failures\` at boot (\`CRITICAL: 1 filesystem(s) failed to mount: first\` is in the log). PR #115's alert generator should turn that into a **Warning** alert *\"Filesystem 'first' is encrypted and locked — unlock it to mount.\"*

A Warning-level alert lives only on the alerts page (\`/alerts\`) and the dashboard alert counter. The Filesystems page itself doesn't render mount-failure alerts inline next to the affected FS row, which I suspect is what \"no alert\" actually means in your screenshot. If so, that's a UX gap (\"surface mount-failure alerts on the Filesystems page card\") rather than a missing-alert bug. Want me to open a follow-up to inline the warning on the FS card itself? Could be a 5-line change once we agree on placement.