### PR TITLE
vm: import qcow2/img into a block subvolume with progress

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -25,6 +25,7 @@ mod router;
 mod telemetry;
 mod terminal;
 mod vm_console;
+mod vm_disk_import;
 
 use auth::{AuthService, Session};
 use router::handle_rpc_request;
@@ -263,6 +264,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/ws", get(ws_handler))
         .route("/ws/terminal", get(terminal::terminal_handler))
         .route("/ws/apps/deploy", get(app_deploy::deploy_handler))
+        .route(
+            "/ws/vm/disk-import",
+            get(vm_disk_import::disk_import_handler),
+        )
         .route("/ws/system/logs", get(log_stream::logs_handler))
         .route("/ws/vm/{vm_id}/vnc", get(vm_console::vnc_handler))
         .route("/ws/vm/{vm_id}/serial", get(vm_console::serial_handler))

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -168,6 +168,7 @@ fn is_read_only(method: &str) -> bool {
                 | "apps.inspect"
                 | "system.firewall.status"
                 | "vm.capabilities"
+                | "vm.images.import_info"
                 | "firmware.available"
                 | "firmware.check"
                 | "firmware.devices"

--- a/engine/nasty-engine/src/router/vm.rs
+++ b/engine/nasty-engine/src/router/vm.rs
@@ -93,6 +93,22 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
+        // Pre-flight for the streaming disk-import WS — surfaces the
+        // image's virtual size so the UI can recommend (or block) a
+        // target subvolume before opening the WebSocket.
+        "vm.images.import_info" => match (require_str(req, "filesystem"), require_str(req, "name"))
+        {
+            (Ok(fs), Ok(name)) => {
+                match crate::vm_disk_import::resolve_image_path(state, fs, name).await {
+                    Ok(path) => match crate::vm_disk_import::read_image_info(&path).await {
+                        Ok(info) => ok(req, info),
+                        Err(e) => err(req, e),
+                    },
+                    Err(e) => err(req, e),
+                }
+            }
+            (Err(r), _) | (_, Err(r)) => r,
+        },
         _ => return None,
     })
 }

