### PR TITLE
apps: subdomain-per-app ingress (V1 of #99)

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -26,11 +26,25 @@ const ROUTE_ID_PREFIX: &str = "nasty-app-";
 /// One ingress rule, ready to be turned into a Caddy route object.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppRoute {
-    /// App name — used both as `/apps/<name>/` path and `@id` suffix.
+    /// App name — used as `@id` suffix and as path-prefix segment when
+    /// `subdomain` is None.
     pub name: String,
     /// Host port the app's container listens on (Docker port mapping
     /// to 127.0.0.1).
     pub host_port: u16,
+    /// Fully-qualified hostname to serve the app under (e.g.
+    /// `jellyfin.example.com`). When set, the emitted Caddy route
+    /// matches by host instead of by `/apps/<name>/` path prefix and
+    /// drops the strip-prefix handler — the app sees itself rooted
+    /// at `/`, which is what most upstream apps assume and what the
+    /// post-install probe in #219 had to disable ingress for when
+    /// the path-prefix mode broke their absolute-path assets.
+    ///
+    /// Caddy's automatic HTTPS picks up the new hostname from the
+    /// match block; the operator's existing ACME config (wildcard
+    /// via DNS-01, or per-name via HTTP-01/TLS-ALPN-01) handles cert
+    /// acquisition. V1 doesn't add per-app ACME knobs.
+    pub subdomain: Option<String>,
 }
 
 /// Caddy admin-API HTTP client.  Cheap to construct — internally
@@ -169,6 +183,7 @@ impl CaddyApi {
                 out.push(AppRoute {
                     name: name.to_string(),
                     host_port: port,
+                    subdomain: extract_route_host(&route),
                 });
             }
         }
