### PR TITLE
webui: validate IP/CIDR fields in network form before submit

### DIFF
--- a/webui/src/lib/network.test.ts
+++ b/webui/src/lib/network.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { findOrphanInterfaces, promoteOrphanedMembers, stripInterfaces } from './network';
+import {
+	findOrphanInterfaces,
+	promoteOrphanedMembers,
+	stripInterfaces,
+	validateDnsServer,
+	validateIpv4Address,
+	validateIpv4Cidr,
+	validateIpv6Address,
+	validateIpv6Cidr,
+} from './network';
 import type {
 	BondConfig,
 	BridgeConfig,
@@ -236,5 +245,134 @@ describe('stripInterfaces', () => {
 		// Tolerant: a stale ref shouldn't make us throw.
 		const net = emptyNet({ interfaces: [iface('eth0')] });
 		expect(stripInterfaces(net, ['ghost']).map((i) => i.name)).toEqual(['eth0']);
+	});
+});
+
+describe('validateIpv4Cidr', () => {
+	it('accepts canonical addresses with valid prefixes', () => {
+		expect(validateIpv4Cidr('192.168.1.10/24')).toBeNull();
+		expect(validateIpv4Cidr('10.0.0.1/8')).toBeNull();
+		expect(validateIpv4Cidr('0.0.0.0/0')).toBeNull();
+		expect(validateIpv4Cidr('255.255.255.255/32')).toBeNull();
+	});
+
+	it('treats empty string as null (caller decides if required)', () => {
+		// The form has multiple optional address rows; an empty one is
+		// fine — it just gets filtered out before submit.
+		expect(validateIpv4Cidr('')).toBeNull();
+		expect(validateIpv4Cidr('   ')).toBeNull();
+	});
+
+	it('flags missing CIDR prefix — the discussion #159 trigger case', () => {
+		// The exact mistake HuxyUK reported: pasted an IP, forgot the
+		// netmask, got a server-side error. The hint mentions the
+		// suggested form so the fix is obvious.
+		const err = validateIpv4Cidr('192.168.1.10');
+		expect(err).toMatch(/CIDR prefix/);
+		expect(err).toContain('/24');
+	});
+
+	it('rejects out-of-range octets', () => {
+		expect(validateIpv4Cidr('256.0.0.1/24')).toBeTruthy();
+		expect(validateIpv4Cidr('192.168.300.1/24')).toBeTruthy();
+	});
+
+	it('rejects out-of-range CIDR prefixes', () => {
+		expect(validateIpv4Cidr('192.168.1.10/33')).toMatch(/0-32/);
+		expect(validateIpv4Cidr('192.168.1.10/-1')).toBeTruthy();
+	});
+
+	it('rejects leading-zero octets (often-typoed, ambiguous)', () => {
+		// Some libraries treat "001" as octal; rejecting it both
+		// avoids the ambiguity and catches a common typo.
+		expect(validateIpv4Cidr('192.168.001.1/24')).toBeTruthy();
+	});
+
+	it('rejects garbage and partial addresses', () => {
+		expect(validateIpv4Cidr('not.an.ip.address/24')).toBeTruthy();
+		expect(validateIpv4Cidr('192.168.1/24')).toBeTruthy();
+		expect(validateIpv4Cidr('192.168.1.1.1/24')).toBeTruthy();
+		expect(validateIpv4Cidr('/24')).toBeTruthy();
+	});
+});
+
+describe('validateIpv6Cidr', () => {
+	it('accepts canonical addresses with valid prefixes', () => {
+		expect(validateIpv6Cidr('fd00::1/64')).toBeNull();
+		expect(validateIpv6Cidr('2001:db8::/32')).toBeNull();
+		expect(validateIpv6Cidr('::1/128')).toBeNull();
+		expect(validateIpv6Cidr('::/0')).toBeNull();
+		expect(validateIpv6Cidr(
+			'2001:0db8:85a3:0000:0000:8a2e:0370:7334/64',
+		)).toBeNull();
+	});
+
+	it('flags missing CIDR prefix', () => {
+		const err = validateIpv6Cidr('fd00::1');
+		expect(err).toMatch(/CIDR prefix/);
+		expect(err).toContain('/64');
+	});
+
+	it('rejects multiple :: compression markers', () => {
+		expect(validateIpv6Cidr('fd00::1::2/64')).toBeTruthy();
+	});
+
+	it('rejects out-of-range CIDR prefixes', () => {
+		expect(validateIpv6Cidr('fd00::1/129')).toMatch(/0-128/);
+	});
+
+	it('rejects garbage groups', () => {
+		expect(validateIpv6Cidr('xyzz::1/64')).toBeTruthy();
+		expect(validateIpv6Cidr('fd00:::1/64')).toBeTruthy();
+		expect(validateIpv6Cidr('fd00:1:2:3:4:5:6:7:8/64')).toBeTruthy();
+	});
+});
+
+describe('validateIpv4Address (no CIDR — gateway + DNS)', () => {
+	it('accepts canonical addresses', () => {
+		expect(validateIpv4Address('192.168.1.1')).toBeNull();
+		expect(validateIpv4Address('1.1.1.1')).toBeNull();
+	});
+
+	it('rejects a CIDR suffix — gateways do not take prefixes', () => {
+		// Easy mistake: copy/paste the address row into the gateway
+		// field. We tell the user exactly what's wrong.
+		expect(validateIpv4Address('192.168.1.1/24')).toMatch(/no CIDR/);
+	});
+
+	it('rejects bad addresses', () => {
+		expect(validateIpv4Address('not-an-ip')).toBeTruthy();
+		expect(validateIpv4Address('192.168.1')).toBeTruthy();
+		expect(validateIpv4Address('256.1.1.1')).toBeTruthy();
+	});
+});
+
+describe('validateIpv6Address (no CIDR — v6 gateway)', () => {
+	it('accepts canonical addresses', () => {
+		expect(validateIpv6Address('fe80::1')).toBeNull();
+		expect(validateIpv6Address('::1')).toBeNull();
+		expect(validateIpv6Address('2001:db8::1')).toBeNull();
+	});
+
+	it('rejects a CIDR suffix', () => {
+		expect(validateIpv6Address('fe80::1/64')).toMatch(/no CIDR/);
+	});
+
+	it('rejects garbage', () => {
+		expect(validateIpv6Address('zzzz::1')).toBeTruthy();
+	});
+});
+
+describe('validateDnsServer', () => {
+	it('accepts both v4 and v6 (no CIDR)', () => {
+		expect(validateDnsServer('1.1.1.1')).toBeNull();
+		expect(validateDnsServer('2606:4700:4700::1111')).toBeNull();
+	});
+
+	it('routes by colon presence — v6 if present, v4 otherwise', () => {
+		// Strings with a colon are always treated as v6 attempts so the
+		// error message matches what the user wrote.
+		expect(validateDnsServer('not:a:v6')).toMatch(/IPv6/);
+		expect(validateDnsServer('not.a.v4')).toMatch(/IPv4/);
 	});
 });

