### PR TITLE
webui: collapse share-wizard protocol switches into per-protocol components

### DIFF
--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -16,6 +16,14 @@
 	import SmbPanel from './SmbPanel.svelte';
 	import IscsiPanel from './IscsiPanel.svelte';
 	import NvmeofPanel from './NvmeofPanel.svelte';
+	import NfsWizardForm from './wizard/NfsWizardForm.svelte';
+	import SmbWizardForm from './wizard/SmbWizardForm.svelte';
+	import IscsiWizardForm from './wizard/IscsiWizardForm.svelte';
+	import NvmeofWizardForm from './wizard/NvmeofWizardForm.svelte';
+	import NfsWizardReview from './wizard/NfsWizardReview.svelte';
+	import SmbWizardReview from './wizard/SmbWizardReview.svelte';
+	import IscsiWizardReview from './wizard/IscsiWizardReview.svelte';
+	import NvmeofWizardReview from './wizard/NvmeofWizardReview.svelte';
 	import {
 		nfs,
 		nfsRefresh,
@@ -38,9 +46,11 @@
 		nvmeLoadProtocol,
 	} from '$lib/sharing/nvmeof.svelte';
 
+	type Tab = 'nfs' | 'smb' | 'iscsi' | 'nvmeof';
+
 	// ── Share creation wizard ────────────────────────────
 	let shareWizardStep: 0 | 1 | 2 | 3 | 4 = $state(0);
-	let shareProtocol: Tab = $state('smb');
+	let shareProtocol = $state<Tab>('smb');
 	let shareSubvolume = $state('');
 	// NFS access
 	let shareNfsHost = $state('');
@@ -50,13 +60,7 @@
 	let shareSmbGuestOk = $state(false);
 	let shareSmbReadOnly = $state(false);
 	let shareSmbValidUsers: string[] = $state([]);
-	let showInlineUserCreate = $state(false);
-	let inlineUsername = $state('');
-	let inlinePassword = $state('');
-	let inlinePasswordConfirm = $state('');
-	let inlineGroups: string[] = $state([]);
-	let showInlineGroupCreate = $state(false);
-	let inlineGroupName = $state('');
+	// SMB inline user/group creation moved into <SmbWizardForm>.
 	// iSCSI access
 	let shareIscsiName = $state('');
 	// NVMe-oF access
@@ -82,10 +86,17 @@
 		} catch { inlineSvFilesystems = []; }
 	}
 
