### PR TITLE
files: sortable columns, rename, and in-page text edit (#88)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -286,7 +286,17 @@ async fn main() -> anyhow::Result<()> {
             post(files_upload_handler).layer(DefaultBodyLimit::max(10_737_418_240)),
         )
         .route("/api/files/mkdir", post(files_mkdir_handler))
-        .route("/api/files/content", get(files_content_handler))
+        .route("/api/files/rename", post(files_rename_handler))
+        .route(
+            "/api/files/content",
+            get(files_content_handler)
+                // 10 MiB cap on edit-in-place writes. The Files page surfaces an
+                // edit affordance only for textual files (conf, yml, md, …) where
+                // hand-editing past a megabyte is already a smell; using upload
+                // for bigger blobs keeps the small fast-path small.
+                .put(files_content_put_handler)
+                .layer(DefaultBodyLimit::max(10 * 1024 * 1024)),
+        )
         .route("/api/auth/check", get(auth_check_handler))
         .route("/health", get(health))
         .with_state(state);
@@ -1109,6 +1119,147 @@ async fn files_mkdir_handler(
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RenameRequest {
+    /// Existing path under /fs. Resolved to a canonical path; the
+    /// rename is rejected if it falls outside FILES_ROOT or targets a
+    /// filesystem root (the first path component under /fs).
+    from: String,
+    /// New path. Doesn't have to exist yet — the parent must, and the
+    /// destination itself must not already be there (we never silently
+    /// overwrite). Cross-directory renames are allowed as long as both
+    /// ends live under the same filesystem (kernel `rename(2)` will
+    /// return EXDEV otherwise; we surface that as a 409 with a hint).
+    to: String,
+}
+
+/// Rename or move a file/directory.  POST /api/files/rename
+/// Body: { from: "first/foo.txt", to: "first/bar.txt" }
+async fn files_rename_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RenameRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_bearer(&headers, &state.auth).await {
+        return e.into_response();
+    }
+
+    // Source must already exist and resolve under /fs.
+    let from = match safe_path(&req.from) {
+        Ok(p) => p,
+        Err(status) => {
+            return (
+                status,
+                Json(serde_json::json!({"error": "Invalid source path"})),
+            )
+                .into_response();
+        }
+    };
+    // Refuse to move filesystem/subvolume roots (depth 1 under /fs).
+    let from_rel = from.strip_prefix(FILES_ROOT).unwrap_or(&from);
+    if from_rel.components().count() <= 1 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot rename filesystem root directories — use the Subvolumes page"})),
+        )
+            .into_response();
+    }
+    if is_inside_block_subvolume(&from) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot rename block subvolume contents — manage via the Subvolumes page"})),
+        )
+            .into_response();
+    }
+
+    // Destination: parent must resolve under /fs and not already exist.
+    // We don't canonicalize the destination itself (it doesn't exist
+    // yet); we canonicalize the parent and join the leaf name back on
+    // so traversal in the leaf is impossible.
+    let clean_to = req.to.replace("\\", "/");
+    let trimmed_to = clean_to.trim_start_matches('/');
+    let (parent_req, leaf) = match trimmed_to.rsplit_once('/') {
+        Some((p, l)) => (p, l),
+        None => {
+            // Renaming to a bare leaf under /fs would land at /fs/<leaf>
+            // which is a filesystem root — refuse.
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "Destination must include a filesystem path component"})),
+            )
+                .into_response();
+        }
+    };
+    if leaf.is_empty() || leaf == "." || leaf == ".." || leaf.contains('/') {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid destination name"})),
+        )
+            .into_response();
+    }
+    let parent = match safe_path(parent_req) {
+        Ok(p) => p,
+        Err(status) => {
+            return (
+                status,
+                Json(serde_json::json!({"error": "Invalid destination parent"})),
+            )
+                .into_response();
+        }
+    };
+    if is_inside_block_subvolume(&parent) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot move into block subvolume contents"})),
+        )
+            .into_response();
+    }
+    let to = parent.join(leaf);
+    if !to.starts_with(FILES_ROOT) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Invalid destination path"})),
+        )
+            .into_response();
+    }
+    if to == from {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({"ok": true, "noop": true})),
+        )
+            .into_response();
+    }
+    if to.exists() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Destination already exists"})),
+        )
+            .into_response();
+    }
+
+    match tokio::fs::rename(&from, &to).await {
+        Ok(()) => {
+            info!("Renamed {} -> {}", from.display(), to.display());
+            (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
+        }
+        // EXDEV (18) — cross-device rename. Reachable when source and
+        // destination live on different bcachefs filesystems mounted
+        // under /fs. `rename(2)` is atomic but inherently single-fs,
+        // so we surface a clear message rather than swallowing it as
+        // a generic 500.
+        Err(e) if e.raw_os_error() == Some(18) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Cross-filesystem rename not supported — use copy + delete"})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
 // ── File content/download endpoint ─────────────────────────────
 
 /// Serve file content with appropriate Content-Type for browser preview.
@@ -1265,6 +1416,108 @@ async fn files_content_handler(
     );
 
     (StatusCode::OK, headers, body).into_response()
+}
+
+/// Overwrite a file with new content. PUT /api/files/content?path=…
+///
+/// Used by the in-page text editor (config files, YAML, scripts).
+/// Body is the raw new contents — Content-Type is ignored. The target
+/// must already exist as a regular file; writing to a missing path
+/// would be the upload endpoint's job, and writing into a directory
+/// or block-subvolume backing file is rejected. Body size is capped
+/// by the route's `DefaultBodyLimit` (10 MiB) — the in-browser editor
+/// isn't where someone should be pasting a gigabyte of logs.
+async fn files_content_put_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    if let Err(e) = validate_bearer(&headers, &state.auth).await {
+        return e.into_response();
+    }
+
+    let req_path = match params.get("path") {
+        Some(p) if !p.is_empty() => p.as_str(),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "path is required"})),
+            )
+                .into_response();
+        }
+    };
+
+    let target = match safe_path(req_path) {
+        Ok(p) => p,
+        Err(status) => {
+            return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        }
+    };
+
+    // Refuse to edit filesystem roots (no regular-file targets there
+    // anyway, but the error message is clearer than "is a directory").
+    let rel = target.strip_prefix(FILES_ROOT).unwrap_or(&target);
+    if rel.components().count() <= 1 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot edit filesystem root directories"})),
+        )
+            .into_response();
+    }
+    if is_inside_block_subvolume(&target) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot edit block subvolume contents — manage via the Subvolumes page"})),
+        )
+            .into_response();
+    }
+
+    let meta = match tokio::fs::metadata(&target).await {
+        Ok(m) => m,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Not found"})),
+            )
+                .into_response();
+        }
+    };
+    if !meta.is_file() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Target is not a regular file"})),
+        )
+            .into_response();
+    }
+
+    // Write to a sibling temp file and rename. Keeps the original
+    // intact if the write fails partway, and means concurrent readers
+    // never see a truncated file. The temp name uses the PID to avoid
+    // colliding with anything else the engine might create.
+    let tmp = target.with_extension(format!("nasty-edit.{}.tmp", std::process::id()));
+    if let Err(e) = tokio::fs::write(&tmp, &body).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("write failed: {e}")})),
+        )
+            .into_response();
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, &target).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("rename failed: {e}")})),
+        )
+            .into_response();
+    }
+    info!("Edited {} ({} bytes)", target.display(), body.len());
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "bytes": body.len()})),
+    )
+        .into_response()
 }
 
 // ── Login endpoint ──────────────────────────────────────────────