--- a/webui/src/lib/network.ts
+++ b/webui/src/lib/network.ts
@@ -106,3 +106,138 @@ export function stripInterfaces(
 	const drop = new Set(names);
 	return (network.interfaces ?? []).filter((i) => !drop.has(i.name));
 }
+
+// ── Address validation ────────────────────────────────────────
+//
+// Rejects the common mistakes (missing prefix, typoed octet, garbage)
+// before the form is sent to the engine so the user gets an inline
+// hint instead of a server-side error toast — discussion #159 had a
+// real instance where the user forgot the `/24` and only saw the
+// failure after submit. The engine still validates everything via
+// NetworkManager, so these helpers are belt-not-suspenders: catch the
+// obvious mistakes early, defer the obscure ones to NM.
+
+function validIpv4Octets(addr: string): boolean {
+	const parts = addr.split('.');
+	if (parts.length !== 4) return false;
+	for (const p of parts) {
+		if (!/^\d{1,3}$/.test(p)) return false;
+		// Reject leading zeros (e.g. "192.168.001.1") — both ambiguous
+		// (some libs treat them as octal) and a strong typo signal.
+		if (p.length > 1 && p.startsWith('0')) return false;
+		const n = parseInt(p, 10);
+		if (n < 0 || n > 255) return false;
+	}
+	return true;
+}
+
+function validIpv6Body(addr: string): boolean {
+	// At most one '::' compression.
+	const dcolon = (addr.match(/::/g) ?? []).length;
+	if (dcolon > 1) return false;
+	// Reject lone ':' or trailing ':' that isn't part of '::'.
+	if (addr === '') return false;
+	if (addr.startsWith(':') && !addr.startsWith('::')) return false;
+	if (addr.endsWith(':') && !addr.endsWith('::')) return false;
+
+	if (dcolon === 1) {
+		// "a::b" — each side is 0..7 groups, total ≤ 7 (the '::'
+		// itself stands in for at least one zero group).
+		const [left, right] = addr.split('::');
+		const leftGroups = left === '' ? [] : left.split(':');
+		const rightGroups = right === '' ? [] : right.split(':');
+		if (leftGroups.length + rightGroups.length > 7) return false;
+		return [...leftGroups, ...rightGroups].every(validIpv6Group);
+	}
+	// No compression: must be exactly 8 groups.
+	const groups = addr.split(':');
+	if (groups.length !== 8) return false;
+	return groups.every(validIpv6Group);
+}
+
+function validIpv6Group(g: string): boolean {
+	return /^[0-9a-fA-F]{1,4}$/.test(g);
+}
+
+/** Validate an IPv4 address with a CIDR prefix (e.g. "192.168.1.10/24"). */
+export function validateIpv4Cidr(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null; // empty = caller decides whether required
+	const slash = value.indexOf('/');
+	if (slash < 0) {
+		return 'Missing CIDR prefix — try "192.168.1.10/24"';
+	}
+	const addr = value.slice(0, slash);
+	const prefix = value.slice(slash + 1);
+	if (!validIpv4Octets(addr)) {
+		return 'Not a valid IPv4 address';
+	}
+	if (!/^\d{1,2}$/.test(prefix)) {
+		return 'CIDR prefix must be a number 0-32';
+	}
+	const p = parseInt(prefix, 10);
+	if (p < 0 || p > 32) {
+		return 'CIDR prefix out of range (0-32)';
+	}
+	return null;
+}
+
+/** Validate an IPv6 address with a CIDR prefix (e.g. "fd00::1/64"). */
+export function validateIpv6Cidr(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	const slash = value.indexOf('/');
+	if (slash < 0) {
+		return 'Missing CIDR prefix — try "fd00::1/64"';
+	}
+	const addr = value.slice(0, slash);
+	const prefix = value.slice(slash + 1);
+	if (!validIpv6Body(addr)) {
+		return 'Not a valid IPv6 address';
+	}
+	if (!/^\d{1,3}$/.test(prefix)) {
+		return 'CIDR prefix must be a number 0-128';
+	}
+	const p = parseInt(prefix, 10);
+	if (p < 0 || p > 128) {
+		return 'CIDR prefix out of range (0-128)';
+	}
+	return null;
+}
+
+/** Validate a bare IPv4 address (no CIDR). Used for gateway + DNS. */
+export function validateIpv4Address(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	if (value.includes('/')) {
+		return 'Plain address only — no CIDR prefix here';
+	}
+	if (!validIpv4Octets(value)) {
+		return 'Not a valid IPv4 address';
+	}
+	return null;
+}
+
+/** Validate a bare IPv6 address (no CIDR). Used for v6 gateway. */
+export function validateIpv6Address(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	if (value.includes('/')) {
+		return 'Plain address only — no CIDR prefix here';
+	}
+	if (!validIpv6Body(value)) {
+		return 'Not a valid IPv6 address';
+	}
+	return null;
+}
+
+/** Validate a DNS server entry: bare v4 or v6 address. */
+export function validateDnsServer(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	// IPv6 typically contains ':', IPv4 has dots and no colons.
+	if (value.includes(':')) {
+		return validateIpv6Address(value);
+	}
+	return validateIpv4Address(value);
+}

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -4,7 +4,14 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { tempUnit } from '$lib/temperature.svelte';
-	import { promoteOrphanedMembers } from '$lib/network';
+	import {
+		promoteOrphanedMembers,
+		validateDnsServer,
+		validateIpv4Address,
+		validateIpv4Cidr,
+		validateIpv6Address,
+		validateIpv6Cidr,
+	} from '$lib/network';
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
@@ -40,7 +47,7 @@
 	let netIpv4Addrs: string[] = $state(['']);
 	let netIpv6Addrs: string[] = $state(['']);
 	// IPv6 form
