### PR TITLE
hardware: parse IEC binary-prefix dmidecode sizes (GiB/MiB/...)

### DIFF
--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -528,7 +528,14 @@ fn collect_kv<'a, I: Iterator<Item = &'a str>>(lines: I) -> HashMap<String, Stri
 }
 
 /// `"16 GB"` → 17179869184; `"8192 MB"` → 8589934592. Returns 0 on
-/// `"No Module Installed"` or any unrecognized format.
+/// `"No Module Installed"` or any unrecognized format. Accepts both
+/// decimal-prefix (`KB`/`MB`/`GB`/`TB`) and binary-prefix (`KiB`/`MiB`/
+/// `GiB`/`TiB`) spellings — different dmidecode versions emit one or
+/// the other, and the values are 1024-based in both cases (DMI table
+/// sizes are always powers of two). The Hardware page silently showed
+/// "0 B / 0 of N slots populated" on machines where dmidecode emits
+/// the IEC form because the old match arms only covered the decimal
+/// spellings.
 fn parse_dmi_size(s: &str) -> u64 {
     let trimmed = s.trim();
     if trimmed.eq_ignore_ascii_case("No Module Installed") {
@@ -539,10 +546,10 @@ fn parse_dmi_size(s: &str) -> u64 {
         return 0;
     };
     match parts.next().unwrap_or("").to_ascii_lowercase().as_str() {
-        "kb" => num * 1024,
-        "mb" => num * 1024 * 1024,
-        "gb" => num * 1024 * 1024 * 1024,
-        "tb" => num * 1024_u64.pow(4),
+        "kb" | "kib" => num * 1024,
+        "mb" | "mib" => num * 1024 * 1024,
+        "gb" | "gib" => num * 1024 * 1024 * 1024,
+        "tb" | "tib" => num * 1024_u64.pow(4),
         _ => 0,
     }
 }
@@ -747,6 +754,24 @@ Device:\tCometLake-S cAVS [a3f0]
         assert_eq!(parse_dmi_size("8192 MB"), 8192 * 1024 * 1024);
         assert_eq!(parse_dmi_size("64 KB"), 64 * 1024);
         assert_eq!(parse_dmi_size("1 TB"), 1024_u64.pow(4));
+    }
+
+    #[test]
+    fn parse_dmi_size_handles_iec_binary_prefixes() {
+        // Newer dmidecode versions emit "32 GiB" instead of "32 GB" for
+        // Memory Device entries. Same 1024-based value either way (DMI
+        // sizes are always powers of two), so the parser has to accept
+        // both spellings. Without this the Hardware page silently shows
+        // "0 B / 0 of N slots populated" on those machines — the
+        // unit-suffix match falls through to the catch-all and we
+        // return 0. Reported live on an Odroid H3 with `Size: 32 GiB`.
+        assert_eq!(parse_dmi_size("32 GiB"), 32 * 1024 * 1024 * 1024);
+        assert_eq!(parse_dmi_size("8 GiB"), 8 * 1024 * 1024 * 1024);
+        assert_eq!(parse_dmi_size("4096 MiB"), 4096 * 1024 * 1024);
+        assert_eq!(parse_dmi_size("64 KiB"), 64 * 1024);
+        assert_eq!(parse_dmi_size("2 TiB"), 2 * 1024_u64.pow(4));
+        // Case-insensitive — some printers use mixed case.
+        assert_eq!(parse_dmi_size("16 gib"), 16 * 1024 * 1024 * 1024);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reported live on an Odroid H3: Hardware page shows **"0 B / 0 of 2 slots populated"** even though \`dmidecode -t memory\` reports 32 GiB DDR4 modules in both slots.

\`\`\`
Size: 32 GiB        ← real DIMM, real size
Locator: Controller0-ChannelA
...
\`\`\`

Root cause: \`parse_dmi_size\` only matched decimal-prefix suffixes (\`KB\`/\`MB\`/\`GB\`/\`TB\`). Newer dmidecode versions emit the IEC binary-prefix spelling instead — \`Size: 32 GiB\` — and the unit-suffix match falls through to the catch-all \`_ => 0\`. \`populated\` is gated on \`size_bytes > 0\`, so \`slots_used\` stayed at 0 too — hence the misleading "0 of 2 slots populated" line above.

Same numeric value either way (DMI sizes are always powers of two, so 32 GB and 32 GiB both mean \`32 * 1024^3\`). Just need to accept both spellings (plus the case-insensitive variants — some printers use "GiB", some "gib").

Added an IEC-spelling test asserting each unit. The existing \`parse_dmi_size_handles_all_units\` covers the decimal-prefix side, so both code paths now have coverage.

## Test plan

- [x] \`cargo test -p nasty-system --lib parse_dmi\` — 7 pass including the new IEC test
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] After deploy: \`/hardware\` reports correct total + per-DIMM size on the H3 (32 GiB × 2).