### PR TITLE
webui: drop WS/nav debug instrumentation from #209

### DIFF
--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -55,12 +55,10 @@ export class NastyClient {
 	 *  or `{error: ...}`. */
 	connect(): Promise<AuthResult> {
 		return new Promise((resolve, reject) => {
-			console.log('[ws] connecting', this.url, new Date().toISOString());
 			this.ws = new WebSocket(this.url);
 			let authResolved = false;
 
 			this.ws.onopen = () => {
-				console.log('[ws] open', new Date().toISOString());
 				// Cookie auth: nothing to send on open. Server speaks first.
 			};
 
@@ -109,13 +107,7 @@ export class NastyClient {
 				}
 			};
 
-			this.ws.onclose = (ev) => {
-				console.log('[ws] close', {
-					code: ev.code,
-					reason: ev.reason,
-					wasClean: ev.wasClean,
-					ts: new Date().toISOString(),
-				});
+			this.ws.onclose = () => {
 				this._authenticated = false;
 				// Reject all pending calls so awaiting code doesn't hang forever
 				for (const pending of this.pending.values()) {

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { beforeNavigate, afterNavigate } from '$app/navigation';
 	import { getClient, resetClient } from '$lib/client';
 	import { login as doLogin, logout as doLogout } from '$lib/auth';
 	import { error as showError, isBusy } from '$lib/toast.svelte';
@@ -286,40 +285,7 @@
 	let reconnectingTimer: ReturnType<typeof setTimeout> | null = null;
 	const RECONNECT_OVERLAY_DELAY_MS = 800;
 
-	// ── Debug instrumentation for WS-disconnect investigation ──
-	//
-	// PR #203 brought repeated `code=1001` (browser-initiated "going
-	// away") closes in the engine log, which only fires on a real page
-	// unload — i.e., a *hard* navigation, not a SvelteKit SPA nav. The
-	// sidebar uses plain `<a href>` which SvelteKit should intercept by
-	// default. Either the interception is silently failing OR something
-	// else is closing the WS and we're mis-reading the close code.
-	//
-	// These logs answer that empirically: open dev tools, navigate
-	// around, and the console tells you which path is firing. If
-	// `[nav] beforeNavigate` fires on a sidebar click → SPA nav works,
-	// 1001 must come from elsewhere. If it doesn't fire → SvelteKit
-	// isn't intercepting and we have a real layout-unmount bug.
-	//
-	// Will be removed once the root cause is found. Logged at the
-	// default level so users don't need to enable anything.
-	beforeNavigate((nav) => {
-		console.log('[nav] beforeNavigate', {
-			from: nav.from?.url?.pathname,
-			to: nav.to?.url?.pathname,
-			type: nav.type,
-		});
-	});
-	afterNavigate((nav) => {
-		console.log('[nav] afterNavigate', {
-			from: nav.from?.url?.pathname,
-			to: nav.to?.url?.pathname,
-			type: nav.type,
-		});
-	});
-
 	onMount(() => {
-		console.log('[layout] mounted', new Date().toISOString());
 		tryConnect();
 		const onReconnect = async () => {
 			powering = false;
@@ -362,7 +328,6 @@
 		const sshPoll = setInterval(checkSshStatus, 30_000);
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
-			console.log('[layout] destroying', new Date().toISOString());
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
 			getClient().offReconnect(onReconnect);
 			getClient().offDisconnect(onDisconnect);


### PR DESCRIPTION
## Summary

- Remove the `[ws] connecting/open/close`, `[nav] beforeNavigate/afterNavigate` and `[layout] mounted/destroying` console.log calls added by #209.
- They were temporary diagnostic logging for the WS-disconnect investigation; root cause has been identified and fixed.

## Why

The cycling we were chasing was every Caddy admin-API mutation (PUT/DELETE in `nasty-apps`) tearing down every live `reverse_proxy` handler instance — which kills every active WS, since the WS goroutine lives inside the handler. Mitigation is `stream_close_delay 30m` on every WS-bearing reverse_proxy block; that change rides with the proxy-swap-caddy branch (PR #203).

With root cause known and fixed, the per-event console output in production is just noise. This PR removes only the instrumentation; no behaviour change.

## Test plan

- [x] `svelte-check` clean (0 errors / 0 warnings)
- [ ] Verify in browser: open WebUI, F12 → Console, navigate sidebar, install/remove an app → no `[ws]`/`[nav]`/`[layout]` lines appear