### PR TITLE
webui: amber-highlight required fields across all create/install forms

### DIFF
--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -11,3 +11,18 @@ export type WithoutChild<T> = T extends { child?: any } ? Omit<T, "child"> : T;
 export type WithoutChildren<T> = T extends { children?: any } ? Omit<T, "children"> : T;
 export type WithoutChildrenOrChild<T> = WithoutChildren<WithoutChild<T>>;
 export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & { ref?: U | null };
+
+/**
+ * Tailwind class string that highlights a form input as "needs filling
+ * in before submit will work". Used on required fields across the
+ * WebUI so a disabled submit button gives the operator a per-input
+ * signal as to *which* fields are blocking — not just a greyed button
+ * with no explanation. Pass `true` when the value is empty or fails
+ * its inline validation; the consumer is responsible for picking what
+ * "empty" means (trim, falsy, etc.). Returns `''` when no decoration
+ * is wanted so callers can inline it in a class= attribute without
+ * a wrapping conditional.
+ */
+export function requiredFieldCls(missing: boolean): string {
+	return missing ? "border-amber-500 ring-1 ring-amber-500/50" : "";
+}

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -3,6 +3,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import { tempUnit, cToF, tempUnitLabel } from '$lib/temperature.svelte';
 	import type { AlertRule, ActiveAlert, AlertMetric, AlertCondition, AlertSeverity } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -154,8 +155,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Alert Rule</h3>
 			<div class="mb-4">
-				<Label for="rule-name">Name</Label>
-				<Input id="rule-name" bind:value={newName} placeholder="My alert rule" class="mt-1" />
+				<Label for="rule-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="rule-name" bind:value={newName} placeholder="My alert rule" class="mt-1 {requiredFieldCls(!newName)}" />
 			</div>
 			<div class="mb-4 flex gap-4">
 				<div class="flex-1">

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -4,6 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe } from '$lib/types';
 	import { formatBytes } from '$lib/format';
 	import { Button } from '$lib/components/ui/button';
@@ -1579,18 +1580,21 @@
 					{/if}
 				{/if}
 
+				{@const appNameMissing = !editingApp && !newName}
+				{@const appNameInvalid = !!newName && !isValidAppName(newName)}
+				{@const imageMissing = !editingApp && !newImage}
 				<div class="mb-4">
