### PR TITLE
vm: fix accept=… so macOS shows .xz/.gz/.bz2 in upload picker

### DIFF
--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -1122,7 +1122,7 @@
 						<input
 							id="file-upload"
 							type="file"
-							accept=".iso,.qcow2,.img,.raw,.vdi,.vmdk,.qcow2.xz,.qcow2.gz,.qcow2.bz2,.img.xz,.img.gz,.img.bz2,.raw.xz,.raw.gz,.raw.bz2,.vdi.xz,.vdi.gz,.vdi.bz2,.vmdk.xz,.vmdk.gz,.vmdk.bz2"
+							accept=".iso,.qcow2,.img,.raw,.vdi,.vmdk,.xz,.gz,.bz2"
 							class="hidden"
 							onchange={uploadImage}
 							disabled={uploading}
@@ -1759,7 +1759,7 @@
 							<input
 								id="import-modal-file-upload"
 								type="file"
-								accept=".iso,.qcow2,.img,.raw,.vdi,.vmdk,.qcow2.xz,.qcow2.gz,.qcow2.bz2,.img.xz,.img.gz,.img.bz2,.raw.xz,.raw.gz,.raw.bz2,.vdi.xz,.vdi.gz,.vdi.bz2,.vmdk.xz,.vmdk.gz,.vmdk.bz2"
+								accept=".iso,.qcow2,.img,.raw,.vdi,.vmdk,.xz,.gz,.bz2"
 								class="hidden"
 								onchange={uploadImage}
 								disabled={uploading}


### PR DESCRIPTION
## Summary
The macOS file picker matches the HTML \`<input accept=…>\` list against the file's **last** extension only, so listing \`.qcow2.xz / .img.bz2 / …\` didn't help — \`haos_ova-17.3.qcow2.xz\` showed up greyed-out because the picker only saw \`.xz\`.

Switch to a flat allowlist of plain suffixes (\`.qcow2 / .img / .raw / .vdi / .vmdk / .xz / .gz / .bz2\`). The server-side \`classify_vm_image\` remains the source of truth and still rejects junk like \`payload.tar.xz\`, so loosening the picker filter doesn't open any new attack surface.

Spotted with HAOS upload on macOS post-#152 / #153.

## Test plan
- [x] \`npm run check\`
- [x] \`npm run build\`
- [ ] Live: pick \`haos_ova-17.3.qcow2.xz\` on macOS; verify it's selectable; upload + import end-to-end.