### PR TITLE
ingress: per-row cert status on host-match routes

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -87,6 +87,34 @@ pub struct CaddyRouteSummary {
     /// by listener — the HTTP-to-HTTPS redirect lives on a different
     /// server and shouldn't be lumped in with the HTTPS routes.
     pub server: String,
+    /// On-disk certificate Caddy currently serves for this route's host.
+    /// Populated by the engine binary after `list_all_route_summaries`
+    /// returns — nasty-apps doesn't have access to the cert directory
+    /// or PEM parser. `None` for non-host routes (`path` / `catch_all`)
+    /// and for host routes Caddy hasn't issued a cert for yet (the
+    /// "pending" state — auto-HTTPS issues asynchronously on first
+    /// request).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cert: Option<HostCert>,
+}
+
+/// Subset of `nasty_system::settings::HostCertInfo` re-shaped for the
+/// Ingress overview wire format. Defined here (rather than re-using
+/// the nasty-system type directly) so `nasty-apps` doesn't grow a dep
+/// on `nasty-system` just for the field — the engine binary copies the
+/// fields across when enriching.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct HostCert {
+    pub issuer: Option<String>,
+    pub issued: Option<String>,
+    pub expires: Option<String>,
+    /// Days until expiry from now; negative = expired. Lets the WebUI
+    /// colour the badge (red ≤ 7, amber ≤ 30, green otherwise) without
+    /// parsing the RFC-2822 expires string client-side.
+    pub expires_in_days: Option<i64>,
+    /// On-disk path; surfaced as a tooltip in the WebUI for debugging
+    /// "which cert is this actually serving" questions.
+    pub path: String,
 }
 
 /// Caddy admin-API HTTP client.  Cheap to construct — internally
@@ -534,6 +562,11 @@ fn summarise_route(server: &str, route: &Value) -> CaddyRouteSummary {
         source: source.to_string(),
         app_name,
         server: server.to_string(),
+        // `cert` is left None here — the cert directory lives outside
+        // this crate's blast radius. The engine binary (which depends on
+        // nasty-system) enriches host-match rows after the walker
+        // returns. See `list_caddy_routes` in nasty-engine/src/router/apps.rs.
+        cert: None,
     }
 }
 

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -30,8 +30,8 @@ use tracing::{error, info, warn};
 
 mod caddy;
 
-pub use caddy::CaddyRouteSummary;
 use caddy::{AppRoute, CaddyApi};
