### PR TITLE
webui: unify subvolumes overview into one table with FS group headers

### DIFF
--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -918,26 +918,28 @@
 		{/if}
 	</div>
 {:else}
-	{#each subvolumeGroups as group (group.fs ?? '__flat__')}
-		{#if group.fs}
-			<h2 class="mt-6 mb-2 flex items-baseline gap-2 text-sm font-semibold">
-				<span>{group.fs}</span>
-				<span class="text-xs font-normal text-muted-foreground">{group.items.length} subvolume{group.items.length === 1 ? '' : 's'}</span>
-			</h2>
-		{/if}
-		<table class="w-full text-sm">
-			<thead>
-				<tr>
-					<SortTh label="Name" active={sortKey === 'name'} dir={sortDir} onclick={() => toggleSort('name')} />
-					<SortTh label="Type" active={sortKey === 'type'} dir={sortDir} onclick={() => toggleSort('type')} />
-					<SortTh label="Size" active={sortKey === 'size'} dir={sortDir} onclick={() => toggleSort('size')} />
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Used by</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Block Device</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Snapshots</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
-				</tr>
-			</thead>
-			<tbody>
+	<table class="w-full text-sm">
+		<thead>
+			<tr>
+				<SortTh label="Name" active={sortKey === 'name'} dir={sortDir} onclick={() => toggleSort('name')} />
+				<SortTh label="Type" active={sortKey === 'type'} dir={sortDir} onclick={() => toggleSort('type')} />
+				<SortTh label="Size" active={sortKey === 'size'} dir={sortDir} onclick={() => toggleSort('size')} />
+				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Used by</th>
+				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Block Device</th>
+				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Snapshots</th>
+				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each subvolumeGroups as group (group.fs ?? '__flat__')}
+				{#if group.fs}
+					<tr class="bg-muted/30">
+						<td colspan="7" class="border-b border-border px-3 py-2">
+							<span class="font-semibold">{group.fs}</span>
+							<span class="ml-2 text-xs text-muted-foreground">{group.items.length} subvolume{group.items.length === 1 ? '' : 's'}</span>
+						</td>
+					</tr>
+				{/if}
 				{#each group.items as sv (svKey(sv))}
 					{@const usage = usageFor(sv)}
 					<tr class="border-b border-border">
@@ -1272,9 +1274,9 @@
 					</tr>
 				{/if}
 			{/each}
+			{/each}
 		</tbody>
 	</table>
-	{/each}
 {/if}
 
 


### PR DESCRIPTION
Follow-up to #169.

Before: the overview rendered **one \`<table>\` per filesystem**, each with its own \`<thead>\`. That had three real problems:

- the column header row repeated for every section, three identical headers stacked vertically
- column widths were computed per-table, so Type / Size / Used by / etc. didn't line up across groups (each table sized itself to its own content)
- the per-FS heading was a tiny \`h2 text-sm font-semibold\` with the count even smaller next to it, easy to miss as a section break

Now: one \`<table>\` for the whole list, with a full-width group-header row (FS name + subvolume count, on a muted background) inserted between groups. One \`<thead>\`, one set of column widths, and the headers actually read as section breaks.

## Test plan
- [ ] open Subvolumes with 2+ mounted filesystems unfiltered — see one table, with a shaded `<tr>` per FS spanning all columns containing the FS name + count
- [ ] columns line up vertically across all subvolumes regardless of which FS they belong to
- [ ] filter to a single FS via the dropdown — header row disappears, flat table
- [ ] single-FS setups (only one mounted FS) — flat table, no header row, dropdown not shown
- [ ] expanding a row's Details still opens the inline detail panel inside the same table
- [ ] sort by Name/Type/Size still works (sorts within each group since rows are interleaved with group headers, but the relative order inside each group respects the sort)