### PR TITLE
apps: pick TCP port for ingress; click-to-switch port chips (#97)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -996,8 +996,17 @@ impl AppsService {
             warn!("Failed to save app manifest: {e}");
         }
 
-        // Auto-create ingress for the first port
-        if let Some(first_port) = req.ports.first() {
+        // Auto-create ingress for the first TCP port. UDP can't serve
+        // HTTP (nginx's `proxy_pass` is TCP-only), so a UDP port is
+        // never a valid ingress target — picking it would publish a
+        // dead /apps/<name>/ route. If the app exposes only UDP, no
+        // ingress is created; the user can still reach the container
+        // directly on the LAN.
+        if let Some(first_port) = req
+            .ports
+            .iter()
+            .find(|p| p.protocol.eq_ignore_ascii_case("tcp"))
+        {
             let host_port = if let Some(hp) = first_port.host_port {
                 hp
             } else {
@@ -1740,9 +1749,13 @@ impl AppsService {
             return Err(AppsError::DockerFailed(stderr.to_string()));
         }
 
-        // Auto-create ingress for the first exposed port
+        // Auto-create ingress for the first exposed TCP port. See the
+        // matching comment in `install()` for why UDP is skipped.
         if let Ok(app) = self.get(&req.name).await
-            && let Some(first_port) = app.ports.first()
+            && let Some(first_port) = app
+                .ports
+                .iter()
+                .find(|p| p.protocol.eq_ignore_ascii_case("tcp"))
         {
             let _ = self
                 .ingress_set(SetIngressRequest {

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -854,6 +854,36 @@
 		return ingresses.find(r => r.name === appName);
 	}
 
+	/** Pick the port the direct-LAN link and reverse-proxy "Open" button
+	 * should target. Prefers the user's chosen ingress port; falls back
+	 * to the first TCP port (UDP can't serve HTTP). Returns null when
+	 * the app has no TCP-reachable port. */
+	function primaryPort(app: App): MappedPort | null {
+		const ing = getIngress(app.name);
+		if (ing && app.ports) {
+			const match = app.ports.find(p => p.host_port === ing.host_port);
+			if (match) return match;
+		}
+		return (app.ports ?? []).find(p => p.protocol?.toLowerCase() === 'tcp') ?? null;
+	}
+
+	let switchingIngressFor = $state<string | null>(null);
+
+	/** Re-point an app's ingress at the given host port. Used by the
+	 * port chips when the user clicks a non-current TCP port. */
+	async function setIngressPort(appName: string, hostPort: number) {
+		switchingIngressFor = appName;
+		try {
+			await withToast(
+				() => client.call('apps.ingress.set', { name: appName, host_port: hostPort }),
+				`Ingress for ${appName} → :${hostPort}`
+			);
+			await loadIngresses();
+		} finally {
+			switchingIngressFor = null;
+		}
+	}
+
 	let search = $state('');
 	let sortDir = $state<'asc' | 'desc'>('asc');
 
@@ -1349,9 +1379,34 @@
 							</div>
 						</td>
 						<td class="p-3 text-xs text-muted-foreground font-mono max-w-[200px] truncate">{app.kind === 'compose' && (app.containers?.length ?? 0) > 1 ? `${app.containers?.length} images` : app.image}</td>
-						<td class="p-3 text-xs font-mono text-muted-foreground">
+						<td class="p-3 text-xs font-mono">
 							{#if app.ports && app.ports.length > 0}
-								{app.ports.map(p => `${p.host_port}:${p.container_port}`).join(', ')}
+								{@const currentIngress = getIngress(app.name)?.host_port}
+								<div class="flex flex-wrap items-center gap-1">
+									{#each app.ports as p}
+										{@const isTcp = (p.protocol ?? 'tcp').toLowerCase() === 'tcp'}
+										{@const isIngress = isTcp && currentIngress === p.host_port}
+										{#if isTcp}
+											<button
+												type="button"
+												disabled={isIngress || switchingIngressFor === app.name}
+												onclick={() => setIngressPort(app.name, p.host_port)}
+												class="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 transition-colors {isIngress ? 'border-blue-500/40 bg-blue-500/15 text-blue-400 cursor-default' : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'}"
+												title={isIngress ? 'Current reverse-proxy target' : `Click to make :${p.host_port} the reverse-proxy target`}
+											>
+												{#if isIngress}<span aria-hidden="true">★</span>{/if}
+												{p.host_port}:{p.container_port}
+											</button>
+										{:else}
+											<span
+												class="inline-flex items-center gap-1 rounded-md border border-border/60 px-1.5 py-0.5 text-muted-foreground/70"
+												title="UDP — reverse proxy doesn't apply"
+											>
+												{p.host_port}:{p.container_port}/udp
+											</span>
+										{/if}
+									{/each}
+								</div>
 							{/if}
 						</td>
 						<td class="p-3">
@@ -1361,12 +1416,13 @@
 						</td>
 						<td class="p-3">
 							<div class="flex items-center gap-1.5">
-								{#if app.ports && app.ports.length > 0}
-									<a href="/apps/{app.name}/" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-400 hover:bg-blue-500/20">
+								{#if primaryPort(app)}
+									{@const pp = primaryPort(app)!}
+									<a href="/apps/{app.name}/" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-400 hover:bg-blue-500/20" title="Reverse proxy target: {pp.host_port}">
 										Open
 									</a>
-									<a href="http://{window.location.hostname}:{app.ports[0].host_port}" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted" title="Direct port access (LAN)">
-										:{app.ports[0].host_port}
+									<a href="http://{window.location.hostname}:{pp.host_port}" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted" title="Direct port access (LAN)">
+										:{pp.host_port}
 									</a>
 								{/if}
 								{#if status?.running}


### PR DESCRIPTION
## Summary
Closes #97.

Two fixes for the "ingress points at the wrong port" pattern Huxy hit with the Jellyfin compose (`8096/tcp` for the web UI, `7359/udp` for autodiscovery — auto-ingress grabbed the UDP one and the /apps/jellyfin/ route was dead):

### Engine
- Auto-ingress in both `install()` (simple) and `compose_install()` now picks the first **TCP** port instead of just the first port. UDP is never a valid ingress target — nginx's `proxy_pass` is TCP-only — so it gets skipped outright.
- If the app exposes only UDP, no ingress is created (rather than a dead one).

### WebUI
- Ports cell renders chips with protocol shown:
  - **TCP chips are buttons** — clicking one re-points ingress at that port via the existing `apps.ingress.set` RPC.
  - **Current ingress port** gets a starred blue chip and is non-clickable.
  - **UDP entries** are dimmed text-only (no click affordance, since they can't serve as ingress).
- The "Open" and direct-port (`:NNNN`) links in the Actions column now follow the selected ingress port instead of `ports[0]`, so the link doesn't disagree with the route.

## Test plan
- [ ] Repro #97: deploy Huxy's Jellyfin compose. Auto-ingress should land on 8096/tcp; "Open" link should reach the web UI.
- [ ] On the apps row, the 8096/tcp chip is starred + disabled; clicking another TCP chip switches ingress (toast confirms, star moves, Open link updates).
- [ ] App with only UDP ports → no Open/direct-port button, no clickable chips (UDP shows dimmed).
- [ ] Simple-app install with a single TCP port → unchanged behaviour.
- [ ] `cargo test -p nasty-apps`, `cargo clippy --all-targets -- -D warnings`, `npm run check`, `npm run build` all pass.