### PR TITLE
webui/apps: surface exec_command errors so Shell doesn't silently fail

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -1087,7 +1087,21 @@
 	}
 
 	async function openShell(name: string) {
-		const cmd = await client.call<string>('apps.exec_command', { name });
+		// apps.exec_command errors when the container has no shell (scratch
+		// or distroless images — haze is the canonical case). Without the
+		// try/catch the rejected promise silently swallowed the click: no
+		// goto, no toast, the user just saw nothing happen. Surface the
+		// engine's message so the operator knows *why* Shell didn't work.
+		let cmd: string;
+		try {
+			cmd = await client.call<string>('apps.exec_command', { name });
+		} catch (e) {
+			const msg = e instanceof Error ? e.message :
+				(typeof e === 'object' && e !== null && 'message' in e) ?
+				String((e as { message: unknown }).message) : String(e);
+			await withToast(async () => { throw new Error(msg); }, '');
+			return;
+		}
 		// Navigate to terminal with pre-filled command
 		goto(`/terminal?cmd=${encodeURIComponent(cmd)}`);
 	}


### PR DESCRIPTION
## Summary

Reported: clicking **Shell** on haze did nothing.

\`apps.exec_command\` rejects with \`"this container has no shell (scratch/distroless image)"\` — but \`openShell\` awaited the promise without a try/catch, so the rejection silently swallowed the click: no \`goto\`, no toast, just nothing happens.

We didn't break this — it was never wired to a feedback path. Easy to miss because every other shell-able app on the box has \`/bin/sh\` and falls through to the happy path. Distroless containers (haze, also chainguard's whole catalogue) make it visible.

## Fix

Wrap the engine call in try/catch and pipe the error to \`withToast\`. The engine's existing message ("no shell ...") becomes a toast, which is informative enough for the operator to know they'd need to \`docker exec\` a real binary from the image if they want to poke around.

## Not in scope

Same silent-failure pattern exists on the per-service Shell button further down (around line 1915) — it composes a static \`docker exec /bin/sh\` and would fail in the terminal for a distroless compose service. That one fails *visibly* (the terminal opens and the user sees the error), so it's lower priority. Left for a separate pass if anyone hits it.

## Test plan

- [x] \`npm run check\` (svelte-check, 0 errors)
- [ ] On the box: click Shell on haze → confirm a toast appears with "this container has no shell (scratch/distroless image)". Click Shell on a shell-able app → still opens the terminal as before.