### PR TITLE
apps: subdomain mode at install time + always-shown Subdomain menu

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1109,6 +1109,20 @@ pub struct InstallAppRequest {
     /// still rejected even with this set.
     #[serde(default)]
     pub allow_unsafe: bool,
+    /// Optional FQDN to serve the app at via subdomain mode (e.g.
+    /// `jellyfin.example.com`). When set, the install pipeline emits a
+    /// host-matching Caddy route instead of the default path-prefix
+    /// route, and skips the post-install probe (subdomain mode roots
+    /// the app at `/`, so the absolute-asset-path failure mode the
+    /// probe catches can't happen). Empty/omitted = path-prefix
+    /// behaviour, the historical default.
+    ///
+    /// Conflict detection happens at the engine-binary layer before
+    /// install runs (see deploy_simple in app_deploy.rs) so the
+    /// operator doesn't pay for an image pull just to discover the
+    /// hostname is taken.
+    #[serde(default)]
+    pub subdomain: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1833,21 +1847,33 @@ impl AppsService {
                     .await
                     .unwrap_or(first_port.container_port)
             };
+            // Operator can opt into subdomain mode at install time via
+            // the install form's "Subdomain (optional)" field; absence
+            // (None / empty) keeps path-prefix mode as the historical
+            // default. Conflict detection runs upstream in
+            // deploy_simple — see app_deploy.rs.
+            let install_subdomain = req
+                .subdomain
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            let chose_subdomain = install_subdomain.is_some();
             if let Err(e) = self
                 .ingress_set(SetIngressRequest {
                     name: req.name.clone(),
                     host_port,
-                    // Install pipeline always uses path-prefix mode for
-                    // its auto-created ingress. The operator opts into
-                    // subdomain mode later via the WebUI / explicit
-                    // apps.ingress.set call — the install form doesn't
-                    // know enough about the operator's DNS / TLS setup
-                    // to pick a subdomain name on their behalf.
-                    subdomain: None,
+                    subdomain: install_subdomain,
                 })
                 .await
             {
                 warn!("Failed to auto-create ingress for '{}': {e}", req.name);
+            } else if chose_subdomain {
+                // Subdomain mode roots the app at `/`, so the absolute-
+                // asset-path failure the probe catches can't happen. Skip
+                // the probe — running it would hit the subdomain URL
+                // (instead of /apps/<name>/), see an Ok answer, and waste
+                // a few seconds doing nothing useful.
             } else if let Some(reason) = probe_proxy_compat(&req.name).await.broken_reason() {
                 // The app's HTML emits absolute root-relative paths (e.g.
                 // /assets/index.js). Loaded via /apps/<name>/, those asset
@@ -3745,6 +3771,12 @@ impl AppsService {
                 )
                 .await;
 
+            // Preserve subdomain mode across pull-and-reinstall. AppConfig
+            // doesn't carry the ingress shape (it lives separately) so we
+            // read it back from the manifest here — without this, every
+            // `apps.pull` would silently downgrade a subdomain-mode ingress
+            // to path-prefix.
+            let existing_subdomain = load_ingress_subdomain(name).await;
             let req = InstallAppRequest {
                 name: name.to_string(),
                 image,
@@ -3754,6 +3786,7 @@ impl AppsService {
                 cpu_limit: config.cpu_limit,
                 memory_limit: config.memory_limit,
                 allow_unsafe: config.allow_unsafe,
+                subdomain: existing_subdomain,
             };
             return self.install(req).await;
         }

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -203,6 +203,43 @@ async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployReq
         }
     };
 
+    // Parse install params + subdomain conflict check up front, *before*
+    // the pull, so the operator doesn't sit through a 60-second image
+    // download just to discover the chosen hostname is already taken.
+    // Same conflict logic the apps.ingress.set RPC runs in #231.
+    let install_params = req.install_params.clone().unwrap_or(serde_json::json!({}));
+    let mut params: nasty_apps::InstallAppRequest = match serde_json::from_value(install_params) {
+        Ok(p) => p,
+        Err(e) => {
+            report_error(
+                socket,
+                &req.name,
+                "parse-params",
+                &format!("invalid params: {e}"),
+            )
+            .await;
+            return;
+        }
+    };
+    params.name = req.name.clone();
+    params.image = image.clone();
+    // Top-level flag wins over anything embedded in install_params, so the
+    // privileged-deploy decision is plainly visible in the deploy request.
+    params.allow_unsafe = req.allow_unsafe;
+    if let Some(ref s) = params.subdomain
+        && let Some(reason) =
+            crate::ingress_conflict::find_subdomain_conflict(state, &params.name, s).await
+    {
+        report_error(
+            socket,
+            &req.name,
+            "validate",
+            &format!("subdomain conflict: {reason}"),
+        )
+        .await;
+        return;
+    }
+
     // Step 1: Pull image via bollard with structured progress
     let _ = socket
         .send(Message::Text(
@@ -227,26 +264,6 @@ async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployReq
             DeployMessage::log("Creating container...").into(),
         ))
         .await;
