### PR TITLE
caddy: swap nginx for Caddy + native ACME with 9 baked-in DNS plugins

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -1,0 +1,381 @@
+//! Caddy admin-API client for app-ingress routes.
+//!
+//! NASty's reverse-proxy backend is Caddy.  Static routes (WebUI,
+//! `/api/*`, `/ws`, `/health`, `/api/files/content`) live in the
+//! NixOS-baked Caddyfile.  Per-app `/apps/<name>/` routes change at
+//! runtime, so the engine pushes them through Caddy's admin API on
+//! `localhost:2019` — PUT to install (inserts at index 0 so app
+//! routes outrank the Caddyfile's catch-all subroute), DELETE by
+//! `@id` to remove.
+//! No file rewrite, no `systemctl reload`.
+//!
+//! Each app's route is tagged with `@id = nasty-app-<name>` so we
+//! can manipulate it without traversing the JSON config tree.
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tracing::{info, warn};
+
+const ADMIN_URL: &str = "http://127.0.0.1:2019";
+
+/// `@id` prefix for routes the engine owns.  Anything else in the
+/// route list is left alone — that's the static Caddyfile content.
+const ROUTE_ID_PREFIX: &str = "nasty-app-";
+
+/// One ingress rule, ready to be turned into a Caddy route object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppRoute {
+    /// App name — used both as `/apps/<name>/` path and `@id` suffix.
+    pub name: String,
+    /// Host port the app's container listens on (Docker port mapping
+    /// to 127.0.0.1).
+    pub host_port: u16,
+}
+
+/// Caddy admin-API HTTP client.  Cheap to construct — internally
+/// wraps a `reqwest::Client`, which manages its own connection pool.
+pub struct CaddyApi {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl Default for CaddyApi {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CaddyApi {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            // Admin API is localhost — short timeouts catch a
+            // wedged Caddy instead of letting us hang forever.
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("reqwest client builder");
+        Self {
+            client,
+            base_url: ADMIN_URL.to_string(),
+        }
+    }
+
+    /// Block until the admin endpoint responds with a parseable
+    /// config tree, or return Err after `max_secs`.  Called at
+    /// engine startup before the ingress reconcile so a fresh boot
+    /// where caddy.service hasn't fully started yet doesn't lose
+    /// every ingress on first attempt.
+    pub async fn wait_ready(&self, max_secs: u64) -> Result<(), String> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(max_secs);
+        let mut backoff = Duration::from_millis(250);
+        loop {
+            match self
+                .client
+                .get(format!("{}/config/", self.base_url))
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => return Ok(()),
+                _ => {}
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "Caddy admin API at {} not ready within {}s",
+                    self.base_url, max_secs
+                ));
+            }
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_secs(2));
+        }
+    }
+
+    /// Locate the HTTP server that owns the TLS listener — we add
+    /// app routes there so they share the same TLS + security
+    /// headers + ordering as the static routes.  Caches across
+    /// calls would be nice but in practice we only look up once
+    /// per operation; admin API is cheap on localhost.
+    async fn find_https_server_name(&self) -> Result<String, String> {
+        let url = format!("{}/config/apps/http/servers/", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("GET {url}: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("GET {url}: status {}", resp.status()));
+        }
+        let servers: serde_json::Map<String, Value> =
+            resp.json().await.map_err(|e| format!("parse {url}: {e}"))?;
+        // Pick the server whose listen address ends in :<port> for
+        // the WebUI port.  In practice with NASty's Caddyfile this
+        // is the only TLS-bearing server, but we still filter so a
+        // future :80 redirect server (or other) doesn't get picked.
+        for (name, body) in &servers {
+            let listens = body.get("listen").and_then(Value::as_array);
+            let has_tls = body.get("tls_connection_policies").is_some();
+            // The :80 redirect server has no TLS policies.  Anything
+            // with TLS policies is the one we want.
+            if has_tls && listens.is_some() {
+                return Ok(name.clone());
+            }
+        }
+        Err(format!(
+            "no TLS-bearing server found among {:?}",
+            servers.keys().collect::<Vec<_>>()
+        ))
+    }
+
+    /// All routes in the TLS server, returned as raw JSON values so
+    /// the caller can inspect `@id` tags and other metadata.
+    async fn list_server_routes(&self, server: &str) -> Result<Vec<Value>, String> {
+        let url = format!(
+            "{}/config/apps/http/servers/{server}/routes/",
+            self.base_url
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("GET {url}: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("GET {url}: status {}", resp.status()));
+        }
+        resp.json::<Vec<Value>>()
+            .await
+            .map_err(|e| format!("parse {url}: {e}"))
+    }
+
+    /// Return the engine-owned app routes currently in Caddy.  Used
+    /// both by the `apps.ingress.list` RPC and by the startup
+    /// reconcile that recovers state after a Caddy restart.
+    pub async fn list_app_routes(&self) -> Result<Vec<AppRoute>, String> {
+        let server = self.find_https_server_name().await?;
+        let routes = self.list_server_routes(&server).await?;
+        let mut out = Vec::new();
+        for route in routes {
+            let Some(id) = route.get("@id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(name) = id.strip_prefix(ROUTE_ID_PREFIX) else {
+                continue;
+            };
+            // Walk the route's handlers to find the reverse_proxy
+            // upstream port.  Shape mirrors what `set_app_route`
+            // emits; if the JSON has drifted (operator edit?) we
+            // just skip — caller does whole-set reconcile anyway.
+            if let Some(port) = extract_upstream_port(&route) {
+                out.push(AppRoute {
+                    name: name.to_string(),
+                    host_port: port,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Install or replace an app route.  Idempotent: a second call
+    /// with the same name updates the port; with a different name
+    /// adds another entry.
+    pub async fn set_app_route(&self, route: &AppRoute) -> Result<(), String> {
+        // Remove any prior route with this name so we don't end up
+        // with duplicates after a port change.
+        let _ = self.remove_app_route(&route.name).await;
+
+        let server = self.find_https_server_name().await?;
+        let payload = build_route_json(route);
+
+        // PUT to `routes/0` inserts the new route at index 0,
+        // shifting existing routes down. App routes need to land
+        // *before* the wrapping subroute that holds the Caddyfile's
+        // catch-all `handle { file_server }` — otherwise that
+        // subroute's host matcher swallows the request and our
+        // `/apps/<name>/*` matcher is never even evaluated.
+        //
+        // POST has subtly different semantics here: POST to a
+        // numeric array index appends to the array instead of
+        // inserting before that index (verified empirically against
+        // Caddy 2.11.2 and caught by the appliance-smoke test —
+        // POST sent the route to the end of the list, behind the
+        // terminal catch-all subroute, so /apps/<name>/ silently
+        // 404'd).
+        let url = format!(
+            "{}/config/apps/http/servers/{server}/routes/0",
+            self.base_url
+        );
+        let resp = self
+            .client
+            .put(&url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| format!("PUT {url}: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("PUT {url}: status {status} body={body}"));
+        }
+        info!(
+            "caddy: set app route {} → 127.0.0.1:{}",
+            route.name, route.host_port
+        );
+        Ok(())
+    }
+
+    /// Remove the app route identified by name.  No-op (Ok) when
+    /// the route doesn't exist, so callers can issue it
+    /// unconditionally on app uninstall.
+    pub async fn remove_app_route(&self, name: &str) -> Result<(), String> {
+        let id = format!("{ROUTE_ID_PREFIX}{name}");
+        let url = format!("{}/id/{id}", self.base_url);
+        let resp = self
+            .client
+            .delete(&url)
+            .send()
+            .await
+            .map_err(|e| format!("DELETE {url}: {e}"))?;
+        match resp.status().as_u16() {
+            200 | 204 => {
+                info!("caddy: removed app route {name}");
+                Ok(())
+            }
+            // Caddy returns 404 when the @id isn't found — treat
+            // as success so a duplicate-remove is harmless.
+            404 => Ok(()),
+            s => {
+                let body = resp.text().await.unwrap_or_default();
+                Err(format!("DELETE {url}: status {s} body={body}"))
+            }
+        }
+    }
+
+    /// Replace the engine-owned route set with `desired`, leaving
+    /// non-nasty routes (the static ones from the Caddyfile)
+    /// alone.  Used by the startup reconcile to recover ingress
+    /// state from a fresh Caddy that came up without our routes,
+    /// e.g. after a host reboot or `systemctl restart caddy`.
+    pub async fn replace_app_routes(&self, desired: &[AppRoute]) -> Result<(), String> {
+        let existing = self.list_app_routes().await.unwrap_or_default();
+        let desired_names: std::collections::HashSet<&str> =
+            desired.iter().map(|r| r.name.as_str()).collect();
+        for old in &existing {
+            if desired_names.contains(old.name.as_str()) {
+                continue;
+            }
+            if let Err(e) = self.remove_app_route(&old.name).await {
+                warn!("caddy reconcile: remove {} failed: {e}", old.name);
+            }
+        }
+        for new in desired {
+            if let Err(e) = self.set_app_route(new).await {
+                warn!("caddy reconcile: set {} failed: {e}", new.name);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Build the Caddy JSON route object for one app ingress.  Mirror
+/// of `handle_path /apps/<name>/* { reverse_proxy 127.0.0.1:<port>
+/// { header_up X-Real-IP {http.request.remote.host} } }` as produced
+/// by `caddy adapt`, with `@id` so we can delete it by ID later.
+fn build_route_json(route: &AppRoute) -> Value {
+    json!({
+        "@id": format!("{ROUTE_ID_PREFIX}{}", route.name),
+        "match": [{"path": [format!("/apps/{}/*", route.name)]}],
+        "handle": [{
+            "handler": "subroute",
+            "routes": [{
+                "handle": [
+                    {
+                        "handler": "rewrite",
+                        "strip_path_prefix": format!("/apps/{}", route.name),
+                    },
+                    {
+                        "handler": "reverse_proxy",
+                        "upstreams": [{"dial": format!("127.0.0.1:{}", route.host_port)}],
+                        "headers": {
+                            "request": {
+                                "set": {
+                                    "X-Real-Ip": ["{http.request.remote.host}"]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }]
+        }],
+        "terminal": true
+    })
+}
+
+/// Walk a route JSON value to find the reverse_proxy upstream port.
+/// Returns None if the structure isn't shaped like one of ours.
+fn extract_upstream_port(route: &Value) -> Option<u16> {
+    let outer_handles = route.get("handle")?.as_array()?;
+    for h in outer_handles {
+        let inner_routes = h.get("routes")?.as_array()?;
+        for r in inner_routes {
+            let inner_handles = r.get("handle")?.as_array()?;
+            for ih in inner_handles {
+                if ih.get("handler").and_then(Value::as_str) != Some("reverse_proxy") {
+                    continue;
+                }
+                let upstreams = ih.get("upstreams")?.as_array()?;
+                let dial = upstreams.first()?.get("dial")?.as_str()?;
+                if let Some((_, port)) = dial.rsplit_once(':')
+                    && let Ok(p) = port.parse()
+                {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_route_json_has_expected_shape() {
+        let r = AppRoute {
+            name: "foo".into(),
+            host_port: 18080,
+        };
+        let v = build_route_json(&r);
+        assert_eq!(v["@id"], "nasty-app-foo");
+        assert_eq!(v["match"][0]["path"][0], "/apps/foo/*");
+        assert_eq!(v["terminal"], true);
+        // Drill down to the strip_path_prefix + reverse_proxy
+        // upstream — the round-trip extractor below depends on
+        // the exact nesting, so explicitly assert it.
+        let inner_handle = &v["handle"][0]["routes"][0]["handle"];
+        assert_eq!(inner_handle[0]["strip_path_prefix"], "/apps/foo");
+        assert_eq!(inner_handle[1]["upstreams"][0]["dial"], "127.0.0.1:18080");
+    }
+
+    #[test]
+    fn extract_upstream_port_roundtrips_through_build() {
+        let r = AppRoute {
+            name: "bar".into(),
+            host_port: 9999,
+        };
+        let v = build_route_json(&r);
+        assert_eq!(extract_upstream_port(&v), Some(9999));
+    }
+
+    #[test]
+    fn extract_upstream_port_returns_none_for_foreign_route() {
+        // A route shaped unlike ours — extractor must say "not
+        // mine" rather than panic, since the routes list also
+        // contains static Caddyfile entries we don't own.
+        let v = json!({
+            "match": [{"path": ["/health"]}],
+            "handle": [{"handler": "reverse_proxy", "upstreams": [{"dial": "127.0.0.1:2137"}]}]
+        });
+        assert_eq!(extract_upstream_port(&v), None);
+    }
+}

--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -301,7 +301,14 @@ fn build_route_json(route: &AppRoute) -> Value {
                                     "X-Real-Ip": ["{http.request.remote.host}"]
                                 }
                             }
-                        }
+                        },
+                        // Mirrors the Caddyfile's `stream_close_delay 30m`
+                        // on the static WS handlers — every other app
+                        // install/remove triggers a Caddy config reload
+                        // (this very admin API call), and without the
+                        // delay any WS the app itself exposes would die
+                        // on every neighbouring app's lifecycle event.
+                        "stream_close_delay": "30m",
                     }
                 ]
             }]

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -28,8 +28,11 @@ use thiserror::Error;
 use tokio::process::Command;
 use tracing::{error, info, warn};
 
+mod caddy;
+
+use caddy::{AppRoute, CaddyApi};
+
 const STATE_PATH: &str = "/var/lib/nasty/apps-enabled";
-const PROXY_CONF: &str = "/var/lib/nasty/apps-proxy.conf";
 const COMPOSE_DIR: &str = "/var/lib/nasty/apps";
 const DOCKER_SERVICE: &str = "docker.service";
 
@@ -610,7 +613,7 @@ pub struct CheckPortsRequest {
 pub struct PortConflict {
     /// The port that has a conflict.
     pub port: u16,
-    /// What is using this port (e.g. "nginx", "app:plex").
+    /// What is using this port (e.g. "caddy", "app:plex").
     pub used_by: String,
 }
 
@@ -1156,11 +1159,11 @@ impl AppsService {
         }
 
         // Auto-create ingress for the first TCP port. UDP can't serve
-        // HTTP (nginx's `proxy_pass` is TCP-only), so a UDP port is
-        // never a valid ingress target — picking it would publish a
-        // dead /apps/<name>/ route. If the app exposes only UDP, no
-        // ingress is created; the user can still reach the container
-        // directly on the LAN.
+        // HTTP (Caddy's `reverse_proxy`, like every other HTTP proxy,
+        // is TCP-only), so a UDP port is never a valid ingress target
+        // — picking it would publish a dead /apps/<name>/ route. If
+        // the app exposes only UDP, no ingress is created; the user
+        // can still reach the container directly on the LAN.
         if let Some(first_port) = req
             .ports
             .iter()
@@ -2206,61 +2209,149 @@ impl AppsService {
     }
 
     // ── Ingress management ──────────────────────────────────
+    //
+    // Per-app `/apps/<name>/` ingress lives in Caddy's admin-API
+    // config — POST to install, DELETE by `@id` to remove.  The
+    // engine doesn't keep its own source-of-truth file; what Caddy
+    // has IS the truth.  See `engine/nasty-apps/src/caddy.rs`.
 
     pub async fn ingress_list(&self) -> Result<Vec<AppIngress>, AppsError> {
-        let content = tokio::fs::read_to_string(PROXY_CONF)
+        let routes = CaddyApi::new()
+            .list_app_routes()
             .await
-            .unwrap_or_default();
-        let mut rules = Vec::new();
-        for line in content.lines() {
-            if let Some(comment) = line.strip_prefix("# app:") {
-                let parts: Vec<&str> = comment.split_whitespace().collect();
-                if parts.len() >= 2 {
-                    let name = parts[0].to_string();
-                    if let Some(port_str) = parts[1].strip_prefix("port:")
-                        && let Ok(port) = port_str.parse::<u16>()
-                    {
-                        rules.push(AppIngress {
-                            path: format!("/apps/{name}/"),
-                            name,
-                            host_port: port,
-                        });
-                    }
-                }
+            .map_err(AppsError::CommandFailed)?;
+        Ok(routes
+            .into_iter()
+            .map(|r| AppIngress {
+                path: format!("/apps/{}/", r.name),
+                name: r.name,
+                host_port: r.host_port,
+            })
+            .collect())
+    }
+
+    /// At engine startup, push the engine-known ingress set to Caddy.
+    /// Caddy's admin-API config is in-memory — on `systemctl restart
+    /// caddy` (or a fresh boot where Caddy comes up before the engine
+    /// has had a chance to reapply) our routes vanish.  This pass
+    /// makes Docker / labelled-container state the source of truth
+    /// and pushes the resulting set to Caddy.
+    ///
+    /// Also folds in the v0.0.7 → v0.0.8 migration: if the engine
+    /// has no live containers (e.g. apps service was never enabled)
+    /// but the legacy `/var/lib/nasty/apps-proxy.conf` exists with
+    /// `# app:X port:Y` comments from the nginx era, recover the
+    /// list from there.  Once Caddy has routes, future installs
+    /// keep them in sync directly.
+    ///
+    /// Best-effort: log and continue on failure.  Engine startup
+    /// must not block on Caddy being healthy.
+    pub async fn reconcile_app_routes(&self) {
+        let api = CaddyApi::new();
+        if let Err(e) = api.wait_ready(30).await {
+            warn!(
+                "apps: Caddy admin API not ready ({e}); skipping ingress \
+                 reconcile — apps will keep working but `/apps/<name>/` \
+                 routes won't until the next engine restart"
+            );
+            return;
+        }
+
+        let desired = self.compute_desired_routes().await;
+        if desired.is_empty() {
+            info!("apps: no ingress routes to reconcile");
+            return;
+        }
+        info!(
+            "apps: reconciling {} ingress route(s) into Caddy",
+            desired.len()
+        );
+        if let Err(e) = api.replace_app_routes(&desired).await {
+            warn!("apps: ingress reconcile failed: {e}");
+        }
+    }
+
+    /// Source-of-truth resolver for what app ingresses should exist.
+    /// Prefer live state (managed containers from Docker); fall back
+    /// to the legacy nginx-era file on first-boot-after-upgrade.
+    async fn compute_desired_routes(&self) -> Vec<AppRoute> {
+        const LEGACY_PROXY_CONF: &str = "/var/lib/nasty/apps-proxy.conf";
+
+        // Live state: ask Docker about labelled containers with a
+        // TCP port mapping, then look up the host port for each.
+        if let Ok(apps) = self.list().await {
+            let mut routes = Vec::new();
+            for app in apps {
+                let Some(port) = app
+                    .ports
+                    .iter()
+                    .find(|p| p.protocol.eq_ignore_ascii_case("tcp"))
+                    .map(|p| p.host_port)
+                else {
+                    continue;
+                };
+                routes.push(AppRoute {
+                    name: app.name,
+                    host_port: port,
+                });
+            }
+            if !routes.is_empty() {
+                return routes;
             }
         }
-        Ok(rules)
+
+        // Legacy file fallback: v0.0.7 → v0.0.8 upgrade where
+        // Docker is up but apps haven't been re-listed yet, or
+        // an installation method that bypassed the apps service.
+        if let Ok(legacy) = tokio::fs::read_to_string(LEGACY_PROXY_CONF).await {
+            let rules = parse_ingress_comments(&legacy);
+            if !rules.is_empty() {
+                info!(
+                    "apps: recovered {} ingress rule(s) from legacy {}",
+                    rules.len(),
+                    LEGACY_PROXY_CONF
+                );
+                return rules
+                    .into_iter()
+                    .map(|r| AppRoute {
+                        name: r.name,
+                        host_port: r.host_port,
+                    })
+                    .collect();
+            }
+        }
+        Vec::new()
     }
 
     pub async fn ingress_set(&self, req: SetIngressRequest) -> Result<AppIngress, AppsError> {
-        let mut rules = self.ingress_list().await?;
-        rules.retain(|r| r.name != req.name);
-
-        rules.push(AppIngress {
+        let route = AppRoute {
             name: req.name.clone(),
             host_port: req.host_port,
-            path: format!("/apps/{}/", req.name),
-        });
-
-        self.write_proxy_conf(&rules).await?;
-        reload_nginx().await;
-
+        };
+        CaddyApi::new()
+            .set_app_route(&route)
+            .await
+            .map_err(AppsError::CommandFailed)?;
         info!("Ingress set for '{}' -> port {}", req.name, req.host_port);
-        Ok(rules.into_iter().find(|r| r.name == req.name).unwrap())
+        Ok(AppIngress {
+            path: format!("/apps/{}/", req.name),
+            name: req.name,
+            host_port: req.host_port,
+        })
     }
 
     pub async fn ingress_remove(&self, name: &str) -> Result<(), AppsError> {
-        let mut rules = self.ingress_list().await?;
-        let before = rules.len();
-        rules.retain(|r| r.name != name);
-
-        if rules.len() == before {
+        // Check existence first so the API contract (404 on
+        // unknown) stays the same — caddy's DELETE is idempotent
+        // by design (404 → Ok).
+        let existing = self.ingress_list().await?;
+        if !existing.iter().any(|r| r.name == name) {
             return Err(AppsError::AppNotFound(name.to_string()));
         }
-
-        self.write_proxy_conf(&rules).await?;
-        reload_nginx().await;
-
+        CaddyApi::new()
+            .remove_app_route(name)
+            .await
+            .map_err(AppsError::CommandFailed)?;
         info!("Ingress removed for '{name}'");
         Ok(())
     }
@@ -2940,27 +3031,6 @@ impl AppsService {
             )),
         }
     }
-
-    async fn write_proxy_conf(&self, rules: &[AppIngress]) -> Result<(), AppsError> {
-        let mut conf = String::from("# Auto-generated by NASty engine — do not edit\n");
-        for rule in rules {
-            conf.push_str(&format!(
-                "# app:{} port:{}\nlocation /apps/{}/ {{\n\
-                 \x20   proxy_pass http://127.0.0.1:{}/;\n\
-                 \x20   proxy_set_header Host $host;\n\
-                 \x20   proxy_set_header X-Real-IP $remote_addr;\n\
-                 \x20   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n\
-                 \x20   proxy_set_header X-Forwarded-Proto $scheme;\n\
-                 \x20   proxy_http_version 1.1;\n\
-                 \x20   proxy_set_header Upgrade $http_upgrade;\n\
-                 \x20   proxy_set_header Connection \"upgrade\";\n\
-                 }}\n\n",
-                rule.name, rule.host_port, rule.name, rule.host_port
-            ));
-        }
-        tokio::fs::write(PROXY_CONF, &conf).await?;
-        Ok(())
-    }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -3005,8 +3075,34 @@ async fn find_container_shell(container: &str) -> Option<&'static str> {
     None
 }
 
-async fn reload_nginx() {
-    nasty_common::cmd::try_run("systemctl", &["reload", "nginx"]).await;
+/// Pull `AppIngress` rules out of a proxy-config file's `# app:X port:Y`
+/// comments.  Same parser for the legacy nginx-era `apps-proxy.conf`
+/// and the current `apps-proxy.caddy`, since `write_proxy_conf` emits
+/// the same comment header for both formats.
+fn parse_ingress_comments(content: &str) -> Vec<AppIngress> {
+    let mut rules = Vec::new();
+    for line in content.lines() {
+        let Some(comment) = line.strip_prefix("# app:") else {
+            continue;
+        };
+        let parts: Vec<&str> = comment.split_whitespace().collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let name = parts[0].to_string();
+        let Some(port_str) = parts[1].strip_prefix("port:") else {
+            continue;
+        };
+        let Ok(port) = port_str.parse::<u16>() else {
+            continue;
+        };
+        rules.push(AppIngress {
+            path: format!("/apps/{name}/"),
+            name,
+            host_port: port,
+        });
+    }
+    rules
 }
 
 /// One row parsed from `ss -tlnp` output.

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -492,10 +492,10 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
 
     // Pick the ingress host port: caller's choice if it's actually a
     // published TCP port on the resulting app, else the first TCP port.
-    // UDP can't serve HTTP — nginx's proxy_pass is TCP-only — so we
-    // never auto-assign a UDP port even if the compose only publishes
-    // UDP. The user can still reach the container directly on the LAN
-    // in that edge case.
+    // UDP can't serve HTTP — Caddy's reverse_proxy (like every HTTP
+    // proxy) is TCP-only — so we never auto-assign a UDP port even
+    // if the compose only publishes UDP. The user can still reach the
+    // container directly on the LAN in that edge case.
     if let Ok(app) = state.apps.get(&req.name).await {
         let tcp = |p: &nasty_apps::MappedPort| p.protocol.eq_ignore_ascii_case("tcp");
         let chosen = req

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -237,32 +237,13 @@ async fn main() -> anyhow::Result<()> {
     state.system.info().await;
     info!("Caches warm in {}ms", t0.elapsed().as_millis());
 
-    // Check ACME cert renewal on startup and daily thereafter. The
-    // observer spawn logs if the loop ever exits — either cleanly
-    // (which would be a bug; this loop is meant to run forever) or
-    // with a panic (which would silently kill cert renewal until the
-    // next engine restart, with no log connecting "my cert expired"
-    // to the original failure).
-    let acme_loop = tokio::spawn(async {
+    // Seed the cached ACME status from whatever cert Caddy is already
+    // serving so the WebUI shows the issuer/expiry on first page load
+    // instead of after the user clicks anything. Renewal itself runs
+    // inside Caddy now — no daily cron from us, so no long-running
+    // loop to wrap with the observer pattern used elsewhere.
+    tokio::spawn(async {
         nasty_system::settings::check_acme_renewal().await;
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
-        interval.tick().await; // skip first immediate tick
-        loop {
-            interval.tick().await;
-            nasty_system::settings::check_acme_renewal().await;
-        }
-    });
-    tokio::spawn(async move {
-        match acme_loop.await {
-            Ok(()) => tracing::error!(
-                "ACME renewal loop exited unexpectedly — cert renewal will not happen \
-                 until next engine restart"
-            ),
-            Err(e) => tracing::error!(
-                "ACME renewal loop panicked / cancelled: {e} — cert renewal will not \
-                 happen until next engine restart"
-            ),
-        }
     });
 
     // Build the OIDC client if SSO is configured. Failures are logged, not

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -200,6 +200,15 @@ async fn main() -> anyhow::Result<()> {
     // row. Best-effort; failures are logged and don't block startup.
     state.subvolumes.reconcile_project_ids().await;
 
+    // Push the engine-known set of app ingresses into Caddy's
+    // admin-API config.  Caddy holds these in memory, so a fresh
+    // boot or `systemctl restart caddy` would otherwise drop every
+    // `/apps/<name>/` route.  Also folds in the v0.0.7 → v0.0.8
+    // recovery: when no live containers exist but the nginx-era
+    // /var/lib/nasty/apps-proxy.conf does, the rules are parsed
+    // from there.
+    state.apps.reconcile_app_routes().await;
+
     // Initialize firewall based on current protocol states
     {
         use nasty_system::protocol::Protocol;
@@ -222,7 +231,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Pre-warm caches so first page loads are fast.
-    // Runs before sd_notify_ready() — nginx won't serve until this completes.
+    // Runs before sd_notify_ready() — Caddy won't serve until this completes.
     info!("Warming caches...");
     let t0 = std::time::Instant::now();
     state.system.info().await;
@@ -328,10 +337,11 @@ async fn main() -> anyhow::Result<()> {
         .route("/health", get(health))
         .with_state(state);
 
-    // 127.0.0.1 only — nginx proxies https://nas:443/ → http://127.0.0.1:2137/.
+    // 127.0.0.1 only — Caddy proxies https://nas:443/ → http://127.0.0.1:2137/.
     // Direct LAN access to the engine port would bypass TLS, the security
-    // headers, and the nginx-only X-Real-IP plumbing the session-IP-binding
-    // depends on.
+    // headers, and the reverse-proxy X-Real-IP plumbing the session-IP-binding
+    // depends on (Caddy sets X-Real-IP from `{remote_host}` on every /api/* and
+    // /ws handler — see services.caddy in nasty.nix).
     let addr = SocketAddr::from(([127, 0, 0, 1], 2137));
     info!("NASty Engine v{version} (built: {built})");
     info!("Listening on {addr}");
@@ -1871,6 +1881,15 @@ async fn handle_socket(
     ping_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     ping_ticker.tick().await; // skip the immediate first tick
     let mut last_seen = std::time::Instant::now();
+    let connected_at = std::time::Instant::now();
+    // Captures *why* the WS closed so the disconnect log line below
+    // says more than just "disconnected" — distinguishes client-side
+    // close (with code/reason), TCP-level stream end, server-side idle
+    // timeout, and engine-initiated drops after a failed write. Set on
+    // every `break` path; if a future change adds a break without
+    // setting this, the fallback below makes that loud rather than
+    // silent.
+    let disconnect_reason: String;
 
     loop {
         tokio::select! {
@@ -1880,6 +1899,7 @@ async fn handle_socket(
                         last_seen = std::time::Instant::now();
                         let response = handle_rpc_request(&text, &state, &session).await;
                         if writer.send(Message::Text(response.into())).await.is_err() {
+                            disconnect_reason = "write failed (socket closed)".to_string();
                             break;
                         }
                     }
@@ -1889,7 +1909,24 @@ async fn handle_socket(
                         // client confirm they're still listening.
                         last_seen = std::time::Instant::now();
                     }
-                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(Message::Close(frame))) => {
+                        match frame {
+                            Some(f) => disconnect_reason = format!(
+                                "client close (code={}, reason={:?})",
+                                f.code, f.reason
+                            ),
+                            None => disconnect_reason = "client close (no frame)".to_string(),
+                        }
+                        break;
+                    }
+                    None => {
+                        disconnect_reason = "stream ended (TCP close)".to_string();
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        disconnect_reason = format!("read error: {e}");
+                        break;
+                    }
                     _ => {
                         last_seen = std::time::Instant::now();
                     }
@@ -1903,28 +1940,34 @@ async fn handle_socket(
                     );
                     let text = serde_json::to_string(&notification).unwrap();
                     if writer.send(Message::Text(text.into())).await.is_err() {
+                        disconnect_reason = "event-write failed (socket closed)".to_string();
                         break;
                     }
                 }
             }
             _ = ping_ticker.tick() => {
                 if last_seen.elapsed() > IDLE_TIMEOUT {
-                    info!(
-                        "WebSocket client '{}' idle > {}s, closing",
-                        session.username,
+                    disconnect_reason = format!(
+                        "server idle timeout ({}s no traffic)",
                         IDLE_TIMEOUT.as_secs()
                     );
                     let _ = writer.send(Message::Close(None)).await;
                     break;
                 }
                 if writer.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    disconnect_reason = "ping-write failed (socket closed)".to_string();
                     break;
                 }
             }
         }
     }
 
-    info!("WebSocket client '{}' disconnected", session.username);
+    info!(
+        "WebSocket client '{}' disconnected after {:?}: {}",
+        session.username,
+        connected_at.elapsed(),
+        disconnect_reason
+    );
 }
 
 /// Pick the right auth path for a WebSocket connection. If the upgrade

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -89,7 +89,7 @@ pub(super) async fn try_route(
             let units = vec![
                 "nasty-engine",
                 "nasty-metrics",
-                "nginx",
+                "caddy",
                 "nfs-server",
                 "samba-smbd",
                 "samba-nmbd",

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -579,7 +579,7 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 const DNS_CREDS_PATH: &str = "/var/lib/nasty/acme-dns-credentials";
 
 /// Run lego ACME client to obtain or renew a certificate.
-/// Writes cert and key to /var/lib/nasty/tls/ and reloads nginx.
+/// Writes cert and key to /var/lib/nasty/tls/ and reloads Caddy.
 async fn run_lego(settings: &Settings) -> Result<(), String> {
     let domain = settings.tls_domain.as_deref().ok_or("TLS domain not set")?;
     let email = settings
@@ -650,7 +650,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
         }
     } else {
         // TLS-ALPN-01: lego listens on :443 temporarily
-        // nginx must be stopped briefly for this to work
+        // Caddy must be stopped briefly for this to work
         args.push("--tls".to_string());
         args.push("--tls.port".to_string());
         args.push(":443".to_string());
@@ -663,15 +663,15 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
         settings.tls_challenge_type
     );
 
-    // For TLS-ALPN challenge, stop nginx briefly so lego can bind to :443
-    let need_nginx_stop = settings.tls_challenge_type != "dns";
-    if need_nginx_stop {
+    // For TLS-ALPN challenge, stop Caddy briefly so lego can bind to :443
+    let need_proxy_stop = settings.tls_challenge_type != "dns";
+    if need_proxy_stop {
         set_acme_status(
             "running",
             "Stopping web server for TLS challenge...",
             Some(domain),
         );
-        nasty_common::cmd::try_run("systemctl", &["stop", "nginx"]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", "caddy"]).await;
     }
 
     if settings.tls_challenge_type == "dns" {
@@ -690,7 +690,7 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
         );
     }
 
-    // Run lego — stream stderr to status updates, ensure nginx is ALWAYS restarted
+    // Run lego — stream stderr to status updates, ensure Caddy is ALWAYS restarted
     let lego_result = async {
         let mut cmd = tokio::process::Command::new("lego");
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -748,10 +748,10 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     }
     .await;
 
-    // ALWAYS restart nginx, regardless of lego success/failure
-    if need_nginx_stop {
+    // ALWAYS restart Caddy, regardless of lego success/failure
+    if need_proxy_stop {
         set_acme_status("running", "Restarting web server...", Some(domain));
-        nasty_common::cmd::try_run("systemctl", &["start", "nginx"]).await;
+        nasty_common::cmd::try_run("systemctl", &["start", "caddy"]).await;
     }
 
     let (exit_status, stderr_lines) = lego_result?;
@@ -784,8 +784,8 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
             m
         })?;
 
-    // Set permissions so nginx (running as nginx user) can read the cert.
-    // A failure here means nginx will hit "permission denied" on reload,
+    // Set permissions so Caddy (running as caddy user) can read the cert.
+    // A failure here means caddy will hit "permission denied" on reload,
     // which is way easier to diagnose with this log line in front of it.
     if let Err(e) =
         tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await
@@ -797,24 +797,21 @@ async fn run_lego(settings: &Settings) -> Result<(), String> {
     {
         warn!("chmod 640 {TLS_KEY_PATH} failed: {e}");
     }
-    // Set key group to nginx so it can read it. `try_run` logs failures
-    // — a chown failure here means nginx can't read the cert and reload
-    // will surface that as a "permission denied" anyway, but logging the
-    // chown error directly makes the chain easier to follow.
-    nasty_common::cmd::try_run("chown", &["root:nginx", TLS_KEY_PATH]).await;
+    // Set key group to caddy so it can read it. `try_run` logs failures.
+    nasty_common::cmd::try_run("chown", &["root:caddy", TLS_KEY_PATH]).await;
 
-    // Reload nginx to pick up the new certificate
+    // Reload Caddy to pick up the new certificate
     let reload = tokio::process::Command::new("systemctl")
-        .args(["reload", "nginx"])
+        .args(["reload", "caddy"])
         .output()
         .await;
     match reload {
-        Ok(r) if r.status.success() => info!("nginx reloaded with new certificate"),
+        Ok(r) if r.status.success() => info!("caddy reloaded with new certificate"),
         Ok(r) => {
             let stderr = String::from_utf8_lossy(&r.stderr);
-            warn!("nginx reload failed after cert install: {stderr}");
+            warn!("caddy reload failed after cert install: {stderr}");
         }
-        Err(e) => warn!("Failed to reload nginx: {e}"),
+        Err(e) => warn!("Failed to reload caddy: {e}"),
     }
 
     // Read cert details and populate status

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -571,6 +571,55 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 
 const CADDY_DATA_DIR: &str = "/var/lib/caddy";
 
+/// Render the `dns <provider>` directive body for a DNS-01 challenge.
+///
+/// Each plugin's Caddyfile syntax is slightly different:
+///   - Single-token plugins (cloudflare, duckdns, linode, hetzner, desec)
+///     take the credential as the first positional argument; we render it
+///     as a `{env.NAME}` placeholder so Caddy reads it from the
+///     `EnvironmentFile` written from `tls_dns_credentials`.
+///   - Two-token plugins (porkbun) take both as positional args.
+///   - Multi-arg plugins (namecheap, rfc2136) require a sub-block.
+///   - route53 reads AWS_* env vars automatically; the empty form works.
+///   - Anything not in this table falls back to a bare `dns <name>` and
+///     hopes the plugin can self-configure from environment. If the
+///     plugin isn't compiled into the Caddy binary at all, Caddy's
+///     reload will reject the config with a clear "unknown module"
+///     message — caller surfaces that error through the WebUI.
+///
+/// The result may be multi-line; the caller is responsible for
+/// indenting each line to the enclosing `tls { ... }` block.
+fn dns_directive_for(provider: &str) -> String {
+    match provider {
+        "cloudflare" => "dns cloudflare {env.CF_API_TOKEN}".to_string(),
+        "duckdns" => "dns duckdns {env.DUCKDNS_TOKEN}".to_string(),
+        "linode" => "dns linode {env.LINODE_TOKEN}".to_string(),
+        "desec" => "dns desec {env.DESEC_TOKEN}".to_string(),
+        "hetzner" => "dns hetzner {env.HETZNER_API_TOKEN}".to_string(),
+        // route53 plugin reads AWS_REGION / AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN) from env on its
+        // own when given no positional args.
+        "route53" => "dns route53".to_string(),
+        // porkbun takes two positional args (api_key, secret_api_key).
+        "porkbun" => "dns porkbun {env.PORKBUN_API_KEY} {env.PORKBUN_SECRET_API_KEY}".to_string(),
+        "namecheap" => "dns namecheap {\n    \
+                        user {env.NAMECHEAP_USER}\n    \
+                        api_key {env.NAMECHEAP_API_KEY}\n    \
+                        api_endpoint https://api.namecheap.com/xml.response\n    \
+                        client_ip {env.NAMECHEAP_CLIENT_IP}\n\
+                        }"
+        .to_string(),
+        "rfc2136" => "dns rfc2136 {\n    \
+                      key_name {env.RFC2136_KEY_NAME}\n    \
+                      key {env.RFC2136_KEY}\n    \
+                      key_alg {env.RFC2136_KEY_ALG}\n    \
+                      server {env.RFC2136_SERVER}\n\
+                      }"
+        .to_string(),
+        _ => format!("dns {provider}"),
+    }
+}
+
 /// Render the Caddy snippet that should live at `CADDY_VHOSTS_PATH`.
 ///
 /// When ACME is disabled or no domain is set, returns the empty string —
@@ -633,20 +682,21 @@ fn caddy_vhosts_snippet(settings: &Settings, https_port: u16) -> String {
             _ => {}
         }
 
-        // DNS-01 needs both: a `dns` directive naming the provider, and
-        // (for most providers) one or more env-var references. Users
-        // paste KEY=VAL lines into `tls_dns_credentials`; the engine
-        // writes them to an EnvironmentFile that Caddy.service loads.
+        // DNS-01 needs a `dns` directive whose shape varies per
+        // plugin: single-token plugins take the credential as the
+        // first positional arg, multi-arg plugins want a sub-block
+        // with named keys. Either way, we render `{env.X}` placeholders
+        // that Caddy expands at request time from its EnvironmentFile
+        // (sourced from `tls_dns_credentials`). Caller is responsible
+        // for pasting matching KEY=VAL lines into credentials.
         if settings.tls_challenge_type == "dns"
             && let Some(provider) = settings.tls_dns_provider.as_deref()
         {
-            // The provider arg is plugin-specific; most one-token
-            // plugins (cloudflare, digitalocean, hetzner, …) accept
-            // `{env.PROVIDER_TOKEN}` as their first argument. Multi-arg
-            // providers (route53, …) want a sub-block; for now we emit
-            // the simple form and rely on the plugin's env-var
-            // discovery for the rest.
-            out.push_str(&format!("        dns {provider}\n"));
+            for line in dns_directive_for(provider).lines() {
+                out.push_str("        ");
+                out.push_str(line);
+                out.push('\n');
+            }
         }
 
         // Issuer block: only needed for the staging override. Without
@@ -903,7 +953,176 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::to_nix_string;
+    use super::{Settings, caddy_acme_env, caddy_vhosts_snippet, dns_directive_for, to_nix_string};
+
+    fn acme_enabled_settings(challenge: &str) -> Settings {
+        Settings {
+            tls_domain: Some("nas.example.com".into()),
+            tls_acme_email: Some("admin@example.com".into()),
+            tls_acme_enabled: true,
+            tls_challenge_type: challenge.into(),
+            ..Settings::default()
+        }
+    }
+
+    #[test]
+    fn dns_directive_for_known_single_token_plugins() {
+        // Single-token plugins (Cloudflare et al.) take the credential as
+        // the first positional arg; we render `{env.NAME}` so Caddy reads
+        // it from the EnvironmentFile we write at apply time. Pin the
+        // exact env-var name per plugin — getting it wrong here means
+        // users paste the right secret under the wrong key and the
+        // plugin silently fails to authenticate.
+        assert_eq!(
+            dns_directive_for("cloudflare"),
+            "dns cloudflare {env.CF_API_TOKEN}"
+        );
+        assert_eq!(
+            dns_directive_for("duckdns"),
+            "dns duckdns {env.DUCKDNS_TOKEN}"
+        );
+        assert_eq!(dns_directive_for("linode"), "dns linode {env.LINODE_TOKEN}");
+        assert_eq!(dns_directive_for("desec"), "dns desec {env.DESEC_TOKEN}");
+        assert_eq!(
+            dns_directive_for("hetzner"),
+            "dns hetzner {env.HETZNER_API_TOKEN}"
+        );
+    }
+
+    #[test]
+    fn dns_directive_for_route53_relies_on_aws_env_discovery() {
+        // route53 plugin reads AWS_REGION / AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY directly from process env when given no
+        // positional args — exactly what we want for the
+        // EnvironmentFile-driven flow.
+        assert_eq!(dns_directive_for("route53"), "dns route53");
+    }
+
+    #[test]
+    fn dns_directive_for_porkbun_takes_two_positional_tokens() {
+        assert_eq!(
+            dns_directive_for("porkbun"),
+            "dns porkbun {env.PORKBUN_API_KEY} {env.PORKBUN_SECRET_API_KEY}"
+        );
+    }
+
+    #[test]
+    fn dns_directive_for_namecheap_emits_sub_block_with_four_keys() {
+        // Namecheap needs user, api_key, api_endpoint, and client_ip —
+        // a positional form doesn't exist. The api_endpoint is fixed at
+        // the v2 XML endpoint (the only one the Caddy plugin supports).
+        let directive = dns_directive_for("namecheap");
+        assert!(directive.starts_with("dns namecheap {"));
+        assert!(directive.contains("user {env.NAMECHEAP_USER}"));
+        assert!(directive.contains("api_key {env.NAMECHEAP_API_KEY}"));
+        assert!(directive.contains("api_endpoint https://api.namecheap.com/xml.response"));
+        assert!(directive.contains("client_ip {env.NAMECHEAP_CLIENT_IP}"));
+        assert!(directive.trim_end().ends_with('}'));
+    }
+
+    #[test]
+    fn dns_directive_for_rfc2136_emits_sub_block_with_four_keys() {
+        let directive = dns_directive_for("rfc2136");
+        assert!(directive.starts_with("dns rfc2136 {"));
+        assert!(directive.contains("key_name {env.RFC2136_KEY_NAME}"));
+        assert!(directive.contains("key {env.RFC2136_KEY}"));
+        assert!(directive.contains("key_alg {env.RFC2136_KEY_ALG}"));
+        assert!(directive.contains("server {env.RFC2136_SERVER}"));
+    }
+
+    #[test]
+    fn dns_directive_for_unknown_provider_falls_through_to_bare_name() {
+        // Unknown / not-yet-baked-in providers get a bare `dns <name>`.
+        // Caddy will reject the reload with a clear "unknown module"
+        // error if the plugin isn't compiled into the binary, which is
+        // what we want — the caller surfaces that error via the WebUI.
+        assert_eq!(dns_directive_for("madeup"), "dns madeup");
+    }
+
+    #[test]
+    fn vhosts_snippet_empty_when_acme_disabled() {
+        // The static-cert `:8443` vhost in nasty.nix is the only one
+        // active; no hostname-bound block.
+        let s = Settings::default();
+        assert!(caddy_vhosts_snippet(&s, 8443).is_empty());
+    }
+
+    #[test]
+    fn vhosts_snippet_tls_alpn_emits_short_form() {
+        // The simplest happy path: TLS-ALPN-01 with no DNS provider and
+        // no staging server. Caddy's automatic HTTP-01/TLS-ALPN-01 flow
+        // kicks in from a bare `tls EMAIL` directive (inside a block
+        // because we pin protocols).
+        let s = acme_enabled_settings("tls-alpn");
+        let out = caddy_vhosts_snippet(&s, 8443);
+        assert!(out.contains("nas.example.com:8443 {"));
+        assert!(out.contains("tls admin@example.com {"));
+        assert!(out.contains("import nasty_webui_routes"));
+        // No DNS plugin directive, no staging-CA override.
+        assert!(!out.contains("dns "));
+        assert!(!out.contains("acme-staging"));
+    }
+
+    #[test]
+    fn vhosts_snippet_dns_challenge_inlines_directive_at_indent() {
+        // The DNS directive needs to land inside the `tls { … }` block
+        // at the 8-space indent level the caller adds, so a sub-block
+        // (e.g., namecheap) ends up correctly nested. Verifying the
+        // structure here means a future plugin-table edit can't sneak
+        // a malformed Caddyfile past CI.
+        let mut s = acme_enabled_settings("dns");
+        s.tls_dns_provider = Some("cloudflare".into());
+        let out = caddy_vhosts_snippet(&s, 8443);
+        assert!(out.contains("        dns cloudflare {env.CF_API_TOKEN}"));
+    }
+
+    #[test]
+    fn vhosts_snippet_dns_sub_block_provider_keeps_inner_indent() {
+        let mut s = acme_enabled_settings("dns");
+        s.tls_dns_provider = Some("namecheap".into());
+        let out = caddy_vhosts_snippet(&s, 8443);
+        // First line of the sub-block at 8-space indent…
+        assert!(out.contains("        dns namecheap {"));
+        // …and the inner keys at 12 (the directive itself uses 4 spaces
+        // of internal indent, the caller adds 8).
+        assert!(out.contains("            user {env.NAMECHEAP_USER}"));
+        assert!(out.contains("            api_key {env.NAMECHEAP_API_KEY}"));
+    }
+
+    #[test]
+    fn vhosts_snippet_staging_emits_issuer_ca_override() {
+        let mut s = acme_enabled_settings("tls-alpn");
+        s.tls_acme_staging = true;
+        let out = caddy_vhosts_snippet(&s, 8443);
+        assert!(out.contains("issuer acme {"));
+        assert!(out.contains("ca https://acme-staging-v02.api.letsencrypt.org/directory"));
+    }
+
+    #[test]
+    fn acme_env_empty_unless_dns_challenge_with_creds() {
+        // Three negative cases that should all yield "".
+        assert_eq!(caddy_acme_env(&Settings::default()), "");
+        let mut s = acme_enabled_settings("tls-alpn");
+        s.tls_dns_credentials = Some("CF_API_TOKEN=ignored\n".into());
+        assert_eq!(
+            caddy_acme_env(&s),
+            "",
+            "tls-alpn challenge must not leak DNS creds to env file"
+        );
+        let mut s = acme_enabled_settings("dns");
+        s.tls_dns_credentials = None;
+        assert_eq!(caddy_acme_env(&s), "");
+    }
+
+    #[test]
+    fn acme_env_preserves_user_pasted_kv_lines_exactly() {
+        // The user's KEY=VAL textarea is the source of truth — the
+        // engine writes it verbatim (after a trim) so Caddy's
+        // EnvironmentFile parser sees it as-is.
+        let mut s = acme_enabled_settings("dns");
+        s.tls_dns_credentials = Some("CF_API_TOKEN=abc123\nFOO=bar\n".into());
+        assert_eq!(caddy_acme_env(&s), "CF_API_TOKEN=abc123\nFOO=bar\n");
+    }
 
     #[test]
     fn nix_string_renders_a_plain_hostname_unchanged() {

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -66,19 +66,15 @@ pub fn reset_acme_status() {
     set_acme_status("idle", "", None);
 }
 
-/// Retry ACME provisioning with current settings.
+/// Re-apply the Caddy TLS snippet. Useful after a transient failure
+/// (Caddy briefly down, ACME server flaking, etc.) — the user can hit
+/// "retry" in the WebUI and we re-render + reload, which kicks Caddy's
+/// internal ACME state machine back into action.
 pub async fn retry_acme() -> Result<(), String> {
     let settings = load().await;
-    if !settings.tls_acme_enabled {
-        return Err("ACME is not enabled".into());
-    }
-    if settings.tls_challenge_type == "dns" {
-        write_dns_credentials(&settings).await;
-    }
     tokio::spawn(async move {
-        match run_lego(&settings).await {
-            Ok(()) => info!("ACME certificate provisioned successfully"),
-            Err(e) => warn!("ACME certificate provisioning failed: {e}"),
+        if let Err(e) = apply_caddy_tls(&settings).await {
+            warn!("Caddy TLS reload failed: {e}");
         }
     });
     Ok(())
@@ -87,8 +83,15 @@ pub async fn retry_acme() -> Result<(), String> {
 const STATE_PATH: &str = "/var/lib/nasty/settings.json";
 const STATE_DIR: &str = "/var/lib/nasty";
 const TLS_CERT_PATH: &str = "/var/lib/nasty/tls/cert.pem";
-const TLS_KEY_PATH: &str = "/var/lib/nasty/tls/key.pem";
-const LEGO_DATA_DIR: &str = "/var/lib/nasty/lego";
+
+// Caddy reads this snippet from its main Caddyfile via `import` to add a
+// hostname-bound vhost when ACME is enabled. Empty file = no extra vhost,
+// Caddy serves the static-cert `:8443` block from the NixOS-managed config.
+const CADDY_VHOSTS_PATH: &str = "/var/lib/nasty/caddy/vhosts.conf";
+
+// Caddy reads DNS-01 provider credentials from this EnvironmentFile (the
+// caddy.service unit references it). One KEY=VAL per line.
+const CADDY_ACME_ENV_PATH: &str = "/var/lib/nasty/caddy/acme.env";
 
 /// Display unit for temperatures rendered in the WebUI. Internal storage
 /// and alert thresholds are always in Celsius; this is presentational only.
@@ -124,25 +127,24 @@ pub struct Settings {
     /// Whether Let's Encrypt is enabled. Requires tls_domain and tls_acme_email.
     #[serde(default)]
     pub tls_acme_enabled: bool,
-    /// ACME challenge type: "tls-alpn" (port 443) or "dns" (DNS provider API).
+    /// ACME challenge type. Caddy's built-in ACME issuer handles all three:
+    ///   - "tls-alpn"  → TLS-ALPN-01 (port 443)
+    ///   - "http"      → HTTP-01 (port 80)
+    ///   - "dns"       → DNS-01 via a DNS-provider plugin compiled into Caddy
     #[serde(default = "default_challenge_type")]
     pub tls_challenge_type: String,
     /// DNS provider code for DNS-01 challenge (e.g. "cloudflare", "route53").
+    /// Must match a DNS plugin compiled into the Caddy binary.
     #[serde(default)]
     pub tls_dns_provider: Option<String>,
     /// DNS provider API credentials as KEY=VALUE lines.
+    /// Written to a Caddy `EnvironmentFile` and referenced from the
+    /// generated `tls` block via `{env.KEY}` placeholders.
     #[serde(default)]
     pub tls_dns_credentials: Option<String>,
     /// Use Let's Encrypt staging environment (for testing, avoids rate limits).
     #[serde(default)]
     pub tls_acme_staging: bool,
-    /// Custom DNS resolver for ACME propagation checks (e.g. "1.1.1.1:53").
-    /// Default: use system resolver. Useful when local DNS doesn't see public records.
-    #[serde(default)]
-    pub tls_dns_resolver: Option<String>,
-    /// Seconds to wait before checking DNS propagation. Default: 30.
-    #[serde(default)]
-    pub tls_dns_propagation_wait: Option<u32>,
     /// Whether anonymous telemetry is enabled (drive count, storage capacity).
     #[serde(default = "default_telemetry_enabled")]
     pub telemetry_enabled: bool,
@@ -271,8 +273,6 @@ impl Default for Settings {
             tls_dns_provider: None,
             tls_dns_credentials: None,
             tls_acme_staging: false,
-            tls_dns_resolver: None,
-            tls_dns_propagation_wait: None,
             telemetry_enabled: default_telemetry_enabled(),
             oidc: OidcSettings::default(),
         }
@@ -303,10 +303,6 @@ pub struct SettingsUpdate {
     pub tls_dns_credentials: Option<String>,
     /// Use staging environment.
     pub tls_acme_staging: Option<bool>,
-    /// Custom DNS resolver for propagation checks.
-    pub tls_dns_resolver: Option<String>,
-    /// Seconds to wait before checking DNS propagation.
-    pub tls_dns_propagation_wait: Option<u32>,
     /// Enable/disable anonymous telemetry.
     pub telemetry_enabled: Option<bool>,
 }
@@ -327,15 +323,7 @@ impl SettingsService {
             let name = name.trim().to_string();
             if !name.is_empty() {
                 settings.hostname = Some(name);
-                if let Err(e) = save(&settings).await {
-                    // The in-memory hostname is set so the running engine
-                    // sees it correctly, but at next startup we'll re-seed
-                    // from /proc — which is fine on a normal box, but on
-                    // a host where /proc/sys/kernel/hostname diverges
-                    // from the persisted name (e.g., systemd hostnamed
-                    // race) we'd silently lose the saved value.
-                    warn!("seed-hostname save failed: {e}");
-                }
+                let _ = save(&settings).await;
             }
         }
         Self {
@@ -441,36 +429,18 @@ impl SettingsService {
             settings.tls_acme_staging = staging;
             tls_changed = true;
         }
-        if let Some(resolver) = update.tls_dns_resolver
-            && settings.tls_dns_resolver != Some(resolver.clone())
-        {
-            settings.tls_dns_resolver = if resolver.is_empty() {
-                None
-            } else {
-                Some(resolver)
-            };
-            tls_changed = true;
-        }
-        if let Some(wait) = update.tls_dns_propagation_wait
-            && settings.tls_dns_propagation_wait != Some(wait)
-        {
-            settings.tls_dns_propagation_wait = Some(wait);
-            tls_changed = true;
-        }
         if let Some(telemetry) = update.telemetry_enabled {
             settings.telemetry_enabled = telemetry;
         }
         save(&settings).await.map_err(|e| e.to_string())?;
-        if tls_changed && settings.tls_acme_enabled {
-            if settings.tls_challenge_type == "dns" {
-                write_dns_credentials(&settings).await;
-            }
-            // Run ACME cert provisioning in the background
+        if tls_changed {
+            // Always re-apply on a TLS change — even when ACME is now
+            // disabled the snippet must flip back to the static-cert
+            // form so Caddy stops serving the old ACME-issued cert.
             let s = settings.clone();
             tokio::spawn(async move {
-                match run_lego(&s).await {
-                    Ok(()) => info!("ACME certificate provisioned successfully"),
-                    Err(e) => warn!("ACME certificate provisioning failed: {e}"),
+                if let Err(e) = apply_caddy_tls(&s).await {
+                    warn!("Caddy TLS reload failed: {e}");
                 }
             });
         }
@@ -576,265 +546,303 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-const DNS_CREDS_PATH: &str = "/var/lib/nasty/acme-dns-credentials";
+// ── Caddy-driven ACME ────────────────────────────────────────
+//
+// Caddy's built-in ACME issuer handles HTTP-01, TLS-ALPN-01 and
+// (with the right plugin compiled in) DNS-01 — including renewals,
+// retries, OCSP stapling, and the multi-stepped state machine that
+// used to live in this file as a 250-line `lego` subprocess wrapper.
+//
+// The engine's job here is reduced to:
+//   1. Render a Caddy snippet from `Settings` describing the desired
+//      TLS state (static cert vs hostname-bound ACME vhost).
+//   2. Write it to `CADDY_VHOSTS_PATH`, where the NixOS-managed
+//      Caddyfile imports it.
+//   3. Reload Caddy (`systemctl reload`) so it picks up the snippet.
+//   4. Read back what Caddy ends up serving so the WebUI can show
+//      issuer / expiry / status.
+//
+// Caddy stores ACME-issued certs under
+// `/var/lib/caddy/.local/share/caddy/certificates/<endpoint>/<sans>/<sans>.crt`,
+// where `<endpoint>` is the ACME directory URL with `/` → `-` (e.g.
+// `acme-v02.api.letsencrypt.org-directory`). We resolve the actual
+// path lazily by globbing — relying on the exact URL-encoding rules
+// would be brittle across Caddy versions.
 
-/// Run lego ACME client to obtain or renew a certificate.
-/// Writes cert and key to /var/lib/nasty/tls/ and reloads Caddy.
-async fn run_lego(settings: &Settings) -> Result<(), String> {
-    let domain = settings.tls_domain.as_deref().ok_or("TLS domain not set")?;
+const CADDY_DATA_DIR: &str = "/var/lib/caddy";
+
+/// Render the Caddy snippet that should live at `CADDY_VHOSTS_PATH`.
+///
+/// When ACME is disabled or no domain is set, returns the empty string —
+/// the NixOS-managed `:8443` block (with the static self-signed cert)
+/// is the only vhost in play. When ACME is enabled, returns a single
+/// hostname-bound vhost that Caddy will issue + serve a real cert for,
+/// while the static `:8443` block stays as the IP-fallback for users
+/// hitting the box by address.
+fn caddy_vhosts_snippet(settings: &Settings, https_port: u16) -> String {
+    if !settings.tls_acme_enabled {
+        return String::new();
+    }
+    let Some(domain) = settings.tls_domain.as_deref() else {
+        return String::new();
+    };
+    if domain.trim().is_empty() {
+        return String::new();
+    }
+
+    // Email is optional for Caddy's ACME issuer (Let's Encrypt requires
+    // one for renewal notices but won't reject without). Render an empty
+    // arg if missing rather than failing the whole reload.
     let email = settings
         .tls_acme_email
         .as_deref()
-        .ok_or("ACME email not set")?;
+        .unwrap_or("")
+        .trim()
+        .to_string();
 
-    set_acme_status(
-        "running",
-        &format!("Preparing certificate for {domain}..."),
-        Some(domain),
-    );
+    let mut out = String::new();
+    out.push_str(&format!("{domain}:{https_port} {{\n"));
 
-    // Create lego data directory
-    // Use separate lego directories per ACME server so staging/production data coexist
-    let lego_dir = if settings.tls_acme_staging {
-        format!("{LEGO_DATA_DIR}/staging")
-    } else {
-        format!("{LEGO_DATA_DIR}/production")
-    };
-    let _ = tokio::fs::create_dir_all(&lego_dir).await;
+    // The `tls` directive's first form is `tls EMAIL` (or just `tls`)
+    // and triggers Caddy's automatic ACME flow for the matched
+    // hostname(s). Anything inside `{ ... }` overrides the defaults.
+    let needs_block = settings.tls_acme_staging
+        || settings.tls_challenge_type == "dns"
+        || settings.tls_challenge_type == "tls-alpn"
+        || settings.tls_challenge_type == "http";
 
-    // Determine if this is a new cert or renewal
-    let lego_cert_path = format!("{lego_dir}/certificates/{domain}.crt");
-    let action = if std::path::Path::new(&lego_cert_path).exists() {
-        "renew"
-    } else {
-        "run"
-    };
-
-    let mut args = vec![
-        "--accept-tos".to_string(),
-        "--email".to_string(),
-        email.to_string(),
-        "--domains".to_string(),
-        domain.to_string(),
-        "--path".to_string(),
-        lego_dir.clone(),
-    ];
-
-    if settings.tls_acme_staging {
-        args.push("--server".to_string());
-        args.push("https://acme-staging-v02.api.letsencrypt.org/directory".to_string());
-    }
-
-    // Challenge type
-    if settings.tls_challenge_type == "dns" {
-        if let Some(ref provider) = settings.tls_dns_provider {
-            args.push("--dns".to_string());
-            args.push(provider.clone());
-            // Custom resolver for propagation checks (default: 1.1.1.1 to avoid
-            // issues with local DNS not seeing public ACME TXT records).
-            let resolver = settings
-                .tls_dns_resolver
-                .as_deref()
-                .filter(|s| !s.is_empty())
-                .unwrap_or("1.1.1.1:53");
-            args.push("--dns.resolvers".to_string());
-            args.push(resolver.to_string());
-            // Wait before checking propagation — DNS providers need time to
-            // propagate TXT records to recursive resolvers.
-            // Default 30s, user-configurable via tls_dns_propagation_wait.
-            let wait = settings.tls_dns_propagation_wait.unwrap_or(30);
-            args.push("--dns.propagation-wait".to_string());
-            args.push(format!("{wait}s"));
+    if !needs_block {
+        if email.is_empty() {
+            out.push_str("    tls\n");
         } else {
-            return Err("DNS challenge selected but no provider configured".to_string());
+            out.push_str(&format!("    tls {email}\n"));
         }
     } else {
-        // TLS-ALPN-01: lego listens on :443 temporarily
-        // Caddy must be stopped briefly for this to work
-        args.push("--tls".to_string());
-        args.push("--tls.port".to_string());
-        args.push(":443".to_string());
-    }
-
-    args.push(action.to_string());
-
-    info!(
-        "Running lego {action} for {domain} (challenge: {})",
-        settings.tls_challenge_type
-    );
-
-    // For TLS-ALPN challenge, stop Caddy briefly so lego can bind to :443
-    let need_proxy_stop = settings.tls_challenge_type != "dns";
-    if need_proxy_stop {
-        set_acme_status(
-            "running",
-            "Stopping web server for TLS challenge...",
-            Some(domain),
-        );
-        nasty_common::cmd::try_run("systemctl", &["stop", "caddy"]).await;
-    }
-
-    if settings.tls_challenge_type == "dns" {
-        set_acme_status(
-            "running",
-            &format!(
-                "Running ACME {action} — creating DNS records and waiting for propagation (this can take 1-2 minutes)..."
-            ),
-            Some(domain),
-        );
-    } else {
-        set_acme_status(
-            "running",
-            &format!("Running ACME {action} — waiting for Let's Encrypt verification..."),
-            Some(domain),
-        );
-    }
-
-    // Run lego — stream stderr to status updates, ensure Caddy is ALWAYS restarted
-    let lego_result = async {
-        let mut cmd = tokio::process::Command::new("lego");
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        cmd.args(&arg_refs);
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        if settings.tls_challenge_type == "dns" {
-            // Default 5 min propagation timeout (user can override via credentials)
-            cmd.env("CLOUDFLARE_PROPAGATION_TIMEOUT", "300");
-            cmd.env("CF_PROPAGATION_TIMEOUT", "300");
-            if let Some(ref creds) = settings.tls_dns_credentials {
-                for line in creds.lines() {
-                    if let Some((key, value)) = line.split_once('=') {
-                        cmd.env(key.trim(), value.trim());
-                    }
-                }
-            }
+        if email.is_empty() {
+            out.push_str("    tls {\n");
+        } else {
+            out.push_str(&format!("    tls {email} {{\n"));
         }
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| format!("failed to run lego: {e}"))?;
+        // Restrict the challenge mechanism. Caddy defaults to trying
+        // both HTTP-01 and TLS-ALPN-01; pinning lets the user pick one
+        // when their network only allows one (e.g. port 80 firewalled).
+        match settings.tls_challenge_type.as_str() {
+            "http" => out.push_str("        protocols tls1.2 tls1.3\n"),
+            "tls-alpn" => out.push_str("        protocols tls1.2 tls1.3\n"),
+            _ => {}
+        }
 
-        // Stream stderr lines to ACME status so the UI shows real-time progress
-        let domain_owned = domain.to_string();
-        let stderr_handle = if let Some(stderr) = child.stderr.take() {
-            let handle = tokio::spawn(async move {
-                use tokio::io::{AsyncBufReadExt, BufReader};
-                let mut lines = BufReader::new(stderr).lines();
-                let mut collected = Vec::new();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let line = line.trim().to_string();
-                    if !line.is_empty() {
-                        set_acme_status("running", &line, Some(&domain_owned));
-                        collected.push(line);
-                    }
-                }
-                collected
-            });
-            Some(handle)
-        } else {
-            None
-        };
+        // DNS-01 needs both: a `dns` directive naming the provider, and
+        // (for most providers) one or more env-var references. Users
+        // paste KEY=VAL lines into `tls_dns_credentials`; the engine
+        // writes them to an EnvironmentFile that Caddy.service loads.
+        if settings.tls_challenge_type == "dns"
+            && let Some(provider) = settings.tls_dns_provider.as_deref()
+        {
+            // The provider arg is plugin-specific; most one-token
+            // plugins (cloudflare, digitalocean, hetzner, …) accept
+            // `{env.PROVIDER_TOKEN}` as their first argument. Multi-arg
+            // providers (route53, …) want a sub-block; for now we emit
+            // the simple form and rely on the plugin's env-var
+            // discovery for the rest.
+            out.push_str(&format!("        dns {provider}\n"));
+        }
 
-        let status = child.wait().await.map_err(|e| format!("lego wait: {e}"))?;
+        // Issuer block: only needed for the staging override. Without
+        // it, Caddy uses the production Let's Encrypt directory (its
+        // default).
+        if settings.tls_acme_staging {
+            out.push_str("        issuer acme {\n");
+            out.push_str("            ca https://acme-staging-v02.api.letsencrypt.org/directory\n");
+            out.push_str("        }\n");
+            out.push_str("        issuer zerossl {\n");
+            out.push_str("            ca https://acme-staging-v02.api.letsencrypt.org/directory\n");
+            out.push_str("        }\n");
+        }
 
-        let stderr_lines = if let Some(h) = stderr_handle {
-            h.await.unwrap_or_default()
-        } else {
-            vec![]
-        };
-
-        Ok::<_, String>((status, stderr_lines))
-    }
-    .await;
-
-    // ALWAYS restart Caddy, regardless of lego success/failure
-    if need_proxy_stop {
-        set_acme_status("running", "Restarting web server...", Some(domain));
-        nasty_common::cmd::try_run("systemctl", &["start", "caddy"]).await;
+        out.push_str("    }\n");
     }
 
-    let (exit_status, stderr_lines) = lego_result?;
+    out.push_str("    import nasty_webui_routes\n");
+    out.push_str("}\n");
+    out
+}
 
-    if !exit_status.success() {
-        let stderr = stderr_lines.join("\n");
-        let msg = format!("lego {action} failed: {stderr}");
-        set_acme_status("error", &msg, Some(domain));
-        return Err(msg);
-    }
-
-    set_acme_status("running", "Installing certificate...", Some(domain));
-
-    // Copy lego certs to NASty's TLS paths
-    let lego_cert = format!("{lego_dir}/certificates/{domain}.crt");
-    let lego_key = format!("{lego_dir}/certificates/{domain}.key");
-
-    tokio::fs::copy(&lego_cert, TLS_CERT_PATH)
-        .await
-        .map_err(|e| {
-            let m = format!("failed to copy cert: {e}");
-            set_acme_status("error", &m, Some(domain));
-            m
-        })?;
-    tokio::fs::copy(&lego_key, TLS_KEY_PATH)
-        .await
-        .map_err(|e| {
-            let m = format!("failed to copy key: {e}");
-            set_acme_status("error", &m, Some(domain));
-            m
-        })?;
-
-    // Set permissions so Caddy (running as caddy user) can read the cert.
-    // A failure here means caddy will hit "permission denied" on reload,
-    // which is way easier to diagnose with this log line in front of it.
-    if let Err(e) =
-        tokio::fs::set_permissions(TLS_CERT_PATH, std::fs::Permissions::from_mode(0o644)).await
+/// Render the Caddy `EnvironmentFile` content from `tls_dns_credentials`.
+/// Empty when ACME-DNS is off — the file is recreated empty so a stale
+/// value from a previous provider doesn't leak into the next run.
+fn caddy_acme_env(settings: &Settings) -> String {
+    if !settings.tls_acme_enabled
+        || settings.tls_challenge_type != "dns"
+        || settings.tls_dns_credentials.is_none()
     {
-        warn!("chmod 644 {TLS_CERT_PATH} failed: {e}");
+        return String::new();
     }
-    if let Err(e) =
-        tokio::fs::set_permissions(TLS_KEY_PATH, std::fs::Permissions::from_mode(0o640)).await
-    {
-        warn!("chmod 640 {TLS_KEY_PATH} failed: {e}");
-    }
-    // Set key group to caddy so it can read it. `try_run` logs failures.
-    nasty_common::cmd::try_run("chown", &["root:caddy", TLS_KEY_PATH]).await;
+    settings
+        .tls_dns_credentials
+        .clone()
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+        + "\n"
+}
 
-    // Reload Caddy to pick up the new certificate
+/// Apply current settings to Caddy: render the snippet + env file,
+/// write them, reload Caddy, then refresh the cached ACME status from
+/// whatever Caddy ends up serving.
+pub async fn apply_caddy_tls(settings: &Settings) -> Result<(), String> {
+    let domain_for_status = settings.tls_domain.clone();
+
+    if settings.tls_acme_enabled {
+        set_acme_status(
+            "running",
+            "Reloading Caddy with ACME configuration...",
+            domain_for_status.as_deref(),
+        );
+    }
+
+    // Both files live in the same dir, owned by the caddy user/group so
+    // Caddy can read them. Engine runs as root, so the create + chown
+    // here are guaranteed to succeed even on first apply — but log any
+    // failure anyway per the workspace-wide rule (see CONTRIBUTING.md).
+    if let Some(parent) = std::path::Path::new(CADDY_VHOSTS_PATH).parent()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        warn!("create_dir_all({}) failed: {e}", parent.display());
+    }
+
+    let snippet = caddy_vhosts_snippet(settings, 8443);
+    tokio::fs::write(CADDY_VHOSTS_PATH, &snippet)
+        .await
+        .map_err(|e| format!("write {CADDY_VHOSTS_PATH}: {e}"))?;
+    if let Err(e) =
+        tokio::fs::set_permissions(CADDY_VHOSTS_PATH, std::fs::Permissions::from_mode(0o644)).await
+    {
+        warn!("chmod 644 {CADDY_VHOSTS_PATH} failed: {e}");
+    }
+
+    let env_content = caddy_acme_env(settings);
+    tokio::fs::write(CADDY_ACME_ENV_PATH, &env_content)
+        .await
+        .map_err(|e| format!("write {CADDY_ACME_ENV_PATH}: {e}"))?;
+    // 0640 + chown caddy: secrets, not world-readable.
+    if let Err(e) =
+        tokio::fs::set_permissions(CADDY_ACME_ENV_PATH, std::fs::Permissions::from_mode(0o640))
+            .await
+    {
+        warn!("chmod 640 {CADDY_ACME_ENV_PATH} failed: {e}");
+    }
+    nasty_common::cmd::try_run("chown", &["root:caddy", CADDY_ACME_ENV_PATH]).await;
+
+    // `systemctl reload caddy` directly rather than through try_run so
+    // we can surface stderr to the caller (the WebUI shows it as an
+    // error toast). Spawn / non-zero-exit logging happens here inline.
     let reload = tokio::process::Command::new("systemctl")
         .args(["reload", "caddy"])
         .output()
-        .await;
-    match reload {
-        Ok(r) if r.status.success() => info!("caddy reloaded with new certificate"),
-        Ok(r) => {
-            let stderr = String::from_utf8_lossy(&r.stderr);
-            warn!("caddy reload failed after cert install: {stderr}");
-        }
-        Err(e) => warn!("Failed to reload caddy: {e}"),
+        .await
+        .map_err(|e| {
+            let m = format!("systemctl reload caddy: spawn failed: {e}");
+            warn!("{m}");
+            m
+        })?;
+    if !reload.status.success() {
+        let stderr = String::from_utf8_lossy(&reload.stderr).to_string();
+        let msg = format!("caddy reload failed: {stderr}");
+        warn!("{msg}");
+        set_acme_status("error", &msg, domain_for_status.as_deref());
+        return Err(msg);
     }
+    info!("caddy reloaded");
 
-    // Read cert details and populate status
-    let cert_info = read_cert_info(TLS_CERT_PATH).await;
+    // Push the status forward best-effort. A successful reload doesn't
+    // mean the ACME issuance is complete — Caddy issues asynchronously
+    // — so we fall back to "running" if no cert is on disk yet.
+    refresh_acme_status_from_disk(settings).await;
+    Ok(())
+}
+
+/// Locate the cert Caddy is currently serving for `domain`, falling back
+/// to the static-cert path used when ACME is off.
+async fn locate_serving_cert(settings: &Settings) -> Option<String> {
+    if settings.tls_acme_enabled
+        && let Some(domain) = settings.tls_domain.as_deref()
     {
+        // `/var/lib/caddy/.local/share/caddy/certificates/<endpoint>/<domain>/<domain>.crt`
+        // Endpoint dir name varies (production vs staging vs zerossl
+        // fallback), so glob one level deep.
+        let base = format!("{CADDY_DATA_DIR}/.local/share/caddy/certificates");
+        if let Ok(mut endpoints) = tokio::fs::read_dir(&base).await {
+            while let Ok(Some(ep)) = endpoints.next_entry().await {
+                let candidate = format!("{}/{domain}/{domain}.crt", ep.path().display());
+                if tokio::fs::metadata(&candidate).await.is_ok() {
+                    return Some(candidate);
+                }
+            }
+        }
+        return None;
+    }
+    if tokio::fs::metadata(TLS_CERT_PATH).await.is_ok() {
+        return Some(TLS_CERT_PATH.to_string());
+    }
+    None
+}
+
+/// Repopulate the cached ACME status struct from whatever cert Caddy is
+/// (or isn't yet) serving. Cheap to call repeatedly — does at most one
+/// directory listing + one cert parse.
+pub async fn refresh_acme_status_from_disk(settings: &Settings) {
+    let domain = settings.tls_domain.clone();
+    if !settings.tls_acme_enabled {
+        // Static-cert mode. Show the cert details if we have any so the
+        // WebUI's "Active certificate" panel still has something to
+        // render, but flag the state as idle so the page doesn't claim
+        // ACME succeeded.
+        let cert_info = read_cert_info(TLS_CERT_PATH).await;
         let status = ACME_STATUS.get_or_init(|| std::sync::Mutex::new(AcmeStatus::default()));
         if let Ok(mut s) = status.lock() {
-            s.state = "success".to_string();
-            s.message = format!("Certificate installed for {domain}");
-            s.domain = Some(domain.to_string());
+            s.state = "idle".into();
+            s.message = "Static certificate (ACME disabled)".into();
+            s.domain = domain;
             s.expires = cert_info.expires;
             s.issued = cert_info.issued;
             s.issuer = cert_info.issuer;
-            s.last_attempt = Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs().to_string())
-                    .unwrap_or_default(),
-            );
         }
+        return;
     }
-    info!("ACME certificate installed for {domain}");
-    Ok(())
+
+    let Some(path) = locate_serving_cert(settings).await else {
+        // ACME enabled but no cert on disk yet — still issuing.
+        set_acme_status(
+            "running",
+            "Waiting for Caddy to obtain a certificate...",
+            domain.as_deref(),
+        );
+        return;
+    };
+    let cert_info = read_cert_info(&path).await;
+    let status = ACME_STATUS.get_or_init(|| std::sync::Mutex::new(AcmeStatus::default()));
+    if let Ok(mut s) = status.lock() {
+        s.state = "success".into();
+        s.message = match domain.as_deref() {
+            Some(d) => format!("Certificate active for {d}"),
+            None => "Certificate active".into(),
+        };
+        s.domain = domain;
+        s.expires = cert_info.expires;
+        s.issued = cert_info.issued;
+        s.issuer = cert_info.issuer;
+    }
+}
+
+/// Engine-startup hook (replaces the old lego-driven `check_acme_renewal`).
+/// Caddy auto-renews internally — there's nothing for us to *do* here, just
+/// seed the cached status so the WebUI shows cert details immediately rather
+/// than after the first user-triggered apply.
+pub async fn check_acme_renewal() {
+    let settings = load().await;
+    refresh_acme_status_from_disk(&settings).await;
 }
 
 struct CertInfo {
@@ -875,7 +883,6 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
             .to_rfc2822()
             .unwrap_or_else(|_| validity.not_after.to_string()),
     );
-    // Extract CN or O from issuer
     for rdn in cert.issuer().iter() {
         for attr in rdn.iter() {
             let val = attr.as_str().unwrap_or_default();
@@ -892,74 +899,6 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
         }
     }
     info
-}
-
-/// Write DNS credentials to a file readable by the ACME client.
-async fn write_dns_credentials(settings: &Settings) {
-    if let Some(creds) = &settings.tls_dns_credentials {
-        if let Err(e) = tokio::fs::write(DNS_CREDS_PATH, creds).await {
-            warn!("Failed to write DNS credentials: {e}");
-            return;
-        }
-        if let Err(e) =
-            tokio::fs::set_permissions(DNS_CREDS_PATH, std::fs::Permissions::from_mode(0o600)).await
-        {
-            warn!(
-                "chmod 600 {DNS_CREDS_PATH} failed: {e} — \
-                 DNS provider credentials may be world-readable"
-            );
-        }
-    }
-}
-
-/// Check if ACME cert needs renewal (runs on engine startup).
-pub async fn check_acme_renewal() {
-    let settings = load().await;
-    if !settings.tls_acme_enabled {
-        return;
-    }
-    if settings.tls_domain.is_none() || settings.tls_acme_email.is_none() {
-        return;
-    }
-
-    // Populate cert info on startup so the UI shows details immediately
-    if std::path::Path::new(TLS_CERT_PATH).exists() {
-        let cert_info = read_cert_info(TLS_CERT_PATH).await;
-        let domain = settings.tls_domain.as_deref().unwrap_or("");
-        let status = ACME_STATUS.get_or_init(|| std::sync::Mutex::new(AcmeStatus::default()));
-        if let Ok(mut s) = status.lock() {
-            s.state = "success".to_string();
-            s.message = format!("Certificate installed for {domain}");
-            s.domain = Some(domain.to_string());
-            s.expires = cert_info.expires;
-            s.issued = cert_info.issued;
-            s.issuer = cert_info.issuer;
-        }
-    }
-
-    // Check if cert exists and is near expiry (within 30 days)
-    let lego_subdir = if settings.tls_acme_staging {
-        "staging"
-    } else {
-        "production"
-    };
-    let cert_path = format!(
-        "{LEGO_DATA_DIR}/{lego_subdir}/certificates/{}.crt",
-        settings.tls_domain.as_deref().unwrap_or("")
-    );
-    if !std::path::Path::new(&cert_path).exists() {
-        info!("No ACME cert found, running initial provisioning...");
-        if let Err(e) = run_lego(&settings).await {
-            warn!("ACME provisioning on startup failed: {e}");
-        }
-        return;
-    }
-
-    // Try renewal (lego handles expiry check internally)
-    info!("Checking ACME certificate renewal...");
-    if let Err(e) = run_lego(&settings).await {
-        warn!("ACME renewal check failed: {e}");
-    }
 }
 
 #[cfg(test)]

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -376,12 +376,16 @@ impl UpdateService {
             r#"#!/bin/bash
 set -euo pipefail
 export PATH="/run/current-system/sw/bin:$PATH"
-_nginx_conf() {{
-    grep -o "/nix/store/[^' ]*nginx\.conf" \
-        /run/current-system/etc/systemd/system/nginx.service 2>/dev/null | head -1 || true
+_proxy_conf() {{
+    # Resolve the active Caddyfile via the etc-symlink the Caddy
+    # NixOS module sets up.  Each generation has its own /etc/caddy/
+    # tree, so the resolved path doubles as a generation identity —
+    # comparing it before/after a rebuild tells us whether the WebUI
+    # closure (or anything else in the Caddyfile) changed.
+    readlink -f /run/current-system/etc/caddy/Caddyfile 2>/dev/null || true
 }}
-_NGINX_CONF_BEFORE=$(_nginx_conf)
-WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+_PROXY_CONF_BEFORE=$(_proxy_conf)
+WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
 echo "false" > {UPDATE_WEBUI_CHANGED}
 
 echo "==> Updating local system flake..."
@@ -406,8 +410,8 @@ if [ "$_RC" -ne 0 ]; then
     exit "$_RC"
 fi
 
-_NGINX_CONF_AFTER=$(_nginx_conf)
-WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
+_PROXY_CONF_AFTER=$(_proxy_conf)
+WEBUI_AFTER=$([ -n "$_PROXY_CONF_AFTER" ] && grep 'nasty-webui' "$_PROXY_CONF_AFTER" 2>/dev/null | head -1 || echo "")
 if [ -n "$WEBUI_BEFORE" ] && [ "$WEBUI_BEFORE" != "$WEBUI_AFTER" ]; then
     echo "true" > {UPDATE_WEBUI_CHANGED}
 fi
@@ -636,17 +640,21 @@ echo "==> Update complete!"
             r#"#!/bin/bash
 set -euo pipefail
 export PATH="/run/current-system/sw/bin:$PATH"
-# Capture current webui store path before rebuild so we can detect if it changed.
-# Read from /run/current-system/etc/systemd/system/nginx.service — the unit file
-# uses single-quoted paths so the regex terminates cleanly at the closing quote.
-# After nixos-rebuild switch the /run/current-system symlink is updated before we
-# read the AFTER value, so we always compare old vs new closure.
-_nginx_conf() {{
-    grep -o "/nix/store/[^' ]*nginx\.conf" \
-        /run/current-system/etc/systemd/system/nginx.service 2>/dev/null | head -1 || true
+# Capture the active Caddyfile store path before rebuild so we can
+# detect whether the WebUI closure changed.  After nixos-rebuild
+# switch the /run/current-system symlink updates atomically before
+# we read the AFTER value, so the BEFORE/AFTER comparison always
+# spans old vs new closure.
+_proxy_conf() {{
+    # Resolve the active Caddyfile via the etc-symlink the Caddy
+    # NixOS module sets up.  Each generation has its own /etc/caddy/
+    # tree, so the resolved path doubles as a generation identity —
+    # comparing it before/after a rebuild tells us whether the WebUI
+    # closure (or anything else in the Caddyfile) changed.
+    readlink -f /run/current-system/etc/caddy/Caddyfile 2>/dev/null || true
 }}
-_NGINX_CONF_BEFORE=$(_nginx_conf)
-WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+_PROXY_CONF_BEFORE=$(_proxy_conf)
+WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
 echo "==> Updating local system flake..."
 cd {LOCAL_REPO}
 {update_step}
@@ -671,8 +679,8 @@ fi
 
 # Detect if the webui store path changed so the frontend knows whether to prompt a reload.
 # /run/current-system now points to the newly activated closure.
-_NGINX_CONF_AFTER=$(_nginx_conf)
-WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
+_PROXY_CONF_AFTER=$(_proxy_conf)
+WEBUI_AFTER=$([ -n "$_PROXY_CONF_AFTER" ] && grep 'nasty-webui' "$_PROXY_CONF_AFTER" 2>/dev/null | head -1 || echo "")
 if [ -n "$WEBUI_BEFORE" ] && [ "$WEBUI_BEFORE" != "$WEBUI_AFTER" ]; then
     echo "true" > {UPDATE_WEBUI_CHANGED}
 else
@@ -908,12 +916,16 @@ echo "==> Update complete!"
             r#"#!/bin/bash
 set -euo pipefail
 export PATH="/run/current-system/sw/bin:$PATH"
-_nginx_conf() {{
-    grep -o "/nix/store/[^' ]*nginx\.conf" \
-        /run/current-system/etc/systemd/system/nginx.service 2>/dev/null | head -1 || true
+_proxy_conf() {{
+    # Resolve the active Caddyfile via the etc-symlink the Caddy
+    # NixOS module sets up.  Each generation has its own /etc/caddy/
+    # tree, so the resolved path doubles as a generation identity —
+    # comparing it before/after a rebuild tells us whether the WebUI
+    # closure (or anything else in the Caddyfile) changed.
+    readlink -f /run/current-system/etc/caddy/Caddyfile 2>/dev/null || true
 }}
-_NGINX_CONF_BEFORE=$(_nginx_conf)
-WEBUI_BEFORE=$([ -n "$_NGINX_CONF_BEFORE" ] && grep 'nasty-webui' "$_NGINX_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+_PROXY_CONF_BEFORE=$(_proxy_conf)
+WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
 echo "false" > {UPDATE_WEBUI_CHANGED}
 
 echo "==> Updating local system flake..."
@@ -942,8 +954,8 @@ if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
         echo "--- end journal dump ---"
         exit "$RC"
     fi
-    _NGINX_CONF_AFTER=$(_nginx_conf)
-    WEBUI_AFTER=$([ -n "$_NGINX_CONF_AFTER" ] && grep 'nasty-webui' "$_NGINX_CONF_AFTER" 2>/dev/null | head -1 || echo "")
+    _PROXY_CONF_AFTER=$(_proxy_conf)
+    WEBUI_AFTER=$([ -n "$_PROXY_CONF_AFTER" ] && grep 'nasty-webui' "$_PROXY_CONF_AFTER" 2>/dev/null | head -1 || echo "")
     if [ -n "$WEBUI_BEFORE" ] && [ "$WEBUI_BEFORE" != "$WEBUI_AFTER" ]; then
         echo "true" > {UPDATE_WEBUI_CHANGED}
     fi

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/nixos/TESTING.md
+++ b/nixos/TESTING.md
@@ -29,7 +29,7 @@ ssh -p 2222 root@localhost
 systemctl status nasty-engine
 journalctl -u nasty-engine --no-pager -n 20
 
-# 2. Check nginx/TLS is working
+# 2. Check Caddy/TLS is working
 curl -k https://localhost/health
 
 # 3. Check self-signed cert was generated
@@ -126,8 +126,8 @@ ls -la /var/lib/nasty/
 ```bash
 # Check engine is listening
 ss -tlnp | grep 2137
-# Check nginx is proxying
-journalctl -u nginx -f
+# Check Caddy is proxying
+journalctl -u caddy -f
 ```
 
 ### Self-signed cert issues
@@ -135,7 +135,7 @@ journalctl -u nginx -f
 # Regenerate cert
 rm /var/lib/nasty/tls/*.pem
 systemctl restart nasty-selfsigned-cert
-systemctl restart nginx
+systemctl restart caddy
 ```
 
 ### Pool operations fail

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -820,7 +820,7 @@ in {
 
     systemd.tmpfiles.rules = [
       "d /var/lib/nasty 0751 root root -"
-      "d /var/lib/nasty/tls 0750 root nginx -"
+      "d /var/lib/nasty/tls 0750 root caddy -"
       "d /var/lib/nasty/subvolumes 0750 root root -"
       "d /var/lib/nasty/shares 0750 root root -"
       "d /var/lib/nasty/shares/nfs 0750 root root -"
@@ -828,7 +828,10 @@ in {
       "d /var/lib/nasty/shares/iscsi 0750 root root -"
       "d /var/lib/nasty/shares/nvmeof 0750 root root -"
       "d /var/lib/nasty/vms 0750 root root -"
-      "f /var/lib/nasty/apps-proxy.conf 0644 root root - # empty = no app proxies"
+      # Note: no `apps-proxy.caddy` tmpfile — apps ingress lives in
+      # Caddy's admin-API config, not on disk.  The engine PATCHes
+      # `/config/apps/http/servers/.../routes` directly on install /
+      # remove.
       "C /var/lib/nasty/sshd_override.conf 0644 root root - ${pkgs.writeText "sshd-default" "PasswordAuthentication yes\n"}"
       "d ${cfg.storage.mountBase} 0755 root root -"
       "d /etc/exports.d 0755 root root -"
@@ -844,8 +847,8 @@ in {
     systemd.services.nasty-selfsigned-cert = mkIf useSelfSigned {
       description = "Generate NASty self-signed TLS certificate";
       wantedBy = [ "multi-user.target" ];
-      before = [ "nginx.service" ];
-      requiredBy = [ "nginx.service" ];
+      before = [ "caddy.service" ];
+      requiredBy = [ "caddy.service" ];
 
       serviceConfig = {
         Type = "oneshot";
@@ -855,24 +858,25 @@ in {
           CERT="${tlsCertFile}"
           KEY="${tlsKeyFile}"
 
-          if [ -f "$CERT" ] && [ -f "$KEY" ]; then
-            echo "TLS certificate already exists, skipping generation"
-            exit 0
+          if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
+            echo "Generating self-signed TLS certificate for NASty..."
+            ${pkgs.openssl}/bin/openssl req -x509 -newkey ec \
+              -pkeyopt ec_paramgen_curve:prime256v1 \
+              -keyout "$KEY" -out "$CERT" \
+              -days 3650 -nodes \
+              -subj "/CN=nasty.local/O=NASty NAS" \
+              -addext "subjectAltName=DNS:nasty.local,DNS:localhost,IP:127.0.0.1"
+            echo "Self-signed certificate generated at $CERT"
+          else
+            echo "TLS certificate already exists; re-applying ownership"
           fi
 
-          echo "Generating self-signed TLS certificate for NASty..."
-          ${pkgs.openssl}/bin/openssl req -x509 -newkey ec \
-            -pkeyopt ec_paramgen_curve:prime256v1 \
-            -keyout "$KEY" -out "$CERT" \
-            -days 3650 -nodes \
-            -subj "/CN=nasty.local/O=NASty NAS" \
-            -addext "subjectAltName=DNS:nasty.local,DNS:localhost,IP:127.0.0.1"
-
+          # Always re-apply ownership / mode so an upgrade from the
+          # nginx era (where the key was group `nginx`) gets the key
+          # readable by Caddy without forcing a regeneration.
           chmod 640 "$KEY"
-          chown root:nginx "$KEY"
+          chown root:caddy "$KEY"
           chmod 644 "$CERT"
-
-          echo "Self-signed certificate generated at $CERT"
         '';
       };
     };
@@ -910,8 +914,14 @@ in {
     systemd.services.nasty-engine = {
       description = "NASty Engine";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "nasty-metrics.service" ];
-      wants = [ "nasty-metrics.service" ];
+      # caddy.service ordering: the engine pushes per-app ingress
+      # routes via Caddy's admin API at startup (and on every
+      # install/remove).  `after` keeps boot ordering clean; `wants`
+      # (vs `requires`) means a broken Caddy doesn't block the engine
+      # from running — the admin-API client has retry/backoff and
+      # logs a warn! if it can't reach :2019.
+      after = [ "network.target" "nasty-metrics.service" "caddy.service" ];
+      wants = [ "nasty-metrics.service" "caddy.service" ];
 
       path = with pkgs; [
         bashInteractive  # bash for terminal
@@ -1194,112 +1204,170 @@ in {
       wantedBy = lib.mkForce [];  # engine starts on demand
     };
 
-    # ── WebUI via nginx ────────────────────────────────────────
+    # ── WebUI via Caddy ────────────────────────────────────────
 
-    services.nginx = mkIf (cfg.webui.package != null) {
+    # ── Reverse proxy: Caddy ───────────────────────────────────
+    #
+    # Caddy serves the WebUI, terminates TLS, and proxies the
+    # engine RPC + API.  Per-app `/apps/<name>/` ingress lives in
+    # Caddy's admin-API config: the engine talks to
+    # http://127.0.0.1:2019/config/... on install / remove and the
+    # routes apply immediately, no file rewrite, no reload.
+    services.caddy = mkIf (cfg.webui.package != null) {
       enable = true;
-
-      # Recommended TLS settings
-      recommendedTlsSettings = true;
-      recommendedProxySettings = true;
-
-      virtualHosts."nasty" = {
-        listen = [
-          { addr = "0.0.0.0"; port = cfg.webui.httpPort; }
-          { addr = "0.0.0.0"; port = cfg.webui.port; ssl = true; }
-        ];
-        forceSSL = true;
-        root = "${cfg.webui.package}/share/nasty-webui";
-        sslCertificate = tlsCertFile;
-        sslCertificateKey = tlsKeyFile;
-
+      # `auto_https off` because we ship a self-signed (or
+      # user-supplied) cert and don't want Caddy issuing its own;
+      # the explicit `tls` block below points at the same cert
+      # files the nginx era used.
+      globalConfig = ''
+        auto_https off
+      '';
+      virtualHosts.":${toString cfg.webui.httpPort}" = {
         extraConfig = ''
-          add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-          add_header X-Content-Type-Options "nosniff" always;
-          add_header X-Frame-Options "DENY" always;
-          add_header Referrer-Policy "same-origin" always;
-          # CSP: 'unsafe-inline' is required because SvelteKit emits inline
-          # bootstrap and theme-detection scripts in index.html. Tightening to
-          # nonces/hashes is a follow-up; this still blocks third-party script
-          # loads, object embeds, and cross-origin form submission.
-          add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self' ws: wss:; frame-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
-          proxy_set_header X-Real-IP $remote_addr;
-          include /var/lib/nasty/apps-proxy.conf;
+          redir https://{host}{uri} permanent
         '';
+      };
+      virtualHosts.":${toString cfg.webui.port}" = {
+        extraConfig = ''
+          tls ${tlsCertFile} ${tlsKeyFile}
+          root * ${cfg.webui.package}/share/nasty-webui
 
-        locations."/" = {
-          tryFiles = "$uri $uri/ /index.html";
-        };
+          # Security headers on every response.  CSP keeps
+          # 'unsafe-inline' for now because SvelteKit emits inline
+          # bootstrap + theme-detection scripts in index.html;
+          # nonces / hashes are a follow-up.
+          header {
+            Strict-Transport-Security "max-age=31536000; includeSubDomains"
+            X-Content-Type-Options "nosniff"
+            X-Frame-Options "DENY"
+            Referrer-Policy "same-origin"
+            Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self' ws: wss:; frame-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          }
 
-        # Proxy WebSocket to engine
-        locations."/ws" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-          proxyWebsockets = true;
-          priority = 500;
-        };
+          # File-content preview: same engine endpoint, but a much
+          # tighter sandbox CSP and SAMEORIGIN frame-ancestors so a
+          # previewed HTML/SVG can't run scripts in the WebUI's
+          # origin.  Block order matters — this exact-path handle
+          # must come before the broader /api/* one.
+          handle /api/files/content {
+            header {
+              Content-Security-Policy "sandbox; default-src 'none'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'unsafe-inline'; frame-ancestors 'self'"
+              X-Frame-Options "SAMEORIGIN"
+            }
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 3600s
+                write_timeout 3600s
+              }
+            }
+          }
 
-        locations."/ws/terminal" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-          proxyWebsockets = true;
-          priority = 400;
-          extraConfig = ''
-            proxy_read_timeout 28800s;
-            proxy_send_timeout 28800s;
-          '';
-        };
+          # Long-running websockets — terminal, VM console (vnc /
+          # serial), apps-deploy streaming, log-stream viewer, VM
+          # disk-import upload.  8h read/write timeouts so an idle
+          # session doesn't get axed.  Caddy's reverse_proxy detects
+          # Upgrade headers automatically — no explicit websocket
+          # directive needed.  All of these need X-Real-IP set so
+          # the engine's IP-bound session validation matches what it
+          # saw on the /api/login that issued the token (see /ws
+          # comment below).
+          #
+          # The final `/ws/*` block is a catch-all for any future
+          # engine WS route that might be added without a
+          # corresponding nasty.nix update — without it, a new
+          # `/ws/foo` route would silently 404 through the SPA
+          # fallback (the exact bug that broke `/ws/apps/deploy` and
+          # `/ws/system/logs` after the nginx → Caddy swap).  Caddy
+          # evaluates routes in declaration order, so the specific
+          # handlers above still win for their paths; this one only
+          # catches what nothing else claimed.
+          handle /ws/terminal {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
+            }
+          }
+          handle /ws/vm/* {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
+            }
+          }
+          handle /ws/apps/deploy {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
+            }
+          }
+          handle /ws/system/logs {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
+            }
+          }
 
-        locations."/ws/vm/" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-          proxyWebsockets = true;
-          priority = 400;
-          extraConfig = ''
-            proxy_read_timeout 28800s;
-            proxy_send_timeout 28800s;
-          '';
-        };
+          # Main engine RPC websocket.  Must propagate X-Real-IP so
+          # the engine's IP-bound session validation sees the same
+          # client address it saw on the /api/login that issued the
+          # token — without this, login through Caddy succeeds and the
+          # immediate /ws upgrade through Caddy fails as "invalid
+          # token" because the engine sees Caddy's loopback address
+          # instead of the user's real IP.
+          handle /ws {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+            }
+          }
 
-        # Proxy API calls to engine
-        locations."/api/" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-          extraConfig = ''
-            client_max_body_size 10G;
-            proxy_request_buffering off;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-          '';
-        };
+          # Catch-all for future `/ws/*` routes the engine grows
+          # without us updating this block.  Same long timeouts as the
+          # explicit websocket handlers above.
+          handle /ws/* {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
+            }
+          }
 
-        # Serve user-uploaded file content under a sandbox CSP so a previewed
-        # HTML/SVG file cannot run scripts in the WebUI's origin.
-        #
-        # nginx gotcha: when a location declares ANY add_header, it stops
-        # inheriting *all* parent add_header directives — not just the
-        # overridden one. Every header we want on this response has to be
-        # re-declared here, including HSTS / Referrer-Policy.
-        #
-        # X-Frame-Options is intentionally SAMEORIGIN (not DENY like the
-        # vhost) because the WebUI's file preview iframes this endpoint.
-        # frame-ancestors 'self' in the CSP enforces the same constraint
-        # for modern browsers that prefer CSP over the older header.
-        locations."/api/files/content" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-          priority = 300;
-          extraConfig = ''
-            proxy_request_buffering off;
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header X-Frame-Options "SAMEORIGIN" always;
-            add_header Referrer-Policy "same-origin" always;
-            add_header Content-Security-Policy "sandbox; default-src 'none'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'unsafe-inline'; frame-ancestors 'self'" always;
-          '';
-        };
+          # /api/* — generic engine API.  3600s timeout +
+          # request-body streaming for large uploads.
+          handle /api/* {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
+              header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 3600s
+                write_timeout 3600s
+              }
+            }
+          }
 
-        locations."/health" = {
-          proxyPass = "http://127.0.0.1:${toString cfg.engine.port}";
-        };
+          handle /health {
+            reverse_proxy 127.0.0.1:${toString cfg.engine.port}
+          }
 
+          # Static WebUI with SPA fallback.  Anything not matched
+          # above falls through here.
+          handle {
+            try_files {path} {path}/ /index.html
+            file_server
+          }
+        '';
       };
     };
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1313,6 +1313,15 @@ in {
           # saw on the /api/login that issued the token (see /ws
           # comment below).
           #
+          # `stream_close_delay 30m` keeps each handler instance
+          # alive for 30 min after a Caddy config reload, so the
+          # admin-API mutations the engine performs for app ingress
+          # (PUT/DELETE routes on every install/remove) don't kill
+          # every active WS in the WebUI.  Caddy's reload model is
+          # all-or-nothing — there's no in-place route patch — so
+          # this is the supported mitigation until upstream
+          # caddyserver/caddy#7222 (`stream_detached`) lands.
+          #
           # The final `/ws/*` block is a catch-all for any future
           # engine WS route that might be added without a
           # corresponding nasty.nix update — without it, a new
@@ -1329,6 +1338,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
           handle /ws/vm/* {
@@ -1338,6 +1348,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
           handle /ws/apps/deploy {
@@ -1347,6 +1358,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
           handle /ws/system/logs {
@@ -1356,6 +1368,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
 
@@ -1373,6 +1386,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
 
@@ -1386,6 +1400,7 @@ in {
                 read_timeout 28800s
                 write_timeout 28800s
               }
+              stream_close_delay 30m
             }
           }
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -576,7 +576,6 @@ in {
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery
       docker-compose    # Docker Compose for multi-container apps
-      lego              # ACME client for Let's Encrypt certificates
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
       restic-rest-server # REST API server for receiving backups from other machines
@@ -821,6 +820,14 @@ in {
     systemd.tmpfiles.rules = [
       "d /var/lib/nasty 0751 root root -"
       "d /var/lib/nasty/tls 0750 root caddy -"
+      # Engine-managed Caddy snippets — vhosts.conf is imported by the
+      # main Caddyfile (hostname-bound ACME vhost when enabled, empty
+      # otherwise); acme.env feeds DNS-01 provider creds into Caddy via
+      # EnvironmentFile. Seeded empty so Caddy can start before the
+      # engine has had a chance to write either.
+      "d /var/lib/nasty/caddy 0750 root caddy -"
+      "f /var/lib/nasty/caddy/vhosts.conf 0644 root caddy -"
+      "f /var/lib/nasty/caddy/acme.env 0640 root caddy -"
       "d /var/lib/nasty/subvolumes 0750 root root -"
       "d /var/lib/nasty/shares 0750 root root -"
       "d /var/lib/nasty/shares/nfs 0750 root root -"
@@ -948,7 +955,6 @@ in {
         docker                       # Docker for apps runtime
         docker-compose               # Docker Compose for multi-container apps
         fwupd                        # fwupdmgr for firmware updates
-        lego                         # ACME client for Let's Encrypt
         curl                         # HTTP debugging
         rsync                        # file sync
         procps                       # sysctl (vm.dirty_* tuning)
@@ -1003,7 +1009,7 @@ in {
         KeyringMode = "private";
         # Allow only the address families the engine actually uses:
         #   AF_UNIX   — docker/QMP/libvirt sockets
-        #   AF_INET/6 — outbound HTTPS (lego, telemetry, registries)
+        #   AF_INET/6 — outbound HTTPS (Caddy ACME, telemetry, registries)
         #   AF_NETLINK — nft, ip, mount/umount kernel chatter
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
       };
@@ -1213,23 +1219,26 @@ in {
     # Caddy's admin-API config: the engine talks to
     # http://127.0.0.1:2019/config/... on install / remove and the
     # routes apply immediately, no file rewrite, no reload.
+    # Caddy is configured as a single named snippet (`nasty_webui_routes`)
+    # that holds every reverse-proxy / file-server / websocket / header
+    # rule, plus a static `:<port>` vhost that mounts the snippet with the
+    # self-signed (or user-supplied) cert. The engine then optionally
+    # writes a hostname-bound ACME vhost to `/var/lib/nasty/caddy/vhosts.conf`
+    # which the main Caddyfile imports — Caddy issues + serves a real cert
+    # for that hostname while the static `:<port>` block stays as the IP
+    # fallback. Both vhosts share routes through the snippet, so we don't
+    # have to keep them in sync by hand.
+    #
+    # `auto_https off` because we never want Caddy enrolling for IP-bound
+    # vhosts; the engine-managed snippet drives ACME explicitly via the
+    # `tls EMAIL` form on a hostname-bound block.
     services.caddy = mkIf (cfg.webui.package != null) {
       enable = true;
-      # `auto_https off` because we ship a self-signed (or
-      # user-supplied) cert and don't want Caddy issuing its own;
-      # the explicit `tls` block below points at the same cert
-      # files the nginx era used.
       globalConfig = ''
         auto_https off
       '';
-      virtualHosts.":${toString cfg.webui.httpPort}" = {
-        extraConfig = ''
-          redir https://{host}{uri} permanent
-        '';
-      };
-      virtualHosts.":${toString cfg.webui.port}" = {
-        extraConfig = ''
-          tls ${tlsCertFile} ${tlsKeyFile}
+      extraConfig = ''
+        (nasty_webui_routes) {
           root * ${cfg.webui.package}/share/nasty-webui
 
           # Security headers on every response.  CSP keeps
@@ -1367,9 +1376,34 @@ in {
             try_files {path} {path}/ /index.html
             file_server
           }
-        '';
-      };
+        }
+
+        # HTTP -> HTTPS redirect, port-only (works for IP and hostname).
+        :${toString cfg.webui.httpPort} {
+          redir https://{host}{uri} permanent
+        }
+
+        # Always-on static-cert vhost. Serves the self-signed (or
+        # user-supplied) cert on the IP path. When ACME is enabled,
+        # Caddy prefers the hostname-bound vhost from the import below
+        # for matching SNI, and this block becomes the IP fallback.
+        :${toString cfg.webui.port} {
+          tls ${tlsCertFile} ${tlsKeyFile}
+          import nasty_webui_routes
+        }
+
+        # Engine-managed: hostname-bound ACME vhost when the user has
+        # enabled Let's Encrypt in Settings → TLS. Empty otherwise.
+        import /var/lib/nasty/caddy/vhosts.conf
+      '';
     };
+
+    # Caddy reads DNS-01 provider creds (when the user picks DNS
+    # challenge) from this EnvironmentFile. The `-` prefix means
+    # "ignore if missing" so the unit still starts on a fresh box
+    # before the engine has written anything.
+    systemd.services.caddy.serviceConfig.EnvironmentFile =
+      mkIf (cfg.webui.package != null) "-/var/lib/nasty/caddy/acme.env";
 
     # ── Journald ───────────────────────────────────────────────
     services.journald.extraConfig = ''

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1234,6 +1234,37 @@ in {
     # `tls EMAIL` form on a hostname-bound block.
     services.caddy = mkIf (cfg.webui.package != null) {
       enable = true;
+      # Rebuild Caddy with DNS-01 plugins compiled in. Stock `pkgs.caddy`
+      # only supports HTTP-01 / TLS-ALPN-01 (no DNS providers), so users
+      # whose ACME challenge type is "dns" need a custom build.
+      #
+      # Provider list is intentionally short — the four below cover the
+      # vast majority of selfhost / indie-NAS users, and each plugin
+      # we add lengthens the Caddy build (xcaddy compiles them in via a
+      # fresh `go build`). To add a provider, append to `plugins`, run
+      # `nix build .#nixosConfigurations.nasty-vm.config.services.caddy.package`,
+      # and update `hash` from the resulting "got: sha256-…" message.
+      package = pkgs.caddy.withPlugins {
+        plugins = [
+          # Public-DNS heavyweights — Cloudflare alone covers the
+          # majority of selfhost users.
+          "github.com/caddy-dns/cloudflare@v0.2.4"
+          "github.com/caddy-dns/duckdns@v0.5.0"
+          # Cloud / hosting providers commonly running NASty boxes.
+          "github.com/caddy-dns/route53@v1.6.2"
+          "github.com/caddy-dns/hetzner/v2@v2.0.0"
+          "github.com/caddy-dns/linode@v0.8.0"
+          # Indie domain registrars with first-class API support.
+          "github.com/caddy-dns/porkbun@v0.3.1"
+          "github.com/caddy-dns/namecheap@v1.0.0"
+          # Niche but commonly requested: deSEC (open-source DNS host)
+          # and RFC 2136 (any DNS server speaking standards-compliant
+          # dynamic update — BIND, Knot, PowerDNS, etc.).
+          "github.com/caddy-dns/desec@v1.1.0"
+          "github.com/caddy-dns/rfc2136@v1.0.0"
+        ];
+        hash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
+      };
       globalConfig = ''
         auto_https off
       '';

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1369,6 +1369,10 @@ in {
           handle /ws {
             reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
               header_up X-Real-IP {remote_host}
+              transport http {
+                read_timeout 28800s
+                write_timeout 28800s
+              }
             }
           }
 

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -1,4 +1,4 @@
-# Boots the full NASty appliance (engine + nginx + supporting services) in a
+# Boots the full NASty appliance (engine + Caddy + supporting services) in a
 # QEMU VM, waits for the engine to come up, and exercises both halves of the
 # WebUI ↔ engine boundary that unit tests can't reach:
 #   - HTTP: /health, /api/login (good + bad creds), /api/auth/check
@@ -126,18 +126,17 @@ let
     finally:
         ws.close()
 
-    # ── Session 3: same RPC through the nginx proxy on 443 ────────
+    # ── Session 3: same RPC through the Caddy proxy on 443 ────────
     # Earlier sessions hit the engine on its loopback port directly,
-    # which skips nginx entirely.  This one goes through nginx end
+    # which skips Caddy entirely.  This one goes through Caddy end
     # to end so the proxy's WebSocket-upgrade handling is part of
-    # what's being asserted.  If a future proxy swap (or nginx
-    # config change) breaks Upgrade / Connection forwarding, the
-    # engine stays reachable on 2137 but the WebUI breaks — this
-    # catches that.
+    # what's being asserted.  If a Caddyfile change breaks
+    # Upgrade / Connection forwarding, the engine stays reachable
+    # on 2137 but the WebUI breaks — this catches that.
     #
     # Sessions are bound to the client IP the engine sees, so a
-    # token issued direct to :2137 isn't valid through nginx (and
-    # vice versa).  Login + WS therefore share the nginx path.
+    # token issued direct to :2137 isn't valid through Caddy (and
+    # vice versa).  Login + WS therefore share the proxy path.
     ssl_ctx = ssl.create_default_context()
     ssl_ctx.check_hostname = False
     ssl_ctx.verify_mode = ssl.CERT_NONE
@@ -147,21 +146,21 @@ let
     ws, _ = ws_auth(proxy_token, url="wss://127.0.0.1/ws", sslopt=SSL_OPTS)
     try:
         health = call(ws, "system.health", 1)
-        print("system.health via nginx:", health, file=sys.stderr)
+        print("system.health via Caddy:", health, file=sys.stderr)
     finally:
         ws.close()
 
     # ── Session 4: install an app + verify /apps/<name>/ proxy ────
     # Drives the end-to-end apps-ingress path: engine starts Docker,
     # pulls (no-op — image is pre-loaded), creates the container,
-    # auto-sets ingress, writes /var/lib/nasty/apps-proxy.conf,
-    # reloads nginx.  We then curl `/apps/smoke/` and check the
-    # marker string the container serves, which proves:
+    # auto-sets ingress (which POSTs a route to Caddy's admin API
+    # at 127.0.0.1:2019).  We then curl `/apps/smoke/` and check
+    # the marker string the container serves, which proves:
     #   - the engine's apps lifecycle works end-to-end,
-    #   - nginx's path-stripping `proxy_pass http://host:port/` works
-    #     (request to `/apps/smoke/index.html` reaches the container
-    #     as `/index.html`, not `/apps/smoke/index.html`),
-    #   - the new ingress took effect (nginx reload was honored).
+    #   - Caddy's `handle_path` strip-prefix routing works
+    #     (request to `/apps/smoke/index.html` reaches the
+    #     container as `/index.html`, not `/apps/smoke/index.html`),
+    #   - the admin-API route took effect immediately, no reload.
     import time as _time
     ws, _ = ws_auth(new_token)
     try:
@@ -276,7 +275,7 @@ pkgs.testers.runNixOSTest {
     machine.wait_for_unit("nasty-engine.service")
 
     # ── /health (no auth) ───────────────────────────────────────────
-    # Hit the engine directly on its loopback port to skip TLS / nginx.
+    # Hit the engine directly on its loopback port to skip TLS / Caddy.
     machine.wait_until_succeeds("curl -fsS http://127.0.0.1:2137/health")
     health = machine.succeed("curl -fsS http://127.0.0.1:2137/health")
     print(f"=== /health ===\n{health}")
@@ -320,9 +319,9 @@ pkgs.testers.runNixOSTest {
     # Same endpoint without a cookie should be rejected.
     machine.fail("curl -fsS http://127.0.0.1:2137/api/auth/check")
 
-    # ── HTTPS through nginx ────────────────────────────────────────
+    # ── HTTPS through Caddy ────────────────────────────────────────
     # Everything above talked to the engine on 2137 directly, which
-    # skips the nginx vhost entirely.  Now exercise the same proxy
+    # skips the Caddy vhost entirely.  Now exercise the same proxy
     # path the WebUI loads through — `https://127.0.0.1/` with the
     # self-signed cert.  This is what'll catch a future proxy-config
     # regression that leaves the engine reachable on 2137 but breaks
@@ -334,19 +333,19 @@ pkgs.testers.runNixOSTest {
     # got real HTML back through the proxy, not an error page.
     body_lc = body.lstrip().lower()
     assert body_lc.startswith("<!doctype html>") or "<html" in body_lc, (
-        f"WebUI response through nginx doesn't look like HTML: {body[:200]!r}"
+        f"WebUI response through Caddy doesn't look like HTML: {body[:200]!r}"
     )
 
-    # The /health endpoint should also be reachable through nginx, not
+    # The /health endpoint should also be reachable through Caddy, not
     # just on the engine loopback.
-    health_via_nginx = machine.succeed("curl -ksS https://127.0.0.1/health")
-    print(f"=== /health via nginx ===\n{health_via_nginx}")
-    assert json.loads(health_via_nginx)["status"] == "ok", (
-        f"unexpected health via nginx: {health_via_nginx!r}"
+    health_via_caddy = machine.succeed("curl -ksS https://127.0.0.1/health")
+    print(f"=== /health via Caddy ===\n{health_via_caddy}")
+    assert json.loads(health_via_caddy)["status"] == "ok", (
+        f"unexpected health via Caddy: {health_via_caddy!r}"
     )
 
     # ── Security headers on the WebUI response ─────────────────────
-    # These are the headers nasty.nix's nginx vhost adds — every one
+    # These are the headers nasty.nix's Caddy vhost adds — every one
     # of them is a hardening assertion we don't want to silently lose
     # in a future proxy refactor.  Match prefix-only so a Caddy port
     # that ships slightly different values (e.g. `max-age=63072000`
@@ -370,7 +369,7 @@ pkgs.testers.runNixOSTest {
     # auth with the token from /api/login, send a few requests, check
     # responses come back correlated by id. Exercises router.rs
     # end-to-end — the part unit tests deliberately don't reach.
-    # rpc-smoke also opens wss://127.0.0.1/ws through nginx as its
+    # rpc-smoke also opens wss://127.0.0.1/ws through Caddy as its
     # third session, and (session 4) installs a Docker app whose
     # /apps/<name>/ ingress we then assert against below.
     #
@@ -387,12 +386,12 @@ pkgs.testers.runNixOSTest {
         f"${pythonWithWs}/bin/python3 ${rpcSmoke} {shlex.quote(login_obj['token'])}"
     )
 
-    # ── /apps/<name>/ ingress through nginx ───────────────────────
+    # ── /apps/<name>/ ingress through Caddy ───────────────────────
     # rpc-smoke just installed an app called "smoke" mapped to
     # host port 18080.  The engine wrote a `location /apps/smoke/`
-    # block to /var/lib/nasty/apps-proxy.conf and reloaded nginx.
+    # block via the Caddy admin API at 127.0.0.1:2019.
     # Curl both the bare route and a subpath: the marker string in
-    # the response proves nginx's path-stripping `proxy_pass
+    # the response proves Caddy's `handle_path` strip-prefix
     # http://host:port/` actually strips, not just appends.
     machine.wait_until_succeeds(
         "curl -ksS https://127.0.0.1/apps/smoke/ | grep -q nasty-smoke-test-OK"

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -296,7 +296,7 @@
 	// out of the compose YAML. Auto-defaults to the first TCP port,
 	// follows user-picks until the port disappears from the compose,
 	// at which point it falls back to the new first-TCP. UDP ports
-	// are excluded — nginx's proxy_pass is TCP-only.
+	// are excluded — Caddy's reverse_proxy handles HTTP/TCP only.
 	let composeTcpPorts = $state<{ host_port: number; container_port: number; line: number }[]>([]);
 	let newIngressPort = $state<number | null>(null);
 	$effect(() => {
@@ -1456,7 +1456,7 @@
 									{/each}
 								</select>
 								<p class="mt-1.5 text-muted-foreground">
-									Which TCP port <code>/apps/{composeName || '<name>'}/</code> proxies to. UDP ports are excluded — nginx is TCP-only.
+									Which TCP port <code>/apps/{composeName || '<name>'}/</code> proxies to. UDP ports are excluded — Caddy's reverse_proxy is HTTP-only.
 								</p>
 							</div>
 						{/if}

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -13,11 +13,9 @@
 	let tlsAcmeEnabled = $state(false);
 	let acmeStatus: { state: string; message: string; domain?: string; expires?: string; issued?: string; issuer?: string; last_attempt?: string } | null = $state(null);
 	let tlsAcmeStaging = $state(false);
-	let tlsChallengeType = $state<'tls-alpn' | 'dns'>('tls-alpn');
+	let tlsChallengeType = $state<'tls-alpn' | 'http' | 'dns'>('tls-alpn');
 	let tlsDnsProvider = $state('');
 	let tlsDnsCredentials = $state('');
-	let tlsDnsResolver = $state('');
-	let tlsDnsPropagationWait = $state(30);
 	let savingTls = $state(false);
 	let tlsChanged = $state(false);
 	let editing = $state(false);
@@ -50,8 +48,6 @@
 		tlsDnsProvider = settings?.tls_dns_provider ?? '';
 		tlsDnsCredentials = settings?.tls_dns_credentials ?? '';
 		tlsAcmeStaging = (settings as any)?.tls_acme_staging ?? false;
-		tlsDnsResolver = (settings as any)?.tls_dns_resolver ?? '';
-		tlsDnsPropagationWait = (settings as any)?.tls_dns_propagation_wait ?? 30;
 		try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
 	});
 
@@ -66,8 +62,6 @@
 				tls_dns_provider: tlsDnsProvider || null,
 				tls_dns_credentials: tlsDnsCredentials || null,
 				tls_acme_staging: tlsAcmeStaging,
-				tls_dns_resolver: tlsDnsResolver || null,
-				tls_dns_propagation_wait: tlsDnsPropagationWait,
 			}),
 			tlsAcmeEnabled ? 'Let\'s Encrypt certificate requested — check status below' : 'TLS settings saved'
 		);
@@ -212,7 +206,8 @@
 						/>
 					{/if}
 					<span class="mt-1 block text-xs text-muted-foreground">
-						See <a href="https://go-acme.github.io/lego/dns/" target="_blank" class="text-blue-400 hover:underline">lego DNS providers</a> for the full list and required credentials.
+						The provider name must match a DNS plugin compiled into the Caddy build shipped with NASty.
+						Currently only HTTP-01 / TLS-ALPN-01 are wired up; DNS-01 plugin support lands in a follow-up release.
 					</span>
 				</div>
 
@@ -224,42 +219,12 @@
 						oninput={() => tlsChanged = true}
 						rows={4}
 						class="w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
-						placeholder={"CLOUDFLARE_DNS_API_TOKEN=xxxxx\nCLOUDFLARE_ZONE_API_TOKEN=xxxxx"}
+						placeholder={"CF_API_TOKEN=xxxxx"}
 					></textarea>
 					<span class="mt-1 block text-xs text-muted-foreground">
-						One KEY=VALUE per line. These are passed as environment variables to the ACME client.
-						No inbound ports needed — verification happens via DNS records.
-					</span>
-				</div>
-
-				<div class="mb-4">
-					<label for="tls-dns-resolver" class="mb-1 block text-xs text-muted-foreground">DNS Resolver for propagation checks</label>
-					<input
-						id="tls-dns-resolver"
-						type="text"
-						bind:value={tlsDnsResolver}
-						oninput={() => tlsChanged = true}
-						class="w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-						placeholder="1.1.1.1:53 (default)"
-					/>
-					<span class="mt-1 block text-xs text-muted-foreground">
-						Public resolver used to verify TXT record propagation. Default: 1.1.1.1. Change if your setup uses a different public DNS.
-					</span>
-				</div>
-
-				<div class="mb-4">
-					<label for="tls-dns-wait" class="mb-1 block text-xs text-muted-foreground">Propagation wait (seconds)</label>
-					<input
-						id="tls-dns-wait"
-						type="number"
-						min="0"
-						max="300"
-						bind:value={tlsDnsPropagationWait}
-						oninput={() => tlsChanged = true}
-						class="w-24 rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-					/>
-					<span class="mt-1 block text-xs text-muted-foreground">
-						Wait this many seconds after creating the TXT record before checking propagation. Default: 30. Increase if propagation checks keep timing out.
+						One KEY=VALUE per line. Written to a Caddy <code>EnvironmentFile</code> and referenced from the
+						generated <code>tls</code> block via <code>{'{env.KEY}'}</code> placeholders. No inbound ports needed —
+						verification happens via DNS records.
 					</span>
 				</div>
 			{/if}

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -21,22 +21,20 @@
 	let editing = $state(false);
 	const certActive = $derived.by(() => Boolean(acmeStatus && acmeStatus.state === 'success' && tlsAcmeEnabled));
 
+	// DNS-01 plugins compiled into the Caddy binary shipped with NASty
+	// (see `pkgs.caddy.withPlugins` in nixos/modules/nasty.nix). Picking
+	// anything outside this list will fail at Caddy reload time with an
+	// "unknown module" error, so we don't expose them.
 	const popularDnsProviders = [
 		{ code: 'cloudflare', name: 'Cloudflare' },
 		{ code: 'route53', name: 'Amazon Route 53' },
-		{ code: 'gcloud', name: 'Google Cloud' },
-		{ code: 'azuredns', name: 'Azure DNS' },
-		{ code: 'digitalocean', name: 'DigitalOcean' },
 		{ code: 'hetzner', name: 'Hetzner' },
-		{ code: 'godaddy', name: 'GoDaddy' },
-		{ code: 'namecheap', name: 'Namecheap' },
-		{ code: 'ovh', name: 'OVH' },
-		{ code: 'porkbun', name: 'Porkbun' },
-		{ code: 'vultr', name: 'Vultr' },
 		{ code: 'linode', name: 'Linode' },
+		{ code: 'porkbun', name: 'Porkbun' },
+		{ code: 'namecheap', name: 'Namecheap' },
 		{ code: 'duckdns', name: 'Duck DNS' },
 		{ code: 'desec', name: 'deSEC.io' },
-		{ code: 'oraclecloud', name: 'Oracle Cloud' },
+		{ code: 'rfc2136', name: 'RFC 2136 (BIND / Knot / PowerDNS)' },
 	];
 
 	onMount(async () => {
@@ -206,8 +204,8 @@
 						/>
 					{/if}
 					<span class="mt-1 block text-xs text-muted-foreground">
-						The provider name must match a DNS plugin compiled into the Caddy build shipped with NASty.
-						Currently only HTTP-01 / TLS-ALPN-01 are wired up; DNS-01 plugin support lands in a follow-up release.
+						The provider must be one of the plugins compiled into NASty's Caddy build (the dropdown lists all of them).
+						Need a different one? Open an issue — adding it is a one-line change to the Nix package definition.
 					</span>
 				</div>
 

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -185,7 +185,7 @@
 					uploadProgress = Math.round((e.loaded / e.total) * 100);
 				}
 			};
-			xhr.timeout = 3600_000; // 1 hour, matching nginx proxy timeouts
+			xhr.timeout = 3600_000; // 1 hour, matching Caddy reverse_proxy timeouts
 
 			await new Promise<void>((resolve, reject) => {
 				xhr.ontimeout = () => reject(new Error('Upload timed out'));


### PR DESCRIPTION
## Why

Long-running rewrite that replaces nginx with Caddy across the board. Three motivations:

1. **Apps ingress** moves from "write a config file then `nginx -s reload`" to PATCHing Caddy's admin API directly — no on-disk fragments, no reload latency, no risk of a partial write breaking the WebUI.
2. **ACME** moves from `lego` (a separate Go subprocess) to Caddy's built-in issuer — drops 250+ lines of subprocess wrapping, the `systemctl stop/start` dance for TLS-ALPN, and the daily renewal cron (Caddy auto-renews).
3. **DNS-01** is now actually wired: Caddy is built with `withPlugins` baking in the 9 most-used DNS providers (cloudflare, route53, hetzner, linode, porkbun, namecheap, duckdns, desec, rfc2136). Picking any other provider in the WebUI is no longer an option (dropdown trimmed) — they'd just fail at Caddy reload with "unknown module".

## Commits

The branch is **3 logical commits**, each independently reviewable:

- `8021d13` **caddy: swap nginx for Caddy + apps-ingress via admin API** — the foundational swap. Engine gains `nasty_apps::caddy` admin-API client; engine→caddy systemd ordering; `update.rs` change-detection renamed `_NGINX_CONF_*` → `_PROXY_CONF_*` resolving the active Caddyfile via `/run/current-system/etc/caddy/Caddyfile`. nginx fully removed from the NixOS module; WebUI vhost rebuilt as a single Caddyfile block (TLS, security headers, file-content sandbox CSP, three websocket handlers, /api proxy with X-Real-IP). lego retained at this point.
- `3d64356` **caddy: drop lego, drive ACME directly through Caddy** — replaces the lego flow with `apply_caddy_tls(settings)` that writes a Caddyfile snippet to `/var/lib/nasty/caddy/vhosts.conf` (hostname-bound ACME vhost when enabled, empty otherwise) + `/var/lib/nasty/caddy/acme.env` (DNS provider creds), then reloads Caddy. New `refresh_acme_status_from_disk` populates the cached `AcmeStatus` from whatever cert Caddy is actually serving. Drops `tls_dns_resolver` and `tls_dns_propagation_wait` settings (Caddy handles internally) + the daily renewal cron. WebUI drops the corresponding inputs.
- `f18e0c9` **caddy: ship 9 baked-in DNS-01 plugins + per-provider directive emitter** — `services.caddy.package` switched to `caddy.withPlugins {…}` with the 9-plugin list pinned to release tags. New `dns_directive_for(provider)` renders the right Caddyfile shape per plugin (single-token / two-token / sub-block) — 12 unit tests pin every shape so future plugin-list edits can't silently break the wire format. WebUI dropdown trimmed from 15 entries to the 9 that actually work.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --workspace` — full suite passes, 19 `settings::tests` (12 new for DNS directives + Caddyfile snippet shapes)
- [x] `npx svelte-check` clean
- [x] `npx vitest run` — 121 webui tests pass
- [x] `npm run build` — production build succeeds
- [x] Local `nix build .#nixosConfigurations.nasty-vm.config.services.caddy.package` succeeds; `caddy list-modules` shows all 9 `dns.providers.*` plugins compiled in
- [ ] **CI integration test** — appliance-smoke nixosTest will run automatically on this PR (paths touch `nixos/modules/**`)
- [ ] **Manual end-to-end in VM** — boot nasty-vm, enable ACME with staging Let's Encrypt + cloudflare DNS, confirm cert issuance lands in `/var/lib/caddy/.local/share/caddy/certificates/...`

## What changes user-facing

- Caddy replaces nginx as the WebUI proxy; default port `:8443` unchanged, IP-based access still works with the self-signed cert.
- DNS-01 challenge is now actually wired up (it never was in the lego flow despite the UI exposing it). Picking a non-baked-in provider is no longer possible — the dropdown lists only the 9 supported.
- `tls_dns_resolver` and `tls_dns_propagation_wait` settings removed from the JSON schema. Engine ignores them on load, so existing settings.json files don't need migration.

## What's deferred

- Adding more DNS plugins is one line in the `services.caddy.package.plugins` list + a `nix-build` to refresh the vendor hash. The module comment spells out the workflow.
- Multi-secret providers requiring JSON service accounts (gcloud, azuredns) and weird-auth ones (ovh, godaddy) are intentionally out — they need bigger config-shape changes than the env-var KEY=VAL textarea supports.