### PR TITLE
iso: real fix for systemd-resolved + useHostResolvConf conflict

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -166,8 +166,20 @@
           ./nixos/modules/linuxquota.nix
           ./nixos/modules/nasty.nix
           ./nixos/configuration.nix
-          ({ ... }: {
+          ({ lib, ... }: {
             boot.isContainer = true;
+            # `boot.isContainer = true` flips
+            # `networking.useHostResolvConf` to true by default (so
+            # containers inherit the host's DNS), but nasty.nix also
+            # enables systemd-resolved — and the two trip the
+            # "Using host resolv.conf is not supported with
+            # systemd-resolved" assertion.  This rootfs is bundled
+            # into the ISO as a store path, so the failed assertion
+            # blocks every ISO build.  Force-disable host resolv.conf
+            # here; nothing actually consumes /etc/resolv.conf inside
+            # this container payload (it's a pre-built closure, not
+            # a running container).
+            networking.useHostResolvConf = lib.mkForce false;
           })
         ];
       };

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -409,19 +409,6 @@ in
   networking.wireless.enable = pkgs.lib.mkForce false;
   networking.useDHCP = pkgs.lib.mkForce true;
 
-  # Recent nixpkgs trips the "Using host resolv.conf is not supported
-  # with systemd-resolved" assertion on the installer image — something
-  # in the installer profile chain (likely via NetworkManager) flips
-  # `networking.useHostResolvConf` to true on the same image where
-  # systemd-resolved is also enabled.  Forcing useHostResolvConf=false
-  # didn't win the option merge (see #187); going at it from the other
-  # side and disabling resolved on the installer does.  The installer
-  # only needs working DNS during `nixos-install`, which the default
-  # NetworkManager DNS plugin (non-resolved) provides directly to
-  # /etc/resolv.conf.  Resolved is still enabled on the installed
-  # appliance via nasty.nix — this only affects the ISO.
-  services.resolved.enable = lib.mkForce false;
-
   # Auto-launch the installer on tty1
   services.getty.autologinUser = lib.mkForce "root";
   programs.bash.loginShellInit = ''


### PR DESCRIPTION
Third (and hopefully last) attempt at the v0.0.7 ISO build assertion.

## What was wrong with #187 / #188

The error trace said "Build x86_64 ISO" and pointed at the systemd-resolved / useHostResolvConf assertion, so I assumed the conflict was in \`nasty-iso\`'s module graph and patched \`nixos/iso.nix\` twice — neither override took effect.

The actual failing target is **\`nasty-rootfs\`**, not \`nasty-iso\`. The ISO embeds \`nasty-rootfs.config.system.build.toplevel\` as a Nix store path (via the \`nasty-rootfs-toplevel\` specialArg) so the installer can lay down a working appliance, which means \`nasty-rootfs\` has to evaluate successfully before \`nasty-iso\` can build.

\`nasty-rootfs\`'s inline module in \`flake.nix\` sets \`boot.isContainer = true\`, which makes NixOS default \`networking.useHostResolvConf = true\` (container-style: inherit DNS from host).  \`nasty.nix\` (imported into \`nasty-rootfs\`, not into \`nasty-iso\`) enables \`services.resolved\`.  Both conditions true → assertion fires.

## Fix

Force \`networking.useHostResolvConf = false\` in the \`nasty-rootfs\` inline module.  Nothing inside that payload actually consumes \`/etc/resolv.conf\` — it's a pre-built closure shipped on the ISO, not a running container — so disabling the host-resolv-conf path is safe and orthogonal to the appliance's own DNS handling at runtime.

Also reverts the no-op iso.nix overrides from #187 and #188 to keep the tree clean.

## Test plan
- [ ] Re-run build-iso workflow against this branch, both x86_64 and aarch64 jobs go green