### PR TITLE
network: surface per-connection NM apply errors to the user

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -234,10 +234,11 @@ pub struct UpdateRequest {
     pub confirm_within_secs: Option<u64>,
 }
 
-/// Response shape for `system.network.update`. All fields are `None` when
-/// no rollback was scheduled (safe change applied directly). When a
-/// rollback is pending, the caller must hit `system.network.confirm` with
-/// `txn_id` before `revert_at_unix` to keep the change.
+/// Response shape for `system.network.update`. Rollback-related fields
+/// are `None` when no rollback was scheduled (safe change applied
+/// directly).  When a rollback is pending, the caller must hit
+/// `system.network.confirm` with `txn_id` before `revert_at_unix` to
+/// keep the change.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct UpdateResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -248,6 +249,28 @@ pub struct UpdateResponse {
     /// the management iface eth0"). Surfaced in the WebUI banner.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_reason: Option<String>,
+    /// Per-connection NetworkManager apply failures, if any.  The
+    /// overall apply is still considered successful — other
+    /// connections may have gone through fine — but these are
+    /// surfaced so the user can see what didn't actually take
+    /// effect instead of assuming everything worked.  Empty in the
+    /// common case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub apply_errors: Vec<NetworkApplyError>,
+}
+
+/// One NetworkManager connection that failed to apply.  Surfaced
+/// in `UpdateResponse.apply_errors` so the WebUI can render the
+/// error instead of pretending the whole apply succeeded.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NetworkApplyError {
+    /// The `nasty-<iface>` connection ID NM was working on.
+    pub connection_id: String,
+    /// NM's verbatim error message.  These look like
+    /// "Activation failed: ..." or "DBus error: ..."; we don't
+    /// try to normalise — they're meant to be readable as-is and
+    /// pasted into a bug report.
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -381,7 +404,7 @@ impl NetworkService {
                 .map_err(|e| format!("write {PENDING_REVERT_PATH}: {e}"))?;
 
             persist_config(&config).await?;
-            apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
 
             let txn_id = new_txn_id();
             let revert_at_unix = unix_now() + secs;
@@ -401,10 +424,11 @@ impl NetworkService {
                 txn_id: Some(txn_id),
                 revert_at_unix: Some(revert_at_unix),
                 risk_reason: Some(reason),
+                apply_errors: outcome_to_apply_errors(&outcome),
             })
         } else {
             persist_config(&config).await?;
-            apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
 
             info!(
                 "Network config updated ({} interfaces, {} bonds, {} bridges, {} VLANs)",
@@ -419,7 +443,10 @@ impl NetworkService {
             // apply_profiles, so reboot picks them up automatically.
             // No nixos-rebuild needed.
 
-            Ok(UpdateResponse::default())
+            Ok(UpdateResponse {
+                apply_errors: outcome_to_apply_errors(&outcome),
+                ..Default::default()
+            })
         }
     }
 
@@ -1315,7 +1342,21 @@ fn parse_dhcp_managed(json: &str) -> Option<std::collections::HashSet<String>> {
     )
 }
 
