### PR TITLE
apps/config: tag image-default env so Edit can grey them out

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1030,6 +1030,16 @@ fn default_tcp() -> String {
 pub struct AppEnv {
     pub name: String,
     pub value: String,
+    /// Set by `apps.config` when this entry's value matches the image's
+    /// own `Config.Env` default for the same key — i.e. the user didn't
+    /// set it explicitly, it just came along with the image. The WebUI
+    /// greys these rows out in Edit and shows an "Override" button so
+    /// the user sees what the image provides without being misled into
+    /// thinking they own it. Always `false` when the WebUI submits env
+    /// back to the engine (install/update) — the engine doesn't read
+    /// this field for create_container; it's purely an Edit-side hint.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_image_default: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -2301,16 +2311,50 @@ impl AppsService {
         }
         ports.sort_by_key(|p| p.container_port);
 
-        // Parse env
+        // Parse env. The container's `Config.Env` is `image defaults
+        // + values we passed at create_container` with no marker for
+        // which is which — so we inspect the image's own Config.Env
+        // here and tag every row that matches a default with
+        // `is_image_default: true`. The WebUI then renders those rows
+        // greyed out with an "Override" button instead of an "x",
+        // so the user can see what the image provides and only opts
+        // into overriding what they actually want to change.
+        //
+        // If the image inspect fails we fall back to flagging nothing
+        // — the Edit form will look like the pre-fix behaviour (image
+        // defaults shown as user-set), which is at worst noisy. The
+        // failure is logged so it's grep-able.
+        let image_env_defaults: HashMap<String, String> =
+            match self.docker()?.inspect_image(&image).await {
+                Ok(img) => img
+                    .config
+                    .and_then(|c| c.env)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|e| {
+                        e.split_once('=')
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                    })
+                    .collect(),
+                Err(e) => {
+                    warn!(
+                        "apps.get_config: image inspect for '{image}' failed: {e} \
+                         — Edit will not distinguish image-default env entries"
+                    );
+                    HashMap::new()
+                }
+            };
         let env: Vec<AppEnv> = config
             .env
             .unwrap_or_default()
             .iter()
             .filter_map(|e| {
                 let (k, v) = e.split_once('=')?;
+                let is_image_default = image_env_defaults.get(k).map(|d| d == v).unwrap_or(false);
                 Some(AppEnv {
                     name: k.to_string(),
                     value: v.to_string(),
+                    is_image_default,
                 })
             })
             .collect();
@@ -4076,10 +4120,12 @@ fn match_subpath_recipe(repo: &str) -> Option<SubPathRecipe> {
                     AppEnv {
                         name: "GF_SERVER_ROOT_URL".to_string(),
                         value: "%(protocol)s://%(domain)s/apps/{name}/".to_string(),
+                        is_image_default: false,
                     },
                     AppEnv {
                         name: "GF_SERVER_SERVE_FROM_SUB_PATH".to_string(),
                         value: "true".to_string(),
+                        is_image_default: false,
                     },
                 ],
             })
