### PR TITLE
apps: pre-deploy check for missing host devices in compose (#98)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -358,6 +358,29 @@ pub struct PortConflict {
     pub used_by: String,
 }
 
+// ── Device check types ────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckDevicesRequest {
+    /// Host device paths to check, e.g. `/dev/dri/renderD128`. Anything
+    /// after the first colon (the in-container path or cgroup perms) is
+    /// the caller's job to strip — this RPC only stat()s host paths.
+    pub paths: Vec<String>,
+}
+
+/// One missing device. `parent_exists` lets the UI distinguish between
+/// "device doesn't exist but its parent dir does" (likely the host has
+/// some GPU but not the requested one) and "parent dir is missing too"
+/// (likely the relevant kernel module isn't loaded — `/dev/dri` not
+/// being present means no DRM driver bound any display device).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DeviceMissing {
+    /// The device path the caller asked about, echoed back.
+    pub path: String,
+    /// True when the path's parent directory exists on the host.
+    pub parent_exists: bool,
+}
+
 // ── Service ─────────────────────────────────────────────────────
 
 pub struct AppsService {
@@ -1728,6 +1751,41 @@ impl AppsService {
         conflicts
     }
 
+    // ── Device existence check ────────────────────────────────────
+
+    /// Stat each requested host path; report the ones that don't exist.
+    /// Cheap enough to call on every keystroke (it's just `stat(2)` per
+    /// path, no Docker round-trip), so the WebUI debounces it the same
+    /// way as `check_ports`. Errors other than ENOENT (permission
+    /// denied, etc.) are treated as "exists" — we'd rather miss a
+    /// warning than block a legitimate deploy because of a stat hiccup.
+    pub async fn check_devices(&self, req: CheckDevicesRequest) -> Vec<DeviceMissing> {
+        let mut missing = Vec::new();
+        for raw in &req.paths {
+            let path = raw.trim();
+            if path.is_empty() {
+                continue;
+            }
+            match tokio::fs::metadata(path).await {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    let parent_exists = match std::path::Path::new(path).parent() {
+                        Some(p) if !p.as_os_str().is_empty() => {
+                            tokio::fs::metadata(p).await.is_ok()
+                        }
+                        _ => false,
+                    };
+                    missing.push(DeviceMissing {
+                        path: raw.clone(),
+                        parent_exists,
+                    });
+                }
+                Err(_) => {}
+            }
+        }
+        missing
+    }
+
     // ── Image inspection ────────────────────────────────────
 
     pub async fn inspect_image(&self, image: &str) -> Result<ImageInspectResult, AppsError> {
@@ -2681,5 +2739,56 @@ mod tests {
             true,
         )
         .unwrap();
+    }
+
+    use super::{AppsService, CheckDevicesRequest};
+
+    #[tokio::test]
+    async fn check_devices_reports_missing_with_parent_existing() {
+        // /dev exists on every Linux host; the named device cannot.
+        let svc = AppsService::new();
+        let r = svc
+            .check_devices(CheckDevicesRequest {
+                paths: vec!["/dev/this-device-cannot-exist-nasty-test".to_string()],
+            })
+            .await;
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].path, "/dev/this-device-cannot-exist-nasty-test");
+        assert!(r[0].parent_exists, "/dev should exist");
+    }
+
+    #[tokio::test]
+    async fn check_devices_flags_missing_parent() {
+        let svc = AppsService::new();
+        let r = svc
+            .check_devices(CheckDevicesRequest {
+                paths: vec!["/this-parent-cannot-exist-nasty-test/whatever".to_string()],
+            })
+            .await;
+        assert_eq!(r.len(), 1);
+        assert!(!r[0].parent_exists);
+    }
+
+    #[tokio::test]
+    async fn check_devices_skips_existing() {
+        // /dev/null is on every Linux host. Don't report it.
+        let svc = AppsService::new();
+        let r = svc
+            .check_devices(CheckDevicesRequest {
+                paths: vec!["/dev/null".to_string()],
+            })
+            .await;
+        assert!(r.is_empty(), "expected empty, got {r:?}");
+    }
+
+    #[tokio::test]
+    async fn check_devices_skips_blank_entries() {
+        let svc = AppsService::new();
+        let r = svc
+            .check_devices(CheckDevicesRequest {
+                paths: vec!["".to_string(), "   ".to_string()],
+            })
+            .await;
+        assert!(r.is_empty());
     }
 }

