### PR TITLE
apps: curated sub-path recipes for Grafana and Vaultwarden

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -699,6 +699,42 @@ pub struct ImageInspectResult {
     /// chowned to that identity by the install pipeline. `None` = root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    /// Known recipe for configuring this image to serve under
+    /// `/apps/<name>/` behind NASty's path-prefix reverse proxy. When
+    /// present, the WebUI offers an "Apply" button that appends the
+    /// recipe's env entries to the form (the user can still edit them).
+    /// Catches apps that *could* run behind a sub-path but only with
+    /// specific env vars set — e.g. Grafana needs `GF_SERVER_ROOT_URL`
+    /// plus `GF_SERVER_SERVE_FROM_SUB_PATH=true`; without those, our
+    /// post-install probe would (correctly) disable ingress and the
+    /// user would only see the direct-port link, even though a one-line
+    /// env change would have made the proxy work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath_recipe: Option<SubPathRecipe>,
+}
+
+/// A small curated mapping of "set these env vars to make this image
+/// serve under `/apps/<name>/`". Hand-curated rather than heuristic —
+/// the value formats differ wildly across apps (Grafana takes a URL
+/// with `%(protocol)s`/`%(domain)s` placeholders; Vaultwarden takes a
+/// bare full URL; etc.) so guessing risks setting something that breaks
+/// the app in non-obvious ways. The WebUI shows the recipe behind an
+/// opt-in button so the user always confirms before it's applied.
+///
+/// Templates: `{name}` is substituted with the App Name field on the
+/// engine side; `{host}` and `{scheme}` are substituted in the WebUI
+/// from `window.location` (the engine can't know which IP/hostname the
+/// user reaches NASty on). Both forms are surfaced as editable env
+/// rows so the user can adjust before installing.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SubPathRecipe {
+    /// Short label shown next to the "Apply" button (e.g. "Grafana
+    /// sub-path mode"). Not the env var key — purely human-readable.
+    pub display_name: String,
+    /// Env vars to add to the install form when the user applies this
+    /// recipe. Values may contain `{name}`, `{host}`, `{scheme}` —
+    /// see template note above.
+    pub env: Vec<AppEnv>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -2862,6 +2898,7 @@ impl AppsService {
             ports: meta.ports,
             volumes: meta.volumes,
             user: meta.user,
+            subpath_recipe: meta.subpath_recipe,
         })
     }
 
