### PR TITLE
fs: locked-volume badges + click-to-unlock on Apps & VMs (#86 PR-C)

### DIFF
--- a/engine/nasty-engine/src/fs_dependents.rs
+++ b/engine/nasty-engine/src/fs_dependents.rs
@@ -164,6 +164,35 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
     out
 }
 
+/// Reverse-index of currently-locked encrypted filesystems → what
+/// would come back to life if they were unlocked. Powers the
+/// "🔒 on tank" badges on the Apps and VMs pages: those pages need
+/// to know "is *my* app/VM blocked by a locked FS, and which one?"
+/// without hitting `find_dependents` per FS in the browser.
+///
+/// Only includes FSes that are currently encrypted AND locked AND
+/// have at least one app or VM among their dependents — empty
+/// entries would just be wire bytes the UI filters back out.
+pub async fn find_locked_dependents(state: &AppState) -> Vec<FsDependents> {
+    let Ok(filesystems) = state.filesystems.list().await else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for fs in filesystems {
+        // Only encrypted-and-locked is interesting here. A plain
+        // unmounted FS has no badge story; an encrypted-but-unlocked
+        // one is just waiting for `fs.mount`.
+        if fs.options.encrypted != Some(true) || fs.options.locked != Some(true) {
+            continue;
+        }
+        let deps = find_dependents(state, &fs.name).await;
+        if !deps.apps.is_empty() || !deps.vms.is_empty() {
+            out.push(deps);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -121,6 +121,7 @@ fn is_read_only(method: &str) -> bool {
                 | "auth.list_users"
                 | "auth.token.list"
                 | "fs.dependents"
+                | "fs.locked_dependents"
                 | "fs.usage"
                 | "fs.scrub.status"
                 | "fs.reconcile.status"
@@ -1416,6 +1417,14 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
             ),
             Err(r) => r,
         },
+        // Reverse-index for the Apps/VMs pages: which apps/VMs are
+        // blocked by a locked encrypted FS, grouped by FS so the
+        // badge can name the blocker. Returns empty list when no
+        // encrypted FS is currently locked.
+        "fs.locked_dependents" => ok(
+            req,
+            crate::fs_dependents::find_locked_dependents(state).await,
+        ),
         "fs.key.export" => match require_str(req, "name") {
             Ok(name) => match state.filesystems.export_key(name).await {
                 Ok(key) => ok(req, key),

--- a/webui/src/lib/components/UnlockFsDialog.svelte
+++ b/webui/src/lib/components/UnlockFsDialog.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { unlockFsState, unlockFsRespond } from '$lib/unlock-fs.svelte';
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import {
+		Dialog,
+		DialogContent,
+		DialogHeader,
+		DialogTitle,
+		DialogDescription,
+		DialogFooter,
+	} from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+
+	let passphrase = $state('');
+	let submitting = $state(false);
+
+	async function submit() {
+		if (!passphrase || submitting) return;
+		const name = unlockFsState.fsName;
+		submitting = true;
+		const result = await withToast(
+			() => getClient().call('fs.unlock', { name, passphrase }),
+			`Filesystem "${name}" unlocked`,
+		);
+		submitting = false;
+		passphrase = '';
+		// `withToast` resolves to undefined on RPC failure (the
+		// toast renders the error). Either way the dialog closes —
+		// the caller decides what to do next based on the boolean.
+		unlockFsRespond(result !== undefined);
+	}
+
+	function cancel() {
+		passphrase = '';
+		unlockFsRespond(false);
+	}
+
+	// Wipe the passphrase whenever the dialog re-opens for a different
+	// filesystem so a typed-but-not-submitted secret doesn't leak
+	// across opens.
+	$effect(() => {
+		if (unlockFsState.open) {
+			passphrase = '';
+			submitting = false;
+		}
+	});
+</script>
+
+<Dialog
+	open={unlockFsState.open}
+	onOpenChange={(v) => {
+		if (!v) cancel();
+	}}
+>
+	<DialogContent class="max-w-sm">
+		<DialogHeader>
+			<DialogTitle>Unlock "{unlockFsState.fsName}"</DialogTitle>
+			<DialogDescription>
+				Enter the passphrase to unlock this encrypted filesystem.
+			</DialogDescription>
+		</DialogHeader>
+		<input
+			type="password"
+			bind:value={passphrase}
+			class="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
+			placeholder="Passphrase"
+			onkeydown={(e) => {
+				if (e.key === 'Enter') submit();
+			}}
+			disabled={submitting}
+		/>
+		<DialogFooter class="gap-2">
+			<Button variant="outline" onclick={cancel} disabled={submitting}>Cancel</Button>
+			<Button onclick={submit} disabled={!passphrase || submitting}>
+				{submitting ? 'Unlocking…' : 'Unlock'}
+			</Button>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>

--- a/webui/src/lib/unlock-fs.svelte.ts
+++ b/webui/src/lib/unlock-fs.svelte.ts
@@ -1,0 +1,42 @@
+/**
+ * Imperative unlock-encrypted-FS dialog. Mount <UnlockFsDialog /> once
+ * in the root layout, then call from anywhere:
+ *
+ *   if (await unlockFs('tank')) { /* refresh local state *\/ }
+ *
+ * Resolves to true when the unlock RPC succeeds (FS keyring now has
+ * the key), false when the user cancels or the RPC fails. Toast
+ * handling is built in — callers don't need their own withToast.
+ *
+ * Used by:
+ *  - the Filesystems page (replaces its inline modal),
+ *  - the Apps and VMs pages, where a locked-FS badge offers
+ *    inline unlock without forcing the user to navigate away.
+ */
+
+interface UnlockFsState {
+	open: boolean;
+	fsName: string;
+	resolve: ((v: boolean) => void) | null;
+}
+
+export const unlockFsState = $state<UnlockFsState>({
+	open: false,
+	fsName: '',
+	resolve: null,
+});
+
+export function unlockFs(fsName: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		unlockFsState.fsName = fsName;
+		unlockFsState.resolve = resolve;
+		unlockFsState.open = true;
+	});
+}
+
+export function unlockFsRespond(value: boolean) {
+	unlockFsState.open = false;
+	unlockFsState.resolve?.(value);
+	unlockFsState.resolve = null;
+	unlockFsState.fsName = '';
+}

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
 	import Toasts from '$lib/components/Toasts.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import ConfirmDangerousDialog from '$lib/components/ConfirmDangerousDialog.svelte';
+	import UnlockFsDialog from '$lib/components/UnlockFsDialog.svelte';
 	import ReconnectSpinner from '$lib/components/ReconnectSpinner.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
@@ -547,6 +548,7 @@
 <Toasts />
 <ConfirmDialog />
 <ConfirmDangerousDialog />
+<UnlockFsDialog />
 
 {#if showLogin}
 	<div class="flex min-h-screen items-center justify-center">

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -14,7 +14,9 @@
 	import SortTh from '$lib/components/SortTh.svelte';
 	import CodeEditor from '$lib/components/CodeEditor.svelte';
 	import { CircleCheck, Circle } from '@lucide/svelte';
-	import type { Filesystem } from '$lib/types';
+	import type { Filesystem, FsDependents } from '$lib/types';
+	import { unlockFs } from '$lib/unlock-fs.svelte';
+	import { Lock } from '@lucide/svelte';
 
 	// Deploy stream state
 	let deployLog: string[] = $state([]);
@@ -101,6 +103,11 @@
 
 	let status: AppsStatus | null = $state(null);
 	let apps: App[] = $state([]);
+	// Map of app-name → locked-FS-name. Populated from
+	// `fs.locked_dependents` so each app row can show a "🔒 on tank"
+	// badge that opens the global unlock dialog. Stays empty when
+	// nothing's locked, so non-encrypted setups pay zero overhead.
+	let lockedFsByApp = $state(new Map<string, string>());
 	let loading = $state(true);
 	let enabling = $state(false);
 	let showInstall = $state(false);
@@ -376,6 +383,34 @@
 				ingresses = [];
 			}
 		} catch { /* ignore */ }
+		await loadLockedFsByApp();
+	}
+
+	/** Build the {appName: lockedFsName} map for the per-row badge.
+	 * Best-effort — failure leaves the map empty (no badges, no error
+	 * toast). Runs alongside every refresh so an unlock from this
+	 * page or another tab clears the badge promptly. */
+	async function loadLockedFsByApp() {
+		try {
+			const locked = await client.call<FsDependents[]>('fs.locked_dependents');
+			const next = new Map<string, string>();
+			for (const fs of locked) {
+				for (const appName of fs.apps) next.set(appName, fs.filesystem);
+			}
+			lockedFsByApp = next;
+		} catch {
+			lockedFsByApp = new Map();
+		}
+	}
+
+	async function unlockBlockingFs(fsName: string) {
+		// Imperative dialog mounted in root layout. Truthy resolution
+		// = unlock RPC succeeded; refresh to clear the badge. The app
+		// itself stays stopped — per #86 PR-B's decision, no
+		// auto-restart on unlock.
+		if (await unlockFs(fsName)) {
+			await refresh();
+		}
 	}
 
 	async function enableApps() {
@@ -1099,6 +1134,18 @@
 									>
 										unsafe
 									</Badge>
+								{/if}
+								{#if lockedFsByApp.get(app.name)}
+									{@const blockingFs = lockedFsByApp.get(app.name)!}
+									<button
+										type="button"
+										onclick={() => unlockBlockingFs(blockingFs)}
+										class="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 px-1.5 py-0.5 text-[0.6rem] font-medium text-amber-400 hover:bg-amber-500/25"
+										title="App is on a locked filesystem. Click to unlock."
+									>
+										<Lock size={10} />
+										on {blockingFs}
+									</button>
 								{/if}
 								{#if app.containers && app.containers.length > 1}
 									<button class="text-xs text-muted-foreground hover:text-foreground" onclick={() => expanded[app.name] = !expanded[app.name]}>

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -15,6 +15,7 @@
 	);
 	import { confirm } from '$lib/confirm.svelte';
 	import { confirmDangerous } from '$lib/confirm-dangerous.svelte';
+	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { summarizeDependents } from '$lib/fs-dependents';
 	import type { Filesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, ReconcileStatus, TieringProfile, TieringProfileId, FsDependents } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -76,8 +77,6 @@
 	let editMetadataReplicas = $state(1);
 	let editMoveIos = $state(32);
 	let editMoveBytes = $state('');
-	let unlockFs: string | null = $state(null);
-	let unlockPassphrase = $state('');
 	let editDegraded = $state(false);
 	let editVerbose = $state(false);
 	let editFsck = $state(false);
@@ -595,16 +594,12 @@
 		await refresh();
 	}
 
-	async function doUnlock() {
-		if (!unlockFs || !unlockPassphrase) return;
-		const name = unlockFs;
-		await withToast(
-			() => client.call('fs.unlock', { name, passphrase: unlockPassphrase }),
-			`Filesystem "${name}" unlocked`
-		);
-		unlockFs = null;
-		unlockPassphrase = '';
-		await refresh();
+	async function doUnlock(name: string) {
+		// Imperative dialog (mounted in root layout) — same UX, but
+		// also reachable from Apps/VMs pages via the locked-FS badge.
+		if (await unlockFs(name)) {
+			await refresh();
+		}
 	}
 
 	async function saveOptions(fsName: string) {
@@ -1325,7 +1320,7 @@
 							</Button>
 						{/if}
 						{#if fs.options.encrypted && fs.options.locked}
-							<Button variant="default" size="xs" onclick={() => { unlockFs = fs.name; unlockPassphrase = ''; }}>
+							<Button variant="default" size="xs" onclick={() => doUnlock(fs.name)}>
 								Unlock
 							</Button>
 						{:else if fs.options.encrypted}
@@ -1697,23 +1692,7 @@
 
 {/if}
 <!-- end pageTab === 'manage' -->
-
-<!-- Unlock Modal -->
-{#if unlockFs}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-		<Card class="w-full max-w-sm">
-			<CardContent class="pt-6">
-				<h3 class="mb-2 text-lg font-semibold">Unlock "{unlockFs}"</h3>
-				<p class="mb-4 text-sm text-muted-foreground">Enter the passphrase to unlock this encrypted filesystem.</p>
-				<input type="password" bind:value={unlockPassphrase}
-					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
-					placeholder="Passphrase"
-					onkeydown={(e) => { if (e.key === 'Enter' && unlockPassphrase) doUnlock(); }} />
-				<div class="flex gap-2">
-					<Button onclick={doUnlock} disabled={!unlockPassphrase}>Unlock</Button>
-					<Button variant="secondary" onclick={() => unlockFs = null}>Cancel</Button>
-				</div>
-			</CardContent>
-		</Card>
-	</div>
-{/if}
+<!-- The unlock modal that used to live here is now a global imperative
+     dialog mounted once in the root layout (see UnlockFsDialog.svelte).
+     The Apps and VMs pages call into the same dialog via `unlockFs(name)`
+     when their locked-FS badge is clicked. -->

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -4,19 +4,24 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { VmStatus, VmCapabilities, Subvolume } from '$lib/types';
+	import type { VmStatus, VmCapabilities, Subvolume, FsDependents } from '$lib/types';
+	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
-	import { CircleCheck, Circle, CircleX } from '@lucide/svelte';
+	import { CircleCheck, Circle, CircleX, Lock } from '@lucide/svelte';
 	import { Terminal } from '@xterm/xterm';
 	import { FitAddon } from '@xterm/addon-fit';
 
 	let vms: VmStatus[] = $state([]);
 	let capabilities: VmCapabilities | null = $state(null);
+	// Map of vm-name → locked-FS-name. Same shape and population
+	// pattern as the apps page; lets each VM row show a "🔒 on tank"
+	// badge so the user sees why their stopped VM can't start.
+	let lockedFsByVm = $state(new Map<string, string>());
 	let blockSubvolumes: Subvolume[] = $state([]);
 	let wizardStep: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 = $state(0); // 0=hidden, -1=prerequisites
 	let loading = $state(true);
@@ -253,6 +258,31 @@
 		await withToast(async () => {
 			vms = await client.call<VmStatus[]>('vm.list');
 		});
+		await loadLockedFsByVm();
+	}
+
+	/** Build the {vmName: lockedFsName} map for the per-row badge.
+	 * Best-effort — failure leaves the map empty. */
+	async function loadLockedFsByVm() {
+		try {
+			const locked = await client.call<FsDependents[]>('fs.locked_dependents');
+			const next = new Map<string, string>();
+			for (const fs of locked) {
+				for (const vmName of fs.vms) next.set(vmName, fs.filesystem);
+			}
+			lockedFsByVm = next;
+		} catch {
+			lockedFsByVm = new Map();
+		}
+	}
+
+	async function unlockBlockingFs(fsName: string) {
+		// Imperative dialog mounted in root layout. VMs aren't
+		// auto-restarted on unlock — user explicitly took them down
+		// when they locked the FS, so they explicitly bring them up.
+		if (await unlockFs(fsName)) {
+			await refresh();
+		}
 	}
 
 	async function loadCapabilities() {
@@ -961,6 +991,18 @@
 						<span class="font-semibold">{vm.name}</span>
 						{#if vm.autostart}
 							<Badge variant="secondary" class="ml-2 text-[0.6rem]">autostart</Badge>
+						{/if}
+						{#if lockedFsByVm.get(vm.name)}
+							{@const blockingFs = lockedFsByVm.get(vm.name)!}
+							<button
+								type="button"
+								onclick={(e) => { e.stopPropagation(); unlockBlockingFs(blockingFs); }}
+								class="ml-2 inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 px-1.5 py-0.5 text-[0.6rem] font-medium text-amber-400 hover:bg-amber-500/25"
+								title="VM has a disk on a locked filesystem. Click to unlock."
+							>
+								<Lock size={10} />
+								on {blockingFs}
+							</button>
 						{/if}
 						{#if vm.description}
 							<span class="ml-2 text-xs text-muted-foreground">{vm.description}</span>


### PR DESCRIPTION
**Stacked on #125, which is stacked on #124.** Merge in order; this PR's diff against \`main\` will compress to ~the badges + global unlock dialog once both prereqs land.

Final piece of @johnnyq's wishlist on issue #86. With #124 (impact preview) and #125 (cascade-stop on lock) landed, the user can lock an encrypted FS knowing what will happen. This PR closes the loop on the *other* side: when an app or VM is sitting stopped because its volume is locked, the row tells you so, and you can unlock without navigating to /filesystems.

## What lands

**On the Apps page** — each app row gets a small amber lock badge "🔒 on tank" next to the name when its container storage lives on a locked FS. Click → unlock dialog opens → enter passphrase → app row badge clears. App stays stopped; user clicks Start when they want it back.

**On the VMs page** — same, keyed off any disk path that resolves to a locked FS. Click handler stops event propagation so it doesn't also toggle the row's details panel.

**On the Filesystems page** — the inline unlock modal that used to live there is now the same global dialog as the badges call into. One fewer copy-paste of unlock UI.

## How

**Engine** — \`fs_dependents.rs\` gets \`find_locked_dependents(state)\`. Walks all filesystems, keeps the encrypted-and-locked ones, runs the existing \`find_dependents\` for each, returns only entries with at least one app or VM. Empty entries are filtered out — they have no card surface to badge.

New RPC \`fs.locked_dependents\` (read-only, any role).

**WebUI** — global imperative unlock dialog:

- \`\$lib/unlock-fs.svelte.ts::unlockFs(name)\` — same shape as \`confirm()\` from \`\$lib/confirm.svelte\`. Resolves to \`true\` on RPC success, \`false\` on cancel or error. Toast handling is built in so callers don't need their own \`withToast\`.
- \`\$lib/components/UnlockFsDialog.svelte\` mounted once in \`routes/+layout.svelte\` alongside \`ConfirmDialog\`. Wipes the passphrase on every re-open so a typed-but-not-submitted secret can't leak across opens.

**Per-row badges**: Apps and VMs pages each fetch \`fs.locked_dependents\` on every refresh, build a \`Map<entityName, lockedFsName>\`, render a clickable amber lock badge when there's a hit. Cost on non-encrypted setups: one zero-result RPC per refresh.

## Why no auto-restart on unlock

Per #125's design discussion: when a user locks, they're explicitly taking the FS offline; surprise auto-restart on unlock would be worse than the current "click Start when ready" model. That's why the badge clears on unlock but the app/VM doesn't auto-launch.

## Test plan

- [x] \`cargo test --workspace --lib\` — full pass
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4844 files, 0 errors
- [x] \`npm --prefix webui run test\` — 101 passing
- [ ] **Manual** with apps + VMs on an encrypted FS:
  - Lock the FS (#125's cascade kicks in) → Apps page shows the badge on every container that was running there → VMs page shows the badge on each VM with a disk on the FS → Filesystems page shows the FS as Locked.
  - Click the badge on Apps → unlock dialog opens → enter passphrase → dialog closes → badges clear on Apps and VMs and Filesystems pages.
  - Click the unlock badge with empty passphrase → "Unlock" button stays disabled.
  - Click on the VM badge → row's expand toggle does NOT fire (e.stopPropagation).