### PR TITLE
alerts: point /boot warning at nasty-cleanup; drop dashboard Configure link

### DIFF
--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -540,8 +540,11 @@ fn evaluate_rules(
                         // Mention the actionable remedy in the message
                         // so the user doesn't have to dig — the typical
                         // path is "trim old generations" not "resize ESP".
+                        // `nasty-cleanup` is the one-shot helper that
+                        // does delete-old-generations + nix-gc +
+                        // switch-to-configuration boot in order.
                         message: format!(
-                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nix-collect-garbage --delete-older-than 7d` and `/run/current-system/bin/switch-to-configuration boot` to reclaim space.",
+                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nasty-cleanup` to reclaim space.",
                             free_mb, rule.threshold
                         ),
                         current_value: free_mb,

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -256,7 +256,6 @@
 			}">
 				<span class="shrink-0 text-base font-bold">{alert.severity === 'critical' ? '!' : '⚠'}</span>
 				<span class="flex-1">{alert.message}</span>
-				<a class="text-xs opacity-70 hover:opacity-100" href="/alerts">Configure</a>
 			</div>
 		{/each}
 	</div>


### PR DESCRIPTION
Two related UX fixes for the /boot-full alert that's been telling users to run a two-command incantation:

## 1. Point the alert at \`nasty-cleanup\` instead of raw nix invocations

PR #183 made \`nasty-cleanup\` do the full sequence in order (delete old generations → \`nix-collect-garbage\` → \`switch-to-configuration boot\`).  So the alert text can drop the long two-command suggestion and just say:

> \`/boot has 61 MB free (threshold: 100 MB). The next system update may fail to install its initrd. Run \`nasty-cleanup\` to reclaim space.\`

## 2. Drop the dashboard "Configure" link

Every alert banner on the dashboard rendered a generic \`Configure\` link to /alerts.  That meant "edit the rule's threshold" — but the dashboard isn't the right place to edit alert rules, and on a clear-remedy alert like /boot the link pointed at the least useful follow-up.  /alerts stays reachable via the sidebar.

## Test plan
- [ ] Trigger the /boot threshold alert; confirm the message reads "Run \`nasty-cleanup\`..." and no Configure link appears