@@ -3724,6 +3761,61 @@ struct ImageMetadata {
     ports: Vec<AppPort>,
     volumes: Vec<AppVolume>,
     user: Option<String>,
+    subpath_recipe: Option<SubPathRecipe>,
+}
+
+/// Look up a sub-path recipe for the given normalized image repo (e.g.
+/// `grafana/grafana`, `vaultwarden/server`, `library/redis`). Matching
+/// on the repo path rather than the full image ref means tagged
+/// variants (`grafana/grafana:11.5`), the OCI registry prefix, and
+/// the `:latest` shortcut all share the same recipe.
+///
+/// Keep this table small and audited: every entry is a vouched-for
+/// recipe with values verified against the upstream's own docs. When
+/// in doubt, *don't* add an entry — leaving an app to fall through to
+/// `probe_proxy_compat` (which disables ingress with a clear reason)
+/// is strictly safer than guessing env values that might
+/// silently break the app behind the scenes.
+fn match_subpath_recipe(repo: &str) -> Option<SubPathRecipe> {
+    match repo {
+        // Grafana: serves correctly behind a sub-path when both vars
+        // are set. Using `%(protocol)s`/`%(domain)s` lets Grafana fill
+        // in scheme + host from its own [server] section at render
+        // time, so the recipe doesn't have to know the operator's
+        // hostname. `serve_from_sub_path` is the toggle that actually
+        // makes Grafana strip the prefix when matching internal routes.
+        // Source: https://grafana.com/tutorials/run-grafana-behind-a-proxy/
+        "grafana/grafana" | "grafana/grafana-oss" | "grafana/grafana-enterprise" => {
+            Some(SubPathRecipe {
+                display_name: "Grafana sub-path mode".to_string(),
+                env: vec![
+                    AppEnv {
+                        name: "GF_SERVER_ROOT_URL".to_string(),
+                        value: "%(protocol)s://%(domain)s/apps/{name}/".to_string(),
+                    },
+                    AppEnv {
+                        name: "GF_SERVER_SERVE_FROM_SUB_PATH".to_string(),
+                        value: "true".to_string(),
+                    },
+                ],
+            })
+        }
+        // Vaultwarden: DOMAIN is the *full* URL (scheme + host + path,
+        // no trailing slash). It's used for CSRF/origin checks and
+        // WebAuthn rpId, so it has to match exactly what the browser
+        // sees — that's why we template both scheme and host and let
+        // the WebUI fill them in from window.location rather than
+        // hard-coding http://. Source:
+        // https://github.com/dani-garcia/vaultwarden/wiki/Proxy-examples
+        "vaultwarden/server" => Some(SubPathRecipe {
+            display_name: "Vaultwarden sub-path mode".to_string(),
+            env: vec![AppEnv {
+                name: "DOMAIN".to_string(),
+                value: "{scheme}://{host}/apps/{name}".to_string(),
+            }],
+        }),
+        _ => None,
+    }
 }
 
 async fn inspect_image_metadata(image: &str) -> Result<ImageMetadata, String> {
@@ -3860,10 +3952,19 @@ async fn inspect_image_metadata(image: &str) -> Result<ImageMetadata, String> {
         .map(|s| s.to_string())
         .filter(|s| !s.is_empty());
 
+    // ── Sub-path recipe ──────────────────────────────────────
+    // Look up by repo (e.g. `grafana/grafana`). The `library/` prefix
+    // that parse_image_ref adds for bare Docker Hub images is stripped
+    // back out here so a hypothetical `library/foo` recipe wouldn't be
+    // necessary (it'd just be `foo` in the table).
+    let lookup_repo = repo.strip_prefix("library/").unwrap_or(&repo);
+    let subpath_recipe = match_subpath_recipe(lookup_repo);
+
     Ok(ImageMetadata {
         ports,
         volumes,
         user,
+        subpath_recipe,
     })
 }
 
@@ -4475,5 +4576,77 @@ services:
         // None so install() leaves the dir root-owned and warns.
         assert_eq!(parse_image_user("plex"), None);
         assert_eq!(parse_image_user("ubuntu"), None);
+    }
+
+    // ── match_subpath_recipe ──
+
+    use super::match_subpath_recipe;
+
+    #[test]
+    fn subpath_recipe_grafana_all_variants() {
+        // grafana, grafana-oss, grafana-enterprise are the three image
+        // names Grafana ships; all need the same env to serve under a
+        // sub-path.
+        for repo in [
+            "grafana/grafana",
+            "grafana/grafana-oss",
+            "grafana/grafana-enterprise",
+        ] {
+            let r = match_subpath_recipe(repo).unwrap_or_else(|| panic!("no recipe for {repo}"));
+            assert_eq!(r.display_name, "Grafana sub-path mode");
+            let keys: Vec<_> = r.env.iter().map(|e| e.name.as_str()).collect();
+            assert!(
+                keys.contains(&"GF_SERVER_ROOT_URL"),
+                "missing GF_SERVER_ROOT_URL for {repo}"
+            );
+            assert!(
+                keys.contains(&"GF_SERVER_SERVE_FROM_SUB_PATH"),
+                "missing GF_SERVER_SERVE_FROM_SUB_PATH for {repo}"
+            );
+            let root = r
+                .env
+                .iter()
+                .find(|e| e.name == "GF_SERVER_ROOT_URL")
+                .unwrap();
+            // Must contain the {name} placeholder so the WebUI can
+            // substitute the app name (otherwise a Grafana installed as
+            // "grafana-prod" would still emit /apps/grafana/ URLs).
+            assert!(
+                root.value.contains("{name}"),
+                "GF_SERVER_ROOT_URL missing {{name}} placeholder"
+            );
+        }
+    }
+
+    #[test]
+    fn subpath_recipe_vaultwarden() {
+        let r = match_subpath_recipe("vaultwarden/server").expect("vaultwarden recipe missing");
+        assert_eq!(r.display_name, "Vaultwarden sub-path mode");
+        assert_eq!(r.env.len(), 1);
+        assert_eq!(r.env[0].name, "DOMAIN");
+        // Both {scheme} and {host} placeholders are required so the
+        // WebUI can render the exact origin the browser sees (Vaultwarden
+        // CSRF-checks against DOMAIN).
+        assert!(r.env[0].value.contains("{scheme}"));
+        assert!(r.env[0].value.contains("{host}"));
+        assert!(r.env[0].value.contains("{name}"));
+        // Trailing slash must NOT be present — Vaultwarden docs are
+        // explicit on this, and a trailing slash breaks the CSRF check.
+        assert!(!r.env[0].value.ends_with('/'));
+    }
+
+    #[test]
+    fn subpath_recipe_unknown_returns_none() {
+        // Unknown apps fall through to the post-install proxy probe
+        // (probe_proxy_compat) — never silently guess.
+        assert_eq!(
+            match_subpath_recipe("library/redis").map(|r| r.display_name),
+            None
+        );
+        assert_eq!(
+            match_subpath_recipe("ghcr.io/consi/haze").map(|r| r.display_name),
+            None
+        );
+        assert_eq!(match_subpath_recipe("").map(|r| r.display_name), None);
     }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1002,6 +1002,16 @@ export interface ImageInspectResult {
 	ports: { name: string; container_port: number; host_port: number | null; protocol: string }[];
 	volumes: { name: string; mount_path: string; host_path: string }[];
 	user?: string | null;
+	/** Curated recipe for serving this image under /apps/<name>/. When
+	 * present, the install form offers an "Apply" button that appends
+	 * the recipe's env entries (with `{name}`/`{host}`/`{scheme}`
+	 * placeholders substituted) — see SubPathRecipe in nasty-apps. */
+	subpath_recipe?: SubPathRecipe | null;
+}
+
+export interface SubPathRecipe {
+	display_name: string;
+	env: { name: string; value: string }[];
 }
 
 export interface AppIngress {

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -4,7 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult } from '$lib/types';
+	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe } from '$lib/types';
 	import { formatBytes } from '$lib/format';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -278,6 +278,12 @@
 	/** Inline status from the last apps.inspect_image call so the user sees
 	 *  why ports weren't auto-detected (image unreachable, no EXPOSE, etc.). */
 	let inspectMsg: string | null = $state(null);
