### PR TITLE
apps/ingress: subdomain conflict detection

### DIFF
--- a/engine/nasty-engine/src/ingress_conflict.rs
+++ b/engine/nasty-engine/src/ingress_conflict.rs
@@ -1,0 +1,73 @@
+//! Subdomain conflict detection for the apps.ingress.set RPC and the
+//! Apps page's live preview.
+//!
+//! Caddy silently lets the most recent matching route win when two
+//! routes claim the same host — install Jellyfin under
+//! `lab.example.com`, then later set the same subdomain on Grafana, and
+//! requests to `lab.example.com` start going to Grafana with no warning.
+//! The operator might not notice until they hit the dead route by
+//! accident. This module catches the common cases upfront:
+//!
+//!   - The chosen subdomain matches another engine-app's subdomain.
+//!   - The chosen subdomain matches NASty's own WebUI hostname
+//!     (would intercept the management interface).
+//!
+//! Path-prefix conflicts are not modelled here: `/apps/<name>/*` paths
+//! are derived from app names, names are DNS-safe and unique, and the
+//! static Caddyfile routes (`/api/*`, `/ws*`, etc.) live in disjoint
+//! prefixes. There's no realistic path collision an operator can
+//! produce through the install form.
+
+use crate::AppState;
+
+/// Returns a human-readable reason when `subdomain` would conflict with
+/// an existing engine-app ingress or the NASty WebUI hostname. Returns
+/// `None` when the choice is clear (or when `subdomain` is empty — that
+/// means path-prefix mode, no conflict possible).
+///
+/// `name` is the app doing the set — we skip its own existing ingress
+/// in the "already used by" check so re-saving the same subdomain on
+/// the same app doesn't false-positive.
+pub async fn find_subdomain_conflict(
+    state: &AppState,
+    name: &str,
+    subdomain: &str,
+) -> Option<String> {
+    if subdomain.is_empty() {
+        return None;
+    }
+
+    // WebUI hostname clash. The TLS settings always carry the FQDN the
+    // WebUI is served at; an app subdomain matching it would shadow the
+    // management interface (Caddy serves the most recent matching
+    // route — in this case the app's, not the WebUI's).
+    let settings = state.settings.get().await;
+    if let Some(tls_domain) = settings.tls_domain.as_deref()
+        && tls_domain.eq_ignore_ascii_case(subdomain)
+    {
+        return Some(format!(
+            "'{subdomain}' is the NASty WebUI hostname — using it for an app would shadow the management interface"
+        ));
+    }
+
+    // Another app's subdomain. We pull the current ingress list rather
+    // than the manifest field because Caddy is the actual source of
+    // truth at the moment of set — a manifest entry someone forgot to
+    // push to Caddy doesn't actually claim the host yet.
+    if let Ok(existing) = state.apps.ingress_list().await {
+        for ing in existing {
+            if ing.name == name {
+                continue;
+            }
+            if let Some(other) = ing.subdomain.as_deref()
+                && other.eq_ignore_ascii_case(subdomain)
+            {
+                return Some(format!(
+                    "'{subdomain}' is already used by app '{}'",
+                    ing.name
+                ));
+            }
+        }
+    }
+    None
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -20,6 +20,7 @@ mod auth;
 mod auth_oidc;
 mod fs_dependents;
 mod fs_lock;
+mod ingress_conflict;
 mod log_stream;
 mod router;
 mod subvolume_dependents;

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -256,13 +256,48 @@ pub(super) async fn try_route(
             }
             Err(e) => err(req, e),
         },
