### PR TITLE
webui: consolidate scattered wizard reset blocks into resetCreateForm

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -733,8 +733,17 @@
 	}
 
 	function resetForm() {
-		newName = ''; newImage = ''; newPorts = []; newEnvs = []; newVolumes = [];
-		newCpuLimit = ''; newMemoryLimit = '';
+		// Simple-installer create form. One field per line so a newly
+		// added `new*` state var only needs to land here in addition
+		// to its declaration — the scan-for-omissions cost stays
+		// linear instead of hiding inside a dense one-liner.
+		newName = '';
+		newImage = '';
+		newPorts = [];
+		newEnvs = [];
+		newVolumes = [];
+		newCpuLimit = '';
+		newMemoryLimit = '';
 		newAllowUnsafe = false;
 		lastInspectedImage = '';
 	}

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -47,6 +47,38 @@
 	let createPickerOpen = $state(false);
 	let editPickerOpen = $state(false);
 
+	/** Reset every create-form field to its declared default. Previously
+	 * the post-create handler only cleared name/sources/password, so
+	 * target credentials (S3 keys, SFTP host, B2 secret, …) and the
+	 * retention spec leaked between successive profile creations. One
+	 * source of truth here keeps the declared defaults and the reset
+	 * in sync. */
+	function resetCreateForm() {
+		newName = '';
+		newSources = '';
+		newTargetType = 'local';
+		newLocalPath = '';
+		newS3Endpoint = '';
+		newS3Bucket = '';
+		newS3Key = '';
+		newS3Secret = '';
+		newSftpHost = '';
+		newSftpUser = '';
+		newSftpPath = '';
+		newRestUrl = '';
+		newB2Bucket = '';
+		newB2Id = '';
+		newB2Key = '';
+		newPassword = '';
+		newSchedule = '';
+		newKeepLast = '7';
+		newKeepDaily = '7';
+		newKeepWeekly = '4';
+		newKeepMonthly = '6';
+		selectedSources = new Set();
+		schedulePreset = 'daily';
+	}
+
 	async function loadSourceData() {
 		try {
 			[subvolumes, filesystems] = await Promise.all([
@@ -210,7 +242,7 @@
 			'Backup profile created'
 		);
 		showCreate = false;
-		newName = ''; newSources = ''; newPassword = '';
+		resetCreateForm();
 		await refresh();
 	}
 

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -90,10 +90,28 @@
 		['3', 'Review'],
 	];
 
+	/** Reset every wizard field to its declared default. One source of
+	 * truth keeps the open-wizard path and the post-create cleanup
+	 * from drifting — the original `openWizard` only reset 6 fields
+	 * while the post-create block reset 11, so target-label fields
+	 * persisted across re-opens until this consolidation. */
+	function resetCreateForm() {
+		newName = '';
+		newType = 'filesystem';
+		newVolsize = '';
+		newCompression = '';
+		newForegroundTarget = '';
+		newBackgroundTarget = '';
+		newPromoteTarget = '';
+		newMetadataTarget = '';
+		newDataReplicas = '';
+		newComments = '';
+		newDirectIo = false;
+	}
+
 	function openWizard() {
 		wizardStep = 1;
-		newName = ''; newType = 'filesystem'; newVolsize = ''; newCompression = '';
-		newComments = ''; newDirectIo = false;
+		resetCreateForm();
 	}
 
 	let showSnap = $state<string | null>(null);
@@ -323,10 +341,7 @@
 		);
 		if (ok !== undefined) {
 			wizardStep = 0;
-			newName = ''; newType = 'filesystem'; newVolsize = ''; newCompression = '';
-			newForegroundTarget = ''; newBackgroundTarget = ''; newPromoteTarget = '';
-			newMetadataTarget = ''; newDataReplicas = '';
-			newComments = ''; newDirectIo = false;
+			resetCreateForm();
 			await refresh();
 		}
 	}

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -87,10 +87,32 @@
 
 	let filesystems: { name: string; mounted: boolean }[] = $state([]);
 