+	/** Curated recipe for serving this image under /apps/<name>/, if the
+	 *  engine recognised the image. Surfaced as an "Apply <Name> sub-path
+	 *  mode" button next to the Environment Variables section — clicking
+	 *  it appends the recipe's env entries to newEnvs with `{name}`,
+	 *  `{host}`, `{scheme}` placeholders substituted. */
+	let subpathRecipe = $state<SubPathRecipe | null>(null);
 
 	// Port conflict state
 	let portConflicts = $state<{ port: number; used_by: string }[]>([]);
@@ -429,6 +435,10 @@
 				const userMsg = `Image runs as ${result.user} — auto-created volume dirs will be chowned to that identity.`;
 				inspectMsg = inspectMsg ? `${inspectMsg} ${userMsg}` : userMsg;
 			}
+			// Stash any sub-path recipe so the UI can render the
+			// "Apply <recipe> sub-path mode" button. We don't auto-apply;
+			// the user opts in so they see what's being added.
+			subpathRecipe = result.subpath_recipe ?? null;
 		} catch (e) {
 			// Registry unreachable / image not found / private without auth.
 			// Surface inline so the user knows to fall back to manual entry.
@@ -437,6 +447,35 @@
 		}
 		inspecting = false;
 		checkPortConflicts();
+	}
+
+	/** Apply the engine-supplied sub-path recipe to the install form.
+	 * Substitutes `{name}` with the App Name field, and `{host}`/`{scheme}`
+	 * with what the browser sees right now — so Vaultwarden's `DOMAIN`
+	 * matches the origin the user will type into their browser (CSRF
+	 * checks rely on exact match). Appends entries to newEnvs rather
+	 * than overwriting, and skips keys the user has already set so the
+	 * user's manual config wins. After apply, clear the recipe state
+	 * so the button doesn't re-trigger on every keystroke.
+	 */
+	function applySubpathRecipe() {
+		if (!subpathRecipe) return;
+		const host = window.location.host;
+		const scheme = window.location.protocol.replace(/:$/, '');
+		const existing = new Set(newEnvs.map(e => e.name));
+		const additions = subpathRecipe.env
+			.filter(e => !existing.has(e.name))
+			.map(e => ({
+				name: e.name,
+				value: e.value
+					.replaceAll('{name}', newName || 'app')
+					.replaceAll('{host}', host)
+					.replaceAll('{scheme}', scheme),
+			}));
+		if (additions.length > 0) {
+			newEnvs = [...newEnvs, ...additions];
+		}
+		subpathRecipe = null;
 	}
 
 	function checkPortConflicts(excludeApp?: string) {
@@ -885,6 +924,7 @@
 		newMemoryLimit = '';
 		newAllowUnsafe = false;
 		lastInspectedImage = '';
+		subpathRecipe = null;
 	}
 
 	function cancelEdit() {
@@ -1342,6 +1382,17 @@
 						<Label>Environment Variables</Label>
 						<Button size="xs" variant="outline" onclick={addEnv}>+ Add</Button>
 					</div>
+					{#if subpathRecipe}
+						<!-- Engine recognised this image as one with a known sub-path recipe
+						     (Grafana, Vaultwarden, ...). Show the recipe behind an opt-in
+						     button so the user confirms before any env vars are added —
+						     the values are templated against window.location at click time
+						     so they match the origin the browser actually uses. -->
+						<div class="mt-1 flex items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-1.5 text-xs">
+							<span class="text-blue-400">Reverse-proxy at <code>/apps/{newName || '&lt;name&gt;'}/</code> supported.</span>
+							<Button size="xs" variant="outline" onclick={applySubpathRecipe}>Apply {subpathRecipe.display_name}</Button>
+						</div>
+					{/if}
 					{#each newEnvs as env, i}
 						<div class="grid grid-cols-[1fr_1fr_auto] gap-2 mt-1 items-center">
 							<Input bind:value={env.name} placeholder="Name" class="h-8 text-xs" />


### PR DESCRIPTION
## Summary

Complement to #219 (probe + auto-disable broken ingress). The probe is a safety net for apps that **genuinely can't** be made to work behind a sub-path (haze). But a lot of self-hostable dashboards **can** — they just need specific env vars set. Without these recipes, those apps fall into the same "Direct port only" trap as the unfixable ones, because the probe sees absolute-path assets in the default-config HTML and disables ingress.

This adds a small curated table — Grafana and Vaultwarden to start — that the install form surfaces as an opt-in "Apply X sub-path mode" button next to the Environment Variables section. When the user clicks it, the recipe's env entries get appended to the form, with templates substituted:

| Placeholder | Substituted with | Why |
|---|---|---|
| `{name}` | App Name field (engine side) | So a Grafana installed as "grafana-prod" emits `/apps/grafana-prod/` URLs |
| `{host}`, `{scheme}` | `window.location` (WebUI side) | Vaultwarden's `DOMAIN` is CSRF-checked against exactly the origin the browser uses, so it must match what the user types — we can't hardcode `http://nasty` from inside the engine |

Existing env keys the user set manually are preserved (additions only).

### Two recipes seeded

- **`grafana/grafana`, `-oss`, `-enterprise`** → `GF_SERVER_ROOT_URL` + `GF_SERVER_SERVE_FROM_SUB_PATH=true`. The URL uses Grafana's own `%(protocol)s` / `%(domain)s` placeholders so it dynamically tracks the request's Host header (operator's hostname doesn't have to be baked in). Verified against the Grafana docs (linked in code).
- **`vaultwarden/server`** → `DOMAIN` only, **no trailing slash** (Vaultwarden's docs are explicit on this — a trailing slash breaks the CSRF check). Templated against `{scheme}://{host}/apps/{name}` so the resolved value matches the exact origin a browser uses.

### Why hand-curated rather than heuristic

Value formats differ wildly between apps:
- Full URL vs. just the path
- Trailing slash significant or not
- `%(protocol)s`-style placeholders vs. literal scheme
- Some need a second toggle (`SERVE_FROM_SUB_PATH=true`), some don't

A heuristic env-name scanner (`*_BASE_URL`, `*_ROOT_URL`, etc.) could surface candidates but couldn't safely auto-fill the value. The plan there is a separate follow-up: scan env keys, surface as a hint with a docs link, but don't pre-fill the value — let the user paste from upstream docs. This PR keeps the bar high: only ship recipes whose values have been verified against the upstream's own docs.

### Behavior in screenshots (post-deploy)

- User types `grafana/grafana` into Container Image
- A blue chip appears next to "Environment Variables": `Reverse-proxy at /apps/<name>/ supported.  [Apply Grafana sub-path mode]`
- Click → two env rows appear, prefilled. User can still edit or remove.
- Install → post-install probe (#219) re-fetches the proxied HTML, sees Grafana now emits paths under `/apps/grafana/`, leaves the ingress in place. Open button works.

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 3 new recipe tests, 49 total pass
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors)
- [ ] End-to-end: install grafana/grafana via WebUI, Apply recipe, confirm proxied UI loads at `/apps/grafana/`; install vaultwarden/server with recipe, confirm login flow works through `/apps/vault/`.