### PR TITLE
nixos: include nasty_apps in RUST_LOG for cloud + appliance profiles

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -61,7 +61,7 @@
     engine = {
       package = nasty-engine;
       port = 2137;
-      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,tower_http=info";
+      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,tower_http=info";
     };
 
     webui = {

--- a/nixos/cloud.nix
+++ b/nixos/cloud.nix
@@ -46,7 +46,7 @@ in
     engine = {
       package = nasty-engine;
       port = 2137;
-      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,tower_http=info";
+      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,tower_http=info";
     };
     webui.package = nasty-webui;
     storage.mountBase = "/storage";


### PR DESCRIPTION
## Summary

Both preset profiles (`cloud.nix` and `appliance-base.nix`) override `services.nasty.engine.logLevel` and **drop `nasty_apps=info`** that the module default in `modules/nasty.nix:91` includes. On every actual deployment that meant all `info!`/`warn!` calls from the `nasty-apps` crate were silenced.

Diagnosed while debugging #216's haze launch on a live appliance install: `journalctl -u nasty-engine` showed only the deploy handler's `Deploy stream started for 'haze'` line, with no install-pipeline logs at all — no `"Installed app 'X'"`, no chown messages, no ingress_set warnings — even though the container had clearly been pulled/created/started successfully.

Both profiles now match the module default verbatim. With this in place, future failures will leave breadcrumbs in the journal the way the install pipeline already intends.

## Test plan

- [ ] After rebuild + redeploy, run `journalctl -u nasty-engine -f` and reinstall haze: confirm the journal shows `Installed app 'haze'` plus any chown/crash-detect lines that fire.