@@ -281,40 +296,71 @@ impl CaddyApi {
 /// { header_up X-Real-IP {http.request.remote.host} } }` as produced
 /// by `caddy adapt`, with `@id` so we can delete it by ID later.
 fn build_route_json(route: &AppRoute) -> Value {
+    // Subdomain mode matches by host and serves the app at its own root
+    // — no path prefix to strip, no risk of the absolute-asset-path
+    // failure that the post-install probe in #219 catches for path-prefix
+    // mode. Path-prefix mode keeps the strip-prefix handler so the
+    // upstream sees clean URLs (`/api/...` rather than `/apps/foo/api/...`).
+    let reverse_proxy = json!({
+        "handler": "reverse_proxy",
+        "upstreams": [{"dial": format!("127.0.0.1:{}", route.host_port)}],
+        "headers": {
+            "request": {
+                "set": {
+                    "X-Real-Ip": ["{http.request.remote.host}"]
+                }
+            }
+        },
+        // Mirrors the Caddyfile's `stream_close_delay 30m` on the static
+        // WS handlers — every other app install/remove triggers a Caddy
+        // config reload (this very admin API call), and without the
+        // delay any WS the app itself exposes would die on every
+        // neighbouring app's lifecycle event.
+        "stream_close_delay": "30m",
+    });
+
+    let (match_block, inner_handles) = match &route.subdomain {
+        Some(host) => (json!([{"host": [host]}]), json!([reverse_proxy])),
+        None => (
+            json!([{"path": [format!("/apps/{}/*", route.name)]}]),
+            json!([
+                {
+                    "handler": "rewrite",
+                    "strip_path_prefix": format!("/apps/{}", route.name),
+                },
+                reverse_proxy,
+            ]),
+        ),
+    };
+
     json!({
         "@id": format!("{ROUTE_ID_PREFIX}{}", route.name),
-        "match": [{"path": [format!("/apps/{}/*", route.name)]}],
+        "match": match_block,
         "handle": [{
             "handler": "subroute",
             "routes": [{
-                "handle": [
-                    {
-                        "handler": "rewrite",
-                        "strip_path_prefix": format!("/apps/{}", route.name),
-                    },
-                    {
-                        "handler": "reverse_proxy",
-                        "upstreams": [{"dial": format!("127.0.0.1:{}", route.host_port)}],
-                        "headers": {
-                            "request": {
-                                "set": {
-                                    "X-Real-Ip": ["{http.request.remote.host}"]
-                                }
-                            }
-                        },
-                        // Mirrors the Caddyfile's `stream_close_delay 30m`
-                        // on the static WS handlers — every other app
-                        // install/remove triggers a Caddy config reload
-                        // (this very admin API call), and without the
-                        // delay any WS the app itself exposes would die
-                        // on every neighbouring app's lifecycle event.
-                        "stream_close_delay": "30m",
-                    }
-                ]
+                "handle": inner_handles,
             }]
         }],
         "terminal": true
     })
+}
+
+/// Pull the first hostname out of the route's `match[].host[]` array,
+/// if any. Returns None for path-prefix routes (their match block has
+/// `path` instead of `host`). Used by `list_app_routes` to round-trip
+/// subdomain mode back into `AppRoute.subdomain` so the reconcile pass
+/// can rebuild Caddy routes in the same mode after a restart.
+fn extract_route_host(route: &Value) -> Option<String> {
+    let matches = route.get("match")?.as_array()?;
+    for m in matches {
+        if let Some(hosts) = m.get("host").and_then(Value::as_array)
+            && let Some(first) = hosts.first().and_then(Value::as_str)
+        {
+            return Some(first.to_string());
+        }
+    }
+    None
 }
 
 /// Walk a route JSON value to find the reverse_proxy upstream port.
@@ -351,6 +397,7 @@ mod tests {
         let r = AppRoute {
             name: "foo".into(),
             host_port: 18080,
+            subdomain: None,
         };
         let v = build_route_json(&r);
         assert_eq!(v["@id"], "nasty-app-foo");
@@ -365,10 +412,33 @@ mod tests {
     }
 
     #[test]
+    fn build_route_json_subdomain_mode_matches_by_host() {
+        // Subdomain mode: match block carries `host`, not `path`; no
+        // strip_path_prefix handler (app is at root). Caddy's automatic
+        // HTTPS picks up the hostname from the match block.
+        let r = AppRoute {
+            name: "jellyfin".into(),
+            host_port: 8096,
+            subdomain: Some("jellyfin.example.com".into()),
+        };
+        let v = build_route_json(&r);
+        assert_eq!(v["@id"], "nasty-app-jellyfin");
+        assert_eq!(v["match"][0]["host"][0], "jellyfin.example.com");
+        assert!(v["match"][0].get("path").is_none());
+        let inner_handle = &v["handle"][0]["routes"][0]["handle"];
+        // First (and only) handler is the reverse_proxy — no rewrite
+        // in front of it.
+        assert_eq!(inner_handle[0]["handler"], "reverse_proxy");
+        assert!(inner_handle.as_array().unwrap().len() == 1);
+        assert_eq!(inner_handle[0]["upstreams"][0]["dial"], "127.0.0.1:8096");
+    }
+
+    #[test]
     fn extract_upstream_port_roundtrips_through_build() {
         let r = AppRoute {
             name: "bar".into(),
             host_port: 9999,
+            subdomain: None,
         };
         let v = build_route_json(&r);
         assert_eq!(extract_upstream_port(&v), Some(9999));
@@ -384,5 +454,33 @@ mod tests {
             "handle": [{"handler": "reverse_proxy", "upstreams": [{"dial": "127.0.0.1:2137"}]}]
         });
         assert_eq!(extract_upstream_port(&v), None);
+    }
+
+    #[test]
+    fn extract_route_host_roundtrips_through_build_subdomain() {
+        // List → set round trip in subdomain mode must preserve the
+        // hostname so reconcile_app_routes can rebuild the same Caddy
+        // shape after an engine restart.
+        let r = AppRoute {
+            name: "vault".into(),
+            host_port: 11000,
+            subdomain: Some("vault.example.com".into()),
+        };
+        let v = build_route_json(&r);
+        assert_eq!(extract_route_host(&v), Some("vault.example.com".into()));
+        assert_eq!(extract_upstream_port(&v), Some(11000));
+    }
+
+    #[test]
+    fn extract_route_host_returns_none_for_path_mode() {
+        // Path-prefix mode has no host match — the helper must say
+        // None so `list_app_routes` round-trips `subdomain: None`.
+        let r = AppRoute {
+            name: "foo".into(),
+            host_port: 1234,
+            subdomain: None,
+        };
+        let v = build_route_json(&r);
+        assert_eq!(extract_route_host(&v), None);
     }
 }

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -790,6 +790,107 @@ async fn load_proxy_disabled_reason(app_name: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// Persist (or clear) the per-app `ingress_subdomain` in the manifest.
+/// Pass `Some(host)` to record subdomain mode, `None` to drop the field
+/// entirely (used by `ingress_remove` so the next tenant of the same
+/// name doesn't inherit a stale subdomain). Mirrors
+/// `save_proxy_disabled_reason` — read-modify-write of the same JSON.
+async fn save_ingress_subdomain(app_name: &str, subdomain: Option<&str>) -> Result<(), AppsError> {
+    let manifest_path = format!("{}/{}.json", COMPOSE_DIR, app_name);
+    let mut manifest: serde_json::Value = match tokio::fs::read_to_string(&manifest_path).await {
+        Ok(s) => serde_json::from_str(&s)
+            .map_err(|e| AppsError::CommandFailed(format!("manifest parse: {e}")))?,
+        // Compose apps don't have a flat manifest; we silently no-op
+        // in that case rather than create a stub that masks the real
+        // compose dir layout. V1 subdomain mode is simple-only anyway.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(AppsError::CommandFailed(format!("manifest read: {e}"))),
+    };
+    let map = match manifest.as_object_mut() {
+        Some(m) => m,
+        None => return Err(AppsError::CommandFailed("manifest not an object".into())),
+    };
+    match subdomain {
+        Some(s) => {
+            map.insert(
+                "ingress_subdomain".to_string(),
+                serde_json::Value::String(s.to_string()),
+            );
+        }
+        None => {
+            map.remove("ingress_subdomain");
+        }
+    }
+    tokio::fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .await
+    .map_err(|e| AppsError::CommandFailed(format!("manifest write: {e}")))?;
+    Ok(())
+}
+
+/// Read `ingress_subdomain` from an app's manifest. Returns `None` when
+/// the manifest is missing, unparseable, has no such field, or carries
+/// an empty string — same "best-effort, default to path-prefix" failure
+/// mode the rest of the apps list reconcile uses.
+async fn load_ingress_subdomain(app_name: &str) -> Option<String> {
+    let manifest_path = format!("{}/{}.json", COMPOSE_DIR, app_name);
+    let content = tokio::fs::read_to_string(&manifest_path).await.ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
+    parsed
+        .get("ingress_subdomain")?
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+/// Validate a subdomain hostname before we hand it to Caddy. RFC 1123-ish:
+/// labels are 1–63 chars of `[A-Za-z0-9-]`, no leading/trailing hyphen,
+/// dots between labels, total length ≤ 253. Reject anything else upfront
+/// so the operator gets a clear error rather than a cryptic Caddy 4xx.
+fn validate_subdomain(host: &str) -> Result<(), String> {
+    if host.is_empty() {
+        return Err("subdomain must not be empty".into());
+    }
+    if host.len() > 253 {
+        return Err(format!("subdomain too long ({} > 253 chars)", host.len()));
+    }
+    // Require at least one dot — a single-label hostname (`jellyfin`)
+    // would still route, but the cert story falls apart (no TLD = no
+    // ACME) and it's almost certainly a user typo. Caddy itself will
+    // serve them but the UX is bad enough that we'd rather reject and
+    // surface a clear message.
+    if !host.contains('.') {
+        return Err(format!(
+            "subdomain '{host}' must be a fully-qualified hostname (contain at least one dot)"
+        ));
+    }
+    for label in host.split('.') {
+        if label.is_empty() {
+            return Err(format!("subdomain '{host}' has an empty label"));
+        }
+        if label.len() > 63 {
+            return Err(format!(
+                "subdomain '{host}' has a label longer than 63 chars: '{label}'"
+            ));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!(
+                "subdomain '{host}' label '{label}' may not start or end with '-'"
+            ));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(format!(
+                "subdomain '{host}' label '{label}' contains invalid characters \
+                 (only A-Z, a-z, 0-9, '-' allowed)"
+            ));
+        }
+    }
+    Ok(())
+}
+
 // ── Types ───────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1071,8 +1172,18 @@ pub struct AppIngress {
     pub name: String,
     /// Host port to proxy to.
     pub host_port: u16,
-    /// URL path prefix (e.g. "/apps/plex/").
+    /// URL path prefix (e.g. "/apps/plex/"). Always set; in subdomain
+    /// mode it's purely informational (the WebUI prefers the
+    /// `subdomain`-derived URL for the Open button) since the app
+    /// answers at root under the configured hostname.
     pub path: String,
+    /// Fully-qualified hostname the app is served under when subdomain
+    /// mode is on (e.g. `jellyfin.example.com`). When set, Caddy
+    /// matches the route by `host` rather than path-prefix, and the
+    /// app sees itself rooted at `/` — sidestepping the absolute-asset
+    /// failure mode that #219's probe disables path-prefix ingress for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdomain: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1081,6 +1192,14 @@ pub struct SetIngressRequest {
     pub name: String,
     /// Host port to proxy to.
     pub host_port: u16,
+    /// Opt into subdomain mode by providing a fully-qualified hostname
+    /// (e.g. `jellyfin.example.com`). When set, the engine emits a
+    /// host-matching Caddy route instead of the default
+    /// `/apps/<name>/` path-prefix route, and persists the choice in
+    /// the app manifest so engine restarts preserve it. Set to `null`
+    /// or omit to use path-prefix mode (the historical default).
+    #[serde(default)]
+    pub subdomain: Option<String>,
 }
 
 // ── Port check types ──────────────────────────────────────────