+pub use caddy::{CaddyRouteSummary, HostCert};
 
 const STATE_PATH: &str = "/var/lib/nasty/apps-enabled";
 const COMPOSE_DIR: &str = "/var/lib/nasty/apps";

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -228,8 +228,32 @@ pub(super) async fn try_route(
         // the Ingress overview page so the operator can see at a glance
         // what's exposed and where each row came from — without shelling
         // in to read the live Caddy config.
+        //
+        // We enrich host-match rows with their on-disk cert info here
+        // (rather than inside nasty-apps' walker) because the cert
+        // directory lives in nasty-system's domain — nasty-apps doesn't
+        // depend on nasty-system, and reaching across crates just for
+        // a single optional field would invert the dep graph.
         "apps.caddy.routes" => match state.apps.list_caddy_routes().await {
-            Ok(v) => ok(req, v),
+            Ok(mut rows) => {
+                for row in &mut rows {
+                    if row.match_kind != "host" {
+                        continue;
+                    }
+                    if let Some(info) =
+                        nasty_system::settings::cert_info_for_host(&row.match_value).await
+                    {
+                        row.cert = Some(nasty_apps::HostCert {
+                            issuer: info.issuer,
+                            issued: info.issued,
+                            expires: info.expires,
+                            expires_in_days: info.expires_in_days,
+                            path: info.path,
+                        });
+                    }
+                }
+                ok(req, rows)
+            }
             Err(e) => err(req, e),
         },
         "apps.ingress.set" => match parse_params(req) {

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -901,6 +901,89 @@ struct CertInfo {
     issuer: Option<String>,
 }
 
+/// Per-host certificate details for the Ingress overview page. Returned
+/// by [`cert_info_for_host`] for each `host`-matching Caddy route so the
+/// WebUI can render an expiry/issuer badge per row.
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
+pub struct HostCertInfo {
+    /// Issuer CN (e.g. `R10`, `Let's Encrypt Authority X3`) or O when no
+    /// CN is present. None when the PEM didn't parse — surfaced as a
+    /// "cert present but unreadable" hint to the WebUI.
+    pub issuer: Option<String>,
+    /// `not_before` from the cert, RFC 2822 string.
+    pub issued: Option<String>,
+    /// `not_after`, RFC 2822 string.
+    pub expires: Option<String>,
+    /// Days until expiry from now (negative when expired). Lets the
+    /// WebUI colour the badge — red when ≤ 7, amber when ≤ 30, green
+    /// otherwise — without parsing dates client-side.
+    pub expires_in_days: Option<i64>,
+    /// Absolute path the cert was read from. Diagnostic; the WebUI
+    /// uses it as a tooltip when the operator hovers the badge.
+    pub path: String,
+}
+
+/// Locate and read the cert Caddy serves for `host`. Walks
+/// `/var/lib/caddy/.local/share/caddy/certificates/<endpoint>/...`
+/// across every issuer endpoint, and matches either:
+///   - directly by hostname (`example.com/example.com.crt`), or
+///   - by an enclosing wildcard cert
+///     (`wildcard_.example.com/wildcard_.example.com.crt` covers
+///     `<anything>.example.com`).
+///
+/// Returns `None` when no cert is on disk yet — Caddy auto-HTTPS issues
+/// asynchronously on first request, so a freshly-set ingress can spend
+/// a few seconds with no cert. The WebUI renders that as "pending"
+/// rather than treating it as a hard failure.
+pub async fn cert_info_for_host(host: &str) -> Option<HostCertInfo> {
+    let path = locate_cert_for_host(host).await?;
+    let info = read_cert_info(&path).await;
+    // Convert `expires` (RFC 2822) to days-from-now. Parse failure is
+    // benign — the caller still sees `expires` as a string, just no
+    // colour-coding. We use chrono since it's already in the deps.
+    let expires_in_days = info.expires.as_deref().and_then(|s| {
+        let parsed = chrono::DateTime::parse_from_rfc2822(s).ok()?;
+        let secs = parsed.timestamp() - chrono::Utc::now().timestamp();
+        Some(secs / 86_400)
+    });
+    Some(HostCertInfo {
+        issuer: info.issuer,
+        issued: info.issued,
+        expires: info.expires,
+        expires_in_days,
+        path,
+    })
+}
+
+async fn locate_cert_for_host(host: &str) -> Option<String> {
+    let base = format!("{CADDY_DATA_DIR}/.local/share/caddy/certificates");
+    let mut endpoints = tokio::fs::read_dir(&base).await.ok()?;
+    while let Ok(Some(ep)) = endpoints.next_entry().await {
+        // Direct match: <endpoint>/<host>/<host>.crt
+        let direct = ep.path().join(host).join(format!("{host}.crt"));
+        if tokio::fs::metadata(&direct).await.is_ok() {
+            return Some(direct.to_string_lossy().into_owned());
+        }
+        // Wildcard match: walk subdirs named `wildcard_.<suffix>` and
+        // check whether `host` ends in `.<suffix>`. Cert filename
+        // mirrors the dir name so we don't have to guess.
+        if let Ok(mut subdirs) = tokio::fs::read_dir(ep.path()).await {
+            while let Ok(Some(sd)) = subdirs.next_entry().await {
+                let name = sd.file_name().to_string_lossy().into_owned();
+                if let Some(suffix) = name.strip_prefix("wildcard_.")
+                    && host.ends_with(&format!(".{suffix}"))
+                {
+                    let candidate = sd.path().join(format!("{name}.crt"));
+                    if tokio::fs::metadata(&candidate).await.is_ok() {
+                        return Some(candidate.to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Read certificate details from a PEM file.
 async fn read_cert_info(cert_path: &str) -> CertInfo {
     let mut info = CertInfo {

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1071,4 +1071,21 @@ export interface CaddyRouteSummary {
 	app_name: string | null;
 	/** Caddy server name ("srv0" | "srv1" | …) for grouping. */
 	server: string;
+	/** On-disk certificate Caddy currently serves for this route's host.
+	 * Populated only for host-match rows that have a cert in Caddy's data
+	 * directory. Absent = no cert yet (pending / Caddy hasn't issued one)
+	 * or not applicable (path / catch-all routes). */
+	cert?: HostCert | null;
+}
+
+/** Subset of the per-host certificate Caddy serves, surfaced on the
+ * Ingress overview row for the corresponding host-match route. */
+export interface HostCert {
+	issuer: string | null;
+	issued: string | null;
+	expires: string | null;
+	/** Days until expiry from now; negative = expired. Used by the WebUI
+	 * to colour the badge — red ≤ 7, amber ≤ 30, green otherwise. */
+	expires_in_days: number | null;
+	path: string;
 }

--- a/webui/src/routes/ingress/+page.svelte
+++ b/webui/src/routes/ingress/+page.svelte
@@ -73,6 +73,37 @@
 			default:          return { class: 'bg-muted text-muted-foreground border-border', label: kind };
 		}
 	}
+
+	/** Visual styling for the per-row Cert badge. Colour follows
+	 * expires_in_days: red when ≤ 7 (or already expired), amber when ≤ 30,
+	 * green otherwise. The badge tooltip carries the full issuer +
+	 * expires-on string so the operator doesn't have to guess from the
+	 * colour alone. */
+	function certBadge(c: import('$lib/types').HostCert): { class: string; label: string; title: string } {
+		const d = c.expires_in_days;
+		let cls = 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30';
+		let label = 'valid';
+		if (d === null || d === undefined) {
+			cls = 'bg-muted text-muted-foreground border-border';
+			label = 'cert';
+		} else if (d < 0) {
+			cls = 'bg-red-500/15 text-red-400 border-red-500/30';
+			label = 'expired';
+		} else if (d <= 7) {
+			cls = 'bg-red-500/15 text-red-400 border-red-500/30';
+			label = `${d}d`;
+		} else if (d <= 30) {
+			cls = 'bg-amber-500/15 text-amber-400 border-amber-500/30';
+			label = `${d}d`;
+		} else {
+			label = `${d}d`;
+		}
+		const parts: string[] = [];
+		if (c.issuer) parts.push(`Issuer: ${c.issuer}`);
+		if (c.expires) parts.push(`Expires: ${c.expires}`);
+		if (c.path) parts.push(`File: ${c.path}`);
+		return { class: cls, label, title: parts.join('\n') };
+	}
 </script>
 
 <svelte:head><title>Ingress · NASty</title></svelte:head>
@@ -111,6 +142,7 @@
 							<th class="p-2 text-left text-xs uppercase text-muted-foreground">Value</th>
 							<th class="p-2 text-left text-xs uppercase text-muted-foreground">Handler</th>
 							<th class="p-2 text-left text-xs uppercase text-muted-foreground">Upstream</th>
+							<th class="p-2 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Cert</th>
 							<th class="p-2 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Source</th>
 							<th class="p-2 text-left text-xs uppercase text-muted-foreground">App</th>
 						</tr>
@@ -127,6 +159,20 @@
 								<td class="p-2 text-xs text-muted-foreground">{r.handler_kind}</td>
 								<td class="p-2 font-mono text-xs">
 									{#if r.upstream}{r.upstream}{:else}<span class="text-muted-foreground">—</span>{/if}
+								</td>
+								<td class="p-2 whitespace-nowrap">
+									{#if r.cert}
+										{@const cb = certBadge(r.cert)}
+										<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] cursor-help {cb.class}" title={cb.title}>{cb.label}</span>
+									{:else if r.match_kind === "host"}
+										<!-- Host route with no cert on disk yet — auto-HTTPS issues
+										     asynchronously on first request, so a freshly-set ingress can
+										     spend a few seconds in this state. Surface it as "pending"
+										     rather than a hard failure so the operator doesn't panic. -->
+										<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] bg-muted text-muted-foreground border-border" title="No cert on disk yet — Caddy issues asynchronously on first request.">pending</span>
+									{:else}
+										<span class="text-muted-foreground">—</span>
+									{/if}
 								</td>
 								<td class="p-2">
 									<span class="inline-flex items-center whitespace-nowrap rounded-md border px-2 py-0.5 text-[0.65rem] {sb.class}">{sb.label}</span>


### PR DESCRIPTION
## Summary

Follow-up to #229. The Ingress overview now answers "what is Caddy serving" — but for host-match (subdomain) routes the natural next question is **"is the cert healthy?"** Without an answer, the operator has to ssh in and openssl-parse certs by hand or trust that Caddy hasn't silently fallen behind on a renew.

Add a per-row **Cert** column populated from the on-disk certificate Caddy actually serves for each host. Badge colours follow days-until-expiry: red ≤ 7 (or already expired), amber ≤ 30, green otherwise. A freshly-set ingress that Caddy hasn't issued a cert for yet renders as a muted **pending** badge instead of nothing — auto-HTTPS issues asynchronously on first request, so "no file yet" isn't a hard failure.

## Engine

- **`nasty-system`** — new pub `cert_info_for_host(host) -> Option<HostCertInfo>`. Walks `/var/lib/caddy/.local/share/caddy/certificates/<endpoint>/...` across every issuer endpoint and matches either:
  - directly by hostname (`example.com/example.com.crt`), or
  - via an enclosing wildcard cert (`wildcard_.example.com` covers `*.example.com`)
  Reuses the existing `read_cert_info` PEM parser. `expires_in_days` computed from the RFC-2822 expires string via chrono (already in deps).
- **`nasty-apps`** — `CaddyRouteSummary` gains optional `cert: Option<HostCert>`. The walker leaves it `None` — nasty-apps doesn't depend on nasty-system, and reaching across crates for one optional field would invert the dep graph.
- **`nasty-engine`** — the `apps.caddy.routes` RPC handler enriches host-match rows after `list_caddy_routes` returns, copying the nasty-system shape into the wire-format `HostCert` struct.

## WebUI

- New `HostCert` type; `CaddyRouteSummary.cert?` field.
- **Cert** column between Upstream and Source. Three states:
  - **Cert present** — badge with `<days>d` label, coloured by expiry, tooltip carries Issuer / Expires / on-disk path
  - **Host route, no cert** — `pending` badge with explanatory tooltip
  - **Non-host route** — `—`

## Out of scope (deliberate)

- **Cert-rotation triggers** — the cert directory is Caddy's; the operator rotates by reconfiguring or via Caddy's own scheduler. Surfacing expiry is the meaningful piece.
- **"Renew now" button** per host — Caddy auto-renews ~30 days before expiry; a manual trigger would mostly be a UX placebo.
- **Per-cert ACME status surface** — that's the existing `system.acme.status` story on /tls and stays there.

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 67 pass
- [x] `cargo test -p nasty-engine` — 50 pass
- [x] `cargo test -p nasty-system --lib` — 207 pass
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors, 0 warnings)
- [ ] Deploy: `/ingress` shows a Cert badge on each host-match row with the cert's days-until-expiry. Hover shows Issuer / Expires / file path. Add a new host-match ingress and confirm it transitions from `pending` to the green badge once Caddy issues. Non-host rows (path / catch-all) show `—`.