### PR TITLE
log: ensure every operation logs failures so we never debug blind again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to NASty
+
+## Logging rule
+
+**Every operation must log enough that a failure can be diagnosed from the journal alone — without shipping a "ship visibility patch then ask the user to retry" round-trip.**
+
+This rule exists because we've burned multi-PR cycles on bugs that were *visible all along* but our code threw the diagnostic away. Discussion #159 took four PRs (#197 → #198 → #199 → #200) to land because the engine was swallowing per-connection NetworkManager errors, then per-field DBus type-mismatch errors. Each "ship more logs and ask the reporter to re-run" trip cost a day of latency.
+
+### How to comply
+
+#### Subprocess invocations — use `nasty_common::cmd`
+
+Always route subprocess calls through one of:
+
+- `cmd::run(program, &[args])`           — returns `Output`, callers can react to status. Logs spawn failure + non-zero exit at `warn!`.
+- `cmd::run_ok(program, &[args])`        — returns `Ok(stdout)` or `Err(stderr-with-context)`. Same logging.
+- `cmd::try_run(program, &[args])`       — best-effort; discards the result but **still logs** spawn failure + non-zero exit at `warn!`. Use for "try to clean up, OK if it doesn't work".
+
+Do **not** call `tokio::process::Command::new(...).output()` / `.status()` directly unless you have a specific reason (long-lived child where you stream stdout, custom env handling, etc.) AND you've thought through the error paths. If you must, the patterns to avoid:
+
+```rust
+// ❌ SILENT — exit code and stderr discarded.
+let _ = tokio::process::Command::new("systemctl").args([...]).output().await;
+
+// ❌ SILENT on Err — spawn failure lost, only success path is handled.
+if let Ok(out) = tokio::process::Command::new("systemctl").args([...]).output().await {
+    /* ... */
+}
+
+// ✅ LOGGED — spawn failure and non-zero exit always go to the journal.
+nasty_common::cmd::try_run("systemctl", &["restart", "foo"]).await;
+```
+
+#### Spawned tasks — log errors before they vanish
+
+A `tokio::spawn` block that produces a `Result` and discards it loses the failure forever. At minimum:
+
+```rust
+// ❌ SILENT
+tokio::spawn(async move {
+    do_thing_that_can_fail().await
+});
+
+// ✅ LOGGED
+tokio::spawn(async move {
+    if let Err(e) = do_thing_that_can_fail().await {
+        warn!("background do_thing failed: {e}");
+    }
+});
+```
+
+If the function being spawned already logs internally (e.g. `apply_caddy_tls` from settings.rs), this isn't needed — but spawning a `JoinHandle` and never awaiting it loses task-level panics, so for important background work consider:
+
+```rust
+let h = tokio::spawn(async move { background_work().await });
+tokio::spawn(async move {
+    if let Err(e) = h.await {
+        warn!("background_work task panicked / cancelled: {e}");
+    }
+});
+```
+
+#### Aggregate operations — don't collapse per-item errors
+
+A loop that processes N items and returns one `Result<(), _>` or one `bool` hides which item failed. This was the exact #197 bug. Pattern:
+
+```rust
+// ❌ HIDES — caller sees "apply failed" with no idea which connection.
+for conn in connections {
+    apply_one(conn).await?;
+}
+Ok(())
+
+// ✅ SURFACES — caller gets a per-item map of {id: error}.
+let mut errors = HashMap::new();
+for conn in connections {
+    if let Err(e) = apply_one(&conn).await {
+        warn!("apply {}: {e}", conn.id);
+        errors.insert(conn.id.clone(), e.to_string());
+    }
+}
+Ok(ApplyOutcome { errors })
+```
+
+The WebUI / RPC response should expose the per-item errors so the user can see *which* operation broke without having to ssh in and read journals.
+
+#### Don't erase the source error
+
+```rust
+// ❌ STATIC — original error type and details lost.
+some_op().await.map_err(|_| "operation failed".to_string())?;
+
+// ✅ KEEPS the cause.
+some_op().await.map_err(|e| format!("operation failed: {e}"))?;
+```
+
+### When silent discards are OK
+
+There are a few legitimate cases where `let _ = ...` is fine — they're all "the failure literally doesn't matter":
+
+- Cleanup paths where the process is exiting anyway (`tokio::fs::remove_file` of a pipe socket on shutdown).
+- Channel sends where the receiver going away is the expected shutdown signal.
+
+Even then, prefer `if let Err(e) = ... { tracing::trace!("…") }` — the `trace!` level keeps the journal quiet but leaves a breadcrumb if someone enables it.
+
+### Enforcement
+
+The standard CI run (`cargo clippy --workspace --all-targets --no-deps -- -D warnings`) will reject anything that violates the project's clippy config in `engine/clippy.toml`. New raw `tokio::process::Command::new` callsites are not enforced yet — they're being migrated as we touch the surrounding code. Don't introduce new ones; use the helpers above.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2471,6 +2471,7 @@ version = "0.0.7"
 dependencies = [
  "bollard",
  "futures-util",
+ "nasty-common",
  "reqwest 0.13.3",
  "schemars 1.2.1",
  "serde",
@@ -2507,6 +2508,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/engine/nasty-apps/Cargo.toml
+++ b/engine/nasty-apps/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+nasty-common = { path = "../nasty-common" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -745,12 +745,14 @@ impl AppsService {
             return Ok(d.clone());
         }
         drop(guard);
-        // Try to connect (Docker may have started after engine)
+        // Try to connect (Docker may have started after engine). Keep the
+        // bollard error in the message so a permission-denied vs
+        // socket-not-found can be distinguished without re-running.
         let d = Docker::connect_with_unix_defaults()
             .or_else(|_| {
                 Docker::connect_with_unix("/var/run/docker.sock", 120, bollard::API_DEFAULT_VERSION)
             })
-            .map_err(|_| AppsError::NotReady("Docker socket not available".into()))?;
+            .map_err(|e| AppsError::NotReady(format!("Docker socket not available: {e}")))?;
         *self.docker.lock().unwrap() = Some(d.clone());
         info!("Connected to Docker socket");
         Ok(d)
@@ -806,36 +808,59 @@ impl AppsService {
 
         // Bootstrap in background
         tokio::spawn(async move {
-            // Wait for Docker to be ready (up to 30s)
+            // Wait for Docker to be ready (up to 30s). Track the last
+            // failure reason so the "didn't become ready" log can say
+            // *why* (permission denied, connection refused, etc.) instead
+            // of just timing out silently.
             let mut ready = false;
+            let mut last_err: Option<String> = None;
             for _ in 0..15 {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                if let Ok(docker) = Docker::connect_with_unix_defaults()
-                    && docker.ping().await.is_ok()
-                {
-                    ready = true;
-                    break;
+                match Docker::connect_with_unix_defaults() {
+                    Ok(docker) => match docker.ping().await {
+                        Ok(_) => {
+                            ready = true;
+                            break;
+                        }
+                        Err(e) => last_err = Some(format!("ping: {e}")),
+                    },
+                    Err(e) => last_err = Some(format!("connect: {e}")),
                 }
             }
 
             if !ready {
-                error!("Docker did not become ready within 30s");
+                error!(
+                    "Docker did not become ready within 30s — last error: {}",
+                    last_err.unwrap_or_else(|| "(no error captured)".into())
+                );
                 return;
             }
 
             // Set up storage directory
             let storage_path = setup_apps_storage(filesystem.as_deref()).await;
 
-            // Create compose directory
-            let _ = tokio::fs::create_dir_all(COMPOSE_DIR).await;
+            // Create compose directory. A failure here means every
+            // subsequent compose-app deploy will hit a confusing
+            // "no such directory" error — the root cause needs to be
+            // visible *now*, in the bootstrap log.
+            if let Err(e) = tokio::fs::create_dir_all(COMPOSE_DIR).await {
+                error!("create_dir_all({COMPOSE_DIR}) failed: {e} — compose deploys will fail");
+            }
 
-            // Persist storage path in config
+            // Persist storage path in config. A failure here means the
+            // chosen storage path won't survive an engine restart, which
+            // breaks app data persistence — log loudly.
             if let Some(ref path) = storage_path {
                 let config = AppsConfig {
                     enabled: true,
                     storage_path: Some(path.clone()),
                 };
-                let _ = AppsService::save_config(&config).await;
+                if let Err(e) = AppsService::save_config(&config).await {
+                    error!(
+                        "AppsConfig save failed: {e} — apps storage path won't \
+                         survive engine restart"
+                    );
+                }
             }
 
             info!("Apps bootstrap complete");
@@ -993,8 +1018,15 @@ impl AppsService {
                     .as_deref()
                     .unwrap_or("/var/lib/nasty/apps-data");
                 let path = format!("{}/{}/{}", base, req.name, v.name);
-                // Ensure the directory exists
-                let _ = tokio::fs::create_dir_all(&path).await;
+                // Ensure the directory exists. A failure here means the
+                // bind-mount will land on a missing path and Docker will
+                // either refuse to start the container or auto-create a
+                // root-owned dir — either way, a logged failure now is
+                // way easier to debug than the resulting "container
+                // exits immediately" report later.
+                if let Err(e) = tokio::fs::create_dir_all(&path).await {
+                    warn!("apps volume: create_dir_all({path}) failed: {e}");
+                }
                 path
             } else {
                 v.host_path.clone()
@@ -1081,7 +1113,9 @@ impl AppsService {
             "allow_unsafe": req.allow_unsafe,
         });
         let manifest_path = format!("{}/{}.json", COMPOSE_DIR, req.name);
-        let _ = tokio::fs::create_dir_all(COMPOSE_DIR).await;
+        if let Err(e) = tokio::fs::create_dir_all(COMPOSE_DIR).await {
+            warn!("create_dir_all({COMPOSE_DIR}) failed: {e}");
+        }
         if let Err(e) = tokio::fs::write(
             &manifest_path,
             serde_json::to_string_pretty(&manifest).unwrap(),

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1891,9 +1891,12 @@ impl AppsService {
 
         let compose_path = format!("{}/docker-compose.yml", project_dir);
         let cleanup = |project_dir: String, name: String, compose_path: String| async move {
-            // Tear down any partially created containers before removing the dir
-            let _ = Command::new("docker")
-                .args([
+            // Tear down any partially created containers before removing the dir.
+            // `try_run` logs failures so a stuck container that prevents the
+            // dir-removal from completing is debuggable.
+            nasty_common::cmd::try_run(
+                "docker",
+                &[
                     "compose",
                     "-f",
                     &compose_path,
@@ -1902,10 +1905,12 @@ impl AppsService {
                     "down",
                     "-v",
                     "--remove-orphans",
-                ])
-                .output()
-                .await;
-            let _ = tokio::fs::remove_dir_all(&project_dir).await;
+                ],
+            )
+            .await;
+            if let Err(e) = tokio::fs::remove_dir_all(&project_dir).await {
+                tracing::warn!("cleanup: remove_dir_all({project_dir}) failed: {e}");
+            }
         };
 
         let output = match result {
@@ -2429,8 +2434,13 @@ impl AppsService {
                 let name = entry.file_name().to_string_lossy().to_string();
                 let path = compose_file.to_string_lossy().to_string();
                 info!("Restoring compose app '{name}'");
-                let _ = Command::new("docker")
-                    .args([
+                // `try_run` logs failures so a compose app that won't
+                // come back up after reboot is debuggable from the
+                // journal — the previous `let _ =` form left this case
+                // completely silent.
+                nasty_common::cmd::try_run(
+                    "docker",
+                    &[
                         "compose",
                         "-f",
                         &path,
@@ -2439,9 +2449,9 @@ impl AppsService {
                         "up",
                         "-d",
                         "--no-build",
-                    ])
-                    .output()
-                    .await;
+                    ],
+                )
+                .await;
             }
         }
     }
@@ -2879,10 +2889,7 @@ async fn find_container_shell(container: &str) -> Option<&'static str> {
 }
 
 async fn reload_nginx() {
-    let _ = Command::new("systemctl")
-        .args(["reload", "nginx"])
-        .output()
-        .await;
+    nasty_common::cmd::try_run("systemctl", &["reload", "nginx"]).await;
 }
 
 /// One row parsed from `ss -tlnp` output.

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -771,9 +771,27 @@ impl AppsService {
     pub fn load_config() -> AppsConfig {
         let content = match std::fs::read_to_string(STATE_PATH) {
             Ok(c) => c,
-            Err(_) => return AppsConfig::default(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return AppsConfig::default(),
+            Err(e) => {
+                // A non-NotFound read error (permissions, IO) means we
+                // *might* be silently resetting a real config. Log
+                // before returning defaults so the user can match a
+                // "my installed apps disappeared" report to the
+                // underlying cause.
+                warn!("apps.json read from {STATE_PATH} failed: {e} — using defaults");
+                return AppsConfig::default();
+            }
         };
-        serde_json::from_str(&content).unwrap_or_default()
+        match serde_json::from_str(&content) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                warn!(
+                    "apps.json parse failed: {e} — file may be corrupt; \
+                     using defaults (any persisted config will be lost)"
+                );
+                AppsConfig::default()
+            }
+        }
     }
 
     async fn save_config(config: &AppsConfig) -> Result<(), AppsError> {
@@ -1231,8 +1249,12 @@ impl AppsService {
             )
             .await?;
 
-        // Clean up ingress and manifest
-        let _ = self.ingress_remove(name).await;
+        // Clean up ingress and manifest. ingress_remove failures get
+        // logged here because an orphaned reverse-proxy entry survives
+        // until the next restart and keeps proxying to a dead container.
+        if let Err(e) = self.ingress_remove(name).await {
+            warn!("ingress_remove({name}) failed during app removal: {e}");
+        }
         let manifest_path = format!("{}/{}.json", COMPOSE_DIR, name);
         let _ = tokio::fs::remove_file(&manifest_path).await;
 
@@ -1393,36 +1415,49 @@ impl AppsService {
                     });
                 }
             } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
-                // Simple app: manifest JSON
-                if let Ok(content) = tokio::fs::read_to_string(&path).await
-                    && let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&content)
-                {
-                    let app_name = manifest
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let image = manifest
-                        .get("image")
-                        .and_then(|i| i.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let unsafe_mode = manifest
-                        .get("allow_unsafe")
-                        .and_then(|b| b.as_bool())
-                        .unwrap_or(false);
-                    if !app_name.is_empty() {
-                        apps.push(App {
-                            name: app_name,
-                            image,
-                            status: "stopped".to_string(),
-                            created: String::new(),
-                            kind: "simple".to_string(),
-                            containers: Vec::new(),
-                            ports: Vec::new(),
-                            unsafe_mode,
-                        });
+                // Simple app: manifest JSON. Log read/parse failures —
+                // a corrupt manifest silently disappearing from the
+                // app list is exactly the "I installed it, where did
+                // it go" debug story we're trying to prevent.
+                let content = match tokio::fs::read_to_string(&path).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!("apps: read manifest {} failed: {e}", path.display());
+                        continue;
                     }
+                };
+                let manifest: serde_json::Value = match serde_json::from_str(&content) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        warn!("apps: parse manifest {} failed: {e}", path.display());
+                        continue;
+                    }
+                };
+                let app_name = manifest
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let image = manifest
+                    .get("image")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let unsafe_mode = manifest
+                    .get("allow_unsafe")
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
+                if !app_name.is_empty() {
+                    apps.push(App {
+                        name: app_name,
+                        image,
+                        status: "stopped".to_string(),
+                        created: String::new(),
+                        kind: "simple".to_string(),
+                        containers: Vec::new(),
+                        ports: Vec::new(),
+                        unsafe_mode,
+                    });
                 }
             }
         }
@@ -2079,7 +2114,9 @@ impl AppsService {
             return Err(AppsError::AppNotFound(name.to_string()));
         }
 
-        let _ = self.ingress_remove(name).await;
+        if let Err(e) = self.ingress_remove(name).await {
+            warn!("ingress_remove({name}) failed during compose app removal: {e}");
+        }
 
         info!("Removed compose app '{name}'");
         Ok(())

--- a/engine/nasty-common/Cargo.toml
+++ b/engine/nasty-common/Cargo.toml
@@ -9,5 +9,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 schemars.workspace = true

--- a/engine/nasty-common/src/cmd.rs
+++ b/engine/nasty-common/src/cmd.rs
@@ -1,0 +1,151 @@
+//! Subprocess helpers with mandatory error logging.
+//!
+//! # Why this exists
+//!
+//! Every "this command quietly didn't work and we have no idea why" support
+//! cycle in this project's history (see discussion #159, PRs #197–#200) traces
+//! back to a `let _ = Command::new(...)...await` somewhere — exit codes and
+//! stderr discarded, the failure invisible in logs, and the only way to
+//! diagnose anything was to ship a dedicated visibility patch and ask the
+//! reporter to retry.
+//!
+//! Routing every subprocess invocation through this module makes that class of
+//! bug impossible: a non-zero exit *always* lands in the journal at `warn!`
+//! with the program name, args, exit status, and stderr. A spawn failure
+//! (binary missing, permission denied, etc.) does the same. Callers that need
+//! the raw `Output` still get it back; callers that don't can use [`try_run`]
+//! and rely on the logging alone.
+//!
+//! # Project rule (engine code)
+//!
+//! Use these helpers — `nasty_common::cmd::{run, run_ok, try_run}` — for every
+//! subprocess invocation. Do not call `tokio::process::Command::new(...).output()`
+//! or `.status()` directly unless you have a *specific* reason (e.g., long-lived
+//! child where you stream stdout) and you've thought through the error paths.
+//! When in doubt, use `run`.
+//!
+//! ```no_run
+//! use nasty_common::cmd;
+//! # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
+//! // Best-effort cleanup — discards Result, still logs spawn errors and
+//! // non-zero exits.
+//! cmd::try_run("systemctl", &["reset-failed", "some-unit"]).await;
+//!
+//! // Caller wants to react to success/failure — return Output.
+//! let out = cmd::run("ip", &["link", "show"]).await?;
+//! if !out.status.success() { /* ... */ }
+//!
+//! // Caller wants stdout-or-error-string semantics.
+//! let stdout = cmd::run_ok("hostname", &[]).await?;
+//! # Ok(()) }
+//! ```
+
+use std::process::Output;
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Spawn a command, await it to completion, and return its `Output`.
+///
+/// Always logs:
+/// - `debug!`  on entry (the program + args)
+/// - `warn!`   if the spawn itself fails (e.g. binary not in PATH)
+/// - `warn!`   if the command exits non-zero (with stderr)
+///
+/// Callers receive the same `Output` they would from `Command::output()`.
+/// The logging happens before the value is returned, so a caller that
+/// inspects `output.status` is *also* getting the failure into the journal
+/// for free.
+pub async fn run(program: &str, args: &[&str]) -> std::io::Result<Output> {
+    debug!(target: "nasty::cmd", "exec: {} {}", program, args.join(" "));
+    let result = Command::new(program).args(args).output().await;
+    log_result(program, args, &result);
+    result
+}
+
+/// Like [`run`] but returns `Ok(stdout)` on success or `Err(stderr-with-context)`
+/// on either spawn failure or non-zero exit. Useful when the caller wants to
+/// surface the error message back to a user (e.g., over JSON-RPC) rather than
+/// react to it programmatically.
+pub async fn run_ok(program: &str, args: &[&str]) -> Result<String, String> {
+    let output = run(program, args)
+        .await
+        .map_err(|e| format!("failed to spawn {program}: {e}"))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(format!(
+            "{program} exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+/// Best-effort: spawn the command, log any failure, discard the result.
+///
+/// Use for "try to clean up state but it's fine if it doesn't work" calls —
+/// e.g. `systemctl reset-failed` before a `start`, or `chmod` after a write.
+/// The non-zero exit will still appear in the journal at `warn!`, so a real
+/// problem (binary missing, permission denied, the cleanup mattering after
+/// all) is debuggable.
+pub async fn try_run(program: &str, args: &[&str]) {
+    let _ = run(program, args).await;
+}
+
+fn log_result(program: &str, args: &[&str], result: &std::io::Result<Output>) {
+    match result {
+        Err(e) => warn!(
+            target: "nasty::cmd",
+            "spawn failed: {} {} — {e}",
+            program,
+            args.join(" ")
+        ),
+        Ok(o) if !o.status.success() => warn!(
+            target: "nasty::cmd",
+            "non-zero exit ({}): {} {} — stderr: {}",
+            o.status,
+            program,
+            args.join(" "),
+            String::from_utf8_lossy(&o.stderr).trim()
+        ),
+        Ok(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_returns_output_on_success() {
+        let out = run("true", &[]).await.expect("spawn true");
+        assert!(out.status.success());
+    }
+
+    #[tokio::test]
+    async fn run_ok_returns_stdout_on_success() {
+        let stdout = run_ok("printf", &["hello"]).await.expect("printf hello");
+        assert_eq!(stdout, "hello");
+    }
+
+    #[tokio::test]
+    async fn run_ok_returns_stderr_on_nonzero_exit() {
+        let err = run_ok("false", &[]).await.expect_err("false should fail");
+        assert!(err.contains("false exited with"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_ok_returns_spawn_error_when_binary_missing() {
+        let err = run_ok("nasty-nonexistent-binary-xyz", &[])
+            .await
+            .expect_err("missing binary");
+        assert!(err.contains("failed to spawn"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn try_run_does_not_panic_on_missing_binary() {
+        // The point: `try_run` swallows the Result but still logs internally;
+        // the caller never has to think about error handling.
+        try_run("nasty-nonexistent-binary-xyz", &[]).await;
+    }
+}

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cmd;
 pub mod jsonrpc;
 pub mod metrics_types;
 pub mod state;

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -438,8 +438,13 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
                 DeployMessage::log("Cleaning up failed deployment...").into(),
             ))
             .await;
-        let _ = Command::new("docker")
-            .args([
+        // Best-effort cleanup of partially-created containers. `try_run`
+        // logs failures so a leak (containers/volumes that didn't get
+        // removed) is debuggable from the journal rather than mysterious
+        // disk-space loss.
+        nasty_common::cmd::try_run(
+            "docker",
+            &[
                 "compose",
                 "-f",
                 &compose_path,
@@ -448,9 +453,9 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
                 "down",
                 "-v",
                 "--remove-orphans",
-            ])
-            .output()
-            .await;
+            ],
+        )
+        .await;
         if !is_update {
             let _ = tokio::fs::remove_dir_all(&compose_dir).await;
         }

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -681,9 +681,15 @@ async fn stream_command(socket: &mut WebSocket, cmd: &str, args: &[&str]) -> Res
         all_lines.push(line);
     }
 
-    // Wait for reader tasks to finish
-    let _ = stdout_task.await;
-    let _ = stderr_task.await;
+    // Wait for reader tasks to finish. If either panics (BufReader,
+    // channel send, line decode), the deployment status the user sees
+    // is missing the tail of docker output — log so it's debuggable.
+    if let Err(e) = stdout_task.await {
+        tracing::warn!("compose stdout reader task panicked / cancelled: {e}");
+    }
+    if let Err(e) = stderr_task.await {
+        tracing::warn!("compose stderr reader task panicked / cancelled: {e}");
+    }
 
     let status = child.wait().await.map_err(|e| e.to_string())?;
 

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -350,9 +350,15 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
         return;
     }
 
-    // Write .env
+    // Write .env. Failure here is non-fatal for `docker compose` (it
+    // falls back to the project name from --project-name) but it can
+    // mask why a `${COMPOSE_PROJECT_NAME}` interpolation came back
+    // empty in user-supplied YAML — log so it's debuggable.
     let env_content = format!("COMPOSE_PROJECT_NAME={}\n", req.name);
-    let _ = tokio::fs::write(format!("{}/.env", compose_dir), &env_content).await;
+    let env_path = format!("{}/.env", compose_dir);
+    if let Err(e) = tokio::fs::write(&env_path, &env_content).await {
+        tracing::warn!("compose .env write to {env_path} failed: {e}");
+    }
 
     // Validate
     let _ = socket

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -432,8 +432,17 @@ async fn upload_vm_image_handler(
         }
     };
 
-    // Get or create the images subvolume
-    let filesystems = state.filesystems.list().await.unwrap_or_default();
+    // Get or create the images subvolume. If list() fails (corrupt state,
+    // permissions) we fall back to an empty set so the upload returns a
+    // user-friendly "no filesystem" error instead of crashing — but we log
+    // the underlying failure so it's debuggable.
+    let filesystems = match state.filesystems.list().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("VM image upload: filesystems.list() failed: {e}");
+            Vec::new()
+        }
+    };
     let fs_name = filesystems
         .first()
         .map(|f| f.name.clone())

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -228,14 +228,31 @@ async fn main() -> anyhow::Result<()> {
     state.system.info().await;
     info!("Caches warm in {}ms", t0.elapsed().as_millis());
 
-    // Check ACME cert renewal on startup and daily thereafter
-    tokio::spawn(async {
+    // Check ACME cert renewal on startup and daily thereafter. The
+    // observer spawn logs if the loop ever exits — either cleanly
+    // (which would be a bug; this loop is meant to run forever) or
+    // with a panic (which would silently kill cert renewal until the
+    // next engine restart, with no log connecting "my cert expired"
+    // to the original failure).
+    let acme_loop = tokio::spawn(async {
         nasty_system::settings::check_acme_renewal().await;
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
         interval.tick().await; // skip first immediate tick
         loop {
             interval.tick().await;
             nasty_system::settings::check_acme_renewal().await;
+        }
+    });
+    tokio::spawn(async move {
+        match acme_loop.await {
+            Ok(()) => tracing::error!(
+                "ACME renewal loop exited unexpectedly — cert renewal will not happen \
+                 until next engine restart"
+            ),
+            Err(e) => tracing::error!(
+                "ACME renewal loop panicked / cancelled: {e} — cert renewal will not \
+                 happen until next engine restart"
+            ),
         }
     });
 
@@ -1981,7 +1998,7 @@ async fn wait_for_auth(
 // ── Background Alert Notifier ──────────────────────────────────
 
 fn spawn_alert_notifier(state: Arc<AppState>) {
-    tokio::spawn(async move {
+    let h = tokio::spawn(async move {
         use nasty_system::notifications;
         use std::collections::HashSet;
 
@@ -2037,6 +2054,21 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
             }
 
             previously_active = current_keys;
+        }
+    });
+    // Observer spawn — alert evaluation is supposed to run forever; if
+    // the loop dies, notifications stop entirely with no log line
+    // connecting "I never got a disk-full alert" to the underlying bug.
+    tokio::spawn(async move {
+        match h.await {
+            Ok(()) => tracing::error!(
+                "alert notifier loop exited unexpectedly — no further notifications \
+                 will fire until engine restart"
+            ),
+            Err(e) => tracing::error!(
+                "alert notifier loop panicked / cancelled: {e} — no further \
+                 notifications will fire until engine restart"
+            ),
         }
     });
 }

--- a/engine/nasty-engine/src/router/backup.rs
+++ b/engine/nasty-engine/src/router/backup.rs
@@ -65,10 +65,16 @@ pub(super) async fn try_route(
                 Ok(s) => s.to_string(),
                 Err(r) => return Some(r),
             };
-            // Run in background, return immediately
+            // Run in background, return immediately. The RPC ack is just
+            // "we accepted the request" — the actual backup status lands
+            // in the journal, with a per-backup-id error so the user can
+            // grep for *which* backup failed.
             let backups = state.backups.clone_for_task();
+            let id_for_log = id.clone();
             tokio::spawn(async move {
-                let _ = backups.run_backup(&id).await;
+                if let Err(e) = backups.run_backup(&id).await {
+                    tracing::warn!("backup '{id_for_log}' failed: {e}");
+                }
             });
             ok(req, "Backup started")
         }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -477,7 +477,13 @@ pub(super) struct VmImageListResult {
 /// source of truth for what counts as a VM image — including
 /// compressed shapes like `.qcow2.xz`.
 pub(super) async fn list_vm_images(state: &AppState) -> VmImageListResult {
-    let filesystems = state.filesystems.list().await.unwrap_or_default();
+    let filesystems = match state.filesystems.list().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("list_vm_images: filesystems.list() failed: {e}");
+            Vec::new()
+        }
+    };
     let mut images = Vec::new();
     let mut subvolume_exists = false;
 
@@ -882,7 +888,16 @@ pub(crate) async fn evaluate_active_alerts(
             }
         };
 
-    let filesystems = state.filesystems.list().await.unwrap_or_default();
+    let filesystems = match state.filesystems.list().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "alert evaluation: filesystems.list() failed: {e} — \
+                 fs-level alerts will be skipped this cycle"
+            );
+            Vec::new()
+        }
+    };
     let disk_health: Vec<nasty_system::DiskHealth> = if state
         .protocols
         .is_enabled(nasty_system::protocol::Protocol::Smart)
@@ -1012,7 +1027,16 @@ pub(crate) async fn evaluate_active_alerts(
     // by the user drop out entirely.
     let mount_failures = state.mount_failures.lock().await;
     if !mount_failures.is_empty() {
-        let current_fses = state.filesystems.list().await.unwrap_or_default();
+        let current_fses = match state.filesystems.list().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "mount-failure alert enrichment: filesystems.list() failed: {e} — \
+                     using empty fs set, alerts may show stale state"
+                );
+                Vec::new()
+            }
+        };
         for name in mount_failures.iter() {
             let fs = current_fses.iter().find(|f| &f.name == name);
             // Already mounted (user fixed it via UI) — drop the alert.

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -112,11 +112,11 @@ pub(super) async fn try_route(
                 return Some(err(req, format!("write config: {e}")));
             }
 
-            // Restart rest-server to pick up new path
-            let _ = tokio::process::Command::new("systemctl")
-                .args(["restart", "nasty-rest-server"])
-                .output()
-                .await;
+            // Restart rest-server to pick up new path. `try_run` logs
+            // failures so a botched restart (config typo, port collision,
+            // etc.) shows up in the journal even though we don't surface
+            // it on the RPC reply (we already ack'd the path write).
+            nasty_common::cmd::try_run("systemctl", &["restart", "nasty-rest-server"]).await;
 
             ok(req, "ok")
         }

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -60,16 +60,24 @@ pub(super) async fn try_route(
                 .as_ref()
                 .and_then(|p| p.get("iqn_prefix"))
                 .and_then(|v| v.as_str())
+                && let Err(e) =
+                    tokio::fs::write("/var/lib/nasty/iscsi-base-iqn", iqn.trim()).await
             {
-                let _ = tokio::fs::write("/var/lib/nasty/iscsi-base-iqn", iqn.trim()).await;
+                // Non-fatal — the engine still has the value in memory
+                // — but at restart it'll fall back to the default IQN,
+                // which is confusing if the user just configured a
+                // custom one.
+                tracing::warn!("persist iscsi base IQN failed: {e}");
             }
             if let Some(nqn) = req
                 .params
                 .as_ref()
                 .and_then(|p| p.get("nqn_prefix"))
                 .and_then(|v| v.as_str())
+                && let Err(e) =
+                    tokio::fs::write("/var/lib/nasty/nvmeof-base-nqn", nqn.trim()).await
             {
-                let _ = tokio::fs::write("/var/lib/nasty/nvmeof-base-nqn", nqn.trim()).await;
+                tracing::warn!("persist nvmeof base NQN failed: {e}");
             }
             ok(req, "ok")
         }

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -111,7 +111,14 @@ pub(super) async fn try_route(
                     metadata_target: None,
                     data_replicas: None,
                 };
-                let _ = state.subvolumes.create(create_req, None).await;
+                if let Err(e) = state.subvolumes.create(create_req, None).await {
+                    // Without this log, the path write below succeeds
+                    // but the subvolume actually doesn't exist —
+                    // rest-server then refuses to start with a confusing
+                    // "no such file" error and the user has nothing to
+                    // tie the two together.
+                    tracing::warn!("rest-server storage subvolume create failed: {e}");
+                }
             }
 
             if let Err(e) = tokio::fs::write("/var/lib/nasty/rest-server-path", &path).await {

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -60,8 +60,7 @@ pub(super) async fn try_route(
                 .as_ref()
                 .and_then(|p| p.get("iqn_prefix"))
                 .and_then(|v| v.as_str())
-                && let Err(e) =
-                    tokio::fs::write("/var/lib/nasty/iscsi-base-iqn", iqn.trim()).await
+                && let Err(e) = tokio::fs::write("/var/lib/nasty/iscsi-base-iqn", iqn.trim()).await
             {
                 // Non-fatal — the engine still has the value in memory
                 // — but at restart it'll fall back to the default IQN,
@@ -74,8 +73,7 @@ pub(super) async fn try_route(
                 .as_ref()
                 .and_then(|p| p.get("nqn_prefix"))
                 .and_then(|v| v.as_str())
-                && let Err(e) =
-                    tokio::fs::write("/var/lib/nasty/nvmeof-base-nqn", nqn.trim()).await
+                && let Err(e) = tokio::fs::write("/var/lib/nasty/nvmeof-base-nqn", nqn.trim()).await
             {
                 tracing::warn!("persist nvmeof base NQN failed: {e}");
             }

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -270,16 +270,22 @@ pub(super) async fn try_route(
                                     let nvmeof = state.nvmeof.clone();
                                     let id = v.id.clone();
                                     let ip = ip.clone();
+                                    let nqn_for_log = v.nqn.clone();
                                     tokio::spawn(async move {
-                                        let _ = nvmeof
+                                        if let Err(e) = nvmeof
                                             .add_port(nasty_sharing::nvmeof::AddPortRequest {
                                                 subsystem_id: id,
                                                 transport: Some("tcp".to_string()),
-                                                addr: Some(ip),
+                                                addr: Some(ip.clone()),
                                                 service_id: Some(4420),
                                                 addr_family: Some("ipv4".to_string()),
                                             })
-                                            .await;
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                "auto-add Tailscale port for '{nqn_for_log}' on {ip} failed: {e}"
+                                            );
+                                        }
                                     });
                                 }
                             }

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -159,15 +159,11 @@ pub(super) async fn try_route(
                 if let Err(e) = tokio::fs::write("/root/.ssh/authorized_keys", &existing).await {
                     return Some(err(req, format!("write authorized_keys: {e}")));
                 }
-                // Set permissions
-                let _ = tokio::process::Command::new("chmod")
-                    .args(["600", "/root/.ssh/authorized_keys"])
-                    .status()
-                    .await;
-                let _ = tokio::process::Command::new("chmod")
-                    .args(["700", "/root/.ssh"])
-                    .status()
-                    .await;
+                // Set permissions. `try_run` logs failures so a chmod
+                // that silently doesn't take effect (and would later
+                // cause sshd to refuse the key) shows up in the journal.
+                nasty_common::cmd::try_run("chmod", &["600", "/root/.ssh/authorized_keys"]).await;
+                nasty_common::cmd::try_run("chmod", &["700", "/root/.ssh"]).await;
             }
             ok(req, "Key added")
         }
@@ -223,10 +219,7 @@ pub(super) async fn try_route(
             {
                 tracing::warn!("Failed to write sshd override: {e}");
             }
-            let _ = tokio::process::Command::new("systemctl")
-                .args(["reload", "sshd"])
-                .status()
-                .await;
+            nasty_common::cmd::try_run("systemctl", &["reload", "sshd"]).await;
             ok(
                 req,
                 format!(

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -379,12 +379,23 @@ pub(super) async fn try_route(
         "system.tailscale.connect" => match parse_params(req) {
             Ok(p) => match state.tailscale.connect(p).await {
                 Ok(v) => {
-                    // Sync NVMe-oF ports for the new Tailscale IP
+                    // Sync NVMe-oF ports for the new Tailscale IP.
+                    // ensure_tailscale_ports() logs per-subsystem
+                    // failures internally with warn!; the observer
+                    // here logs the spawn-panic case so a missed
+                    // port-sync isn't completely silent.
                     if let Some(ref ip) = v.ip {
                         let nvmeof = state.nvmeof.clone();
                         let ip = ip.clone();
-                        tokio::spawn(async move {
+                        let h = tokio::spawn(async move {
                             nvmeof.ensure_tailscale_ports(&ip).await;
+                        });
+                        tokio::spawn(async move {
+                            if let Err(e) = h.await {
+                                tracing::warn!(
+                                    "tailscale-connect: ensure_tailscale_ports task panicked / cancelled: {e}"
+                                );
+                            }
                         });
                     }
                     ok(req, v)

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -146,7 +146,9 @@ pub(super) async fn try_route(
                     "Invalid SSH public key — must start with ssh-rsa, ssh-ed25519, etc.",
                 ));
             }
-            let _ = tokio::fs::create_dir_all("/root/.ssh").await;
+            if let Err(e) = tokio::fs::create_dir_all("/root/.ssh").await {
+                tracing::warn!("create_dir_all(/root/.ssh) failed: {e}");
+            }
             let mut existing = tokio::fs::read_to_string("/root/.ssh/authorized_keys")
                 .await
                 .unwrap_or_default();
@@ -397,7 +399,16 @@ pub(super) async fn try_route(
                 // (Tailscale IPs are in the 100.x.y.z range)
                 let nvmeof = state.nvmeof.clone();
                 tokio::spawn(async move {
-                    let subsystems = nvmeof.list().await.unwrap_or_default();
+                    let subsystems = match nvmeof.list().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(
+                                "tailscale-disconnect cleanup: nvmeof.list() failed, \
+                                 leaving any 100.x ports orphaned: {e}"
+                            );
+                            return;
+                        }
+                    };
                     for subsys in &subsystems {
                         for port in &subsys.ports {
                             if port.addr.starts_with("100.") {

--- a/engine/nasty-engine/src/telemetry.rs
+++ b/engine/nasty-engine/src/telemetry.rs
@@ -116,7 +116,7 @@ pub async fn send_report(state: &AppState) -> bool {
 
 /// Spawn the daily telemetry background task.
 pub fn spawn_daily(state: Arc<AppState>) {
-    tokio::spawn(async move {
+    let h = tokio::spawn(async move {
         // Random initial delay (0-24h) to spread load across instances
         let jitter = rand::rng().random_range(0..TELEMETRY_INTERVAL.as_secs());
         debug!("Telemetry: first report in {}s", jitter);
@@ -126,6 +126,15 @@ pub fn spawn_daily(state: Arc<AppState>) {
         loop {
             ticker.tick().await;
             send_report(&state).await;
+        }
+    });
+    // Observer spawn — telemetry loop is supposed to run forever; if
+    // it exits (cleanly or by panic) we want a single log line so the
+    // user can see why telemetry stopped reporting.
+    tokio::spawn(async move {
+        match h.await {
+            Ok(()) => tracing::warn!("telemetry loop exited unexpectedly"),
+            Err(e) => tracing::warn!("telemetry loop panicked / cancelled: {e}"),
         }
     });
 }

--- a/engine/nasty-metrics/src/main.rs
+++ b/engine/nasty-metrics/src/main.rs
@@ -222,9 +222,16 @@ async fn disk_collector(state: Arc<AppState>) {
 /// bcachefs metrics collector: samples every 5s.
 async fn bcachefs_collector(state: Arc<AppState>) {
     loop {
-        let metrics = tokio::task::spawn_blocking(collect_bcachefs::collect_all)
-            .await
-            .unwrap_or_default();
+        let metrics = match tokio::task::spawn_blocking(collect_bcachefs::collect_all).await {
+            Ok(v) => v,
+            Err(e) => {
+                // Spawn error means the worker thread panicked or was
+                // cancelled. Without this log the bcachefs panel just
+                // freezes on stale data with no clue why.
+                tracing::warn!("bcachefs collector worker panicked / cancelled: {e}");
+                Default::default()
+            }
+        };
         *state.bcachefs.write().await = metrics;
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     }
@@ -237,9 +244,13 @@ async fn kernel_error_collector(state: Arc<AppState>) {
     ));
     loop {
         let c = collector.clone();
-        let summary = tokio::task::spawn_blocking(move || c.lock().unwrap().collect())
-            .await
-            .unwrap_or_default();
+        let summary = match tokio::task::spawn_blocking(move || c.lock().unwrap().collect()).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("kernel error collector worker panicked / cancelled: {e}");
+                Default::default()
+            }
+        };
         *state.kernel_errors.write().await = summary;
         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
     }

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -774,7 +774,12 @@ async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
     if changed {
         match serde_json::to_string_pretty(&json) {
             Ok(out) => {
-                let _ = tokio::fs::write(SAVECONFIG, out).await;
+                if let Err(e) = tokio::fs::write(SAVECONFIG, out).await {
+                    // The patched config exists in memory but won't survive
+                    // a restart — log so a "iSCSI config keeps reverting"
+                    // bug is debuggable from a single message.
+                    warn!("write patched saveconfig to {SAVECONFIG} failed: {e}");
+                }
             }
             Err(e) => warn!("Failed to serialize patched saveconfig.json: {e}"),
         }

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -357,10 +357,7 @@ async fn write_share_conf(share: &SmbShare) -> Result<(), SmbError> {
     // (valid_users, guest ok, etc.) — filesystem permissions should be permissive.
     // Using chown with usernames fails when the user only exists in Samba's
     // database (pdbedit) but not as a UNIX system user.
-    let _ = tokio::process::Command::new("chmod")
-        .args(["0777", &share.path])
-        .output()
-        .await;
+    nasty_common::cmd::try_run("chmod", &["0777", &share.path]).await;
 
     Ok(())
 }
@@ -528,11 +525,9 @@ impl SmbService {
 
     /// Delete a Linux system user and remove their Samba password.
     pub async fn delete_user(&self, username: &str) -> Result<(), SmbError> {
-        // Remove Samba password
-        let _ = tokio::process::Command::new("smbpasswd")
-            .args(["-x", username])
-            .output()
-            .await;
+        // Remove Samba password. `try_run` logs failures so a stale
+        // pdbedit entry that survives a "delete user" is debuggable.
+        nasty_common::cmd::try_run("smbpasswd", &["-x", username]).await;
 
         // Delete system user
         let output = tokio::process::Command::new("userdel")

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -595,6 +595,8 @@ impl FilesystemService {
                 None => continue,
             };
 
+            // None falls through to (0, 0, 0). The cause is logged inside
+            // get_mount_usage itself so we don't need to match here.
             let (total, used, available) = get_mount_usage(mount_point).await.unwrap_or((0, 0, 0));
 
             let name = Path::new(mount_point)
@@ -997,6 +999,7 @@ impl FilesystemService {
         saved_opts.uuid = Some(uuid.clone());
         saved_opts.devices = req.devices.iter().map(|d| d.path.clone()).collect();
         save_fs_mounted_with_opts(&req.name, saved_opts).await;
+        // Logged inside get_mount_usage on failure.
         let (total, used, available) = get_mount_usage(&mount_point).await.unwrap_or((0, 0, 0));
 
         let fs_devices = req
@@ -1362,7 +1365,14 @@ impl FilesystemService {
                     opts.io_scheduler = Some(v.clone());
                 }
             }
-            let _ = save_fs_state(&state).await;
+            if let Err(e) = save_fs_state(&state).await {
+                // The runtime FS state is updated in memory, but at next
+                // boot we'll fall back to whatever was last persisted —
+                // so user-tweaked mount options silently revert. Log so
+                // the user can match a "my settings keep resetting"
+                // bug to the persistence failure that caused it.
+                warn!("save_fs_state after option update failed: {e}");
+            }
         }
 
         if mount_changed {
@@ -2674,12 +2684,27 @@ async fn get_fs_uuid(device: &str) -> Option<String> {
 
 /// Get filesystem usage via statvfs-style info from `df`
 async fn get_mount_usage(mount_point: &str) -> Option<(u64, u64, u64)> {
-    let output = cmd::run_ok("df", &["-B1", "--output=size,used,avail", mount_point])
-        .await
-        .ok()?;
+    let output = match cmd::run_ok("df", &["-B1", "--output=size,used,avail", mount_point]).await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            // Reporting all-zeros to capacity dashboards on a real query
+            // failure makes the UI lie ("disk empty!" when it's actually
+            // inaccessible). Log so a "0/0/0" reading can be matched to
+            // the underlying df failure.
+            warn!("df --output=size,used,avail {mount_point} failed: {e}");
+            return None;
+        }
+    };
 
-    // Skip header line, parse second line
-    let line = output.lines().nth(1)?;
+    // Skip header line, parse second line.
+    let Some(line) = output.lines().nth(1) else {
+        warn!(
+            "df output for {mount_point} had no second line — got: {:?}",
+            output
+        );
+        return None;
+    };
     let nums: Vec<u64> = line
         .split_whitespace()
         .filter_map(|s| s.parse().ok())
@@ -2687,6 +2712,10 @@ async fn get_mount_usage(mount_point: &str) -> Option<(u64, u64, u64)> {
     if nums.len() == 3 {
         Some((nums[0], nums[1], nums[2]))
     } else {
+        warn!(
+            "df output for {mount_point} didn't parse as 3 u64s — got: {:?}",
+            line
+        );
         None
     }
 }
@@ -2793,21 +2822,46 @@ type FsState = HashMap<String, FsMountOptions>;
 async fn save_fs_mounted_with_opts(fs_name: &str, opts: FsMountOptions) {
     let mut state = load_fs_state().await;
     state.insert(fs_name.to_string(), opts);
-    let _ = save_fs_state(&state).await;
+    if let Err(e) = save_fs_state(&state).await {
+        // The mount itself worked — Linux has the mount in its table —
+        // but next boot won't know to remount this fs. Log so the user
+        // can match a "filesystem isn't mounted after reboot" report
+        // to the persistence error.
+        warn!("save_fs_state(mounted: {fs_name}) failed: {e}");
+    }
 }
 
 async fn save_fs_unmounted(fs_name: &str) {
     let mut state = load_fs_state().await;
     state.remove(fs_name);
-    let _ = save_fs_state(&state).await;
+    if let Err(e) = save_fs_state(&state).await {
+        warn!("save_fs_state(unmounted: {fs_name}) failed: {e}");
+    }
 }
 
 async fn load_fs_state() -> FsState {
     let content = match tokio::fs::read_to_string(FS_STATE_PATH).await {
         Ok(c) => c,
-        Err(_) => return FsState::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return FsState::new(),
+        Err(e) => {
+            // A non-NotFound read error means we *might* be silently
+            // resetting persisted mount state — log so a "filesystems
+            // didn't auto-mount" report can be matched to the real
+            // cause (permissions, IO error, etc.).
+            warn!("read {FS_STATE_PATH} failed: {e} — using empty state");
+            return FsState::new();
+        }
     };
-    serde_json::from_str(&content).unwrap_or_default()
+    match serde_json::from_str(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "parse {FS_STATE_PATH} failed: {e} — file may be corrupt; \
+                 using empty state (mount-option overrides will be lost)"
+            );
+            FsState::new()
+        }
+    }
 }
 
 async fn save_fs_state(state: &FsState) -> Result<(), FilesystemError> {

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -451,10 +451,19 @@ impl FilesystemService {
 
         // Wait for udev to finish device enumeration before any mount attempts.
         info!("Waiting for block devices to settle...");
-        let _ = tokio::process::Command::new("udevadm")
+        match tokio::process::Command::new("udevadm")
             .args(["settle", "--timeout=30"])
             .status()
-            .await;
+            .await
+        {
+            Ok(s) if s.success() => {}
+            Ok(s) => warn!(
+                "udevadm settle exited {s} — proceeding to mount with possibly-incomplete device enumeration"
+            ),
+            Err(e) => warn!(
+                "udevadm settle failed to spawn: {e} — proceeding to mount blind, expect mount failures if devices haven't enumerated"
+            ),
+        }
 
         let mut failed_names = Vec::new();
 
@@ -501,10 +510,21 @@ impl FilesystemService {
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 }
                 // Refresh blkid cache after devices appear
-                let _ = tokio::process::Command::new("blkid")
+                match tokio::process::Command::new("blkid")
                     .arg("-g")
                     .output()
-                    .await;
+                    .await
+                {
+                    Ok(o) if o.status.success() => {}
+                    Ok(o) => warn!(
+                        "blkid -g cache refresh exited {}: {} — mount probe may use a stale cache",
+                        o.status,
+                        String::from_utf8_lossy(&o.stderr).trim()
+                    ),
+                    Err(e) => {
+                        warn!("blkid -g failed to spawn: {e} — mount probe may use a stale cache")
+                    }
+                }
             }
 
             info!("Mounting filesystem '{name}'...");

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1229,16 +1229,19 @@ impl FilesystemService {
     /// Export the stored encryption key for a filesystem.
     pub async fn export_key(&self, name: &str) -> Result<String, FilesystemError> {
         let key_path = format!("{KEYS_DIR}/{name}.key");
-        tokio::fs::read_to_string(&key_path).await.map_err(|_| {
-            FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'"))
+        tokio::fs::read_to_string(&key_path).await.map_err(|e| {
+            // Keep the io::Error kind in the message — "permission denied"
+            // vs "not found" is the difference between a real bug and a
+            // user with no stored key.
+            FilesystemError::CommandFailed(format!("read key for '{name}' at {key_path}: {e}"))
         })
     }
 
     /// Delete the stored encryption key (switch to passphrase-only mode).
     pub async fn delete_key(&self, name: &str) -> Result<(), FilesystemError> {
         let key_path = format!("{KEYS_DIR}/{name}.key");
-        tokio::fs::remove_file(&key_path).await.map_err(|_| {
-            FilesystemError::CommandFailed(format!("no stored key for filesystem '{name}'"))
+        tokio::fs::remove_file(&key_path).await.map_err(|e| {
+            FilesystemError::CommandFailed(format!("delete key for '{name}' at {key_path}: {e}"))
         })
     }
 
@@ -1405,8 +1408,22 @@ impl FilesystemService {
 
     /// List block devices available for filesystem creation
     pub async fn list_devices(&self) -> Result<Vec<BlockDevice>, FilesystemError> {
-        // Collect all device paths already used by filesystems
-        let filesystems = self.list().await.unwrap_or_default();
+        // Collect all device paths already used by filesystems. If list()
+        // fails (corrupt state file, permissions, …) we fall back to an
+        // empty set so the caller still gets *some* answer, but we log
+        // the failure so the operator can see why "available devices"
+        // suddenly includes ones that are actually in use.
+        let filesystems = match self.list().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "list_devices: failed to enumerate existing filesystems ({e}) — \
+                     falling back to empty set; some devices may appear available \
+                     even though they're actually in use"
+                );
+                Vec::new()
+            }
+        };
         let used_devices: std::collections::HashSet<String> = filesystems
             .iter()
             .flat_map(|f| f.devices.iter().map(|d| d.path.clone()))

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2684,8 +2684,7 @@ async fn get_fs_uuid(device: &str) -> Option<String> {
 
 /// Get filesystem usage via statvfs-style info from `df`
 async fn get_mount_usage(mount_point: &str) -> Option<(u64, u64, u64)> {
-    let output = match cmd::run_ok("df", &["-B1", "--output=size,used,avail", mount_point]).await
-    {
+    let output = match cmd::run_ok("df", &["-B1", "--output=size,used,avail", mount_point]).await {
         Ok(o) => o,
         Err(e) => {
             // Reporting all-zeros to capacity dashboards on a real query

--- a/engine/nasty-system/src/firmware.rs
+++ b/engine/nasty-system/src/firmware.rs
@@ -110,11 +110,10 @@ impl FirmwareService {
     /// Check for available firmware updates.
     /// Returns the device list with update info populated.
     pub async fn check_updates(&self) -> Vec<FirmwareDevice> {
-        // First refresh metadata from LVFS
-        let _ = Command::new("fwupdmgr")
-            .args(["refresh", "--force"])
-            .output()
-            .await;
+        // First refresh metadata from LVFS — best-effort. A failure here
+        // means the device list won't have the latest firmware versions
+        // available, which is logged at warn! by `try_run`.
+        nasty_common::cmd::try_run("fwupdmgr", &["refresh", "--force"]).await;
 
         let mut devices = self.list_devices().await;
 

--- a/engine/nasty-system/src/notifications.rs
+++ b/engine/nasty-system/src/notifications.rs
@@ -210,8 +210,12 @@ async fn send_telegram(
         .map_err(|e| format!("telegram request: {e}"))?;
 
     if !resp.status().is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(format!("telegram API error: {body}"));
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
+        return Err(format!("telegram API error {status}: {body}"));
     }
 
     Ok(())
@@ -244,7 +248,10 @@ async fn send_webhook(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
         return Err(format!("webhook error {status}: {body}"));
     }
 
@@ -277,7 +284,10 @@ async fn send_ntfy(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
         return Err(format!("ntfy error {status}: {body}"));
     }
 
@@ -310,7 +320,10 @@ async fn send_signal(
 
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
         return Err(format!("signal API error {status}: {body}"));
     }
 

--- a/engine/nasty-system/src/nut.rs
+++ b/engine/nasty-system/src/nut.rs
@@ -165,7 +165,14 @@ impl NutService {
         if is_nut_running().await {
             // Spawn restart in background — some drivers (nutdrv_qx) take 20-30s
             // to probe USB and we don't want the API call to block/timeout.
-            tokio::spawn(async { restart_nut_services().await });
+            // restart_nut_services() logs per-service errors itself; the spawn
+            // wrapper just guards against a task-panic vanishing into nothing.
+            let h = tokio::spawn(async { restart_nut_services().await });
+            tokio::spawn(async move {
+                if let Err(e) = h.await {
+                    warn!("NUT restart task panicked / cancelled: {e}");
+                }
+            });
         }
 
         Ok(config.clone())
@@ -323,10 +330,19 @@ async fn restart_nut_services() {
         "nut-server.service",
         "nut-driver.service",
     ] {
-        let _ = tokio::process::Command::new("systemctl")
+        match tokio::process::Command::new("systemctl")
             .args(["restart", svc])
             .output()
-            .await;
+            .await
+        {
+            Ok(o) if o.status.success() => {}
+            Ok(o) => warn!(
+                "systemctl restart {svc} exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            ),
+            Err(e) => warn!("systemctl restart {svc} failed to spawn: {e}"),
+        }
     }
 }
 

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -346,9 +346,7 @@ impl ProtocolService {
                 // each one even if one of the stops fails.
                 for started_svc in &started {
                     if let Err(stop_err) = systemctl("stop", started_svc).await {
-                        warn!(
-                            "rollback stop of {started_svc} failed: {stop_err}"
-                        );
+                        warn!("rollback stop of {started_svc} failed: {stop_err}");
                     }
                 }
                 // Roll back persistent state. A failure here means

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -266,7 +266,17 @@ impl ProtocolService {
                 );
                 let mut state = load_state().await;
                 state.set(proto, false);
-                let _ = save_state(&state).await;
+                if let Err(e) = save_state(&state).await {
+                    // The in-memory state shows disabled, but at next
+                    // engine restart we'll re-evaluate from the
+                    // persisted state — so the auto-disable will be
+                    // forgotten and the user will see the protocol
+                    // re-enabling itself.
+                    warn!(
+                        "auto-disable persistence for {} failed: {e}",
+                        proto.display_name()
+                    );
+                }
             }
         }
     }
@@ -330,13 +340,30 @@ impl ProtocolService {
             );
             if let Err(e) = systemctl("start", svc).await {
                 warn!("Failed to start {svc}: {e}");
-                // Roll back: stop any services we already started
+                // Roll back: stop any services we already started.
+                // systemctl() already logs spawn / non-zero failures
+                // internally; this loop just makes sure we attempt
+                // each one even if one of the stops fails.
                 for started_svc in &started {
-                    let _ = systemctl("stop", started_svc).await;
+                    if let Err(stop_err) = systemctl("stop", started_svc).await {
+                        warn!(
+                            "rollback stop of {started_svc} failed: {stop_err}"
+                        );
+                    }
                 }
-                // Roll back persistent state
+                // Roll back persistent state. A failure here means
+                // the protocol stays "enabled" in saved state but the
+                // services aren't actually running — at next engine
+                // start they'll be re-attempted, which is what we want,
+                // but the operator should know the persistence flip
+                // didn't take.
                 state.set(proto, false);
-                let _ = save_state(&state).await;
+                if let Err(save_err) = save_state(&state).await {
+                    warn!(
+                        "rollback persistence for {} failed: {save_err}",
+                        proto.display_name()
+                    );
+                }
                 return Err(format!("Failed to start {}: {e}", proto.display_name()));
             }
             started.push(*svc);

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -327,7 +327,15 @@ impl SettingsService {
             let name = name.trim().to_string();
             if !name.is_empty() {
                 settings.hostname = Some(name);
-                let _ = save(&settings).await;
+                if let Err(e) = save(&settings).await {
+                    // The in-memory hostname is set so the running engine
+                    // sees it correctly, but at next startup we'll re-seed
+                    // from /proc — which is fine on a normal box, but on
+                    // a host where /proc/sys/kernel/hostname diverges
+                    // from the persisted name (e.g., systemd hostnamed
+                    // race) we'd silently lose the saved value.
+                    warn!("seed-hostname save failed: {e}");
+                }
             }
         }
         Self {

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -663,10 +663,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             "Stopping web server for TLS challenge...",
             Some(domain),
         );
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", "nginx"])
-            .output()
-            .await;
+        nasty_common::cmd::try_run("systemctl", &["stop", "nginx"]).await;
     }
 
     if settings.tls_challenge_type == "dns" {
@@ -746,10 +743,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     // ALWAYS restart nginx, regardless of lego success/failure
     if need_nginx_stop {
         set_acme_status("running", "Restarting web server...", Some(domain));
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["start", "nginx"])
-            .output()
-            .await;
+        nasty_common::cmd::try_run("systemctl", &["start", "nginx"]).await;
     }
 
     let (exit_status, stderr_lines) = lego_result?;
@@ -785,11 +779,11 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     // Set permissions so nginx (running as nginx user) can read the cert
     let _ = tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await;
     let _ = tokio::fs::set_permissions(TLS_KEY_PATH, std::fs::Permissions::from_mode(0o640)).await;
-    // Set key group to nginx so it can read it
-    let _ = tokio::process::Command::new("chown")
-        .args(["root:nginx", TLS_KEY_PATH])
-        .output()
-        .await;
+    // Set key group to nginx so it can read it. `try_run` logs failures
+    // — a chown failure here means nginx can't read the cert and reload
+    // will surface that as a "permission denied" anyway, but logging the
+    // chown error directly makes the chain easier to follow.
+    nasty_common::cmd::try_run("chown", &["root:nginx", TLS_KEY_PATH]).await;
 
     // Reload nginx to pick up the new certificate
     let reload = tokio::process::Command::new("systemctl")

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -776,9 +776,19 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             m
         })?;
 
-    // Set permissions so nginx (running as nginx user) can read the cert
-    let _ = tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await;
-    let _ = tokio::fs::set_permissions(TLS_KEY_PATH, std::fs::Permissions::from_mode(0o640)).await;
+    // Set permissions so nginx (running as nginx user) can read the cert.
+    // A failure here means nginx will hit "permission denied" on reload,
+    // which is way easier to diagnose with this log line in front of it.
+    if let Err(e) =
+        tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await
+    {
+        warn!("chmod 644 {TLS_CERT_PATH} failed: {e}");
+    }
+    if let Err(e) =
+        tokio::fs::set_permissions(TLS_KEY_PATH, std::fs::Permissions::from_mode(0o640)).await
+    {
+        warn!("chmod 640 {TLS_KEY_PATH} failed: {e}");
+    }
     // Set key group to nginx so it can read it. `try_run` logs failures
     // — a chown failure here means nginx can't read the cert and reload
     // will surface that as a "permission denied" anyway, but logging the
@@ -886,8 +896,14 @@ async fn write_dns_credentials(settings: &Settings) {
             warn!("Failed to write DNS credentials: {e}");
             return;
         }
-        let _ = tokio::fs::set_permissions(DNS_CREDS_PATH, std::fs::Permissions::from_mode(0o600))
-            .await;
+        if let Err(e) =
+            tokio::fs::set_permissions(DNS_CREDS_PATH, std::fs::Permissions::from_mode(0o600)).await
+        {
+            warn!(
+                "chmod 600 {DNS_CREDS_PATH} failed: {e} — \
+                 DNS provider credentials may be world-readable"
+            );
+        }
     }
 }
 

--- a/engine/nasty-system/src/tuning.rs
+++ b/engine/nasty-system/src/tuning.rs
@@ -408,8 +408,15 @@ async fn apply_iscsi_cmdsn_depth(depth: u32) -> Result<(), String> {
                     continue;
                 }
                 let attr_path = tpg.path().join("attrib/default_cmdsn_depth");
-                if attr_path.exists() {
-                    let _ = tokio::fs::write(&attr_path, depth.to_string()).await;
+                if attr_path.exists()
+                    && let Err(e) = tokio::fs::write(&attr_path, depth.to_string()).await
+                {
+                    // sysfs writes are typically EACCES (kernel says no
+                    // for this attribute) or EBUSY (target is in use).
+                    // Either way, the value won't take effect — log so
+                    // the user isn't left wondering why their tuning
+                    // didn't apply.
+                    warn!("write {} = {depth} failed: {e}", attr_path.display());
                 }
             }
         }
@@ -442,8 +449,10 @@ async fn apply_iscsi_login_timeout(timeout: u32) -> Result<(), String> {
                     continue;
                 }
                 let attr_path = tpg.path().join("param/login_timeout");
-                if attr_path.exists() {
-                    let _ = tokio::fs::write(&attr_path, timeout.to_string()).await;
+                if attr_path.exists()
+                    && let Err(e) = tokio::fs::write(&attr_path, timeout.to_string()).await
+                {
+                    warn!("write {} = {timeout} failed: {e}", attr_path.display());
                 }
             }
         }

--- a/engine/nasty-system/src/tuning.rs
+++ b/engine/nasty-system/src/tuning.rs
@@ -372,11 +372,10 @@ async fn apply_smb_tuning(config: &TuningConfig) -> Result<(), String> {
         .await
         .map_err(|e| format!("failed to write {SMB_TUNING_CONF}: {e}"))?;
 
-    // Reload Samba config (non-fatal if smbd isn't running)
-    let _ = tokio::process::Command::new("smbcontrol")
-        .args(["smbd", "reload-config"])
-        .output()
-        .await;
+    // Reload Samba config (non-fatal if smbd isn't running). `try_run`
+    // logs the "smbd not running" error at warn! so we still see it in
+    // the journal if reload was actually expected to take effect.
+    nasty_common::cmd::try_run("smbcontrol", &["smbd", "reload-config"]).await;
 
     info!("SMB tuning config written and reload requested");
     Ok(())

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -360,14 +360,11 @@ impl UpdateService {
             )?
         };
 
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["reset-failed", UPDATE_UNIT])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", UPDATE_UNIT])
-            .output()
-            .await;
+        // Best-effort cleanup of any prior unit state. `try_run` logs spawn
+        // failures and non-zero exits at warn! — a missing-unit "exited 5"
+        // shows up in the journal but doesn't propagate.
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", UPDATE_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", UPDATE_UNIT]).await;
 
         let flake_temp_path = "/tmp/nasty-upgrade-flake.nix";
         tokio::fs::write(flake_temp_path, &next_flake)
@@ -572,14 +569,11 @@ echo "==> Update complete!"
         }
 
         // Clean up any previous update unit
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["reset-failed", UPDATE_UNIT])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", UPDATE_UNIT])
-            .output()
-            .await;
+        // Best-effort cleanup of any prior unit state. `try_run` logs spawn
+        // failures and non-zero exits at warn! — a missing-unit "exited 5"
+        // shows up in the journal but doesn't propagate.
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", UPDATE_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", UPDATE_UNIT]).await;
 
         // Build the update script:
         // 1. Update the local wrapper flake inputs (channel-specific:
@@ -798,14 +792,11 @@ echo "==> Update complete!"
             ));
         }
 
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["reset-failed", UPDATE_UNIT])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", UPDATE_UNIT])
-            .output()
-            .await;
+        // Best-effort cleanup of any prior unit state. `try_run` logs spawn
+        // failures and non-zero exits at warn! — a missing-unit "exited 5"
+        // shows up in the journal but doesn't propagate.
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", UPDATE_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", UPDATE_UNIT]).await;
 
         let flake_path = format!("{NIXOS_FLAKE_DIR}/flake.nix");
         let current_flake = tokio::fs::read_to_string(&flake_path)
@@ -1009,14 +1000,11 @@ echo "==> Update complete!"
             return Err(UpdateError::AlreadyRunning);
         }
 
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["reset-failed", UPDATE_UNIT])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", UPDATE_UNIT])
-            .output()
-            .await;
+        // Best-effort cleanup of any prior unit state. `try_run` logs spawn
+        // failures and non-zero exits at warn! — a missing-unit "exited 5"
+        // shows up in the journal but doesn't propagate.
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", UPDATE_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", UPDATE_UNIT]).await;
 
         let path = std::env::var("PATH").unwrap_or_default();
         let output = tokio::process::Command::new("systemd-run")
@@ -1176,14 +1164,11 @@ echo "==> Update complete!"
             )));
         }
 
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["reset-failed", UPDATE_UNIT])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("systemctl")
-            .args(["stop", UPDATE_UNIT])
-            .output()
-            .await;
+        // Best-effort cleanup of any prior unit state. `try_run` logs spawn
+        // failures and non-zero exits at warn! — a missing-unit "exited 5"
+        // shows up in the journal but doesn't propagate.
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", UPDATE_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", UPDATE_UNIT]).await;
 
         let path = std::env::var("PATH").unwrap_or_default();
         let script = format!(

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1243,8 +1243,13 @@ echo "==> Switch to generation {gen_id} complete!"
         let profile_link = format!("/nix/var/nix/profiles/system-{gen_id}-link");
         let current_link = "/nix/var/nix/profiles/system";
 
-        let gen_target = tokio::fs::read_link(&profile_link).await.map_err(|_| {
-            UpdateError::CommandFailed(format!("generation {gen_id} does not exist"))
+        let gen_target = tokio::fs::read_link(&profile_link).await.map_err(|e| {
+            // Keep the io::Error in the message — "permission denied" or
+            // any other failure mode shouldn't be misreported as "doesn't
+            // exist" (that drove a debug-cycle once already).
+            UpdateError::CommandFailed(format!(
+                "generation {gen_id}: read_link({profile_link}): {e}"
+            ))
         })?;
         let current_target = tokio::fs::read_link(current_link)
             .await

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Primary version path — writable by the update script, not managed by NixOS.
 const VERSION_PATH: &str = "/var/lib/nasty/version";
@@ -1275,10 +1275,15 @@ echo "==> Switch to generation {gen_id} complete!"
             UpdateError::CommandFailed(format!("failed to remove generation {gen_id}: {e}"))
         })?;
 
-        // Clean up the label if any
+        // Clean up the label if any. A persistence failure here
+        // leaves a stale label pointing at a deleted generation —
+        // surface it so the user can match a "phantom label" report
+        // to the underlying save error.
         let mut labels = load_generation_labels().await;
-        if labels.remove(&gen_id).is_some() {
-            let _ = save_generation_labels(&labels).await;
+        if labels.remove(&gen_id).is_some()
+            && let Err(e) = save_generation_labels(&labels).await
+        {
+            warn!("save_generation_labels after delete of gen {gen_id} failed: {e}");
         }
 
         info!("Deleted generation {gen_id}");

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -801,12 +801,12 @@ impl VmService {
         let qmp_path = qmp_socket_path(id);
         let _ = qmp::execute(&qmp_path, "quit", None).await;
 
-        // If QMP quit didn't work, try killing by PID
+        // If QMP quit didn't work, try killing by PID. `try_run` logs
+        // a kill failure (e.g. PID already gone, EPERM) — useful when
+        // a VM "won't stop" reproduces and we want to know why kill -9
+        // didn't take effect.
         if let Some(pid) = self.get_pid(id).await {
-            let _ = Command::new("kill")
-                .args(["-9", &pid.to_string()])
-                .output()
-                .await;
+            nasty_common::cmd::try_run("kill", &["-9", &pid.to_string()]).await;
         }
 
         // Clean up socket files


### PR DESCRIPTION
## Why

Discussion #159 took **four PRs** (#197 → #198 → #199 → #200) to land because the engine was swallowing per-connection NetworkManager errors. Each fix had to start with a *\"ship visibility patch and ask the reporter to retry\"* round-trip. The audit that followed found the same anti-pattern in 100+ other places — all silent today, all latent #159s waiting to happen the first time the right environment hits them.

This PR is the systemic fix: **every operation now logs enough that a failure can be diagnosed from the journal alone**, plus a workspace-wide helper that makes the right pattern the easy one.

## What's in here

### New: \`nasty_common::cmd::{run, run_ok, try_run}\`
Workspace-wide subprocess helpers that **always** log spawn failures and non-zero exits at \`warn!\`. Four unit tests pin every behavior (success / non-zero exit / spawn failure / missing binary).

### New: \`CONTRIBUTING.md\`
Documents the rule for future contributors with right-vs-wrong patterns side-by-side:
- which helper to use when
- patterns to avoid (\`let _ =\`, \`if let Ok\` w/o else, error erasure via \`.map_err(|_| \"static\")\`)
- the aggregate-error-collapse trap from #197 with the fix shown

### Six audit sweeps
1. **f6f9b87** — 26 bare \`let _ = Command::new(...)\` callsites migrated to \`try_run\` (11 files).
2. **c58a248** — Spawned tasks losing \`Result\` errors (router/share, router/backup, router/system Tailscale-disconnect cleanup); \`unwrap_or_default()\` on important \`list()\` calls; \`.map_err(|_| static)\` erasure (Docker socket, key file ops, update read_link, notification body reads); \`tokio::fs\` ops in non-cleanup paths; Apps Docker bootstrap timeout context.
3. **481845d** — Verifier-found: metrics collector \`JoinError\` lost on panic; persisted-state \`save_fs_state\` failures; corruption-recovery logging in \`apps/load_config\` and \`load_fs_state\`; \`get_mount_usage\` internal logging; compose manifest discovery silent skip; ingress-remove orphan entries.
4. **18e23a2** — Long-running spawn loops (ACME renewal, telemetry, alert notifier) gain observer-spawn pattern that logs both clean exit and panic; app deploy reader-task \`JoinError\` joins log on panic.
5. **d5ba2b3** — Final tailscale.connect NVMe-oF spawn observer.
6. **0ca4539** — Persisted-state failures + service rollback (rest-server subvolume create, hostname-seed save, protocol auto-disable / rollback, generation-label cleanup).

## Verified

- \`cargo fmt --check\` clean
- \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` clean
- \`cargo test --workspace\` — **332 tests pass**, including 4 new ones in \`nasty_common::cmd\`
- Verifier agent: \"no HIGH-severity sites remain — safe to stop and ship\"

## Deferred (intentional)

- **WebSocket / channel sends** where receiver-disconnect is the expected shutdown signal — per CONTRIBUTING.md, legit.
- **\`tokio::fs::remove_file\` / \`remove_dir_all\` cleanup paths** — same.
- **The ~106 direct \`Command::new\` callsites that already match Ok/Err properly** — they're fine; will be migrated opportunistically as surrounding code is touched.
- **Clippy \`disallowed-methods\` lint** forbidding future raw \`Command::new\` — needs all remaining sites migrated first to avoid \`#[allow]\` spam. Future follow-up.

## Test plan

- [x] Unit tests for \`nasty_common::cmd\` (4 new tests).
- [x] Full \`cargo test --workspace\` green (332 tests).
- [x] Full \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` green.
- [ ] Smoke test the apps install path (logged-error coverage on docker bootstrap timeout).
- [ ] Trigger a failed bond-create with bad NM config; confirm \`apply_config\` per-connection error reaches the journal (regression coverage for #197 class of bug).