### PR TITLE
apps: fetch registry token for ghcr.io and quay.io too

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3730,30 +3730,22 @@ async fn inspect_image_metadata(image: &str) -> Result<ImageMetadata, String> {
     let (registry, repo, tag) = parse_image_ref(image);
     let client = reqwest::Client::new();
 
-    // Get auth token for Docker Hub
-    let token = if registry == "registry-1.docker.io" {
-        let token_url = format!(
-            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{}:pull",
-            repo
-        );
-        let resp: serde_json::Value = client
-            .get(&token_url)
-            .send()
-            .await
-            .map_err(|e| e.to_string())?
-            .json()
-            .await
-            .map_err(|e| e.to_string())?;
-        resp["token"].as_str().map(String::from)
-    } else {
-        None
-    };
-
     let registry_url = if registry.starts_with("http") {
         registry.clone()
     } else {
         format!("https://{registry}")
     };
+
+    // Fetch an anonymous bearer token for registries that require one even
+    // for public images. We previously hard-coded the Docker Hub flow
+    // (auth.docker.io / service=registry.docker.io), which meant any
+    // ghcr.io / quay.io / etc. image silently 401'd — the unauth response
+    // came back as an error JSON without `config.digest`, and the user
+    // saw "no config digest in manifest" with no ports prefilled. This
+    // generalises to any registry that publishes the standard Bearer
+    // realm at `https://<registry>/token?…`, which is what Docker Hub,
+    // ghcr.io, and quay.io all do.
+    let token = fetch_registry_token(&client, &registry, &repo).await;
 
     // Fetch manifest. Accept both single-arch manifests and multi-arch
     // manifest lists / OCI indexes; for the latter we pick the linux/amd64
@@ -3873,6 +3865,47 @@ async fn inspect_image_metadata(image: &str) -> Result<ImageMetadata, String> {
         volumes,
         user,
     })
+}
+
+/// Ask a registry for an anonymous pull token. Best-effort: returns
+/// `None` if the registry isn't one we know how to talk to or the token
+/// endpoint doesn't respond. The caller then makes the manifest request
+/// without auth, which works for genuinely open registries and produces
+/// a clearer 401 for ones that need auth we don't have.
+///
+/// Each registry hosts its own token endpoint at a different path; we
+/// keep a small table rather than chasing `WWW-Authenticate` headers
+/// from a 401 (which would be the technically correct approach but
+/// doubles the round-trips for the common case).
+async fn fetch_registry_token(
+    client: &reqwest::Client,
+    registry: &str,
+    repo: &str,
+) -> Option<String> {
+    let token_url = match registry {
+        "registry-1.docker.io" => format!(
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"
+        ),
+        "ghcr.io" => format!("https://ghcr.io/token?service=ghcr.io&scope=repository:{repo}:pull"),
+        "quay.io" => {
+            format!("https://quay.io/v2/auth?service=quay.io&scope=repository:{repo}:pull")
+        }
+        _ => return None,
+    };
+    let resp: serde_json::Value = client
+        .get(&token_url)
+        .send()
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+    // Both `token` and `access_token` are seen in the wild — ghcr returns
+    // `token`, some Docker Hub flows have returned `access_token`. Try both.
+    resp["token"]
+        .as_str()
+        .or_else(|| resp["access_token"].as_str())
+        .map(String::from)
 }
 
 async fn fetch_manifest_json(


### PR DESCRIPTION
## Summary

Follow-up to #216. Trying to install `ghcr.io/consi/haze` via the WebUI after #216 merged still showed:

> Could not inspect image (command failed: image inspect failed: no config digest in manifest) — set ports manually.

Ports defaulted to 80, Volumes weren't prefilled. The multi-arch handling from #216 never got a chance to fire because the manifest request hit a 401 first.

Root cause: `inspect_image_metadata`'s token branch was hard-coded to `registry-1.docker.io` (`auth.docker.io/token?service=registry.docker.io`). ghcr.io requires a bearer token even for anonymous pulls of public images — the unauthenticated manifest request comes back with `{"errors":[{"code":"UNAUTHORIZED",...}]}`, which has no `config.digest` and no `manifests` array, so we fell through to the old error path.

Pulled the token logic into `fetch_registry_token()` with a small table covering the three registries NASty users actually pull from:

| Registry | Token endpoint |
|---|---|
| `registry-1.docker.io` | `https://auth.docker.io/token?service=registry.docker.io&scope=…` |
| `ghcr.io` | `https://ghcr.io/token?service=ghcr.io&scope=…` |
| `quay.io` | `https://quay.io/v2/auth?service=quay.io&scope=…` |

Also accept `access_token` in the response body alongside `token` — some Docker Hub flows return the OAuth2 spelling.

I'd rather chase `WWW-Authenticate: Bearer realm="…"` from a 401 to be fully general, but that doubles round-trips for the common case and these three cover what's actually being installed. New registries can be added one match arm at a time.

## Verified

```
curl -sS "https://ghcr.io/token?service=ghcr.io&scope=repository:consi/haze:pull"
# → {"token":"djE6Y29uc2k..."}
# manifest with Bearer auth → manifest list → linux/amd64 sub-manifest → config blob:
#   ExposedPorts: {'4420/tcp': {}}
#   Volumes:      {'/var/lib/haze': {}}
#   User:         nonroot:nonroot
```

So the install form should now prefill port 4420, the `/var/lib/haze` Volume row, and surface "Image runs as nonroot:nonroot".

## Test plan
- [x] `cargo test -p nasty-apps --lib` — 46 pass
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Retry haze install via WebUI: confirm ports/volumes are prefilled and the install completes cleanly.