@@ -1717,6 +1836,13 @@ impl AppsService {
                 .ingress_set(SetIngressRequest {
                     name: req.name.clone(),
                     host_port,
+                    // Install pipeline always uses path-prefix mode for
+                    // its auto-created ingress. The operator opts into
+                    // subdomain mode later via the WebUI / explicit
+                    // apps.ingress.set call — the install form doesn't
+                    // know enough about the operator's DNS / TLS setup
+                    // to pick a subdomain name on their behalf.
+                    subdomain: None,
                 })
                 .await
             {
@@ -2668,6 +2794,7 @@ impl AppsService {
                 .ingress_set(SetIngressRequest {
                     name: req.name.clone(),
                     host_port: first_port.host_port,
+                    subdomain: None,
                 })
                 .await;
         }
@@ -2831,6 +2958,7 @@ impl AppsService {
                 path: format!("/apps/{}/", r.name),
                 name: r.name,
                 host_port: r.host_port,
+                subdomain: r.subdomain,
             })
             .collect())
     }
@@ -2916,9 +3044,18 @@ impl AppsService {
                 else {
                     continue;
                 };
+                // Persist the subdomain mode across engine restarts by
+                // reading it back from the manifest. Without this, the
+                // reconcile pass rebuilds every route in path-prefix mode
+                // and silently downgrades user-chosen subdomain ingresses
+                // on every restart — the same "ingress comes back from
+                // the dead after a reboot" trap that proxy_disabled_reason
+                // had before #225 honoured the manifest.
+                let subdomain = load_ingress_subdomain(&app.name).await;
                 routes.push(AppRoute {
                     name: app.name,
                     host_port: port,
+                    subdomain,
                 });
             }
             if saw_managed_apps {
@@ -2942,6 +3079,9 @@ impl AppsService {
                     .map(|r| AppRoute {
                         name: r.name,
                         host_port: r.host_port,
+                        // Legacy nginx-era config doesn't encode subdomain
+                        // mode — recovered routes default to path-prefix.
+                        subdomain: None,
                     })
                     .collect();
             }
@@ -2950,19 +3090,50 @@ impl AppsService {
     }
 
     pub async fn ingress_set(&self, req: SetIngressRequest) -> Result<AppIngress, AppsError> {
+        // Treat "" as None — the WebUI submits an empty string when
+        // the operator clears the field rather than omitting it.
+        let subdomain = req
+            .subdomain
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        if let Some(ref host) = subdomain {
+            validate_subdomain(host).map_err(AppsError::CommandFailed)?;
+        }
         let route = AppRoute {
             name: req.name.clone(),
             host_port: req.host_port,
+            subdomain: subdomain.clone(),
         };
         CaddyApi::new()
             .set_app_route(&route)
             .await
             .map_err(AppsError::CommandFailed)?;
-        info!("Ingress set for '{}' -> port {}", req.name, req.host_port);
+        // Persist subdomain choice so the reconcile path
+        // (engine restart) rebuilds the same Caddy shape rather than
+        // silently downgrading to path-prefix mode.
+        if let Err(e) = save_ingress_subdomain(&req.name, subdomain.as_deref()).await {
+            warn!(
+                "Could not persist ingress_subdomain for '{}': {e} — \
+                 the route is set in Caddy but may revert on engine restart",
+                req.name
+            );
+        }
+        info!(
+            "Ingress set for '{}' -> port {} (mode: {})",
+            req.name,
+            req.host_port,
+            match subdomain {
+                Some(ref h) => h.as_str(),
+                None => "/apps/<name>/",
+            }
+        );
         Ok(AppIngress {
             path: format!("/apps/{}/", req.name),
             name: req.name,
             host_port: req.host_port,
+            subdomain,
         })
     }
 
@@ -2978,6 +3149,12 @@ impl AppsService {
             .remove_app_route(name)
             .await
             .map_err(AppsError::CommandFailed)?;
+        // Clear the persisted subdomain so the next install / ingress_set
+        // on the same name starts from path-prefix default rather than
+        // inheriting whatever the previous tenant had.
+        if let Err(e) = save_ingress_subdomain(name, None).await {
+            warn!("ingress_remove: could not clear ingress_subdomain for '{name}': {e}");
+        }
         info!("Ingress removed for '{name}'");
         Ok(())
     }
@@ -3731,6 +3908,8 @@ fn parse_ingress_comments(content: &str) -> Vec<AppIngress> {
             path: format!("/apps/{name}/"),
             name,
             host_port: port,
+            // Legacy nginx-era format never recorded subdomain mode.
+            subdomain: None,
         });
     }
     rules
