### PR TITLE
network: bridges/bonds inherit primary member's MAC by default

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -110,6 +110,19 @@ pub struct BondConfig {
     pub ipv6: IpConfig,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u16>,
+    /// When true, the bond's MAC address is taken from the primary
+    /// member's live MAC instead of letting NM/the kernel generate
+    /// a random one. Keeps DHCP servers handing out the same lease
+    /// across the enslave step — important when one of the members
+    /// is the management interface, since otherwise the user's
+    /// session lands on a new IP.
+    ///
+    /// Defaults to `true` because the surprise-IP-change on the
+    /// random-MAC default is the much louder failure mode. Users
+    /// who want a different identity for the bond can opt out via
+    /// the "Don't inherit member MAC" checkbox in the WebUI.
+    #[serde(default = "default_true")]
+    pub inherit_member_mac: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -150,6 +163,13 @@ pub struct BridgeConfig {
     /// 15-second blackhole when STP is off but forward-delay still applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub forward_delay_s: Option<u8>,
+    /// When true, the bridge's MAC address is taken from the primary
+    /// member's live MAC instead of letting NM/the kernel generate
+    /// a random one. See `BondConfig::inherit_member_mac` for the
+    /// rationale; the rule is identical (DHCP-stable identity for
+    /// the master across the enslave step).
+    #[serde(default = "default_true")]
+    pub inherit_member_mac: bool,
 }
 
 fn inherit_ip() -> IpConfig {
@@ -426,7 +446,7 @@ impl NetworkService {
                 .map_err(|e| format!("write {PENDING_REVERT_PATH}: {e}"))?;
 
             persist_config(&config).await?;
-            apply_config(&config).await?;
+            apply_config(&config, mgmt_iface.as_deref()).await?;
 
             let txn_id = new_txn_id();
             let revert_at_unix = unix_now() + secs;
@@ -449,7 +469,7 @@ impl NetworkService {
             })
         } else {
             persist_config(&config).await?;
-            apply_config(&config).await?;
+            apply_config(&config, mgmt_iface.as_deref()).await?;
 
             info!(
                 "Network config updated ({} interfaces, {} bonds, {} bridges, {} VLANs)",
@@ -531,7 +551,10 @@ impl NetworkService {
             warn!("restore: persist failed: {e}");
             return;
         }
-        if let Err(e) = apply_config(&prev).await {
+        // Restore path: we don't know which iface the user is on
+        // (they might have reconnected on a new IP). MAC inheritance
+        // for any masters in `prev` falls back to "first member".
+        if let Err(e) = apply_config(&prev, None).await {
             warn!("restore: apply failed: {e}");
             return;
         }
@@ -780,7 +803,11 @@ async fn perform_rollback(txn_id: &str) {
         warn!("rollback {txn_id}: persist failed: {e}");
         return;
     }
-    if let Err(e) = apply_config(&prev).await {
+    // Rollback runs from a tokio task without a session — no mgmt
+    // iface to prefer. Same as `restore_pending_revert`: pre-existing
+    // masters in the rolled-back config fall back to first-member
+    // MAC, which matches what was applied originally.
+    if let Err(e) = apply_config(&prev, None).await {
         warn!("rollback {txn_id}: apply failed: {e}");
         return;
     }
@@ -1513,13 +1540,28 @@ fn parse_dhcp_managed(json: &str) -> Option<std::collections::HashSet<String>> {
     )
 }
 
-async fn apply_config(config: &NetworkConfig) -> Result<(), String> {
+async fn apply_config(config: &NetworkConfig, mgmt_iface: Option<&str>) -> Result<(), String> {
     // Post-cutover (phase 3b-beta): NetworkManager is the active
     // backend. Convert the resolved config to layered form, then to
     // NM profiles, then push to NM via DBus. NM owns DHCP, DNS, and
     // L2 management; the engine just authors the connection profiles.
+    //
+    // Build a name → MAC map from live state so bond/bridge masters
+    // with `inherit_member_mac=true` can adopt their primary
+    // member's MAC. Without this, NM creates the master with a
+    // random MAC and DHCP gives it a new lease — which yanks the
+    // user's session if they're enslaving the management iface.
+    let live_macs = enumerate_interfaces()
+        .await
+        .into_iter()
+        .map(|i| (i.name, i.mac))
+        .collect();
+    let mac_ctx = nm::MacContext {
+        live_macs,
+        mgmt_iface: mgmt_iface.map(|s| s.to_string()),
+    };
     let layered_cfg = layered::to_layered(config);
-    let profiles = nm::to_nm_profiles(&layered_cfg);
+    let profiles = nm::to_nm_profiles_with_macs(&layered_cfg, &mac_ctx);
     let client = nm::dbus::NmDbusClient::new()
         .await
         .map_err(|e| format!("connect to NetworkManager: {e}"))?;
@@ -1574,6 +1616,7 @@ mod tests {
             mtu: None,
             stp: false,
             forward_delay_s: None,
+            inherit_member_mac: false,
         }
     }
 
@@ -1585,6 +1628,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            inherit_member_mac: false,
         }
     }
 

--- a/engine/nasty-system/src/network/layered.rs
+++ b/engine/nasty-system/src/network/layered.rs
@@ -76,6 +76,13 @@ pub enum LinkKind {
         #[serde(default)]
         members: Vec<String>,
         mode: BondMode,
+        /// User-controlled: when true, the bond inherits its MAC
+        /// from the primary member (mgmt iface preferred, else
+        /// first declared member). See `BondConfig::inherit_member_mac`.
+        /// Default true; the WebUI exposes an inverted "Don't inherit"
+        /// checkbox.
+        #[serde(default = "default_true")]
+        inherit_member_mac: bool,
     },
     Bridge {
         #[serde(default)]
@@ -84,6 +91,11 @@ pub enum LinkKind {
         stp: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         forward_delay_s: Option<u8>,
+        /// Same as `LinkKind::Bond::inherit_member_mac` — controls
+        /// whether the bridge adopts a member's MAC (DHCP-stable)
+        /// instead of getting a random one (NM/kernel default).
+        #[serde(default = "default_true")]
+        inherit_member_mac: bool,
     },
     Vlan {
         parent: String,
@@ -178,6 +190,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             kind: LinkKind::Bond {
                 members: bond.members.clone(),
                 mode: bond.mode.clone(),
+                inherit_member_mac: bond.inherit_member_mac,
             },
         });
         push_addresses(&mut addresses, &bond.name, &bond.ipv4, &bond.ipv6);
@@ -192,6 +205,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
                 members: bridge.members.clone(),
                 stp: bridge.stp,
                 forward_delay_s: bridge.forward_delay_s,
+                inherit_member_mac: bridge.inherit_member_mac,
             },
         });
         push_addresses(&mut addresses, &bridge.name, &bridge.ipv4, &bridge.ipv6);
