### PR TITLE
alerts: use full path for switch-to-configuration in /boot warning

### DIFF
--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -541,7 +541,7 @@ fn evaluate_rules(
                         // so the user doesn't have to dig — the typical
                         // path is "trim old generations" not "resize ESP".
                         message: format!(
-                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nix-collect-garbage --delete-older-than 7d` and `switch-to-configuration boot` to reclaim space.",
+                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nix-collect-garbage --delete-older-than 7d` and `/run/current-system/bin/switch-to-configuration boot` to reclaim space.",
                             free_mb, rule.threshold
                         ),
                         current_value: free_mb,


### PR DESCRIPTION
## Summary

The "/boot is full" alert suggests running \`switch-to-configuration boot\`, but that command isn't on \$PATH — it lives inside the active generation's closure. Copy-pasting it yields \`bash: switch-to-configuration: command not found\`.

Spell out \`/run/current-system/bin/switch-to-configuration boot\` so the suggestion actually works.

## Test plan
- [ ] Trigger the /boot threshold alert and confirm the message renders the full path