### PR TITLE
update: dev-build Upgrade refreshes nixpkgs + bcachefs-tools too

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -582,7 +582,9 @@ echo "==> Update complete!"
             .await;
 
         // Build the update script:
-        // 1. Update the local wrapper flake input for nasty
+        // 1. Update the local wrapper flake inputs (channel-specific:
+        //    Mild/Spicy pin nasty to a release tag, Nasty refreshes
+        //    nixpkgs + bcachefs-tools + nasty)
         // 2. Rebuild from local flake (which keeps hardware-configuration.nix)
         let channel = read_channel().await;
         let token = read_github_token().await;
@@ -614,8 +616,17 @@ echo "==> Update complete!"
                 )
             }
             ReleaseChannel::Nasty => (
+                // Refresh every flake input the wrapper owns, not just
+                // `nasty`. Without this, the weekly nixpkgs bump never
+                // reaches `main`-tracking users — they'd see only the
+                // new nasty commits while their kernel + system
+                // packages stayed pinned to whatever the wrapper's
+                // lock had at install time. Mirrors the tagged-release
+                // upgrade path which already refreshes all three.
                 format!(
-                    "echo \"==> Updating NASty input ({})...\"\n\
+                    "echo \"==> Updating wrapper flake inputs (nixpkgs, bcachefs-tools, nasty[{}])...\"\n\
+                     nix flake update nixpkgs\n\
+                     nix flake update bcachefs-tools\n\
                      nix flake update nasty",
                     nasty_input.tracked_ref
                 ),


### PR DESCRIPTION
The \`Nasty\` (main-tracking) channel's Upgrade button only ran \`nix flake update nasty\`. So the weekly nixpkgs bump landing in this repo was invisible to dev-build users: their wrapper's \`flake.lock\` kept its install-time nixpkgs rev forever, the rebuilt generation carried the same old kernel, \`is_reboot_required\` returned false, and the reboot banner never appeared. The user's complaint: "nixpkgs were updated but after upgrade of NASty I'm still on old kernel."

Refresh all three wrapper-owned inputs (\`nixpkgs\`, \`bcachefs-tools\`, \`nasty\`) on every dev-build Upgrade, matching what the tagged-release upgrade path already does (\`upgrade_tagged_release\`, lines 393-395).

Users tracking \`main\` self-selected for the bleeding edge — they want the kernel bumps, not just the WebUI churn. Fine-grained control still lives in the Upstream panel (Version Switch), where they can untick \`nixpkgs\` if they specifically want to hold the kernel back.

## Test plan
- [ ] on a system tracking \`main\`, with an outdated \`nixpkgs\` lock entry, click **Upgrade** on the Update page
- [ ] the upgrade log shows the three \`nix flake update …\` calls and rebuilds
- [ ] the "Kernel/driver update — click to restart" banner appears in the layout header once the new generation is built with a different kernel
- [ ] after reboot, \`uname -r\` reflects the new kernel
- [ ] on a system already on the latest \`nixpkgs\`, **Upgrade** is a no-op rebuild (lock unchanged → script skips the rebuild branch in the Version-Switch path, or rebuilds harmlessly in the apply path)
- [ ] Mild/Spicy channel users — no change (their branch still does the tag override; unchanged code path)