@@ -274,18 +288,24 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 ipv6,
                 mtu: link.mtu,
             }),
-            LinkKind::Bond { members, mode } => bonds.push(BondConfig {
+            LinkKind::Bond {
+                members,
+                mode,
+                inherit_member_mac,
+            } => bonds.push(BondConfig {
                 name: link.name.clone(),
                 members: members.clone(),
                 mode: mode.clone(),
                 ipv4,
                 ipv6,
                 mtu: link.mtu,
+                inherit_member_mac: *inherit_member_mac,
             }),
             LinkKind::Bridge {
                 members,
                 stp,
                 forward_delay_s,
+                inherit_member_mac,
             } => bridges.push(BridgeConfig {
                 name: link.name.clone(),
                 members: members.clone(),
@@ -294,6 +314,7 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 mtu: link.mtu,
                 stp: *stp,
                 forward_delay_s: *forward_delay_s,
+                inherit_member_mac: *inherit_member_mac,
             }),
             LinkKind::Vlan { parent, id } => vlans.push(VlanConfig {
                 parent: parent.clone(),
@@ -477,6 +498,7 @@ mod tests {
             mtu: None,
             stp: false,
             forward_delay_s: None,
+            inherit_member_mac: false,
         }
     }
 
@@ -488,6 +510,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            inherit_member_mac: false,
         }
     }
 
@@ -663,6 +686,7 @@ mod tests {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
                 forward_delay_s: None,
+                inherit_member_mac: false,
             },
         }
     }
