### PR TITLE
nasty-cleanup: re-sync /boot after generation deletion + GC

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -599,8 +599,15 @@ in {
         nix-env --delete-generations +3 -p /nix/var/nix/profiles/system 2>/dev/null || true
         echo "==> Running garbage collection..."
         nix-collect-garbage 2>&1
+        # Re-sync /boot to match the surviving generations: GC removed
+        # their store paths but systemd-boot's entries (and the kernel +
+        # initrd copies under /boot) stick around until we rebuild the
+        # bootloader.  Without this the /boot-full alert keeps firing
+        # even after nix-collect-garbage reclaimed everything in /.
+        echo "==> Re-syncing bootloader entries (/boot cleanup)..."
+        /run/current-system/bin/switch-to-configuration boot
         echo "==> Done."
-        df -h /
+        df -h / /boot
       '')
 
       (writeShellScriptBin "nasty-rebuild" ''


### PR DESCRIPTION
## Summary

\`nasty-cleanup\` does \`delete-generations + nix-collect-garbage\` and then prints \`df -h /\`. That reclaims store space but leaves systemd-boot's entries pointing at the now-deleted kernel/initrd files — \`/boot\` stays full, the /boot-free-space alert keeps firing, and the next update can still ENOSPC trying to install its initrd.

Add a third step that runs \`/run/current-system/bin/switch-to-configuration boot\` to rebuild the bootloader entries from the surviving generations only. Also report \`df -h / /boot\` instead of just \`/\` so the user sees both reclamations.

## Test plan
- [ ] Run \`nasty-cleanup\` on a box with stale generation entries and confirm /boot space increases
- [ ] Re-run on a clean box and confirm no errors when there's nothing to prune