### PR TITLE
ci: surface curated package-version diff in weekly bump PRs

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -80,6 +80,50 @@ jobs:
             echo "summary=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Diff high-signal package versions
+        # Evaluate a curated list of packages against both nixpkgs revs
+        # and surface any version deltas in the PR body. One nix eval
+        # per rev = two tarball fetches; runs in roughly 30–60 s on
+        # GitHub-hosted runners.
+        id: pkgdiff
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          set -eu
+          eval_versions() {
+            local rev="$1"
+            nix eval --json --impure --expr "
+              let
+                pkgs = (builtins.getFlake \"github:NixOS/nixpkgs/$rev\").legacyPackages.x86_64-linux;
+                names = [
+                  \"qemu\" \"docker\" \"openssl\" \"openssh\" \"networkmanager\"
+                  \"samba\" \"nfs-utils\" \"nginx\" \"targetcli-fb\" \"lvm2\"
+                  \"util-linux\" \"glibc\"
+                ];
+                versionOf = name:
+                  if builtins.hasAttr name pkgs then
+                    let tried = builtins.tryEval (builtins.getAttr name pkgs).version;
+                    in if tried.success then tried.value else null
+                  else null;
+              in builtins.listToAttrs (map (n: { name = n; value = versionOf n; }) names)
+            "
+          }
+          BEFORE_JSON=$(eval_versions "${{ steps.update.outputs.before }}")
+          AFTER_JSON=$(eval_versions "${{ steps.update.outputs.after }}")
+          DIFF=$(jq -rn --argjson b "$BEFORE_JSON" --argjson a "$AFTER_JSON" '
+            $b | to_entries
+              | map(select(.value != null and $a[.key] != null and .value != $a[.key]))
+              | .[] | "- \(.key): \(.value) → \($a[.key])"
+          ')
+          {
+            echo 'block<<DIFFEOF'
+            if [ -n "$DIFF" ]; then
+              echo "**Package version changes** (curated):"
+              echo
+              printf '%s\n' "$DIFF"
+            fi
+            echo DIFFEOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Open PR
         if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
@@ -100,6 +144,8 @@ jobs:
 
             **nixpkgs**: `${{ steps.update.outputs.before }}` → `${{ steps.update.outputs.after }}`
             ${{ steps.kernel.outputs.summary && format('**Kernel**: {0}', steps.kernel.outputs.summary) || '' }}
+
+            ${{ steps.pkgdiff.outputs.block }}
 
             Compare: https://github.com/NixOS/nixpkgs/compare/${{ steps.update.outputs.before }}...${{ steps.update.outputs.after }}
 


### PR DESCRIPTION
## Summary
- the weekly bump PR title already names the kernel delta but the body just gave a nixpkgs commit range — reviewers had to click through to guess whether docker/openssl/qemu/etc. moved
- evaluate a curated list of high-signal packages against both nixpkgs revs in one \`nix eval\` per rev (two tarball fetches, ~30–60 s on GitHub-hosted runners) and dump any version deltas straight into the PR body
- packages: \`qemu\`, \`docker\`, \`openssl\`, \`openssh\`, \`networkmanager\`, \`samba\`, \`nfs-utils\`, \`nginx\`, \`targetcli-fb\`, \`lvm2\`, \`util-linux\`, \`glibc\`. Kernel still surfaced separately in the title via the existing step
- attribute lookups are \`tryEval\`-wrapped and gated on \`hasAttr\`, so a missing/renamed/aliased package in either rev contributes nothing rather than failing the whole step
- if no curated package changed versions, the section is omitted entirely (only nixpkgs rev + kernel + compare-link remain)

## Test plan
- [ ] trigger the workflow manually (\`gh workflow run "Weekly nixpkgs bump"\`) against a known nixpkgs delta
- [ ] resulting PR body includes a "**Package version changes** (curated):" section with bullet rows like \`- docker: 27.5.1 → 28.0.0\` only for packages that actually moved
- [ ] when no curated package moved, the section is absent (no empty heading)