### PR TITLE
ci: push aarch64 engine/webui/bcachefs-tools to cachix too

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,3 +73,42 @@ jobs:
             --no-link -L
           nix build .#packages.x86_64-linux.bcachefs-tools \
             --no-link -L
+
+  aarch64-cache-push:
+    name: Build & push aarch64 packages to Cachix
+    # No native aarch64 NixOS test job (the smoke tests live under
+    # checks.x86_64-linux), so this runs in parallel with bcachefs-smoke
+    # and just ensures the aarch64 engine/webui/bcachefs-tools land in
+    # cachix.  Without this, aarch64 boxes (Pi, Odroid, etc.) miss the
+    # cache for every upgrade and rebuild Rust + npm + bcachefs-tools
+    # locally — 10+ minutes of CPU per upgrade.
+    runs-on: ubuntu-24.04-arm
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v17
+        with:
+          name: nasty
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Compute npm deps hash
+        # Same trick as the x86_64 job — webui build's npmDepsHash must
+        # match the current package-lock.json.
+        run: |
+          HASH=$(nix run nixpkgs#prefetch-npm-deps -- webui/package-lock.json 2>/dev/null)
+          sed -i "s|npmDepsHash = \".*\"|npmDepsHash = \"$HASH\"|" flake.nix
+
+      - name: Build aarch64 packages
+        run: |
+          nix build .#packages.aarch64-linux.engine \
+            --no-link -L
+          nix build .#packages.aarch64-linux.webui \
+            --no-link -L
+          nix build .#packages.aarch64-linux.bcachefs-tools \
+            --no-link -L


### PR DESCRIPTION
## Summary

The integration workflow only pushed \`.#packages.x86_64-linux.{engine,webui,bcachefs-tools}\` to cachix after the smoke tests, so nasty.cachix.org has never carried aarch64 store paths. Every aarch64 NASty box (Pi, Odroid, RK35xx, etc.) misses cache on every upgrade and rebuilds Rust + npm + bcachefs-tools locally — that's the 10+ minute gap between x86_64 and ARM upgrade times users have been seeing.

Discovered while debugging why \`nasty.0f.ee\` updates "manually" while \`nas.0f.ee\` flies — same wrapper-flake config, identical cachix substituter, different architecture.

## Approach

Add a parallel \`aarch64-cache-push\` job on \`ubuntu-24.04-arm\` (free on public repos, native ARM hardware, no QEMU). Mirrors the x86_64 push: install Nix, attach cachix auth, recompute npmDepsHash, build the three aarch64 outputs. Same \`if:\` guard so we only populate cache on push-to-main and manual dispatch.

No smoke-test gate because there's no \`checks.aarch64-linux\` test target today — the build itself is the validation. If we add aarch64 NixOS tests later, they can gate this push.

## Test plan
- [ ] Merge → workflow runs on next push to main → confirm the \`aarch64-cache-push\` job goes green
- [ ] On the aarch64 box, next upgrade should show \`copying path ...nasty-engine-... from 'https://nasty.cachix.org'\` instead of \`building '...nasty-engine-...drv'\`