### PR TITLE
webui: refresh sysInfo on WebSocket reconnect

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -291,6 +291,13 @@
 					return;
 				}
 			} catch { /* health check failed, continue with stale UI */ }
+			// Engine binary is the same, but the kernel/bcachefs module may have
+			// changed underneath (e.g. a bcachefs-tools-only bump rebuilt the DKMS
+			// module without moving the engine commit). The footer reads
+			// system.info, which is fetched once on connect and cached client-side
+			// — without this trigger it shows the pre-reboot version until the
+			// user hits cmd+R.
+			sysInfoRefresh.trigger();
 		};
 		const onDisconnect = () => { reconnecting = true; };
 		getClient().onReconnect(onReconnect);


### PR DESCRIPTION
## Summary
The footer's \`NASty / kernel / bcachefs\` lines are fed by \`system.info\`, fetched once on connect and tracked via a \`sysInfoRefresh\` counter that nothing bumps after a reboot. The \`/+layout.svelte\` reconnect handler already \`location.reload()\`s when the engine commit changed (forcing a re-fetch of everything), but does nothing if the engine binary is the same — leaving the footer showing the pre-reboot version until the user hits cmd+R.

That second path matters more than I thought: a bcachefs-tools URL bump that rebuilds the DKMS module without bumping the nasty input keeps the engine commit pinned, so the reload branch is skipped and the footer is stale even after a reboot loaded the new module.

Add a \`sysInfoRefresh.trigger()\` at the end of the reconnect handler. The \`location.reload()\` branch is unaffected (it \`return\`s before reaching the trigger), so this only fires when the engine binary is unchanged — exactly the case the existing flow misses.

## Test plan
- [x] \`npm run check\` — 0 errors
- [x] \`npm run build\` — clean
- [ ] Live: trigger a reboot-affecting upgrade where the engine commit doesn't change (e.g. bcachefs-tools-only bump on a main-tracker), verify the footer updates without cmd+R.