-async fn apply_config(config: &NetworkConfig, mgmt_iface: Option<&str>) -> Result<(), String> {
+fn outcome_to_apply_errors(outcome: &nm::dbus::NmApplyOutcome) -> Vec<NetworkApplyError> {
+    outcome
+        .errors
+        .iter()
+        .map(|(id, message)| NetworkApplyError {
+            connection_id: id.clone(),
+            message: message.clone(),
+        })
+        .collect()
+}
+
+async fn apply_config(
+    config: &NetworkConfig,
+    mgmt_iface: Option<&str>,
+) -> Result<nm::dbus::NmApplyOutcome, String> {
     // NetworkManager is the active backend.  Convert the resolved
     // config to layered form, then to NM profiles, then push to NM
     // via DBus.  NM owns DHCP, DNS, and L2 management; the engine
@@ -1352,15 +1393,16 @@ async fn apply_config(config: &NetworkConfig, mgmt_iface: Option<&str>) -> Resul
         outcome.errors.len(),
     );
     if !outcome.errors.is_empty() {
-        // Best-effort apply: report per-connection errors via the
-        // outcome, but don't fail the whole apply unless ALL
+        // Best-effort apply: log per-connection errors and return
+        // them in the outcome so the caller can surface them to
+        // the user, but don't fail the whole apply unless ALL
         // connections failed (which would indicate something
         // genuinely broken — NM not running, DBus permissions, etc.).
         for (id, msg) in &outcome.errors {
             warn!("network apply: connection '{id}' failed: {msg}");
         }
     }
-    Ok(())
+    Ok(outcome)
 }
 #[cfg(test)]
 mod tests {

--- a/webui/src/lib/rollbackState.svelte.ts
+++ b/webui/src/lib/rollbackState.svelte.ts
@@ -9,7 +9,7 @@
  * from the settings page during the confirm window. */
 
 import { getClient } from './client';
-import { withToast } from './toast.svelte';
+import { error as toastError, withToast } from './toast.svelte';
 import type { NetworkPendingTxn, NetworkUpdateRequest, NetworkUpdateResponse } from './types';
 
 export interface PendingRollback {
@@ -56,6 +56,19 @@ export async function applyNetworkUpdate(
 			revertAtUnix: res.revert_at_unix,
 			riskReason: res.risk_reason ?? null,
 		};
+	}
+	// Surface per-connection NM errors as an explicit error toast.
+	// The success toast above already fired — engine treats partial
+	// failures as overall success — but the user needs to know that
+	// not everything went through.  Without this, a bond that NM
+	// rejected silently looks like it "worked" in the UI.
+	if (res?.apply_errors && res.apply_errors.length > 0) {
+		const lines = res.apply_errors
+			.map((e) => `${e.connection_id}: ${e.message}`)
+			.join('\n');
+		toastError(
+			`Network applied, but ${res.apply_errors.length} connection(s) reported errors:\n${lines}`,
+		);
 	}
 	return res;
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -693,12 +693,23 @@ export interface NetworkUpdateRequest extends NetworkConfig {
 	confirm_within_secs?: number;
 }
 
-/** Returned by `system.network.update`. Fields are populated only when the
- * server scheduled a rollback. */
+/** Returned by `system.network.update`.  Rollback-related fields are
+ * populated only when the server scheduled one; `apply_errors` is
+ * populated when one or more NM connections failed to apply (other
+ * connections in the same payload may have succeeded — the engine
+ * treats this as a partial success rather than a whole-apply
+ * failure, but surfaces the per-connection messages so the user
+ * isn't lied to). */
 export interface NetworkUpdateResponse {
 	txn_id?: string | null;
 	revert_at_unix?: number | null;
 	risk_reason?: string | null;
+	apply_errors?: NetworkApplyError[];
+}
+
+export interface NetworkApplyError {
+	connection_id: string;
+	message: string;
 }
 
 /** One pending rollback transaction, as returned by `system.network.pending`.


### PR DESCRIPTION
Diagnostic fix for [discussion #159](https://github.com/orgs/nasty-project/discussions/159#discussioncomment-16934918) — user creates a bond in the UI, sees a success toast, finds no bond in \`nmcli\` / \`ip link\`.

## What was broken

\`apply_config\` in \`engine/nasty-system/src/network.rs\` issues a multi-connection apply over NM DBus and collects per-connection results in \`outcome.errors[]\`.  The existing code logged those at \`warn!\` level and returned \`Ok(())\` — the WebUI saw a fully-successful response even when an individual connection (a bond, bridge, VLAN, whatever) had been rejected by NM.

The error message NM produced was usually informative ("interface name conflict", "Activation failed: …").  It just never reached the screen, leaving the user staring at a UI that says "yes" and a system that says "no".

## What this changes

- \`apply_config\` returns the \`NmApplyOutcome\` instead of \`()\`.
- \`UpdateResponse\` (the \`system.network.update\` RPC return type) grows an \`apply_errors: Vec<NetworkApplyError>\` field of \`{connection_id, message}\` tuples.
- Both \`update()\` call sites — with-rollback and without — fill it in from the outcome.
- WebUI \`applyNetworkUpdate\` adds an explicit error toast alongside the existing success toast when \`apply_errors\` is non-empty.

The engine still treats partial NM failure as overall success — other connections may have gone through fine — but the user now sees which specific connections didn't take effect, and why.

## Out of scope

This doesn't fix the underlying bond-create-silently-fails bug — that likely needs orphan NM-profile cleanup on a v0.0.7-migrated box where the engine enumerated short interface names (\`enp6s0f0\`) but the kernel hands out suffixed ones (\`enp6s0f0np0\`).  Separate investigation.

This PR just makes the failure visible so the next diagnosis conversation has the actual NM error in hand.

## Test plan
- \`cargo fmt --check\`, \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`, \`cargo test --workspace\` (338 tests) all pass locally.
- \`npx svelte-check\` 0/0/0 across 96 files.