### PR TITLE
fs: impact-preview dialog before locking encrypted filesystems (#86)

### DIFF
--- a/engine/nasty-engine/src/fs_dependents.rs
+++ b/engine/nasty-engine/src/fs_dependents.rs
@@ -1,0 +1,187 @@
+//! Aggregate "what depends on this filesystem" across services.
+//!
+//! Backs the impact-preview dialog before destructive FS operations
+//! (currently the encrypted-FS Lock action — see issue #86's discussion).
+//! Walks each downstream service that can reference a filesystem path,
+//! returns names/IDs grouped by service. Read-only — never mutates.
+//!
+//! Matching strategy: most services store a path. We treat a path as
+//! "depending on FS X" when it lives under `/fs/<X>/` (the canonical
+//! NASty mount root, see `NASTY_MOUNT_BASE` in nasty-storage). Paths
+//! that point to `/dev/loopN` are mapped to the underlying subvolume's
+//! filesystem via `Subvolume.block_device` — that's how VM disks and
+//! iSCSI/NVMe-oF backstores get detected.
+//!
+//! This module deliberately doesn't `tokio::join!` the queries —
+//! list-call latency is dominated by `apps.list()` (Docker round-trip)
+//! and parallelizing the others doesn't move the wall clock noticeably.
+//! Sequential keeps the failure mode trivial: one slow service blocks
+//! the rest, but the dialog is acceptable up to several hundred ms.
+
+use std::collections::HashSet;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::AppState;
+
+/// Names/IDs of every downstream entity that depends on a given
+/// filesystem. Empty fields are serialized as `[]` so the WebUI can
+/// render unconditionally without null-checking.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct FsDependents {
+    pub filesystem: String,
+    pub mounted: bool,
+    pub subvolumes: Vec<String>,
+    pub apps: Vec<String>,
+    pub vms: Vec<String>,
+    pub backup_jobs: Vec<String>,
+    pub nfs_shares: Vec<String>,
+    pub smb_shares: Vec<String>,
+    pub iscsi_targets: Vec<String>,
+    pub nvmeof_subsystems: Vec<String>,
+}
+
+/// True if `path` falls under `/fs/<fs_name>/` (the canonical NASty
+/// mount root). Trailing slash matters: without it `/fs/tank2` would
+/// match a query for FS `tank`.
+fn path_belongs_to_fs(path: &str, fs_name: &str) -> bool {
+    let prefix = format!("/fs/{fs_name}/");
+    path.starts_with(&prefix) || path == format!("/fs/{fs_name}")
+}
+
+/// Build the dependents view by querying every service that can hold
+/// a filesystem reference. Best-effort: a service that errors out
+/// contributes an empty list rather than failing the whole query.
+pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
+    let mut out = FsDependents {
+        filesystem: fs_name.to_string(),
+        ..Default::default()
+    };
+
+    // Filesystem mount state — orients the UI message ("currently
+    // mounted, will be unmounted" vs "already unmounted, only
+    // revoking the key").
+    if let Ok(fs) = state.filesystems.get(fs_name).await {
+        out.mounted = fs.mounted;
+    }
+
+    // Subvolumes are the cheapest hop: we already filter by fs.
+    let subvols = state
+        .subvolumes
+        .list_all(Some(fs_name), None)
+        .await
+        .unwrap_or_default();
+    // Block devices owned by subvolumes on this FS — used to detect
+    // VM disks / iSCSI backstores / NVMe-oF namespaces that reference
+    // them by `/dev/loopN` rather than path.
+    let block_devs: HashSet<String> = subvols
+        .iter()
+        .filter_map(|s| s.block_device.clone())
+        .collect();
+    out.subvolumes = subvols.into_iter().map(|s| s.name).collect();
+
+    // Apps: when the docker storage is on this FS, every app is on
+    // it (their layered images, named volumes, default bind base
+    // all live under the apps storage path). Per-app bind mounts
+    // outside that base are a refinement we can add later — they're
+    // surfaced via app inspect, not the lightweight `list()`.
+    let apps_status = state.apps.status().await;
+    if apps_status
+        .storage_path
+        .as_deref()
+        .is_some_and(|p| path_belongs_to_fs(p, fs_name))
+        && let Ok(apps) = state.apps.list().await
+    {
+        out.apps = apps.into_iter().map(|a| a.name).collect();
+    }
+
+    // VMs: disk path either under /fs/<X>/... directly, or a loop
+    // device that's the block_device of a subvolume on this FS.
+    if let Ok(vms) = state.vms.list().await {
+        for vm in vms {
+            let touches_fs = vm
+                .config
+                .disks
+                .iter()
+                .any(|d| path_belongs_to_fs(&d.path, fs_name) || block_devs.contains(&d.path));
+            if touches_fs {
+                out.vms.push(vm.config.name);
+            }
+        }
+    }
+
+    // Backup jobs: any source under /fs/<X>/. A job pointing only
+    // somewhere else (e.g. a subset of a different FS) is left alone.
+    let profiles = state.backups.list_profiles().await;
+    for p in profiles {
+        if p.sources.iter().any(|src| path_belongs_to_fs(src, fs_name)) {
+            out.backup_jobs.push(p.name);
+        }
+    }
+
+    // Shares: NFS/SMB use a single `path`; iSCSI/NVMe-oF use device
+    // paths that are usually loop devices for block subvolumes.
+    if let Ok(shares) = state.nfs.list().await {
+        out.nfs_shares = shares
+            .into_iter()
+            .filter(|s| path_belongs_to_fs(&s.path, fs_name))
+            .map(|s| s.id)
+            .collect();
+    }
+    if let Ok(shares) = state.smb.list().await {
+        out.smb_shares = shares
+            .into_iter()
+            .filter(|s| path_belongs_to_fs(&s.path, fs_name))
+            .map(|s| s.name)
+            .collect();
+    }
+    if let Ok(targets) = state.iscsi.list().await {
+        out.iscsi_targets = targets
+            .into_iter()
+            .filter(|t| {
+                t.luns.iter().any(|l| {
+                    path_belongs_to_fs(&l.backstore_path, fs_name)
+                        || block_devs.contains(&l.backstore_path)
+                })
+            })
+            .map(|t| t.iqn)
+            .collect();
+    }
+    if let Ok(subs) = state.nvmeof.list().await {
+        out.nvmeof_subsystems = subs
+            .into_iter()
+            .filter(|s| {
+                s.namespaces.iter().any(|n| {
+                    path_belongs_to_fs(&n.device_path, fs_name)
+                        || block_devs.contains(&n.device_path)
+                })
+            })
+            .map(|s| s.nqn)
+            .collect();
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_match_handles_prefix_and_exact() {
+        // Trailing slash matters — without it /fs/tank2 would falsely
+        // match a query for /fs/tank.
+        assert!(path_belongs_to_fs("/fs/tank/foo", "tank"));
+        assert!(path_belongs_to_fs("/fs/tank/sub/file", "tank"));
+        // Exact match (no trailing slash, no children) — the FS
+        // mount-point itself, not a child path.
+        assert!(path_belongs_to_fs("/fs/tank", "tank"));
+        // Sibling-prefix attack: /fs/tank2 must not match `tank`.
+        assert!(!path_belongs_to_fs("/fs/tank2/foo", "tank"));
+        assert!(!path_belongs_to_fs("/fs/tank2", "tank"));
+        // Other roots untouched.
+        assert!(!path_belongs_to_fs("/var/lib/nasty", "tank"));
+        assert!(!path_belongs_to_fs("", "tank"));
+    }
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::{prelude::*, reload};
 mod app_deploy;
 mod auth;
 mod auth_oidc;
+mod fs_dependents;
 mod log_stream;
 mod router;
 mod telemetry;

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -120,6 +120,7 @@ fn is_read_only(method: &str) -> bool {
                 | "auth.me"
                 | "auth.list_users"
                 | "auth.token.list"
+                | "fs.dependents"
                 | "fs.usage"
                 | "fs.scrub.status"
                 | "fs.reconcile.status"
@@ -1404,6 +1405,15 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
                 Ok(fs) => ok(req, fs),
                 Err(e) => err(req, e),
             },
+            Err(r) => r,
+        },
+        // Read-only impact preview before destructive FS operations.
+        // Powers the rich Lock confirmation dialog (issue #86 follow-up).
+        "fs.dependents" => match require_str(req, "name") {
+            Ok(name) => ok(
+                req,
+                crate::fs_dependents::find_dependents(state, name).await,
+            ),
             Err(r) => r,
         },
         "fs.key.export" => match require_str(req, "name") {

--- a/webui/src/lib/components/ConfirmDialog.svelte
+++ b/webui/src/lib/components/ConfirmDialog.svelte
@@ -16,7 +16,13 @@
 		<DialogHeader>
 			<DialogTitle>{confirmState.title}</DialogTitle>
 			{#if confirmState.message}
-				<DialogDescription>{confirmState.message}</DialogDescription>
+				<!-- whitespace-pre-line preserves embedded `\n` as line breaks
+				     while collapsing other whitespace runs. Lets callers pass
+				     multi-line messages (e.g. the FS-dependents impact preview)
+				     without having to switch to a richer dialog component. -->
+				<DialogDescription class="whitespace-pre-line"
+					>{confirmState.message}</DialogDescription
+				>
 			{/if}
 		</DialogHeader>
 		<DialogFooter class="gap-2">

--- a/webui/src/lib/fs-dependents.test.ts
+++ b/webui/src/lib/fs-dependents.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeDependents } from './fs-dependents';
+import type { FsDependents } from './types';
+
+function deps(over: Partial<FsDependents> = {}): FsDependents {
+	return {
+		filesystem: 'tank',
+		mounted: true,
+		subvolumes: [],
+		apps: [],
+		vms: [],
+		backup_jobs: [],
+		nfs_shares: [],
+		smb_shares: [],
+		iscsi_targets: [],
+		nvmeof_subsystems: [],
+		...over,
+	};
+}
+
+describe('summarizeDependents', () => {
+	it('returns null when nothing depends on the filesystem', () => {
+		// Caller short-circuits to the simple confirm dialog when this
+		// helper returns null — no point listing zero things.
+		expect(summarizeDependents(deps())).toBeNull();
+	});
+
+	it('singular noun when only one item in a category', () => {
+		// "1 app (jellyfin)" not "1 apps (jellyfin)". Hand-rolled
+		// pluralization is fragile but the labels are hand-curated.
+		const summary = summarizeDependents(deps({ apps: ['jellyfin'] }));
+		expect(summary).toBe('• 1 app (jellyfin)');
+	});
+
+	it('plural noun and comma-joined names when multiple items', () => {
+		// Issue #86 reproducer-style content: jellyfin + transmission
+		// running on the FS. The summary line shows count + names.
+		const summary = summarizeDependents(deps({ apps: ['jellyfin', 'transmission'] }));
+		expect(summary).toBe('• 2 apps (jellyfin, transmission)');
+	});
+
+	it('emits one bullet per non-empty category, in stable order', () => {
+		// Order matters for predictable rendering across reloads.
+		// Subvolumes first, then apps, then VMs, etc. — matches
+		// the order users typically scan.
+		const summary = summarizeDependents(
+			deps({
+				subvolumes: ['data'],
+				apps: ['jellyfin'],
+				vms: ['win11'],
+			}),
+		);
+		expect(summary).toBe(
+			'• 1 subvolume (data)\n' + '• 1 app (jellyfin)\n' + '• 1 VM (win11)',
+		);
+	});
+
+	it('caps the inline list at 5 items with a +N more summary', () => {
+		// Busy box could have 30 backup jobs touching the FS — we
+		// truncate so the dialog doesn't sprawl. The cap is exposed
+		// in this test so a future tweak shows up here first.
+		const apps = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+		const summary = summarizeDependents(deps({ apps }));
+		expect(summary).toBe('• 7 apps (a, b, c, d, e, … +2 more)');
+	});
+
+	it('formats VMs with the uppercase label', () => {
+		// Hand-curated label list keeps the abbreviation correct.
+		const summary = summarizeDependents(deps({ vms: ['lin', 'win'] }));
+		expect(summary).toBe('• 2 VMs (lin, win)');
+	});
+});

--- a/webui/src/lib/fs-dependents.ts
+++ b/webui/src/lib/fs-dependents.ts
@@ -1,0 +1,44 @@
+import type { FsDependents } from './types';
+
+/** Build a human-readable summary of which downstream entities depend
+ * on a filesystem, suitable for a confirmation dialog body. Returns
+ * `null` when nothing depends on the FS (caller should use the
+ * lighter "are you sure?" prompt instead). Pure — no DOM, easy
+ * to unit-test. */
+export function summarizeDependents(deps: FsDependents): string | null {
+	const groups: { label: string; items: string[] }[] = [
+		{ label: 'subvolume', items: deps.subvolumes },
+		{ label: 'app', items: deps.apps },
+		{ label: 'VM', items: deps.vms },
+		{ label: 'backup job', items: deps.backup_jobs },
+		{ label: 'NFS share', items: deps.nfs_shares },
+		{ label: 'SMB share', items: deps.smb_shares },
+		{ label: 'iSCSI target', items: deps.iscsi_targets },
+		{ label: 'NVMe-oF subsystem', items: deps.nvmeof_subsystems },
+	];
+	const non_empty = groups.filter((g) => g.items.length > 0);
+	if (non_empty.length === 0) return null;
+
+	const lines = non_empty.map((g) => `• ${formatLine(g.label, g.items)}`);
+	return lines.join('\n');
+}
+
+/** Format one group as a single line: `• 2 apps (jellyfin, transmission)`.
+ * Pluralization is naive — singular/plural by trailing `s` — and we
+ * cap the inline name list at 5 to keep the dialog from growing
+ * unbounded on busy boxes; the rest get a `… +N more` summary. */
+function formatLine(label: string, items: string[]): string {
+	const noun = items.length === 1 ? label : pluralize(label);
+	const max = 5;
+	const shown = items.slice(0, max);
+	const more = items.length - shown.length;
+	const tail = more > 0 ? `${shown.join(', ')}, … +${more} more` : shown.join(', ');
+	return `${items.length} ${noun} (${tail})`;
+}
+
+function pluralize(label: string): string {
+	// "subvolume" → "subvolumes", "iSCSI target" → "iSCSI targets",
+	// "VM" → "VMs". The labels in `summarizeDependents` are
+	// hand-curated to make this trivial.
+	return `${label}s`;
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -111,6 +111,24 @@ export interface PassthroughConfig {
 	ids: PassthroughDeviceId[];
 }
 
+/** Aggregated view of everything that depends on a filesystem,
+ * returned by `fs.dependents`. Powers the impact-preview dialog
+ * before destructive operations like Lock — the WebUI lists these
+ * so the user sees what will break before they confirm. Empty
+ * arrays serialize as `[]` so consumers can render unconditionally. */
+export interface FsDependents {
+	filesystem: string;
+	mounted: boolean;
+	subvolumes: string[];
+	apps: string[];
+	vms: string[];
+	backup_jobs: string[];
+	nfs_shares: string[];
+	smb_shares: string[];
+	iscsi_targets: string[];
+	nvmeof_subsystems: string[];
+}
+
 export interface ServiceStatus {
 	name: string;
 	running: boolean;

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -15,7 +15,8 @@
 	);
 	import { confirm } from '$lib/confirm.svelte';
 	import { confirmDangerous } from '$lib/confirm-dangerous.svelte';
-	import type { Filesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, ReconcileStatus, TieringProfile, TieringProfileId } from '$lib/types';
+	import { summarizeDependents } from '$lib/fs-dependents';
+	import type { Filesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, ReconcileStatus, TieringProfile, TieringProfileId, FsDependents } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
@@ -555,11 +556,21 @@
 	}
 
 	async function lockFs(fs: Filesystem) {
-		const ok = await confirm(
-			`Lock Filesystem "${fs.name}"`,
-			`This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.`,
-			{ confirmLabel: 'Lock' },
-		);
+		// Pre-lock impact preview: ask the engine which apps/VMs/shares/
+		// backups touch this filesystem, then surface the concrete list
+		// in the confirm dialog. Failure to fetch is non-fatal — falls
+		// back to the generic warning, same as before this PR (#86).
+		let detail: string | null = null;
+		try {
+			const deps = await client.call<FsDependents>('fs.dependents', { name: fs.name });
+			detail = summarizeDependents(deps);
+		} catch { /* non-fatal — render the generic message */ }
+
+		const message = detail
+			? `Locking will unmount the filesystem and revoke its encryption key from the kernel. The following will stop or break until you unlock and remount:\n\n${detail}\n\nContinue?`
+			: `This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.`;
+
+		const ok = await confirm(`Lock Filesystem "${fs.name}"`, message, { confirmLabel: 'Lock' });
 		if (!ok) return;
 		await withToast(
 			() => client.call('fs.lock', { name: fs.name }, 120000),


### PR DESCRIPTION
First slice of @johnnyq's wishlist from [issue #86](https://github.com/nasty-project/nasty/issues/86#issuecomment-4415714748). Two follow-up PRs planned (auto-stop dependents, locked-volume badges on apps/VMs pages); this one ships the data primitive and the immediate UX win.

## Before / after

**Before** — generic warning regardless of context:
> *Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately…*

**After** — concrete list:
> *Locking will unmount the filesystem and revoke its encryption key from the kernel. The following will stop or break until you unlock and remount:*
>
> *• 2 apps (jellyfin, transmission)*
> *• 1 VM (win11)*
> *• 3 NFS shares (media, backups, photos)*
>
> *Continue?*

If nothing depends on the FS, the dialog falls back to the original simple message.

## Engine

New \`nasty-engine/src/fs_dependents.rs\` aggregates across services:

| Source | Match logic |
|---|---|
| Subvolumes | \`subvolume.filesystem == fs_name\` |
| Apps | docker storage path under \`/fs/<X>/\` → all apps |
| VMs | disk path under \`/fs/<X>/\` OR loop device matches a block subvolume on \`X\` |
| Backup jobs | any source under \`/fs/<X>/\` |
| NFS / SMB shares | share path under \`/fs/<X>/\` |
| iSCSI / NVMe-oF | LUN/namespace path under \`/fs/<X>/\` OR loop-device match |

Path matching is anchored — \`/fs/tank2/...\` correctly doesn't match a query for FS \`tank\`. Best-effort: a service that errors out contributes an empty list rather than failing the whole query.

New RPC \`fs.dependents\` (read-only, available to any role).

## WebUI

- \`\$lib/fs-dependents.ts::summarizeDependents\` — pure helper that builds the bullet-list message body from the typed response. Inline name list capped at 5 with \`… +N more\` so busy boxes don't sprawl the dialog. 6 unit tests.
- \`lockFs\` fetches \`fs.dependents\` before opening the confirm dialog. Fetch failure falls back to the old generic warning — the lock action is never blocked by the preview.
- \`ConfirmDialog\` gains \`whitespace-pre-line\` on the description so embedded \`\\n\` renders as line breaks. Single-paragraph callers are unaffected.

## What this PR is not (per scoping discussion)

- **Auto-stop dependents on lock** — adds timeout / partial-failure recovery surface, deferred. PR-B for issue #86.
- **Locked-volume badges on Apps/VMs pages** — cosmetic, builds directly on this PR's data primitive. PR-C.
- **Per-app bind mounts** — \`apps.list()\` doesn't expose volume bindings; getting that per-app would require an \`apps.inspect\` round-trip per app. The docker-storage-path heuristic catches the common case (apps storage on the locked FS → all apps affected); per-app bind mounts to other paths are a refinement worth doing only if it shows up in practice.

## Test plan

- [x] \`cargo test --workspace --lib\` — full pass (1 new \`path_match_*\` test in \`fs_dependents\`)
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4842 files, 0 errors, 0 warnings
- [x] \`npm --prefix webui run test\` — 101 passing (6 new for \`summarizeDependents\`)
- [ ] **Manual** on a box with at least one app + share on an encrypted FS:
  - Click Lock → dialog lists the app and share names.
  - Lock another encrypted FS with no dependents → dialog shows the simple fallback message.
  - Lock fails on dependents-fetch (e.g. apps daemon down) → dialog still appears with the fallback message; no spinner, no error toast.