### PR TITLE
fs: stop apps and VMs before locking encrypted FS (#86 PR-B)

### DIFF
--- a/engine/nasty-engine/Cargo.toml
+++ b/engine/nasty-engine/Cargo.toml
@@ -37,3 +37,9 @@ tokio-util = { workspace = true, features = ["io"] }
 openidconnect = { version = "4", default-features = false, features = ["accept-rfc3339-timestamps", "accept-string-booleans"] }
 http = "1"
 url = "2"
+
+[dev-dependencies]
+# `test-util` enables tokio::time::pause/start_paused for fs_lock's
+# wait-with-timeout tests. The `tokio = { features = ["full"] }`
+# workspace dep doesn't include test-util.
+tokio = { workspace = true, features = ["test-util"] }

--- a/engine/nasty-engine/src/fs_lock.rs
+++ b/engine/nasty-engine/src/fs_lock.rs
@@ -1,0 +1,208 @@
+//! Lock-with-dependents orchestration for encrypted filesystems.
+//!
+//! Issue #86 follow-up to the impact-preview dialog (#124). When the
+//! user clicks Lock and confirms, we want to actually carry out the
+//! cascade — stop apps and VMs that touch the FS, then unmount and
+//! revoke the key — instead of leaving the unmount to fail with EBUSY
+//! and the user with a half-broken state.
+//!
+//! Order of operations:
+//!   1. App containers (docker stop, blocking; uses Docker's own
+//!      stop-then-kill timeout).
+//!   2. VMs (QMP `system_powerdown`, then poll for shutdown up to
+//!      `VM_SHUTDOWN_TIMEOUT`, fall back to `kill` if still running).
+//!   3. The underlying `FilesystemService::lock(name)` (unmount +
+//!      keyctl unlink, unchanged from before).
+//!
+//! Out of scope (deliberately, see PR description):
+//! - Backup jobs: scheduled, idempotent on failure. Letting them try
+//!   and fail post-lock is acceptable; their next run after unlock
+//!   succeeds normally. Actively killing a running rclone/restic mid-
+//!   transfer is a worse outcome than letting it error.
+//! - Shares (NFS/SMB/iSCSI/NVMe-oF): the daemons tolerate a missing
+//!   path. Clients see I/O errors that recover when the FS comes
+//!   back. Stopping the daemons would also affect *other* shares on
+//!   other filesystems, which is too broad.
+//!
+//! Failure modes:
+//! - App stop fails → abort, report which app, leave anything we
+//!   already stopped *stopped* (don't try to "undo" — adds another
+//!   failure surface and the user just confirmed they want the lock).
+//! - VM graceful shutdown times out → force-kill and continue. The
+//!   user wanted the lock; an unresponsive guest doesn't get a veto.
+
+use std::time::Duration;
+
+use nasty_storage::filesystem::Filesystem;
+use tracing::{info, warn};
+
+use crate::AppState;
+use crate::fs_dependents::find_dependents;
+
+/// How long to wait for a VM to shut down gracefully before falling
+/// back to kill. Generous because Windows guests can take 30+ seconds
+/// to honor system_powerdown when busy.
+const VM_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Polling interval for the VM-shutdown wait loop. 1s keeps the
+/// total `lock` latency tight without thrashing the engine.
+const VM_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Lock an encrypted filesystem after stopping its dependents. Wraps
+/// the lower-level `FilesystemService::lock` so the storage layer
+/// doesn't need to know about apps/VMs/shares — orchestration lives
+/// here in the engine layer where `AppState` is.
+pub async fn lock_with_dependents(state: &AppState, fs_name: &str) -> Result<Filesystem, String> {
+    let deps = find_dependents(state, fs_name).await;
+
+    // Apps first: docker stop is blocking, runs Docker's stop-then-kill
+    // timeout, returns when the container is actually stopped. Errors
+    // bubble up immediately because there's no clean recovery — if
+    // we can't stop an app, the FS will refuse to unmount anyway.
+    for app in &deps.apps {
+        info!("Lock cascade: stopping app '{app}'");
+        if let Err(e) = state.apps.stop(app).await {
+            return Err(format!(
+                "lock aborted: app '{app}' failed to stop ({e}). \
+                 Stopped apps are not restarted automatically — \
+                 see Apps page once the issue is resolved."
+            ));
+        }
+    }
+
+    // VMs: graceful shutdown via QMP, then poll. If the guest doesn't
+    // honor it within VM_SHUTDOWN_TIMEOUT, force-kill. This matches
+    // user intent: they confirmed they want the lock; an unresponsive
+    // guest shouldn't block it.
+    for vm_name in &deps.vms {
+        if !is_vm_running(state, vm_name).await {
+            continue;
+        }
+        info!("Lock cascade: requesting graceful shutdown of VM '{vm_name}'");
+        if let Err(e) = state.vms.stop(vm_name).await {
+            warn!("Lock cascade: VM '{vm_name}' stop request failed: {e}; trying kill");
+        } else if wait_until_stopped(
+            || async { !is_vm_running(state, vm_name).await },
+            VM_SHUTDOWN_TIMEOUT,
+            VM_POLL_INTERVAL,
+        )
+        .await
+        {
+            continue;
+        }
+
+        warn!(
+            "Lock cascade: VM '{vm_name}' didn't shut down in {VM_SHUTDOWN_TIMEOUT:?}, force-killing"
+        );
+        if let Err(e) = state.vms.kill(vm_name).await {
+            return Err(format!(
+                "lock aborted: VM '{vm_name}' didn't shut down gracefully and force-kill failed ({e}). \
+                 Manually stop the VM, then retry."
+            ));
+        }
+    }
+
+    // Now the FS is quiescent — drop to the storage-layer lock for the
+    // actual unmount + key revoke.
+    state
+        .filesystems
+        .lock(fs_name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn is_vm_running(state: &AppState, name: &str) -> bool {
+    state
+        .vms
+        .list()
+        .await
+        .ok()
+        .and_then(|vms| vms.into_iter().find(|v| v.config.name == name))
+        .is_some_and(|v| v.running)
+}
+
+/// Poll `predicate` every `interval` up to `timeout`. Returns true
+/// when the predicate first becomes true, false on timeout. Pulled
+/// out so the timeout/poll math is unit-testable without spinning up
+/// real services.
+async fn wait_until_stopped<F, Fut>(predicate: F, timeout: Duration, interval: Duration) -> bool
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if predicate().await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_returns_true_immediately_when_predicate_starts_true() {
+        // Common case: app stop returned, VM was already stopped, etc.
+        // Don't spin pointlessly — first check should short-circuit.
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result = wait_until_stopped(
+            move || {
+                let c = calls_c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    true
+                }
+            },
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+        )
+        .await;
+        assert!(result);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_returns_true_when_predicate_flips_mid_poll() {
+        // Realistic scenario: VM takes 5s to shut down. Predicate
+        // returns false initially, then true once shutdown completes.
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_c = calls.clone();
+        let result = wait_until_stopped(
+            move || {
+                let c = calls_c.clone();
+                async move {
+                    let n = c.fetch_add(1, Ordering::SeqCst);
+                    // Stops pretending-to-run on the 4th call (3 polls in).
+                    n >= 3
+                }
+            },
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+        )
+        .await;
+        assert!(result);
+        assert!(calls.load(Ordering::SeqCst) >= 4);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_returns_false_on_timeout() {
+        // Stuck VM scenario: predicate stays false. Waiter must give
+        // up at the deadline so caller can fall back to kill.
+        let result = wait_until_stopped(
+            || async { false },
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+        )
+        .await;
+        assert!(!result);
+    }
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -19,6 +19,7 @@ mod app_deploy;
 mod auth;
 mod auth_oidc;
 mod fs_dependents;
+mod fs_lock;
 mod log_stream;
 mod router;
 mod telemetry;

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -1401,7 +1401,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             Err(e) => invalid(req, e),
         },
         "fs.lock" => match require_str(req, "name") {
-            Ok(name) => match state.filesystems.lock(name).await {
+            Ok(name) => match crate::fs_lock::lock_with_dependents(state, name).await {
                 Ok(fs) => ok(req, fs),
                 Err(e) => err(req, e),
             },

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -561,17 +561,33 @@
 		// in the confirm dialog. Failure to fetch is non-fatal — falls
 		// back to the generic warning, same as before this PR (#86).
 		let detail: string | null = null;
+		let willStop = false;
 		try {
 			const deps = await client.call<FsDependents>('fs.dependents', { name: fs.name });
 			detail = summarizeDependents(deps);
+			// Apps and VMs get actively stopped by the engine before
+			// unmount (PR-B follow-up). Shares/backups are left alone
+			// (the engine's lock_with_dependents comments explain why)
+			// — they'll error gracefully on the next access.
+			willStop = deps.apps.length > 0 || deps.vms.length > 0;
 		} catch { /* non-fatal — render the generic message */ }
 
-		const message = detail
-			? `Locking will unmount the filesystem and revoke its encryption key from the kernel. The following will stop or break until you unlock and remount:\n\n${detail}\n\nContinue?`
-			: `This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.`;
+		let message: string;
+		if (detail && willStop) {
+			message = `Locking will stop the following apps and VMs, then unmount the filesystem and revoke its encryption key from the kernel:\n\n${detail}\n\nApps stop immediately. VMs are asked to shut down gracefully (up to 60s) before being force-killed. They will not be restarted automatically when you unlock the filesystem.\n\nContinue?`;
+		} else if (detail) {
+			message = `Locking will unmount the filesystem and revoke its encryption key from the kernel. The following will see I/O errors until you unlock and remount:\n\n${detail}\n\nContinue?`;
+		} else {
+			message = `This will unmount the filesystem and revoke the encryption key from the kernel. Any NFS, SMB, iSCSI, or NVMe-oF shares, apps, or VMs running on this filesystem will stop immediately and stay broken until you unlock it again with the passphrase.`;
+		}
 
-		const ok = await confirm(`Lock Filesystem "${fs.name}"`, message, { confirmLabel: 'Lock' });
+		const ok = await confirm(`Lock Filesystem "${fs.name}"`, message, {
+			confirmLabel: willStop ? 'Stop and Lock' : 'Lock',
+		});
 		if (!ok) return;
+		// Bumped timeout: the engine cascade can take up to ~60s if a VM
+		// drags on graceful shutdown. The default 120s already covered
+		// long unmounts; this comment is just to document expectations.
 		await withToast(
 			() => client.call('fs.lock', { name: fs.name }, 120000),
 			`Filesystem "${fs.name}" locked`,


### PR DESCRIPTION
**Stacked on #124.** Merge that first; this PR's diff against \`main\` will compress once it lands.

Second slice of @johnnyq's wishlist on issue #86. PR #124 made the impact dialog concrete; this PR makes the engine actually carry out what the dialog promises.

## What changes for the user

**Before**: clicking Lock on a filesystem with a running app/VM produced a cryptic toast (\`umount: target is busy\`) at the unmount step. The user had to manually \`docker stop\` / shut down VMs first, then retry.

**After**: the dialog body, button label, and behaviour match what's about to happen.

- With apps/VMs running on the FS:
  > *Locking will stop the following apps and VMs, then unmount the filesystem and revoke its encryption key from the kernel:*
  >
  > *• 2 apps (jellyfin, transmission)*
  > *• 1 VM (win11)*
  >
  > *Apps stop immediately. VMs are asked to shut down gracefully (up to 60s) before being force-killed. They will not be restarted automatically when you unlock the filesystem.*
  >
  > Button: **Stop and Lock**

- With only passive dependents (shares, backup jobs, bare subvolumes): the dialog stays in the "you will see I/O errors" mode and the button stays \`Lock\`.

## Engine

New \`nasty-engine/src/fs_lock.rs\`:

- \`lock_with_dependents(state, fs_name)\` orchestrates: apps via \`docker stop\` (blocking); VMs via QMP \`system_powerdown\` + 60s poll + fall-back to force-kill; then the existing \`FilesystemService::lock\` (unmount + keyctl unlink).
- Lives in the engine layer, not \`nasty-storage\` — the storage module shouldn't need to know about apps/VMs/shares. Layering preserved.
- \`wait_until_stopped(predicate, timeout, interval)\` polling helper, pulled out as a generic so it's unit-testable without real services. 3 tests cover starts-true short-circuit, mid-poll flip, timeout fall-through. Uses \`tokio::test(start_paused = true)\` so the 60s/1s timings don't actually elapse.
- \`nasty-engine\` Cargo.toml adds \`tokio = { features = ["test-util"] }\` to dev-dependencies — the workspace's \`features = ["full"]\` doesn't include \`test-util\` despite the name. (Same explicit-add pattern \`nasty-system\` already uses.)

Router: \`fs.lock\` now routes through \`lock_with_dependents\` instead of calling \`state.filesystems.lock\` directly. Same payload shape.

## Failure-mode design

- **App stop fails** → abort with a clear error naming the offending app. Previously-stopped apps stay stopped — no "undo" dance, since undoing has its own failure surface and the user just confirmed they want the lock.
- **VM doesn't shut down in 60s** → force-kill and continue. The user wanted the lock; an unresponsive guest doesn't get a veto. The 60s window is generous (Windows Update mid-shutdown can hold for 30+s) without being so long it makes the UI look hung.
- **VM force-kill fails too** → abort with "manually stop the VM, then retry" message.

## What this PR is not (PR-C scope)

- Locked-volume badges + click-to-unlock on the Apps/VMs cards. Builds on #124's data primitive; small follow-up.
- Auto-restart apps/VMs on unlock. Decided against — the user's mental model after a Lock is "I deliberately took this offline"; surprise auto-restart on Unlock would be worse than the current "you click Start to bring things back".

## Why backups + shares are deliberately untouched

- **Backups**: killing rclone/restic mid-transfer is a worse outcome than letting the next scheduled run error out (the failing-but-recoverable path is well-trodden by both tools).
- **Shares**: stopping NFS/SMB/iSCSI/NVMe-oF daemons would also stop shares pointing at *other* filesystems on the box. Too broad. Daemons handle the missing-path case fine — clients see I/O errors that recover when the FS comes back.

## Test plan

- [x] \`cargo test --workspace --lib\` — full pass (3 new \`fs_lock::tests::wait_*\`)
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — clean
- [x] \`npm --prefix webui run test\` — 101 passing
- [ ] **Manual** with at least one running app + one running VM on an encrypted FS:
  - Click Lock → dialog says "Stop and Lock" → confirm → engine logs show stopping each in order → unmount + key revoke → FS appears Locked with no kernel-buffered key.
  - Click Lock with a wedged VM (\`stop -SIGSTOP $qemu_pid\` to simulate) → dialog confirms → 60s elapses → engine logs force-kill → lock proceeds.
  - Click Lock with no dependents → original simple "Lock" flow, unchanged.