--- a/webui/src/lib/components/SortTh.svelte
+++ b/webui/src/lib/components/SortTh.svelte
@@ -6,16 +6,20 @@
 		active,
 		dir,
 		onclick,
+		align = 'left',
 	}: {
 		label: string;
 		active: boolean;
 		dir: 'asc' | 'desc';
 		onclick: () => void;
+		/** Cell alignment. Defaults to "left"; pass "right" for numeric
+		 * columns so the label hugs the right edge of the cell. */
+		align?: 'left' | 'right';
 	} = $props();
 </script>
 
-<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">
-	<button class="flex items-center gap-1 hover:text-foreground" {onclick}>
+<th class="border-b-2 border-border p-3 text-xs uppercase text-muted-foreground {align === 'right' ? 'text-right' : 'text-left'}">
+	<button class="flex items-center gap-1 hover:text-foreground {align === 'right' ? 'ml-auto' : ''}" {onclick}>
 		{label}
 		{#if active}
 			{#if dir === 'asc'}<ChevronUp size={13} />{:else}<ChevronDown size={13} />{/if}

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -3,7 +3,8 @@
 	import { goto } from '$app/navigation';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download } from '@lucide/svelte';
+	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil } from '@lucide/svelte';
+	import SortTh from '$lib/components/SortTh.svelte';
 
 	interface FileEntry {
 		name: string;
@@ -81,11 +82,37 @@
 		} else {
 			previewText = '';
 		}