-					<Label for="app-name">App Name</Label>
-					<Input id="app-name" value={newName} oninput={(e) => { newName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="whoami" class="mt-1" disabled={!!editingApp} />
-					{#if newName && !isValidAppName(newName)}
+					<Label for="app-name">App Name {#if appNameMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="app-name" value={newName} oninput={(e) => { newName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="whoami" class="mt-1 {requiredFieldCls(appNameMissing || appNameInvalid)}" disabled={!!editingApp} />
+					{#if appNameInvalid}
 						<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, dots. Max 53 chars.</span>
 					{:else}
 						<span class="mt-1 block text-xs text-muted-foreground">Must be DNS-safe (lowercase, no spaces).</span>
 					{/if}
 				</div>
 				<div class="mb-4">
-					<Label for="app-image">Container Image</Label>
-					<Input id="app-image" bind:value={newImage} placeholder="traefik/whoami:latest" class="mt-1" onblur={inspectImage} />
+					<Label for="app-image">Container Image {#if imageMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="app-image" bind:value={newImage} placeholder="traefik/whoami:latest" class="mt-1 {requiredFieldCls(imageMissing)}" onblur={inspectImage} />
 					{#if inspecting}
 						<span class="mt-1 block text-xs text-muted-foreground">Detecting exposed ports...</span>
 					{:else if inspectMsg}
@@ -1766,24 +1770,27 @@
 					<Button variant="secondary" onclick={cancelEdit}>Cancel</Button>
 				</div>
 				{:else if installMode === 'compose' && (showCompose || editingCompose)}
+				{@const composeNameMissing = !editingCompose && !composeName}
+				{@const composeNameInvalid = !!composeName && !isValidAppName(composeName)}
+				{@const composeContentMissing = !composeContent.trim()}
 				<!-- Compose form: two columns at lg+ — form on the left, warnings + ingress picker on the right. -->
 				<div class="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)]">
 					<div>
 						<div class="mb-4">
-							<Label for="compose-name">App Name</Label>
-							<Input id="compose-name" value={composeName} oninput={(e) => { composeName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="my-stack" class="mt-1" disabled={!!editingCompose} />
-							{#if composeName && !isValidAppName(composeName)}
+							<Label for="compose-name">App Name {#if composeNameMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+							<Input id="compose-name" value={composeName} oninput={(e) => { composeName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="my-stack" class="mt-1 {requiredFieldCls(composeNameMissing || composeNameInvalid)}" disabled={!!editingCompose} />
+							{#if composeNameInvalid}
 								<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, dots. Max 53 chars.</span>
 							{/if}
 						</div>
 						<div class="mb-4">
-							<Label for="compose-file">docker-compose.yml</Label>
+							<Label for="compose-file">docker-compose.yml {#if composeContentMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 							<CodeEditor
 								bind:value={composeContent}
 								lang="yaml"
 								errorLines={composeErrorLines}
 								oninput={checkComposeConflicts}
-								class="mt-1 h-96"
+								class="mt-1 h-96 {composeContentMissing ? 'ring-1 ring-amber-500/50 rounded-md' : ''}"
 							/>
 						</div>
 						<!-- Allow unsafe — opt out of strict compose sandbox -->

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -4,6 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import { formatBytes } from '$lib/format';
 	import type { BackupProfile, BackupSnapshot, BackupStatus, Subvolume, Filesystem } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
@@ -380,12 +381,12 @@
 				<h3 class="text-lg font-semibold">New Backup Profile</h3>
 
 				<div>
-					<Label for="bk-name">Name</Label>
-					<Input id="bk-name" bind:value={newName} placeholder="Daily offsite" class="mt-1 max-w-sm" />
+					<Label for="bk-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="bk-name" bind:value={newName} placeholder="Daily offsite" class="mt-1 max-w-sm {requiredFieldCls(!newName)}" />
 				</div>
 
 				<div>
-					<Label>Sources</Label>
+					<Label>Sources {#if !newSources}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 					<div class="mt-1 space-y-1">
 						<!-- System config -->
 						<label class="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/30 {selectedSources.has('/var/lib/nasty') ? 'bg-muted/20' : ''}">
@@ -485,8 +486,8 @@
 				{/if}
 
 				<div>
-					<Label for="bk-pass">Encryption Password</Label>
-					<Input id="bk-pass" type="password" bind:value={newPassword} placeholder="strong-password" class="mt-1" />
+					<Label for="bk-pass">Encryption Password {#if !newPassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="bk-pass" type="password" bind:value={newPassword} placeholder="strong-password" class="mt-1 {requiredFieldCls(!newPassword)}" />
 					<p class="mt-1 text-xs text-muted-foreground">Used to encrypt the backup repository. Store this safely — losing it means losing access to backups.</p>
 				</div>
 

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -5,6 +5,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil } from '@lucide/svelte';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 
 	interface FileEntry {
 		name: string;
@@ -398,7 +399,7 @@
 {#if showMkdir}
 	<div class="mb-4 flex items-center gap-2">
 		<input type="text" bind:value={newDirName} placeholder="Folder name"
-			class="h-9 w-64 rounded-md border border-input bg-transparent px-3 text-sm"
+			class="h-9 w-64 rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newDirName.trim())}"
 			onkeydown={(e) => { if (e.key === 'Enter') createDir(); if (e.key === 'Escape') showMkdir = false; }} />
 		<Button size="sm" onclick={createDir} disabled={!newDirName.trim()}>Create</Button>
 		<Button variant="secondary" size="sm" onclick={() => showMkdir = false}>Cancel</Button>
@@ -502,7 +503,7 @@
 				<input
 					type="text"
 					bind:value={renameValue}
-					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm font-mono"
+					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm font-mono {requiredFieldCls(!renameValue.trim() || renameValue === renameTarget.name)}"
 					onkeydown={(e) => { if (e.key === 'Enter') confirmRename(); if (e.key === 'Escape') renameTarget = null; }}
 					autofocus
 				/>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { tempUnit } from '$lib/temperature.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import {
 		promoteOrphanedMembers,
 		validateDnsServer,
@@ -1105,8 +1106,8 @@
 					<p class="text-xs text-muted-foreground">Tag traffic on a physical interface with a VLAN ID.</p>
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label for="vlan-parent" class="text-xs text-muted-foreground">Parent Interface</label>
-							<select id="vlan-parent" bind:value={vlanParent} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm">
+							<label for="vlan-parent" class="text-xs text-muted-foreground">Parent Interface {#if !vlanParent}<span class="text-amber-500">required</span>{/if}</label>
+							<select id="vlan-parent" bind:value={vlanParent} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm {requiredFieldCls(!vlanParent)}">
 								<option value="">Select...</option>
 								{#if networkState}
 									{#each networkState.interfaces.filter(i => i.kind === 'physical' || i.kind === 'bond') as iface}

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -4,6 +4,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import {
 		iscsi,
 		iscsiToggleSort,
@@ -44,8 +45,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Target</h3>
 			<div class="mb-4">
-				<Label for="iscsi-device">Block Subvolume</Label>
-				<select id="iscsi-device" bind:value={iscsi.newDevice} onchange={iscsiOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+				<Label for="iscsi-device">Block Subvolume {#if !iscsi.newDevice}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="iscsi-device" bind:value={iscsi.newDevice} onchange={iscsiOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!iscsi.newDevice)}">
 					<option value="">Select a block subvolume...</option>
 					{#each iscsi.blockSubvolumes as sv}
 						<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -56,8 +57,8 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="iscsi-name">Target Name</Label>
-				<Input id="iscsi-name" bind:value={iscsi.newName} placeholder="dbserver" class="mt-1" />
+				<Label for="iscsi-name">Target Name {#if !iscsi.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="iscsi-name" bind:value={iscsi.newName} placeholder="dbserver" class="mt-1 {requiredFieldCls(!iscsi.newName)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">IQN: iqn.2137-01.com.nasty:{iscsi.newName || '...'}</span>
 			</div>
 			<Button onclick={iscsiCreate} disabled={!iscsi.newName || !iscsi.newDevice}>Create</Button>
@@ -139,8 +140,8 @@
 									{#if iscsi.addLunTarget === target.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Block Device or Subvolume</Label>
-												<select bind:value={iscsi.addLunPath} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
+												<Label class="text-xs">Block Device or Subvolume {#if !iscsi.addLunPath}<span class="text-amber-500">required</span>{/if}</Label>
+												<select bind:value={iscsi.addLunPath} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!iscsi.addLunPath)}">
 													<option value="">Select...</option>
 													{#each iscsi.blockSubvolumes as sv}
 														<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -186,8 +187,8 @@
 									{#if iscsi.addAclTarget === target.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Initiator IQN</Label>
-												<Input bind:value={iscsi.addAclIqn} placeholder="iqn.2024-01.com.client:initiator1" class="mt-1 h-8 text-xs" />
+												<Label class="text-xs">Initiator IQN {#if !iscsi.addAclIqn}<span class="text-amber-500">required</span>{/if}</Label>
+												<Input bind:value={iscsi.addAclIqn} placeholder="iqn.2024-01.com.client:initiator1" class="mt-1 h-8 text-xs {requiredFieldCls(!iscsi.addAclIqn)}" />
 											</div>
 											<div class="grid grid-cols-2 gap-2 mb-2">
 												<div>

--- a/webui/src/routes/sharing/NfsPanel.svelte
+++ b/webui/src/routes/sharing/NfsPanel.svelte
@@ -4,6 +4,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import {
 		nfs,
 		nfsToggleSort,
@@ -107,8 +108,8 @@
 							{#if nfs.addClientShare === share.id}
 								<div class="flex items-end gap-2">
 									<div>
-										<Label class="text-xs">Host / Network</Label>
-										<Input bind:value={nfs.addClientHost} placeholder="192.168.1.0/24" class="mt-1 h-8 w-44 text-xs" />
+										<Label class="text-xs">Host / Network {#if !nfs.addClientHost}<span class="text-amber-500">required</span>{/if}</Label>
+										<Input bind:value={nfs.addClientHost} placeholder="192.168.1.0/24" class="mt-1 h-8 w-44 text-xs {requiredFieldCls(!nfs.addClientHost)}" />
 									</div>
 									<div>
 										<Label class="text-xs">Options</Label>

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -5,6 +5,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import {
 		nvme,
 		nvmeToggleSort,
@@ -45,8 +46,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Share</h3>
 			<div class="mb-4">
-				<Label for="nvme-device">Block Subvolume</Label>
-				<select id="nvme-device" bind:value={nvme.newDevice} onchange={nvmeOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+				<Label for="nvme-device">Block Subvolume {#if !nvme.newDevice}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="nvme-device" bind:value={nvme.newDevice} onchange={nvmeOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!nvme.newDevice)}">
 					<option value="">Select a block subvolume...</option>
 					{#each nvme.blockSubvolumes as sv}
 						<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -57,8 +58,8 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="nvme-name">Share Name</Label>
-				<Input id="nvme-name" bind:value={nvme.newName} placeholder="faststore" class="mt-1" />
+				<Label for="nvme-name">Share Name {#if !nvme.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="nvme-name" bind:value={nvme.newName} placeholder="faststore" class="mt-1 {requiredFieldCls(!nvme.newName)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">NQN: nqn.2137.com.nasty:{nvme.newName || '...'}</span>
 			</div>
 			<div class="grid grid-cols-2 gap-4 mb-4">
@@ -135,8 +136,8 @@
 									{#if nvme.addNsSubsys === subsys.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Block Device</Label>
-												<select bind:value={nvme.addNsDevice} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
+												<Label class="text-xs">Block Device {#if !nvme.addNsDevice}<span class="text-amber-500">required</span>{/if}</Label>
+												<select bind:value={nvme.addNsDevice} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!nvme.addNsDevice)}">
 													<option value="">Select...</option>
 													{#each nvme.blockSubvolumes as sv}
 														<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -224,8 +225,8 @@
 									{#if nvme.addHostSubsys === subsys.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Host NQN</Label>
-												<Input bind:value={nvme.addHostNqn} placeholder="nqn.2024-01.com.client:host1" class="mt-1 h-8 text-xs" />
+												<Label class="text-xs">Host NQN {#if !nvme.addHostNqn}<span class="text-amber-500">required</span>{/if}</Label>
+												<Input bind:value={nvme.addHostNqn} placeholder="nqn.2024-01.com.client:host1" class="mt-1 h-8 text-xs {requiredFieldCls(!nvme.addHostNqn)}" />
 											</div>
 											<div class="flex gap-2">
 												<Button size="xs" onclick={nvmeAddHost} disabled={!nvme.addHostNqn}>Add</Button>

--- a/webui/src/routes/sharing/SmbPanel.svelte
+++ b/webui/src/routes/sharing/SmbPanel.svelte
@@ -8,6 +8,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import {
 		smb,
 		smbToggleSort,
@@ -56,8 +57,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Share</h3>
 			<div class="mb-4">
-				<Label for="smb-subvol">Subvolume</Label>
-				<select id="smb-subvol" bind:value={smb.newSubvolume} onchange={smbOnSubvolumeSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+				<Label for="smb-subvol">Subvolume {#if !smb.newSubvolume}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="smb-subvol" bind:value={smb.newSubvolume} onchange={smbOnSubvolumeSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!smb.newSubvolume)}">
 					<option value="">Select a subvolume...</option>
 					{#each smb.subvolumes as sv}
 						<option value={sv.path}>{sv.filesystem}/{sv.name} ({sv.path})</option>
@@ -69,8 +70,8 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="smb-name">Share Name</Label>
-				<Input id="smb-name" bind:value={smb.newName} placeholder="documents" class="mt-1" />
+				<Label for="smb-name">Share Name {#if !smb.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="smb-name" bind:value={smb.newName} placeholder="documents" class="mt-1 {requiredFieldCls(!smb.newName)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">Name visible to network clients</span>
 			</div>
 			<div class="mb-4">

--- a/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
@@ -7,6 +7,7 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import type { SmbGroup } from '$lib/types';
 	import { smb } from '$lib/sharing/smb.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 
 	interface Props {
 		name: string;
@@ -117,18 +118,19 @@
 			<Card class="mt-3 max-w-md">
 				<CardContent class="pt-4">
 					<h3 class="mb-4 text-lg font-semibold">New System User</h3>
+					{@const inlinePwMismatch = !!inlinePasswordConfirm && inlinePassword !== inlinePasswordConfirm}
 					<div class="mb-4">
-						<Label for="inline-username">Username</Label>
-						<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1" />
+						<Label for="inline-username">Username {#if !inlineUsername}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!inlineUsername)}" />
 					</div>
 					<div class="mb-4">
-						<Label for="inline-password">Password</Label>
-						<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1" />
+						<Label for="inline-password">Password {#if !inlinePassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePassword)}" />
 					</div>
 					<div class="mb-4">
-						<Label for="inline-password-confirm">Confirm Password</Label>
-						<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1" />
-						{#if inlinePasswordConfirm && inlinePassword !== inlinePasswordConfirm}
+						<Label for="inline-password-confirm">Confirm Password {#if !inlinePasswordConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePasswordConfirm || inlinePwMismatch)}" />
+						{#if inlinePwMismatch}
 							<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 						{/if}
 					</div>
@@ -150,7 +152,7 @@
 							{/each}
 							{#if showInlineGroupCreate}
 								<div class="flex items-center gap-1.5">
-									<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs" />
+									<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs {requiredFieldCls(!inlineGroupName.trim())}" />
 									<Button size="xs" disabled={!inlineGroupName.trim()} onclick={createInlineGroup}>Create</Button>
 									<Button size="xs" variant="secondary" onclick={() => showInlineGroupCreate = false}>Cancel</Button>
 								</div>

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -5,6 +5,7 @@
 	import { formatBytes } from '$lib/format';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import type { Filesystem, Subvolume, SubvolumeDependents, Snapshot, SubvolumeType, NfsShare, SmbShare, IscsiTarget, NvmeofSubsystem, App, AppsStatus, VmStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -775,8 +776,8 @@
 			{#if wizardStep === 1}
 			{#if mountedFilesystems.length > 1}
 				<div class="mb-4">
-					<Label for="sv-filesystem">Filesystem</Label>
-					<select id="sv-filesystem" bind:value={newFilesystem} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+					<Label for="sv-filesystem">Filesystem {#if !newFilesystem}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<select id="sv-filesystem" bind:value={newFilesystem} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newFilesystem)}">
 						{#each mountedFilesystems as p}
 							<option value={p.name}>{p.name}</option>
 						{/each}
@@ -784,8 +785,8 @@
 				</div>
 			{/if}
 			<div class="mb-4">
-				<Label for="sv-name">Name</Label>
-				<Input id="sv-name" bind:value={newName} placeholder="documents or projects/web" class="mt-1" />
+				<Label for="sv-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="sv-name" bind:value={newName} placeholder="documents or projects/web" class="mt-1 {requiredFieldCls(!newName)}" />
 				<p class="mt-1 text-xs text-muted-foreground">Use <span class="font-mono">/</span> for nested subvolumes (e.g. projects/web)</p>
 			</div>
 			<div class="mb-4">
@@ -1484,8 +1485,8 @@
 			<p class="text-sm text-muted-foreground">Create a read-only point-in-time copy.</p>
 		</Dialog.Header>
 		<div class="mb-4">
-			<Label for="snap-name">Snapshot Name</Label>
-			<Input id="snap-name" bind:value={snapName} placeholder="snap-2026-03-12" class="mt-1" />
+			<Label for="snap-name">Snapshot Name {#if !snapName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="snap-name" bind:value={snapName} placeholder="snap-2026-03-12" class="mt-1 {requiredFieldCls(!snapName)}" />
 		</div>
 		<Dialog.Footer>
 			<Button size="sm" onclick={createSnapshot} disabled={!snapName}>Create</Button>
@@ -1501,8 +1502,8 @@
 			<p class="text-sm text-muted-foreground">Create a writable copy (COW — instant, shares data until modified).</p>
 		</Dialog.Header>
 		<div class="mb-4">
-			<Label for="clone-name">Clone Name</Label>
-			<Input id="clone-name" bind:value={cloneName} placeholder="my-clone" class="mt-1" />
+			<Label for="clone-name">Clone Name {#if !cloneName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="clone-name" bind:value={cloneName} placeholder="my-clone" class="mt-1 {requiredFieldCls(!cloneName)}" />
 		</div>
 		<Dialog.Footer>
 			<Button size="sm" onclick={cloneSubvolume} disabled={!cloneName}>Create</Button>

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -3,6 +3,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import type { UserInfo, ApiTokenInfo, ApiTokenCreated, Filesystem, SmbGroup } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -372,18 +373,23 @@
 	<Card class="mb-6 max-w-md">
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New User</h3>
+			{@const newUserPwTooShort = !!newPassword && newPassword.length < 8}
+			{@const newUserPwMismatch = !!newPasswordConfirm && newPassword !== newPasswordConfirm}
 			<div class="mb-4">
-				<Label for="new-username">Username</Label>
-				<Input id="new-username" bind:value={newUsername} placeholder="johndoe" autocomplete="off" class="mt-1" />
+				<Label for="new-username">Username {#if !newUsername}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-username" bind:value={newUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!newUsername)}" />
 			</div>
 			<div class="mb-4">
-				<Label for="new-password">Password</Label>
-				<Input id="new-password" type="password" bind:value={newPassword} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1" />
+				<Label for="new-password">Password {#if !newPassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-password" type="password" bind:value={newPassword} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPassword || newUserPwTooShort)}" />
+				{#if newUserPwTooShort}
+					<span class="mt-1 block text-xs text-destructive">At least 8 characters required</span>
+				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="new-password-confirm">Confirm Password</Label>
-				<Input id="new-password-confirm" type="password" bind:value={newPasswordConfirm} autocomplete="new-password" class="mt-1" />
-				{#if newPasswordConfirm && newPassword !== newPasswordConfirm}
+				<Label for="new-password-confirm">Confirm Password {#if !newPasswordConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-password-confirm" type="password" bind:value={newPasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPasswordConfirm || newUserPwMismatch)}" />
+				{#if newUserPwMismatch}
 					<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 				{/if}
 			</div>
@@ -574,14 +580,15 @@
 		<Dialog.Header>
 			<Dialog.Title>Change Password for "{sysPwUser}"</Dialog.Title>
 		</Dialog.Header>
+		{@const sysPwMismatch = !!sysPwConfirm && sysPwNew !== sysPwConfirm}
 		<div class="mb-4">
-			<Label for="sys-pw-new">New Password</Label>
-			<Input id="sys-pw-new" type="password" bind:value={sysPwNew} autocomplete="new-password" class="mt-1" />
+			<Label for="sys-pw-new">New Password {#if !sysPwNew}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="sys-pw-new" type="password" bind:value={sysPwNew} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwNew)}" />
 		</div>
 		<div class="mb-4">
-			<Label for="sys-pw-confirm">Confirm Password</Label>
-			<Input id="sys-pw-confirm" type="password" bind:value={sysPwConfirm} autocomplete="new-password" class="mt-1" />
-			{#if sysPwConfirm && sysPwNew !== sysPwConfirm}
+			<Label for="sys-pw-confirm">Confirm Password {#if !sysPwConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="sys-pw-confirm" type="password" bind:value={sysPwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwConfirm || sysPwMismatch)}" />
+			{#if sysPwMismatch}
 				<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 			{/if}
 		</div>
@@ -610,8 +617,8 @@
 	<Card class="mb-4 max-w-md">
 		<CardContent class="pt-4 space-y-3">
 			<div>
-				<Label for="group-name">Group Name</Label>
-				<Input id="group-name" bind:value={newGroupName} placeholder="e.g. engineering" class="mt-1" />
+				<Label for="group-name">Group Name {#if !newGroupName.trim()}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="group-name" bind:value={newGroupName} placeholder="e.g. engineering" class="mt-1 {requiredFieldCls(!newGroupName.trim())}" />
 			</div>
 			<Button size="sm" onclick={createGroup} disabled={!newGroupName.trim()}>Create</Button>
 		</CardContent>
@@ -699,8 +706,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New API Token</h3>
 			<div class="mb-4">
-				<Label for="token-name">Name</Label>
-				<Input id="token-name" bind:value={newTokenName} placeholder="e.g. k8s-cluster" autocomplete="off" class="mt-1" />
+				<Label for="token-name">Name {#if !newTokenName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="token-name" bind:value={newTokenName} placeholder="e.g. k8s-cluster" autocomplete="off" class="mt-1 {requiredFieldCls(!newTokenName)}" />
 			</div>
 			<div class="mb-4">
 				<Label for="token-role">Role</Label>
@@ -793,14 +800,19 @@
 		<Dialog.Header>
 			<Dialog.Title>Change Password for "{pwUser}"</Dialog.Title>
 		</Dialog.Header>
+		{@const pwTooShort = !!pwNew && pwNew.length < 8}
+		{@const pwMismatch = !!pwConfirm && pwNew !== pwConfirm}
 		<div class="mb-4">
-			<Label for="pw-new">New Password</Label>
-			<Input id="pw-new" type="password" bind:value={pwNew} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1" />
+			<Label for="pw-new">New Password {#if !pwNew}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="pw-new" type="password" bind:value={pwNew} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwNew || pwTooShort)}" />
+			{#if pwTooShort}
+				<span class="mt-1 block text-xs text-destructive">At least 8 characters required</span>
+			{/if}
 		</div>
 		<div class="mb-4">
-			<Label for="pw-confirm">Confirm Password</Label>
-			<Input id="pw-confirm" type="password" bind:value={pwConfirm} autocomplete="new-password" class="mt-1" />
-			{#if pwConfirm && pwNew !== pwConfirm}
+			<Label for="pw-confirm">Confirm Password {#if !pwConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="pw-confirm" type="password" bind:value={pwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwConfirm || pwMismatch)}" />
+			{#if pwMismatch}
 				<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 			{/if}
 		</div>

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -4,6 +4,7 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
 	import type { VmStatus, VmCapabilities, Subvolume, FsDependents, NetworkState, UsbPassthrough, HardwareSummary, UsbDevice } from '$lib/types';
 	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { Button } from '$lib/components/ui/button';
@@ -1050,8 +1051,8 @@
 			<!-- Step 1: General -->
 			{:else if wizardStep === 1}
 			<div class="mb-4">
-				<Label for="vm-name">Name</Label>
-				<Input id="vm-name" bind:value={newName} placeholder="my-vm" class="mt-1" />
+				<Label for="vm-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="vm-name" bind:value={newName} placeholder="my-vm" class="mt-1 {requiredFieldCls(!newName)}" />
 			</div>
 			<div class="mb-4">
 				<Label for="vm-desc">Description</Label>


### PR DESCRIPTION
## Summary

Reported on the apps Install dialog: pasting a docker run command without \`--name\` left App Name empty, Install greyed out, no signal as to *which* field was blocking. Same UX gap across the rest of the WebUI — ~20 disabled submit buttons all gave the operator zero hint about what was missing.

Add a tiny \`requiredFieldCls(missing)\` helper in \`\$lib/utils\` that returns Tailwind amber border + ring classes, plus a uniform \`required\` chip in each Label. Applied across every create/install form whose submit button is gated on a required field being empty/invalid.

## Coverage

| Page | Form | Required fields decorated |
|---|---|---|
| Apps | Install | App Name, Container Image (subdomain conflict already amber from #231) |
| Apps | Compose | App Name, \`docker-compose.yml\` |
| Backups | Create profile | Name, Sources, Encryption Password |
| Users | New User | Username, Password (+ min-8), Confirm (+ mismatch) |
| Users | Change Password | New (+ min-8), Confirm (+ mismatch) |
| Users | Change System Password | New, Confirm (+ mismatch) |
| Users | Create Group | Name |
| Users | Create Token | Name |
| VMs | Wizard | Name |
| Subvolumes | Wizard | Filesystem, Name |
| Subvolumes | Snapshot | Name |
| Subvolumes | Clone | Name |
| Alerts | Create Rule | Name |
| Files | Create Folder | Name |
| Files | Rename | Name (non-empty + must change) |
| Settings | Create VLAN | Parent Interface |
| Sharing — NFS | Add Client | Host / Network |
| Sharing — SMB | Create Share | Subvolume, Share Name |
| Sharing — iSCSI | Create Target | Block Subvolume, Target Name |
| Sharing — iSCSI | Add LUN | Block Device |
| Sharing — iSCSI | Add ACL | Initiator IQN |
| Sharing — NVMe-oF | Create Share | Block Subvolume, Share Name |
| Sharing — NVMe-oF | Add Namespace | Block Device |
| Sharing — NVMe-oF | Add Host | Host NQN |
| Sharing — SMB Wizard | Inline create Group / User | Group name, Username, Password, Confirm |

## Design notes

- **Helper takes a plain boolean** (\`missing\`) so each call site controls what "missing" means (trim, falsy, mismatch, \`length < 8\`, etc.) — the helper just renders the visual treatment, doesn't model validation.
- **Edit flows are exempt** — fields pre-fill from existing config; decorating amber there would be a false alarm.
- **Optional fields stay plain** (Comments, CHAP credentials, app Resource Limits, etc.).
- **Validation messages stay where they were**. Amber border is the upfront "this is blocking submit" hint; the existing red inline message ("Passwords do not match", "Must be lowercase letters…") still explains the specific failure when relevant.

## Test plan

- [x] \`npm run check\` (svelte-check, 0 errors, 0 warnings)
- [ ] Walk every form in the table above with the form in its initial state: confirm amber borders on the listed fields and "required" chips in the labels.
- [ ] Type a valid value into each: amber decoration disappears, submit enables.
- [ ] Edit App / open a pre-filled rename → no amber treatment (false-alarm guard).