@@ -4096,6 +4142,7 @@ fn match_subpath_recipe(repo: &str) -> Option<SubPathRecipe> {
             env: vec![AppEnv {
                 name: "DOMAIN".to_string(),
                 value: "{scheme}://{host}/apps/{name}".to_string(),
+                is_image_default: false,
             }],
         }),
         _ => None,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -996,7 +996,12 @@ export interface AppConfig {
 	name: string;
 	image: string;
 	ports: { name: string; container_port: number; host_port: number | null; protocol: string }[];
-	env: { name: string; value: string }[];
+	/** `is_image_default: true` means the row's value matches the image's
+	 * own `Config.Env` default for that key — the user didn't set it.
+	 * Edit greys these rows out with an "Override" button so the user
+	 * sees what the image provides without being misled into thinking
+	 * they own it. Only present when the engine recognised the default. */
+	env: { name: string; value: string; is_image_default?: boolean }[];
 	volumes: { name: string; mount_path: string; host_path: string }[];
 	cpu_limit: string | null;
 	memory_limit: string | null;

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -262,7 +262,12 @@
 	let newName = $state('');
 	let newImage = $state('');
 	let newPorts = $state<{ name: string; container_port: number; host_port: string; protocol: string }[]>([]);
-	let newEnvs = $state<{ name: string; value: string }[]>([]);
+	/** `is_image_default` = the row's value came from the image's own
+	 * `Config.Env` (not set by the user). Greyed out in Edit, shown with
+	 * an "Override" button that flips `overriding` to true and makes the
+	 * row editable — only overridden rows end up in updateApp's req.env,
+	 * so the user's override list stays clean of image internals. */
+	let newEnvs = $state<{ name: string; value: string; is_image_default?: boolean; overriding?: boolean }[]>([]);
 	let newVolumes = $state<{ name: string; mount_path: string; host_path: string }[]>([]);
 	/** Index into `newVolumes` of the row whose host_path picker is
 	 * currently open; null when no picker is up. */
@@ -820,7 +825,13 @@
 			}));
 		}
 		if (newEnvs.length > 0) {
-			params.env = newEnvs.filter(e => e.name);
+			// Same image-default filter as updateApp — symmetric so an
+			// install path that somehow seeded image-default rows (e.g.
+			// re-using Edit state, or a future paste-from-running flow)
+			// wouldn't quietly pin those values either.
+			params.env = newEnvs
+				.filter(e => e.name && (!e.is_image_default || e.overriding))
+				.map(e => ({ name: e.name, value: e.value }));
 		}
 		if (newVolumes.length > 0) {
 			params.volumes = newVolumes.filter(v => v.name && v.mount_path).map(v => ({
@@ -861,7 +872,12 @@
 			host_port: p.host_port?.toString() ?? '',
 			protocol: p.protocol,
 		}));
-		newEnvs = config.env.map(e => ({ name: e.name, value: e.value }));
+		newEnvs = config.env.map(e => ({
+			name: e.name,
+			value: e.value,
+			is_image_default: e.is_image_default ?? false,
+			overriding: false,
+		}));
 		newVolumes = config.volumes.map(v => ({ name: v.name, mount_path: v.mount_path, host_path: v.host_path }));
 		newCpuLimit = config.cpu_limit ?? '';
 		newMemoryLimit = config.memory_limit ?? '';
@@ -885,7 +901,13 @@
 			}));
 		}
 		if (newEnvs.length > 0) {
-			params.env = newEnvs.filter(e => e.name);
+			// Drop image-default rows unless the user explicitly clicked
+			// Override on them. Without this, every Edit + Save would
+			// pin all image defaults into req.env — silently masking
+			// any future upstream change to those defaults.
+			params.env = newEnvs
+				.filter(e => e.name && (!e.is_image_default || e.overriding))
+				.map(e => ({ name: e.name, value: e.value }));
 		}
 		if (newVolumes.length > 0) {
 			params.volumes = newVolumes.filter(v => v.name && v.mount_path).map(v => ({
@@ -1394,10 +1416,24 @@
 						</div>
 					{/if}
 					{#each newEnvs as env, i}
-						<div class="grid grid-cols-[1fr_1fr_auto] gap-2 mt-1 items-center">
-							<Input bind:value={env.name} placeholder="Name" class="h-8 text-xs" />
-							<Input bind:value={env.value} placeholder="Value" class="h-8 text-xs" />
-							<Button size="xs" variant="ghost" onclick={() => removeEnv(i)}>x</Button>
+						{@const greyed = env.is_image_default && !env.overriding}
+						<div class="grid grid-cols-[1fr_1fr_auto] gap-2 mt-1 items-center" title={greyed ? "Image default — click Override to change." : ""}>
+							<Input bind:value={env.name} placeholder="Name" class="h-8 text-xs {greyed ? 'opacity-60' : ''}" disabled={greyed} />
+							<Input bind:value={env.value} placeholder="Value" class="h-8 text-xs {greyed ? 'opacity-60' : ''}" disabled={greyed} />
+							{#if env.is_image_default && !env.overriding}
+								<!-- Image-default rows show Override (not "x") — removing an image-default
+								     would be a no-op since Docker still injects it from the image. Override
+								     flips the row to user-owned so updateApp pins this exact value. -->
+								<Button size="xs" variant="outline" onclick={() => { env.overriding = true; }}>Override</Button>
+							{:else if env.is_image_default && env.overriding}
+								<!-- Reverting drops the explicit override; Docker falls back to
+								     whatever the image declares (including any future upstream
+								     change). The typed value stays in the input but is ignored
+								     on save — the greyed appearance signals "won't be saved". -->
+								<Button size="xs" variant="ghost" onclick={() => { env.overriding = false; }} title="Revert to image default on save">↺</Button>
+							{:else}
+								<Button size="xs" variant="ghost" onclick={() => removeEnv(i)}>x</Button>
+							{/if}
 						</div>
 					{/each}
 				</div>


### PR DESCRIPTION
## Summary

Reported: opening **Edit** on a freshly installed haze showed five env vars (`PATH`, `SSL_CERT_FILE`, `HAZE_BIND`, `HAZE_DATA_DIR`, `HAZE_LOG`) as if the user had set them. They hadn't — `ghcr.io/consi/haze:latest` bakes all five into its own `Config.Env`, and `apps.config` was returning the container's full env without distinguishing image defaults from user overrides.

Hidden hazard: clicking **Save** would have re-installed haze with all five vars in `req.env`, pinning them at the value they had the day Edit was opened. A later upstream image bumping (say) `HAZE_LOG`'s default to `haze=warn` would have been silently masked by the saved override.

## Approach: don't hide image defaults, *mark them*

User feedback on an earlier "just strip them" sketch was that surfacing them — greyed out, with an explicit Override button — is more honest UX. Adopted.

### Engine

- `AppEnv` gains `is_image_default: bool` (default `false`, skipped when serializing `false` so the field only appears when meaningful).
- `apps.config` inspects the image's `Config.Env` and tags every container-env entry whose value matches a default.
- Image inspect failure logs + falls back to no tagging (a noisy Edit form is better than no Edit form).

### WebUI

- Image-default rows render with `opacity-60` + disabled inputs and a blue **Override** button instead of the red `x`.
- Clicking Override flips a per-row `overriding` flag — row becomes editable; a revert (↺) button lets the user back out.
- `updateApp` filters `req.env` to rows that are either user-added or have `overriding` set, so the saved override list stays clean of image internals and Docker keeps authority over any default the user didn't explicitly override.
- Symmetric filter on `install()` so any seeded image-default rows from a future paste-from-running flow wouldn't sneak into `req.env` either.

## Visual

Before this PR, Edit haze showed five rows like normal user-set env. After: the same five rows render greyed out with an Override button on each. The user knows what the image provides and only opts into overriding what they actually want to change.

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 55 pass (no new tests; engine change is pure dataflow tag, WebUI change is render + filter logic best verified visually)
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors)
- [ ] After deploy: Edit haze → confirm five rows render greyed with Override buttons. Click Override on `HAZE_BIND`, change value, Save → confirm container picks up the new value and other four stay at image defaults. Edit again → confirm only the overridden one is non-greyed.