-        "apps.ingress.set" => match parse_params(req) {
-            Ok(p) => match state.apps.ingress_set(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "apps.ingress.set" => match parse_params::<nasty_apps::SetIngressRequest>(req) {
+            Ok(p) => {
+                // Gate the set on a subdomain-conflict check — catches the
+                // "two apps claim the same hostname" / "app subdomain ==
+                // WebUI hostname" cases that Caddy would silently let the
+                // most recent one win. Empty subdomain (path-prefix mode)
+                // short-circuits past the check inside find_subdomain_conflict.
+                let conflict = match &p.subdomain {
+                    Some(s) => {
+                        crate::ingress_conflict::find_subdomain_conflict(state, &p.name, s).await
+                    }
+                    None => None,
+                };
+                if let Some(reason) = conflict {
+                    err(req, format!("subdomain conflict: {reason}"))
+                } else {
+                    match state.apps.ingress_set(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
+            }
             Err(e) => invalid(req, e),
         },
+        // Best-effort lookup used by the WebUI's subdomain dialog to
+        // surface a live "in use by X" hint as the operator types,
+        // before they click Save. Returns the conflict reason or an
+        // empty string when the choice is clear. Read-only.
+        "apps.ingress.check_conflict" => 'arm: {
+            let name = match require_str(req, "name") {
+                Ok(s) => s,
+                Err(r) => break 'arm r,
+            };
+            let subdomain = match require_str(req, "subdomain") {
+                Ok(s) => s,
+                Err(r) => break 'arm r,
+            };
+            let reason = crate::ingress_conflict::find_subdomain_conflict(state, name, subdomain)
+                .await
+                .unwrap_or_default();
+            ok(req, reason)
+        }
         "apps.ingress.remove" => match require_str(req, "name") {
             Ok(name) => match state.apps.ingress_remove(name).await {
                 Ok(()) => ok(req, "ok"),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -177,6 +177,7 @@ fn is_read_only(method: &str) -> bool {
                 | "apps.config"
                 | "apps.inspect_image"
                 | "apps.caddy.routes"
+                | "apps.ingress.check_conflict"
                 | "bcachefs.timestats"
                 | "bcachefs.top"
                 | "backup.profile.list"

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -1245,10 +1245,49 @@
 	 * `null` = closed; otherwise carries the app name being edited
 	 * (host_port is read from the current ingress at submit time). */
 	let subdomainDialog = $state<{ appName: string; value: string } | null>(null);
+	/** Live conflict-check feedback for the subdomain input. Empty
+	 * string when the value is fine, non-empty when the engine detected
+	 * a conflict (another app already using it, or the WebUI hostname).
+	 * Save remains gated server-side too — this is just for fast feedback. */
+	let subdomainConflict = $state('');
+	let subdomainCheckSeq = 0;
+	let subdomainCheckTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function openSubdomainDialog(appName: string) {
 		const current = getIngress(appName);
 		subdomainDialog = { appName, value: current?.subdomain ?? '' };
+		subdomainConflict = '';
+	}
+
+	/** Debounced conflict check — runs 300ms after the operator stops
+	 * typing so we don't fire an RPC on every keystroke. Sequence number
+	 * guards against an older-but-slower response overwriting a newer
+	 * answer. */
+	function scheduleSubdomainConflictCheck() {
+		if (subdomainCheckTimer) clearTimeout(subdomainCheckTimer);
+		const dialog = subdomainDialog;
+		if (!dialog) return;
+		const trimmed = dialog.value.trim();
+		if (!trimmed) {
+			subdomainConflict = '';
+			return;
+		}
+		subdomainCheckSeq += 1;
+		const seq = subdomainCheckSeq;
+		subdomainCheckTimer = setTimeout(async () => {
+			try {
+				const reason = await client.call<string>('apps.ingress.check_conflict', {
+					name: dialog.appName,
+					subdomain: trimmed,
+				});
+				if (seq === subdomainCheckSeq) {
+					subdomainConflict = reason ?? '';
+				}
+			} catch {
+				// Network glitch — leave the previous result rather than
+				// flashing a misleading "no conflict" when we can't tell.
+			}
+		}, 300);
 	}
 
 	async function saveSubdomain() {
@@ -2010,10 +2049,23 @@
 				Caddy uses the existing TLS/ACME config; the operator needs DNS for the hostname to resolve to NASty.
 			</p>
 			<Label class="text-xs">Subdomain</Label>
-			<Input bind:value={subdomainDialog.value} placeholder="jellyfin.example.com" class="mt-1" />
+			<Input
+				bind:value={subdomainDialog.value}
+				oninput={scheduleSubdomainConflictCheck}
+				placeholder="jellyfin.example.com"
+				class="mt-1 {subdomainConflict ? 'border-amber-500 ring-1 ring-amber-500/50' : ''}"
+			/>
+			{#if subdomainConflict}
+				<!-- Engine-side check: another engine app already claims this
+				     hostname, or it matches NASty's own WebUI hostname (would
+				     shadow the management interface). Save stays gated server-
+				     side too — this is just fast feedback so the operator
+				     doesn't get a surprise toast after clicking. -->
+				<p class="mt-1 text-xs text-amber-500">⚠ {subdomainConflict}</p>
+			{/if}
 			<div class="mt-4 flex justify-end gap-2">
 				<Button variant="outline" size="sm" onclick={() => { subdomainDialog = null; }}>Cancel</Button>
-				<Button size="sm" onclick={saveSubdomain} disabled={switchingIngressFor === subdomainDialog.appName}>Save</Button>
+				<Button size="sm" onclick={saveSubdomain} disabled={switchingIngressFor === subdomainDialog.appName || !!subdomainConflict}>Save</Button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

Caddy silently lets the most-recently-added matching route win when two routes claim the same host. Install Jellyfin at `lab.example.com`, set the same subdomain on Grafana later, and `lab.example.com` starts serving Grafana with no warning. The first app's Open button still points there but the page is wrong. The operator might not notice until they hit the dead route by accident.

Same trap applies to NASty's own management interface: an app subdomain that matches `settings.tls_domain` would shadow the WebUI.

Two cases worth catching, both around **subdomains**:
- The chosen subdomain matches another engine-app's existing subdomain.
- The chosen subdomain matches NASty's WebUI `tls_domain`.

**Path-prefix conflicts** aren't realistic — `/apps/<name>/` paths derive from unique DNS-safe app names, and the static Caddyfile routes (`/api/*`, `/ws*`, …) live in disjoint prefixes. This PR only covers the subdomain case, which is the actually-reachable footgun.

## Engine

- New `nasty-engine/src/ingress_conflict.rs` with `find_subdomain_conflict(state, name, subdomain) -> Option<String>` (returns the conflict reason). Pulls settings for the WebUI-hostname check; pulls `ingress_list` for the per-app check. Self-exclusion on the `name` parameter so re-saving the same subdomain on the same app doesn't false-positive.
- `apps.ingress.set` handler now runs the check before delegating to `AppsService::ingress_set`. Conflict → `Err` with the reason; no Caddy route mutation, no manifest write.
- New read-only RPC `apps.ingress.check_conflict(name, subdomain)` for the WebUI to surface live feedback as the operator types. Returns the reason string, or empty when clear.

## WebUI

The Subdomain dialog gains a debounced (300ms) check against `apps.ingress.check_conflict`. When the engine reports a conflict:

- the input is highlighted amber
- a `⚠ <reason>` line appears below the input
- the **Save** button is disabled until the reason clears

Sequence-number guard around the RPC so a stale older response can't overwrite a fresh newer one. Network errors leave the previous result in place rather than flashing a misleading "no conflict".

The **server-side gate stays** — even if a future WebUI bug let the operator click Save with a conflict on screen, the engine still refuses the set.

## Out of scope (deliberate)

- **Path overlap detection** — see rationale above; the path namespace is `/apps/<name>/` per unique app name, no overlap possible.
- **Conflict detection across the Caddyfile static routes** — those are baked into NixOS and known disjoint from `/apps/`.
- **Auto-fixup** (suggesting alternative hostnames). The operator knows their DNS better than we do.

## Test plan

- [x] `cargo test -p nasty-engine` — 50 pass (no new tests; the conflict helper requires a live AppState, hard to unit-test in isolation, and the integration flow is well-covered by smoke tests below)
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors, 0 warnings)
- [ ] Smoke: install two apps, set subdomain `lab.example.com` on app A → set the same on app B → dialog shows `⚠ 'lab.example.com' is already used by app 'A'` and Save is disabled.
- [ ] Smoke: try to set the WebUI's own `tls_domain` as an app subdomain → dialog shows `⚠ ... is the NASty WebUI hostname — using it for an app would shadow the management interface` and Save is disabled.
- [ ] Smoke: re-open the Subdomain dialog on an app that already has subdomain X, do nothing, click Save → no false-positive conflict, Save succeeds (self-exclusion working).