@@ -5064,5 +5243,53 @@ services:
             None
         );
         assert_eq!(match_subpath_recipe("").map(|r| r.display_name), None);
+    }
+
+    // ── validate_subdomain ──
+
+    use super::validate_subdomain;
+
+    #[test]
+    fn validate_subdomain_accepts_normal_fqdns() {
+        // The common-case operator input — anything with a dot and
+        // hyphens-not-at-edges should pass. Caddy will pick up the
+        // hostname from the match block and obtain a cert via the
+        // operator's existing ACME config.
+        assert!(validate_subdomain("jellyfin.example.com").is_ok());
+        assert!(validate_subdomain("vault.nasty.local").is_ok());
+        assert!(validate_subdomain("grafana-prod.lab.example.com").is_ok());
+        assert!(validate_subdomain("a.b").is_ok());
+    }
+
+    #[test]
+    fn validate_subdomain_rejects_single_label() {
+        // No dot → likely a user typo. Caddy would technically serve
+        // it but the cert story collapses (no TLD = no ACME), so we
+        // reject and surface a clear message.
+        let err = validate_subdomain("jellyfin").unwrap_err();
+        assert!(err.contains("fully-qualified"), "msg was: {err}");
+    }
+
+    #[test]
+    fn validate_subdomain_rejects_empty_and_garbage() {
+        assert!(validate_subdomain("").is_err());
+        assert!(validate_subdomain("a..b").is_err()); // empty label
+        assert!(validate_subdomain("foo.example.com.").is_err()); // trailing-dot empty label
+        assert!(validate_subdomain("-foo.example.com").is_err()); // leading hyphen
+        assert!(validate_subdomain("foo-.example.com").is_err()); // trailing hyphen
+        assert!(validate_subdomain("foo bar.example.com").is_err()); // space
+        assert!(validate_subdomain("foo_bar.example.com").is_err()); // underscore
+        assert!(validate_subdomain("foo.example.com:8080").is_err()); // port suffix
+        assert!(validate_subdomain("http://foo.example.com").is_err()); // scheme
+    }
+
+    #[test]
+    fn validate_subdomain_rejects_too_long() {
+        // 64-char label
+        let too_long_label = format!("{}.example.com", "a".repeat(64));
+        assert!(validate_subdomain(&too_long_label).is_err());
+        // 254-char total
+        let too_long_total = format!("{}.example.com", "a".repeat(254 - ".example.com".len()));
+        assert!(validate_subdomain(&too_long_total).is_err());
     }
 }

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -508,6 +508,9 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
                 .ingress_set(nasty_apps::SetIngressRequest {
                     name: req.name.clone(),
                     host_port: p.host_port,
+                    // Compose-deploy auto-ingress always uses path-prefix;
+                    // subdomain is an explicit opt-in via apps.ingress.set.
+                    subdomain: None,
                 })
                 .await;
         }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1047,4 +1047,10 @@ export interface AppIngress {
 	name: string;
 	host_port: number;
 	path: string;
+	/** Fully-qualified hostname when the app is served in subdomain mode
+	 * (Caddy matches the route by host instead of path prefix). Set via
+	 * apps.ingress.set. When present, the Open button links to
+	 * https://<subdomain>/ rather than /apps/<name>/. Omitted/null =
+	 * path-prefix mode, the historical default. */
+	subdomain?: string | null;
 }

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -1218,15 +1218,60 @@
 	let switchingIngressFor = $state<string | null>(null);
 
 	/** Re-point an app's ingress at the given host port. Used by the
-	 * port chips when the user clicks a non-current TCP port. */
+	 * port chips when the user clicks a non-current TCP port. Preserves
+	 * subdomain mode if the current ingress already had one. */
 	async function setIngressPort(appName: string, hostPort: number) {
 		switchingIngressFor = appName;
 		try {
+			const current = getIngress(appName);
 			await withToast(
-				() => client.call('apps.ingress.set', { name: appName, host_port: hostPort }),
+				() => client.call('apps.ingress.set', {
+					name: appName,
+					host_port: hostPort,
+					// Sticky: switching the host port shouldn't drop a
+					// subdomain choice the operator already made.
+					subdomain: current?.subdomain ?? null,
+				}),
 				`Ingress for ${appName} → :${hostPort}`
 			);
 			await loadIngresses();
+		} finally {
+			switchingIngressFor = null;
+		}
+	}
+
+	// ── Subdomain mode dialog ─────────────────────────────────
+	/** Per-app modal opened by the "···" menu's "Subdomain" item.
+	 * `null` = closed; otherwise carries the app name being edited
+	 * (host_port is read from the current ingress at submit time). */
+	let subdomainDialog = $state<{ appName: string; value: string } | null>(null);
+
+	function openSubdomainDialog(appName: string) {
+		const current = getIngress(appName);
+		subdomainDialog = { appName, value: current?.subdomain ?? '' };
+	}
+
+	async function saveSubdomain() {
+		if (!subdomainDialog) return;
+		const { appName, value } = subdomainDialog;
+		const current = getIngress(appName);
+		if (!current) {
+			subdomainDialog = null;
+			return;
+		}
+		const subdomain = value.trim() || null;
+		switchingIngressFor = appName;
+		try {
+			await withToast(
+				() => client.call('apps.ingress.set', {
+					name: appName,
+					host_port: current.host_port,
+					subdomain,
+				}),
+				subdomain ? `Ingress for ${appName} → ${subdomain}` : `Ingress for ${appName} → /apps/${appName}/`
+			);
+			await loadIngresses();
+			subdomainDialog = null;
 		} finally {
 			switchingIngressFor = null;
 		}
@@ -1863,8 +1908,15 @@
 							<div class="flex items-center gap-1.5">
 								{#if primaryPort(app)}
 									{@const pp = primaryPort(app)!}
-									{#if getIngress(app.name)}
-										<a href="/apps/{app.name}/" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-400 hover:bg-blue-500/20" title="Reverse proxy target: {pp.host_port}">
+									{@const ing = getIngress(app.name)}
+									{#if ing}
+										{@const openHref = ing.subdomain
+											? `${window.location.protocol}//${ing.subdomain}/`
+											: `/apps/${app.name}/`}
+										{@const openTitle = ing.subdomain
+											? `Reverse proxy: ${ing.subdomain} → :${pp.host_port}`
+											: `Reverse proxy target: ${pp.host_port}`}
+										<a href={openHref} target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-400 hover:bg-blue-500/20" title={openTitle}>
 											Open
 										</a>
 									{:else if app.proxy_disabled_reason}
@@ -1896,6 +1948,12 @@
 													<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; openShell(app.name); }}>Shell</button>
 												{/if}
 												<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; pullApp(app.name); }}>Pull image</button>