-	let netIpv6Method: 'slaac' | 'static' | 'dhcp' | 'disabled' = $state('slaac');
+	let netIpv6Method = $state<'slaac' | 'static' | 'dhcp' | 'disabled'>('slaac');
 	let netIpv6Gateway = $state('');
 	// MTU on inline interface form (string so an empty value means "unset")
 	let netMtu = $state('');
@@ -79,6 +86,34 @@
 	let netGateway = $state('');
 	let netNameservers = $state('');
 	let netChanged = $state(false);
+
+	// Per-input validation. Each entry is null when the field is OK
+	// (empty or correctly formed) or a short, fixable error message
+	// when not. Computed reactively so the inline hints update as the
+	// user types. The Save button stays disabled while any field is in
+	// error — mirrors the engine-side validation NM does, but locally
+	// so the user gets a hint *before* submit (discussion #159).
+	const netIpv4AddrErrors = $derived(netIpv4Addrs.map(validateIpv4Cidr));
+	const netGatewayError = $derived(netDhcp ? null : validateIpv4Address(netGateway));
+	const netIpv6AddrErrors = $derived(netIpv6Addrs.map(validateIpv6Cidr));
+	const netIpv6GatewayError = $derived(
+		netIpv6Method === 'static' ? validateIpv6Address(netIpv6Gateway) : null,
+	);
+	const netNameserversErrors = $derived(
+		netNameservers
+			.split(/[,\s]+/)
+			.map((s) => s.trim())
+			.filter(Boolean)
+			.map((s) => ({ value: s, err: validateDnsServer(s) }))
+			.filter((entry) => entry.err !== null),
+	);
+	const netHasErrors = $derived(
+		netIpv4AddrErrors.some((e) => e !== null) ||
+			netGatewayError !== null ||
+			netIpv6AddrErrors.some((e) => e !== null) ||
+			netIpv6GatewayError !== null ||
+			netNameserversErrors.length > 0,
+	);
 
 	// Log level
 	let logFilter = $state('');
