### PR TITLE
webui: diagnostic instrumentation for the WS-disconnect mystery

### DIFF
--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -55,10 +55,12 @@ export class NastyClient {
 	 *  or `{error: ...}`. */
 	connect(): Promise<AuthResult> {
 		return new Promise((resolve, reject) => {
+			console.log('[ws] connecting', this.url, new Date().toISOString());
 			this.ws = new WebSocket(this.url);
 			let authResolved = false;
 
 			this.ws.onopen = () => {
+				console.log('[ws] open', new Date().toISOString());
 				// Cookie auth: nothing to send on open. Server speaks first.
 			};
 
@@ -107,7 +109,13 @@ export class NastyClient {
 				}
 			};
 
-			this.ws.onclose = () => {
+			this.ws.onclose = (ev) => {
+				console.log('[ws] close', {
+					code: ev.code,
+					reason: ev.reason,
+					wasClean: ev.wasClean,
+					ts: new Date().toISOString(),
+				});
 				this._authenticated = false;
 				// Reject all pending calls so awaiting code doesn't hang forever
 				for (const pending of this.pending.values()) {

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { beforeNavigate, afterNavigate } from '$app/navigation';
 	import { getClient, resetClient } from '$lib/client';
 	import { login as doLogin, logout as doLogout } from '$lib/auth';
 	import { error as showError, isBusy } from '$lib/toast.svelte';
@@ -285,7 +286,40 @@
 	let reconnectingTimer: ReturnType<typeof setTimeout> | null = null;
 	const RECONNECT_OVERLAY_DELAY_MS = 800;
 
+	// ── Debug instrumentation for WS-disconnect investigation ──
+	//
+	// PR #203 brought repeated `code=1001` (browser-initiated "going
+	// away") closes in the engine log, which only fires on a real page
+	// unload — i.e., a *hard* navigation, not a SvelteKit SPA nav. The
+	// sidebar uses plain `<a href>` which SvelteKit should intercept by
+	// default. Either the interception is silently failing OR something
+	// else is closing the WS and we're mis-reading the close code.
+	//
+	// These logs answer that empirically: open dev tools, navigate
+	// around, and the console tells you which path is firing. If
+	// `[nav] beforeNavigate` fires on a sidebar click → SPA nav works,
+	// 1001 must come from elsewhere. If it doesn't fire → SvelteKit
+	// isn't intercepting and we have a real layout-unmount bug.
+	//
+	// Will be removed once the root cause is found. Logged at the
+	// default level so users don't need to enable anything.
+	beforeNavigate((nav) => {
+		console.log('[nav] beforeNavigate', {
+			from: nav.from?.url?.pathname,
+			to: nav.to?.url?.pathname,
+			type: nav.type,
+		});
+	});
+	afterNavigate((nav) => {
+		console.log('[nav] afterNavigate', {
+			from: nav.from?.url?.pathname,
+			to: nav.to?.url?.pathname,
+			type: nav.type,
+		});
+	});
+
 	onMount(() => {
+		console.log('[layout] mounted', new Date().toISOString());
 		tryConnect();
 		const onReconnect = async () => {
 			powering = false;
@@ -328,6 +362,7 @@
 		const sshPoll = setInterval(checkSshStatus, 30_000);
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
+			console.log('[layout] destroying', new Date().toISOString());
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
 			getClient().offReconnect(onReconnect);
 			getClient().offDisconnect(onDisconnect);


### PR DESCRIPTION
## Why

Engine logs on the caddy branch (#203) show repeated WebSocket closes with \`code=1001\` *\"going away\"* — but that code only fires when the browser is unloading the page (real navigation), not on a SvelteKit SPA nav. The sidebar uses plain \`<a href>\` which SvelteKit should intercept by default, so either:

1. **SvelteKit is silently failing to intercept**, and every sidebar click is a full page reload (real bug), or
2. **Something else is closing the WS** and we're mis-reading the close code.

We can't tell from server logs alone. This is **temporary instrumentation** to answer it empirically.

## What

Logs the following to the browser console:

- \`[nav] beforeNavigate {from, to, type}\` — fires only on SvelteKit SPA nav.
- \`[nav] afterNavigate {from, to, type}\` — same.
- \`[layout] mounted ts\` — fires once on app load when SPA nav works; fires on every page when it doesn't.
- \`[layout] destroying ts\` — fires only on real page unload.
- \`[ws] connecting url ts\` / \`[ws] open ts\`
- \`[ws] close {code, reason, wasClean, ts}\` — exact close code per drop.

## How to use

1. Pull this branch on the test box, deploy, refresh.
2. Open browser dev tools → Console.
3. Click around the sidebar.
4. Send me the console output.

Interpretation:

- If \`[nav] beforeNavigate\` fires on a sidebar click → SPA works; \`1001\` must come from elsewhere.
- If it doesn't fire → SvelteKit isn't intercepting, sidebar links are doing real page loads, and we have a layout structure bug to fix.

## Test plan

This PR adds no behaviour, only logs. Will be **removed** in the follow-up PR that fixes whatever the logs reveal.

- [x] \`npx svelte-check\` clean
- [x] \`npx vitest run\` — 121 webui tests pass