### PR TITLE
update: dump switch-to-configuration journal on rebuild failure

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -395,7 +395,19 @@ nix flake update bcachefs-tools
 nix flake update nasty
 
 echo "==> Rebuilding system..."
-NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}
+_RC=0
+NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake} || _RC=$?
+if [ "$_RC" -ne 0 ]; then
+    echo
+    echo "==> nixos-rebuild switch failed (exit $_RC)."
+    echo "==> Below is the tail of the switch-to-configuration journal — it"
+    echo "    usually carries the real error (systemd-boot tracebacks, failed"
+    echo "    service starts, ENOSPC on /boot, etc):"
+    echo "--- journalctl -u nixos-rebuild-switch-to-configuration -n 60 ---"
+    journalctl -u nixos-rebuild-switch-to-configuration --no-pager -n 60 || true
+    echo "--- end journal dump ---"
+    exit "$_RC"
+fi
 
 _NGINX_CONF_AFTER=$(_nginx_conf)
 WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
@@ -638,7 +650,19 @@ cd {LOCAL_REPO}
 # No custom GC logic needed here — just rebuild.
 
 echo "==> Rebuilding system..."
-NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}
+_RC=0
+NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake} || _RC=$?
+if [ "$_RC" -ne 0 ]; then
+    echo
+    echo "==> nixos-rebuild switch failed (exit $_RC)."
+    echo "==> Below is the tail of the switch-to-configuration journal — it"
+    echo "    usually carries the real error (systemd-boot tracebacks, failed"
+    echo "    service starts, ENOSPC on /boot, etc):"
+    echo "--- journalctl -u nixos-rebuild-switch-to-configuration -n 60 ---"
+    journalctl -u nixos-rebuild-switch-to-configuration --no-pager -n 60 || true
+    echo "--- end journal dump ---"
+    exit "$_RC"
+fi
 
 # Detect if the webui store path changed so the frontend knows whether to prompt a reload.
 # /run/current-system now points to the newly activated closure.
@@ -907,6 +931,13 @@ if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
         echo "==> Rebuild failed (exit $RC). Restoring previous flake.lock so update can be retried."
         cp flake.lock.pre-rebuild flake.lock
         rm -f flake.lock.pre-rebuild
+        echo
+        echo "==> Below is the tail of the switch-to-configuration journal — it"
+        echo "    usually carries the real error (systemd-boot tracebacks, failed"
+        echo "    service starts, ENOSPC on /boot, etc):"
+        echo "--- journalctl -u nixos-rebuild-switch-to-configuration -n 60 ---"
+        journalctl -u nixos-rebuild-switch-to-configuration --no-pager -n 60 || true
+        echo "--- end journal dump ---"
         exit "$RC"
     fi
     _NGINX_CONF_AFTER=$(_nginx_conf)


### PR DESCRIPTION
## Summary
When \`nixos-rebuild switch\` fails, the wrapper script previously printed just \`==> Rebuild failed (exit N)\` and bailed. The actual error lives in the journal of the transient \`nixos-rebuild-switch-to-configuration\` unit — that's where systemd-boot tracebacks (ENOSPC on /boot), failed service starts, tmpfiles errors, etc. surface — but the wrapper never reads it. Users staring at "exit 4. no other info" can't troubleshoot, which is exactly the situation in discussion #159.

Append a \`journalctl -u nixos-rebuild-switch-to-configuration -n 60\` dump to the failure path of all three rebuild wrappers (\`upgrade_tagged_release\`, \`version_switch\`, the local dev rebuild). 60 lines covers the typical systemd-boot Python traceback (~25 lines) plus most service-start failure messages with headroom.

## Test plan
- [x] \`cargo test -p nasty-system\`
- [x] \`cargo clippy -p nasty-system -p nasty-engine --no-deps -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] Live: induce a switch-to-configuration failure (e.g. fill /boot) and verify the update log shows the journal tail with the real error.

Closes part of #159.