### PR TITLE
apps: reject /fs/<typo>/… bind sources before they pollute rootfs

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -279,11 +279,44 @@ fn find_line(haystack: &str, needle: &str) -> Option<u32> {
     None
 }
 
-/// Same forbidden-bind rules as the compose deploy validator: no
-/// traversal, no `/`, no engine state. Used to gate `fix_volume_perms`
-/// so the WebUI can't be tricked into chowning `/etc` because the user
-/// pasted an evil path.
-fn validate_chown_target(host_path: &str) -> Result<(), AppsError> {
+/// If `path` is `/fs/<X>/…`, return `Some("X")`. Otherwise `None`
+/// (bare `/fs`, `/fs/`, or anything outside `/fs/`). This is just
+/// string parsing — `fs_root_is_mounted` below does the actual
+/// stat() check. Split out so it can be unit-tested without
+/// touching the real `/fs`.
+fn fs_root_segment(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("/fs/")?;
+    let seg = rest.split('/').next()?;
+    if seg.is_empty() { None } else { Some(seg) }
+}
+
+/// True when a bind path's first `/fs/<X>/` segment names an actual
+/// mounted filesystem. Compares the `st_dev` of `/fs/<X>` against
+/// `/fs` — they only differ when `<X>` is a separate mountpoint, so
+/// a stale rootfs directory from a previous buggy run still reports
+/// as not-mounted. Paths outside `/fs/` (allow_unsafe territory)
+/// pass through as true — they're the user's responsibility, not
+/// ours to manage.
+fn fs_root_is_mounted(path: &str) -> bool {
+    let Some(fs_name) = fs_root_segment(path) else {
+        // Either the path isn't under /fs/ at all, or it's the bare
+        // /fs root — pre-creating that is not a thing we'd ever do.
+        return path.strip_prefix("/fs/").is_none();
+    };
+    use std::os::unix::fs::MetadataExt;
+    let fs_path = format!("/fs/{fs_name}");
+    let (Ok(child), Ok(parent)) = (std::fs::metadata(&fs_path), std::fs::metadata("/fs")) else {
+        return false;
+    };
+    child.dev() != parent.dev()
+}
+
+/// Security half of the bind validator: no `..` traversal, no host
+/// root, no engine state, must be absolute. These failures are
+/// admin-policy violations the user can't fix from the wizard — the
+/// volume-warning code skips them silently because surfacing them
+/// would just be noise.
+fn validate_chown_target_security(host_path: &str) -> Result<(), AppsError> {
     if host_path.contains("..") {
         return Err(AppsError::ForbiddenBind(format!(
             "'{host_path}' contains '..'"
@@ -304,6 +337,34 @@ fn validate_chown_target(host_path: &str) -> Result<(), AppsError> {
             "'{host_path}' is not absolute"
         )));
     }
+    Ok(())
+}
+
+/// Filesystem-existence half of the bind validator: a path of the
+/// form `/fs/<X>/…` requires `<X>` to be a real mounted bcachefs
+/// filesystem. Without this guard, `precreate_compose_binds` would
+/// `mkdir -p` the path on rootfs, which a) pollutes `/fs` with
+/// phantom entries from typos and b) silently masks "wrong
+/// filesystem name" mistakes. Unlike the security checks, this one
+/// is user-fixable — the volume-warning code surfaces it as a hard
+/// error in the wizard so the user sees what's wrong with their
+/// compose.
+fn validate_fs_root_mounted(host_path: &str) -> Result<(), AppsError> {
+    if let Some(fs_name) = fs_root_segment(host_path)
+        && !fs_root_is_mounted(host_path)
+    {
+        return Err(AppsError::ForbiddenBind(format!(
+            "filesystem '{fs_name}' is not mounted at /fs/{fs_name} — fix the bind source path"
+        )));
+    }
+    Ok(())
+}
+
+/// Full bind validator used by `fix_volume_perms` and the
+/// pre-create step. Combines the security and FS-mounted checks.
+fn validate_chown_target(host_path: &str) -> Result<(), AppsError> {
+    validate_chown_target_security(host_path)?;
+    validate_fs_root_mounted(host_path)?;
     Ok(())
 }
 
@@ -577,6 +638,12 @@ pub struct VolumeMismatch {
     /// it to expected at create time, so it's informational rather
     /// than an error.
     pub exists: bool,
+    /// True when the path is `/fs/<X>/…` and `<X>` is not a mounted
+    /// filesystem. Distinct from `!exists` because pre-create would
+    /// `mkdir -p` it on rootfs — a hard error the user must fix in
+    /// their compose, not a "we'll create it for you" hint.
+    #[serde(default)]
+    pub filesystem_missing: bool,
     /// 1-based line number of the volume entry in the compose file
     /// (for editor underlining). Best-effort: we substring-match the
     /// host path against the source; ambiguous duplicates resolve to
@@ -2057,13 +2124,35 @@ impl AppsService {
                 Some(u) => u,
                 None => continue,
             };
-            // We don't allow chowning the engine state dir, so we also
-            // don't bother surfacing warnings about it — they'd be
-            // unactionable.
-            if validate_chown_target(&bind.host_path).is_err() {
+            // Engine-state / `..` / root binds are admin-policy
+            // violations the user can't fix from the wizard — silently
+            // skip those. Filesystem-missing failures (`/fs/<X>/…`
+            // where `<X>` isn't mounted) ARE user-fixable and get
+            // surfaced as a distinct mismatch below.
+            if validate_chown_target_security(&bind.host_path).is_err() {
                 continue;
             }
             let line = find_line(&req.compose, &bind.host_path);
+            if validate_fs_root_mounted(&bind.host_path).is_err() {
+                // Don't even stat() — the path's prefix is invalid and
+                // would normally turn into a rootfs mkdir at deploy
+                // time. Flag it as filesystem_missing so the WebUI
+                // shows a hard "fix your compose" message instead of
+                // the friendly "will be created" hint.
+                out.push(VolumeMismatch {
+                    service: bind.service,
+                    host_path: bind.host_path,
+                    mount_path: bind.mount_path,
+                    expected_uid,
+                    expected_gid: bind.expected_gid,
+                    current_uid: None,
+                    current_gid: None,
+                    exists: false,
+                    filesystem_missing: true,
+                    line,
+                });
+                continue;
+            }
             match tokio::fs::metadata(&bind.host_path).await {
                 Ok(md) => {
                     let cur_uid = md.uid();
@@ -2080,6 +2169,7 @@ impl AppsService {
                             current_uid: Some(cur_uid),
                             current_gid: Some(cur_gid),
                             exists: true,
+                            filesystem_missing: false,
                             line,
                         });
                     }
@@ -2097,6 +2187,7 @@ impl AppsService {
                         current_uid: None,
                         current_gid: None,
                         exists: false,
+                        filesystem_missing: false,
                         line,
                     });
                 }
@@ -3355,13 +3446,64 @@ services:
     }
 
     #[test]
-    fn validate_chown_target_accepts_normal_paths() {
-        for ok in ["/home/jellyfin", "/fs/tank/media", "/var/lib/foo"] {
+    fn validate_chown_target_accepts_paths_outside_fs() {
+        // Paths outside `/fs/` get past the FS-mounted check
+        // unconditionally — the user opted into allow_unsafe territory
+        // and we don't manage those mounts.
+        for ok in ["/home/jellyfin", "/var/lib/foo"] {
             assert!(
                 validate_chown_target(ok).is_ok(),
                 "expected accept for {ok}"
             );
         }
+    }
+
+    #[test]
+    fn fs_root_segment_extracts_first_path_segment() {
+        assert_eq!(super::fs_root_segment("/fs/tank/media"), Some("tank"));
+        assert_eq!(super::fs_root_segment("/fs/first"), Some("first"));
+        assert_eq!(
+            super::fs_root_segment("/fs/pool/subvol/nested/path"),
+            Some("pool"),
+        );
+    }
+
+    #[test]
+    fn fs_root_segment_returns_none_outside_fs() {
+        assert_eq!(super::fs_root_segment("/home/user"), None);
+        assert_eq!(super::fs_root_segment("/etc"), None);
+        assert_eq!(super::fs_root_segment("relative/path"), None);
+    }
+
+    #[test]
+    fn fs_root_segment_returns_none_for_bare_fs() {
+        // `/fs/` with nothing after isn't a valid bind source — we
+        // never pre-create the root of /fs.
+        assert_eq!(super::fs_root_segment("/fs/"), None);
+        assert_eq!(super::fs_root_segment("/fs"), None);
+    }
+
+    #[test]
+    fn validate_fs_root_mounted_passes_paths_outside_fs() {
+        // Paths outside /fs aren't our concern — they're allow_unsafe
+        // host paths, the user owns them.
+        assert!(super::validate_fs_root_mounted("/home/jellyfin").is_ok());
+        assert!(super::validate_fs_root_mounted("/var/lib/foo").is_ok());
+    }
+
+    #[test]
+    fn validate_fs_root_mounted_rejects_unmounted_fs() {
+        // No /fs/this-filesystem-does-not-exist-nasty-test on any
+        // CI runner. The error message must name the missing fs so
+        // the WebUI can show a clear hint.
+        let e =
+            super::validate_fs_root_mounted("/fs/this-filesystem-does-not-exist-nasty-test/media")
+                .unwrap_err()
+                .to_string();
+        assert!(
+            e.contains("this-filesystem-does-not-exist-nasty-test"),
+            "error should name the missing fs: {e}",
+        );
     }
 
     #[tokio::test]
@@ -3386,6 +3528,9 @@ services:
 
     #[tokio::test]
     async fn check_volumes_flags_missing_source_dir() {
+        // /tmp is outside /fs so the FS-mounted check passes and the
+        // path falls into the normal "doesn't exist yet — will be
+        // pre-created" branch.
         let svc = AppsService::new();
         let r = svc
             .check_volumes(CheckVolumesRequest {
@@ -3402,7 +3547,34 @@ services:
             .await;
         assert_eq!(r.len(), 1);
         assert!(!r[0].exists);
+        assert!(!r[0].filesystem_missing);
         assert_eq!(r[0].expected_uid, 3001);
+    }
+
+    #[tokio::test]
+    async fn check_volumes_flags_filesystem_missing_for_unmounted_fs() {
+        // `/fs/<X>/…` where `<X>` is not mounted: the original bug
+        // would have led to `mkdir -p /fs/<X>/...` on rootfs during
+        // pre-create. We surface this as a distinct mismatch with
+        // filesystem_missing=true so the WebUI shows a "fix your
+        // source path" warning instead of a friendly create hint.
+        let svc = AppsService::new();
+        let r = svc
+            .check_volumes(CheckVolumesRequest {
+                compose: r#"
+services:
+  app:
+    image: foo
+    user: "3001:100"
+    volumes:
+      - /fs/this-filesystem-does-not-exist-nasty-test/media:/media
+"#
+                .to_string(),
+            })
+            .await;
+        assert_eq!(r.len(), 1);
+        assert!(r[0].filesystem_missing);
+        assert!(!r[0].exists);
     }
 
     // ── parse_ss_listener_line ──

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -947,6 +947,34 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     _ => {}
                 }
 
+                // `/fs/<X>/…` must reference a real mounted filesystem.
+                // Without this gate, the pre-create step would `mkdir -p`
+                // a phantom path on rootfs, leaving stale dirs under /fs
+                // every time someone typos a filesystem name. Refuse the
+                // deploy unconditionally — even with allow_unsafe, polluting
+                // the rootfs with /fs/<typo>/... is never what the user
+                // wanted.
+                if let Some(rest) = source.strip_prefix("/fs/") {
+                    let fs_name = rest.split('/').next().unwrap_or("");
+                    if !fs_name.is_empty() {
+                        let fs_path = format!("/fs/{fs_name}");
+                        use std::os::unix::fs::MetadataExt;
+                        let mounted = match (std::fs::metadata(&fs_path), std::fs::metadata("/fs"))
+                        {
+                            (Ok(c), Ok(p)) => c.dev() != p.dev(),
+                            _ => false,
+                        };
+                        if !mounted {
+                            return Err(format!(
+                                "{} bind-mounts '{}' — no filesystem is mounted at /fs/{} (typo? pick an existing filesystem from Storage → Filesystems)",
+                                scope("volumes"),
+                                source,
+                                fs_name,
+                            ));
+                        }
+                    }
+                }
+
                 if !allow_unsafe {
                     let allowed = in_app_dir || source.starts_with("/fs/") || source == "/fs";
                     if !allowed {
@@ -1230,8 +1258,35 @@ mod tests {
 
     #[test]
     fn strict_allows_app_dir_and_share_root_binds() {
+        // `/fs/<X>` is now gated on `<X>` being a mounted filesystem
+        // (see fs_root_mounted check in validate_compose) — the test
+        // can't guarantee any `/fs/*` mount exists on the runner, so
+        // the `/fs/photos` case lives in its own integration-style
+        // test in nasty-apps where it'd need a real mount fixture.
         ok_strict(
-            "services:\n  ok:\n    image: alpine\n    volumes:\n      - \"/var/lib/nasty/apps/myapp/data:/data\"\n      - \"/fs/photos:/photos:ro\"\n      - \"named-vol:/x\"\n",
+            "services:\n  ok:\n    image: alpine\n    volumes:\n      - \"/var/lib/nasty/apps/myapp/data:/data\"\n      - \"named-vol:/x\"\n",
+        );
+    }
+
+    #[test]
+    fn strict_rejects_unmounted_fs_root() {
+        // The "deploys would mkdir /fs/<typo>/... on rootfs" bug. The
+        // strict-mode validator must catch this before any pre-create
+        // step runs, with an error that names the offending fs.
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    volumes:\n      - \"/fs/this-fs-does-not-exist-nasty-test/media:/media\"\n",
+            "this-fs-does-not-exist-nasty-test",
+        );
+    }
+
+    #[test]
+    fn unsafe_also_rejects_unmounted_fs_root() {
+        // allow_unsafe relaxes the path-allowlist for `/fs/`, but it
+        // does NOT relax the "filesystem must be mounted" check — a
+        // typo'd fs name would still pollute rootfs.
+        err_unsafe(
+            "services:\n  bad:\n    image: alpine\n    volumes:\n      - \"/fs/this-fs-does-not-exist-nasty-test/media:/media\"\n",
+            "this-fs-does-not-exist-nasty-test",
         );
     }
 

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -291,12 +291,16 @@
 		current_uid: number | null;
 		current_gid: number | null;
 		exists: boolean;
+		filesystem_missing?: boolean;
 		line: number | null;
 	};
 	let volumeMismatches = $state<VolumeMismatch[]>([]);
+	// Underline every actionable line: existing-owner mismatches need
+	// the user's attention, and a missing-filesystem path is a hard
+	// error in the source field.
 	let composeVolumeErrorLines = $derived(
 		volumeMismatches
-			.filter(m => m.exists && m.line != null)
+			.filter(m => (m.exists || m.filesystem_missing) && m.line != null)
 			.map(m => m.line as number)
 	);
 	let fixingVolume = $state<string | null>(null); // host_path currently being chowned
@@ -1341,50 +1345,69 @@
 							</div>
 						{/if}
 						{#if volumeMismatches.length > 0}
-							<div class="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
-								<p class="mb-2 font-medium">
-									Bind-mount permissions don't match the container's <code>user:</code> — the container will likely fail with <em>Permission denied</em>.
-								</p>
-								{#each volumeMismatches as m}
-									{@const expectedLabel = `${m.expected_uid}:${m.expected_gid ?? m.expected_uid}`}
-									<div class="mb-2 last:mb-0">
-										<div>
+							{@const fsMissing = volumeMismatches.filter(m => m.filesystem_missing)}
+							{@const ownerMismatches = volumeMismatches.filter(m => !m.filesystem_missing)}
+							{#if fsMissing.length > 0}
+								<div class="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+									<p class="mb-2 font-medium">
+										Bind source points at a filesystem that isn't mounted — fix the source path, the deploy will fail otherwise.
+									</p>
+									{#each fsMissing as m}
+										{@const fsName = m.host_path.replace(/^\/fs\//, '').split('/')[0]}
+										<div class="mb-1 last:mb-0">
 											<span class="font-semibold">Line {m.line ?? '?'}:</span>
-											<code>{m.host_path}</code>
-											{#if m.exists}
-												is owned by <code>{m.current_uid}:{m.current_gid}</code>, but
-											{:else}
-												doesn't exist yet —
-											{/if}
-											service <span class="font-semibold">{m.service}</span> will run as <code>{expectedLabel}</code>.
+											<code>{m.host_path}</code> — no filesystem is mounted at
+											<code>/fs/{fsName}</code>. Pick an existing filesystem (see Storage → Filesystems).
 										</div>
-										{#if m.exists}
-											<div class="mt-1 flex flex-wrap gap-2">
-												<Button
-													size="xs"
-													variant="secondary"
-													disabled={fixingVolume === m.host_path}
-													onclick={() => fixVolume(m.host_path, m.expected_uid, m.expected_gid, false)}
-												>
-													{fixingVolume === m.host_path ? 'Chowning…' : `Chown to ${expectedLabel}`}
-												</Button>
-												<Button
-													size="xs"
-													variant="ghost"
-													disabled={fixingVolume === m.host_path}
-													onclick={() => fixVolume(m.host_path, m.expected_uid, m.expected_gid, true)}
-													title="Recursive — rewrites every existing file's owner"
-												>
-													…and contents
-												</Button>
+									{/each}
+								</div>
+							{/if}
+							{#if ownerMismatches.length > 0}
+								<div class="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+									<p class="mb-2 font-medium">
+										Bind-mount permissions don't match the container's <code>user:</code> — the container will likely fail with <em>Permission denied</em>.
+									</p>
+									{#each ownerMismatches as m}
+										{@const expectedLabel = `${m.expected_uid}:${m.expected_gid ?? m.expected_uid}`}
+										<div class="mb-2 last:mb-0">
+											<div>
+												<span class="font-semibold">Line {m.line ?? '?'}:</span>
+												<code>{m.host_path}</code>
+												{#if m.exists}
+													is owned by <code>{m.current_uid}:{m.current_gid}</code>, but
+												{:else}
+													doesn't exist yet —
+												{/if}
+												service <span class="font-semibold">{m.service}</span> will run as <code>{expectedLabel}</code>.
 											</div>
-										{:else}
-											<div class="mt-1 text-muted-foreground">Will be created with the right ownership when you deploy.</div>
-										{/if}
-									</div>
-								{/each}
+											{#if m.exists}
+												<div class="mt-1 flex flex-wrap gap-2">
+													<Button
+														size="xs"
+														variant="secondary"
+														disabled={fixingVolume === m.host_path}
+														onclick={() => fixVolume(m.host_path, m.expected_uid, m.expected_gid, false)}
+													>
+														{fixingVolume === m.host_path ? 'Chowning…' : `Chown to ${expectedLabel}`}
+													</Button>
+													<Button
+														size="xs"
+														variant="ghost"
+														disabled={fixingVolume === m.host_path}
+														onclick={() => fixVolume(m.host_path, m.expected_uid, m.expected_gid, true)}
+														title="Recursive — rewrites every existing file's owner"
+													>
+														…and contents
+													</Button>
+												</div>
+											{:else}
+												<div class="mt-1 text-muted-foreground">Will be created with the right ownership when you deploy.</div>
+											{/if}
+										</div>
+									{/each}
 							</div>
 						{/if}
+					{/if}
 					</div>
 				</div>
 				{/if}


### PR DESCRIPTION
## Summary

Spotted by Bartosz live on `10.10.10.61`: a compose binding `/fs/tank/media` where no filesystem is mounted at `/fs/tank` (typo, the real one is `first`) — and **NASty created `/fs/tank/media` on the rootfs**, because `precreate_compose_binds` from #131 calls `mkdir -p` on any missing source. Every typo'd filesystem name would leave a phantom dir under `/fs`.

## Three layers of fix

1. **Engine — split the validator.** `validate_chown_target` now decomposes into `validate_chown_target_security` (the existing `..` / `/` / engine-state / non-absolute checks) and `validate_fs_root_mounted` (`/fs/<X>/…` requires `<X>` to be a real mountpoint — verified via `st_dev` comparison so a stale rootfs leftover still reports as not-mounted). `fix_volume_perms` and `precreate_compose_binds` call the combined validator and refuse with a clear "filesystem 'tank' is not mounted at /fs/tank" error.
2. **Engine — surface it as user-actionable.** `VolumeMismatch` gets a new `filesystem_missing: bool`. `check_volumes` skips security violations silently (unactionable) but emits FS-missing failures as a distinct mismatch so the WebUI can render them prominently.
3. **Engine — defense in depth.** `validate_compose` in `app_deploy.rs` rejects unmounted `/fs/<X>/…` regardless of `allow_unsafe`. Even if a user bypasses the WebUI warning, the deploy stops before any pre-create runs.
4. **WebUI — distinct rendering.** The volume-warning section splits into a red "filesystem isn't mounted" panel for `filesystem_missing` entries (no chown buttons — the user has to fix the source) and the existing amber permissions panel for owner mismatches.

## Tests
- 7 new engine tests in `nasty-apps`: helpers (`fs_root_segment`, `validate_fs_root_mounted`) under various path shapes, plus `check_volumes` round-trip for the new branch.
- 2 new engine tests in `nasty-engine/app_deploy`: `validate_compose` rejects the typo path under both strict and allow_unsafe modes.
- `strict_allows_app_dir_and_share_root_binds` updated to drop its `/fs/photos` case (the test runner has no `/fs/*` mount, and that exact assertion is now the responsibility of the new FS-mounted tests).
- All 343+ workspace tests pass; `cargo clippy --all-targets -- -D warnings` clean; `npm run check` + `npm run build` clean.

## Test plan
- [ ] Live repro on `10.10.10.61`: paste the Jellyfin compose with `source: /fs/tank/media` (no `tank` exists). Wizard now shows a red "filesystem isn't mounted at /fs/tank" panel. Clicking Deploy fails with a matching engine error. No `/fs/tank/` directory appears on rootfs.
- [ ] Fix the path to `/fs/first/media` → wizard falls back to the existing amber permissions card and offers the chown buttons.