-
-    let install_params = req.install_params.clone().unwrap_or(serde_json::json!({}));
-    let mut params: nasty_apps::InstallAppRequest = match serde_json::from_value(install_params) {
-        Ok(p) => p,
-        Err(e) => {
-            report_error(
-                socket,
-                &req.name,
-                "parse-params",
-                &format!("invalid params: {e}"),
-            )
-            .await;
-            return;
-        }
-    };
-    params.name = req.name.clone();
-    params.image = image;
-    // Top-level flag wins over anything embedded in install_params, so the
-    // privileged-deploy decision is plainly visible in the deploy request.
-    params.allow_unsafe = req.allow_unsafe;
 
     if req.allow_unsafe {
         crate::auth::audit(

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -289,6 +289,15 @@
 	let volumePickerIndex = $state<number | null>(null);
 	let newCpuLimit = $state('');
 	let newMemoryLimit = $state('');
+	/** Optional FQDN for subdomain-mode ingress at install time
+	 * (`jellyfin.example.com`). Empty = path-prefix mode, the default.
+	 * Live-checked against engine conflict state below as the operator
+	 * types so a hostname that's already in use surfaces immediately. */
+	let newSubdomain = $state('');
+	/** Engine-reported conflict for `newSubdomain`; '' when clear. */
+	let newSubdomainConflict = $state('');
+	let newSubdomainCheckSeq = 0;
+	let newSubdomainCheckTimer: ReturnType<typeof setTimeout> | null = null;
 	/** Opt out of the strict bind-mount sandbox for simple apps. Persisted per-app. */
 	let newAllowUnsafe = $state(false);
 	/** Same flag, separate state for the compose dialog. */
@@ -903,6 +912,12 @@
 		}
 		if (newCpuLimit) params.cpu_limit = newCpuLimit;
 		if (newMemoryLimit) params.memory_limit = newMemoryLimit;
+		// Subdomain-mode opt-in. Engine validates again (and re-checks
+		// for conflicts on its own) so this is just passthrough — if the
+		// operator typed a hostname that became taken between the live
+		// conflict check and Save, install fails with a clear error.
+		const subdomainTrimmed = newSubdomain.trim();
+		if (subdomainTrimmed) params.subdomain = subdomainTrimmed;
 
 		const ok = await streamDeploy({
 			kind: 'simple',
@@ -1006,8 +1021,41 @@
 		newCpuLimit = '';
 		newMemoryLimit = '';
 		newAllowUnsafe = false;
+		newSubdomain = '';
+		newSubdomainConflict = '';
 		lastInspectedImage = '';
 		subpathRecipe = null;
+	}
+
+	/** Debounced 300ms check of the install-form Subdomain field against
+	 * engine state (other apps' subdomains + the WebUI hostname). Mirrors
+	 * the per-app dialog's check from #231 — same RPC, same sequence guard
+	 * so a stale slow response can't overwrite a fresh fast one. The
+	 * `name` we send is the install form's appName so the engine's
+	 * self-exclusion lines up with what install() will register. */
+	function scheduleNewSubdomainConflictCheck() {
+		if (newSubdomainCheckTimer) clearTimeout(newSubdomainCheckTimer);
+		const trimmed = newSubdomain.trim();
+		if (!trimmed) {
+			newSubdomainConflict = '';
+			return;
+		}
+		newSubdomainCheckSeq += 1;
+		const seq = newSubdomainCheckSeq;
+		const appName = (newName || '').trim().toLowerCase();
+		newSubdomainCheckTimer = setTimeout(async () => {
+			try {
+				const reason = await client.call<string>('apps.ingress.check_conflict', {
+					name: appName,
+					subdomain: trimmed,
+				});
+				if (seq === newSubdomainCheckSeq) {
+					newSubdomainConflict = reason ?? '';
+				}
+			} catch {
+				/* leave the previous result rather than flashing "no conflict" */
+			}
+		}, 300);
 	}
 
 	function cancelEdit() {
@@ -1244,7 +1292,7 @@
 	/** Per-app modal opened by the "···" menu's "Subdomain" item.
 	 * `null` = closed; otherwise carries the app name being edited
 	 * (host_port is read from the current ingress at submit time). */
-	let subdomainDialog = $state<{ appName: string; value: string } | null>(null);
+	let subdomainDialog = $state<{ appName: string; value: string; host_port: number } | null>(null);
 	/** Live conflict-check feedback for the subdomain input. Empty
 	 * string when the value is fine, non-empty when the engine detected
 	 * a conflict (another app already using it, or the WebUI hostname).
@@ -1255,7 +1303,16 @@
 
 	function openSubdomainDialog(appName: string) {
 		const current = getIngress(appName);
-		subdomainDialog = { appName, value: current?.subdomain ?? '' };
+		// When no ingress exists (e.g. the post-install probe disabled
+		// one for a haze-class app), fall back to the app's first TCP
+		// port so saveSubdomain can synthesise a fresh ingress. Without
+		// this fallback the dialog used to be hidden entirely from the
+		// menu — operators of probe-disabled apps had no UI path to
+		// rescue them into subdomain mode.
+		const app = apps.find(a => a.name === appName);
+		const fallbackPort = app?.ports?.find(p => p.protocol?.toLowerCase() === 'tcp')?.host_port;
+		const host_port = current?.host_port ?? fallbackPort ?? 0;
+		subdomainDialog = { appName, value: current?.subdomain ?? '', host_port };
 		subdomainConflict = '';
 	}
 
@@ -1292,19 +1349,29 @@
 
 	async function saveSubdomain() {
 		if (!subdomainDialog) return;
-		const { appName, value } = subdomainDialog;
+		const { appName, value, host_port } = subdomainDialog;
 		const current = getIngress(appName);
-		if (!current) {
+		const subdomain = value.trim() || null;
+		// No-op guard for the haze-class case: app has no current ingress
+		// (probe disabled it) AND operator saved with an empty subdomain.
+		// Creating a path-prefix ingress in that scenario would just be
+		// killed by the probe again, leaving the operator confused. Close
+		// the dialog silently — saving with a non-empty subdomain still
+		// creates the ingress, which is the actual rescue path.
+		if (!current && !subdomain) {
 			subdomainDialog = null;
 			return;
 		}
-		const subdomain = value.trim() || null;
+		if (host_port === 0) {
+			subdomainDialog = null;
+			return;
+		}
 		switchingIngressFor = appName;
 		try {
 			await withToast(
 				() => client.call('apps.ingress.set', {
 					name: appName,
-					host_port: current.host_port,
+					host_port,
 					subdomain,
 				}),
 				subdomain ? `Ingress for ${appName} → ${subdomain}` : `Ingress for ${appName} → /apps/${appName}/`
@@ -1633,6 +1700,30 @@
 					</div>
 				</div>
 
+				<!-- Subdomain (optional) — opt into subdomain-mode ingress from
+				     day one. Empty = path-prefix mode + post-install probe (the
+				     historical default). Non-empty = host-match Caddy route +
+				     probe skipped. Live conflict check below. -->
+				<div class="mb-4">
+					<Label>Subdomain <span class="text-muted-foreground font-normal">(optional)</span></Label>
+					<Input
+						bind:value={newSubdomain}
+						oninput={scheduleNewSubdomainConflictCheck}
+						placeholder="jellyfin.example.com"
+						class="mt-1 h-8 text-xs {newSubdomainConflict ? 'border-amber-500 ring-1 ring-amber-500/50' : ''}"
+					/>
+					{#if newSubdomainConflict}
+						<p class="mt-1 text-xs text-amber-500">⚠ {newSubdomainConflict}</p>
+					{:else}
+						<p class="mt-1 text-[0.65rem] text-muted-foreground">
+							Leave empty to serve under <code>/apps/{newName || '&lt;name&gt;'}/</code>.
+							Set an FQDN to serve at its own root — required for apps that emit
+							absolute paths (haze, jellyfin). Caddy uses the existing TLS/ACME
+							config; the operator points DNS at NASty.
+						</p>
+					{/if}
+				</div>
+
 				<!-- Allow unsafe — opt out of strict bind-mount sandbox -->
 				<div class="mb-4 rounded-md border border-border p-3">
 					<label class="flex items-start gap-2 cursor-pointer">
@@ -1657,7 +1748,7 @@
 					{#if editingApp}
 						<Button onclick={updateApp} disabled={!newImage}>Save</Button>
 					{:else}
-						<Button onclick={install} disabled={!newName || !newImage || !isValidAppName(newName)}>Install</Button>
+						<Button onclick={install} disabled={!newName || !newImage || !isValidAppName(newName) || !!newSubdomainConflict}>Install</Button>
 					{/if}
 					<Button variant="secondary" onclick={cancelEdit}>Cancel</Button>
 				</div>
@@ -1987,10 +2078,11 @@
 													<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; openShell(app.name); }}>Shell</button>
 												{/if}
 												<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; pullApp(app.name); }}>Pull image</button>
-												{#if getIngress(app.name)}
-													<!-- Only meaningful when ingress exists. Path-prefix mode is fine
-													     for most apps; this lets the operator opt into subdomain mode
-													     for things that emit absolute root-path assets (haze-class). -->
+												{#if app.ports?.some(p => p.protocol?.toLowerCase() === 'tcp')}
+													<!-- Always shown for apps with a TCP port. Lets the operator
+													     opt into / out of subdomain mode regardless of whether the
+													     current ingress is path-prefix, subdomain, or absent (the
+													     post-install probe disabled it for a haze-class app). -->
 													<button class="w-full px-3 py-1.5 text-left text-xs hover:bg-muted" onclick={() => { expanded[`menu-${app.name}`] = false; openSubdomainDialog(app.name); }}>Subdomain…</button>
 												{/if}
 												{#if app.kind === 'simple'}


### PR DESCRIPTION
## Summary

Two related gaps the haze install surfaced, both feeding into the same UX question: "how does the operator pick subdomain mode for this app?"

Before this PR:
- **Install form had no subdomain field.** The auto-ingress always picked path-prefix mode, and the post-install probe then disabled it for apps that emit absolute root-path assets (haze).
- **The per-app `···` → `Subdomain…` menu was gated on `getIngress(name)` being non-empty.** Probe-disabled apps had no ingress, so the menu item was *hidden* — operators of haze-class apps had no UI path to rescue them into subdomain mode without removing + reinstalling + manually setting an ingress, which the install form couldn't do either. Closed loop.

## Engine

- `InstallAppRequest` gains `subdomain: Option<String>`. `install()` threads it into the auto-`ingress_set` call and **skips the post-install probe** when set — subdomain mode roots the app at `/`, so the probe's "absolute-asset paths break path prefix" check can't trigger anyway.
- `deploy_simple` (the WS handler) now parses `install_params` **before** the image pull and runs the same subdomain conflict check the `apps.ingress.set` RPC uses (#231). Saves the operator a 60-second image download just to discover the chosen hostname is already in use.
- `apps.pull` (the recreate-after-image-pull path) now reads the existing ingress's subdomain from the manifest before reinstalling. Without this, every `apps.pull` would silently downgrade a subdomain-mode ingress to path-prefix — `AppConfig` doesn't carry the ingress shape and the `InstallAppRequest` reconstruction would have lost it.

## WebUI

- **Install form** gains a "Subdomain (optional)" input, live-checked against engine state with the same 300ms-debounced sequence-guard pattern from #231. Install button disabled when a conflict is reported. Empty = path-prefix mode + post-install probe (the historical default).
- **Per-app `···` → `Subdomain…` menu** drops the `getIngress` gate. Now shown for any app with at least one TCP port, regardless of whether the current ingress is path-prefix, subdomain, or absent. `openSubdomainDialog` falls back to the app's first TCP port when no current ingress exists, so `saveSubdomain` can synthesise a fresh ingress from a previously probe-disabled app.
- `saveSubdomain` no-ops on the "no current ingress + empty value" combination — creating a path-prefix ingress in that scenario would just be killed by the probe again and confuse the operator.

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 67 pass
- [x] `cargo test -p nasty-engine` — 50 pass
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` (svelte-check, 0 errors, 0 warnings)
- [ ] **Install with subdomain from day one**: install a fresh haze with Subdomain field set → confirm the auto-ingress is host-match, probe doesn't fire, app is reachable at the subdomain immediately.
- [ ] **Live conflict on install form**: type a subdomain that another app already uses → input goes amber + Install disabled + warning visible. Clear the input → controls re-enable.
- [ ] **Rescue an existing haze**: install haze without a subdomain (probe disables ingress, "Direct port only" badge appears). Open the `···` menu → "Subdomain…" is now visible → set a subdomain → save → ingress is created in subdomain mode, Open button now links to the subdomain.
- [ ] **apps.pull preserves subdomain**: set subdomain on an app, then trigger Pull image → confirm the subdomain still works (no silent downgrade to path-prefix).