+												{#if getIngress(app.name)}
+													<!-- Only meaningful when ingress exists. Path-prefix mode is fine
+													     for most apps; this lets the operator opt into subdomain mode
+													     for things that emit absolute root-path assets (haze-class). -->
+													<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; openSubdomainDialog(app.name); }}>Subdomain…</button>
+												{/if}
 												{#if app.kind === 'simple'}
 													<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; inspectApp(app.name); }}>Inspect</button>
 												{/if}
@@ -1939,6 +1997,26 @@
 			</tbody>
 		</table>
 	{/if}
+{/if}
+
+<!-- Subdomain ingress dialog (per-app "···" → "Subdomain…") -->
+{#if subdomainDialog}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<div class="w-[90vw] max-w-md rounded-lg border border-border bg-[#0f1117] p-5 shadow-2xl">
+			<h3 class="mb-1 text-base font-semibold">Reverse-proxy ingress for <code class="text-blue-400">{subdomainDialog.appName}</code></h3>
+			<p class="mb-3 text-xs text-muted-foreground">
+				Empty = serve at <code>/apps/{subdomainDialog.appName}/</code> (path-prefix mode, the default).
+				Set a fully-qualified hostname to serve the app at its own root — works for apps that emit absolute paths (haze, jellyfin, etc.).
+				Caddy uses the existing TLS/ACME config; the operator needs DNS for the hostname to resolve to NASty.
+			</p>
+			<Label class="text-xs">Subdomain</Label>
+			<Input bind:value={subdomainDialog.value} placeholder="jellyfin.example.com" class="mt-1" />
+			<div class="mt-4 flex justify-end gap-2">
+				<Button variant="outline" size="sm" onclick={() => { subdomainDialog = null; }}>Cancel</Button>
+				<Button size="sm" onclick={saveSubdomain} disabled={switchingIngressFor === subdomainDialog.appName}>Save</Button>
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- Volume host-path picker (simple installer Volume rows) -->


### PR DESCRIPTION
## Summary

V1 of #99. Serves apps at `jellyfin.example.com` instead of `/apps/jellyfin/`. The Caddy admin-API plumbing we already use for path-prefix routes is extended to match by `host` instead. Solves the SPA absolute-root-path problem #219 had to work around with a probe + auto-disable — subdomain mode means the app sees itself rooted at `/`, no path manipulation needed.

Scope decisions confirmed in chat:
- **One mode per app.** When `subdomain` is set, path-prefix route disappears. No coexistence.
- **Lean on existing ACME config.** Operator's wildcard cert (DNS-01) or per-name ACME (HTTP-01/TLS-ALPN-01) handles certs. Engine just emits the host-match route; Caddy does the rest.

## Engine

`AppRoute.subdomain: Option<String>` threads through:

- **`caddy.rs`** — `build_route_json` branches on `subdomain`: subdomain mode emits `match.host` and drops the `strip_path_prefix` handler. `list_app_routes` round-trips the host back out via new `extract_route_host`.
- **`lib.rs`** — `SetIngressRequest`/`AppIngress` gain `subdomain`. `ingress_set` validates via `validate_subdomain` (RFC 1123-ish: dots, hyphens-not-at-edges, ≤63-char labels, ≤253 total; single-label hostnames rejected since they break ACME), persists the choice in the per-app manifest, and pushes a host-matching route.
- **`compute_desired_routes`** (reconcile) — reads `ingress_subdomain` from the manifest via `load_ingress_subdomain`, preserving mode across engine restarts. Same shape as #225's `proxy_disabled_reason` honour-the-manifest pattern.
- **`ingress_remove`** clears the persisted subdomain so the next tenant of the same name starts from path-prefix default.
- Auto-ingress at install time stays path-prefix; the operator opts into subdomain mode explicitly afterwards.

## WebUI

- `AppIngress.subdomain` in types.
- Per-app "**···**" menu gains "**Subdomain…**" (only when ingress already exists — subdomain mode is opt-in *from* path-prefix mode).
- Modal: text input for the hostname; empty = path-prefix, non-empty = host-match. Saves via `apps.ingress.set`.
- Open button: when `ingress.subdomain` is set, links to `<scheme>://<subdomain>/` (matching `window.location.protocol`) instead of `/apps/<name>/`. Title attribute reflects the mode.
- `setIngressPort` preserves the existing subdomain choice on port switches.

## Out of scope (real follow-ups, not stop-ship)

- **Compose apps**: simple-only for V1. `save_ingress_subdomain` no-ops on missing manifests so compose flows aren't broken; the WebUI just doesn't expose the field for compose apps because they have no manifest to persist into.
- **Per-app ACME / cert status UX** — pre-flight check that the operator's TLS config covers the chosen hostname; per-app challenge type pick; cert-issuance status badges.
- **Conflict detection** — two apps claiming the same subdomain. Caddy will accept the most recent and silently shadow the first.
- **Wildcard cert prerequisite check** on the TLS settings page.

## Tests

- `caddy.rs`: 3 new — `build_route_json_subdomain_mode_matches_by_host`, `extract_route_host_roundtrips_through_build_subdomain`, `extract_route_host_returns_none_for_path_mode`.
- `lib.rs`: 4 new for `validate_subdomain` — FQDN happy path, single-label reject, garbage shapes (`a..b`, `-foo`, `foo bar`, scheme prefix, port suffix), length limits (>63-char label, >253-char total).

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 62 pass (7 new)
- [x] `cargo test -p nasty-engine` — 50 pass
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors, 0 warnings)
- [ ] Deploy: install jellyfin → "···" → "Subdomain…" → enter `jellyfin.<your-domain>` → confirm Caddy emits a host-match route, Caddy obtains a cert via the existing ACME config, and the Open button links to the subdomain. Reinstall haze + set subdomain → confirm `/favicon.svg` now loads correctly (no path-prefix asset miss).