+	// Whether the currently-chosen protocol stores its data on a block
+	// subvolume (iSCSI, NVMe-oF) instead of a filesystem subvolume
+	// (NFS, SMB). Used by the source-picker, the inline-subvolume
+	// creator, and the suggested-quota copy. Single derived = no more
+	// inline `shareProtocol === 'iscsi' || shareProtocol === 'nvmeof'`
+	// expressions across the wizard.
+	const isBlock = $derived(shareProtocol === 'iscsi' || shareProtocol === 'nvmeof');
+
 	async function inlineCreateSubvolume() {
 		if (!inlineSvName || !inlineSvFs) return;
 		inlineSvCreating = true;
-		const isBlock = shareProtocol === 'iscsi' || shareProtocol === 'nvmeof';
 		const params: Record<string, unknown> = {
 			filesystem: inlineSvFs,
 			name: inlineSvName,
@@ -133,57 +144,59 @@
 
 	$effect(() => { if (shareWizardStep > 0) loadShareSubvolumes(); });
 
-	const filteredShareSubvolumes = $derived.by(() => {
-		const isBlock = shareProtocol === 'iscsi' || shareProtocol === 'nvmeof';
-		return shareSubvolumes.filter(sv =>
+	const filteredShareSubvolumes = $derived(
+		shareSubvolumes.filter(sv =>
 			isBlock ? (sv.subvolume_type === 'block' && sv.block_device) : sv.subvolume_type === 'filesystem'
-		);
-	});
+		)
+	);
+
+	// Per-protocol "create one share" hook. Each entry knows its own
+	// API method + payload shape; createShare() just dispatches. This
+	// replaces a 4-way if/else cascade with a single registry lookup.
+	const protocolCreators: Record<
+		'nfs' | 'smb' | 'iscsi' | 'nvmeof',
+		(sv: Subvolume) => Promise<unknown>
+	> = {
+		nfs: (sv) => withToast(
+			() => client.call('share.nfs.create', {
+				path: sv.path,
+				clients: [{ host: shareNfsHost || '*', options: shareNfsOptions }],
+			}),
+			'NFS share created',
+		),
+		smb: (sv) => withToast(
+			() => client.call('share.smb.create', {
+				name: shareSmbName || sv.name,
+				path: sv.path,
+				guest_ok: shareSmbGuestOk,
+				read_only: shareSmbReadOnly,
+				valid_users: shareSmbValidUsers,
+			}),
+			'SMB share created',
+		),
+		iscsi: (sv) => withToast(
+			() => client.call('share.iscsi.create', {
+				name: shareIscsiName || sv.name,
+				device_path: sv.block_device,
+			}),
+			'iSCSI target created',
+		),
+		nvmeof: (sv) => withToast(
+			() => client.call('share.nvmeof.create', {
+				name: shareNvmeofName || sv.name,
+				device_path: sv.block_device,
+				addr: shareNvmeofAddr,
+				port: parseInt(shareNvmeofPort) || 4420,
+			}),
+			'NVMe-oF subsystem created',
+		),
+	};
 
 	async function createShare() {
 		if (!shareSubvolume) return;
 		const sv = shareSubvolumes.find(s => s.path === shareSubvolume || s.block_device === shareSubvolume);
 		if (!sv) return;
-
-		let ok;
-		if (shareProtocol === 'nfs') {
-			ok = await withToast(
-				() => client.call('share.nfs.create', {
-					path: sv.path,
-					clients: [{ host: shareNfsHost || '*', options: shareNfsOptions }],
-				}),
-				'NFS share created'
-			);
-		} else if (shareProtocol === 'smb') {
-			ok = await withToast(
-				() => client.call('share.smb.create', {
-					name: shareSmbName || sv.name,
-					path: sv.path,
-					guest_ok: shareSmbGuestOk,
-					read_only: shareSmbReadOnly,
-					valid_users: shareSmbValidUsers,
-				}),
-				'SMB share created'
-			);
-		} else if (shareProtocol === 'iscsi') {
-			ok = await withToast(
-				() => client.call('share.iscsi.create', {
-					name: shareIscsiName || sv.name,
-					device_path: sv.block_device,
-				}),
-				'iSCSI target created'
-			);
-		} else if (shareProtocol === 'nvmeof') {
-			ok = await withToast(
-				() => client.call('share.nvmeof.create', {
-					name: shareNvmeofName || sv.name,
-					device_path: sv.block_device,
-					addr: shareNvmeofAddr,
-					port: parseInt(shareNvmeofPort) || 4420,
-				}),
-				'NVMe-oF subsystem created'
-			);
-		}
+		const ok = await protocolCreators[shareProtocol](sv);
 		if (ok !== undefined) {
 			shareWizardStep = 0;
 			nfsRefresh(); smbRefresh(); iscsiRefresh(); nvmeRefresh();
@@ -191,7 +204,6 @@
 	}
 
 	// ── Tab state ────────────────────────────────────────
-	type Tab = 'nfs' | 'smb' | 'iscsi' | 'nvmeof';
 	const TABS: { key: Tab; label: string; hash: string }[] = [
 		{ key: 'smb',    label: 'SMB',     hash: '#smb' },
 		{ key: 'nfs',    label: 'NFS',     hash: '#nfs' },
@@ -341,7 +353,7 @@
 				<select bind:value={shareSubvolume} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
 					<option value="">Select a subvolume...</option>
 					{#each filteredShareSubvolumes as sv}
-						{#if shareProtocol === 'iscsi' || shareProtocol === 'nvmeof'}
+						{#if isBlock}
 							<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
 						{:else}
 							<option value={sv.path}>{sv.filesystem}/{sv.name} ({sv.path})</option>
@@ -350,7 +362,7 @@
 				</select>
 				{#if filteredShareSubvolumes.length === 0 && !showInlineCreate}
 					<p class="mt-1 text-xs text-muted-foreground">
-						No {shareProtocol === 'iscsi' || shareProtocol === 'nvmeof' ? 'block' : 'filesystem'} subvolumes available.
+						No {isBlock ? 'block' : 'filesystem'} subvolumes available.
 					</p>
 					<Button size="sm" class="mt-2" onclick={() => { showInlineCreate = true; loadInlineFilesystems(); }}>Create Subvolume</Button>
 				{:else if !showInlineCreate}
@@ -358,7 +370,7 @@
 				{/if}
 				{#if showInlineCreate}
 					<div class="mt-3 rounded-lg border border-border bg-secondary/20 p-3 space-y-3">
-						<p class="text-xs font-medium">New {shareProtocol === 'iscsi' || shareProtocol === 'nvmeof' ? 'block' : 'filesystem'} subvolume</p>
+						<p class="text-xs font-medium">New {isBlock ? 'block' : 'filesystem'} subvolume</p>
 						{#if inlineSvFilesystems.length > 1}
 							<div>
 								<Label class="text-xs">Filesystem</Label>
@@ -374,12 +386,12 @@
 							<Input bind:value={inlineSvName} placeholder="e.g. media" class="mt-1 h-8 text-sm" />
 						</div>
 						<div>
-							<Label class="text-xs">Quota (GiB) <span class="text-muted-foreground font-normal">{shareProtocol === 'iscsi' || shareProtocol === 'nvmeof' ? '— required for block' : '— optional'}</span></Label>
+							<Label class="text-xs">Quota (GiB) <span class="text-muted-foreground font-normal">{isBlock ? '— required for block' : '— optional'}</span></Label>
 							<Input bind:value={inlineSvQuota} type="number" placeholder="e.g. 100" class="mt-1 h-8 text-sm" />
 						</div>
 						<div class="flex gap-2">
 							<Button size="sm" onclick={inlineCreateSubvolume}
-								disabled={!inlineSvName || !inlineSvFs || inlineSvCreating || ((shareProtocol === 'iscsi' || shareProtocol === 'nvmeof') && !inlineSvQuota)}>
+								disabled={!inlineSvName || !inlineSvFs || inlineSvCreating || (isBlock && !inlineSvQuota)}>
 								{inlineSvCreating ? 'Creating...' : 'Create'}
 							</Button>
 							<Button variant="secondary" size="sm" onclick={() => showInlineCreate = false}>Cancel</Button>
@@ -407,167 +419,22 @@
 			<!-- Step 3: Access (protocol-specific) -->
 			{:else if shareWizardStep === 3}
 			{#if shareProtocol === 'nfs'}
-				<div class="mb-4">
-					<Label>Allowed Network</Label>
-					<Input bind:value={shareNfsHost} placeholder="192.168.1.0/24 or * for any" class="mt-1" />
-				</div>
-				<div class="mb-4">
-					<Label>Export Options</Label>
-					<Input bind:value={shareNfsOptions} class="mt-1" />
-				</div>
+				<NfsWizardForm bind:host={shareNfsHost} bind:options={shareNfsOptions} />
 			{:else if shareProtocol === 'smb'}
-				<div class="mb-4">
-					<Label>Share Name</Label>
-					<Input bind:value={shareSmbName} placeholder="documents" class="mt-1" />
-				</div>
-				<div class="mb-4 flex gap-4">
-					<label class="flex items-center gap-2 text-sm cursor-pointer">
-						<input type="checkbox" bind:checked={shareSmbGuestOk} class="rounded border-input" />
-						Allow guests
-					</label>
-					<label class="flex items-center gap-2 text-sm cursor-pointer">
-						<input type="checkbox" bind:checked={shareSmbReadOnly} class="rounded border-input" />
-						Read-only
-					</label>
-				</div>
-				{#if !shareSmbGuestOk}
-					<div class="mb-4">
-						<Label>Allowed Users & Groups</Label>
-						<p class="mt-1 mb-3 text-xs text-muted-foreground">Leave empty to allow all authenticated users.</p>
-
-						{#if shareSmbValidUsers.length > 0}
-							<div class="mb-3 rounded-md border border-green-500/30 bg-green-500/5 p-3">
-								<p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-green-400/70">Has access</p>
-								<div class="flex flex-wrap gap-2">
-									{#each shareSmbValidUsers as entry}
-										<span class="flex items-center gap-1 rounded-md border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs">
-											{entry}
-											<button class="ml-1 text-muted-foreground hover:text-destructive" onclick={() => { shareSmbValidUsers = shareSmbValidUsers.filter(u => u !== entry); }}>&times;</button>
-										</span>
-									{/each}
-								</div>
-							</div>
-						{/if}
-
-						{#if smb.systemUsers.some(u => !shareSmbValidUsers.includes(u.username)) || smb.groups.some(g => !shareSmbValidUsers.includes(`@${g.name}`))}
-							<div class="mb-3 rounded-md border border-border p-3">
-								<p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground/70">Click to add</p>
-								<div class="flex flex-wrap gap-2">
-									{#each smb.systemUsers.filter(u => !shareSmbValidUsers.includes(u.username)) as user}
-										<Button size="xs" variant="secondary" onclick={() => { shareSmbValidUsers = [...shareSmbValidUsers, user.username]; }}>
-											{user.username}
-										</Button>
-									{/each}
-									{#each smb.groups.filter(g => !shareSmbValidUsers.includes(`@${g.name}`)) as group}
-										<Button size="xs" variant="secondary" class="text-blue-400" onclick={() => { shareSmbValidUsers = [...shareSmbValidUsers, `@${group.name}`]; }}>
-											@{group.name}
-										</Button>
-									{/each}
-								</div>
-							</div>
-						{/if}
-						{#if showInlineUserCreate}
-							<Card class="mt-3 max-w-md">
-								<CardContent class="pt-4">
-									<h3 class="mb-4 text-lg font-semibold">New System User</h3>
-									<div class="mb-4">
-										<Label for="inline-username">Username</Label>
-										<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1" />
-									</div>
-									<div class="mb-4">
-										<Label for="inline-password">Password</Label>
-										<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1" />
-									</div>
-									<div class="mb-4">
-										<Label for="inline-password-confirm">Confirm Password</Label>
-										<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1" />
-										{#if inlinePasswordConfirm && inlinePassword !== inlinePasswordConfirm}
-											<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
-										{/if}
-									</div>
-									<div class="mb-4">
-										<Label>Add to Groups</Label>
-										<div class="mt-1 flex flex-wrap gap-2">
-											{#each smb.groups as group}
-												<label class="flex items-center gap-1.5 text-sm cursor-pointer rounded border border-border px-2 py-1 hover:bg-muted/30">
-													<input type="checkbox" class="rounded border-input"
-														onchange={(e) => {
-															const checked = (e.target as HTMLInputElement).checked;
-															if (checked) inlineGroups = [...inlineGroups, group.name];
-															else inlineGroups = inlineGroups.filter(g => g !== group.name);
-														}}
-														checked={inlineGroups.includes(group.name)}
-													/>
-													{group.name}
-												</label>
-											{/each}
-											{#if showInlineGroupCreate}
-												<div class="flex items-center gap-1.5">
-													<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs" />
-													<Button size="xs" disabled={!inlineGroupName.trim()} onclick={async () => {
-														await withToast(() => client.call('smb.group.create', { name: inlineGroupName.trim() }), `Group "${inlineGroupName}" created`);
-														smb.groups = await client.call('smb.group.list');
-														inlineGroups = [...inlineGroups, inlineGroupName.trim()];
-														inlineGroupName = '';
-														showInlineGroupCreate = false;
-													}}>Create</Button>
-													<Button size="xs" variant="secondary" onclick={() => showInlineGroupCreate = false}>Cancel</Button>
-												</div>
-											{:else}
-												<Button size="sm" onclick={() => showInlineGroupCreate = true}>Create Group</Button>
-											{/if}
-										</div>
-									</div>
-									<div class="flex gap-2">
-										<Button onclick={async () => {
-											const ok = await withToast(
-												() => client.call('smb.user.create', { username: inlineUsername, password: inlinePassword }),
-												`User "${inlineUsername}" created`
-											);
-											if (ok !== undefined) {
-												for (const g of inlineGroups) {
-													await client.call('smb.group.add_member', { group: g, user: inlineUsername }).catch(() => {});
-												}
-												shareSmbValidUsers = [...shareSmbValidUsers, inlineUsername];
-												smb.systemUsers = [...smb.systemUsers, { username: inlineUsername, uid: 0 }];
-												showInlineUserCreate = false;
-												inlineUsername = ''; inlinePassword = ''; inlinePasswordConfirm = ''; inlineGroups = [];
-											}
-										}} disabled={!inlineUsername || !inlinePassword || inlinePassword !== inlinePasswordConfirm}>
-											Create & Add
-										</Button>
-										<Button variant="secondary" onclick={() => { showInlineUserCreate = false; }}>Cancel</Button>
-									</div>
-								</CardContent>
-							</Card>
-						{:else}
-							<div class="mt-2 flex gap-2">
-								<Button size="sm" onclick={() => showInlineUserCreate = true}>Create System User</Button>
-							</div>
-						{/if}
-					</div>
-				{/if}
+				<SmbWizardForm
+					bind:name={shareSmbName}
+					bind:guestOk={shareSmbGuestOk}
+					bind:readOnly={shareSmbReadOnly}
+					bind:validUsers={shareSmbValidUsers}
+				/>
 			{:else if shareProtocol === 'iscsi'}
-				<div class="mb-4">
-					<Label>Target Name</Label>
-					<Input bind:value={shareIscsiName} placeholder="dbserver" class="mt-1" />
-					<p class="mt-1 text-xs text-muted-foreground">IQN: iqn.2137-01.com.nasty:{shareIscsiName || '...'}</p>
-				</div>
+				<IscsiWizardForm bind:name={shareIscsiName} />
 			{:else if shareProtocol === 'nvmeof'}
-				<div class="mb-4">
-					<Label>Subsystem Name</Label>
-					<Input bind:value={shareNvmeofName} placeholder="storage-vol" class="mt-1" />
-				</div>
-				<div class="grid grid-cols-2 gap-4 mb-4">
-					<div>
-						<Label>Listen Address</Label>
-						<Input bind:value={shareNvmeofAddr} placeholder="0.0.0.0" class="mt-1" />
-					</div>
-					<div>
-						<Label>Port</Label>
-						<Input bind:value={shareNvmeofPort} placeholder="4420" class="mt-1" />
-					</div>
-				</div>
+				<NvmeofWizardForm
+					bind:name={shareNvmeofName}
+					bind:addr={shareNvmeofAddr}
+					bind:port={shareNvmeofPort}
+				/>
 			{/if}
 			<div class="flex gap-2">
 				<Button variant="secondary" size="sm" onclick={() => shareWizardStep = 2}>← Back</Button>
@@ -583,25 +450,24 @@
 				<span class="text-muted-foreground">Source</span>
 				<span class="font-mono text-xs">{sv ? `${sv.filesystem}/${sv.name}` : shareSubvolume}</span>
 				{#if shareProtocol === 'nfs'}
-					<span class="text-muted-foreground">Allowed</span>
-					<span>{shareNfsHost || '*'}</span>
-					<span class="text-muted-foreground">Options</span>
-					<span class="text-xs">{shareNfsOptions}</span>
+					<NfsWizardReview host={shareNfsHost} options={shareNfsOptions} />
 				{:else if shareProtocol === 'smb'}
-					<span class="text-muted-foreground">Share Name</span>
-					<span>{shareSmbName || sv?.name}</span>
-					{#if shareSmbGuestOk}<span class="text-muted-foreground">Guests</span><span>Allowed</span>{/if}
-					{#if shareSmbReadOnly}<span class="text-muted-foreground">Access</span><span>Read-only</span>{/if}
-					<span class="text-muted-foreground">Allowed Users</span>
-					<span>{shareSmbValidUsers.length > 0 ? shareSmbValidUsers.join(', ') : 'All authenticated users'}</span>
+					<SmbWizardReview
+						name={shareSmbName}
+						fallbackName={sv?.name ?? ''}
+						guestOk={shareSmbGuestOk}
+						readOnly={shareSmbReadOnly}
+						validUsers={shareSmbValidUsers}
+					/>
 				{:else if shareProtocol === 'iscsi'}
-					<span class="text-muted-foreground">Target</span>
-					<span class="font-mono text-xs">iqn.2137-01.com.nasty:{shareIscsiName || sv?.name}</span>
+					<IscsiWizardReview name={shareIscsiName} fallbackName={sv?.name ?? ''} />
 				{:else if shareProtocol === 'nvmeof'}
-					<span class="text-muted-foreground">Subsystem</span>
-					<span>{shareNvmeofName || sv?.name}</span>
-					<span class="text-muted-foreground">Listen</span>
-					<span>{shareNvmeofAddr}:{shareNvmeofPort}</span>
+					<NvmeofWizardReview
+						name={shareNvmeofName}
+						fallbackName={sv?.name ?? ''}
+						addr={shareNvmeofAddr}
+						port={shareNvmeofPort}
+					/>
 				{/if}
 			</div>
 			<div class="flex gap-2">

--- a/webui/src/routes/sharing/wizard/IscsiWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/IscsiWizardForm.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+
+	interface Props {
+		name: string;
+	}
+	let { name = $bindable() }: Props = $props();
+</script>
+
+<div class="mb-4">
+	<Label>Target Name</Label>
+	<Input bind:value={name} placeholder="dbserver" class="mt-1" />
+	<p class="mt-1 text-xs text-muted-foreground">IQN: iqn.2137-01.com.nasty:{name || '...'}</p>
+</div>

--- a/webui/src/routes/sharing/wizard/IscsiWizardReview.svelte
+++ b/webui/src/routes/sharing/wizard/IscsiWizardReview.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	interface Props {
+		name: string;
+		fallbackName: string;
+	}
+	let { name, fallbackName }: Props = $props();
+</script>
+
+<span class="text-muted-foreground">Target</span>
+<span class="font-mono text-xs">iqn.2137-01.com.nasty:{name || fallbackName}</span>

--- a/webui/src/routes/sharing/wizard/NfsWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/NfsWizardForm.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+
+	interface Props {
+		host: string;
+		options: string;
+	}
+	let { host = $bindable(), options = $bindable() }: Props = $props();
+</script>
+
+<div class="mb-4">
+	<Label>Allowed Network</Label>
+	<Input bind:value={host} placeholder="192.168.1.0/24 or * for any" class="mt-1" />
+</div>
+<div class="mb-4">
+	<Label>Export Options</Label>
+	<Input bind:value={options} class="mt-1" />
+</div>

--- a/webui/src/routes/sharing/wizard/NfsWizardReview.svelte
+++ b/webui/src/routes/sharing/wizard/NfsWizardReview.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	interface Props {
+		host: string;
+		options: string;
+	}
+	let { host, options }: Props = $props();
+</script>
+
+<span class="text-muted-foreground">Allowed</span>
+<span>{host || '*'}</span>
+<span class="text-muted-foreground">Options</span>
+<span class="text-xs">{options}</span>

--- a/webui/src/routes/sharing/wizard/NvmeofWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/NvmeofWizardForm.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+
+	interface Props {
+		name: string;
+		addr: string;
+		port: string;
+	}
+	let { name = $bindable(), addr = $bindable(), port = $bindable() }: Props = $props();
+</script>
+
+<div class="mb-4">
+	<Label>Subsystem Name</Label>
+	<Input bind:value={name} placeholder="storage-vol" class="mt-1" />
+</div>
+<div class="grid grid-cols-2 gap-4 mb-4">
+	<div>
+		<Label>Listen Address</Label>
+		<Input bind:value={addr} placeholder="0.0.0.0" class="mt-1" />
+	</div>
+	<div>
+		<Label>Port</Label>
+		<Input bind:value={port} placeholder="4420" class="mt-1" />
+	</div>
+</div>

--- a/webui/src/routes/sharing/wizard/NvmeofWizardReview.svelte
+++ b/webui/src/routes/sharing/wizard/NvmeofWizardReview.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	interface Props {
+		name: string;
+		fallbackName: string;
+		addr: string;
+		port: string;
+	}
+	let { name, fallbackName, addr, port }: Props = $props();
+</script>
+
+<span class="text-muted-foreground">Subsystem</span>
+<span>{name || fallbackName}</span>
+<span class="text-muted-foreground">Listen</span>
+<span>{addr}:{port}</span>

--- a/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import type { SmbGroup } from '$lib/types';
+	import { smb } from '$lib/sharing/smb.svelte';
+
+	interface Props {
+		name: string;
+		guestOk: boolean;
+		readOnly: boolean;
+		validUsers: string[];
+	}
+	let {
+		name = $bindable(),
+		guestOk = $bindable(),
+		readOnly = $bindable(),
+		validUsers = $bindable(),
+	}: Props = $props();
+
+	const client = getClient();
+
+	// Inline user/group creation flow lives in the component because
+	// these fields are only meaningful while the SMB step of the wizard
+	// is open. Hoisting them onto the page would leak them across
+	// protocol switches.
+	let showInlineUserCreate = $state(false);
+	let inlineUsername = $state('');
+	let inlinePassword = $state('');
+	let inlinePasswordConfirm = $state('');
+	let inlineGroups: string[] = $state([]);
+	let showInlineGroupCreate = $state(false);
+	let inlineGroupName = $state('');
+
+	async function createInlineGroup() {
+		await withToast(
+			() => client.call('smb.group.create', { name: inlineGroupName.trim() }),
+			`Group "${inlineGroupName}" created`
+		);
+		smb.groups = await client.call<SmbGroup[]>('smb.group.list');
+		inlineGroups = [...inlineGroups, inlineGroupName.trim()];
+		inlineGroupName = '';
+		showInlineGroupCreate = false;
+	}
+
+	async function createInlineUser() {
+		const ok = await withToast(
+			() => client.call('smb.user.create', { username: inlineUsername, password: inlinePassword }),
+			`User "${inlineUsername}" created`
+		);
+		if (ok !== undefined) {
+			for (const g of inlineGroups) {
+				await client.call('smb.group.add_member', { group: g, user: inlineUsername }).catch(() => {});
+			}
+			validUsers = [...validUsers, inlineUsername];
+			smb.systemUsers = [...smb.systemUsers, { username: inlineUsername, uid: 0 }];
+			showInlineUserCreate = false;
+			inlineUsername = ''; inlinePassword = ''; inlinePasswordConfirm = ''; inlineGroups = [];
+		}
+	}
+</script>
+
+<div class="mb-4">
+	<Label>Share Name</Label>
+	<Input bind:value={name} placeholder="documents" class="mt-1" />
+</div>
+<div class="mb-4 flex gap-4">
+	<label class="flex items-center gap-2 text-sm cursor-pointer">
+		<input type="checkbox" bind:checked={guestOk} class="rounded border-input" />
+		Allow guests
+	</label>
+	<label class="flex items-center gap-2 text-sm cursor-pointer">
+		<input type="checkbox" bind:checked={readOnly} class="rounded border-input" />
+		Read-only
+	</label>
+</div>
+{#if !guestOk}
+	<div class="mb-4">
+		<Label>Allowed Users & Groups</Label>
+		<p class="mt-1 mb-3 text-xs text-muted-foreground">Leave empty to allow all authenticated users.</p>
+
+		{#if validUsers.length > 0}
+			<div class="mb-3 rounded-md border border-green-500/30 bg-green-500/5 p-3">
+				<p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-green-400/70">Has access</p>
+				<div class="flex flex-wrap gap-2">
+					{#each validUsers as entry}
+						<span class="flex items-center gap-1 rounded-md border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs">
+							{entry}
+							<button class="ml-1 text-muted-foreground hover:text-destructive" onclick={() => { validUsers = validUsers.filter(u => u !== entry); }}>&times;</button>
+						</span>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		{#if smb.systemUsers.some(u => !validUsers.includes(u.username)) || smb.groups.some(g => !validUsers.includes(`@${g.name}`))}
+			<div class="mb-3 rounded-md border border-border p-3">
+				<p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground/70">Click to add</p>
+				<div class="flex flex-wrap gap-2">
+					{#each smb.systemUsers.filter(u => !validUsers.includes(u.username)) as user}
+						<Button size="xs" variant="secondary" onclick={() => { validUsers = [...validUsers, user.username]; }}>
+							{user.username}
+						</Button>
+					{/each}
+					{#each smb.groups.filter(g => !validUsers.includes(`@${g.name}`)) as group}
+						<Button size="xs" variant="secondary" class="text-blue-400" onclick={() => { validUsers = [...validUsers, `@${group.name}`]; }}>
+							@{group.name}
+						</Button>
+					{/each}
+				</div>
+			</div>
+		{/if}
+		{#if showInlineUserCreate}
+			<Card class="mt-3 max-w-md">
+				<CardContent class="pt-4">
+					<h3 class="mb-4 text-lg font-semibold">New System User</h3>
+					<div class="mb-4">
+						<Label for="inline-username">Username</Label>
+						<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1" />
+					</div>
+					<div class="mb-4">
+						<Label for="inline-password">Password</Label>
+						<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1" />
+					</div>
+					<div class="mb-4">
+						<Label for="inline-password-confirm">Confirm Password</Label>
+						<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1" />
+						{#if inlinePasswordConfirm && inlinePassword !== inlinePasswordConfirm}
+							<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
+						{/if}
+					</div>
+					<div class="mb-4">
+						<Label>Add to Groups</Label>
+						<div class="mt-1 flex flex-wrap gap-2">
+							{#each smb.groups as group}
+								<label class="flex items-center gap-1.5 text-sm cursor-pointer rounded border border-border px-2 py-1 hover:bg-muted/30">
+									<input type="checkbox" class="rounded border-input"
+										onchange={(e) => {
+											const checked = (e.target as HTMLInputElement).checked;
+											if (checked) inlineGroups = [...inlineGroups, group.name];
+											else inlineGroups = inlineGroups.filter(g => g !== group.name);
+										}}
+										checked={inlineGroups.includes(group.name)}
+									/>
+									{group.name}
+								</label>
+							{/each}
+							{#if showInlineGroupCreate}
+								<div class="flex items-center gap-1.5">
+									<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs" />
+									<Button size="xs" disabled={!inlineGroupName.trim()} onclick={createInlineGroup}>Create</Button>
+									<Button size="xs" variant="secondary" onclick={() => showInlineGroupCreate = false}>Cancel</Button>
+								</div>
+							{:else}
+								<Button size="sm" onclick={() => showInlineGroupCreate = true}>Create Group</Button>
+							{/if}
+						</div>
+					</div>
+					<div class="flex gap-2">
+						<Button onclick={createInlineUser} disabled={!inlineUsername || !inlinePassword || inlinePassword !== inlinePasswordConfirm}>
+							Create & Add
+						</Button>
+						<Button variant="secondary" onclick={() => { showInlineUserCreate = false; }}>Cancel</Button>
+					</div>
+				</CardContent>
+			</Card>
+		{:else}
+			<div class="mt-2 flex gap-2">
+				<Button size="sm" onclick={() => showInlineUserCreate = true}>Create System User</Button>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/webui/src/routes/sharing/wizard/SmbWizardReview.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardReview.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	interface Props {
+		name: string;
+		fallbackName: string;
+		guestOk: boolean;
+		readOnly: boolean;
+		validUsers: string[];
+	}
+	let { name, fallbackName, guestOk, readOnly, validUsers }: Props = $props();
+</script>
+
+<span class="text-muted-foreground">Share Name</span>
+<span>{name || fallbackName}</span>
+{#if guestOk}
+	<span class="text-muted-foreground">Guests</span>
+	<span>Allowed</span>
+{/if}
+{#if readOnly}
+	<span class="text-muted-foreground">Access</span>
+	<span>Read-only</span>
+{/if}
+<span class="text-muted-foreground">Allowed Users</span>
+<span>{validUsers.length > 0 ? validUsers.join(', ') : 'All authenticated users'}</span>


### PR DESCRIPTION
## Summary

Follow-up to the four-PR per-protocol panel split (#141–#144). After those landed, the wizard's step-3 access form and step-4 review were still inline 4-way `shareProtocol === '…'` cascades. This PR breaks them up.

### New components in `routes/sharing/wizard/`

| | Form | Review |
|---|---|---|
| NFS | host + options | label/value pairs |
| SMB | name + guestOk + readOnly + valid_users + **inline user/group create** | label/value pairs |
| iSCSI | name | label/value pairs |
| NVMe-oF | name + addr + port | label/value pairs |

**`SmbWizardForm`** is the chunky one (~175 lines) — it owns the inline system-user / group-create flow that the wizard's SMB step exposes. Hoisting those vars onto the page leaked state across protocol switches; moving them inside the component is the right home.

### Page-level simplifications

- **`const isBlock = $derived(…)`** — single derived replaces 5 inline `shareProtocol === 'iscsi' || shareProtocol === 'nvmeof'` expressions across `inlineCreateSubvolume`, `filteredShareSubvolumes`, and the inline-subvolume-create copy.
- **`protocolCreators` registry** — one record keyed by protocol with a single create function per entry. `createShare()` is now a one-line dispatch instead of a 40-line if/else cascade.

### Side fix

`shareProtocol` was typed as `Tab` (declared further down the script). TypeScript saw the `$state('smb')` initial and narrowed to the literal `'smb'`, which broke the `=== 'iscsi'` check inside the new `isBlock` derived. Hoist `type Tab` to the top of the script and use the rune's type parameter `$state<Tab>('smb')` so the field actually has the union type.

### Numbers

| | page lines | `shareProtocol === '…'` count |
|---|---|---|
| start of this PR | 664 | 24 |
| this PR | **530** | **15** |

The remaining 15 break down as:
- 2 in the `isBlock` derived (definitional — what "block protocol" means)
- 8 in step-3 / step-4 component dispatch switches (each branch is now one component call; further removal needs a unified state shape across protocols, out of scope)
- 4 in suggest-name + `smbEnsureSystemUsers` checks (small, leaving inline)
- 1 in a `toggleProtocol` button hack

### Combined arc (NFS panel → here)

| stage | page lines | conditionals |
|---|---|---|
| start (pre-#141) | 1,779 | 24 |
| post-NFS (#141) | 1,586 | 24 |
| post-SMB (#142) | 1,295 | 24 |
| post-iSCSI (#143) | 1,013 | 24 |
| post-NVMe-oF (#144) | 664 | 24 |
| **this PR** | **530** | **15** |

Total: −1,249 lines (~70%) since start, conditionals down ~38%.

## Test plan
- [ ] Cross-protocol wizard works for all four: pick protocol → pick subvolume → fill access fields → review → create.
- [ ] SMB wizard's inline "Create System User" flow still works (was moved into `SmbWizardForm`).
- [ ] SMB wizard's inline "Create Group" flow inside the user-create card still works.
- [ ] Suggested share-name from picked subvolume still pre-fills the right field (smb/iscsi/nvmeof).
- [ ] Step 4 review reflects the entered values correctly per protocol.
- [ ] No regression on the standalone panels (NFS / SMB / iSCSI / NVMe-oF tabs unchanged).
- [ ] `npm run check`, `npm run build` pass.