### PR TITLE
webui: VM wizard bridge picker + inline create (#69)

### DIFF
--- a/webui/src/lib/components/BridgeCreator.svelte
+++ b/webui/src/lib/components/BridgeCreator.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
+	import type { NetworkState, NetworkConfig } from '$lib/types';
+
+	interface Props {
+		networkState: NetworkState | null;
+		/** Called after a successful create with the new bridge's name. The
+		 * caller is responsible for re-fetching network state. */
+		onCreated?: (bridgeName: string) => void | Promise<void>;
+		/** Called when the user clicks Cancel. */
+		onCancel?: () => void;
+	}
+
+	let { networkState, onCreated, onCancel }: Props = $props();
+
+	let bridgeName = $state('br0');
+	let bridgeMembers: string[] = $state([]);
+	let bridgeMtu = $state('');
+	// Inverted UI flag (checked = NM generates a random MAC). Default
+	// unchecked: bridges adopt the primary member's MAC so DHCP keeps
+	// handing out the same lease and the user's WebUI session survives
+	// the enslave step.
+	let bridgeNoInheritMac = $state(false);
+	let busy = $state(false);
+
+	function parseMtu(v: unknown): number | null {
+		if (v === null || v === undefined || v === '') return null;
+		const n = typeof v === 'number' ? v : parseInt(String(v), 10);
+		return Number.isFinite(n) && n > 0 ? n : null;
+	}
+
+	async function create() {
+		if (!bridgeName || !networkState) return;
+		busy = true;
+		try {
+			const network = networkState.config;
+			const mtu = parseMtu(bridgeMtu);
+			const payload: NetworkConfig = {
+				interfaces: network.interfaces || [],
+				dns: network.dns || [],
+				bonds: network.bonds || [],
+				vlans: network.vlans || [],
+				bridges: [
+					...(network.bridges || []),
+					{
+						name: bridgeName,
+						members: bridgeMembers,
+						ipv4: { method: 'inherit', addresses: [], gateway: null },
+						ipv6: { method: 'inherit', addresses: [], gateway: null },
+						mtu,
+						inherit_member_mac: !bridgeNoInheritMac,
+					},
+				],
+			};
+			const res = await applyNetworkUpdate(payload, `Bridge ${bridgeName} created`);
+			if (res !== undefined) {
+				const created = bridgeName;
+				bridgeName = 'br0';
+				bridgeMembers = [];
+				bridgeMtu = '';
+				bridgeNoInheritMac = false;
+				await onCreated?.(created);
+			}
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<div class="rounded-lg border border-border bg-secondary/20 p-4 space-y-3">
+	<div class="text-sm font-medium">Create Bridge Interface</div>
+	<p class="text-xs text-muted-foreground">A virtual switch for VMs to share the host's network. Members are optional — leave empty for a host-internal bridge that VMs attach to via veth pairs, or add a physical interface to bridge VMs onto the LAN.</p>
+	<div>
+		<label for="bridge-name" class="text-xs text-muted-foreground">Name</label>
+		<input id="bridge-name" bind:value={bridgeName} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
+	</div>
+	<div>
+		<div class="text-xs text-muted-foreground mb-1">Members (optional)</div>
+		{#if networkState}
+			<div class="flex flex-wrap gap-2">
+				{#each networkState.interfaces.filter(i => i.kind === 'physical' || i.kind === 'bond') as iface}
+					<label class="flex items-center gap-1.5 text-sm">
+						<input type="checkbox" checked={bridgeMembers.includes(iface.name)}
+							onchange={() => { bridgeMembers = bridgeMembers.includes(iface.name) ? bridgeMembers.filter(m => m !== iface.name) : [...bridgeMembers, iface.name]; }} />
+						{iface.name}
+					</label>
+				{/each}
+			</div>
+		{/if}
+	</div>
+	<div>
+		<label for="bridge-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
+		<input id="bridge-mtu" type="number" min="68" max="65535" bind:value={bridgeMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
+	</div>
+	<div>
+		<label class="flex items-start gap-2 text-xs">
+			<input type="checkbox" bind:checked={bridgeNoInheritMac} class="mt-0.5" />
+			<span>
+				<span class="text-foreground">Don't inherit member MAC</span>
+				<span class="block text-muted-foreground mt-0.5">By default, the bridge adopts the primary member's MAC so DHCP keeps handing out the same lease across the enslave step. Check this to let NM/the kernel pick a random MAC instead — you'll likely get a new IP.</span>
+			</span>
+		</label>
+	</div>
+	{#if networkState?.mgmt_iface && bridgeMembers.includes(networkState.mgmt_iface)}
+		<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300 space-y-1">
+			<div class="font-medium">Heads up — this bridges your management interface</div>
+			<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. The bridge will adopt its IP and route. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
+			{#if bridgeMembers.length > 1}
+				<p>With multiple members, the bridge will use <span class="font-mono">{networkState.mgmt_iface}</span>'s MAC (the management interface, preferred when it's a member). The other members keep their own MACs as bridge slaves — they're L2-only inside the bridge.</p>
+			{/if}
+			{#if bridgeNoInheritMac}
+				<p class="font-medium">⚠ "Don't inherit member MAC" is checked. Your DHCP server will treat the bridge as a new client and is very likely to hand out a different IP — your session will land on the new IP and you'll need to reconnect there to confirm before the 30-second rollback fires.</p>
+			{/if}
+		</div>
+	{/if}
+	<div class="flex gap-2">
+		<Button size="sm" onclick={create} disabled={!bridgeName || busy}>{busy ? 'Creating…' : 'Create Bridge'}</Button>
+		{#if onCancel}
+			<Button size="sm" variant="ghost" onclick={onCancel} disabled={busy}>Cancel</Button>
+		{/if}
+	</div>
+</div>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -10,6 +10,7 @@
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
 	import { Copy, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
 
 	let activeTab: 'general' | 'network' | 'notifications' | 'metrics' | 'tuning' = $state('general');
@@ -60,14 +61,6 @@
 	let vlanMtu = $state('');
 	// Bridge form
 	let showBridgeForm = $state(false);
-	let bridgeName = $state('br0');
-	let bridgeMembers: string[] = $state([]);
-	let bridgeMtu = $state('');
-	// Same as `bondNoInheritMac` — inverted UI flag (checked = NM
-	// generates a random MAC). Default unchecked: bridges adopt
-	// the primary member's MAC, so DHCP keeps handing out the same
-	// lease and the user's WebUI session survives the enslave step.
-	let bridgeNoInheritMac = $state(false);
 	// ── General tab state ───────────────────────────────────
 	let settings: Settings | null = $state(null);
 	let info: SystemInfo | null = $state(null);
@@ -485,32 +478,8 @@
 		showVlanForm = false; vlanParent = ''; vlanId = 100; vlanMtu = '';
 	}
 
-	async function createBridge() {
-		if (!bridgeName || !network) return;
-		const mtu = parseMtu(bridgeMtu);
-		const payload: NetworkConfig = {
-			interfaces: network.interfaces || [],
-			dns: network.dns || [],
-			bonds: network.bonds || [],
-			vlans: network.vlans || [],
-			// `inherit` = adopt the primary member's L3 (DHCP lease, static
-			// addrs, default route). The server resolves it to a concrete
-			// Static/Dhcp before persisting so reboot reapplies the same L3.
-			// For host-internal bridges (no members), inherit resolves to
-			// Disabled — the bridge is L2-only, which is what VMs want.
-			bridges: [...(network.bridges || []), {
-				name: bridgeName,
-				members: bridgeMembers,
-				ipv4: { method: 'inherit', addresses: [], gateway: null },
-				ipv6: { method: 'inherit', addresses: [], gateway: null },
-				mtu,
-				// Checkbox is "Don't inherit member MAC" → invert.
-				inherit_member_mac: !bridgeNoInheritMac,
-			}],
-		};
-		await applyNetworkUpdate(payload, `Bridge ${bridgeName} created`);
+	async function refreshNetworkState() {
 		networkState = await client.call<NetworkState>('system.network.get');
-		showBridgeForm = false; bridgeName = 'br0'; bridgeMembers = []; bridgeMtu = ''; bridgeNoInheritMac = false;
 	}
 
 	async function deleteBond(name: string) {
@@ -1080,54 +1049,11 @@
 			{/if}
 
 			{#if showBridgeForm}
-				<div class="rounded-lg border border-border bg-secondary/20 p-4 space-y-3">
-					<div class="text-sm font-medium">Create Bridge Interface</div>
-					<p class="text-xs text-muted-foreground">A virtual switch for VMs to share the host's network. Members are optional — leave empty for a host-internal bridge that VMs attach to via veth pairs, or add a physical interface to bridge VMs onto the LAN.</p>
-					<div>
-						<label for="bridge-name" class="text-xs text-muted-foreground">Name</label>
-						<input id="bridge-name" bind:value={bridgeName} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
-					</div>
-					<div>
-						<div class="text-xs text-muted-foreground mb-1">Members (optional)</div>
-						{#if networkState}
-							<div class="flex flex-wrap gap-2">
-								{#each networkState.interfaces.filter(i => i.kind === 'physical' || i.kind === 'bond') as iface}
-									<label class="flex items-center gap-1.5 text-sm">
-										<input type="checkbox" checked={bridgeMembers.includes(iface.name)}
-											onchange={() => { bridgeMembers = bridgeMembers.includes(iface.name) ? bridgeMembers.filter(m => m !== iface.name) : [...bridgeMembers, iface.name]; }} />
-										{iface.name}
-									</label>
-								{/each}
-							</div>
-						{/if}
-					</div>
-					<div>
-						<label for="bridge-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
-						<input id="bridge-mtu" type="number" min="68" max="65535" bind:value={bridgeMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
-					</div>
-					<div>
-						<label class="flex items-start gap-2 text-xs">
-							<input type="checkbox" bind:checked={bridgeNoInheritMac} class="mt-0.5" />
-							<span>
-								<span class="text-foreground">Don't inherit member MAC</span>
-								<span class="block text-muted-foreground mt-0.5">By default, the bridge adopts the primary member's MAC so DHCP keeps handing out the same lease across the enslave step. Check this to let NM/the kernel pick a random MAC instead — you'll likely get a new IP.</span>
-							</span>
-						</label>
-					</div>
-					{#if networkState?.mgmt_iface && bridgeMembers.includes(networkState.mgmt_iface)}
-						<div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-300 space-y-1">
-							<div class="font-medium">Heads up — this bridges your management interface</div>
-							<p>You're connected through <span class="font-mono">{networkState.mgmt_iface}</span>. The bridge will adopt its IP and route. After applying, you'll have 30 seconds to keep the change before it auto-rolls back.</p>
-							{#if bridgeMembers.length > 1}
-								<p>With multiple members, the bridge will use <span class="font-mono">{networkState.mgmt_iface}</span>'s MAC (the management interface, preferred when it's a member). The other members keep their own MACs as bridge slaves — they're L2-only inside the bridge.</p>
-							{/if}
-							{#if bridgeNoInheritMac}
-								<p class="font-medium">⚠ "Don't inherit member MAC" is checked. Your DHCP server will treat the bridge as a new client and is very likely to hand out a different IP — your session will land on the new IP and you'll need to reconnect there to confirm before the 30-second rollback fires.</p>
-							{/if}
-						</div>
-					{/if}
-					<Button size="sm" onclick={createBridge} disabled={!bridgeName}>Create Bridge</Button>
-				</div>
+				<BridgeCreator
+					{networkState}
+					onCreated={async () => { await refreshNetworkState(); showBridgeForm = false; }}
+					onCancel={() => { showBridgeForm = false; }}
+				/>
 			{/if}
 
 			{#if showVlanForm}

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -4,7 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { VmStatus, VmCapabilities, Subvolume, FsDependents } from '$lib/types';
+	import type { VmStatus, VmCapabilities, Subvolume, FsDependents, NetworkState } from '$lib/types';
 	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -12,6 +12,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
 	import { CircleCheck, Circle, CircleX, Lock } from '@lucide/svelte';
 	import { Terminal } from '@xterm/xterm';
 	import { FitAddon } from '@xterm/addon-fit';
@@ -23,6 +24,7 @@
 	// badge so the user sees why their stopped VM can't start.
 	let lockedFsByVm = $state(new Map<string, string>());
 	let blockSubvolumes: Subvolume[] = $state([]);
+	let networkState: NetworkState | null = $state(null);
 	let wizardStep: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 = $state(0); // 0=hidden, -1=prerequisites
 	let loading = $state(true);
 	let editTab: 'general' | 'system' | 'storage' | 'network' | 'passthrough' = $state('general');
@@ -92,6 +94,14 @@
 	let newNetMode = $state('user');
 	let newNetBridge = $state('');
 	let newNetMac = $state('');
+	let showInlineBridgeForm = $state(false);
+
+	// Auto-select first bridge when switching into bridge mode with bridges available.
+	$effect(() => {
+		if (newNetMode === 'bridge' && !newNetBridge && networkState && networkState.config.bridges.length > 0) {
+			newNetBridge = networkState.config.bridges[0].name;
+		}
+	});
 
 	async function loadFilesystems() {
 		try {
@@ -250,9 +260,15 @@
 	});
 
 	onMount(async () => {
-		await Promise.all([refresh(), loadCapabilities(), loadFilesystems(), loadImages(), loadSubvolumes()]);
+		await Promise.all([refresh(), loadCapabilities(), loadFilesystems(), loadImages(), loadSubvolumes(), loadNetwork()]);
 		loading = false;
 	});
+
+	async function loadNetwork() {
+		try {
+			networkState = await client.call<NetworkState>('system.network.get');
+		} catch { /* ignore — bridge picker will show empty state */ }
+	}
 
 	async function refresh() {
 		await withToast(async () => {
@@ -344,8 +360,12 @@
 		}
 		if (newDescription) params.description = newDescription;
 		// Network
+		if (newNetMode === 'bridge' && !newNetBridge) {
+			await withToast(async () => { throw new Error('Pick a bridge or switch to NAT mode'); }, '');
+			return;
+		}
 		const net: Record<string, unknown> = { mode: newNetMode };
-		if (newNetMode === 'bridge' && newNetBridge) net.bridge = newNetBridge;
+		if (newNetMode === 'bridge') net.bridge = newNetBridge;
 		if (newNetMac) net.mac = newNetMac;
 		params.networks = [net];
 		// Passthrough
@@ -874,7 +894,37 @@
 			{#if newNetMode === 'bridge'}
 				<div class="mb-4">
 					<Label>Bridge Interface</Label>
-					<Input bind:value={newNetBridge} placeholder="br0" class="mt-1" />
+					{#if !networkState}
+						<p class="mt-1 text-xs text-muted-foreground">Loading bridges…</p>
+					{:else if showInlineBridgeForm}
+						<div class="mt-2">
+							<BridgeCreator
+								{networkState}
+								onCreated={async (name) => {
+									await loadNetwork();
+									newNetBridge = name;
+									showInlineBridgeForm = false;
+								}}
+								onCancel={() => { showInlineBridgeForm = false; }}
+							/>
+						</div>
+					{:else if networkState.config.bridges.length === 0}
+						<div class="mt-1 rounded border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+							<p class="font-medium mb-1">No bridges configured</p>
+							<p class="text-muted-foreground mb-2">VMs in bridge mode need an existing host bridge — NASty does not auto-create one. Create one here without leaving the wizard.</p>
+							<Button size="sm" variant="secondary" onclick={() => { showInlineBridgeForm = true; }}>+ Create bridge</Button>
+						</div>
+					{:else}
+						<div class="mt-1 flex gap-2">
+							<select bind:value={newNetBridge} class="h-9 flex-1 rounded-md border border-input bg-transparent px-3 text-sm">
+								<option value="" disabled>Select a bridge…</option>
+								{#each networkState.config.bridges as br}
+									<option value={br.name}>{br.name}{br.members.length > 0 ? ` (${br.members.join(', ')})` : ' (host-internal)'}</option>
+								{/each}
+							</select>
+							<Button size="sm" variant="ghost" onclick={() => { showInlineBridgeForm = true; }}>+ New</Button>
+						</div>
+					{/if}
 				</div>
 			{/if}
 			<details class="mb-4">
@@ -947,7 +997,7 @@
 					<span class="font-mono text-xs">{newIso}</span>
 				{/if}
 				<span class="text-muted-foreground">Network</span>
-				<span>{newNetMode === 'bridge' ? `Bridge (${newNetBridge || 'br0'})` : 'NAT'}</span>
+				<span>{newNetMode === 'bridge' ? `Bridge (${newNetBridge || 'none selected'})` : 'NAT'}</span>
 				{#if newPassthrough.length > 0}
 					<span class="text-muted-foreground">Passthrough</span>
 					<span>{newPassthrough.length} device{newPassthrough.length !== 1 ? 's' : ''}</span>


### PR DESCRIPTION
## Summary
- Replace the freeform "Bridge Interface" text input in the VM create wizard with a dropdown of existing bridges. Bridge entries display members (or `(host-internal)`) so it's clear which one carries which uplink.
- Add inline bridge creation right inside step 4 of the wizard — both as the empty-state action ("+ Create bridge") and as a `+ New` button next to the dropdown — so the user never has to leave the wizard and lose their in-progress state.
- Extract the bridge form into a reusable `BridgeCreator.svelte` component shared between Settings → Network and the VM wizard. Same `applyNetworkUpdate` flow, same mgmt-iface warning, same auto-rollback banner — no drift between the two code paths.

Closes #69.

## Why
Before: bridge field accepted any string. If the user typed a non-existent name (or left the default `br0` placeholder when no bridge existed), `qemu-bridge-helper` failed at VM start. There is no auto-create path on the engine side — `engine/nasty-vm/src/lib.rs` just hands the bridge name straight to the helper.

After: the dropdown is constrained to bridges that actually exist. If none exist, the user can create one inline (with the same NM-managed plumbing as Settings → Network) and the wizard auto-selects the freshly-created bridge so they continue to step 5.

## Test plan
- [ ] On a host with no bridges: open VM wizard → step 4 → switch to Bridge mode → see empty-state card → "+ Create bridge" → form opens inline → create a host-internal bridge (no members) → form closes, dropdown auto-selects it.
- [ ] On a host with existing bridges: dropdown lists them with member labels, "+ New" button opens the form.
- [ ] Inline creation with mgmt-iface as a member shows the heads-up warning and triggers the 30s auto-rollback banner.
- [ ] Settings → Network → "+ Bridge" still works (now using the shared component).
- [ ] `npm run check` and `npm run build` pass.