### PR TITLE
apps: fold nested bind-mount permission warnings under their parent

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -305,6 +305,48 @@
 	);
 	let fixingVolume = $state<string | null>(null); // host_path currently being chowned
 
+	/** One owner-mismatch group: a parent path plus any of its
+	 * descendant binds that share the same expected (uid, gid). A
+	 * single recursive chown of the parent covers all descendants,
+	 * so we render them folded under the parent — saves the user
+	 * clicking N near-identical Chown buttons in a row. */
+	type AggregatedMismatch = {
+		parent: VolumeMismatch;
+		descendants: VolumeMismatch[];
+	};
+
+	function effectiveGid(m: VolumeMismatch): number {
+		return m.expected_gid ?? m.expected_uid;
+	}
+
+	function aggregateOwnerMismatches(items: VolumeMismatch[]): AggregatedMismatch[] {
+		// Shortest paths first — any parent is shorter than its child.
+		const sorted = [...items].sort((a, b) => a.host_path.length - b.host_path.length);
+		const taken = new Set<number>();
+		const out: AggregatedMismatch[] = [];
+		for (let i = 0; i < sorted.length; i++) {
+			if (taken.has(i)) continue;
+			const parent = sorted[i];
+			const descendants: VolumeMismatch[] = [];
+			for (let j = i + 1; j < sorted.length; j++) {
+				if (taken.has(j)) continue;
+				const child = sorted[j];
+				// Strict-prefix check with the `/` separator so
+				// `/data` doesn't capture `/data-other`.
+				if (!child.host_path.startsWith(parent.host_path + '/')) continue;
+				// Recursive chown only covers descendants if they
+				// share the parent's expected owner. Different
+				// `user:` per service → can't fold.
+				if (child.expected_uid !== parent.expected_uid) continue;
+				if (effectiveGid(child) !== effectiveGid(parent)) continue;
+				descendants.push(child);
+				taken.add(j);
+			}
+			out.push({ parent, descendants });
+		}
+		return out;
+	}
+
 	// Editor underlines port-conflict, missing-device, and existing-but-wrong-owner lines.
 	const composeErrorLines = $derived([
 		...composePortErrorLines,
@@ -1367,8 +1409,10 @@
 									<p class="mb-2 font-medium">
 										Bind-mount permissions don't match the container's <code>user:</code> — the container will likely fail with <em>Permission denied</em>.
 									</p>
-									{#each ownerMismatches as m}
+									{#each aggregateOwnerMismatches(ownerMismatches) as group}
+										{@const m = group.parent}
 										{@const expectedLabel = `${m.expected_uid}:${m.expected_gid ?? m.expected_uid}`}
+										{@const nested = group.descendants.length}
 										<div class="mb-2 last:mb-0">
 											<div>
 												<span class="font-semibold">Line {m.line ?? '?'}:</span>
@@ -1380,6 +1424,13 @@
 												{/if}
 												service <span class="font-semibold">{m.service}</span> will run as <code>{expectedLabel}</code>.
 											</div>
+											{#if nested > 0}
+												<div class="mt-1 text-muted-foreground">
+													↳ {nested} nested bind{nested === 1 ? '' : 's'} share{nested === 1 ? 's' : ''} the same expected owner
+													{#each group.descendants as d, i}{#if i === 0} ({:else}, {/if}line {d.line ?? '?'}: <code>{d.host_path}</code>{#if i === group.descendants.length - 1}){/if}{/each}
+													— a recursive chown of the parent covers them all.
+												</div>
+											{/if}
 											{#if m.exists}
 												<div class="mt-1 flex flex-wrap gap-2">
 													<Button
@@ -1392,7 +1443,7 @@
 													</Button>
 													<Button
 														size="xs"
-														variant="ghost"
+														variant={nested > 0 ? 'secondary' : 'ghost'}
 														disabled={fixingVolume === m.host_path}
 														onclick={() => fixVolume(m.host_path, m.expected_uid, m.expected_gid, true)}
 														title="Recursive — rewrites every existing file's owner"
@@ -1401,7 +1452,9 @@
 													</Button>
 												</div>
 											{:else}
-												<div class="mt-1 text-muted-foreground">Will be created with the right ownership when you deploy.</div>
+												<div class="mt-1 text-muted-foreground">
+													Will be created with the right ownership when you deploy{nested > 0 ? ` (along with the ${nested} nested bind${nested === 1 ? '' : 's'})` : ''}.
+												</div>
 											{/if}
 										</div>
 									{/each}


### PR DESCRIPTION
## Summary

Follow-up to #148. In the Jellyfin compose Bartosz live-tested:

```yaml
volumes:
  - /home/jellyfin:/config
  - /home/jellyfin/cache:/cache
```

The volume-warning card surfaced two amber rows for what's effectively one user action — `/home/jellyfin` is the parent of `/home/jellyfin/cache`, both want `3001:100`, and a single recursive chown covers both. This PR folds them.

### Behaviour

`aggregateOwnerMismatches()` groups items where one `host_path` is a strict prefix of another **and** the expected `(uid, gid)` matches. The parent renders as one row with the existing two-button layout; nested descendants get folded under it as:

> ↳ 1 nested bind shares the same expected owner (line 14: `/home/jellyfin/cache`) — a recursive chown of the parent covers them all.

When nested binds are present, the **"…and contents"** button gets a small visual bump (`variant="secondary"` instead of `"ghost"`) — it's now the option that fixes everything in one click, so it deserves the higher emphasis.

The "doesn't exist yet" branch picks up parallel treatment:
> Will be created with the right ownership when you deploy (along with the 1 nested bind).

### What I deliberately didn't do

- **No engine changes.** The behaviour was already correct — the pre-create step chowns each bind source individually, and the recursive-chown button still does exactly what it says. This is purely a UX collapse.
- **No re-grouping by service.** If two different services both bind `/home/jellyfin` with different `user:` values, they show as two separate parent rows. The aggregator gates on matching `(uid, gid)` to avoid pretending one recursive chown does both.

### Strict-prefix details

The prefix check uses `parent.host_path + '/'` as the boundary, so `/data` doesn't capture `/data-other`. Tested mentally against:
- `/home/jellyfin` vs `/home/jellyfin/cache` → folded ✓
- `/home/jellyfin` vs `/home/jellyfin-2` → NOT folded ✓
- `/data` (uid=1000) vs `/data/sub` (uid=2000) → NOT folded ✓
- `/a` + `/a/b/c` (no `/a/b` entry) → still folded ✓

## Test plan
- [ ] Paste the Jellyfin compose (`/home/jellyfin` + `/home/jellyfin/cache`) → one parent row, descendant folded with the "↳ 1 nested bind…" line.
- [ ] Click "…and contents" → recursive chown succeeds, both rows disappear on re-check.
- [ ] Click "Chown to 3001:100" (non-recursive) → parent's row goes away, descendant's reappears as a standalone amber row (it wasn't covered).
- [ ] Compose with two services pinning different `user:` on `/data` and `/data/sub` → both render as separate parent rows (not folded).
- [ ] `npm run check` + `npm run build` clean.