### PR TITLE
ci: bump peter-evans/create-pull-request to v8

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Open PR
         if: steps.update.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           # Prefer a PAT so downstream CI fires; fall back to the
           # default token (CI won't auto-run in that case — see the


### PR DESCRIPTION
v8 runs on Node.js 24; v7 will stop working on GitHub-hosted runners once Node 20 is removed (scheduled September 2026). Inputs/outputs unchanged from v7 — the only release note is the runtime swap.

## Test plan
- [ ] next scheduled weekly nixpkgs bump run completes without the Node 20 deprecation warning and opens the PR successfully