### PR TITLE
ups: add remote NUT server mode

### DIFF
--- a/engine/nasty-system/src/nut.rs
+++ b/engine/nasty-system/src/nut.rs
@@ -10,21 +10,55 @@ const NUT_CONF_DIR: &str = "/var/lib/nasty/nut";
 
 // ── Config structs ───────────────────────────────────────────
 
-/// NUT (Network UPS Tools) configuration for a locally connected UPS.
+/// Where the UPS lives.  `Local` runs the full NUT stack
+/// (driver + upsd + upsmon) against a USB/serial UPS connected to
+/// this host.  `Remote` runs only upsmon and points it at an
+/// already-running NUT server elsewhere (e.g. a Ubiquiti UPS, a
+/// Synology, a neighbouring NASty).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NutMode {
+    #[default]
+    Local,
+    Remote,
+}
+
+/// NUT (Network UPS Tools) configuration.  In `local` mode the
+/// `driver`/`port` fields describe the attached UPS; in `remote`
+/// mode they're ignored and `remote_*` fields describe the upstream
+/// NUT server.  `ups_name` is reused in both modes — locally it's
+/// the name we expose, remotely it's the name the upstream uses.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct NutConfig {
+    /// Whether the UPS is attached locally or monitored over the network.
+    #[serde(default)]
+    pub mode: NutMode,
     /// NUT driver name (e.g. `usbhid-ups`, `blazer_usb`, `snmp-ups`).
+    /// Local mode only.
     #[serde(default = "default_driver")]
     pub driver: String,
     /// Device port. `auto` for USB auto-detection, or a path like `/dev/ttyS0`.
+    /// Local mode only.
     #[serde(default = "default_port")]
     pub port: String,
     /// UPS identifier used by upsc/upsd (e.g. `ups`).
     #[serde(default = "default_ups_name")]
     pub ups_name: String,
-    /// Human-readable description.
+    /// Human-readable description.  Local mode only.
     #[serde(default)]
     pub description: String,
+    /// Hostname or IP of the remote NUT server.  Remote mode only.
+    #[serde(default)]
+    pub remote_host: String,
+    /// Port the remote NUT server listens on (default 3493).  Remote mode only.
+    #[serde(default = "default_remote_port")]
+    pub remote_port: u16,
+    /// Username configured in the remote upsd.users.  Remote mode only.
+    #[serde(default)]
+    pub remote_username: String,
+    /// Password configured in the remote upsd.users.  Remote mode only.
+    #[serde(default)]
+    pub remote_password: String,
     /// Initiate shutdown when battery drops below this percentage.
     #[serde(default = "default_shutdown_percent")]
     pub shutdown_on_battery_percent: u32,
