### PR TITLE
iso: disable systemd-resolved on the installer image

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -409,16 +409,18 @@ in
   networking.wireless.enable = pkgs.lib.mkForce false;
   networking.useDHCP = pkgs.lib.mkForce true;
 
-  # installation-cd-base.nix sets `useHostResolvConf = true` to copy the
-  # live medium's resolv.conf into the installer, but recent nixpkgs
-  # also pulls in systemd-resolved on the same image (via
-  # NetworkManager) — and the two are mutually exclusive by NixOS
-  # assertion ("Using host resolv.conf is not supported with
-  # systemd-resolved"). Disable host-resolv-conf and let resolved
-  # provide DNS during the install; the installer just needs working
-  # name resolution and resolved gives us that via the stub at
-  # /run/systemd/resolve/stub-resolv.conf.
-  networking.useHostResolvConf = lib.mkForce false;
+  # Recent nixpkgs trips the "Using host resolv.conf is not supported
+  # with systemd-resolved" assertion on the installer image — something
+  # in the installer profile chain (likely via NetworkManager) flips
+  # `networking.useHostResolvConf` to true on the same image where
+  # systemd-resolved is also enabled.  Forcing useHostResolvConf=false
+  # didn't win the option merge (see #187); going at it from the other
+  # side and disabling resolved on the installer does.  The installer
+  # only needs working DNS during `nixos-install`, which the default
+  # NetworkManager DNS plugin (non-resolved) provides directly to
+  # /etc/resolv.conf.  Resolved is still enabled on the installed
+  # appliance via nasty.nix — this only affects the ISO.
+  services.resolved.enable = lib.mkForce false;
 
   # Auto-launch the installer on tty1
   services.getty.autologinUser = lib.mkForce "root";


### PR DESCRIPTION
## Followup to #187 — same assertion, different angle

#187 tried to fix the "Using host resolv.conf is not supported with systemd-resolved" assertion by forcing \`networking.useHostResolvConf = false\` in the ISO config.  The v0.0.7 ISO rebuild ([run 25883807142](https://github.com/nasty-project/nasty/actions/runs/25883807142)) tripped the **same** assertion — my override didn't win the option merge for reasons I couldn't quickly pin down in nixpkgs.

Going at it from the other side: force \`services.resolved.enable = false\` on the ISO.  Either condition being false makes the assertion pass, and this option is easier to override cleanly.

The installer only needs working DNS during \`nixos-install\`, which NetworkManager's default DNS plugin (non-resolved) provides by writing \`/etc/resolv.conf\` directly.  Resolved is still enabled on the installed appliance via \`nasty.nix\` — this override only affects the ISO build.

## Test plan
- [ ] Re-run \`build-iso\` workflow against this branch, both x86_64 and aarch64 jobs go green