--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -144,6 +144,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.settings.timezones"
                 | "audit.list"
                 | "apps.check_ports"
+                | "apps.check_devices"
                 | "apps.status"
                 | "apps.logs"
                 | "apps.compose.logs"
@@ -2545,6 +2546,10 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         },
         "apps.check_ports" => match parse_params(req) {
             Ok(p) => ok(req, state.apps.check_ports(p).await),
+            Err(e) => invalid(req, e),
+        },
+        "apps.check_devices" => match parse_params(req) {
+            Ok(p) => ok(req, state.apps.check_devices(p).await),
             Err(e) => invalid(req, e),
         },
         "apps.config" => match require_str(req, "name") {

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -250,10 +250,19 @@
 
 	// Port conflict state
 	let portConflicts = $state<{ port: number; used_by: string }[]>([]);
-	let composeErrorLines = $state<number[]>([]);
+	let composePortErrorLines = $state<number[]>([]);
 	let composePortLineMap = $state<Map<number, number>>(new Map()); // port → line number
 	let checkingPorts = $state(false);
 	let portCheckTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Device existence state — populated for compose mode only (the simple
+	// installer doesn't surface a `devices:` field).
+	let deviceMissing = $state<{ path: string; parent_exists: boolean }[]>([]);
+	let composeDeviceErrorLines = $state<number[]>([]);
+	let composeDeviceLineMap = $state<Map<string, number>>(new Map()); // path → line number
+
+	// Editor underlines both port-conflict and missing-device lines.
+	const composeErrorLines = $derived([...composePortErrorLines, ...composeDeviceErrorLines]);
 
 	const client = getClient();
 	let startupPoll: ReturnType<typeof setInterval> | null = null;
@@ -317,6 +326,11 @@
 	}
 
 	function checkComposeConflicts() {
+		checkComposePortConflicts();
+		checkComposeDeviceConflicts();
+	}
+
+	function checkComposePortConflicts() {
 		// Parse host ports from compose YAML (best-effort), tracking line numbers
 		const portLines: { port: number; line: number }[] = [];
 		const lines = composeContent.split('\n');
@@ -327,7 +341,8 @@
 		const ports = portLines.map(p => p.port);
 		if (ports.length === 0) {
 			portConflicts = [];
-			composeErrorLines = [];
+			composePortErrorLines = [];
+			composePortLineMap = new Map();
 			return;
 		}
 		checkingPorts = true;
@@ -337,9 +352,62 @@
 		).then(r => {
 			portConflicts = r;
 			const conflictPorts = new Set(r.map(c => c.port));
-			composeErrorLines = portLines.filter(p => conflictPorts.has(p.port)).map(p => p.line);
+			composePortErrorLines = portLines.filter(p => conflictPorts.has(p.port)).map(p => p.line);
 			composePortLineMap = new Map(portLines.map(p => [p.port, p.line]));
-		}).catch(() => { portConflicts = []; composeErrorLines = []; composePortLineMap = new Map(); }).finally(() => { checkingPorts = false; });
+		}).catch(() => { portConflicts = []; composePortErrorLines = []; composePortLineMap = new Map(); }).finally(() => { checkingPorts = false; });
+	}
+
+	/** Parse `devices:` block entries from compose YAML, tracking the host
+	 * path of each entry (everything before the first colon) and its
+	 * source-line number. We track the section by indent rather than
+	 * regex-on-every-line so we don't mis-classify volumes or env vars
+	 * that happen to start with a dash. */
+	function parseComposeDeviceLines(content: string): { path: string; line: number }[] {
+		const out: { path: string; line: number }[] = [];
+		const lines = content.split('\n');
+		let inDevices = false;
+		let devicesIndent = -1;
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			const indentMatch = line.match(/^(\s*)/);
+			const indent = indentMatch ? indentMatch[1].length : 0;
+			const trimmed = line.trim();
+			if (!trimmed || trimmed.startsWith('#')) continue;
+			if (inDevices && indent <= devicesIndent && !trimmed.startsWith('-')) {
+				inDevices = false;
+			}
+			if (trimmed.match(/^devices:\s*(#.*)?$/)) {
+				inDevices = true;
+				devicesIndent = indent;
+				continue;
+			}
+			if (inDevices) {
+				// `- /dev/foo`, `- /dev/foo:/dev/foo`, `- "/dev/foo:/dev/foo:rwm"`
+				const m = line.match(/^\s*-\s*"?([^":\s]+)/);
+				if (m) out.push({ path: m[1], line: i + 1 });
+			}
+		}
+		return out;
+	}
+
+	function checkComposeDeviceConflicts() {
+		const deviceLines = parseComposeDeviceLines(composeContent);
+		if (deviceLines.length === 0) {
+			deviceMissing = [];
+			composeDeviceErrorLines = [];
+			composeDeviceLineMap = new Map();
+			return;
+		}
+		const paths = deviceLines.map(d => d.path);
+		client.call<{ path: string; parent_exists: boolean }[]>(
+			'apps.check_devices',
+			{ paths }
+		).then(r => {
+			deviceMissing = r;
+			const missingSet = new Set(r.map(m => m.path));
+			composeDeviceErrorLines = deviceLines.filter(d => missingSet.has(d.path)).map(d => d.line);
+			composeDeviceLineMap = new Map(deviceLines.map(d => [d.path, d.line]));
+		}).catch(() => { deviceMissing = []; composeDeviceErrorLines = []; composeDeviceLineMap = new Map(); });
 	}
 
 	onMount(async () => {
@@ -710,7 +778,11 @@
 		showCompose = false;
 		editingCompose = null;
 		portConflicts = [];
-		composeErrorLines = [];
+		composePortErrorLines = [];
+		composePortLineMap = new Map();
+		deviceMissing = [];
+		composeDeviceErrorLines = [];
+		composeDeviceLineMap = new Map();
 		composeName = ''; composeContent = '';
 		composeAllowUnsafe = false;
 	}
@@ -1067,6 +1139,21 @@
 								{@const alt = c.port < 1000 ? c.port + 8000 : c.port + 1}
 								{@const lineNo = composePortLineMap.get(c.port)}
 							<div><span class="font-semibold">Line {lineNo}:</span> port {c.port} is already in use by <span class="font-semibold">{c.used_by}</span> — change to e.g. <code>{alt}</code></div>
+							{/each}
+						</div>
+					{/if}
+					{#if deviceMissing.length > 0}
+						<div class="mt-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+							{#each deviceMissing as d}
+								{@const lineNo = composeDeviceLineMap.get(d.path)}
+								<div>
+									<span class="font-semibold">Line {lineNo}:</span> device <code>{d.path}</code> doesn't exist on this host
+									{#if !d.parent_exists}
+										— parent directory missing too, the kernel driver may not be loaded (e.g. <code>i915</code> for Intel GPU)
+									{:else}
+										— check the device name (<code>ls {(d.path.split('/').slice(0, -1).join('/')) || '/'}</code>) or whether the device is physically present
+									{/if}
+								</div>
 							{/each}
 						</div>
 					{/if}


### PR DESCRIPTION
## Summary
- Add `apps.check_devices` RPC mirroring `apps.check_ports`: stat each requested host path, return the missing ones with a `parent_exists` hint.
- Compose editor now parses the `devices:` block on every keystroke (debounced via the same path as port checks), underlines missing-device lines, and shows a red banner under the editor with the path, line number, and a hint that distinguishes "device gone" (parent dir exists — wrong device name / hardware not present) from "driver not loaded" (parent dir also missing — e.g. `/dev/dri` itself doesn't exist when no DRM driver bound).

Partial fix for #98 — the device half. The UID/GID half ships in a separate PR.

## Why
Pasted compose stacks that reference a host device used to fail at the docker-compose-up step with a generic "no such file or directory" error buried in the deploy log. The most common case is GPU passthrough (`/dev/dri/renderD128` from the official Jellyfin compose snippet). Now the user sees the problem before clicking Deploy.

## Test plan
- [ ] Paste a compose with `devices: - /dev/dri/renderD128:/dev/dri/renderD128` on a host without an Intel GPU → red banner appears under the editor with the device path and a hint about the i915 driver.
- [ ] Same compose on a host with `/dev/dri` populated → no banner.
- [ ] Compose with no `devices:` block → no banner, no superfluous RPC traffic.
- [ ] `cargo test -p nasty-apps`, `cargo clippy --all-targets -- -D warnings`, `npm run check`, `npm run build` all pass.