@@ -676,6 +700,7 @@ mod tests {
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
+                inherit_member_mac: false,
             },
         }
     }

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -168,10 +168,46 @@ pub enum NmTypeSpecific {
 
 // ── Converter ──────────────────────────────────────────────────
 
+/// Per-apply context that's not in the layered model itself. Currently
+/// just for MAC inheritance — without it, NM creates bonds/bridges
+/// with a random MAC, which makes DHCP servers see "a new client" and
+/// hand out a different lease the moment a master comes up. If the
+/// user is enslaving their management interface, that yanks the
+/// session and lands them on a new IP. Inheriting the primary
+/// member's MAC keeps DHCP recognising the same client.
+///
+/// `mgmt_iface` is the management interface name resolved from the
+/// caller's socket (same one the risk classifier uses). When it's
+/// among a master's members, prefer its MAC over the first member's
+/// MAC — that's the one the user is currently reachable on, and
+/// keeping it stable preserves their session across the enslave step.
+#[derive(Debug, Default)]
+pub struct MacContext {
+    /// Live `name → MAC` map from `enumerate_interfaces()`. Empty
+    /// for tests / migration / nm_preview where live state isn't
+    /// readily available — callers fall back to NM's default
+    /// (random MAC) which is fine when the bridge/bond doesn't
+    /// touch the management path.
+    pub live_macs: HashMap<String, String>,
+    pub mgmt_iface: Option<String>,
+}
+
+/// Convenience wrapper that calls into [`to_nm_profiles_with_macs`]
+/// with an empty context. Used by tests and by migration code paths
+/// where we don't have live MAC info to plumb through.
+pub fn to_nm_profiles(layered: &LayeredConfig) -> Vec<NmConnection> {
+    to_nm_profiles_with_macs(layered, &MacContext::default())
+}
+
 /// Project a `LayeredConfig` to NM connection profiles. One `NmConnection`
 /// per `Link`, with members getting `controller = <master>` + IP method
 /// `disabled` (the master owns the L3).
-pub fn to_nm_profiles(layered: &LayeredConfig) -> Vec<NmConnection> {
+///
+/// Bond/bridge masters get their `mac` populated from the primary
+/// member's live MAC (preferring the management iface when it's a
+/// member). The serializer then emits this as `bridge.mac-address`
+/// for bridges and `802-3-ethernet.cloned-mac-address` for bonds.
+pub fn to_nm_profiles_with_macs(layered: &LayeredConfig, ctx: &MacContext) -> Vec<NmConnection> {
     // Per-link IP settings, indexed by link name.
     let mut addrs_by_link: HashMap<&str, (NmIpSettings, NmIpSettings)> = HashMap::new();
     for addr in &layered.addresses {
@@ -221,9 +257,57 @@ pub fn to_nm_profiles(layered: &LayeredConfig) -> Vec<NmConnection> {
                 conn.ipv4.dns.clone_from(&dns_v4);
                 conn.ipv6.dns.clone_from(&dns_v6);
             }
+            // Bond/bridge masters: inherit the primary member's MAC
+            // *if the user opted in* (default for new bridges/bonds;
+            // can be turned off via the WebUI's "Don't inherit member
+            // MAC" checkbox). Skipping inheritance lets NM/the kernel
+            // assign a random MAC, which makes DHCP servers see a new
+            // client identity — that's the right call for some users
+            // who want a separate identity for the master, and the
+            // wrong one for users enslaving their mgmt iface, hence
+            // the toggle. `pick_primary_member` prefers the mgmt iface
+            // when it's a member so the user's session survives the
+            // enslave step.
+            if inherits_member_mac(&link.kind)
+                && let Some(member) = pick_primary_member(&link.kind, ctx)
+                && let Some(mac) = ctx.live_macs.get(member)
+            {
+                conn.mac = Some(mac.clone());
+            }
             conn
         })
         .collect()
+}
+
+fn inherits_member_mac(kind: &LinkKind) -> bool {
+    match kind {
+        LinkKind::Bond {
+            inherit_member_mac, ..
+        }
+        | LinkKind::Bridge {
+            inherit_member_mac, ..
+        } => *inherit_member_mac,
+        _ => false,
+    }
+}
+
+/// Pick which member's MAC the master should adopt. When the user's
+/// management interface is in the member list, return that — DHCP
+/// will keep handing out the same lease, so their session survives.
+/// Otherwise fall back to the first declared member; that's the most
+/// common bridge/bond case (one or two members, list order matches
+/// user intent). Returns `None` when the link isn't a master.
+fn pick_primary_member<'a>(kind: &'a LinkKind, ctx: &'a MacContext) -> Option<&'a str> {
+    let members = match kind {
+        LinkKind::Bond { members, .. } | LinkKind::Bridge { members, .. } => members.as_slice(),
+        _ => return None,
+    };
+    if let Some(mgmt) = ctx.mgmt_iface.as_deref()
+        && members.iter().any(|m| m == mgmt)
+    {
+        return Some(mgmt);
+    }
+    members.first().map(|s| s.as_str())
 }
 
 /// Bucket DNS server strings by family. A colon means IPv6; absence
@@ -407,6 +491,12 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
             if let Some(mtu) = p.mtu {
                 out.push_str(&format!("mtu={mtu}\n"));
             }
+            // Bridge MAC also lives here (`bridge.mac-address`), not
+            // in [802-3-ethernet]. Without it NM creates the bridge
+            // with a kernel-random MAC and DHCP hands out a new lease.
+            if let Some(mac) = &p.mac {
+                out.push_str(&format!("mac-address={mac}\n"));
+            }
             out.push('\n');
         }
         NmTypeSpecific::Vlan { parent, id } => {
@@ -546,6 +636,14 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
             if let Some(mtu) = p.mtu {
                 bridge.insert("mtu".into(), into_value(u32::from(mtu)));
             }
+            // Bridge MAC: same reasoning. NM's `bridge.mac-address`
+            // pins the bridge interface's MAC at activation time;
+            // without it the kernel generates a random MAC and
+            // DHCP hands out a new lease (issue from the bridge
+            // creation test on 10.10.10.61).
+            if let Some(mac) = &p.mac {
+                bridge.insert("mac-address".into(), into_value(mac.clone()));
+            }
             out.insert("bridge".into(), bridge);
         }
         NmTypeSpecific::Vlan { parent, id } => {
@@ -674,6 +772,7 @@ mod tests {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
                 forward_delay_s: None,
+                inherit_member_mac: false,
             },
         }
     }
