### PR TITLE
ci: bump actions/setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
v6.0.0's only breaking change is limiting automatic caching to npm. The job already passes \`cache: 'npm'\` explicitly, so this is a no-op upgrade for us.

## Test plan
- [ ] CI on this PR's check job runs green