### PR TITLE
subvolume: progress-bar disk usage and always-on usage tracking

### DIFF
--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -73,8 +73,17 @@ pub struct Subvolume {
     pub subvolume_type: SubvolumeType,
     /// Absolute filesystem path to the subvolume directory.
     pub path: String,
-    /// Disk usage in bytes (filesystem subvolumes only, from `du`).
+    /// Disk usage in bytes. For filesystem subvolumes, comes from the
+    /// per-project quota (set on every create, so tracking is always
+    /// on); `None` only on legacy subvolumes created before the
+    /// always-track change. For block subvolumes, comes from the
+    /// backing image's allocated size.
     pub used_bytes: Option<u64>,
+    /// Hard quota limit in bytes for filesystem subvolumes. `None`
+    /// means no limit set (the subvolume can grow to fill the
+    /// filesystem). Always `None` for block subvolumes — their
+    /// ceiling is `volsize_bytes`, not a quota.
+    pub quota_bytes: Option<u64>,
     /// Compression algorithm applied to this subvolume (e.g. `lz4`, `zstd`).
     pub compression: Option<String>,
     /// Free-text description or notes for this subvolume.
@@ -573,12 +582,19 @@ impl SubvolumeService {
                 })
                 .collect();
 
-            // Get size: project quota for filesystem subvols, stat for block subvols
-            let size = match attrs.meta.subvolume_type {
-                SubvolumeType::Block => block_image_size(&path_str),
+            // Get size + quota: project quota for filesystem subvols, stat for block subvols.
+            // hard_bytes == 0 in repquota means "no limit" → translate to None.
+            let (size, quota_bytes) = match attrs.meta.subvolume_type {
+                SubvolumeType::Block => (block_image_size(&path_str), None),
                 SubvolumeType::Filesystem => {
                     let projid = project_id_for(fs_name, name);
-                    project_usages.get(&projid).copied()
+                    match project_usages.get(&projid) {
+                        Some(info) => (
+                            Some(info.used_bytes),
+                            (info.hard_bytes > 0).then_some(info.hard_bytes),
+                        ),
+                        None => (None, None),
+                    }
                 }
             };
 
@@ -598,6 +614,7 @@ impl SubvolumeService {
                 subvolume_type: attrs.meta.subvolume_type,
                 path: path_str.clone(),
                 used_bytes: size,
+                quota_bytes,
                 compression: attrs.meta.compression,
                 comments: attrs.meta.comments,
                 volsize_bytes: attrs.meta.volsize_bytes,
@@ -757,12 +774,14 @@ impl SubvolumeService {
             .await;
         }
 
-        // For filesystem subvolumes: enforce size via bcachefs project quota
-        if req.subvolume_type == SubvolumeType::Filesystem
-            && let Some(size) = req.volsize_bytes
-        {
+        // For filesystem subvolumes: always assign a project ID so usage
+        // tracking via repquota works regardless of whether the user set
+        // a hard limit. `0` is the quota-tools convention for "no limit"
+        // — repquota still reports usage, it just won't enforce.
+        if req.subvolume_type == SubvolumeType::Filesystem {
             let projid = project_id_for(&req.filesystem, &req.name);
-            set_project_quota(&mount_point, &subvol_path, projid, size).await;
+            let limit = req.volsize_bytes.unwrap_or(0);
+            set_project_quota(&mount_point, &subvol_path, projid, limit).await;
         }
 
         // For block subvolumes: create sparse file and attach loop device
@@ -1686,10 +1705,19 @@ fn block_image_size(subvol_path: &str) -> Option<u64> {
     std::fs::metadata(&img_path).ok().map(|m| m.len())
 }
 
+/// Per-project quota state extracted from `repquota` — both the live
+/// usage and the hard limit. `hard_bytes == 0` is the quota-tools
+/// convention for "no limit".
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ProjectQuotaInfo {
+    pub used_bytes: u64,
+    pub hard_bytes: u64,
+}
+
 /// Query project quota usage for all projects on a filesystem in one shot.
-/// Returns a map of project_id → used_bytes.
+/// Returns a map of project_id → (used, hard limit).
 /// Falls back to empty map if repquota is unavailable or fails.
-async fn query_project_usages(mount_point: &str) -> HashMap<u32, u64> {
+async fn query_project_usages(mount_point: &str) -> HashMap<u32, ProjectQuotaInfo> {
     let mut usages = HashMap::new();
 
     // repquota -P --raw-grace outputs KB values with numeric project IDs when using -n
@@ -1719,7 +1747,15 @@ async fn query_project_usages(mount_point: &str) -> HashMap<u32, u64> {
             Some(v) => v,
             None => continue,
         };
-        usages.insert(projid, used_kb * 1024);
+        let _soft_kb = parts.next();
+        let hard_kb: u64 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        usages.insert(
+            projid,
+            ProjectQuotaInfo {
+                used_bytes: used_kb * 1024,
+                hard_bytes: hard_kb * 1024,
+            },
+        );
     }
 
     usages

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -265,6 +265,8 @@ export interface Subvolume {
 	subvolume_type: SubvolumeType;
 	path: string;
 	used_bytes: number | null;
+	/** Hard quota limit in bytes (filesystem subvolumes only). null = no limit. */
+	quota_bytes: number | null;
 	compression: string | null;
 	comments: string | null;
 	volsize_bytes: number | null;

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -566,6 +566,23 @@
 		return subvolumeUsage.get(svKey(sv)) ?? { system: null, nfs: 0, smb: 0, iscsi: 0, nvmeof: 0 };
 	}
 
+	// Pick a ceiling to scale the disk-usage bar against:
+	// - block subvolumes: the configured volsize is the hard cap
+	// - filesystem subvolumes with a quota: that quota
+	// - filesystem subvolumes without a quota: filesystem total — the bar
+	//   then reads as "% of FS occupied by this subvolume", which is the
+	//   only meaningful denominator we have
+	function sizeDisplay(sv: Subvolume): { used: number | null; ceiling: number | null; source: 'volsize' | 'quota' | 'filesystem' | null } {
+		if (sv.subvolume_type === 'block') {
+			return { used: sv.used_bytes, ceiling: sv.volsize_bytes, source: sv.volsize_bytes ? 'volsize' : null };
+		}
+		if (sv.quota_bytes != null) {
+			return { used: sv.used_bytes, ceiling: sv.quota_bytes, source: 'quota' };
+		}
+		const fsTotal = filesystems.find(f => f.name === sv.filesystem)?.total_bytes ?? null;
+		return { used: sv.used_bytes, ceiling: fsTotal && fsTotal > 0 ? fsTotal : null, source: fsTotal && fsTotal > 0 ? 'filesystem' : null };
+	}
+
 	// Unique device labels from the filesystem chosen in the create wizard
 	// (for tiering dropdowns). Tracks `newFilesystem`, not the page filter,
 	// so the wizard reflects the FS the user is creating in.
@@ -942,6 +959,8 @@
 				{/if}
 				{#each group.items as sv (svKey(sv))}
 					{@const usage = usageFor(sv)}
+					{@const size = sizeDisplay(sv)}
+					{@const sizePct = size.used != null && size.ceiling ? Math.min(100, Math.max(0, (size.used / size.ceiling) * 100)) : 0}
 					<tr class="border-b border-border">
 						<td class="p-3">
 							<button class="text-left hover:text-blue-400 transition-colors" onclick={() => openDetail(sv)}>
@@ -958,16 +977,26 @@
 								{sv.subvolume_type === 'filesystem' ? 'File Share' : 'Block'}
 							</Badge>
 						</td>
-						<td class="p-3 text-sm">
-							{#if sv.volsize_bytes}
-								{formatBytes(sv.volsize_bytes)}
-								{#if sv.used_bytes !== null}
-									<span class="text-xs text-muted-foreground">({formatBytes(sv.used_bytes)} used)</span>
-								{/if}
-							{:else if sv.used_bytes !== null}
-								{formatBytes(sv.used_bytes)}
+						<td class="p-3 text-sm w-48">
+							{#if size.used == null}
+								<span class="text-muted-foreground">—</span>
+							{:else if size.ceiling == null}
+								{formatBytes(size.used)}
 							{:else}
-								—
+								<div class="space-y-0.5">
+									<div class="flex items-baseline justify-between gap-2 text-xs">
+										<span class="font-mono">{formatBytes(size.used)}</span>
+										<span class="text-muted-foreground" title={size.source === 'filesystem' ? `${sizePct.toFixed(1)}% of filesystem total` : `${sizePct.toFixed(1)}% of ${formatBytes(size.ceiling)} ${size.source === 'volsize' ? 'volume' : 'quota'}`}>
+											{sizePct < 1 && size.used > 0 ? '<1' : sizePct.toFixed(0)}% {size.source === 'filesystem' ? 'of FS' : 'of ' + formatBytes(size.ceiling)}
+										</span>
+									</div>
+									<div class="h-1 w-full overflow-hidden rounded bg-muted">
+										<div
+											class="h-full transition-all {sizePct >= 90 ? 'bg-red-500' : sizePct >= 75 ? 'bg-amber-500' : 'bg-emerald-500'}"
+											style="width: {sizePct}%"
+										></div>
+									</div>
+								</div>
 							{/if}
 						</td>
 						<td class="p-3">


### PR DESCRIPTION
Addresses #81 from the disk-usage angle. Companion to #169's "Used by" column (which is about *what depends on* a subvolume) — this one is about *how much is in it*.

## Summary

Two engine changes:

1. **Always assign a project quota ID on filesystem subvolume create**, even when the user didn't set a quota limit (\`hard=0\` is the quota-tools convention for "no limit"). \`repquota\`'s row exists from day one, so usage is populated from the start instead of showing \`—\` until the user happens to set a quota.

2. **Parse the hard limit out of \`repquota\`** and expose it as a new \`quota_bytes\` field on \`Subvolume\` (\`None\` when unlimited).

One WebUI change:

3. **Rewrite the Size cell as a progress-bar usage view.** Ceiling depends on the subvolume kind:
   - block: \`volsize_bytes\` (the configured cap)
   - filesystem with quota: \`quota_bytes\`
   - filesystem without quota: \`filesystem.total_bytes\` — the bar reads as "% of the parent FS this subvolume occupies", which is the only meaningful denominator we have

Bar colour shifts amber at 75% and red at 90%. Hover tooltip spells out the denominator so the bar's meaning is unambiguous.

## Known caveat

Legacy subvolumes created **before** this change still lack a project ID and will continue to show \`—\` until recreated. A one-shot reconcile (assign project IDs to existing subvolumes that don't have one) is left for a follow-up if it bites anyone — keeping this PR focused.

## Test plan

- [ ] create a new file-share subvolume with no quota, drop a file into it — the row shows actual used bytes + a bar (% of FS)
- [ ] create a new file-share subvolume with a quota set — bar scales against the quota, tooltip reads "% of <quota> quota"
- [ ] create a new block subvolume — bar scales against volsize, tooltip reads "% of <volsize> volume"
- [ ] write enough into a quota'd subvolume to cross 75% and 90% — bar shifts amber then red
- [ ] empty subvolume reports \`0 B\` with a 0% bar, not \`—\`
- [ ] legacy subvolume from before this change still shows \`—\` (acknowledged caveat); recreating it surfaces usage