### PR TITLE
ws: server-initiated ping/pong + exponential client reconnect backoff

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1855,18 +1855,44 @@ async fn handle_socket(
     let mut event_rx = state.events.subscribe();
     let (mut writer, mut reader) = socket.split();
 
+    // Server-initiated WebSocket-level keepalive. Without this, a client
+    // that vanishes silently (laptop suspended, NAT mapping dropped,
+    // upstream link cut) stays in the engine's WS-task list until the
+    // OS's TCP retransmit timeouts eventually unwind — minutes later.
+    // Pinging every 30 s and dropping the connection if we haven't seen
+    // any traffic in IDLE_TIMEOUT closes dead clients fast, frees their
+    // `event_rx` subscription, and matches what the WebUI client expects
+    // from a healthy proxy (Caddy holds the upgrade open as long as both
+    // ends are talking, so visible ping traffic is what keeps it alive
+    // through every intermediary).
+    const PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+    const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+    let mut ping_ticker = tokio::time::interval(PING_INTERVAL);
+    ping_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    ping_ticker.tick().await; // skip the immediate first tick
+    let mut last_seen = std::time::Instant::now();
+
     loop {
         tokio::select! {
             msg = reader.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
+                        last_seen = std::time::Instant::now();
                         let response = handle_rpc_request(&text, &state, &session).await;
                         if writer.send(Message::Text(response.into())).await.is_err() {
                             break;
                         }
                     }
+                    Some(Ok(Message::Pong(_))) | Some(Ok(Message::Ping(_))) => {
+                        // Axum's tungstenite layer auto-replies to Pings,
+                        // so we just record the heartbeat. Pongs from the
+                        // client confirm they're still listening.
+                        last_seen = std::time::Instant::now();
+                    }
                     Some(Ok(Message::Close(_))) | None => break,
-                    _ => {}
+                    _ => {
+                        last_seen = std::time::Instant::now();
+                    }
                 }
             }
             event = event_rx.recv() => {
@@ -1879,6 +1905,20 @@ async fn handle_socket(
                     if writer.send(Message::Text(text.into())).await.is_err() {
                         break;
                     }
+                }
+            }
+            _ = ping_ticker.tick() => {
+                if last_seen.elapsed() > IDLE_TIMEOUT {
+                    info!(
+                        "WebSocket client '{}' idle > {}s, closing",
+                        session.username,
+                        IDLE_TIMEOUT.as_secs()
+                    );
+                    let _ = writer.send(Message::Close(None)).await;
+                    break;
+                }
+                if writer.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    break;
                 }
             }
         }

--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -28,6 +28,14 @@ export class NastyClient {
 	private reconnectHandlers: (() => void)[] = [];
 	private disconnectHandlers: (() => void)[] = [];
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	/** Exponential reconnect delay — doubles on each failed attempt up to a
+	 *  cap, resets to the floor on a successful auth. The previous version
+	 *  used a fixed 3 s delay, which during a longer outage produced 20
+	 *  attempts per minute — friendlier to spam the server slower and
+	 *  faster to reconnect from a transient blip. */
+	private reconnectDelayMs = 1000;
+	private static readonly RECONNECT_DELAY_FLOOR_MS = 1000;
+	private static readonly RECONNECT_DELAY_CEIL_MS = 30_000;
 	private _authenticated = false;
 	/** Set to true after the first successful auth; cleared by disconnect(). */
 	private _shouldReconnect = false;
@@ -67,6 +75,9 @@ export class NastyClient {
 						const wasReconnect = this._shouldReconnect;
 						this._authenticated = true;
 						this._shouldReconnect = true;
+						// Successful connect — reset the backoff so the next
+						// disconnect retries quickly.
+						this.reconnectDelayMs = NastyClient.RECONNECT_DELAY_FLOOR_MS;
 						this._readyResolve?.();
 						this._readyResolve = null;
 						if (wasReconnect) {
@@ -160,10 +171,20 @@ export class NastyClient {
 		});
 	}
 
-	/** Schedule a reconnection attempt. Deduplicates to avoid multiple timers. */
+	/** Schedule a reconnection attempt. Deduplicates to avoid multiple timers.
+	 *  Uses an exponential backoff: starts at RECONNECT_DELAY_FLOOR_MS, doubles
+	 *  on each failed attempt up to RECONNECT_DELAY_CEIL_MS, and resets to the
+	 *  floor on a successful reconnect (see onmessage). Faster reconnect from
+	 *  transient blips than the old fixed 3 s, and friendlier to the server
+	 *  during a longer outage (a stuck client used to spam ~20 attempts/min). */
 	private _scheduleReconnect() {
 		if (this.reconnectTimer) return; // already scheduled
 		this._readyPromise = new Promise((res) => { this._readyResolve = res; });
+		const delay = this.reconnectDelayMs;
+		this.reconnectDelayMs = Math.min(
+			this.reconnectDelayMs * 2,
+			NastyClient.RECONNECT_DELAY_CEIL_MS,
+		);
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
 			this.connect().catch((err) => {
@@ -182,7 +203,7 @@ export class NastyClient {
 					this._scheduleReconnect();
 				}
 			});
-		}, 3000);
+		}, delay);
 	}
 
 	/** Enable with localStorage.setItem('nasty-debug', '1') then reload */


### PR DESCRIPTION
## Why

Two small reliability fixes for the JSON-RPC WebSocket between WebUI and engine.

**Server**: today, a client that vanishes silently (laptop suspended, NAT mapping dropped, upstream link cut) stays in the engine's WS-task list until the OS's TCP retransmit timeouts eventually unwind — minutes later. The dead task still holds an \`event_rx\` subscription, so broadcast notifications back up in the channel and the engine's memory footprint slowly grows. There's also no ping traffic to keep Caddy + every intermediary's idle-connection assumptions happy.

**Client**: reconnect was a fixed 3 s delay. On a transient blip that's slow; during a longer outage it's ~20 attempts/min, friendlier to space out.

## What

**Engine** (\`nasty-engine/src/main.rs\` WS handler):
- Send a \`Message::Ping\` every **30 s**.
- Close the connection if there's been no traffic at all for **90 s** (i.e. 3 missed Pongs).
- Track \`last_seen\` from any inbound message, including Pong frames.
- \`MissedTickBehavior::Skip\` so a slow process doesn't backlog pings.

**WebUI** (\`webui/src/lib/rpc.ts\`):
- Reconnect backoff: starts at **1 s**, doubles on each failed attempt, capped at **30 s**.
- Resets to the floor on a successful auth, so the next blip retries fast.

## Test plan

- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\` clean
- [x] \`cargo test --workspace\` — full suite passes
- [x] \`npx svelte-check\` clean; 121 vitest tests pass
- [ ] Manual: kill the WS client (close browser tab without graceful close), confirm engine logs \`WebSocket client 'admin' idle > 90s, closing\` ~90 s later.
- [ ] Manual: stop \`nasty-engine\`, watch reconnect attempts in the browser console — should be 1 s, 2 s, 4 s, 8 s, 16 s, 30 s, 30 s, ... Then \`systemctl start nasty-engine\` and confirm reconnect lands on next attempt.