### PR TITLE
subvolume: show actual allocation for block images, not volsize

### DIFF
--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -1758,9 +1758,16 @@ fn unregister_project(projid: u32) {
 
 /// Get disk usage for a block subvolume by statting the sparse image file directly.
 /// Much faster than `du -sb` since it's a single syscall instead of a tree walk.
+/// Actual on-disk allocation for a block subvolume's image, in bytes.
+///
+/// We use `st_blocks * 512` (allocated blocks) rather than `m.len()` (logical
+/// size) so sparse images report what's truly written. Since the image is
+/// created with `truncate -s <volsize>`, `len()` always equals volsize and
+/// would make the progress bar a constant 100%.
 fn block_image_size(subvol_path: &str) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
     let img_path = format!("{subvol_path}/{BLOCK_FILE_NAME}");
-    std::fs::metadata(&img_path).ok().map(|m| m.len())
+    std::fs::metadata(&img_path).ok().map(|m| m.blocks() * 512)
 }
 
 /// Per-project quota state extracted from `repquota` — both the live


### PR DESCRIPTION
## Summary

In the Subvolumes overview, every block subvolume reads "100% of <volsize>" — see the screenshot in the linked discussion. That's because `block_image_size()` returns `metadata.len()`, and we create the image with `truncate -s <volsize>`, so the logical size always equals the volsize.

Switch to `st_blocks * 512` (actually-allocated bytes) so the progress bar reflects what the consumer has truly written into the sparse image. A barely-used iSCSI target on a 50 GiB image now reads e.g. `1.2 GiB / 50 GiB` instead of a constant `50.0 GiB / 50.0 GiB`.

## Test plan
- [ ] Build engine, restart, open Subvolumes overview
- [ ] Confirm a freshly-created block subvolume shows ~0 B used (vs. its volsize)
- [ ] Write some data through the iSCSI/NVMe-oF mount, confirm "used" grows
- [ ] Confirm file-share subvolumes are unaffected