--- a/engine/nasty-engine/src/vm_disk_import.rs
+++ b/engine/nasty-engine/src/vm_disk_import.rs
@@ -1,0 +1,561 @@
+//! Import a VM image (qcow2/img/raw) onto a block subvolume by streaming
+//! `qemu-img convert` over a WebSocket.
+//!
+//! Mirrors `app_deploy.rs`: the first WS message carries auth + params,
+//! subsequent server frames are `{ type, data }` log/error/done plus a
+//! `{ type: "progress", percent }` shape parsed off `qemu-img convert -p`.
+//!
+//! Why this exists: bootable distros that ship as qcow2 (Home Assistant
+//! HAOS, OPNsense, CoreOS) can't be used as a "boot image" the way an ISO
+//! installer can — they're already an installed disk. The user needs to
+//! lay them down on a block subvolume and attach the subvolume as a VM
+//! disk. Doing that by hand requires shelling into the appliance and
+//! running qemu-img. This endpoint makes it a UI affordance.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::extract::{
+    State,
+    ws::{Message, WebSocket, WebSocketUpgrade},
+};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tracing::{info, warn};
+
+use crate::AppState;
+use crate::router::VM_IMAGE_EXTENSIONS;
+
+pub async fn disk_import_handler(
+    ws: WebSocketUpgrade,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+    let pre_auth_token = crate::token_from_headers(&headers);
+    ws.on_upgrade(move |socket| handle_import(socket, state, client_ip, pre_auth_token))
+}
+
+#[derive(Deserialize)]
+struct ImportRequest {
+    #[serde(default)]
+    token: Option<String>,
+    /// Filesystem on which the source image lives (it's resolved to
+    /// `<mount>/vms/images/<image_name>`, the same layout `vm.image.list`
+    /// returns).
+    image_filesystem: String,
+    image_name: String,
+    /// Block subvolume that receives the converted image. Must already
+    /// exist and have its loop device attached (so a `block_device` is
+    /// present). The UI nudges users through `subvolume.create` when no
+    /// suitable target exists.
+    target_filesystem: String,
+    target_subvolume: String,
+}
+
+#[derive(Serialize)]
+struct ImportMessage {
+    #[serde(rename = "type")]
+    msg_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    percent: Option<f64>,
+}
+
+impl ImportMessage {
+    fn log(s: impl Into<String>) -> String {
+        serde_json::to_string(&Self {
+            msg_type: "log",
+            data: Some(s.into()),
+            percent: None,
+        })
+        .unwrap()
+    }
+    fn error(s: impl Into<String>) -> String {
+        serde_json::to_string(&Self {
+            msg_type: "error",
+            data: Some(s.into()),
+            percent: None,
+        })
+        .unwrap()
+    }
+    fn progress(pct: f64) -> String {
+        serde_json::to_string(&Self {
+            msg_type: "progress",
+            data: None,
+            percent: Some(pct),
+        })
+        .unwrap()
+    }
+    fn done(s: impl Into<String>) -> String {
+        serde_json::to_string(&Self {
+            msg_type: "done",
+            data: Some(s.into()),
+            percent: None,
+        })
+        .unwrap()
+    }
+}
+
+async fn send_text(socket: &mut WebSocket, text: String) {
+    let _ = socket.send(Message::Text(text.into())).await;
+}
+
+async fn handle_import(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_ip: String,
+    pre_auth_token: Option<String>,
+) {
+    let req: ImportRequest = match socket.recv().await {
+        Some(Ok(Message::Text(text))) => match serde_json::from_str(&text) {
+            Ok(r) => r,
+            Err(e) => {
+                send_text(
+                    &mut socket,
+                    ImportMessage::error(format!("invalid request: {e}")),
+                )
+                .await;
+                return;
+            }
+        },
+        _ => return,
+    };
+
+    let token = match pre_auth_token.or_else(|| req.token.clone()) {
+        Some(t) => t,
+        None => {
+            send_text(&mut socket, ImportMessage::error("missing session")).await;
+            return;
+        }
+    };
+
+    // Admin-only: this writes to a block device and runs a long-lived
+    // qemu-img process — the same risk profile as compose deploys.
+    let session = match state.auth.validate(&token, &client_ip).await {
+        Ok(s) if s.role == crate::auth::Role::Admin => s,
+        Ok(s) => {
+            crate::auth::audit(
+                "vm_disk_import_denied",
+                &s.username,
+                &client_ip,
+                &format!("role={:?}", s.role),
+            );
+            send_text(
+                &mut socket,
+                ImportMessage::error("forbidden: admin role required"),
+            )
+            .await;
+            return;
+        }
+        Err(_) => {
+            send_text(&mut socket, ImportMessage::error("invalid token")).await;
+            return;
+        }
+    };
+
+    info!(
+        "VM disk import started: image={}:{} target={}:{} user={}",
+        req.image_filesystem,
+        req.image_name,
+        req.target_filesystem,
+        req.target_subvolume,
+        session.username,
+    );
+
+    let image_path = match resolve_image_path(&state, &req.image_filesystem, &req.image_name).await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            send_text(&mut socket, ImportMessage::error(e)).await;
+            return;
+        }
+    };
+
+    let target =
+        match resolve_target_block_device(&state, &req.target_filesystem, &req.target_subvolume)
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                send_text(&mut socket, ImportMessage::error(e)).await;
+                return;
+            }
+        };
+
+    // Read image metadata up front so we can refuse early when the
+    // virtual size doesn't fit the target — the alternative is letting
+    // qemu-img run for several minutes and then fail with a write error,
+    // which gives the user no useful information.
+    let info = match read_image_info(&image_path).await {
+        Ok(i) => i,
+        Err(e) => {
+            send_text(&mut socket, ImportMessage::error(e)).await;
+            return;
+        }
+    };
+
+    send_text(
+        &mut socket,
+        ImportMessage::log(format!(
+            "Source: {} ({}, virtual {} bytes)",
+            image_path.display(),
+            info.format,
+            info.virtual_size,
+        )),
+    )
+    .await;
+
+    if let Some(vs) = target.volsize_bytes
+        && info.virtual_size > vs
+    {
+        send_text(
+            &mut socket,
+            ImportMessage::error(format!(
+                "image is too large: virtual size {} bytes > target subvolume {} bytes. \
+                 Recreate the subvolume with at least {} bytes (e.g. {} GiB).",
+                info.virtual_size,
+                vs,
+                info.virtual_size,
+                // Round up to whole GiB so the UI's hint is copyable.
+                info.virtual_size.div_ceil(1024 * 1024 * 1024)
+            )),
+        )
+        .await;
+        return;
+    }
+
+    send_text(
+        &mut socket,
+        ImportMessage::log(format!(
+            "Target: subvolume '{}' on '{}' → {}",
+            target.name, target.filesystem, target.block_device
+        )),
+    )
+    .await;
+
+    crate::auth::audit(
+        "vm.disk.import",
+        &session.username,
+        &client_ip,
+        &format!(
+            "image={}:{} target={}:{} dev={}",
+            req.image_filesystem,
+            req.image_name,
+            req.target_filesystem,
+            req.target_subvolume,
+            target.block_device,
+        ),
+    );
+
+    if let Err(e) = run_convert(&mut socket, &image_path, &target.block_device).await {
+        send_text(
+            &mut socket,
+            ImportMessage::error(format!("qemu-img convert failed: {e}")),
+        )
+        .await;
+        return;
+    }
+
+    send_text(&mut socket, ImportMessage::progress(100.0)).await;
+    send_text(&mut socket, ImportMessage::done("ok")).await;
+    info!(
+        "VM disk import finished: image={}:{} target={}",
+        req.image_filesystem, req.image_name, target.block_device,
+    );
+}
+
+pub(crate) struct ResolvedTarget {
+    pub name: String,
+    pub filesystem: String,
+    pub block_device: String,
+    pub volsize_bytes: Option<u64>,
+}
+
+pub(crate) async fn resolve_target_block_device(
+    state: &AppState,
+    filesystem: &str,
+    subvolume: &str,
+) -> Result<ResolvedTarget, String> {
+    let sv = state
+        .subvolumes
+        .get(filesystem, subvolume, None)
+        .await
+        .map_err(|e| format!("target subvolume not found: {e}"))?;
+
+    if sv.subvolume_type != nasty_storage::subvolume::SubvolumeType::Block {
+        return Err(format!(
+            "target subvolume '{}' on '{}' is a filesystem subvolume — only block subvolumes can receive a disk image",
+            sv.name, sv.filesystem
+        ));
+    }
+
+    let block_device = sv
+        .block_device
+        .clone()
+        .ok_or_else(|| {
+            format!(
+                "target subvolume '{}' on '{}' has no loop device attached. Attach it first via subvolume.attach.",
+                sv.name, sv.filesystem,
+            )
+        })?;
+
+    // Refuse if anything else is already exporting this device — writing
+    // through it while iSCSI/NVMe-oF clients are connected would silently
+    // corrupt them.
+    if let Some(why) = crate::router::check_block_device_conflict(state, &block_device, "vm").await
+    {
+        return Err(format!("target busy: {why}"));
+    }
+    if let Ok(vms) = state.vms.list().await {
+        for vm in &vms {
+            for disk in &vm.config.disks {
+                if disk.path == block_device && vm.running {
+                    return Err(format!(
+                        "target busy: device {} is attached to running VM '{}'. Stop the VM first.",
+                        block_device, vm.config.name
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(ResolvedTarget {
+        name: sv.name,
+        filesystem: sv.filesystem,
+        block_device,
+        volsize_bytes: sv.volsize_bytes,
+    })
+}
+
+/// Resolve `(filesystem, image_name)` to an absolute path under
+/// `<mount>/vms/images/`. Rejects path traversal and unsupported
+/// extensions before we hand the path to qemu-img.
+pub(crate) async fn resolve_image_path(
+    state: &AppState,
+    filesystem: &str,
+    image_name: &str,
+) -> Result<PathBuf, String> {
+    // file_name() strips directory components and rejects ".." / "/".
+    let safe_name = Path::new(image_name)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| format!("invalid image name: '{image_name}'"))?;
+    if safe_name != image_name {
+        return Err(format!(
+            "invalid image name: '{image_name}' (must not contain path separators)"
+        ));
+    }
+
+    let ext = Path::new(safe_name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+    if !VM_IMAGE_EXTENSIONS
+        .iter()
+        .any(|e| e.eq_ignore_ascii_case(&ext))
+    {
+        return Err(format!(
+            "unsupported image extension '.{ext}' — expected one of {VM_IMAGE_EXTENSIONS:?}"
+        ));
+    }
+    // ISOs are bootable installers, not pre-installed disk images — converting
+    // one onto a block subvolume produces a non-bootable mess. Block the path
+    // here so the UI's affordance can't trip on it.
+    if ext == "iso" {
+        return Err(
+            "ISO images are installer media, not disk images — boot the VM from the ISO instead of importing it"
+                .to_string(),
+        );
+    }
+
+    let fs = state
+        .filesystems
+        .get(filesystem)
+        .await
+        .map_err(|e| format!("filesystem '{filesystem}' not found: {e}"))?;
+    let mp = fs
+        .mount_point
+        .ok_or_else(|| format!("filesystem '{filesystem}' is not mounted"))?;
+    let candidate = Path::new(&mp).join("vms").join("images").join(safe_name);
+    if !candidate.is_file() {
+        return Err(format!(
+            "image '{safe_name}' not found at {}",
+            candidate.display()
+        ));
+    }
+    Ok(candidate)
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ImageInfo {
+    pub format: String,
+    pub virtual_size: u64,
+    pub actual_size: u64,
+}
+
+pub(crate) async fn read_image_info(path: &Path) -> Result<ImageInfo, String> {
+    let out = Command::new("qemu-img")
+        .args(["info", "--output=json", "--force-share"])
+        .arg(path)
+        .output()
+        .await
+        .map_err(|e| format!("failed to spawn qemu-img: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "qemu-img info failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .map_err(|e| format!("failed to parse qemu-img info: {e}"))?;
+    let format = json
+        .get("format")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let virtual_size = json
+        .get("virtual-size")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "qemu-img info: missing virtual-size".to_string())?;
+    let actual_size = json
+        .get("actual-size")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    Ok(ImageInfo {
+        format,
+        virtual_size,
+        actual_size,
+    })
+}
+
+/// Spawn `qemu-img convert -p` and forward progress to the socket. The
+/// `-p` flag writes lines like `    (12.34/100%)` to stdout, separated
+/// by `\r` (in-place updates) — we read raw bytes and split on either
+/// `\r` or `\n` so each progress tick gets surfaced.
+async fn run_convert(socket: &mut WebSocket, input: &Path, output_dev: &str) -> Result<(), String> {
+    let mut child = Command::new("qemu-img")
+        .args(["convert", "-p", "-O", "raw"])
+        .arg(input)
+        .arg(output_dev)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn qemu-img: {e}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "qemu-img stdout missing".to_string())?;
+    let stderr = child.stderr.take();
+
+    // Stderr drains in the background — qemu-img writes warnings here
+    // and a stuck reader can backpressure the child.
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stderr {
+            let _ = s.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
+    let mut reader = stdout;
+    let mut buf = [0u8; 256];
+    let mut line = String::new();
+    let mut last_pct: Option<f64> = None;
+    loop {
+        let n = reader
+            .read(&mut buf)
+            .await
+            .map_err(|e| format!("qemu-img stdout read: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        for &b in &buf[..n] {
+            if b == b'\r' || b == b'\n' {
+                if !line.is_empty() {
+                    if let Some(p) = parse_progress(&line) {
+                        // Throttle: forward whole percent ticks (and the
+                        // final 100). qemu-img emits 0.50, 1.00, 1.50…
+                        // — without throttling we'd flood the socket
+                        // with hundreds of frames per second.
+                        let send = match last_pct {
+                            None => true,
+                            Some(prev) => p - prev >= 1.0 || (p >= 100.0 && prev < 100.0),
+                        };
+                        if send {
+                            send_text(socket, ImportMessage::progress(p)).await;
+                            last_pct = Some(p);
+                        }
+                    }
+                    line.clear();
+                }
+            } else {
+                line.push(b as char);
+            }
+        }
+    }
+
+    // Flush any trailing partial line (qemu-img may not terminate the
+    // last update on success).
+    if !line.is_empty()
+        && let Some(p) = parse_progress(&line)
+    {
+        send_text(socket, ImportMessage::progress(p)).await;
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("qemu-img wait: {e}"))?;
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+    if !status.success() {
+        let stderr_text = String::from_utf8_lossy(&stderr_buf);
+        let detail = stderr_text.lines().last().unwrap_or("").trim();
+        if detail.is_empty() {
+            warn!("qemu-img convert exited {status}");
+            return Err(format!("exit {status}"));
+        }
+        warn!("qemu-img convert exited {status}: {detail}");
+        return Err(format!("exit {status}: {detail}"));
+    }
+    Ok(())
+}
+
+/// Extract `12.34` from a line like `    (12.34/100%)`. Returns None for
+/// any other shape (qemu-img occasionally emits informational warnings
+/// on stdout that don't carry a percent).
+fn parse_progress(line: &str) -> Option<f64> {
+    let trimmed = line.trim();
+    let inside = trimmed.strip_prefix('(')?.strip_suffix(')')?;
+    let pct = inside.strip_suffix("/100%")?;
+    pct.parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_progress;
+
+    #[test]
+    fn parses_qemu_img_progress() {
+        assert_eq!(parse_progress("    (0.50/100%)"), Some(0.5));
+        assert_eq!(parse_progress("(12.34/100%)"), Some(12.34));
+        assert_eq!(parse_progress(" (100.00/100%) "), Some(100.0));
+    }
+
+    #[test]
+    fn rejects_other_lines() {
+        assert!(parse_progress("Warning: ...").is_none());
+        assert!(parse_progress("").is_none());
+        assert!(parse_progress("(abc/100%)").is_none());
+        assert!(parse_progress("(50/99%)").is_none());
+    }
+}

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -218,6 +218,146 @@
 		return `${bytes} B`;
 	}
 
+	// ── Disk-image import (qcow2/img → block subvolume) ────────────
+	// Streams `qemu-img convert -p -O raw` over /ws/vm/disk-import. The
+	// flow is "lay an upstream image down on a pre-allocated block
+	// subvolume so the VM can boot from it" — the canonical use case is
+	// distros that ship as qcow2 (HAOS, OPNsense, CoreOS) which can't
+	// be used as installer ISOs.
+	type ImageInfo = { format: string; virtual_size: number; actual_size: number };
+	let importOpen = $state(false);
+	let importImageKey = $state(''); // "filesystem/name" to drive a <select>
+	let importTargetKey = $state(''); // "filesystem/subvolume" same idea
+	let importInfo: ImageInfo | null = $state(null);
+	let importInfoError = $state('');
+	let importInfoLoading = $state(false);
+	let importLog: string[] = $state([]);
+	let importProgress: number | null = $state(null);
+	let importBusy = $state(false);
+	let importDone = $state(false);
+	let importError = $state('');
+	let importWs: WebSocket | null = null;
+
+	// Only images that can become a disk show in the picker — ISOs are
+	// installer media and the engine rejects them up front, so hiding
+	// them here keeps the affordance honest.
+	const IMPORTABLE_EXTS = ['.qcow2', '.img', '.raw'];
+	let importableImages = $derived(
+		imageFiles.filter((img) => IMPORTABLE_EXTS.some((ext) => img.name.toLowerCase().endsWith(ext))),
+	);
+
+	async function openImportModal() {
+		await Promise.all([loadImages(), loadSubvolumes()]);
+		importImageKey = '';
+		importTargetKey = '';
+		importInfo = null;
+		importInfoError = '';
+		importLog = [];
+		importProgress = null;
+		importBusy = false;
+		importDone = false;
+		importError = '';
+		importOpen = true;
+	}
+
+	function closeImportModal() {
+		if (importBusy) return; // can't dismiss mid-flight; would orphan the WS
+		importOpen = false;
+		importWs?.close();
+		importWs = null;
+	}
+
+	// Whenever the user picks an image, fetch virtual-size so we can
+	// disable target subvolumes that are too small before any bytes
+	// move.
+	$effect(() => {
+		const key = importImageKey;
+		if (!key) {
+			importInfo = null;
+			importInfoError = '';
+			return;
+		}
+		const [filesystem, ...rest] = key.split('/');
+		const name = rest.join('/');
+		importInfoLoading = true;
+		importInfo = null;
+		importInfoError = '';
+		client
+			.call<ImageInfo>('vm.images.import_info', { filesystem, name })
+			.then((info) => {
+				// Guard against a stale response after the user picked a
+				// different image while this one was inflight.
+				if (importImageKey === key) importInfo = info;
+			})
+			.catch((e) => {
+				if (importImageKey === key) importInfoError = String(e);
+			})
+			.finally(() => {
+				if (importImageKey === key) importInfoLoading = false;
+			});
+	});
+
+	async function startImport() {
+		if (!importImageKey || !importTargetKey || !importInfo) return;
+		const [image_filesystem, ...iRest] = importImageKey.split('/');
+		const image_name = iRest.join('/');
+		const [target_filesystem, ...tRest] = importTargetKey.split('/');
+		const target_subvolume = tRest.join('/');
+
+		importBusy = true;
+		importDone = false;
+		importError = '';
+		importLog = [];
+		importProgress = 0;
+
+		const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+		const ws = new WebSocket(`${wsProto}//${window.location.host}/ws/vm/disk-import`);
+		importWs = ws;
+
+		ws.onopen = () => {
+			ws.send(
+				JSON.stringify({
+					image_filesystem,
+					image_name,
+					target_filesystem,
+					target_subvolume,
+				}),
+			);
+		};
+		ws.onmessage = (event) => {
+			try {
+				const msg = JSON.parse(event.data);
+				if (msg.type === 'log') {
+					importLog = [...importLog, msg.data];
+				} else if (msg.type === 'progress') {
+					importProgress = msg.percent;
+				} else if (msg.type === 'error') {
+					importError = msg.data;
+					importLog = [...importLog, `ERROR: ${msg.data}`];
+					importBusy = false;
+					ws.close();
+				} else if (msg.type === 'done') {
+					importDone = true;
+					importBusy = false;
+					importProgress = 100;
+					ws.close();
+				}
+			} catch {
+				/* ignore */
+			}
+		};
+		ws.onerror = () => {
+			importError = 'WebSocket connection failed';
+			importBusy = false;
+		};
+		ws.onclose = () => {
+			if (!importDone && !importError) {
+				importError = 'Connection closed unexpectedly';
+				importBusy = false;
+			}
+		};
+	}
+
 	// Initialize serial console (xterm) when element mounts
 	$effect(() => {
 		if (consoleEl && consoleVm && consoleMode === 'serial' && !consoleTerm) {
@@ -648,6 +788,9 @@
 <div class="mb-4 flex items-center gap-3">
 	<Button size="sm" onclick={() => wizardStep === 0 ? openWizard() : (wizardStep = 0)}>
 		{wizardStep !== 0 ? 'Cancel' : 'Create VM'}
+	</Button>
+	<Button size="sm" variant="outline" onclick={openImportModal} disabled={wizardStep !== 0}>
+		Import disk image…
 	</Button>
 	{#if vms.length > 3}
 		<Input bind:value={search} placeholder="Filter..." class="h-9 w-40" />
@@ -1487,6 +1630,128 @@
 			{/each}
 		</tbody>
 	</table>
+{/if}
+
+<!-- Disk-Image Import Modal -->
+{#if importOpen}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<div class="flex flex-col w-[90vw] max-w-3xl max-h-[85vh] rounded-lg border border-border bg-card shadow-2xl">
+			<div class="flex items-center justify-between px-4 py-2 border-b border-border">
+				<span class="text-sm font-semibold">Import disk image</span>
+				<Button variant="ghost" size="xs" onclick={closeImportModal} disabled={importBusy}>
+					Close
+				</Button>
+			</div>
+			<div class="flex-1 overflow-auto px-4 py-3 space-y-3">
+				<div>
+					<Label class="text-xs">Source image</Label>
+					{#if importableImages.length === 0}
+						<p class="mt-1 text-xs text-muted-foreground">
+							No qcow2/img/raw images uploaded yet. Upload one via the Create VM wizard.
+						</p>
+					{:else}
+						<select
+							bind:value={importImageKey}
+							disabled={importBusy}
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
+						>
+							<option value="">Select an image…</option>
+							{#each importableImages as img}
+								<option value={`${img.filesystem}/${img.name}`}>
+									{img.name} ({img.filesystem}, {formatSize(img.size_bytes)})
+								</option>
+							{/each}
+						</select>
+					{/if}
+					{#if importInfoLoading}
+						<p class="mt-1 text-xs text-muted-foreground">Reading image metadata…</p>
+					{:else if importInfoError}
+						<p class="mt-1 text-xs text-destructive">{importInfoError}</p>
+					{:else if importInfo}
+						<p class="mt-1 text-xs text-muted-foreground">
+							Format <span class="font-mono">{importInfo.format}</span>, virtual size
+							<span class="font-mono">{formatSize(importInfo.virtual_size)}</span>
+							(on-disk {formatSize(importInfo.actual_size)})
+						</p>
+					{/if}
+				</div>
+
+				<div>
+					<Label class="text-xs">Target block subvolume</Label>
+					{#if blockSubvolumes.length === 0}
+						<p class="mt-1 text-xs text-muted-foreground">
+							No block subvolumes available. Create one on the Subvolumes page first.
+						</p>
+						<Button size="xs" class="mt-1" onclick={() => goto('/subvolumes')}>Subvolumes</Button>
+					{:else}
+						<select
+							bind:value={importTargetKey}
+							disabled={importBusy}
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm"
+						>
+							<option value="">Select a target…</option>
+							{#each blockSubvolumes as sv}
+								{@const tooSmall = !!importInfo && !!sv.volsize_bytes && sv.volsize_bytes < importInfo.virtual_size}
+								<option value={`${sv.filesystem}/${sv.name}`} disabled={tooSmall}>
+									{sv.filesystem}/{sv.name}
+									({sv.volsize_bytes ? formatSize(sv.volsize_bytes) : '—'}, {sv.block_device})
+									{tooSmall ? '— too small' : ''}
+								</option>
+							{/each}
+						</select>
+						<p class="mt-1 text-xs text-muted-foreground">
+							The whole subvolume is overwritten — any prior contents are destroyed.
+						</p>
+					{/if}
+				</div>
+
+				{#if importProgress !== null || importLog.length > 0}
+					<div>
+						<div class="flex items-center gap-2 mb-1">
+							{#if importBusy}
+								<div class="h-3 w-3 animate-spin rounded-full border-2 border-muted border-t-primary"></div>
+							{:else if importError}
+								<div class="h-3 w-3 rounded-full bg-destructive"></div>
+							{:else if importDone}
+								<div class="h-3 w-3 rounded-full bg-green-500"></div>
+							{/if}
+							<span class="text-xs font-medium">
+								{importDone ? 'Import complete' : importError ? 'Import failed' : 'Importing…'}
+							</span>
+							{#if importProgress !== null}
+								<span class="text-xs text-muted-foreground ml-auto font-mono">{importProgress.toFixed(1)}%</span>
+							{/if}
+						</div>
+						<div class="h-2 rounded-full bg-muted overflow-hidden">
+							<div
+								class="h-full transition-all {importError ? 'bg-destructive' : 'bg-primary'}"
+								style="width: {importProgress ?? 0}%"
+							></div>
+						</div>
+						{#if importLog.length > 0}
+							<pre
+								class="mt-2 max-h-40 overflow-auto rounded border border-border bg-[#0f1117] p-2 text-xs font-mono text-green-400 whitespace-pre-wrap"
+							>{importLog.join('\n')}</pre>
+						{/if}
+					</div>
+				{/if}
+			</div>
+			<div class="flex items-center justify-end gap-2 px-4 py-2 border-t border-border">
+				{#if !importBusy && !importDone}
+					<Button variant="ghost" size="sm" onclick={closeImportModal}>Cancel</Button>
+					<Button
+						size="sm"
+						onclick={startImport}
+						disabled={!importImageKey || !importTargetKey || !importInfo || importInfoLoading}
+					>
+						Start import
+					</Button>
+				{:else if importDone}
+					<Button size="sm" onclick={closeImportModal}>Done</Button>
+				{/if}
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- Console Modal -->


### PR DESCRIPTION
## Summary
- New `/ws/vm/disk-import` WebSocket streams `qemu-img convert -p -O raw <image> <loop>` as `{type:"progress",percent}` + log/error/done frames, mirroring the apps deploy WS pattern.
- New `vm.images.import_info` RPC returns `{format, virtual_size, actual_size}` so the UI can size-check the target before opening the socket.
- "Import disk image…" toolbar button on the VMs page opens a modal with image picker (qcow2/img/raw only — ISOs filtered out), target block-subvolume picker (oversize-aware, too-small targets disabled), progress bar, and a live log tail.

Closes #65 — the existing "upload boot image" path treats every image as an installer; HAOS / OPNsense / CoreOS et al. ship as pre-installed qcow2 disks and need to be laid down on a block subvolume to boot.

## Safety
Admin-only and audited (`vm.disk.import`). The endpoint refuses:
- ISOs (installer media, not disk images),
- images outside the managed `vms/images/` tree (`..` / absolute paths rejected),
- block targets without an attached loop device,
- targets smaller than the source's virtual size (refused up front, before any bytes move),
- targets already exported via iSCSI/NVMe-oF or attached to a running VM.

## Scope deferred
- No "auto-create target subvolume" path in this PR — workflow assumes the user pre-creates a block subvolume sized for the image. The modal points users to the Subvolumes page when none exist. Trivial follow-up if wanted.

## Test plan
- [x] `cargo build -p nasty-engine`
- [x] `cargo test -p nasty-engine` (new `parse_progress` unit tests pass)
- [x] `cargo clippy -p nasty-engine --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (webui type-check, 0 errors)
- [x] `npm run build` (webui builds clean)
- [ ] Live smoke on `10.10.10.61`: import a small qcow2 onto a block subvolume; verify progress bar advances and resulting disk boots as a VM.