### PR TITLE
iso: disable useHostResolvConf to coexist with systemd-resolved

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -409,6 +409,17 @@ in
   networking.wireless.enable = pkgs.lib.mkForce false;
   networking.useDHCP = pkgs.lib.mkForce true;
 
+  # installation-cd-base.nix sets `useHostResolvConf = true` to copy the
+  # live medium's resolv.conf into the installer, but recent nixpkgs
+  # also pulls in systemd-resolved on the same image (via
+  # NetworkManager) — and the two are mutually exclusive by NixOS
+  # assertion ("Using host resolv.conf is not supported with
+  # systemd-resolved"). Disable host-resolv-conf and let resolved
+  # provide DNS during the install; the installer just needs working
+  # name resolution and resolved gives us that via the stub at
+  # /run/systemd/resolve/stub-resolv.conf.
+  networking.useHostResolvConf = lib.mkForce false;
+
   # Auto-launch the installer on tty1
   services.getty.autologinUser = lib.mkForce "root";
   programs.bash.loginShellInit = ''


### PR DESCRIPTION
## The bug

v0.0.7 ISO build fails on current nixos-unstable with:

\`\`\`
Failed assertions:
- Using host resolv.conf is not supported with systemd-resolved
\`\`\`

See run [25882778977](https://github.com/nasty-project/nasty/actions/runs/25882778977).

\`installation-cd-base.nix\` sets \`networking.useHostResolvConf = true\` historically (copy the live medium's resolv.conf into the installer).  Recent nixpkgs also pulls in systemd-resolved on the same image (via NetworkManager — which our v0.0.7 release just migrated to).  The two are mutually exclusive per a NixOS assertion.

## Fix

Force \`networking.useHostResolvConf = false\` in \`nixos/iso.nix\`.  The installer just needs working DNS, which systemd-resolved provides via its stub at \`/run/systemd/resolve/stub-resolv.conf\`.

## Test plan
- [ ] Re-run the build-iso workflow against this branch and confirm both x86_64 and aarch64 jobs go green