+		// Switching files (or closing the modal) must drop the edit
+		// buffer so the next open starts in read mode.
+		editing = false;
+		editBuffer = '';
 	});
 
-	const visibleEntries = $derived(
-		showHidden ? entries : entries.filter(e => !e.name.startsWith('.'))
-	);
+	const visibleEntries = $derived.by(() => {
+		const filtered = showHidden ? entries : entries.filter(e => !e.name.startsWith('.'));
+		const sign = sortDir === 'asc' ? 1 : -1;
+		const sorted = [...filtered].sort((a, b) => {
+			// Directories first regardless of column. Most users navigate
+			// by folder, and inverting that within a "size" or "modified"
+			// sort would make the listing harder to scan.
+			if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+			let cmp = 0;
+			if (sortKey === 'name') {
+				cmp = a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+			} else if (sortKey === 'size') {
+				cmp = a.size - b.size;
+			} else {
+				cmp = a.modified - b.modified;
+			}
+			// Fall back to name as a tiebreaker so equal-mtime/size rows
+			// stay stably ordered between renders.
+			if (cmp === 0) {
+				cmp = a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+			}
+			return sign * cmp;
+		});
+		return sorted;
+	});
 
 	// Upload state
 	let uploading = $state(false);
@@ -98,6 +125,29 @@
 
 	// Delete confirmation
 	let deleteTarget: FileEntry | null = $state(null);
+
+	// Rename inline
+	let renameTarget: FileEntry | null = $state(null);
+	let renameValue = $state('');
+
+	// Edit (text files in the preview modal)
+	let editing = $state(false);
+	let editBuffer = $state('');
+	let editSaving = $state(false);
+
+	// Sort state — directories always group above files; within each
+	// group we order by the user's chosen column and direction.
+	type SortKey = 'name' | 'size' | 'modified';
+	let sortKey = $state<SortKey>('name');
+	let sortDir = $state<'asc' | 'desc'>('asc');
+	function toggleSort(key: SortKey) {
+		if (sortKey === key) {
+			sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortKey = key;
+			sortDir = key === 'name' ? 'asc' : 'desc';
+		}
+	}
 
 	onMount(() => browse(''));
 
@@ -225,6 +275,74 @@
 		deleteTarget = null;
 		await browse(currentPath);
 	}
