### PR TITLE
cleanup: drop tier-1 v0.0.7 compat scaffolding

### DIFF
--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -332,13 +332,6 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
                     params: MethodParams::Schema(gen_schema::<VersionSwitchRequest>(generator)),
                     result: None,
                 },
-                Method {
-                    name: "system.version.cleanup",
-                    desc: "Purge any stale legacy backup directory left by older Version-page builds.",
-                    role: "admin",
-                    params: MethodParams::None,
-                    result: None,
-                },
             ],
         ),
         (

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -16,7 +16,7 @@ pub struct User {
     pub username: String,
     /// Argon2 password hash. None for users provisioned via OIDC who have never set
     /// a local password; such users can only authenticate through the configured IdP.
-    #[serde(default, deserialize_with = "deserialize_password_hash")]
+    #[serde(default)]
     pub password_hash: Option<String>,
     pub role: Role,
     /// When true, the user must change their password before accessing anything else.
@@ -29,22 +29,6 @@ pub struct User {
     /// never collides with an existing user.
     #[serde(default)]
     pub oidc_issuer: Option<String>,
-}
-
-/// Accept legacy auth.json files where `password_hash` is a plain string (not Option).
-fn deserialize_password_hash<'de, D>(d: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::IntoDeserializer;
-    let v = serde_json::Value::deserialize(d)?;
-    match v {
-        serde_json::Value::Null => Ok(None),
-        serde_json::Value::String(s) if s.is_empty() => Ok(None),
-        serde_json::Value::String(s) => Ok(Some(s)),
-        other => Option::<String>::deserialize(other.into_deserializer())
-            .map_err(|e: serde_json::Error| serde::de::Error::custom(e.to_string())),
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -218,9 +218,10 @@ pub struct NetworkState {
 }
 
 /// Request shape for `system.network.update`. The `NetworkConfig` fields
-/// are flattened in for backwards compatibility — old clients posting a
-/// bare `NetworkConfig` still parse — and `confirm_within_secs` is the
-/// optional opt-in to the confirm-or-rollback safety net.
+/// are flattened so callers post one flat object instead of wrapping the
+/// config under a `config:` key — that's the WebUI's actual call shape.
+/// `confirm_within_secs` is the optional opt-in to the
+/// confirm-or-rollback safety net.
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
 pub struct UpdateRequest {
     #[serde(flatten)]

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -76,9 +76,6 @@
 	});
 	let savingNetwork = $state(false);
 	let netDhcp = $state(true);
-	// Legacy single-address vars (used by syncNetworkForm for onMount compat)
-	let netAddress = $state('');
-	let netPrefix = $state('24');
 	let netGateway = $state('');
 	let netNameservers = $state('');
 	let netChanged = $state(false);
@@ -190,14 +187,6 @@
 		if (!network || !network.interfaces.length) return;
 		const iface = network.interfaces[0];
 		netDhcp = iface.ipv4.method === 'dhcp';
-		if (iface.ipv4.addresses.length > 0) {
-			const parts = iface.ipv4.addresses[0].split('/');
-			netAddress = parts[0] ?? '';
-			netPrefix = parts[1] ?? '24';
-		} else {
-			netAddress = '';
-			netPrefix = '24';
-		}
 		netGateway = iface.ipv4.gateway ?? '';
 		netNameservers = network.dns.join(', ');
 		netChanged = false;
@@ -270,39 +259,6 @@
 			'Log level updated'
 		);
 		savingLog = false;
-	}
-
-	async function saveNetwork() {
-		savingNetwork = true;
-		const nameservers = netNameservers
-			.split(/[,\s]+/)
-			.map((s) => s.trim())
-			.filter(Boolean);
-
-		// Build new config from current state + form values
-		const ifaceName = network?.interfaces?.[0]?.name || networkState?.interfaces?.[0]?.name || 'eth0';
-		const ipv4Method = netDhcp ? 'dhcp' : 'static';
-		const ipv4Addresses = netDhcp ? [] : [`${netAddress.trim()}/${netPrefix}`];
-		const ipv4Gateway = netDhcp ? null : (netGateway.trim() || null);
-
-		const payload: NetworkConfig = {
-			interfaces: [{
-				name: ifaceName,
-				enabled: true,
-				ipv4: { method: ipv4Method, addresses: ipv4Addresses, gateway: ipv4Gateway },
-				ipv6: network?.interfaces?.[0]?.ipv6 ?? { method: 'slaac', addresses: [], gateway: null },
-				mtu: network?.interfaces?.[0]?.mtu ?? null,
-			}],
-			dns: nameservers,
-			bonds: network?.bonds ?? [],
-			vlans: network?.vlans ?? [],
-			bridges: network?.bridges ?? [],
-		};
-
-		await applyNetworkUpdate(payload, 'Network configuration applied');
-		networkState = await client.call<NetworkState>('system.network.get');
-		syncNetworkForm();
-		savingNetwork = false;
 	}
 
 	async function loadMetrics() {


### PR DESCRIPTION
Follow-up to #190.  Bundle of small migration-era cleanups.

## Removed

### apidoc — \`system.version.cleanup\` doc stub
No router handler exists; this was an orphan documentation entry from the pre-cutover version-page rework. \`gh api\`-ing the method would return method-not-found today. Dropping the entry.

### auth.rs — \`deserialize_password_hash\` custom fn
Existed to coerce legacy plain-string \`password_hash\` values (and an empty string) to \`Option<String>\`. The default \`Option<String>\` deserializer already accepts both \`null\` and a plain string — the only behavioral delta was turning \`""\` into \`None\`, which protected against a state **nothing in the code path actually writes** (every writer emits \`Some(hash)\` or \`None\`). Login already fails on an empty hash either way (argon2 verify rejects), so even on a hypothetical hand-edited auth.json the user-visible behavior is the same.

### webui/settings — dead \`saveNetwork()\` + \`netAddress\` / \`netPrefix\`
\`saveNetwork()\` was a single-address-per-interface save handler from before the WebUI supported multi-IP. **Zero callers** — \`applyNetworkUpdate\` is invoked exclusively from \`saveInterfaceConfig\` (the per-interface multi-address flow) and the bond / vlan create paths. \`netAddress\` and \`netPrefix\` only ever fed it; \`syncNetworkForm\` would parse the first CIDR string and write both. The live UI binds to \`netIpv4Addrs[]\` (CIDR strings, multiple allowed), which is unchanged. svelte-check confirms zero references to the deleted vars after the surgery.

### network.rs — misleading "backwards compatibility" comment
\`#[serde(flatten)]\` on \`UpdateRequest.config\` is not a compat shim — the flat shape **is** the WebUI's call shape (typed as \`NetworkUpdateRequest extends NetworkConfig\` in \`types.ts\`). Rewriting the comment to reflect that.

## Diff

\`\`\`
engine/nasty-apidoc/src/main.rs        |  7 ------
engine/nasty-engine/src/auth.rs        | 18 +-------------
engine/nasty-system/src/network.rs     |  7 +++---
webui/src/routes/settings/+page.svelte | 44 ----------------------------------
4 files changed, 5 insertions(+), 71 deletions(-)
\`\`\`

## Test plan
- \`cargo fmt --check\`, \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`, \`cargo test --workspace\` (338 tests) all pass locally.
- \`npx svelte-check\` 0 errors / 0 warnings across 96 files.
- Manually verify: open Settings → Network on a running box, change an IPv4 address, click Save → applies via the alive code path.

## What I deferred from the original tier-1 audit
The original audit also flagged the apidoc cleanup line as a "stale-backup purge" item — but the entry itself was orphaned (no handler), so the actual purge code I'd assumed was there doesn't exist. Nothing more to remove on that thread.