### PR TITLE
engine: extract named parsers for ss / bcachefs / proc-mounts output

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2672,6 +2672,46 @@ async fn reload_nginx() {
         .await;
 }
 
+/// One row parsed from `ss -tlnp` output.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SsListener {
+    pub port: u16,
+    pub process: String,
+}
+
+/// Parse a single non-header line of `ss -tlnp` output. The header
+/// row and any line that doesn't carry a parseable `host:port` are
+/// returned as `None`. Format example:
+///
+///   `LISTEN 0 4096 0.0.0.0:443 0.0.0.0:* users:(("nginx",pid=1753,fd=6))`
+///
+/// We name the columns we care about (local addr, users blob) rather
+/// than accessing `fields[3]` and `fields[5]` positionally — that way
+/// an `ss` column reorder in a future iproute2 release fails this
+/// unit test instead of silently breaking port-conflict detection.
+pub(crate) fn parse_ss_listener_line(line: &str) -> Option<SsListener> {
+    let mut fields = line.split_whitespace();
+    let _state = fields.next()?; // "LISTEN"
+    let _recv_q = fields.next()?;
+    let _send_q = fields.next()?;
+    let local = fields.next()?; // local address:port
+    let _peer = fields.next()?; // peer address:port
+
+    // Local can be "0.0.0.0:443", "[::]:443", "*:443", "127.0.0.1:8080", etc.
+    let port: u16 = local.rsplit(':').next()?.parse().ok()?;
+
+    // Users blob looks like `users:(("nginx",pid=1753,fd=6))`. Some lines
+    // have no `users:` column (e.g. when `ss` is run without enough
+    // privilege to peek at PIDs); fall back to "unknown".
+    let process = fields
+        .next()
+        .and_then(|users| users.split('"').nth(1))
+        .unwrap_or("unknown")
+        .to_string();
+
+    Some(SsListener { port, process })
+}
+
 /// Query system TCP listeners via `ss -tlnp` and return (port, process_name) pairs.
 async fn system_listeners() -> Result<Vec<(u16, String)>, AppsError> {
     let output = Command::new("ss")
@@ -2684,29 +2724,12 @@ async fn system_listeners() -> Result<Vec<(u16, String)>, AppsError> {
     let mut listeners = Vec::new();
 
     for line in stdout.lines().skip(1) {
-        // Format: "LISTEN 0 4096 0.0.0.0:443 0.0.0.0:* users:(("nginx",pid=1753,fd=6))"
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() < 5 {
+        let Some(l) = parse_ss_listener_line(line) else {
             continue;
-        }
-        let local = fields[3];
-        // Extract port from "0.0.0.0:443" or "[::]:443" or "*:443"
-        let port_str = local.rsplit(':').next().unwrap_or("");
-        let port: u16 = match port_str.parse() {
-            Ok(p) => p,
-            Err(_) => continue,
         };
-
-        // Extract process name from users:(("name",...))
-        let process = if let Some(users) = fields.get(5) {
-            users.split('"').nth(1).unwrap_or("unknown").to_string()
-        } else {
-            "unknown".to_string()
-        };
-
         // Deduplicate (IPv4 + IPv6 both show up)
-        if !listeners.iter().any(|(p, _): &(u16, String)| *p == port) {
-            listeners.push((port, process));
+        if !listeners.iter().any(|(p, _): &(u16, String)| *p == l.port) {
+            listeners.push((l.port, l.process));
         }
     }
 
@@ -3380,5 +3403,77 @@ services:
         assert_eq!(r.len(), 1);
         assert!(!r[0].exists);
         assert_eq!(r[0].expected_uid, 3001);
+    }
+
+    // ── parse_ss_listener_line ──
+
+    use super::{SsListener, parse_ss_listener_line};
+
+    #[test]
+    fn parse_ss_ipv4_with_process() {
+        let l = parse_ss_listener_line(
+            r#"LISTEN 0      4096   0.0.0.0:443 0.0.0.0:* users:(("nginx",pid=1753,fd=6))"#,
+        )
+        .expect("should parse");
+        assert_eq!(
+            l,
+            SsListener {
+                port: 443,
+                process: "nginx".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_ss_ipv6_dual_bind() {
+        // `[::]:443` is the IPv6-any form ss emits when a TCP socket is
+        // bound on `::` and there's no explicit IPv4-only socket.
+        let l = parse_ss_listener_line(
+            r#"LISTEN 0      4096   [::]:80 [::]:* users:(("caddy",pid=42,fd=3))"#,
+        )
+        .expect("should parse");
+        assert_eq!(l.port, 80);
+        assert_eq!(l.process, "caddy");
+    }
+
+    #[test]
+    fn parse_ss_wildcard_address() {
+        let l = parse_ss_listener_line(r#"LISTEN 0 128 *:22 *:* users:(("sshd",pid=900,fd=4))"#)
+            .expect("should parse");
+        assert_eq!(l.port, 22);
+        assert_eq!(l.process, "sshd");
+    }
+
+    #[test]
+    fn parse_ss_without_users_column() {
+        // Without `-p` or without privilege, `ss` omits the trailing
+        // users column entirely. We still want the port; process
+        // falls back to "unknown".
+        let l = parse_ss_listener_line(r#"LISTEN 0 4096 127.0.0.1:9100 0.0.0.0:*"#)
+            .expect("should parse");
+        assert_eq!(l.port, 9100);
+        assert_eq!(l.process, "unknown");
+    }
+
+    #[test]
+    fn parse_ss_header_returns_none() {
+        // The first row of `ss -tlnp` output is the column header. Our
+        // caller `.skip(1)`s past it, but the parser should also bail
+        // because "Local" isn't a parseable port.
+        let h = parse_ss_listener_line(
+            "State Recv-Q Send-Q Local Address:Port Peer Address:Port Process",
+        );
+        assert!(h.is_none(), "header should not parse: {h:?}");
+    }
+
+    #[test]
+    fn parse_ss_blank_line_returns_none() {
+        assert!(parse_ss_listener_line("").is_none());
+        assert!(parse_ss_listener_line("   ").is_none());
+    }
+
+    #[test]
+    fn parse_ss_garbage_returns_none() {
+        assert!(parse_ss_listener_line("not ss output").is_none());
     }
 }

--- a/engine/nasty-metrics/src/collect_bcachefs.rs
+++ b/engine/nasty-metrics/src/collect_bcachefs.rs
@@ -91,7 +91,7 @@ pub struct BackgroundOps {
     pub btree_write_buffer: Option<String>,
 }
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize)]
 pub struct CompressionEntry {
     pub algorithm: String,
     pub compressed_bytes: u64,
@@ -100,21 +100,34 @@ pub struct CompressionEntry {
 
 // ── Discovery ───────────────────────────────────────────────────
 
+/// Extract the mount point of a bcachefs row from a `/proc/mounts`
+/// line. Returns `None` for non-bcachefs rows, header garbage, or
+/// malformed lines. The `/proc/mounts` format is fixed by the kernel
+/// (man proc(5)): `device mount_point fstype options dump pass` —
+/// five whitespace-separated fields. We name the fields we care
+/// about (fstype, mount_point) so a kernel reorder shows up here as
+/// a test failure rather than a silent skip.
+fn parse_bcachefs_mount_line(line: &str) -> Option<&str> {
+    let mut fields = line.split_whitespace();
+    let _device = fields.next()?;
+    let mount_point = fields.next()?;
+    let fstype = fields.next()?;
+    if fstype != "bcachefs" {
+        return None;
+    }
+    Some(mount_point)
+}
+
 /// Discover mounted bcachefs filesystems from /proc/mounts.
 pub fn discover_filesystems() -> Vec<BcachefsFs> {
     let content = std::fs::read_to_string("/proc/mounts").unwrap_or_default();
     let mut result = Vec::new();
 
     for line in content.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 3 {
+        let Some(mount_point) = parse_bcachefs_mount_line(line) else {
             continue;
-        }
-        if parts[2] != "bcachefs" {
-            continue;
-        }
-
-        let mount_point = parts[1].to_string();
+        };
+        let mount_point = mount_point.to_string();
         let fs_name = Path::new(&mount_point)
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
@@ -423,35 +436,39 @@ pub fn read_background_ops(sysfs: &Path) -> BackgroundOps {
 
 // ── Compression stats ───────────────────────────────────────────
 
+/// Parse one row of `sysfs/compression_stats`. The header line and
+/// any malformed row return `None`. Format is whitespace-separated:
+///
+///   `type    compressed      uncompressed    average extent size`
+///   `lz4     1.2G            3.5G            128K`
+///
+/// Empty rows (all-zero) yield `None` so the caller doesn't have to
+/// filter them after the fact.
+fn parse_compression_line(line: &str) -> Option<CompressionEntry> {
+    let mut fields = line.split_whitespace();
+    let algorithm = fields.next()?.to_string();
+    let compressed = parse_human_bytes(fields.next()?).unwrap_or(0);
+    let uncompressed = parse_human_bytes(fields.next()?).unwrap_or(0);
+    if compressed == 0 && uncompressed == 0 {
+        return None;
+    }
+    Some(CompressionEntry {
+        algorithm,
+        compressed_bytes: compressed,
+        uncompressed_bytes: uncompressed,
+    })
+}
+
 /// Parse compression_stats from sysfs.
 pub fn read_compression_stats(sysfs: &Path) -> Vec<CompressionEntry> {
-    let mut entries = Vec::new();
     let Ok(content) = std::fs::read_to_string(sysfs.join("compression_stats")) else {
-        return entries;
+        return Vec::new();
     };
-
-    // Format (tab-separated, first line is header):
-    //   type    compressed      uncompressed    average extent size
-    //   lz4     1.2G            3.5G            128K
-    for line in content.lines().skip(1) {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 3 {
-            continue;
-        }
-        let algorithm = parts[0].to_string();
-        let compressed = parse_human_bytes(parts[1]).unwrap_or(0);
-        let uncompressed = parse_human_bytes(parts[2]).unwrap_or(0);
-
-        if compressed > 0 || uncompressed > 0 {
-            entries.push(CompressionEntry {
-                algorithm,
-                compressed_bytes: compressed,
-                uncompressed_bytes: uncompressed,
-            });
-        }
-    }
-
-    entries
+    content
+        .lines()
+        .skip(1)
+        .filter_map(parse_compression_line)
+        .collect()
 }
 
 // ── Collect all ─────────────────────────────────────────────────
@@ -522,4 +539,76 @@ fn parse_human_bytes(s: &str) -> Option<u64> {
         .parse::<f64>()
         .ok()
         .map(|v| (v * multiplier as f64) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompressionEntry, parse_bcachefs_mount_line, parse_compression_line};
+
+    #[test]
+    fn parse_compression_lz4_row() {
+        // Real-shape row from sysfs/compression_stats (tab-separated in
+        // the kernel, whitespace-separated after `lines()`).
+        let row = parse_compression_line("lz4    1.2G    3.5G    128K").expect("should parse");
+        assert_eq!(
+            row,
+            CompressionEntry {
+                algorithm: "lz4".to_string(),
+                compressed_bytes: 1_288_490_188,
+                uncompressed_bytes: 3_758_096_384,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_compression_zstd_row() {
+        let row = parse_compression_line("zstd  500M  2.0G").expect("should parse");
+        assert_eq!(row.algorithm, "zstd");
+        assert!(row.compressed_bytes > 0);
+        assert!(row.uncompressed_bytes > 0);
+    }
+
+    #[test]
+    fn parse_compression_all_zero_returns_none() {
+        // bcachefs sysfs lists every supported algorithm even when
+        // unused; filter those out at parse time.
+        assert!(parse_compression_line("zstd 0 0").is_none());
+        assert!(parse_compression_line("gzip 0B 0B").is_none());
+    }
+
+    #[test]
+    fn parse_compression_short_row_returns_none() {
+        assert!(parse_compression_line("lz4").is_none());
+        assert!(parse_compression_line("lz4 1.2G").is_none());
+        assert!(parse_compression_line("").is_none());
+    }
+
+    #[test]
+    fn parse_proc_mounts_bcachefs_single_device() {
+        let mp = parse_bcachefs_mount_line("/dev/sda /mnt/tank bcachefs rw,relatime 0 0")
+            .expect("should parse");
+        assert_eq!(mp, "/mnt/tank");
+    }
+
+    #[test]
+    fn parse_proc_mounts_bcachefs_multi_device() {
+        let mp = parse_bcachefs_mount_line(
+            "/dev/sda:/dev/sdb /mnt/pool bcachefs rw,compression=zstd 0 0",
+        )
+        .expect("should parse");
+        assert_eq!(mp, "/mnt/pool");
+    }
+
+    #[test]
+    fn parse_proc_mounts_skips_non_bcachefs() {
+        assert!(parse_bcachefs_mount_line("/dev/sda /mnt/tank ext4 rw 0 0").is_none());
+        assert!(parse_bcachefs_mount_line("tmpfs /run tmpfs rw 0 0").is_none());
+    }
+
+    #[test]
+    fn parse_proc_mounts_skips_short_lines() {
+        assert!(parse_bcachefs_mount_line("").is_none());
+        assert!(parse_bcachefs_mount_line("/dev/sda").is_none());
+        assert!(parse_bcachefs_mount_line("/dev/sda /mnt").is_none());
+    }
 }

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2569,25 +2569,46 @@ async fn read_fs_options_show_super(device: Option<&str>) -> FilesystemOptions {
     opts
 }
 
+/// One row pulled from `/proc/mounts` for a bcachefs filesystem.
+/// `devices` is the colon-separated source split into individual
+/// device paths (`/dev/sda:/dev/sdb` → `["/dev/sda", "/dev/sdb"]`),
+/// since multi-device bcachefs filesystems are first-class.
+#[derive(Debug, PartialEq, Eq)]
+struct ProcMountsBcachefs {
+    devices: Vec<String>,
+    mount_point: String,
+}
+
+/// Parse one `/proc/mounts` line into a bcachefs mount entry, or
+/// `None` for non-bcachefs or malformed rows. The kernel format is
+/// fixed (man proc(5): `device mount_point fstype options dump pass`),
+/// so this stays simple — but naming the fields keeps the call site
+/// readable and gives us a test seam for any future regression.
+fn parse_bcachefs_mount_line(line: &str) -> Option<ProcMountsBcachefs> {
+    let mut fields = line.split_whitespace();
+    let device = fields.next()?;
+    let mount_point = fields.next()?;
+    let fstype = fields.next()?;
+    if fstype != "bcachefs" {
+        return None;
+    }
+    Some(ProcMountsBcachefs {
+        devices: device.split(':').map(String::from).collect(),
+        mount_point: mount_point.to_string(),
+    })
+}
+
 /// Parse /proc/mounts for bcachefs entries.
 /// Returns map of mount_point -> list of devices.
 async fn read_bcachefs_mounts() -> Result<HashMap<String, Vec<String>>, FilesystemError> {
     let content = tokio::fs::read_to_string("/proc/mounts")
         .await
         .unwrap_or_default();
-
-    let mut mounts: HashMap<String, Vec<String>> = HashMap::new();
-
-    for line in content.lines() {
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() >= 3 && parts[2] == "bcachefs" {
-            let device_str = parts[0]; // could be "dev1:dev2" for multi-device
-            let mount_point = parts[1].to_string();
-            let devices: Vec<String> = device_str.split(':').map(String::from).collect();
-            mounts.insert(mount_point, devices);
-        }
-    }
-
+    let mounts = content
+        .lines()
+        .filter_map(parse_bcachefs_mount_line)
+        .map(|m| (m.mount_point, m.devices))
+        .collect();
     Ok(mounts)
 }
 
@@ -2938,6 +2959,46 @@ mod tests {
         );
         assert!(parse_device_table_line("").is_none());
         assert!(parse_device_table_line("nonsense without colon-paren").is_none());
+    }
+
+    // ── parse_bcachefs_mount_line ──────────────────────────────────
+
+    #[test]
+    fn parse_bcachefs_mount_single_device() {
+        let m = parse_bcachefs_mount_line("/dev/sda /mnt/tank bcachefs rw,relatime 0 0")
+            .expect("should parse");
+        assert_eq!(m.mount_point, "/mnt/tank");
+        assert_eq!(m.devices, vec!["/dev/sda".to_string()]);
+    }
+
+    #[test]
+    fn parse_bcachefs_mount_multi_device() {
+        let m = parse_bcachefs_mount_line(
+            "/dev/sda:/dev/sdb:/dev/sdc /mnt/pool bcachefs rw,compression=zstd 0 0",
+        )
+        .expect("should parse");
+        assert_eq!(m.mount_point, "/mnt/pool");
+        assert_eq!(
+            m.devices,
+            vec![
+                "/dev/sda".to_string(),
+                "/dev/sdb".to_string(),
+                "/dev/sdc".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_bcachefs_mount_skips_other_fstypes() {
+        assert!(parse_bcachefs_mount_line("/dev/sda /mnt ext4 rw 0 0").is_none());
+        assert!(parse_bcachefs_mount_line("tmpfs /run tmpfs rw 0 0").is_none());
+    }
+
+    #[test]
+    fn parse_bcachefs_mount_skips_short_lines() {
+        assert!(parse_bcachefs_mount_line("").is_none());
+        assert!(parse_bcachefs_mount_line("/dev/sda").is_none());
+        assert!(parse_bcachefs_mount_line("/dev/sda /mnt").is_none());
     }
 
     // ── parse_bcachefs_opt ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix C from the [code-by-hand audit](https://blog.k10s.dev/im-going-back-to-writing-code-by-hand/) thread — the "magic numbers / positional access" anti-pattern.

Three callsites parsed tool output by indexing into split-whitespace vectors (`fields[3]`, `parts[2]`), with the column meaning lurking only in a `// Format: …` comment. A column reorder in any of those upstream tools — `ss`, bcachefs sysfs, kernel `/proc/mounts` — would silently break parsing: port-conflict detection would miss a listener, bcachefs discovery would skip a filesystem.

### What changed

| location | new parser | tests |
|---|---|---|
| `nasty-apps/src/lib.rs` (was `fields[3]` + `fields.get(5)`) | `parse_ss_listener_line` returning `Option<SsListener { port, process }>` | 7 — IPv4, IPv6 `[::]:N`, wildcard `*:N`, no-`users:` column, header row, blank, garbage |
| `nasty-metrics/src/collect_bcachefs.rs` (was `parts[0..3]`) | `parse_compression_line` returning `Option<CompressionEntry>`; encodes the "all-zero rows are noise" filter | 4 — lz4 / zstd rows, all-zero rejection, short-row rejection. `+ PartialEq, Eq` on `CompressionEntry` so the tests can `assert_eq!` whole structs. |
| `nasty-storage/src/filesystem.rs` + `nasty-metrics/src/collect_bcachefs.rs` (was `parts[2] == "bcachefs"`) | `parse_bcachefs_mount_line` in each crate | 8 — single-device, multi-device colon source, non-bcachefs rows, short-line garbage |

**19 new unit tests.** No behaviour change — same input, same outputs, just through named fields instead of positional indices.

### Why two copies of `parse_bcachefs_mount_line`

`nasty-storage` and `nasty-metrics` both parse `/proc/mounts` to find bcachefs filesystems but they don't share a common deps crate. A 15-line parser duplicated in two places isn't worth introducing `nasty-common`-style coupling for; each crate gets its own copy with its own tests. The shape is identical so any divergence would show up in code review.

## Test plan
- [x] `cargo test --workspace` — 343 tests pass (was 324, +19)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Live smoke on `10.10.10.61`: paste a compose stack with a port that's already taken by nginx; the port-conflict warning should still surface in the apps page. (The `ss` parser fan-out hasn't changed semantically, but it's the most exposed of the three.)