+	/** Reset every wizard field to its declared default. Single source of
+	 * truth so a newly-added `new*` state var only needs to land in one
+	 * place — adding the field to the declarations above and to this
+	 * function keeps `openWizard` and the post-create cleanup in sync
+	 * automatically. */
+	function resetCreateForm() {
+		newName = '';
+		newCpus = 1;
+		newMemory = 1024;
+		newDisk = '';
+		newDiskCreate = false;
+		newDiskFs = '';
+		newDiskSize = 10;
+		newIso = '';
+		newDescription = '';
+		newBootOrder = 'disk';
+		newAutostart = false;
+		newPassthrough = [];
+		newUsbPassthrough = [];
+		newNetMode = 'user';
+		newNetBridge = '';
+		newNetMac = '';
+	}
+
 	async function openWizard() {
-		newName = ''; newCpus = 1; newMemory = 1024; newDisk = ''; newDiskCreate = false;
-		newDiskFs = ''; newDiskSize = 10; newIso = ''; newDescription = '';
-		newBootOrder = 'disk'; newAutostart = false; newPassthrough = []; newUsbPassthrough = [];
+		resetCreateForm();
 		await Promise.all([loadSubvolumes(), loadFilesystems(), loadImages(), loadUsbDevices()]);
 		wizardStep = canCreateVm ? 1 : -1; // -1 = prerequisites
 	}
@@ -403,11 +425,7 @@
 		);
 		if (ok !== undefined) {
 			wizardStep = 0;
-			newName = ''; newCpus = 1; newMemory = 1024; newDisk = '';
-			newDiskCreate = false; newDiskFs = ''; newDiskSize = 10;
-			newIso = ''; newDescription = ''; newBootOrder = 'disk';
-			newAutostart = false; newPassthrough = []; newUsbPassthrough = [];
-			newNetMode = 'user'; newNetBridge = ''; newNetMac = '';
+			resetCreateForm();
 			await refresh();
 		}
 	}


### PR DESCRIPTION
## Summary

Fix B from the [code-by-hand audit](https://blog.k10s.dev/im-going-back-to-writing-code-by-hand/) thread — the "scattered state cleanup" anti-pattern.

I hit it personally while shipping PR #133 (USB passthrough): adding `newUsbPassthrough` required updating **two** reset sites in `vms/+page.svelte` (`openWizard` and post-create), and the second one was easy to forget. Same pattern in three other wizards, with worse symptoms:

- **subvolumes/+page.svelte** — `openWizard` reset 6 of 11 fields. Target labels (foreground / background / promote / metadata) persisted across re-open.
- **backups/+page.svelte** — post-create reset only `newName`, `newSources`, `newPassword`. So **S3 keys, SFTP host, B2 secret, and the retention spec** all persisted between successive profile creations. Latent bug class.
- **apps/+page.svelte** — already had a `resetForm()` (good!) but it was a single-line `newName = ''; newImage = ''; newPorts = []; …` — easy to miss a field on scan.

One `resetCreateForm()` per wizard, called from every reset site. Adding a new wizard field is now a **two-edit change** (declaration + reset fn) instead of a "find every site that resets the form" exercise. Same effect as a `Object.assign(state, DEFAULTS)` pattern but without the bigger refactor of moving every `new*` into a single state object.

## What changes for users

Mostly nothing for the happy path. One observable side-effect on the backups page: the second profile you create now starts from a clean form instead of inheriting the first profile's credentials. That was almost certainly a bug (target keys leaking between profiles), but worth flagging.

## Test plan
- [ ] `vms/`: open wizard → fill fields → cancel → reopen → all fields are at defaults.
- [ ] `vms/`: create a VM with USB passthrough → after success, reopen wizard → USB list is empty.
- [ ] `subvolumes/`: open wizard → set foreground target → cancel → reopen → target is empty.
- [ ] `backups/`: create an S3 profile with credentials → open create form again → credentials are empty.
- [ ] `apps/`: install a simple app → click Install App again → form starts blank.
- [ ] `npm run check` and `npm run build` pass.