### PR TITLE
webui: debounce the reconnect overlay

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -274,11 +274,25 @@
 	}));
 
 	let reconnecting = $state(false);
+	// Debounce timer for the reconnect overlay. WebSocket disconnects of
+	// well under a second happen routinely (page navigations, NixOS
+	// activations restarting the engine in ~2s, transient network blips
+	// behind a Caddy reverse_proxy, etc.) and the WS auto-reconnects fast
+	// enough that flashing the full-screen overlay just makes the UI feel
+	// flaky. Only show the overlay if the disconnect persists past this
+	// threshold; if reconnect happens first we cancel the pending state-
+	// change and the user sees nothing.
+	let reconnectingTimer: ReturnType<typeof setTimeout> | null = null;
+	const RECONNECT_OVERLAY_DELAY_MS = 800;
 
 	onMount(() => {
 		tryConnect();
 		const onReconnect = async () => {
 			powering = false;
+			if (reconnectingTimer) {
+				clearTimeout(reconnectingTimer);
+				reconnectingTimer = null;
+			}
 			reconnecting = false;
 			// Check if engine was updated while we were disconnected.
 			// If the commit changed, the WebUI bundle likely changed too — force reload.
@@ -299,7 +313,13 @@
 			// user hits cmd+R.
 			sysInfoRefresh.trigger();
 		};
-		const onDisconnect = () => { reconnecting = true; };
+		const onDisconnect = () => {
+			if (reconnectingTimer) clearTimeout(reconnectingTimer);
+			reconnectingTimer = setTimeout(() => {
+				reconnecting = true;
+				reconnectingTimer = null;
+			}, RECONNECT_OVERLAY_DELAY_MS);
+		};
 		getClient().onReconnect(onReconnect);
 		getClient().onDisconnect(onDisconnect);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
@@ -308,6 +328,7 @@
 		const sshPoll = setInterval(checkSshStatus, 30_000);
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
+			if (reconnectingTimer) clearTimeout(reconnectingTimer);
 			getClient().offReconnect(onReconnect);
 			getClient().offDisconnect(onDisconnect);
 			getClient().disconnect();


### PR DESCRIPTION
## Why

The \"connecting to engine\" overlay was set instantly on every WebSocket close — including the routine ones that auto-reconnect in well under a second (page navigations, NixOS activations cycling \`nasty-engine.service\` in ~2s, transient blips behind Caddy). Result: the UI feels flaky even when nothing real is broken; users see the swirl multiple times an hour and reasonably suspect the engine is restarting.

Hit live during #203 testing on a real box — the engine logs showed only 2 WS disconnects in 30 minutes (one for a rebuild, one for a 3-second blip), but in the browser the overlay flashed several times because every drop, however brief, instantly painted it.

## What

- Gates the overlay on an **800 ms debounce**. If the WS reconnects before the timer fires (the common case), nothing visible happens.
- Genuine outages still show the overlay — \`nixos-rebuild switch\` of the engine binary takes ~2 s, well past the threshold — and any longer disconnect appears 800 ms in.
- Cleans up the pending timer on reconnect *and* on layout teardown so there's no leak / stale state-change.

## Test plan

- [x] \`npx svelte-check\` clean (via \`nix shell nixpkgs#nodejs_22\`)
- [x] \`npx vitest run\` — 121 webui tests pass
- [ ] Manual: tail \`journalctl -u nasty-engine -f\`, click around the WebUI, confirm the overlay no longer flashes on routine page navs but DOES appear during \`systemctl restart nasty-engine\`.