### PR TITLE
vm: accept compressed images (xz/gz/bz2) + vdi/vmdk

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -510,15 +510,20 @@ async fn upload_vm_image_handler(
         session.username, file_name, images_path
     );
 
-    let extensions = ["iso", "qcow2", "img", "raw"];
-    let ext = std::path::Path::new(&file_name)
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_lowercase())
-        .unwrap_or_default();
-
-    if !extensions.contains(&ext.as_str()) {
-        return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": format!("Invalid file type. Supported: {:?}", extensions) }))).into_response();
+    // Validate the filename through the central classifier so plain
+    // and compressed shapes (e.g. .qcow2.xz, .img.bz2) are all
+    // accepted via the same allowlist the importer and lister use.
+    if vm_disk_import::classify_vm_image(&file_name).is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "Invalid file type. Supported: {}",
+                    vm_disk_import::supported_image_extensions_hint()
+                )
+            })),
+        )
+            .into_response();
     }
 
     let dest_path = std::path::Path::new(&images_path).join(&file_name);

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -466,15 +466,16 @@ pub(super) async fn check_block_device_conflict(
 
 // ── VM image management ─────────────────────────────────────────
 
-pub(super) const VM_IMAGE_EXTENSIONS: &[&str] = &["iso", "qcow2", "img", "raw"];
-
 #[derive(serde::Serialize)]
 pub(super) struct VmImageListResult {
     subvolume_exists: bool,
     images: Vec<serde_json::Value>,
 }
 
-/// List all VM images from `vms/images` directories across all filesystems.
+/// List all VM images from `vms/images` directories across all
+/// filesystems. The classifier in `vm_disk_import` is the single
+/// source of truth for what counts as a VM image — including
+/// compressed shapes like `.qcow2.xz`.
 pub(super) async fn list_vm_images(state: &AppState) -> VmImageListResult {
     let filesystems = state.filesystems.list().await.unwrap_or_default();
     let mut images = Vec::new();
@@ -496,32 +497,30 @@ pub(super) async fn list_vm_images(state: &AppState) -> VmImageListResult {
         if let Ok(mut entries) = tokio::fs::read_dir(&dir).await {
             while let Ok(Some(entry)) = entries.next_entry().await {
                 let path = entry.path();
-                let is_image = path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .map(|e| {
-                        VM_IMAGE_EXTENSIONS
-                            .iter()
-                            .any(|ext| e.eq_ignore_ascii_case(ext))
-                    })
-                    .unwrap_or(false);
-
-                if is_image {
-                    let name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let size = tokio::fs::metadata(&path)
-                        .await
-                        .map(|m| m.len())
-                        .unwrap_or(0);
-                    images.push(serde_json::json!({
-                        "name": name,
-                        "path": path.to_string_lossy(),
-                        "filesystem": fs.name,
-                        "size_bytes": size,
-                    }));
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                let Some(kind) = crate::vm_disk_import::classify_vm_image(name) else {
+                    continue;
+                };
+                // Skip the hidden tmp files an in-flight decompression
+                // leaves behind so they don't pollute the picker.
+                if name.starts_with(".nasty-import.") {
+                    continue;
                 }
+                let size = tokio::fs::metadata(&path)
+                    .await
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                images.push(serde_json::json!({
+                    "name": name,
+                    "path": path.to_string_lossy(),
+                    "filesystem": fs.name,
+                    "size_bytes": size,
+                    "format": kind.format,
+                    "compression": kind.compression,
+                }));
             }
         }
     }

--- a/engine/nasty-engine/src/router/vm.rs
+++ b/engine/nasty-engine/src/router/vm.rs
@@ -100,10 +100,12 @@ pub(super) async fn try_route(
         {
             (Ok(fs), Ok(name)) => {
                 match crate::vm_disk_import::resolve_image_path(state, fs, name).await {
-                    Ok(path) => match crate::vm_disk_import::read_image_info(&path).await {
-                        Ok(info) => ok(req, info),
-                        Err(e) => err(req, e),
-                    },
+                    Ok((path, kind)) => {
+                        match crate::vm_disk_import::read_image_info(&path, &kind).await {
+                            Ok(info) => ok(req, info),
+                            Err(e) => err(req, e),
+                        }
+                    }
                     Err(e) => err(req, e),
                 }
             }

--- a/engine/nasty-engine/src/vm_disk_import.rs
+++ b/engine/nasty-engine/src/vm_disk_import.rs
@@ -26,7 +26,80 @@ use tokio::process::Command;
 use tracing::{info, warn};
 
 use crate::AppState;
-use crate::router::VM_IMAGE_EXTENSIONS;
+
+/// Disk-image formats we can read. qemu-img handles every one of
+/// these natively (`-f qcow2|raw|vdi|vmdk` etc), so adding a format
+/// here is enough to surface it in the upload picker and the
+/// importer. ISO is in the list because the uploader still accepts
+/// it (it's a valid VM boot medium) — the importer rejects ISO
+/// separately since converting an installer to a raw disk produces
+/// a non-bootable mess.
+const VM_IMAGE_FORMATS: &[&str] = &["iso", "qcow2", "img", "raw", "vdi", "vmdk"];
+
+/// Compression wrappers we recognize. Pair is (file-suffix,
+/// decompressor-binary). HAOS ships as `haos_ova-*.qcow2.xz`,
+/// OPNsense as `OPNsense-*.img.bz2`, etc.
+const COMPRESSION_WRAPPERS: &[(&str, &str)] = &[("xz", "xz"), ("gz", "gzip"), ("bz2", "bzip2")];
+
+/// Result of name-based classification. `compression` is None for
+/// already-uncompressed images.
+#[derive(Debug, Clone)]
+pub(crate) struct VmImageKind {
+    pub format: &'static str,
+    pub compression: Option<&'static str>,
+}
+
+/// Pattern-match an image filename to a `(format, compression?)` pair.
+/// Returns None for names that don't match a supported shape — used by
+/// the upload handler, the list filter, and the importer so all three
+/// agree on what's a VM image.
+pub(crate) fn classify_vm_image(name: &str) -> Option<VmImageKind> {
+    let lower = name.to_ascii_lowercase();
+    // Try compressed forms first because `.qcow2.xz` would otherwise
+    // also match the plain `.xz` test below (which we don't have, but
+    // belt-and-suspenders).
+    for &(suffix, _) in COMPRESSION_WRAPPERS {
+        if let Some(inner) = lower.strip_suffix(&format!(".{suffix}")) {
+            for &fmt in VM_IMAGE_FORMATS {
+                if inner.ends_with(&format!(".{fmt}")) {
+                    return Some(VmImageKind {
+                        format: fmt,
+                        compression: Some(suffix),
+                    });
+                }
+            }
+            // `.xz` of something unrecognized — refuse rather than
+            // letting the user upload arbitrary archives into vms/images.
+            return None;
+        }
+    }
+    for &fmt in VM_IMAGE_FORMATS {
+        if lower.ends_with(&format!(".{fmt}")) {
+            return Some(VmImageKind {
+                format: fmt,
+                compression: None,
+            });
+        }
+    }
+    None
+}
+
+/// Comma-separated allowlist string for error messages — keeps every
+/// rejection echoing the same list the upload picker is built from.
+pub(crate) fn supported_image_extensions_hint() -> String {
+    let mut exts: Vec<String> = VM_IMAGE_FORMATS.iter().map(|f| format!(".{f}")).collect();
+    for &fmt in VM_IMAGE_FORMATS {
+        // ISOs only make sense uncompressed (we boot from them, never
+        // import) so don't advertise `.iso.xz`.
+        if fmt == "iso" {
+            continue;
+        }
+        for &(suffix, _) in COMPRESSION_WRAPPERS {
+            exts.push(format!(".{fmt}.{suffix}"));
+        }
+    }
+    exts.join(", ")
+}
 
 pub async fn disk_import_handler(
     ws: WebSocketUpgrade,
@@ -170,14 +243,14 @@ async fn handle_import(
         session.username,
     );
 
-    let image_path = match resolve_image_path(&state, &req.image_filesystem, &req.image_name).await
-    {
-        Ok(p) => p,
-        Err(e) => {
-            send_text(&mut socket, ImportMessage::error(e)).await;
-            return;
-        }
-    };
+    let (image_path, kind) =
+        match resolve_image_path(&state, &req.image_filesystem, &req.image_name).await {
+            Ok(p) => p,
+            Err(e) => {
+                send_text(&mut socket, ImportMessage::error(e)).await;
+                return;
+            }
+        };
 
     let target =
         match resolve_target_block_device(&state, &req.target_filesystem, &req.target_subvolume)
@@ -190,11 +263,38 @@ async fn handle_import(
             }
         };
 
-    // Read image metadata up front so we can refuse early when the
-    // virtual size doesn't fit the target — the alternative is letting
-    // qemu-img run for several minutes and then fail with a write error,
-    // which gives the user no useful information.
-    let info = match read_image_info(&image_path).await {
+    // If the source is wrapped (xz/gz/bz2), decompress it to a sibling
+    // hidden file under vms/images/ first. The intermediate file is
+    // typically much smaller than the raw disk that qemu-img will
+    // eventually produce on the loop device (qcow2 is sparse), and
+    // landing it next to the original keeps the temp on the same
+    // filesystem so cleanup is a cheap unlink.
+    let decompressed: Option<DecompressedFile> = match kind.compression {
+        Some(compression) => match decompress_to_tmp(&mut socket, &image_path, compression).await {
+            Ok(d) => Some(d),
+            Err(e) => {
+                send_text(
+                    &mut socket,
+                    ImportMessage::error(format!("decompression failed: {e}")),
+                )
+                .await;
+                return;
+            }
+        },
+        None => None,
+    };
+    // The path qemu-img actually reads: the decompressed sibling when
+    // we had a wrapper, otherwise the original.
+    let work_path = decompressed
+        .as_ref()
+        .map(|d| d.path.as_path())
+        .unwrap_or(&image_path);
+
+    // Read metadata from the path qemu-img is about to read so we can
+    // refuse early when the virtual size doesn't fit the target —
+    // letting qemu-img run for minutes and then failing with a write
+    // error gives the user no useful information.
+    let info = match qemu_img_info(work_path).await {
         Ok(i) => i,
         Err(e) => {
             send_text(&mut socket, ImportMessage::error(e)).await;
@@ -205,10 +305,13 @@ async fn handle_import(
     send_text(
         &mut socket,
         ImportMessage::log(format!(
-            "Source: {} ({}, virtual {} bytes)",
+            "Source: {} ({}, virtual {} bytes){}",
             image_path.display(),
             info.format,
             info.virtual_size,
+            kind.compression
+                .map(|c| format!(" (decompressed from {c})"))
+                .unwrap_or_default(),
         )),
     )
     .await;
@@ -246,21 +349,23 @@ async fn handle_import(
         &session.username,
         &client_ip,
         &format!(
-            "image={}:{} target={}:{} dev={}",
+            "image={}:{} target={}:{} dev={} compression={}",
             req.image_filesystem,
             req.image_name,
             req.target_filesystem,
             req.target_subvolume,
             target.block_device,
+            kind.compression.unwrap_or("none"),
         ),
     );
 
-    if let Err(e) = run_convert(&mut socket, &image_path, &target.block_device).await {
+    if let Err(e) = run_convert(&mut socket, work_path, &target.block_device).await {
         send_text(
             &mut socket,
             ImportMessage::error(format!("qemu-img convert failed: {e}")),
         )
         .await;
+        // decompressed dropped here → tmp file unlinked
         return;
     }
 
@@ -270,6 +375,120 @@ async fn handle_import(
         "VM disk import finished: image={}:{} target={}",
         req.image_filesystem, req.image_name, target.block_device,
     );
+    // decompressed dropped here → tmp file unlinked
+}
+
+/// Decompressed-source guard: when this struct drops, the tmp file is
+/// unlinked. Means every early-return path in handle_import cleans up
+/// without the caller having to remember.
+struct DecompressedFile {
+    path: PathBuf,
+}
+
+impl Drop for DecompressedFile {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            warn!(
+                "failed to remove decompressed tmp {}: {e}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+async fn decompress_to_tmp(
+    socket: &mut WebSocket,
+    source: &Path,
+    compression: &str,
+) -> Result<DecompressedFile, String> {
+    let (bin, label) = match compression {
+        "xz" => ("xz", "xz"),
+        "gz" => ("gzip", "gzip"),
+        "bz2" => ("bzip2", "bzip2"),
+        other => return Err(format!("unsupported compression: {other}")),
+    };
+
+    let parent = source
+        .parent()
+        .ok_or_else(|| "image has no parent directory".to_string())?;
+    let stem = source
+        .file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|n| n.strip_suffix(&format!(".{compression}")))
+        .ok_or_else(|| "image name doesn't end with the declared compression suffix".to_string())?;
+    // Hidden + nasty-prefixed so a half-aborted run is obviously
+    // ours and easy to clean up by hand. Collisions across concurrent
+    // imports of the same file would be a problem in theory but the
+    // engine serializes nothing here — overwriting is fine, the last
+    // writer wins and both convert calls would target the same loop
+    // device anyway (which we already lock out via the running-VM /
+    // export-conflict checks).
+    let tmp = parent.join(format!(".nasty-import.{stem}"));
+    let _ = tokio::fs::remove_file(&tmp).await;
+
+    send_text(
+        socket,
+        ImportMessage::log(format!(
+            "Decompressing {label} → {}…",
+            tmp.file_name().and_then(|n| n.to_str()).unwrap_or("<tmp>")
+        )),
+    )
+    .await;
+
+    // stdin: the source file; stdout: the tmp file. Using -dc keeps
+    // the original around so the user's upload isn't consumed.
+    let tmp_file = std::fs::File::create(&tmp).map_err(|e| format!("create tmp: {e}"))?;
+    let mut child = Command::new(bin)
+        .args(["-dc"])
+        .arg(source)
+        .stdout(std::process::Stdio::from(tmp_file))
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            // Try to give an actionable hint when the binary isn't on PATH.
+            if matches!(e.kind(), std::io::ErrorKind::NotFound) {
+                format!(
+                    "decompressor '{bin}' not found — install it on the appliance (NixOS module should pull it in)"
+                )
+            } else {
+                format!("spawn {bin}: {e}")
+            }
+        })?;
+
+    let stderr = child.stderr.take();
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stderr {
+            let _ = s.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
+    let status = child.wait().await.map_err(|e| format!("{bin} wait: {e}"))?;
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+    if !status.success() {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        let stderr_text = String::from_utf8_lossy(&stderr_buf);
+        let detail = stderr_text.lines().last().unwrap_or("").trim();
+        return Err(if detail.is_empty() {
+            format!("{bin} exited {status}")
+        } else {
+            format!("{bin} exited {status}: {detail}")
+        });
+    }
+
+    let bytes = tokio::fs::metadata(&tmp)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let mib = bytes as f64 / (1024.0 * 1024.0);
+    send_text(
+        socket,
+        ImportMessage::log(format!("Decompression complete ({mib:.1} MiB)")),
+    )
+    .await;
+
+    Ok(DecompressedFile { path: tmp })
 }
 
 pub(crate) struct ResolvedTarget {
@@ -336,13 +555,15 @@ pub(crate) async fn resolve_target_block_device(
 }
 
 /// Resolve `(filesystem, image_name)` to an absolute path under
-/// `<mount>/vms/images/`. Rejects path traversal and unsupported
-/// extensions before we hand the path to qemu-img.
+/// `<mount>/vms/images/`. Rejects path traversal, unsupported extensions,
+/// and ISOs (which are installer media, not disk images) before we hand
+/// the path to qemu-img. Returns both the resolved path and the
+/// recognized kind so the caller knows whether to decompress.
 pub(crate) async fn resolve_image_path(
     state: &AppState,
     filesystem: &str,
     image_name: &str,
-) -> Result<PathBuf, String> {
+) -> Result<(PathBuf, VmImageKind), String> {
     // file_name() strips directory components and rejects ".." / "/".
     let safe_name = Path::new(image_name)
         .file_name()
@@ -354,23 +575,16 @@ pub(crate) async fn resolve_image_path(
         ));
     }
 
-    let ext = Path::new(safe_name)
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_lowercase())
-        .unwrap_or_default();
-    if !VM_IMAGE_EXTENSIONS
-        .iter()
-        .any(|e| e.eq_ignore_ascii_case(&ext))
-    {
-        return Err(format!(
-            "unsupported image extension '.{ext}' — expected one of {VM_IMAGE_EXTENSIONS:?}"
-        ));
-    }
+    let kind = classify_vm_image(safe_name).ok_or_else(|| {
+        format!(
+            "unsupported image name '{safe_name}' — expected one of {}",
+            supported_image_extensions_hint()
+        )
+    })?;
     // ISOs are bootable installers, not pre-installed disk images — converting
     // one onto a block subvolume produces a non-bootable mess. Block the path
     // here so the UI's affordance can't trip on it.
-    if ext == "iso" {
+    if kind.format == "iso" {
         return Err(
             "ISO images are installer media, not disk images — boot the VM from the ISO instead of importing it"
                 .to_string(),
@@ -392,17 +606,43 @@ pub(crate) async fn resolve_image_path(
             candidate.display()
         ));
     }
-    Ok(candidate)
+    Ok((candidate, kind))
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub struct ImageInfo {
     pub format: String,
+    /// 0 when unknown (compressed source — the qcow2 lives behind the
+    /// xz/gz/bz2 wrapper, so qemu-img can't peek without decompression).
+    /// Surfaced for the UI as a "size known after decompression" hint.
     pub virtual_size: u64,
     pub actual_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compression: Option<String>,
 }
 
-pub(crate) async fn read_image_info(path: &Path) -> Result<ImageInfo, String> {
+/// Read image metadata for the preflight RPC. For compressed sources
+/// we don't decompress just to peek — that would take ~20s for a HAOS
+/// xz, blocking the UI on every modal open. Instead we surface
+/// `virtual_size: 0` and let the WS importer reveal the real size after
+/// it decompresses for real.
+pub(crate) async fn read_image_info(path: &Path, kind: &VmImageKind) -> Result<ImageInfo, String> {
+    if let Some(compression) = kind.compression {
+        let actual_size = tokio::fs::metadata(path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+        return Ok(ImageInfo {
+            format: kind.format.to_string(),
+            virtual_size: 0,
+            actual_size,
+            compression: Some(compression.to_string()),
+        });
+    }
+    qemu_img_info(path).await
+}
+
+async fn qemu_img_info(path: &Path) -> Result<ImageInfo, String> {
     let out = Command::new("qemu-img")
         .args(["info", "--output=json", "--force-share"])
         .arg(path)
@@ -434,6 +674,7 @@ pub(crate) async fn read_image_info(path: &Path) -> Result<ImageInfo, String> {
         format,
         virtual_size,
         actual_size,
+        compression: None,
     })
 }
 
@@ -542,7 +783,7 @@ fn parse_progress(line: &str) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_progress;
+    use super::{classify_vm_image, parse_progress};
 
     #[test]
     fn parses_qemu_img_progress() {
@@ -557,5 +798,54 @@ mod tests {
         assert!(parse_progress("").is_none());
         assert!(parse_progress("(abc/100%)").is_none());
         assert!(parse_progress("(50/99%)").is_none());
+    }
+
+    #[test]
+    fn classifies_plain_images() {
+        let q = classify_vm_image("alpine.qcow2").unwrap();
+        assert_eq!(q.format, "qcow2");
+        assert_eq!(q.compression, None);
+
+        let v = classify_vm_image("Win10.vdi").unwrap();
+        assert_eq!(v.format, "vdi");
+
+        let m = classify_vm_image("ubuntu.vmdk").unwrap();
+        assert_eq!(m.format, "vmdk");
+
+        let i = classify_vm_image("debian-12.iso").unwrap();
+        assert_eq!(i.format, "iso");
+    }
+
+    #[test]
+    fn classifies_compressed_images() {
+        let haos = classify_vm_image("haos_ova-12.0.qcow2.xz").unwrap();
+        assert_eq!(haos.format, "qcow2");
+        assert_eq!(haos.compression, Some("xz"));
+
+        let opn = classify_vm_image("OPNsense-25.1.img.bz2").unwrap();
+        assert_eq!(opn.format, "img");
+        assert_eq!(opn.compression, Some("bz2"));
+
+        let gz = classify_vm_image("disk.raw.gz").unwrap();
+        assert_eq!(gz.format, "raw");
+        assert_eq!(gz.compression, Some("gz"));
+    }
+
+    #[test]
+    fn classify_is_case_insensitive() {
+        // Cloud-image downloads sometimes camelcase the extension.
+        let q = classify_vm_image("Disk.QCOW2.XZ").unwrap();
+        assert_eq!(q.format, "qcow2");
+        assert_eq!(q.compression, Some("xz"));
+    }
+
+    #[test]
+    fn rejects_unrelated_archives() {
+        assert!(classify_vm_image("payload.tar.xz").is_none());
+        assert!(classify_vm_image("notes.txt").is_none());
+        assert!(classify_vm_image("backup.gz").is_none());
+        assert!(classify_vm_image("").is_none());
+        // OVA isn't supported yet — a future patch will untar it.
+        assert!(classify_vm_image("appliance.ova").is_none());
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -920,6 +920,14 @@ in {
         nix              # nix flake lock (for bcachefs-tools version switching)
         git              # for update check (git ls-remote)
         qemu             # QEMU/KVM for virtual machines
+        # Decompressors for the VM disk-import flow: HAOS ships as
+        # *.qcow2.xz, OPNsense as *.img.bz2, lots of cloud images as
+        # *.qcow2.gz. The engine shells out to whichever matches the
+        # uploaded file's wrapper before handing the inner image to
+        # qemu-img convert.
+        xz
+        gzip
+        bzip2
         docker                       # Docker for apps runtime
         docker-compose               # Docker Compose for multi-container apps
         fwupd                        # fwupdmgr for firmware updates

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -224,7 +224,16 @@
 	// subvolume so the VM can boot from it" — the canonical use case is
 	// distros that ship as qcow2 (HAOS, OPNsense, CoreOS) which can't
 	// be used as installer ISOs.
-	type ImageInfo = { format: string; virtual_size: number; actual_size: number };
+	type ImageInfo = {
+		format: string;
+		virtual_size: number;
+		actual_size: number;
+		/** Set when the source is a compressed wrapper (xz/gz/bz2). In
+		 * that case virtual_size is 0 — the engine doesn't decompress
+		 * just to peek, so the true virtual size is only known after
+		 * the WS import starts. */
+		compression?: string | null;
+	};
 	let importOpen = $state(false);
 	let importImageKey = $state(''); // "filesystem/name" to drive a <select>
 	let importTargetMode: 'existing' | 'create' = $state('existing');
@@ -250,8 +259,14 @@
 
 	// Only images that can become a disk show in the picker — ISOs are
 	// installer media and the engine rejects them up front, so hiding
-	// them here keeps the affordance honest.
-	const IMPORTABLE_EXTS = ['.qcow2', '.img', '.raw'];
+	// them here keeps the affordance honest. Compressed wrappers
+	// (xz/gz/bz2) are accepted around any disk format — the engine
+	// decompresses to a sibling tmp file before running qemu-img.
+	const IMPORTABLE_BASE_EXTS = ['.qcow2', '.img', '.raw', '.vdi', '.vmdk'];
+	const IMPORTABLE_COMPRESSION = ['', '.xz', '.gz', '.bz2'];
+	const IMPORTABLE_EXTS = IMPORTABLE_BASE_EXTS.flatMap((b) =>
+		IMPORTABLE_COMPRESSION.map((c) => `${b}${c}`),
+	);
 	let importableImages = $derived(
 		imageFiles.filter((img) => IMPORTABLE_EXTS.some((ext) => img.name.toLowerCase().endsWith(ext))),
 	);
@@ -303,8 +318,11 @@
 	// Auto-fill the size from the image's virtual_size (rounded up to
 	// the next whole GiB) once we've fetched the info, unless the user
 	// has already typed a size — clobbering their input would be rude.
+	// For compressed sources the engine doesn't decompress for the
+	// preflight (would block the modal for ~30s on HAOS), so
+	// virtual_size is 0 and we leave the field for the user to fill.
 	$effect(() => {
-		if (importInfo && !importSvSizeTouched) {
+		if (importInfo && importInfo.virtual_size > 0 && !importSvSizeTouched) {
 			const gib = Math.ceil(importInfo.virtual_size / (1024 * 1024 * 1024));
 			importNewSvSize = Math.max(gib, 1);
 		}
@@ -1096,12 +1114,12 @@
 						<input
 							id="file-upload"
 							type="file"
-							accept=".iso,.qcow2,.img,.raw"
+							accept=".iso,.qcow2,.img,.raw,.vdi,.vmdk,.qcow2.xz,.qcow2.gz,.qcow2.bz2,.img.xz,.img.gz,.img.bz2,.raw.xz,.raw.gz,.raw.bz2,.vdi.xz,.vdi.gz,.vdi.bz2,.vmdk.xz,.vmdk.gz,.vmdk.bz2"
 							class="hidden"
 							onchange={uploadImage}
 							disabled={uploading}
 						/>
-						<span class="text-xs text-muted-foreground">ISO, qcow2, img, raw</span>
+						<span class="text-xs text-muted-foreground">ISO, qcow2, img, raw, vdi, vmdk (xz/gz/bz2 OK)</span>
 					</div>
 					{#if uploading}
 						<div class="mt-2 flex items-center gap-2">
@@ -1722,7 +1740,7 @@
 					<Label class="text-xs">Source image</Label>
 					{#if importableImages.length === 0}
 						<p class="mt-1 text-xs text-muted-foreground">
-							No qcow2/img/raw images uploaded yet. Upload one via the Create VM wizard.
+							No disk images uploaded yet — supported: qcow2 / img / raw / vdi / vmdk, optionally .xz / .gz / .bz2. Upload one via the Create VM wizard.
 						</p>
 					{:else}
 						<select
@@ -1743,11 +1761,19 @@
 					{:else if importInfoError}
 						<p class="mt-1 text-xs text-destructive">{importInfoError}</p>
 					{:else if importInfo}
-						<p class="mt-1 text-xs text-muted-foreground">
-							Format <span class="font-mono">{importInfo.format}</span>, virtual size
-							<span class="font-mono">{formatSize(importInfo.virtual_size)}</span>
-							(on-disk {formatSize(importInfo.actual_size)})
-						</p>
+						{#if importInfo.compression}
+							<p class="mt-1 text-xs text-muted-foreground">
+								Format <span class="font-mono">{importInfo.format}</span> compressed with
+								<span class="font-mono">{importInfo.compression}</span>
+								(on-disk {formatSize(importInfo.actual_size)}). Virtual size is reported after decompression.
+							</p>
+						{:else}
+							<p class="mt-1 text-xs text-muted-foreground">
+								Format <span class="font-mono">{importInfo.format}</span>, virtual size
+								<span class="font-mono">{formatSize(importInfo.virtual_size)}</span>
+								(on-disk {formatSize(importInfo.actual_size)})
+							</p>
+						{/if}
 					{/if}
 				</div>
 
@@ -1833,8 +1859,10 @@
 							</div>
 						</div>
 						<p class="mt-1 text-xs text-muted-foreground">
-							{#if importInfo}
+							{#if importInfo && importInfo.virtual_size > 0}
 								Pre-filled to {Math.ceil(importInfo.virtual_size / (1024 * 1024 * 1024))} GiB (image virtual size). Bump it if you want headroom for guest growth.
+							{:else if importInfo && importInfo.compression}
+								Compressed source — virtual size unknown until decompression. Set the size to match what the image expects (HAOS is 32 GiB, OPNsense is 8 GiB).
 							{:else}
 								Pick an image above to auto-fill the minimum size.
 							{/if}


### PR DESCRIPTION
## Summary
Most upstream VM images ship compressed — HAOS as `*.qcow2.xz`, OPNsense as `*.img.bz2`, cloud images as `*.qcow2.gz` — but the prior upload/import flow accepted only `.iso/.qcow2/.img/.raw`, so users had to decompress locally before uploading the (much larger) result. This routes upload, list, and import through a single classifier that accepts:

- **Formats**: qcow2, img, raw, vdi, vmdk (qemu-img handles all natively — adds VDI/VMDK as a side benefit).
- **Wrappers**: optionally `.xz`, `.gz`, `.bz2`.

So `haos_ova-12.0.qcow2.xz` now uploads, lists, and imports end-to-end.

## How it works
- New `classify_vm_image(name) -> Option<{ format, compression? }>` in `vm_disk_import.rs`. Upload validator, list filter, and import resolver all go through it — guarantees the three surfaces stay in sync.
- On import, when the source is compressed the engine decompresses to a sibling hidden file under `vms/images/` first (`xz -dc` / `gzip -dc` / `bzip2 -dc`), then runs `qemu-img convert` on the decompressed file. A `Drop` guard unlinks the tmp on every exit path so a failed convert doesn't leave orphans.
- Compressed sources skip the upfront virtual-size probe (decompressing just to peek would block the modal for ~30 s on HAOS). The UI surfaces a "size known after decompression" note; the engine size-checks the target after decompression but before `convert` starts.
- NixOS module: `xz` / `gzip` / `bzip2` added to the engine's `systemPackages` so the decompression spawn never falls back to a not-found error.

## OVA?
Not in this PR. OVA is a tar archive containing one or more VMDK/VDI plus an OVF manifest — needs an extract step, a disk-locate step, and an answer for multi-disk OVAs. Happy to do it as a follow-up if it's a common ask.

## Test plan
- [x] `cargo build -p nasty-engine`
- [x] `cargo test -p nasty-engine` (45 tests; new classifier tests cover qcow2/vdi/vmdk, .xz/.gz/.bz2 wrappers, case-insensitivity, and rejection of `.tar.xz` / `.ova` / `.gz` of unknown payload)
- [x] `cargo clippy -p nasty-engine --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (0 errors, 0 warnings)
- [x] `npm run build`
- [ ] Live smoke on `10.10.10.61`: upload HAOS qcow2.xz, import via "Create new" target, verify decompress → convert → VM boots.