+
+	function startRename(entry: FileEntry) {
+		renameTarget = entry;
+		renameValue = entry.name;
+	}
+
+	async function confirmRename() {
+		if (!renameTarget) return;
+		const newName = renameValue.trim();
+		if (!newName || newName === renameTarget.name) {
+			renameTarget = null;
+			return;
+		}
+		if (newName.includes('/')) {
+			alert('Name cannot contain slashes — use this directory only.');
+			return;
+		}
+		const from = currentPath ? `${currentPath}/${renameTarget.name}` : renameTarget.name;
+		const to = currentPath ? `${currentPath}/${newName}` : newName;
+		const res = await fetch('/api/files/rename', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ from, to }),
+		});
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({}));
+			alert(data.error || 'Failed to rename');
+			return;
+		}
+		renameTarget = null;
+		renameValue = '';
+		await browse(currentPath);
+	}
+
+	function startEdit() {
+		if (!previewFile) return;
+		editBuffer = previewText;
+		editing = true;
+	}
+
+	function cancelEdit() {
+		editing = false;
+		editBuffer = '';
+	}
+
+	async function saveEdit() {
+		if (!previewFile) return;
+		editSaving = true;
+		const path = currentPath ? `${currentPath}/${previewFile.name}` : previewFile.name;
+		try {
+			const res = await fetch(`/api/files/content?path=${encodeURIComponent(path)}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+				body: editBuffer,
+			});
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				alert(data.error || 'Failed to save');
+				return;
+			}
+			previewText = editBuffer;
+			editing = false;
+			// Refresh the listing so the modified timestamp updates.
+			await browse(currentPath);
+		} finally {
+			editSaving = false;
+		}
+	}
 </script>
 
 <!-- Toolbar -->
@@ -300,12 +418,12 @@
 {:else}
 	<table class="w-full text-sm">
 		<thead>
-			<tr class="border-b-2 border-border">
-				<th class="p-3 text-left text-xs uppercase text-muted-foreground">Name</th>
-				<th class="p-3 text-right text-xs uppercase text-muted-foreground">Size</th>
-				<th class="p-3 text-right text-xs uppercase text-muted-foreground">Modified</th>
+			<tr>
+				<SortTh label="Name" active={sortKey === 'name'} dir={sortDir} onclick={() => toggleSort('name')} />
+				<SortTh label="Size" active={sortKey === 'size'} dir={sortDir} onclick={() => toggleSort('size')} align="right" />
+				<SortTh label="Modified" active={sortKey === 'modified'} dir={sortDir} onclick={() => toggleSort('modified')} align="right" />
 				{#if !isRoot}
-					<th class="w-10"></th>
+					<th class="w-10 border-b-2 border-border"></th>
 				{/if}
 			</tr>
 		</thead>
@@ -351,6 +469,12 @@
 									</a>
 								{/if}
 								<button
+									class="text-muted-foreground/40 hover:text-foreground transition-colors"
+									onclick={() => startRename(entry)}
+									title="Rename">
+									<Pencil size={14} />
+								</button>
+								<button
 									class="text-muted-foreground/40 hover:text-destructive transition-colors"
 									onclick={() => deleteTarget = entry}
 									title="Delete">
@@ -363,6 +487,32 @@
 			{/each}
 		</tbody>
 	</table>
+{/if}
+
+<!-- Rename modal -->
+{#if renameTarget}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<Card class="w-full max-w-sm">
+			<CardContent class="pt-6">
+				<h3 class="mb-2 text-lg font-semibold">Rename {renameTarget.is_dir ? 'folder' : 'file'}</h3>
+				<p class="mb-3 text-sm text-muted-foreground">
+					New name for <span class="font-mono font-medium text-foreground">{renameTarget.name}</span>:
+				</p>
+				<!-- svelte-ignore a11y_autofocus -->
+				<input
+					type="text"
+					bind:value={renameValue}
+					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm font-mono"
+					onkeydown={(e) => { if (e.key === 'Enter') confirmRename(); if (e.key === 'Escape') renameTarget = null; }}
+					autofocus
+				/>
+				<div class="flex gap-2">
+					<Button onclick={confirmRename} disabled={!renameValue.trim() || renameValue === renameTarget.name}>Rename</Button>
+					<Button variant="secondary" onclick={() => { renameTarget = null; renameValue = ''; }}>Cancel</Button>
+				</div>
+			</CardContent>
+		</Card>
+	</div>
 {/if}
 
 <!-- Delete confirmation -->
@@ -390,19 +540,36 @@
 <!-- File preview modal -->
 {#if previewFile}
 	{@const cat = fileCategory(previewFile.name)}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm" role="button" tabindex="-1" onclick={() => previewFile = null} onkeydown={(e) => { if (e.key === 'Escape') previewFile = null; }}>
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm" role="button" tabindex="-1" onclick={() => { if (!editing) previewFile = null; }} onkeydown={(e) => { if (e.key === 'Escape' && !editing) previewFile = null; }}>
 		<div class="relative flex flex-col max-w-[90vw] max-h-[90vh] rounded-lg border border-border bg-[#0f1117] shadow-2xl" role="presentation" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
 			<!-- Header -->
 			<div class="flex items-center justify-between px-4 py-2 border-b border-border">
-				<span class="text-sm font-semibold text-white font-mono">{previewFile.name}</span>
+				<span class="text-sm font-semibold text-white font-mono">{previewFile.name}{editing ? ' (editing)' : ''}</span>
 				<div class="flex items-center gap-2">
+					{#if cat === 'text' && !isRoot}
+						{#if editing}
+							<Button size="xs" onclick={saveEdit} disabled={editSaving}>
+								{editSaving ? 'Saving…' : 'Save'}
+							</Button>
+							<Button variant="ghost" size="xs" onclick={cancelEdit} disabled={editSaving} class="text-white hover:text-white/80">
+								Cancel
+							</Button>
+						{:else}
+							<button
+								class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+								onclick={startEdit}
+								title="Edit this file in the browser">
+								<Pencil size={12} /> Edit
+							</button>
+						{/if}
+					{/if}
 					<a
 						href={contentUrl(previewFile)}
 						download={previewFile.name}
 						class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
 						<Download size={12} /> Download
 					</a>
-					<Button variant="ghost" size="xs" onclick={() => previewFile = null} class="text-white hover:text-white/80">
+					<Button variant="ghost" size="xs" onclick={() => { if (!editing) previewFile = null; }} disabled={editing} class="text-white hover:text-white/80">
 						Close
 					</Button>
 				</div>
@@ -426,7 +593,16 @@
 				{:else if cat === 'pdf'}
 					<iframe src={contentUrl(previewFile)} class="w-full h-[80vh]" title={previewFile.name}></iframe>
 				{:else if cat === 'text'}
-					<pre class="w-full max-h-[80vh] overflow-auto text-xs text-green-400 font-mono whitespace-pre-wrap p-4">{previewText || 'Loading...'}</pre>
+					{#if editing}
+						<textarea
+							bind:value={editBuffer}
+							spellcheck="false"
+							class="w-[80vw] max-w-3xl h-[70vh] resize-none rounded-md border border-input bg-background p-3 text-xs text-foreground font-mono"
+							disabled={editSaving}
+						></textarea>
+					{:else}
+						<pre class="w-full max-h-[80vh] overflow-auto text-xs text-green-400 font-mono whitespace-pre-wrap p-4">{previewText || 'Loading...'}</pre>
+					{/if}
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

Tackles the contained subset of #88:

- **Click-to-sort** on Name / Size / Modified columns. Reuses the existing `SortTh` component, which gains an `align="right"` mode for numeric columns. Directories always group above files regardless of column.
- **Rename** — pencil action on every row opens a small modal. Enter confirms; Escape cancels. Backed by new `POST /api/files/rename` with `{from, to}` body. Same-FS moves come "for free" since `rename(2)` doesn't care whether source and destination share a parent.
- **Edit text files in-page** — the text-preview modal gains an Edit button that swaps the read-only `<pre>` for an editable `<textarea>`. Save flushes via new `PUT /api/files/content?path=…` (10 MiB body cap, tmpfile + rename, so concurrent readers never see a truncated file).

Cross-filesystem rename returns 409 with an explicit message — true cross-FS *move* is a copy-then-delete which is a follow-up.

### What's still on #88, deliberately deferred
- **Copy** — needs streaming + progress UX (think `/ws/apps/deploy` pattern), sparse-file handling, mid-copy cleanup. Own PR.
- **Cross-FS move** — once copy lands, "move" is copy + delete; one user action, two engine calls.
- **Bulk actions** — multi-select state, shift-click range, a `<BulkActionsBar>` component reusable across pages.

## Test plan
- [ ] Click each column header — sort order flips between ascending and descending; switching column resets to the natural default (alpha asc for Name, newest/biggest first for Modified/Size).
- [ ] Rename a file — pencil → modal → new name → Enter. Listing refreshes; old name gone.
- [ ] Try to rename to an existing name → 409, alert shows the server's message.
- [ ] Try to rename a filesystem root (top-level dir under /fs) → action absent (no rename button at depth 0 since `!isRoot` already gates the column).
- [ ] Open a YAML/conf file → Edit → modify → Save → reload reopen → changes persisted, Modified timestamp updated.
- [ ] Try to save a 10+ MiB blob → 413 from the body limit; existing file untouched.
- [ ] Slash in rename input → client-side alert before the round-trip.
- [ ] `cargo clippy --all-targets -- -D warnings`, `cargo test -p nasty-engine`, `npm run check`, `npm run build` all pass.