@@ -687,6 +786,7 @@ mod tests {
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
+                inherit_member_mac: false,
             },
         }
     }
@@ -853,6 +953,7 @@ mod tests {
                     members: vec![],
                     stp: true,
                     forward_delay_s: Some(0),
+                    inherit_member_mac: false,
                 },
             }],
             ..Default::default()
@@ -1025,6 +1126,7 @@ mod tests {
                     members: vec![],
                     stp: true,
                     forward_delay_s: Some(4),
+                    inherit_member_mac: false,
                 },
             }],
             ..Default::default()
@@ -1297,6 +1399,7 @@ mod tests {
                     members: vec![],
                     stp: true,
                     forward_delay_s: Some(7),
+                    inherit_member_mac: false,
                 },
             }],
             ..Default::default()
@@ -1584,5 +1687,209 @@ mod tests {
             deterministic_uuid_for("eth0"),
             deterministic_uuid_for("eth1")
         );
+    }
+
+    // ── MAC inheritance ──────────────────────────────────────────
+
+    fn live_macs(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(n, m)| ((*n).to_string(), (*m).to_string()))
+            .collect()
+    }
+
+    fn link_bridge_inherit(name: &str, members: &[&str]) -> Link {
+        Link {
+            name: name.into(),
+            enabled: true,
+            mtu: None,
+            mac: None,
+            kind: LinkKind::Bridge {
+                members: members.iter().map(|s| (*s).to_string()).collect(),
+                stp: false,
+                forward_delay_s: None,
+                inherit_member_mac: true,
+            },
+        }
+    }
+
+    fn link_bond_inherit(name: &str, members: &[&str]) -> Link {
+        Link {
+            name: name.into(),
+            enabled: true,
+            mtu: None,
+            mac: None,
+            kind: LinkKind::Bond {
+                members: members.iter().map(|s| (*s).to_string()).collect(),
+                mode: BondMode::Lacp,
+                inherit_member_mac: true,
+            },
+        }
+    }
+
+    #[test]
+    fn pick_primary_prefers_mgmt_iface_when_member() {
+        // Reproducer for the .61 → .62 surprise: user's mgmt iface
+        // is in the bond's members. Bond should adopt mgmt's MAC so
+        // DHCP keeps handing out the same lease and the session
+        // survives the enslave step.
+        let kind = LinkKind::Bond {
+            members: vec!["eth0".into(), "eth1".into()],
+            mode: BondMode::Lacp,
+            inherit_member_mac: true,
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[("eth0", "aa:..."), ("eth1", "bb:...")]),
+            mgmt_iface: Some("eth1".into()),
+        };
+        assert_eq!(pick_primary_member(&kind, &ctx), Some("eth1"));
+    }
+
+    #[test]
+    fn pick_primary_falls_back_to_first_when_mgmt_not_a_member() {
+        // Bond not touching the mgmt path: pick first declared
+        // member as the MAC source. Order matches user intent in
+        // the WebUI.
+        let kind = LinkKind::Bond {
+            members: vec!["eth1".into(), "eth2".into()],
+            mode: BondMode::Lacp,
+            inherit_member_mac: true,
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[]),
+            mgmt_iface: Some("eth0".into()), // mgmt not in members
+        };
+        assert_eq!(pick_primary_member(&kind, &ctx), Some("eth1"));
+    }
+
+    #[test]
+    fn pick_primary_returns_none_for_non_master() {
+        // Physical/VLAN are not master types. The MAC inheritance
+        // rule doesn't apply to them; their MAC comes from the
+        // hardware directly (or kernel for VLANs).
+        let physical = LinkKind::Physical;
+        let vlan = LinkKind::Vlan {
+            parent: "eth0".into(),
+            id: 100,
+        };
+        let ctx = MacContext::default();
+        assert_eq!(pick_primary_member(&physical, &ctx), None);
+        assert_eq!(pick_primary_member(&vlan, &ctx), None);
+    }
+
+    #[test]
+    fn dict_bridge_emits_mac_address_when_inherit_true() {
+        // The headline fix: with inherit_member_mac=true and a known
+        // member MAC, the bridge connection's [bridge] section
+        // carries `mac-address`. NM uses this to pin the bridge's
+        // MAC at activation, keeping DHCP recognising the same client.
+        let layered = LayeredConfig {
+            links: vec![link_phys("ens18"), link_bridge_inherit("br0", &["ens18"])],
+            ..Default::default()
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[("ens18", "bc:24:11:34:a0:27")]),
+            mgmt_iface: None,
+        };
+        let profiles = to_nm_profiles_with_macs(&layered, &ctx);
+        let br = profiles.iter().find(|p| p.id == "nasty-br0").unwrap();
+        let dict = to_settings_dict(br);
+        let bridge = dict.get("bridge").expect("bridge section");
+        let mac: String = bridge["mac-address"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(mac, "bc:24:11:34:a0:27");
+    }
+
+    #[test]
+    fn dict_bridge_omits_mac_address_when_inherit_false() {
+        // Opt-out: user toggled "Don't inherit member MAC" → no
+        // mac-address field → NM/kernel assign a random MAC at
+        // activation (the previous default). Test guards against
+        // the flag being silently ignored.
+        let layered = LayeredConfig {
+            links: vec![link_phys("ens18"), link_bridge("br0", &["ens18"])],
+            ..Default::default()
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[("ens18", "bc:24:11:34:a0:27")]),
+            mgmt_iface: None,
+        };
+        let profiles = to_nm_profiles_with_macs(&layered, &ctx);
+        let br = profiles.iter().find(|p| p.id == "nasty-br0").unwrap();
+        assert!(br.mac.is_none());
+        let dict = to_settings_dict(br);
+        let bridge = dict.get("bridge").expect("bridge section");
+        assert!(!bridge.contains_key("mac-address"));
+    }
+
+    #[test]
+    fn dict_bond_emits_cloned_mac_address_when_inherit_true() {
+        // Bonds put MAC in [802-3-ethernet] (not [bridge]) — NM
+        // models bonds as having an underlying ethernet layer.
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0"), link_bond_inherit("bond0", &["eth0"])],
+            ..Default::default()
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[("eth0", "aa:bb:cc:dd:ee:ff")]),
+            mgmt_iface: None,
+        };
+        let profiles = to_nm_profiles_with_macs(&layered, &ctx);
+        let bond = profiles.iter().find(|p| p.id == "nasty-bond0").unwrap();
+        let dict = to_settings_dict(bond);
+        let eth = dict.get("802-3-ethernet").expect("ethernet section");
+        let mac: String = eth["cloned-mac-address"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert_eq!(mac, "aa:bb:cc:dd:ee:ff");
+    }
+
+    #[test]
+    fn keyfile_bridge_mac_address_in_bridge_section() {
+        let layered = LayeredConfig {
+            links: vec![link_phys("ens18"), link_bridge_inherit("br0", &["ens18"])],
+            ..Default::default()
+        };
+        let ctx = MacContext {
+            live_macs: live_macs(&[("ens18", "bc:24:11:34:a0:27")]),
+            mgmt_iface: None,
+        };
+        let br = to_nm_profiles_with_macs(&layered, &ctx)
+            .into_iter()
+            .find(|p| p.id == "nasty-br0")
+            .unwrap();
+        let keyfile = serialize_keyfile(&br);
+        // Has to land in the [bridge] section, not [ethernet].
+        let bridge_idx = keyfile.find("[bridge]").expect("bridge section");
+        let after = &keyfile[bridge_idx..];
+        let next_section = after[1..].find('[').map_or(after.len(), |i| i + 1);
+        assert!(
+            after[..next_section].contains("mac-address=bc:24:11:34:a0:27"),
+            "[bridge] block missing mac-address: {:?}",
+            &after[..next_section]
+        );
+    }
+
+    #[test]
+    fn empty_mac_context_inherits_nothing() {
+        // Tests / migration code paths use `to_nm_profiles` (the
+        // empty-context wrapper). Bridges/bonds get no inherited
+        // MAC — same as the pre-#96-followup behaviour. Guards
+        // against test scaffolding accidentally pinning a member's
+        // MAC because of the new code path.
+        let layered = LayeredConfig {
+            links: vec![link_phys("eth0"), link_bridge_inherit("br0", &["eth0"])],
+            ..Default::default()
+        };
+        // No live_macs — even with inherit_member_mac=true, there's
+        // no MAC to inherit.
+        let profiles = to_nm_profiles(&layered);
+        let br = profiles.iter().find(|p| p.id == "nasty-br0").unwrap();
+        assert!(br.mac.is_none());
     }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -625,6 +625,12 @@ export interface BondConfig {
 	ipv4: IpConfig;
 	ipv6: IpConfig;
 	mtu: number | null;
+	/** When true (default for newly-created bonds), the bond's MAC is
+	 * taken from the primary member's live MAC instead of letting NM
+	 * generate a random one. Keeps DHCP servers handing out the same
+	 * lease across the enslave step — important when one of the
+	 * members is the management interface. */
+	inherit_member_mac?: boolean;
 }
 
 export interface VlanConfig {
@@ -643,6 +649,10 @@ export interface BridgeConfig {
 	mtu: number | null;
 	stp?: boolean;
 	forward_delay_s?: number | null;
+	/** Same semantics as `BondConfig.inherit_member_mac`: when true,
+	 * the bridge takes its MAC from the primary member instead of
+	 * getting a kernel-random MAC at creation. */
+	inherit_member_mac?: boolean;
 }
 
 export interface NetworkConfig {

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -49,6 +49,10 @@
 	let bondMembers: string[] = $state([]);
 	let bondMode: 'lacp' | 'active_backup' | 'balance_rr' | 'balance_xor' = $state('active_backup');
 	let bondMtu = $state('');
+	// Inverted in the UI ("Don't inherit member MAC"). Default OFF
+	// (i.e. inherit_member_mac=true) so bonds get DHCP-stable
+	// identity by default — same logic as bridges below.
+	let bondNoInheritMac = $state(false);
 	// VLAN form
 	let showVlanForm = $state(false);
 	let vlanParent = $state('');
@@ -59,6 +63,11 @@
 	let bridgeName = $state('br0');
 	let bridgeMembers: string[] = $state([]);
 	let bridgeMtu = $state('');
+	// Same as `bondNoInheritMac` — inverted UI flag (checked = NM
+	// generates a random MAC). Default unchecked: bridges adopt
+	// the primary member's MAC, so DHCP keeps handing out the same
+	// lease and the user's WebUI session survives the enslave step.
+	let bridgeNoInheritMac = $state(false);
 	// ── General tab state ───────────────────────────────────
 	let settings: Settings | null = $state(null);
 	let info: SystemInfo | null = $state(null);
@@ -443,13 +452,22 @@
 		const payload: NetworkConfig = {
 			interfaces: network.interfaces || [],
 			dns: network.dns || [],
-			bonds: [...(network.bonds || []), { name: bondName, members: bondMembers, mode: bondMode, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null }, mtu }],
+			bonds: [...(network.bonds || []), {
+				name: bondName,
+				members: bondMembers,
+				mode: bondMode,
+				ipv4: { method: 'dhcp', addresses: [], gateway: null },
+				ipv6: { method: 'slaac', addresses: [], gateway: null },
+				mtu,
+				// Checkbox is "Don't inherit member MAC" → invert.
+				inherit_member_mac: !bondNoInheritMac,
+			}],
 			vlans: network.vlans || [],
 			bridges: network.bridges || [],
 		};
 		await applyNetworkUpdate(payload, `Bond ${bondName} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
-		showBondForm = false; bondName = 'bond0'; bondMembers = []; bondMtu = '';
+		showBondForm = false; bondName = 'bond0'; bondMembers = []; bondMtu = ''; bondNoInheritMac = false;
 	}
 
 	async function createVlan() {
@@ -480,11 +498,19 @@
 			// Static/Dhcp before persisting so reboot reapplies the same L3.
 			// For host-internal bridges (no members), inherit resolves to
 			// Disabled — the bridge is L2-only, which is what VMs want.
-			bridges: [...(network.bridges || []), { name: bridgeName, members: bridgeMembers, ipv4: { method: 'inherit', addresses: [], gateway: null }, ipv6: { method: 'inherit', addresses: [], gateway: null }, mtu }],
+			bridges: [...(network.bridges || []), {
+				name: bridgeName,
+				members: bridgeMembers,
+				ipv4: { method: 'inherit', addresses: [], gateway: null },
+				ipv6: { method: 'inherit', addresses: [], gateway: null },
+				mtu,
+				// Checkbox is "Don't inherit member MAC" → invert.
+				inherit_member_mac: !bridgeNoInheritMac,
+			}],
 		};
 		await applyNetworkUpdate(payload, `Bridge ${bridgeName} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
-		showBridgeForm = false; bridgeName = 'br0'; bridgeMembers = []; bridgeMtu = '';
+		showBridgeForm = false; bridgeName = 'br0'; bridgeMembers = []; bridgeMtu = ''; bridgeNoInheritMac = false;
 	}
 
 	async function deleteBond(name: string) {
@@ -1028,6 +1054,27 @@
 						<label for="bond-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
 						<input id="bond-mtu" type="number" min="68" max="65535" bind:value={bondMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
 					</div>
+					<div>
+						<label class="flex items-start gap-2 text-xs">
+							<input type="checkbox" bind:checked={bondNoInheritMac} class="mt-0.5" />
+							<span>
+								<span class="text-foreground">Don't inherit member MAC</span>
+								<span class="block text-muted-foreground mt-0.5">By default, the bond adopts the primary member's MAC so DHCP keeps handing out the same lease across the enslave step. Check this to let the kernel pick from active slaves instead.</span>
+							</span>
+						</label>
+					</div>
+					{#if networkState?.mgmt_iface && bondMembers.includes(networkState.mgmt_iface)}
+						<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300 space-y-1">
+							<div class="font-medium">Heads up — this bonds your management interface</div>
+							<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
+							{#if bondMembers.length > 1}
+								<p>The bond will use <span class="font-mono">{networkState.mgmt_iface}</span>'s MAC (the management interface, preferred when it's a member among multiple).</p>
+							{/if}
+							{#if bondNoInheritMac}
+								<p class="font-medium">⚠ "Don't inherit member MAC" is checked. Your DHCP server will treat the bond as a new client and is very likely to hand out a different IP — your session will land on the new IP and you'll need to reconnect there to confirm.</p>
+							{/if}
+						</div>
+					{/if}
 					<Button size="sm" onclick={createBond} disabled={bondMembers.length < 2}>Create Bond</Button>
 				</div>
 			{/if}
@@ -1058,10 +1105,25 @@
 						<label for="bridge-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
 						<input id="bridge-mtu" type="number" min="68" max="65535" bind:value={bridgeMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
 					</div>
+					<div>
+						<label class="flex items-start gap-2 text-xs">
+							<input type="checkbox" bind:checked={bridgeNoInheritMac} class="mt-0.5" />
+							<span>
+								<span class="text-foreground">Don't inherit member MAC</span>
+								<span class="block text-muted-foreground mt-0.5">By default, the bridge adopts the primary member's MAC so DHCP keeps handing out the same lease across the enslave step. Check this to let NM/the kernel pick a random MAC instead — you'll likely get a new IP.</span>
+							</span>
+						</label>
+					</div>
 					{#if networkState?.mgmt_iface && bridgeMembers.includes(networkState.mgmt_iface)}
-						<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300">
-							<div class="font-medium mb-1">Heads up — this bridges your management interface</div>
-							<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. The bridge will adopt its IP and route, but you may briefly see the page reconnect. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
+						<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300 space-y-1">
+							<div class="font-medium">Heads up — this bridges your management interface</div>
+							<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. The bridge will adopt its IP and route. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
+							{#if bridgeMembers.length > 1}
+								<p>With multiple members, the bridge will use <span class="font-mono">{networkState.mgmt_iface}</span>'s MAC (the management interface, preferred when it's a member). The other members keep their own MACs as bridge slaves — they're L2-only inside the bridge.</p>
+							{/if}
+							{#if bridgeNoInheritMac}
+								<p class="font-medium">⚠ "Don't inherit member MAC" is checked. Your DHCP server will treat the bridge as a new client and is very likely to hand out a different IP — your session will land on the new IP and you'll need to reconnect there to confirm before the 30-second rollback fires.</p>
+							{/if}
 						</div>
 					{/if}
 					<Button size="sm" onclick={createBridge} disabled={!bridgeName}>Create Bridge</Button>


### PR DESCRIPTION
Hit live on 10.10.10.61. Creating a bridge that included \`ens18\` (management interface) as a member produced a bridge with a kernel-random MAC (\`96:68:9d:...\` instead of \`bc:24:11:34:...\`). DHCP server treated it as a new client → handed out a new lease (\`.62\` instead of \`.61\`) → WebUI session yanked.

Engine logs caught it cleanly:

\`\`\`
br0:    96:68:9d:66:0e:8a   ← kernel-random
ens18:  bc:24:11:34:a0:27   ← stayed on the slave
\`\`\`

## Fix

Make MAC inheritance the default, with an explicit opt-out toggle in the create-bridge / create-bond forms.

### Engine

- New \`inherit_member_mac\` field on \`BondConfig\` and \`BridgeConfig\`, default \`true\` via \`#[serde(default = \"default_true\")]\`. When true, the master adopts the primary member's MAC so DHCP servers keep recognising the same client.
- **Primary member picking**: prefer the management interface when it's in the member list, otherwise fall back to the first declared member. Matters in multi-member topologies — the user's session is on a specific member; the bond/bridge should adopt that one's MAC, not whichever happened to be listed first.
- New \`nm::MacContext { live_macs, mgmt_iface }\` plumbed from \`apply_config\` (which builds it from \`enumerate_interfaces\` plus the caller's resolved mgmt iface). \`to_nm_profiles\` is now a thin wrapper that calls \`to_nm_profiles_with_macs\` with an empty context — preserves the migration / nm_preview / test call sites without changing their signatures.
- Bridge serializer (both keyfile and DBus dict) now emits \`bridge.mac-address\` from \`NmConnection.mac\`. Bonds/VLANs continue to use \`802-3-ethernet.cloned-mac-address\` — NM models them as having an underlying ethernet layer.

### WebUI

- Bond and Bridge create forms gain an **inverted** \"Don't inherit member MAC\" checkbox. Default off → inherit on, which is the safe behaviour. Checking it sets \`inherit_member_mac: false\` on the config so users who want a fresh MAC for the master can still get it.
- The mgmt-iface warning panel grows two paragraphs:
  - **Multi-member**: tells the user which member's MAC will be used (mgmt iface is preferred when it's in the list).
  - **Opt-out checked**: stronger warning that DHCP will likely land them on a new IP, so they should plan to confirm the rollback from there.

## Back-compat

Existing networking.json bonds/bridges loaded without the field default to \`true\` via serde — meaning **on the next apply** their masters would get the inherited MAC where they previously had a random one. That's a one-time MAC change for any pre-existing bridge/bond. Documented here so it's not a surprise:

- Pre-existing bridge/bond on user's box: MAC changes once on next apply.
- DHCP server may give a new lease (depends on whether it remembers the old random MAC vs. the inherited one).

In practice nasty users hit this exact problem when they tried to create their first bridge — the new default fixes the experience for everyone, and the one-time MAC change is the right direction (towards the DHCP-stable identity that the user originally intended).

## Test plan

- [x] \`cargo test -p nasty-system --lib\` — 195 passing (8 new \`*mac*\` tests):
  - \`pick_primary_*\` — mgmt prefer, first-member fallback, non-master None
  - \`dict_bridge_emits_mac_address_when_inherit_true\` (and \`when_inherit_false\` companion)
  - \`dict_bond_emits_cloned_mac_address_when_inherit_true\`
  - \`keyfile_bridge_mac_address_in_bridge_section\` (right NM section)
  - \`empty_mac_context_inherits_nothing\` (test / migration paths still safe)
- [x] \`cargo fmt --check\` + \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` — clean
- [x] \`npm --prefix webui run check\` — 4842 files, 0 errors
- [x] \`npm --prefix webui run test\` — 101 passing
- [ ] **Manual on 10.10.10.61**: re-do the bridge-with-ens18 test that triggered \`.62\`. After this PR, the bridge should come up with ens18's MAC, DHCP should hand back \`.61\`, and the session survives.