### PR TITLE
apps/reconcile: honour proxy_disabled_reason on engine restart

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2884,9 +2884,30 @@ impl AppsService {
 
         // Live state: ask Docker about labelled containers with a
         // TCP port mapping, then look up the host port for each.
+        // If we successfully enumerated *any* managed apps, treat the
+        // resulting route set as authoritative — even when it's empty
+        // after filtering (e.g. all apps have proxy_disabled_reason
+        // set). Falling back to the legacy file in that case would
+        // resurrect routes the probe explicitly killed.
         if let Ok(apps) = self.list().await {
+            let saw_managed_apps = !apps.is_empty();
             let mut routes = Vec::new();
             for app in apps {
+                // Skip apps whose post-install probe disabled the
+                // reverse proxy (haze-class apps that emit absolute
+                // root-path assets). Without this check, every engine
+                // restart re-added the ingress the probe killed —
+                // user installs haze, ingress disabled, restart engine,
+                // ingress is back, /apps/haze/ goes blank again until
+                // someone notices and re-removes it. The manifest is
+                // the source of truth; honour it.
+                if app.proxy_disabled_reason.is_some() {
+                    info!(
+                        "apps: '{}' has proxy_disabled_reason — skipping ingress reconcile",
+                        app.name
+                    );
+                    continue;
+                }
                 let Some(port) = app
                     .ports
                     .iter()
@@ -2900,7 +2921,7 @@ impl AppsService {
                     host_port: port,
                 });
             }
-            if !routes.is_empty() {
+            if saw_managed_apps {
                 return routes;
             }
         }


### PR DESCRIPTION
## Summary

Latent bug caught while diagnosing a separate WebUI staleness issue. \`reconcile_app_routes\` runs at engine startup and rebuilds Caddy's app-ingress route set from the live container list. Up to now it took every managed container with a TCP port mapping and added a route — **without checking the per-app manifest for \`proxy_disabled_reason\`**.

Symptom this would have produced:

1. User installs haze.
2. Post-install probe (#219) correctly detects absolute root-path assets and disables ingress. Manifest records \`proxy_disabled_reason\`.
3. Operator restarts the engine (reboot, \`nixos-rebuild switch\`, \`systemctl restart nasty-engine\`).
4. Reconcile fires, enumerates labelled containers, adds a Caddy route for haze. **Ingress is back.**
5. \`/apps/haze/\` goes blank again until someone notices and re-removes it.

Hasn't bitten anyone live yet only because the affected box hadn't restarted since the probe fired.

## Fix

When iterating \`self.list()\` in \`compute_desired_routes\`, skip apps whose \`proxy_disabled_reason\` is set. The manifest already carries this flag (\`load_proxy_disabled_reason\` populates it during \`list_internal\` / \`list_offline\`), so reconcile just needed to honour it.

While there, tightened the live-state-vs-legacy-file branching. The old code returned the legacy-file result whenever \`routes\` came back empty — which would have *resurrected* routes the probe explicitly killed if every managed app happened to be proxy-disabled. Now: if we got *any* managed apps from Docker, treat the filtered result as authoritative (even when it's empty). Only fall through to the legacy file when we genuinely couldn't list apps.

## Test plan

- [x] \`cargo test -p nasty-apps --lib\` — 55 pass (no new test; the reconcile path needs a Docker socket to exercise meaningfully, and the surrounding load_proxy_disabled_reason / list flow is already covered)
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] Reinstall haze, confirm probe disables ingress, then \`systemctl restart nasty-engine\` — confirm Caddy still has no haze route and the journal shows \`apps: 'haze' has proxy_disabled_reason — skipping ingress reconcile\`.