### PR TITLE
webui: dev-build upgrade refreshes nixpkgs + bcachefs-tools too

### DIFF
--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -381,7 +381,11 @@
 				inputs: versionRows.map((row) => ({
 					name: row.name,
 					url: row.url.trim(),
-					update: row.name === 'nasty'
+					// Refresh every wrapper input, not just `nasty`. Without
+					// this the kernel + bcachefs-tools stay pinned to whatever
+					// flake.lock had at install time even as `main` brings in
+					// upstream bumps — see #175 for the parallel apply() fix.
+					update: true
 				}))
 			}),
 			'Development build update started'


### PR DESCRIPTION
## The bug

PR #175 patched `apply()`'s dev-build path to refresh all three wrapper-flake inputs. Turns out **nothing in the WebUI calls `apply()`** — the "Update to latest development build" button calls `system.version.switch` instead. That codepath only refreshes inputs whose \`update\` flag is true, and the button hard-coded that flag to:

\`\`\`js
update: row.name === 'nasty'
\`\`\`

So every dev-build upgrade on every box has been running just \`nix flake update nasty\` — nixpkgs and bcachefs-tools never moved past whatever flake.lock had at install time. End result: kernel pinned forever, even as the weekly nixpkgs-bump bot landed fresh revs in main.

Diagnosed live on a box that was stuck on 6.18.26 for days across "several upgrades": journalctl showed only \`• Updated input 'nasty':\` in every run, and the unit name "NASty version switch" (not "NASty system update") gave away the wrong code path.

## The fix

Set \`update: true\` for all rows in \`upgradeDevBuild()\`. version_switch's existing lock-restore-on-failure (commit 74c0d08) still kicks in if the rebuild fails, so a flaky upgrade leaves flake.lock as it was — safer than apply() for this button.

## Test plan
- [ ] Open Update page on a dev-build box, click "Update to latest development build"
- [ ] In journalctl -u nasty-update, confirm \`• Updated input 'nixpkgs':\` and \`• Updated input 'bcachefs-tools':\` appear alongside \`'nasty'\`
- [ ] Confirm running kernel bumps on next reboot when nixpkgs has moved