### PR TITLE
flake: bump bcachefs-tools v1.38.2 → v1.38.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1777745911,
-        "narHash": "sha256-zUrvqds6gkqZLV5BbwZDf+IsClNn8CwiC4VdAUO2CWY=",
+        "lastModified": 1778432413,
+        "narHash": "sha256-DR/aGCfqXUOubVEVmeJYOiF71rMYRYq8k23EXqluh5k=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "bba7b97dcdd6e22cde5a2dc6e2dfff64751838f2",
+        "rev": "ff765d6b9dea0ce10652d88290a9e53dae52c9fa",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.38.2",
+        "ref": "v1.38.3",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,11 @@
         cargoDeps = pkgs.rustPlatform.importCargoLock {
           lockFile = "${bcachefs-tools}/Cargo.lock";
         };
+        # bcachefs-tools v1.38.3 added libunwind as a pkg-config dep
+        # (Makefile:113 fails with "pkg-config error: libunwind" without it).
+        # Nixpkgs' base derivation hasn't picked this up yet, so we add it
+        # to buildInputs here so the override builds against the new release.
+        buildInputs = (old.buildInputs or []) ++ [ pkgs.libunwind ];
       });
     in base.overrideAttrs (old: {
       passthru = old.passthru // {

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.38.2 release tag.
+    # Pinned to v1.38.3 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.2";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
   };

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.2";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # Installer payload template. Bootstrap substitutes the tagged release


### PR DESCRIPTION
Picks up upstream v1.38.3. Source diff: https://github.com/koverstreet/bcachefs-tools/compare/v1.38.2...v1.38.3

The DKMS-built kernel module follows the tools version (kernelModule passthru pinned via `bcachefs-tools.passthru.kernelModule` in flake.nix), so this also bumps the kernel-side bcachefs.

## Test plan
- [ ] CI (appliance-smoke integration test exercises mount/unmount, scrub, subvolume create/delete, snapshot create/delete, block-subvolume loop attach)
- [ ] Live smoke on `10.10.10.61`: rebuild, reboot, verify existing filesystems mount cleanly + `bcachefs version` reports 1.38.3.