@@ -45,6 +79,9 @@ fn default_port() -> String {
 fn default_ups_name() -> String {
     "ups".into()
 }
+fn default_remote_port() -> u16 {
+    3493
+}
 fn default_shutdown_percent() -> u32 {
     20
 }
@@ -58,10 +95,15 @@ fn default_shutdown_command() -> String {
 impl Default for NutConfig {
     fn default() -> Self {
         Self {
+            mode: NutMode::default(),
             driver: default_driver(),
             port: default_port(),
             ups_name: default_ups_name(),
             description: String::new(),
+            remote_host: String::new(),
+            remote_port: default_remote_port(),
+            remote_username: String::new(),
+            remote_password: String::new(),
             shutdown_on_battery_percent: default_shutdown_percent(),
             shutdown_on_battery_seconds: default_shutdown_seconds(),
             shutdown_command: default_shutdown_command(),
@@ -72,10 +114,15 @@ impl Default for NutConfig {
 /// Partial update for NUT configuration.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct NutConfigUpdate {
+    pub mode: Option<NutMode>,
     pub driver: Option<String>,
     pub port: Option<String>,
     pub ups_name: Option<String>,
     pub description: Option<String>,
+    pub remote_host: Option<String>,
+    pub remote_port: Option<u16>,
+    pub remote_username: Option<String>,
+    pub remote_password: Option<String>,
     pub shutdown_on_battery_percent: Option<u32>,
     pub shutdown_on_battery_seconds: Option<u32>,
     pub shutdown_command: Option<String>,
@@ -127,6 +174,9 @@ impl NutService {
     pub async fn update_config(&self, update: NutConfigUpdate) -> Result<NutConfig, String> {
         let mut config = self.state.write().await;
 
+        if let Some(v) = update.mode {
+            config.mode = v;
+        }
         if let Some(v) = update.driver {
             config.driver = v;
         }
@@ -142,6 +192,18 @@ impl NutService {
         if let Some(v) = update.description {
             config.description = v;
         }
+        if let Some(v) = update.remote_host {
+            config.remote_host = v;
+        }
+        if let Some(v) = update.remote_port {
+            config.remote_port = v;
+        }
+        if let Some(v) = update.remote_username {
+            config.remote_username = v;
+        }
+        if let Some(v) = update.remote_password {
+            config.remote_password = v;
+        }
         if let Some(v) = update.shutdown_on_battery_percent {
             if v > 100 {
                 return Err("shutdown_on_battery_percent must be 0-100".into());
@@ -155,6 +217,11 @@ impl NutService {
             config.shutdown_command = v;
         }
 
+        if config.mode == NutMode::Remote && config.remote_host.is_empty() {
+            return Err("remote_host is required when mode = remote".into());
+        }
+        let new_mode = config.mode;
+
         save(&config).await.map_err(|e| e.to_string())?;
 
         // Regenerate config files so next restart picks them up.
@@ -162,12 +229,12 @@ impl NutService {
         if let Err(e) = write_config_files(&config).await {
             warn!("Failed to write NUT config files: {e}");
         }
-        if is_nut_running().await {
+        if is_nut_enabled().await {
             // Spawn restart in background — some drivers (nutdrv_qx) take 20-30s
             // to probe USB and we don't want the API call to block/timeout.
             // restart_nut_services() logs per-service errors itself; the spawn
             // wrapper just guards against a task-panic vanishing into nothing.
-            let h = tokio::spawn(async { restart_nut_services().await });
+            let h = tokio::spawn(async move { reconcile_nut_services(new_mode).await });
             tokio::spawn(async move {
                 if let Err(e) = h.await {
                     warn!("NUT restart task panicked / cancelled: {e}");
@@ -178,10 +245,18 @@ impl NutService {
         Ok(config.clone())
     }
 
-    /// Read live UPS status via `upsc`.
+    /// Read live UPS status via `upsc`.  In local mode talks to the
+    /// local upsd; in remote mode talks to the upstream NUT server.
     pub async fn status(&self) -> UpsStatus {
         let config = self.state.read().await;
-        read_ups_status(&config.ups_name).await
+        let target = match config.mode {
+            NutMode::Local => format!("{}@localhost", config.ups_name),
+            NutMode::Remote => format!(
+                "{}@{}:{}",
+                config.ups_name, config.remote_host, config.remote_port
+            ),
+        };
+        read_ups_status(&target).await
     }
 
     /// Write NUT config files. Called before starting services.
@@ -198,6 +273,19 @@ pub async fn write_config_files(config: &NutConfig) -> Result<(), String> {
         .await
         .map_err(|e| format!("failed to create {NUT_CONF_DIR}: {e}"))?;
 
+    match config.mode {
+        NutMode::Local => write_local_configs(config).await?,
+        NutMode::Remote => write_remote_configs(config).await?,
+    }
+
+    info!(
+        "NUT config files written to {NUT_CONF_DIR} (mode={:?})",
+        config.mode
+    );
+    Ok(())
+}
+
+async fn write_local_configs(config: &NutConfig) -> Result<(), String> {
     // ups.conf
     let ups_conf = format!(
         "[{name}]\n  driver = {driver}\n  port = {port}\n  desc = \"{desc}\"\n",
@@ -233,8 +321,39 @@ pub async fn write_config_files(config: &NutConfig) -> Result<(), String> {
         cmd = config.shutdown_command,
     );
     write_file("upsmon.conf", &upsmon_conf).await?;
+    Ok(())
+}
 
-    info!("NUT config files written to {NUT_CONF_DIR}");
+async fn write_remote_configs(config: &NutConfig) -> Result<(), String> {
+    // In remote mode we don't run upsd or any driver — only upsmon,
+    // pointed at the upstream NUT server in `secondary` role
+    // (modern NUT name; replaces the deprecated `slave`).  Credentials
+    // come from the remote upsd.users; we never see them here.
+    //
+    // Stale ups.conf/upsd.conf/upsd.users from a prior local-mode
+    // session are left in place — nut-driver and nut-server aren't
+    // started in remote mode, so they don't get read.
+    let upsmon_conf = format!(
+        concat!(
+            "MONITOR {name}@{host}:{port} 1 {user} {pass} secondary\n",
+            "SHUTDOWNCMD \"{cmd}\"\n",
+            "MINSUPPLIES 1\n",
+            "POLLFREQ 5\n",
+            "POLLFREQALERT 5\n",
+            "HOSTSYNC 15\n",
+            "DEADTIME 15\n",
+            "RBWARNTIME 43200\n",
+            "NOCOMMWARNTIME 300\n",
+            "FINALDELAY 5\n",
+        ),
+        name = config.ups_name,
+        host = config.remote_host,
+        port = config.remote_port,
+        user = config.remote_username,
+        pass = config.remote_password,
+        cmd = config.shutdown_command,
+    );
+    write_file("upsmon.conf", &upsmon_conf).await?;
     Ok(())
 }
 
@@ -246,8 +365,10 @@ async fn write_file(name: &str, content: &str) -> Result<(), String> {
         .await
         .map_err(|e| format!("failed to write {path}: {e}"))?;
 
-    // upsd.users contains credentials — restrict to owner-only
-    if name == "upsd.users" {
+    // upsd.users (local upsd creds) and upsmon.conf (the MONITOR line
+    // embeds either local upsd creds or the remote NUT server's creds)
+    // both contain plaintext passwords — restrict to owner+group.
+    if name == "upsd.users" || name == "upsmon.conf" {
         tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640))
             .await
             .map_err(|e| format!("failed to set permissions on {path}: {e}"))?;
@@ -258,10 +379,9 @@ async fn write_file(name: &str, content: &str) -> Result<(), String> {
 
 // ── Status reading ───────────────────────────────────────────
 
-async fn read_ups_status(ups_name: &str) -> UpsStatus {
-    let target = format!("{ups_name}@localhost");
+async fn read_ups_status(target: &str) -> UpsStatus {
     let output = tokio::process::Command::new("upsc")
-        .arg(&target)
+        .arg(target)
         .env("NUT_CONFPATH", NUT_CONF_DIR)
         .output()
         .await;
@@ -314,22 +434,92 @@ async fn read_ups_status(ups_name: &str) -> UpsStatus {
 
 // ── Service control helpers ──────────────────────────────────
 
-async fn is_nut_running() -> bool {
-    tokio::process::Command::new("systemctl")
-        .args(["is-active", "--quiet", "nut-server.service"])
-        .status()
-        .await
-        .map(|s| s.success())
-        .unwrap_or(false)
+/// All systemd units the NUT stack could ever own.  The actual set
+/// that *should* run depends on mode — see [`services_for_mode`].
+const ALL_NUT_SERVICES: &[&str] = &[
+    "nut-driver.service",
+    "nut-server.service",
+    "nut-monitor.service",
+];
+
+/// Which systemd units should be running for a given mode.
+/// Used by protocol.rs at start/stop time and by [`reconcile_nut_services`]
+/// after a config change.
+pub fn services_for_mode(mode: NutMode) -> &'static [&'static str] {
+    match mode {
+        NutMode::Local => ALL_NUT_SERVICES,
+        NutMode::Remote => &["nut-monitor.service"],
+    }
 }
 
-async fn restart_nut_services() {
-    info!("Restarting NUT services after config change");
-    for svc in &[
-        "nut-monitor.service",
-        "nut-server.service",
-        "nut-driver.service",
-    ] {
+/// Read mode from disk synchronously (blocking).  Called from
+/// protocol.rs, which needs the unit list before it can await
+/// anything.  Falls back to Local on any error so a missing or
+/// corrupt nut.json doesn't disable monitoring entirely.
+pub fn mode_sync() -> NutMode {
+    match std::fs::read_to_string(STATE_PATH) {
+        Ok(content) => serde_json::from_str::<NutConfig>(&content)
+            .map(|c| c.mode)
+            .unwrap_or_default(),
+        Err(_) => NutMode::default(),
+    }
+}
+
+/// The systemd unit whose "active" state tells us the NUT protocol
+/// is healthy in the current mode.  upsd is local-only; upsmon runs
+/// in both modes and is the right canary.
+pub fn status_unit(mode: NutMode) -> &'static str {
+    match mode {
+        NutMode::Local => "nut-server.service",
+        NutMode::Remote => "nut-monitor.service",
+    }
+}
+
+async fn is_nut_enabled() -> bool {
+    // "Any NUT-stack service is currently active" — used to decide
+    // whether to restart after a config update.  We can't just check
+    // one specific unit because the set depends on mode and the
+    // user might be flipping that very setting.
+    for svc in ALL_NUT_SERVICES {
+        let ok = tokio::process::Command::new("systemctl")
+            .args(["is-active", "--quiet", svc])
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            return true;
+        }
+    }
+    false
+}
+
+async fn reconcile_nut_services(mode: NutMode) {
+    let want: std::collections::HashSet<&str> = services_for_mode(mode).iter().copied().collect();
+    info!("Reconciling NUT services for mode={mode:?}: want {want:?}");
+
+    // Stop any service that should NOT be running in this mode.
+    for svc in ALL_NUT_SERVICES {
+        if want.contains(svc) {
+            continue;
+        }
+        match tokio::process::Command::new("systemctl")
+            .args(["stop", svc])
+            .output()
+            .await
+        {
+            Ok(o) if o.status.success() => {}
+            Ok(o) => warn!(
+                "systemctl stop {svc} exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            ),
+            Err(e) => warn!("systemctl stop {svc} failed to spawn: {e}"),
+        }
+    }
+
+    // Restart (or start) every service that should be running.
+    for svc in services_for_mode(mode) {
         match tokio::process::Command::new("systemctl")
             .args(["restart", svc])
             .output()

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -92,11 +92,12 @@ impl Protocol {
             ],
             Protocol::Iscsi => &["target.service"],
             Protocol::Nvmeof => &[], // configfs-based, no daemon
-            Protocol::Nut => &[
-                "nut-driver.service",
-                "nut-server.service",
-                "nut-monitor.service",
-            ],
+            // NUT runs a different subset of services in local vs
+            // remote modes — see `nut::services_for_mode`.  Remote
+            // mode only needs upsmon; upsd/driver have nothing local
+            // to talk to.  We read the mode synchronously here so
+            // start/stop sequencing in this trait stays sync.
+            Protocol::Nut => crate::nut::services_for_mode(crate::nut::mode_sync()),
             Protocol::Ssh => &["sshd.service"],
             Protocol::Avahi => &["avahi-daemon.service"],
             Protocol::Smart => &["smartd.service"],
@@ -417,7 +418,12 @@ async fn is_protocol_running(proto: Protocol) -> bool {
             // NVMe-oF is "running" if nvmet configfs is available
             std::path::Path::new("/sys/kernel/config/nvmet").exists()
         }
-        Protocol::Nut => systemctl_is_active("nut-server.service").await,
+        Protocol::Nut => {
+            // Pick the canary unit based on mode — upsd doesn't run
+            // in remote mode, so checking nut-server there would
+            // always report "down" even though monitoring is healthy.
+            systemctl_is_active(crate::nut::status_unit(crate::nut::mode_sync())).await
+        }
         Protocol::Ssh => systemctl_is_active("sshd.service").await,
         Protocol::Avahi => systemctl_is_active("avahi-daemon.service").await,
         Protocol::Smart => systemctl_is_active("smartd.service").await,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -562,11 +562,18 @@ export interface Settings {
 	telemetry_enabled: boolean;
 }
 
+export type NutMode = 'local' | 'remote';
+
 export interface NutConfig {
+	mode: NutMode;
 	driver: string;
 	port: string;
 	ups_name: string;
 	description: string;
+	remote_host: string;
+	remote_port: number;
+	remote_username: string;
+	remote_password: string;
 	shutdown_on_battery_percent: number;
 	shutdown_on_battery_seconds: number;
 	shutdown_command: string;

--- a/webui/src/routes/ups/+page.svelte
+++ b/webui/src/routes/ups/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
-	import type { NutConfig, UpsStatus } from '$lib/types';
+	import type { NutConfig, NutMode, UpsStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 
 	const client = getClient();
@@ -11,10 +11,15 @@
 	let savingNut = $state(false);
 	let upsStatus: UpsStatus | null = $state(null);
 	let upsStatusInterval: ReturnType<typeof setInterval> | null = null;
+	let nutMode: NutMode = $state('local');
 	let nutDriver = $state('');
 	let nutPort = $state('');
 	let nutUpsName = $state('');
 	let nutDescription = $state('');
+	let nutRemoteHost = $state('');
+	let nutRemotePort = $state('3493');
+	let nutRemoteUsername = $state('');
+	let nutRemotePassword = $state('');
 	let nutShutdownPercent = $state('');
 	let nutShutdownSeconds = $state('');
 	let nutShutdownCommand = $state('');
@@ -30,10 +35,15 @@
 	async function loadNut() {
 		nutConfig = await client.call<NutConfig>('system.nut.config.get');
 		if (nutConfig) {
+			nutMode = nutConfig.mode;
 			nutDriver = nutConfig.driver;
 			nutPort = nutConfig.port;
 			nutUpsName = nutConfig.ups_name;
 			nutDescription = nutConfig.description;
+			nutRemoteHost = nutConfig.remote_host;
+			nutRemotePort = nutConfig.remote_port.toString();
+			nutRemoteUsername = nutConfig.remote_username;
+			nutRemotePassword = nutConfig.remote_password;
 			nutShutdownPercent = nutConfig.shutdown_on_battery_percent.toString();
 			nutShutdownSeconds = nutConfig.shutdown_on_battery_seconds.toString();
 			nutShutdownCommand = nutConfig.shutdown_command;
@@ -46,10 +56,15 @@
 		savingNut = true;
 		await withToast(
 			() => client.call('system.nut.config.update', {
+				mode: nutMode,
 				driver: nutDriver,
 				port: nutPort,
 				ups_name: nutUpsName,
-				description: nutDescription || undefined,
+				description: nutDescription,
+				remote_host: nutRemoteHost,
+				remote_port: parseInt(nutRemotePort) || 3493,
+				remote_username: nutRemoteUsername,
+				remote_password: nutRemotePassword,
 				shutdown_on_battery_percent: parseInt(nutShutdownPercent) || undefined,
 				shutdown_on_battery_seconds: parseInt(nutShutdownSeconds) || undefined,
 				shutdown_command: nutShutdownCommand || undefined,
@@ -188,38 +203,81 @@
 			{/if}
 
 			<section class="rounded-lg border border-border p-5">
-				<h3 class="mb-4 text-sm font-semibold">UPS Hardware</h3>
-				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					<div>
-						<label for="nut-driver" class="mb-1 block text-xs text-muted-foreground">Driver</label>
-						<select id="nut-driver" bind:value={nutDriver}
-							class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm">
-							<option value="usbhid-ups">usbhid-ups (USB HID)</option>
-							<option value="blazer_usb">blazer_usb (Megatec/Q1 USB)</option>
-							<option value="nutdrv_qx">nutdrv_qx (Q* protocol USB)</option>
-							<option value="snmp-ups">snmp-ups (SNMP)</option>
-							<option value="apcsmart">apcsmart (APC Smart serial)</option>
-						</select>
-						<p class="mt-0.5 text-[0.6rem] text-muted-foreground">NUT driver for your UPS hardware.</p>
-					</div>
-					<div>
-						<label for="nut-port" class="mb-1 block text-xs text-muted-foreground">Port</label>
-						<input id="nut-port" type="text" bind:value={nutPort}
-							class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm font-mono" />
-						<p class="mt-0.5 text-[0.6rem] text-muted-foreground">"auto" for USB, or a device path like /dev/ttyS0.</p>
-					</div>
-					<div>
-						<label for="nut-name" class="mb-1 block text-xs text-muted-foreground">UPS Name</label>
-						<input id="nut-name" type="text" bind:value={nutUpsName}
-							class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
-						<p class="mt-0.5 text-[0.6rem] text-muted-foreground">Identifier for upsc (e.g. "ups").</p>
-					</div>
-					<div class="sm:col-span-2 lg:col-span-3">
-						<label for="nut-desc" class="mb-1 block text-xs text-muted-foreground">Description</label>
-						<input id="nut-desc" type="text" bind:value={nutDescription} placeholder="My UPS"
-							class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
-					</div>
+				<h3 class="mb-4 text-sm font-semibold">UPS Source</h3>
+				<div class="mb-4 inline-flex rounded-md border border-input bg-background p-0.5 text-sm">
+					<button type="button"
+						class="rounded px-3 py-1 {nutMode === 'local' ? 'bg-muted font-semibold' : 'text-muted-foreground'}"
+						onclick={() => nutMode = 'local'}>Local UPS</button>
+					<button type="button"
+						class="rounded px-3 py-1 {nutMode === 'remote' ? 'bg-muted font-semibold' : 'text-muted-foreground'}"
+						onclick={() => nutMode = 'remote'}>Remote NUT server</button>
 				</div>
+
+				{#if nutMode === 'local'}
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						<div>
+							<label for="nut-driver" class="mb-1 block text-xs text-muted-foreground">Driver</label>
+							<select id="nut-driver" bind:value={nutDriver}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm">
+								<option value="usbhid-ups">usbhid-ups (USB HID)</option>
+								<option value="blazer_usb">blazer_usb (Megatec/Q1 USB)</option>
+								<option value="nutdrv_qx">nutdrv_qx (Q* protocol USB)</option>
+								<option value="snmp-ups">snmp-ups (SNMP)</option>
+								<option value="apcsmart">apcsmart (APC Smart serial)</option>
+							</select>
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">NUT driver for your UPS hardware.</p>
+						</div>
+						<div>
+							<label for="nut-port" class="mb-1 block text-xs text-muted-foreground">Port</label>
+							<input id="nut-port" type="text" bind:value={nutPort}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm font-mono" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">"auto" for USB, or a device path like /dev/ttyS0.</p>
+						</div>
+						<div>
+							<label for="nut-name" class="mb-1 block text-xs text-muted-foreground">UPS Name</label>
+							<input id="nut-name" type="text" bind:value={nutUpsName}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">Identifier for upsc (e.g. "ups").</p>
+						</div>
+						<div class="sm:col-span-2 lg:col-span-3">
+							<label for="nut-desc" class="mb-1 block text-xs text-muted-foreground">Description</label>
+							<input id="nut-desc" type="text" bind:value={nutDescription} placeholder="My UPS"
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
+						</div>
+					</div>
+				{:else}
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						<div class="sm:col-span-2">
+							<label for="nut-rhost" class="mb-1 block text-xs text-muted-foreground">Server host</label>
+							<input id="nut-rhost" type="text" bind:value={nutRemoteHost} placeholder="ups.lan or 10.0.0.5"
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm font-mono" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">Hostname or IP of the existing NUT server (e.g. Ubiquiti UPS, Synology).</p>
+						</div>
+						<div>
+							<label for="nut-rport" class="mb-1 block text-xs text-muted-foreground">Port</label>
+							<input id="nut-rport" type="number" min="1" max="65535" bind:value={nutRemotePort}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm font-mono" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">Default 3493.</p>
+						</div>
+						<div>
+							<label for="nut-rname" class="mb-1 block text-xs text-muted-foreground">UPS Name</label>
+							<input id="nut-rname" type="text" bind:value={nutUpsName}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">Name the remote upsd uses for the UPS.</p>
+						</div>
+						<div>
+							<label for="nut-ruser" class="mb-1 block text-xs text-muted-foreground">Username</label>
+							<input id="nut-ruser" type="text" bind:value={nutRemoteUsername}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
+							<p class="mt-0.5 text-[0.6rem] text-muted-foreground">As configured in the remote upsd.users.</p>
+						</div>
+						<div>
+							<label for="nut-rpass" class="mb-1 block text-xs text-muted-foreground">Password</label>
+							<input id="nut-rpass" type="password" bind:value={nutRemotePassword}
+								class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm" />
+						</div>
+					</div>
+				{/if}
 			</section>
 
 			<section class="rounded-lg border border-border p-5">


### PR DESCRIPTION
## Summary

Adds a `local` / `remote` mode toggle for NUT so a NASty can act as a NUT *secondary* watching an existing NUT server (Ubiquiti UPS, Synology, neighbouring NASty, ...) instead of needing a UPS attached directly.

- **Local mode (default, existing behaviour):** runs nut-driver + nut-server + nut-monitor; upsmon is `master`; status reads `<ups>@localhost`.
- **Remote mode (new):** runs only nut-monitor; upsmon is `secondary` and points at `<host>:<port>` with the supplied credentials; status reads `<ups>@<host>:<port>` directly.

## How it works

- `NutConfig` gains `mode: NutMode { Local, Remote }` (`#[serde(default)]` → Local for existing on-disk configs, so this is backwards-compat) plus `remote_host`, `remote_port` (default 3493), `remote_username`, `remote_password`.
- `Protocol::Nut::services()` returns a different unit list per mode (`nut::services_for_mode(mode_sync())`). `is_protocol_running` checks the right canary unit per mode (`status_unit`).
- Switching modes via the WebUI triggers `reconcile_nut_services(new_mode)` — stops units that shouldn't run in the new mode, restarts those that should. No need to toggle the NUT protocol off/on by hand.
- `upsmon.conf` is now 0640 in both modes (it embeds plaintext credentials: local upsd creds in local mode, remote NUT creds in remote mode).

## WebUI

`UPS Source` section gets a Local / Remote toggle. Local keeps the existing driver/port/name/description fields. Remote replaces them with host / port / UPS name / username / password. Shutdown Policy is shared between modes.

Fixes #78.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, all `nasty-system` unit tests pass (206/206)
- [x] `svelte-check` clean (0 errors / 0 warnings)
- [ ] On-box: with existing local-USB UPS config, upgrade → confirm config still loads (mode = local by default) and UPS status still reads
- [ ] On-box: flip to Remote mode pointing at another NUT server, save → confirm nut-driver/nut-server stop, nut-monitor restarts pointing at the remote, status reads upstream values
- [ ] On-box: flip back to Local mode → confirm all three services come back up