### PR TITLE
webui/apps: paste-parse treat docker named volumes as auto-managed

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -223,7 +223,22 @@
 			} else if ((t === '-v' || t === '--volume') && i + 1 < tokens.length) {
 				const parts = tokens[++i].split(':');
 				if (parts.length >= 2) {
-					volumes.push({ name: `vol-${volumes.length}`, host_path: expandShellVars(parts[0]), mount_path: parts[1] });
+					// `-v src:dest`: src is a *bind mount* only when it's an
+					// absolute host path (Docker rule — anything else, like
+					// `haze-data:/var/lib/haze`, is a Docker named volume).
+					// For named volumes we want NASty's auto-managed storage
+					// instead — leave host_path empty, the install pipeline
+					// auto-creates a chowned dir under /fs/<x>/apps/<name>/.
+					// Without this branch the parser was stuffing the volume
+					// name (`haze-data`) into host_path, which the engine
+					// then rejects as not under /fs/.
+					const src = parts[0];
+					const isBindMount = src.startsWith('/');
+					volumes.push({
+						name: isBindMount ? `vol-${volumes.length}` : src,
+						host_path: isBindMount ? expandShellVars(src) : '',
+						mount_path: parts[1],
+					});
 				}
 			} else if (t === '-d' || t === '--detach' || t === '--restart' || t === '--restart=always' || t.startsWith('--restart=')) {
 				// skip flags we handle implicitly


### PR DESCRIPTION
## Summary

Reported live: pasting upstream's haze command —

\`\`\`
docker run --rm -p 4420:4420 -v haze-data:/var/lib/haze ghcr.io/consi/haze:latest
\`\`\`

— produced a Volume row with **host_path=\`haze-data\`** and mount_path=\`/var/lib/haze\`. \`haze-data\` is a Docker named volume, not a host path; clicking Install then fails validation (\"not under /fs/\").

Docker's actual rule for \`-v src:dest\`: \`src\` is a bind mount **only when it's an absolute path on the host**. Everything else (\`haze-data\`, \`my_volume\`) is a named volume living in Docker's own data dir.

For NASty, named volumes don't map to bind mounts at all — they map to the install pipeline's **auto-managed storage** (empty \`host_path\` → engine creates \`/fs/<x>/apps/<name>/<vol>/\` at install time and chowns it to the image's runtime user, see #216). The parser was splitting on \`:\` and stuffing \`parts[0]\` into \`host_path\` unconditionally; the fix branches on \`src.startsWith('/')\`:

- **Absolute path** → bind mount; keep \`host_path = src\` (after shell-var expansion, same as before).
- **Anything else** → named volume; \`host_path = ''\` (auto-manage), use the volume name as the row's \`name\` so the auto-created dir gets a descriptive name under apps storage.

## Test plan

- [x] \`npm run check\` (svelte-check, 0 errors)
- [ ] After deploy: paste the haze command into the dialog → confirm the Volume row shows \"haze-data\" in **name** + \`/var/lib/haze\` in mount-path + empty host-path. Install completes; engine auto-creates \`/fs/first/apps/haze/haze-data/\` chowned to 65532.
- [ ] Regression: paste a command with \`-v /tank/media:/data\` → host_path stays \`/tank/media\` (bind mount preserved).