### PR TITLE
subvolumes: move per-row Usage to engine; closes #81

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -22,6 +22,7 @@ mod fs_dependents;
 mod fs_lock;
 mod log_stream;
 mod router;
+mod subvolume_dependents;
 mod telemetry;
 mod terminal;
 mod vm_console;

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -143,6 +143,7 @@ fn is_read_only(method: &str) -> bool {
                 | "bcachefs.usage"
                 | "service.protocol.list"
                 | "subvolume.list_all"
+                | "subvolume.list_dependents"
                 | "subvolume.find_by_property"
                 | "subvolume.children"
                 | "smb.user.list"

--- a/engine/nasty-engine/src/router/subvolume.rs
+++ b/engine/nasty-engine/src/router/subvolume.rs
@@ -25,6 +25,23 @@ pub(super) async fn try_route(
                 Err(e) => err(req, e),
             }
         }
+        // Aggregate "what depends on each subvolume" — same shape as
+        // fs.dependents but one level deeper. Read-only batched call:
+        // the Subvolumes page's Usage column wants the value for every
+        // row at once, so we walk each downstream service once and
+        // bucket references by owning subvolume rather than paying
+        // service-fanout N times.
+        "subvolume.list_dependents" => {
+            let all = crate::subvolume_dependents::find_all_subvolume_dependents(state).await;
+            // Apply the same scope guard as subvolume.list_all — a
+            // filesystem-scoped session shouldn't see usage data for
+            // subvolumes on other filesystems.
+            let filtered = match session.filesystem.as_deref() {
+                Some(fs) => all.into_iter().filter(|d| d.filesystem == fs).collect(),
+                None => all,
+            };
+            ok(req, filtered)
+        }
         "subvolume.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
                 if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {

--- a/engine/nasty-engine/src/subvolume_dependents.rs
+++ b/engine/nasty-engine/src/subvolume_dependents.rs
@@ -1,0 +1,308 @@
+//! Aggregate "what depends on this subvolume" across services.
+//!
+//! Sibling to `fs_dependents`, one level deeper: instead of asking
+//! "what's on filesystem X", asks "what's in subvolume Y". Powers the
+//! Usage column on the Subvolumes page (issue #81).
+//!
+//! Matching strategy is path-prefix based, same as fs_dependents:
+//! a path "belongs to" a subvolume when it's the subvolume's mount
+//! point or lives under `<mount_point>/`. Block subvolumes also
+//! match by their `block_device` (e.g. `/dev/loopN`) so VM disks
+//! and iSCSI/NVMe-oF backstores that reference them by device path
+//! get attributed to the right subvolume too.
+//!
+//! Apps are attributed coarsely: every NASty-managed app lives under
+//! `apps.status().storage_path` (the apps-data subvolume), so they
+//! all attribute to whichever subvolume owns that path. Per-app
+//! bind mounts outside that storage are a refinement that would need
+//! per-app inspect — left for later, same as in fs_dependents.
+
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::AppState;
+
+/// Names/IDs of every downstream entity that lives inside (or is
+/// backed by) a given subvolume. Empty fields serialise as `[]` so
+/// the WebUI can render without null-checking.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct SubvolumeDependents {
+    pub filesystem: String,
+    pub name: String,
+    pub path: String,
+    pub apps: Vec<String>,
+    pub vms: Vec<String>,
+    pub backup_jobs: Vec<String>,
+    pub nfs_shares: Vec<String>,
+    pub smb_shares: Vec<String>,
+    pub iscsi_targets: Vec<String>,
+    pub nvmeof_subsystems: Vec<String>,
+}
+
+/// Find the subvolume (by path) that owns `target`. Returns `None`
+/// when no subvolume's path is a prefix of `target` — orphaned paths
+/// (sitting on the FS root outside any subvolume, or pointing somewhere
+/// entirely off-tree) contribute to nothing, which is the conservative
+/// behaviour. `paths_desc` must be sorted longest-first so the prefix
+/// match picks the most-specific subvolume:
+/// `/fs/tank/apps/grafana/data` attributes to `/fs/tank/apps/grafana`
+/// rather than `/fs/tank` when both happen to exist as subvolumes.
+fn owning_subvol<'a>(paths_desc: &'a [String], target: &str) -> Option<&'a str> {
+    for p in paths_desc {
+        if target == p.as_str() || target.starts_with(&format!("{p}/")) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Walk every downstream service once, and bucket every reference into
+/// the subvolume that owns its path. Batched (rather than per-subvolume)
+/// because the Usage column wants the value for every row at once —
+/// per-subvolume would mean N × cost-of-listing-each-service round-trips
+/// per page load, where the dominant cost (apps.list = a Docker
+/// round-trip) doesn't get cheaper at finer granularity.
+pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDependents> {
+    let subvols = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .unwrap_or_default();
+
+    // Seed the result: one entry per known subvolume, keyed by path so
+    // attribution is a hashmap lookup, not a linear scan per service hit.
+    let mut by_path: HashMap<String, SubvolumeDependents> = HashMap::new();
+    // Index of block-device → subvolume path, for the loop-backed case.
+    let mut by_block_dev: HashMap<String, String> = HashMap::new();
+    // Subvolume paths sorted longest-first so the prefix match picks
+    // the most-specific subvolume — `/fs/tank/apps/grafana/data`
+    // attributes to `/fs/tank/apps/grafana` rather than `/fs/tank` if
+    // both happen to exist.
+    let mut paths_desc: Vec<String> = Vec::with_capacity(subvols.len());
+
+    for sv in &subvols {
+        by_path.insert(
+            sv.path.clone(),
+            SubvolumeDependents {
+                filesystem: sv.filesystem.clone(),
+                name: sv.name.clone(),
+                path: sv.path.clone(),
+                ..Default::default()
+            },
+        );
+        if let Some(bd) = sv.block_device.clone() {
+            by_block_dev.insert(bd, sv.path.clone());
+        }
+        paths_desc.push(sv.path.clone());
+    }
+    paths_desc.sort_by_key(|p| std::cmp::Reverse(p.len()));
+
+    // Apps. Coarse: every managed app inherits the subvolume that
+    // hosts the apps storage path. Per-app bind mounts that escape
+    // that path are a refinement worth wiring later if anyone asks
+    // (it'd need `apps.config` per app rather than `apps.list`).
+    let apps_status = state.apps.status().await;
+    if let Some(storage_path) = apps_status.storage_path.as_deref()
+        && let Some(owning) = owning_subvol(&paths_desc, storage_path)
+        && let Some(deps) = by_path.get_mut(owning)
+        && let Ok(apps) = state.apps.list().await
+    {
+        deps.apps = apps.into_iter().map(|a| a.name).collect();
+    }
+
+    // VMs. Each VM disk path either points into a subvolume (image
+    // file) or *is* a subvolume's block_device (loop-backed). Dedup
+    // per-VM because a VM with multiple disks on the same subvolume
+    // should appear once, not once per disk.
+    if let Ok(vms) = state.vms.list().await {
+        for vm in vms {
+            let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for disk in &vm.config.disks {
+                if let Some(p) = owning_subvol(&paths_desc, &disk.path) {
+                    owners.insert(p.to_string());
+                }
+                if let Some(p) = by_block_dev.get(&disk.path) {
+                    owners.insert(p.clone());
+                }
+            }
+            for path in owners {
+                if let Some(deps) = by_path.get_mut(&path) {
+                    deps.vms.push(vm.config.name.clone());
+                }
+            }
+        }
+    }
+
+    // Backup jobs.
+    let profiles = state.backups.list_profiles().await;
+    for p in profiles {
+        let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for src in &p.sources {
+            if let Some(o) = owning_subvol(&paths_desc, src) {
+                owners.insert(o.to_string());
+            }
+        }
+        for path in owners {
+            if let Some(deps) = by_path.get_mut(&path) {
+                deps.backup_jobs.push(p.name.clone());
+            }
+        }
+    }
+
+    // NFS shares.
+    if let Ok(shares) = state.nfs.list().await {
+        for s in shares {
+            if let Some(p) = owning_subvol(&paths_desc, &s.path)
+                && let Some(deps) = by_path.get_mut(p)
+            {
+                deps.nfs_shares.push(s.id);
+            }
+        }
+    }
+
+    // SMB shares.
+    if let Ok(shares) = state.smb.list().await {
+        for s in shares {
+            if let Some(p) = owning_subvol(&paths_desc, &s.path)
+                && let Some(deps) = by_path.get_mut(p)
+            {
+                deps.smb_shares.push(s.name);
+            }
+        }
+    }
+
+    // iSCSI targets. Each LUN's backstore_path is either a file path
+    // (image-backed) or a block device (loop-backed).
+    if let Ok(targets) = state.iscsi.list().await {
+        for t in targets {
+            let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for l in &t.luns {
+                if let Some(p) = owning_subvol(&paths_desc, &l.backstore_path) {
+                    owners.insert(p.to_string());
+                }
+                if let Some(p) = by_block_dev.get(&l.backstore_path) {
+                    owners.insert(p.clone());
+                }
+            }
+            for path in owners {
+                if let Some(deps) = by_path.get_mut(&path) {
+                    deps.iscsi_targets.push(t.iqn.clone());
+                }
+            }
+        }
+    }
+
+    // NVMe-oF subsystems.
+    if let Ok(subs) = state.nvmeof.list().await {
+        for s in subs {
+            let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for n in &s.namespaces {
+                if let Some(p) = owning_subvol(&paths_desc, &n.device_path) {
+                    owners.insert(p.to_string());
+                }
+                if let Some(p) = by_block_dev.get(&n.device_path) {
+                    owners.insert(p.clone());
+                }
+            }
+            for path in owners {
+                if let Some(deps) = by_path.get_mut(&path) {
+                    deps.nvmeof_subsystems.push(s.nqn.clone());
+                }
+            }
+        }
+    }
+
+    // Return in input order so the Subvolumes page can pair entries
+    // by index if it ever wants to (today it joins on path/name).
+    subvols
+        .into_iter()
+        .filter_map(|sv| by_path.remove(&sv.path))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owning_subvol_picks_longest_prefix() {
+        // Sorted longest-first, same shape `find_all_subvolume_dependents`
+        // builds it. Nested subvolume paths should win over their
+        // shorter ancestors — a disk under /fs/tank/apps/grafana/data
+        // attributes to /fs/tank/apps/grafana, not /fs/tank.
+        let paths = vec![
+            "/fs/tank/apps/grafana".to_string(),
+            "/fs/tank/apps".to_string(),
+            "/fs/tank".to_string(),
+        ];
+        assert_eq!(
+            owning_subvol(&paths, "/fs/tank/apps/grafana/data/x.db"),
+            Some("/fs/tank/apps/grafana")
+        );
+        assert_eq!(
+            owning_subvol(&paths, "/fs/tank/apps/other-app/foo"),
+            Some("/fs/tank/apps")
+        );
+        assert_eq!(
+            owning_subvol(&paths, "/fs/tank/media/movie.mkv"),
+            Some("/fs/tank")
+        );
+    }
+
+    #[test]
+    fn owning_subvol_exact_match_counts() {
+        // The mount point itself is "in" the subvolume — needed so
+        // an NFS share rooted exactly at /fs/tank/media (a common
+        // case: share the whole subvolume) attributes correctly.
+        let paths = vec!["/fs/tank/media".to_string()];
+        assert_eq!(
+            owning_subvol(&paths, "/fs/tank/media"),
+            Some("/fs/tank/media")
+        );
+    }
+
+    #[test]
+    fn owning_subvol_rejects_sibling_prefix() {
+        // Without the trailing-slash check, /fs/tank2/foo would falsely
+        // match a subvolume at /fs/tank. Same trap fs_dependents has a
+        // dedicated test for; we want the analogous guarantee here.
+        let paths = vec!["/fs/tank".to_string()];
+        assert_eq!(owning_subvol(&paths, "/fs/tank2/foo"), None);
+        assert_eq!(owning_subvol(&paths, "/fs/tank2"), None);
+    }
+
+    #[test]
+    fn owning_subvol_orphan_paths_return_none() {
+        // A path entirely off-tree — engine state, a host bind mount,
+        // an arbitrary /tmp file — has no owning subvolume. The caller
+        // skips attribution rather than crediting it to whatever happens
+        // to be first in the list.
+        let paths = vec!["/fs/tank".to_string()];
+        assert_eq!(owning_subvol(&paths, "/var/lib/nasty/foo"), None);
+        assert_eq!(owning_subvol(&paths, "/tmp/whatever"), None);
+        assert_eq!(owning_subvol(&paths, ""), None);
+    }
+
+    #[test]
+    fn dependents_struct_defaults_serialise_as_empty_arrays() {
+        // The WebUI renders the Usage column unconditionally — empty
+        // fields must arrive as `[]`, not omitted, or the icons-row
+        // map() would crash on undefined.
+        let d = SubvolumeDependents::default();
+        let j = serde_json::to_value(&d).unwrap();
+        for k in [
+            "apps",
+            "vms",
+            "backup_jobs",
+            "nfs_shares",
+            "smb_shares",
+            "iscsi_targets",
+            "nvmeof_subsystems",
+        ] {
+            assert!(j.get(k).unwrap().is_array(), "{k} should be an array");
+            assert_eq!(j[k].as_array().unwrap().len(), 0);
+        }
+    }
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -116,6 +116,24 @@ export interface PassthroughConfig {
  * before destructive operations like Lock — the WebUI lists these
  * so the user sees what will break before they confirm. Empty
  * arrays serialize as `[]` so consumers can render unconditionally. */
+/** Per-subvolume version of FsDependents. Returned by `subvolume.list_dependents`
+ * (batched: all subvolumes in one call). Powers the Usage column on the
+ * Subvolumes page so the operator sees at a glance what an unsafe rm/destroy
+ * would take with it — apps, VMs, shares, backup jobs that live on or are
+ * backed by this subvolume. */
+export interface SubvolumeDependents {
+	filesystem: string;
+	name: string;
+	path: string;
+	apps: string[];
+	vms: string[];
+	backup_jobs: string[];
+	nfs_shares: string[];
+	smb_shares: string[];
+	iscsi_targets: string[];
+	nvmeof_subsystems: string[];
+}
+
 export interface FsDependents {
 	filesystem: string;
 	mounted: boolean;

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -5,7 +5,7 @@
 	import { formatBytes } from '$lib/format';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { Filesystem, Subvolume, Snapshot, SubvolumeType, NfsShare, SmbShare, IscsiTarget, NvmeofSubsystem, App, AppsStatus, VmStatus } from '$lib/types';
+	import type { Filesystem, Subvolume, SubvolumeDependents, Snapshot, SubvolumeType, NfsShare, SmbShare, IscsiTarget, NvmeofSubsystem, App, AppsStatus, VmStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
@@ -237,9 +237,17 @@
 	let allVms: VmStatus[] = $state([]);
 	let allApps: App[] = $state([]);
 	let appsStoragePath: string | null = $state(null);
+	/** Engine-computed per-subvolume usage. Source of truth for the
+	 * Usage column — see `subvolume.list_dependents` in
+	 * nasty-engine/src/subvolume_dependents.rs. The local consumer
+	 * lists above (allNfs/allSmb/...) are kept for the detail pane,
+	 * which still wants full entity objects for drilldown, but
+	 * counts/names in the table proper come from this server-side
+	 * compute. Keyed by subvolume path for O(1) lookup per row. */
+	let dependentsByPath = $state(new Map<string, SubvolumeDependents>());
 
 	async function loadShares() {
-		const [nfs, smb, iscsi, nvmeof, vms, appsList, appsStat] = await Promise.allSettled([
+		const [nfs, smb, iscsi, nvmeof, vms, appsList, appsStat, deps] = await Promise.allSettled([
 			client.call<NfsShare[]>('share.nfs.list'),
 			client.call<SmbShare[]>('share.smb.list'),
 			client.call<IscsiTarget[]>('share.iscsi.list'),
@@ -247,6 +255,7 @@
 			client.call<VmStatus[]>('vm.list'),
 			client.call<App[]>('apps.list'),
 			client.call<AppsStatus>('apps.status'),
+			client.call<SubvolumeDependents[]>('subvolume.list_dependents'),
 		]);
 		allNfs = nfs.status === 'fulfilled' ? nfs.value : [];
 		allSmb = smb.status === 'fulfilled' ? smb.value : [];
@@ -255,6 +264,11 @@
 		allVms = vms.status === 'fulfilled' ? vms.value : [];
 		allApps = appsList.status === 'fulfilled' ? appsList.value : [];
 		appsStoragePath = appsStat.status === 'fulfilled' ? (appsStat.value.storage_path ?? null) : null;
+		const next = new Map<string, SubvolumeDependents>();
+		if (deps.status === 'fulfilled') {
+			for (const d of deps.value) next.set(d.path, d);
+		}
+		dependentsByPath = next;
 	}
 
 	// Tree: find parent chain and children for the selected subvolume
@@ -566,42 +580,26 @@
 		nvmeof: number;
 		apps: number;
 		vms: number;
+		backups: number;
 	}
+	// Counts come from `subvolume.list_dependents` (engine-side, matches
+	// `fs.dependents` patterns including longest-prefix path attribution
+	// for nested subvolumes). The `system` badge stays client-side because
+	// it's a static SYSTEM_SUBVOLUMES table, not engine-derived state.
 	const subvolumeUsage = $derived.by(() => {
 		const out = new Map<string, SubvolumeUsage>();
 		for (const sv of subvolumes) {
-			// Apps: the engine has one global apps.storage_path; if it
-			// lives inside this subvolume, all currently-deployed apps
-			// are consuming it.  Per-app bind-mount detection (apps that
-			// mount specific paths outside the default storage) is left
-			// as future work — needs per-app config inspection.
-			const appsHere = appsStoragePath && pathIsUnder(appsStoragePath, sv.path)
-				? allApps.length
-				: 0;
-
-			// VMs: block subvolumes hold raw disks (disk.path == block_device);
-			// filesystem subvolumes typically hold qcow2 files under sv.path.
-			const vmsHere = allVms.filter(vm =>
-				vm.disks.some(d =>
-					(sv.block_device != null && d.path === sv.block_device) ||
-					pathIsUnder(d.path, sv.path)
-				)
-			).length;
-
-			const usage: SubvolumeUsage = {
+			const d = dependentsByPath.get(sv.path);
+			out.set(svKey(sv), {
 				system: SYSTEM_SUBVOLUMES[sv.name] ?? null,
-				nfs: allNfs.filter(s => s.path === sv.path).length,
-				smb: allSmb.filter(s => s.path === sv.path).length,
-				iscsi: sv.block_device
-					? allIscsi.filter(t => t.luns.some(l => l.backstore_path === sv.block_device)).length
-					: 0,
-				nvmeof: sv.block_device
-					? allNvmeof.filter(sub => sub.namespaces.some(ns => ns.device_path === sv.block_device)).length
-					: 0,
-				apps: appsHere,
-				vms: vmsHere,
-			};
-			out.set(svKey(sv), usage);
+				nfs: d?.nfs_shares.length ?? 0,
+				smb: d?.smb_shares.length ?? 0,
+				iscsi: d?.iscsi_targets.length ?? 0,
+				nvmeof: d?.nvmeof_subsystems.length ?? 0,
+				apps: d?.apps.length ?? 0,
+				vms: d?.vms.length ?? 0,
+				backups: d?.backup_jobs.length ?? 0,
+			});
 		}
 		return out;
 	});
@@ -614,7 +612,7 @@
 	}
 
 	function usageFor(sv: Subvolume): SubvolumeUsage {
-		return subvolumeUsage.get(svKey(sv)) ?? { system: null, nfs: 0, smb: 0, iscsi: 0, nvmeof: 0, apps: 0, vms: 0 };
+		return subvolumeUsage.get(svKey(sv)) ?? { system: null, nfs: 0, smb: 0, iscsi: 0, nvmeof: 0, apps: 0, vms: 0, backups: 0 };
 	}
 
 	// Pick a ceiling to scale the disk-usage bar against:
@@ -1070,10 +1068,13 @@
 								{#if usage.nvmeof > 0}
 									<Badge class="bg-cyan-950 text-cyan-400 text-[0.6rem]" title="{usage.nvmeof} NVMe-oF subsystem{usage.nvmeof === 1 ? '' : 's'}">NVMe-oF{usage.nvmeof > 1 ? ` ×${usage.nvmeof}` : ''}</Badge>
 								{/if}
-								{#if usage.system && usage.apps === 0 && usage.vms === 0 && usage.nfs === 0 && usage.smb === 0 && usage.iscsi === 0 && usage.nvmeof === 0}
+								{#if usage.backups > 0}
+									<Badge class="bg-teal-950 text-teal-400 text-[0.6rem]" title="{usage.backups} backup job{usage.backups === 1 ? '' : 's'} reading from this subvolume">Backups{usage.backups > 1 ? ` ×${usage.backups}` : ''}</Badge>
+								{/if}
+								{#if usage.system && usage.apps === 0 && usage.vms === 0 && usage.nfs === 0 && usage.smb === 0 && usage.iscsi === 0 && usage.nvmeof === 0 && usage.backups === 0}
 									<Badge class="bg-slate-800 text-slate-300 text-[0.6rem]" title={usage.system}>System</Badge>
 								{/if}
-								{#if !usage.system && usage.apps === 0 && usage.vms === 0 && usage.nfs === 0 && usage.smb === 0 && usage.iscsi === 0 && usage.nvmeof === 0}
+								{#if !usage.system && usage.apps === 0 && usage.vms === 0 && usage.nfs === 0 && usage.smb === 0 && usage.iscsi === 0 && usage.nvmeof === 0 && usage.backups === 0}
 									<span class="text-xs text-muted-foreground">—</span>
 								{/if}
 							</div>


### PR DESCRIPTION
## Summary

Closes #81. The Usage column itself shipped in \`b886a10\` (text+count badges per consumer type), but the attribution math lived client-side, reaching into already-fetched VM / NFS / SMB / iSCSI / NVMe-oF / apps lists and matching paths locally. Two problems with that:

- Each call site reinvented prefix-matching logic. The \`fs.dependents\` sibling on the engine handles tricky cases the local computation got wrong:
  - Sibling-prefix attacks (\`/fs/tank2\` must not match \`/fs/tank\`)
  - Longest-prefix attribution when subvolumes nest (\`/fs/tank/apps/grafana/data\` should attribute to \`grafana\`, not \`tank\` *and* \`apps\` *and* \`grafana\`)
  - Dual block-device matching for loop-backed iSCSI/NVMe-oF LUNs
- Per-subvolume counts and per-FS dependents were two separate code paths solving the same problem at different granularities.

## What ships

**Engine** — new \`subvolume.list_dependents\` RPC. Sibling to \`fs.dependents\`, one level deeper. Same struct shape (\`filesystem\`, \`name\`, \`path\`, \`apps[]\`, \`vms[]\`, \`backup_jobs[]\`, \`nfs_shares[]\`, \`smb_shares[]\`, \`iscsi_targets[]\`, \`nvmeof_subsystems[]\`), same path-match rules, same best-effort failure mode (a service that errors contributes an empty list). Batched: returns the full set for every subvolume in one call, because the Usage column wants every row's answer at once and per-subvolume would N× the apps.list / Docker round-trip. Read-only; filesystem-scoped sessions only see their own subvolumes.

**WebUI** — \`subvolumeUsage\` derived map switched to read from the engine response keyed by subvolume path. The local \`allApps\`/\`allVms\`/... lists stay for the detail-pane drilldown (which still wants full entity objects, not just names), but counts in the table proper now come from the single source of truth.

**Bonus**: surfaces \`backup_jobs\` as a new "Backups" badge. The engine was already computing it in \`fs.dependents\` but the client-side subvolume computation had no equivalent — and backup-source attribution is the exact "please don't accidentally delete a subvolume my nightly snapshot reads from" signal an operator wants. Teal badge with hover count.

## Tests

5 new unit tests for the prefix-matching helper:
- \`owning_subvol_picks_longest_prefix\` — nested subvolumes attribute correctly
- \`owning_subvol_exact_match_counts\` — mount-point itself attributes to the subvolume
- \`owning_subvol_rejects_sibling_prefix\` — \`/fs/tank2\` doesn't match \`tank\`
- \`owning_subvol_orphan_paths_return_none\` — off-tree paths credit nothing
- \`dependents_struct_defaults_serialise_as_empty_arrays\` — empty lists serialise as \`[]\` so the WebUI can render unconditionally

## Test plan

- [x] \`cargo test -p nasty-engine\` — 50 pass including 5 new
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`npm run check\` (svelte-check, 0 errors)
- [ ] Deploy: open Subvolumes page → confirm badges still appear, counts match what's actually deployed; create an NFS share on a subvolume → after the 5s refresh tick, NFS badge appears; install an app → Apps badge picks it up. Confirm Backups badge appears for any backup job sourced from a subvolume.