@@ -860,10 +895,20 @@
 										{#if !netDhcp}
 											<div class="space-y-1">
 												{#each netIpv4Addrs as addr, i}
-													<div class="flex items-center gap-2">
-														<input bind:value={netIpv4Addrs[i]} placeholder="192.168.1.100/24" oninput={() => netChanged = true} class="flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
-														{#if netIpv4Addrs.length > 1}
-															<button onclick={() => { netIpv4Addrs = netIpv4Addrs.filter((_, j) => j !== i); netChanged = true; }} class="text-xs text-muted-foreground hover:text-foreground">x</button>
+													<div>
+														<div class="flex items-center gap-2">
+															<input
+																bind:value={netIpv4Addrs[i]}
+																placeholder="192.168.1.100/24"
+																oninput={() => netChanged = true}
+																class="flex-1 rounded-md border bg-background px-2 py-1 font-mono text-sm {netIpv4AddrErrors[i] ? 'border-destructive' : 'border-input'}"
+															/>
+															{#if netIpv4Addrs.length > 1}
+																<button onclick={() => { netIpv4Addrs = netIpv4Addrs.filter((_, j) => j !== i); netChanged = true; }} class="text-xs text-muted-foreground hover:text-foreground">x</button>
+															{/if}
+														</div>
+														{#if netIpv4AddrErrors[i]}
+															<p class="mt-0.5 text-xs text-destructive">{netIpv4AddrErrors[i]}</p>
 														{/if}
 													</div>
 												{/each}
@@ -871,7 +916,16 @@
 											</div>
 											<div class="mt-2">
 												<label for="net-gateway" class="text-xs text-muted-foreground">Gateway</label>
-												<input id="net-gateway" bind:value={netGateway} placeholder="192.168.1.1" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
+												<input
+													id="net-gateway"
+													bind:value={netGateway}
+													placeholder="192.168.1.1"
+													oninput={() => netChanged = true}
+													class="mt-1 w-full rounded-md border bg-background px-2 py-1 font-mono text-sm {netGatewayError ? 'border-destructive' : 'border-input'}"
+												/>
+												{#if netGatewayError}
+													<p class="mt-0.5 text-xs text-destructive">{netGatewayError}</p>
+												{/if}
 											</div>
 										{/if}
 									</div>
@@ -889,10 +943,20 @@
 										{#if netIpv6Method === 'static'}
 											<div class="space-y-1">
 												{#each netIpv6Addrs as addr, i}
-													<div class="flex items-center gap-2">
-														<input bind:value={netIpv6Addrs[i]} placeholder="fd00::1/64" oninput={() => netChanged = true} class="flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
-														{#if netIpv6Addrs.length > 1}
-															<button onclick={() => { netIpv6Addrs = netIpv6Addrs.filter((_, j) => j !== i); netChanged = true; }} class="text-xs text-muted-foreground hover:text-foreground">x</button>
+													<div>
+														<div class="flex items-center gap-2">
+															<input
+																bind:value={netIpv6Addrs[i]}
+																placeholder="fd00::1/64"
+																oninput={() => netChanged = true}
+																class="flex-1 rounded-md border bg-background px-2 py-1 font-mono text-sm {netIpv6AddrErrors[i] ? 'border-destructive' : 'border-input'}"
+															/>
+															{#if netIpv6Addrs.length > 1}
+																<button onclick={() => { netIpv6Addrs = netIpv6Addrs.filter((_, j) => j !== i); netChanged = true; }} class="text-xs text-muted-foreground hover:text-foreground">x</button>
+															{/if}
+														</div>
+														{#if netIpv6AddrErrors[i]}
+															<p class="mt-0.5 text-xs text-destructive">{netIpv6AddrErrors[i]}</p>
 														{/if}
 													</div>
 												{/each}
@@ -900,7 +964,16 @@
 											</div>
 											<div class="mt-2">
 												<label for="net-ipv6-gw" class="text-xs text-muted-foreground">Gateway</label>
-												<input id="net-ipv6-gw" bind:value={netIpv6Gateway} placeholder="fd00::1" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
+												<input
+													id="net-ipv6-gw"
+													bind:value={netIpv6Gateway}
+													placeholder="fd00::1"
+													oninput={() => netChanged = true}
+													class="mt-1 w-full rounded-md border bg-background px-2 py-1 font-mono text-sm {netIpv6GatewayError ? 'border-destructive' : 'border-input'}"
+												/>
+												{#if netIpv6GatewayError}
+													<p class="mt-0.5 text-xs text-destructive">{netIpv6GatewayError}</p>
+												{/if}
 											</div>
 										{/if}
 									</div>
@@ -915,16 +988,30 @@
 									<!-- DNS -->
 									<div>
 										<label for="net-dns" class="text-xs text-muted-foreground">DNS Servers</label>
-										<input id="net-dns" bind:value={netNameservers} placeholder="1.1.1.1, 8.8.8.8" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
+										<input
+											id="net-dns"
+											bind:value={netNameservers}
+											placeholder="1.1.1.1, 8.8.8.8"
+											oninput={() => netChanged = true}
+											class="mt-1 w-full rounded-md border bg-background px-2 py-1 font-mono text-sm {netNameserversErrors.length > 0 ? 'border-destructive' : 'border-input'}"
+										/>
+										{#if netNameserversErrors.length > 0}
+											<p class="mt-0.5 text-xs text-destructive">
+												{netNameserversErrors[0].err} ({netNameserversErrors[0].value})
+											</p>
+										{/if}
 									</div>
 
 									{#if netChanged && !netDhcp}
 										<p class="text-xs text-amber-500">Changing the IP will move your connection to the new address.</p>
 									{/if}
 
-									<Button size="sm" onclick={saveInterfaceConfig} disabled={savingNetwork || !netChanged}>
+									<Button size="sm" onclick={saveInterfaceConfig} disabled={savingNetwork || !netChanged || netHasErrors}>
 										{savingNetwork ? 'Applying\u2026' : 'Apply'}
 									</Button>
+									{#if netChanged && netHasErrors}
+										<p class="text-xs text-destructive">Fix the highlighted fields before applying.</p>
+									{/if}
 								</div>
 							{/if}
 						</div>


### PR DESCRIPTION
## Why

HuxyUK pasted an IPv4 into the address field without the CIDR prefix and only saw the failure as a server-side error toast after clicking Apply ([discussion #159 final reply](https://github.com/orgs/nasty-project/discussions/159#discussioncomment-16936276)). The engine still validates everything through NetworkManager, but the catch-server-side-then-toast pattern is exactly the \"I tried to save and don't know what's wrong\" UX we keep getting bitten by.

## What

Five focused validators in \`webui/src/lib/network.ts\`:

| Helper                  | Use                          | Empty input |
|-------------------------|------------------------------|-------------|
| \`validateIpv4Cidr\`    | Static IPv4 address rows     | OK (filtered out before submit) |
| \`validateIpv6Cidr\`    | Static IPv6 address rows     | OK |
| \`validateIpv4Address\` | IPv4 gateway (bare, no CIDR) | OK |
| \`validateIpv6Address\` | IPv6 gateway                 | OK |
| \`validateDnsServer\`   | DNS server entries           | OK |

Each returns \`null\` (empty or valid) or a short, fixable error message. The \"missing CIDR\" hint includes the suggested form (\`'try \"192.168.1.10/24\"'\`) so the fix is obvious. Rejects the common typos: out-of-range octets / prefixes, leading-zero octets (octal-ambiguous), multiple \`::\` in v6, garbage groups, missing dots, plain IP in a CIDR field, CIDR in a gateway field.

Wired into \`settings/+page.svelte\` via \`$derived\` per-input error state. Each invalid field gets a red border + inline hint; the Apply button stays disabled while any field is in error, with a \"Fix the highlighted fields before applying\" message under it.

The inline-edit form is the only place static IPs land — bond / bridge / vlan create forms default to DHCP and reuse this same form for L3, so the fix covers the whole user surface in one place.

## Test plan

- [x] 28 new vitest cases pin every validator's behavior (35 total in \`network.test\` now), including the exact \"forgot CIDR\" case from #159.
- [x] \`npx vitest run\` — 121 webui tests pass.
- [x] \`npx svelte-check\` — clean.
- [x] \`npm run build\` — production build succeeds.
- [ ] Manual: type a bare IP in the form, see the inline \"Missing CIDR prefix\" hint with the suggested fix; Apply is disabled until corrected.