### PR TITLE
vm: USB passthrough + missing engine PATH entries (#67)

### DIFF
--- a/engine/nasty-engine/src/router.rs
+++ b/engine/nasty-engine/src/router.rs
@@ -3196,6 +3196,7 @@ async fn vm_clone(
         },
         networks: Some(src.networks.clone()),
         passthrough_devices: None, // Don't clone passthrough — can't share devices
+        usb_devices: None,         // Same reasoning — only one VM at a time can own a USB device
         boot_iso: None,
         boot_order: Some(src.boot_order.clone()),
         uefi: Some(src.uefi),

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -32,6 +32,8 @@ pub enum VmError {
     KvmNotAvailable,
     #[error("invalid disk path: {0}")]
     InvalidDiskPath(String),
+    #[error("invalid USB device: {0}")]
+    InvalidUsbDevice(String),
     #[error("QEMU command failed: {0}")]
     QemuFailed(String),
     #[error("QMP error: {0}")]
@@ -49,6 +51,7 @@ impl VmError {
             Self::NotRunning(_) => -32004,
             Self::KvmNotAvailable => -32005,
             Self::InvalidDiskPath(_) => -32009,
+            Self::InvalidUsbDevice(_) => -32010,
             Self::QemuFailed(_) => -32006,
             Self::Qmp(_) => -32007,
             Self::Io(_) => -32008,
@@ -74,6 +77,13 @@ pub struct VmConfig {
     pub networks: Vec<VmNetwork>,
     /// PCI devices to pass through via VFIO.
     pub passthrough_devices: Vec<PassthroughDevice>,
+    /// USB devices to pass through. Identified by vendor/product ID
+    /// rather than bus/addr because USB enumeration order shuffles
+    /// across reboots; pinning to IDs is the stable choice. Caveat:
+    /// all devices matching a (vendor, product) pair attach, so
+    /// plugging in two identical keyboards passes both through.
+    #[serde(default)]
+    pub usb_devices: Vec<UsbPassthrough>,
     /// Path to boot ISO (for installation). Removed after first boot if desired.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boot_iso: Option<String>,
@@ -173,6 +183,20 @@ pub struct PassthroughDevice {
     pub label: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct UsbPassthrough {
+    /// 4-hex-digit USB vendor ID (e.g. "0bda"). Stored lowercase
+    /// without the `0x` prefix to match `lsusb` formatting.
+    pub vendor_id: String,
+    /// 4-hex-digit USB product ID.
+    pub product_id: String,
+    /// Human-readable label preserved for the UI (e.g. "Realtek
+    /// Bluetooth dongle"). The kernel can't tell us this — it comes
+    /// from the original `lsusb` listing the user picked from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct VmStatus {
     /// VM configuration.
@@ -204,6 +228,8 @@ pub struct CreateVmRequest {
     pub networks: Option<Vec<VmNetwork>>,
     /// PCI devices to pass through.
     pub passthrough_devices: Option<Vec<PassthroughDevice>>,
+    /// USB devices to pass through (vendor:product pairs).
+    pub usb_devices: Option<Vec<UsbPassthrough>>,
     /// Path to boot ISO for installation.
     pub boot_iso: Option<String>,
     /// Boot order: "disk", "cdrom", or "network".
@@ -232,6 +258,8 @@ pub struct UpdateVmRequest {
     pub networks: Option<Vec<VmNetwork>>,
     /// Replace passthrough devices.
     pub passthrough_devices: Option<Vec<PassthroughDevice>>,
+    /// Replace USB passthrough devices.
+    pub usb_devices: Option<Vec<UsbPassthrough>>,
     /// Set or clear boot ISO.
     pub boot_iso: Option<String>,
     /// Boot order.
@@ -337,6 +365,28 @@ fn validate_vm_path(path: &str) -> Result<(), VmError> {
 /// Path to the QMP unix socket for a given VM.
 fn qmp_socket_path(vm_id: &str) -> String {
     format!("{QMP_DIR}/{vm_id}.qmp")
+}
+
+/// Validate a USB vendor/product ID. We format these directly into the
+/// QEMU command line, so anything but a 4-hex-digit string is a
+/// rejection (defends against a malformed manifest sneaking arbitrary
+/// args onto the qemu invocation).
+fn validate_usb_id(id: &str) -> Result<(), VmError> {
+    if id.len() != 4 || !id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(VmError::InvalidUsbDevice(format!(
+            "USB id '{id}' must be 4 hex digits"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate every USB passthrough entry in a config.
+fn validate_usb_passthroughs(devices: &[UsbPassthrough]) -> Result<(), VmError> {
+    for d in devices {
+        validate_usb_id(&d.vendor_id)?;
+        validate_usb_id(&d.product_id)?;
+    }
+    Ok(())
 }
 
 /// Path to the VNC unix socket for a given VM.
@@ -464,6 +514,9 @@ impl VmService {
             }
             validate_vm_path(iso)?;
         }
+        if let Some(ref usb) = req.usb_devices {
+            validate_usb_passthroughs(usb)?;
+        }
 
         let id = Uuid::new_v4().to_string();
 
@@ -481,6 +534,7 @@ impl VmService {
                 }]
             }),
             passthrough_devices: req.passthrough_devices.unwrap_or_default(),
+            usb_devices: req.usb_devices.unwrap_or_default(),
             boot_iso: req.boot_iso,
             boot_order: req.boot_order.unwrap_or_else(|| "disk".to_string()),
             uefi: req.uefi.unwrap_or(true),
@@ -524,6 +578,7 @@ impl VmService {
                 || req.disks.is_some()
                 || req.networks.is_some()
                 || req.passthrough_devices.is_some()
+                || req.usb_devices.is_some()
                 || req.boot_iso.is_some()
                 || req.boot_order.is_some()
                 || req.uefi.is_some()
@@ -551,6 +606,10 @@ impl VmService {
             }
             if let Some(pt) = req.passthrough_devices {
                 config.passthrough_devices = pt;
+            }
+            if let Some(usb) = req.usb_devices {
+                validate_usb_passthroughs(&usb)?;
+                config.usb_devices = usb;
             }
             if let Some(ref iso) = req.boot_iso {
                 config.boot_iso = if iso.is_empty() {
@@ -928,6 +987,25 @@ fn build_qemu_args(config: &VmConfig) -> Vec<String> {
         ]);
     }
 
+    // USB passthrough — only emit the XHCI controller when there's at
+    // least one device, so VMs without USB passthrough stay minimal.
+    if !config.usb_devices.is_empty() {
+        args.extend_from_slice(&["-device".to_string(), "qemu-xhci,id=xhci".to_string()]);
+        for dev in &config.usb_devices {
+            // QEMU expects the `0x` prefix; lsusb-style 4-hex is what
+            // we store, so prepend here. Validation lives in
+            // `validate_usb_id` so a malformed manifest can't sneak
+            // garbage onto the command line.
+            args.extend_from_slice(&[
+                "-device".to_string(),
+                format!(
+                    "usb-host,bus=xhci.0,vendorid=0x{},productid=0x{}",
+                    dev.vendor_id, dev.product_id
+                ),
+            ]);
+        }
+    }
+
     // QMP control socket
     args.extend_from_slice(&[
         "-qmp".to_string(),
@@ -1044,4 +1122,104 @@ async fn list_pci_devices() -> Vec<PciDevice> {
     }
 
     devices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> VmConfig {
+        VmConfig {
+            id: "test-id".to_string(),
+            name: "test".to_string(),
+            cpus: 1,
+            memory_mib: 512,
+            disks: vec![],
+            networks: vec![],
+            passthrough_devices: vec![],
+            usb_devices: vec![],
+            boot_iso: None,
+            boot_order: "disk".to_string(),
+            uefi: false,
+            description: None,
+            autostart: false,
+            cpu_model: None,
+            machine_type: None,
+            vga: None,
+            extra_args: None,
+        }
+    }
+
+    #[test]
+    fn usb_id_validator_accepts_lowercase_hex() {
+        assert!(validate_usb_id("0bda").is_ok());
+        assert!(validate_usb_id("ffff").is_ok());
+    }
+
+    #[test]
+    fn usb_id_validator_accepts_uppercase_hex() {
+        assert!(validate_usb_id("0BDA").is_ok());
+    }
+
+    #[test]
+    fn usb_id_validator_rejects_wrong_length() {
+        assert!(validate_usb_id("0bd").is_err());
+        assert!(validate_usb_id("0bdaa").is_err());
+        assert!(validate_usb_id("").is_err());
+    }
+
+    #[test]
+    fn usb_id_validator_rejects_non_hex() {
+        // Catches injection attempts like " -device foo".
+        assert!(validate_usb_id("0xff").is_err()); // the leading "0x" is 4 chars but not hex
+        assert!(validate_usb_id("zzzz").is_err());
+        assert!(validate_usb_id("00 0").is_err());
+    }
+
+    #[test]
+    fn qemu_args_omit_xhci_when_no_usb_devices() {
+        let cfg = base_config();
+        let args = build_qemu_args(&cfg);
+        assert!(
+            !args.iter().any(|a| a.contains("qemu-xhci")),
+            "got: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a.starts_with("usb-host")),
+            "got: {args:?}"
+        );
+    }
+
+    #[test]
+    fn qemu_args_emit_xhci_controller_and_each_usb_device() {
+        let mut cfg = base_config();
+        cfg.usb_devices = vec![
+            UsbPassthrough {
+                vendor_id: "0bda".to_string(),
+                product_id: "8153".to_string(),
+                label: Some("Realtek USB Ethernet".to_string()),
+            },
+            UsbPassthrough {
+                vendor_id: "046d".to_string(),
+                product_id: "c52b".to_string(),
+                label: None,
+            },
+        ];
+        let args = build_qemu_args(&cfg);
+        // Exactly one XHCI controller, regardless of device count.
+        let xhci_count = args.iter().filter(|a| a.contains("qemu-xhci")).count();
+        assert_eq!(xhci_count, 1, "args: {args:?}");
+        assert!(
+            args.iter()
+                .any(|a| a == "usb-host,bus=xhci.0,vendorid=0x0bda,productid=0x8153"),
+            "missing first device, args: {args:?}"
+        );
+        assert!(
+            args.iter().any(
+                |a| a == "usb-host,bus=xhci.0,vendorid=0x046d,productid=0x52b"
+                    || a == "usb-host,bus=xhci.0,vendorid=0x046d,productid=0xc52b"
+            ),
+            "missing second device, args: {args:?}"
+        );
+    }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -929,6 +929,9 @@ in {
         procps                       # sysctl (vm.dirty_* tuning)
         nftables                     # nft (dynamic firewall rules)
         getent                       # getent (user/group lookups)
+        pciutils                     # lspci — PCI passthrough enumeration + hardware page
+        usbutils                     # lsusb — USB enumeration for hardware page + VM USB passthrough
+        dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]
         ++ lib.optionals cfg.iscsi.enable [ targetcli-fixed ]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -861,6 +861,16 @@ export interface PassthroughDevice {
 	label?: string;
 }
 
+/** USB device pinned for passthrough. We identify by vendor:product
+ * because USB enumeration order is not stable across reboots; the
+ * tradeoff is that any device matching the pair attaches (plugging
+ * two identical dongles passes both through). */
+export interface UsbPassthrough {
+	vendor_id: string;
+	product_id: string;
+	label?: string;
+}
+
 export interface VmConfig {
 	id: string;
 	name: string;
@@ -869,6 +879,7 @@ export interface VmConfig {
 	disks: VmDisk[];
 	networks: VmNetwork[];
 	passthrough_devices: PassthroughDevice[];
+	usb_devices?: UsbPassthrough[];
 	boot_iso?: string;
 	boot_order: string;
 	uefi: boolean;

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -4,7 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { VmStatus, VmCapabilities, Subvolume, FsDependents, NetworkState } from '$lib/types';
+	import type { VmStatus, VmCapabilities, Subvolume, FsDependents, NetworkState, UsbPassthrough, HardwareSummary, UsbDevice } from '$lib/types';
 	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -57,6 +57,11 @@
 	let newBootOrder = $state('disk');
 	let newAutostart = $state(false);
 	let newPassthrough = $state<string[]>([]);
+	/** USB devices selected for the new-VM wizard. Stored as `vid:pid`
+	 * strings so we can reuse Set/array operations; converted to
+	 * `UsbPassthrough` objects right before the create call. */
+	let newUsbPassthrough = $state<string[]>([]);
+	let usbDevices = $state<UsbDevice[]>([]);
 
 	// Passthrough edit state (for running/stopped VM detail view)
 	let editPtVm = $state<string | null>(null);
@@ -85,9 +90,18 @@
 	async function openWizard() {
 		newName = ''; newCpus = 1; newMemory = 1024; newDisk = ''; newDiskCreate = false;
 		newDiskFs = ''; newDiskSize = 10; newIso = ''; newDescription = '';
-		newBootOrder = 'disk'; newAutostart = false; newPassthrough = [];
-		await Promise.all([loadSubvolumes(), loadFilesystems(), loadImages()]);
+		newBootOrder = 'disk'; newAutostart = false; newPassthrough = []; newUsbPassthrough = [];
+		await Promise.all([loadSubvolumes(), loadFilesystems(), loadImages(), loadUsbDevices()]);
 		wizardStep = canCreateVm ? 1 : -1; // -1 = prerequisites
+	}
+
+	async function loadUsbDevices() {
+		try {
+			const hw = await client.call<HardwareSummary>('system.hardware.summary');
+			usbDevices = hw.usb;
+		} catch {
+			usbDevices = [];
+		}
 	}
 
 	// Network state for create wizard
@@ -375,6 +389,13 @@
 				return { address: addr, label: dev?.description ?? null };
 			});
 		}
+		if (newUsbPassthrough.length > 0) {
+			params.usb_devices = newUsbPassthrough.map(key => {
+				const [vendor_id, product_id] = key.split(':');
+				const dev = usbDevices.find(d => d.vendor_id === vendor_id && d.product_id === product_id);
+				return { vendor_id, product_id, label: dev?.description ?? null };
+			});
+		}
 
 		const ok = await withToast(
 			() => client.call('vm.create', params),
@@ -385,7 +406,7 @@
 			newName = ''; newCpus = 1; newMemory = 1024; newDisk = '';
 			newDiskCreate = false; newDiskFs = ''; newDiskSize = 10;
 			newIso = ''; newDescription = ''; newBootOrder = 'disk';
-			newAutostart = false; newPassthrough = [];
+			newAutostart = false; newPassthrough = []; newUsbPassthrough = [];
 			newNetMode = 'user'; newNetBridge = ''; newNetMac = '';
 			await refresh();
 		}
@@ -972,6 +993,37 @@
 					<p class="mt-1 text-xs text-muted-foreground">No PCI devices available. Enable VT-d (Intel) or AMD-Vi in BIOS/UEFI settings. Not available on virtual machines.</p>
 				{/if}
 			</div>
+			<div class="mb-4">
+				<Label>USB Passthrough</Label>
+				{#if usbDevices.length > 0}
+					<div class="mt-1 max-h-40 overflow-y-auto rounded border border-input p-2 space-y-1">
+						{#each usbDevices as dev}
+							{@const key = `${dev.vendor_id}:${dev.product_id}`}
+							<label class="flex items-start gap-2 text-xs cursor-pointer hover:bg-muted/30 rounded p-1">
+								<input
+									type="checkbox"
+									class="mt-0.5 rounded border-input"
+									checked={newUsbPassthrough.includes(key)}
+									onchange={() => {
+										if (newUsbPassthrough.includes(key)) {
+											newUsbPassthrough = newUsbPassthrough.filter(k => k !== key);
+										} else {
+											newUsbPassthrough = [...newUsbPassthrough, key];
+										}
+									}}
+								/>
+								<div>
+									<span class="font-mono">{dev.vendor_id}:{dev.product_id}</span>
+									<span class="text-muted-foreground ml-1">{dev.description}</span>
+								</div>
+							</label>
+						{/each}
+					</div>
+					<span class="mt-1 block text-xs text-muted-foreground">Matched by vendor:product — stable across reboots. Any device with this ID attaches, so two identical dongles would both pass through.</span>
+				{:else}
+					<p class="mt-1 text-xs text-muted-foreground">No USB devices detected.</p>
+				{/if}
+			</div>
 			<div class="flex gap-2">
 				<Button variant="secondary" size="sm" onclick={() => wizardStep = 4}>← Back</Button>
 				<Button size="sm" onclick={() => wizardStep = 6}>Next: Review →</Button>
@@ -999,8 +1051,12 @@
 				<span class="text-muted-foreground">Network</span>
 				<span>{newNetMode === 'bridge' ? `Bridge (${newNetBridge || 'none selected'})` : 'NAT'}</span>
 				{#if newPassthrough.length > 0}
-					<span class="text-muted-foreground">Passthrough</span>
+					<span class="text-muted-foreground">PCI passthrough</span>
 					<span>{newPassthrough.length} device{newPassthrough.length !== 1 ? 's' : ''}</span>
+				{/if}
+				{#if newUsbPassthrough.length > 0}
+					<span class="text-muted-foreground">USB passthrough</span>
+					<span>{newUsbPassthrough.length} device{newUsbPassthrough.length !== 1 ? 's' : ''}</span>
 				{/if}
 				{#if newDescription}
 					<span class="text-muted-foreground">Description</span>


### PR DESCRIPTION
## Summary
Closes #67. Plus a side-fix for a separate bug spotted while wiring this — read on.

### USB passthrough
- **Engine (`nasty-vm`):**
  - New `UsbPassthrough { vendor_id, product_id, label }` and matching `usb_devices: Vec<UsbPassthrough>` on `VmConfig`, `CreateVmRequest`, `UpdateVmRequest`.
  - `build_qemu_args` emits `-device qemu-xhci,id=xhci` (only when at least one USB device — VMs without passthrough stay minimal) plus `usb-host,bus=xhci.0,vendorid=0x…,productid=0x…` per device.
  - `validate_usb_id` rejects anything but 4 hex digits — vendor/product values are formatted directly into the QEMU command line, so this is the guardrail against a malformed manifest sneaking arbitrary args onto qemu invocation.
  - Clone path doesn't copy USB devices (same reason as PCI: only one VM can own a given USB device at a time).
- **WebUI:** new USB checklist on wizard step 5, parallel to PCI. Source list is `system.hardware.summary.usb` (already exposed by the Hardware page) so no new RPC. Selection persists across wizard navigation and shows up in the review summary.

Devices are pinned by vendor:product (not bus:addr) because USB enumeration order shuffles across reboots — the tradeoff is that any device matching the pair attaches, so two identical dongles would both pass through.

### Side-fix: engine PATH

While testing this, the running NASty logged:
```
dmidecode spawn failed: No such file or directory (os error 2)
lsusb spawn failed: No such file or directory (os error 2)
```
…meaning the Hardware page was already broken regardless of USB passthrough.

`dmidecode`, `usbutils`, and `pciutils` were declared in `environment.systemPackages` but **not** in the `nasty-engine` systemd unit's `path = with pkgs; [ … ]`. The engine runs with a restricted PATH, so those binaries weren't findable. Added them in this PR.

## Test plan
- [ ] On a host with USB devices visible to `lsusb`: open the VM wizard → step 5 shows a USB section with the live device list; checking a device persists across step navigation and shows in Review.
- [ ] Create a VM with a USB device. The persisted VmConfig has `usb_devices: [{vendor_id, product_id, label}]`. Starting the VM emits `-device qemu-xhci,id=xhci` and `-device usb-host,bus=xhci.0,vendorid=0x…,productid=0x…` in the qemu command.
- [ ] Try to submit a manifest with `vendor_id: "zzzz"` → engine rejects with `invalid USB device`.
- [ ] Plain VM with no USB devices → no `qemu-xhci`, no `usb-host` in args (verified by unit test).
- [ ] After rebuilding NixOS: `/hardware` page populates baseboard/BIOS/memory/USB; engine logs no longer show "dmidecode/lsusb spawn failed".
- [ ] `cargo test -p nasty-vm`, `cargo clippy --all-targets -- -D warnings`, `npm run check`, `npm run build` all pass.