### PR TITLE
subvolume: backfill project IDs for pre-#176 subvolumes at startup

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -195,6 +195,14 @@ async fn main() -> anyhow::Result<()> {
     // doesn't accidentally re-persist the orphans.
     state.network.run_migration_if_needed().await;
 
+    // Backfill project quota IDs on filesystem subvolumes that
+    // predate the always-assign change (#176). Without this, those
+    // subvolumes have no repquota row, so their `used_bytes` stays
+    // `None` and the WebUI shows `—` forever. Idempotent: scans
+    // repquota output and only writes for subvolumes that lack a
+    // row. Best-effort; failures are logged and don't block startup.
+    state.subvolumes.reconcile_project_ids().await;
+
     // Initialize firewall based on current protocol states
     {
         use nasty_system::protocol::Protocol;

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -539,10 +539,7 @@ impl SubvolumeService {
             let subvols = match self.list(&fs.name, None).await {
                 Ok(v) => v,
                 Err(e) => {
-                    warn!(
-                        "reconcile_project_ids: list({}) failed: {e}",
-                        fs.name
-                    );
+                    warn!("reconcile_project_ids: list({}) failed: {e}", fs.name);
                     continue;
                 }
             };

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -515,6 +515,67 @@ impl SubvolumeService {
         dev_map
     }
 
+    /// One-shot migration: assign a project quota ID to every
+    /// filesystem subvolume that doesn't have one yet. Idempotent —
+    /// safe to run on every engine startup. Necessary because
+    /// subvolumes created before the always-assign-project-id change
+    /// (#176) have no quota row, so `repquota` can't report their
+    /// usage and the WebUI's size cell shows `—`.
+    pub async fn reconcile_project_ids(&self) {
+        let filesystems = match self.filesystems.list().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("reconcile_project_ids: filesystems.list failed: {e}");
+                return;
+            }
+        };
+
+        for fs in filesystems.into_iter().filter(|f| f.mounted) {
+            let Some(mount_point) = fs.mount_point.clone() else {
+                continue;
+            };
+            let project_usages = query_project_usages(&mount_point).await;
+
+            let subvols = match self.list(&fs.name, None).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        "reconcile_project_ids: list({}) failed: {e}",
+                        fs.name
+                    );
+                    continue;
+                }
+            };
+
+            let mut assigned = 0usize;
+            for sv in subvols
+                .into_iter()
+                .filter(|s| s.subvolume_type == SubvolumeType::Filesystem)
+            {
+                let projid = project_id_for(&fs.name, &sv.name);
+                if project_usages.contains_key(&projid) {
+                    continue;
+                }
+                info!(
+                    "reconcile_project_ids: assigning project {projid} to {} ({}@{})",
+                    sv.path, sv.name, fs.name
+                );
+                // hard=0 means tracked-but-unlimited; matches the
+                // semantics applied at create time for subvolumes
+                // without an explicit quota.
+                set_project_quota(&mount_point, &sv.path, projid, 0).await;
+                assigned += 1;
+            }
+
+            if assigned > 0 {
+                info!(
+                    "reconcile_project_ids: assigned {assigned} project ID(s) on filesystem '{}'",
+                    fs.name
+                );
+            }
+        }
+    }
+
     /// Get the mount point for a filesystem, or error if not mounted
     async fn fs_mount_point(&self, fs_name: &str) -> Result<String, SubvolumeError> {
         let fs = self


### PR DESCRIPTION
Follow-up to #176.

## Summary

Filesystem subvolumes created **before** #176's always-assign-project-ID change have no per-project quota row, so \`repquota\` can't report their usage and the WebUI's Size cell shows \`—\` forever.

Walk every mounted filesystem at engine startup and assign a project ID to any filesystem subvolume that lacks one. Idempotent — a fully-reconciled system does no writes on subsequent startups.

Detection reuses the existing \`repquota\` output: if \`project_id_for(fs, name)\` is missing from that map, that subvolume gets \`set_project_quota(mount, path, projid, 0)\` (same hard=0 / tracked-but-unlimited form used at create time when no quota is requested).

Failures are logged and never block startup — pure backfill, not a correctness guarantee.

## Test plan

- [ ] system with legacy subvolumes (created before #176): upgrade + reboot
- [ ] engine log shows \`reconcile_project_ids: assigning project … to /fs/…\` for each missing subvolume
- [ ] WebUI Size cell renders usage + bar for those subvolumes instead of \`—\`
- [ ] restart again: log shows the function ran but assigned 0 IDs (idempotent)
- [ ] system with no legacy subvolumes: no writes, no spurious log spam