### PR TITLE
webui: defer required-field amber until submit is clicked

### DIFF
--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -15,14 +15,21 @@ export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & { ref?:
 /**
  * Tailwind class string that highlights a form input as "needs filling
  * in before submit will work". Used on required fields across the
- * WebUI so a disabled submit button gives the operator a per-input
- * signal as to *which* fields are blocking — not just a greyed button
- * with no explanation. Pass `true` when the value is empty or fails
- * its inline validation; the consumer is responsible for picking what
- * "empty" means (trim, falsy, etc.). Returns `''` when no decoration
- * is wanted so callers can inline it in a class= attribute without
- * a wrapping conditional.
+ * WebUI so a submit attempt with a missing field gives the operator a
+ * per-input signal as to *which* fields are blocking — instead of a
+ * silent greyed button.
+ *
+ * `tried` defers the decoration until the operator has tried to
+ * submit at least once. Without that gate, every form opens with
+ * every required field lit up amber which reads like an alarm before
+ * the operator has done anything (reported). The expected pattern is
+ * "clean on open → amber after a failed Install click → clean again
+ * once filled in". Default is `true` so call sites that want the
+ * always-on behaviour don't have to pass it.
+ *
+ * `missing` is computed by the call site — the helper doesn't model
+ * what "missing" means (trim? falsy? mismatch? wrong format?).
  */
-export function requiredFieldCls(missing: boolean): string {
-	return missing ? "border-amber-500 ring-1 ring-amber-500/50" : "";
+export function requiredFieldCls(missing: boolean, tried: boolean = true): string {
+	return tried && missing ? "border-amber-500 ring-1 ring-amber-500/50" : "";
 }

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -18,6 +18,7 @@
 	let showCreate = $state(false);
 
 	let newName = $state('');
+	let createTried = $state(false);
 	let newMetric = $state<AlertMetric>('fs_usage_percent');
 	let newCondition = $state<AlertCondition>('above');
 	let newThreshold = $state(80);
@@ -76,7 +77,8 @@
 	}
 
 	async function createRule() {
-		if (!newName) return;
+		if (!newName) { createTried = true; return; }
+		createTried = false;
 		// disk_temperature thresholds are stored in Celsius. If the user is
 		// viewing Fahrenheit, the value typed in the input is in °F — convert
 		// before sending so the alert evaluator sees the canonical unit.
@@ -99,6 +101,7 @@
 		if (ok !== undefined) {
 			showCreate = false;
 			newName = '';
+			createTried = false;
 			newThreshold = 80;
 			await refresh();
 		}
@@ -155,8 +158,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Alert Rule</h3>
 			<div class="mb-4">
-				<Label for="rule-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="rule-name" bind:value={newName} placeholder="My alert rule" class="mt-1 {requiredFieldCls(!newName)}" />
+				<Label for="rule-name">Name {#if !newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="rule-name" bind:value={newName} placeholder="My alert rule" class="mt-1 {requiredFieldCls(!newName, createTried)}" />
 			</div>
 			<div class="mb-4 flex gap-4">
 				<div class="flex-1">
@@ -189,7 +192,7 @@
 					</select>
 				</div>
 			</div>
-			<Button onclick={createRule} disabled={!newName}>Create</Button>
+			<Button onclick={createRule}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -303,6 +303,13 @@
 	let newAllowUnsafe = $state(false);
 	/** Same flag, separate state for the compose dialog. */
 	let composeAllowUnsafe = $state(false);
+	/** Has the operator clicked Install / Deploy on this form at least
+	 * once? Gates the amber required-field decoration so a fresh form
+	 * opens clean rather than lit up with "required" everywhere. Set
+	 * true by the submit handlers when a required field is empty;
+	 * cleared by resetForm / cancelCompose. */
+	let installTried = $state(false);
+	let composeTried = $state(false);
 	let inspecting = $state(false);
 	let lastInspectedImage = '';
 	/** Inline status from the last apps.inspect_image call so the user sees
@@ -876,7 +883,12 @@
 	}
 
 	async function install() {
-		if (!newName || !newImage) return;
+		// Flip the "tried" gate before bailing on missing fields so the
+		// amber required-field decoration shows up exactly when the
+		// operator expects: after they clicked Install and it didn't
+		// proceed, never before.
+		if (!newName || !newImage) { installTried = true; return; }
+		installTried = false;
 		if (!await waitForDocker()) return;
 		const appName = newName.toLowerCase();
 		if (!isValidAppName(appName)) {
@@ -1024,6 +1036,7 @@
 		newAllowUnsafe = false;
 		newSubdomain = '';
 		newSubdomainConflict = '';
+		installTried = false;
 		lastInspectedImage = '';
 		subpathRecipe = null;
 	}
@@ -1185,7 +1198,8 @@
 
 	// Compose functions
 	async function installCompose() {
-		if (!composeName || !composeContent.trim()) return;
+		if (!composeName || !composeContent.trim()) { composeTried = true; return; }
+		composeTried = false;
 		if (!await waitForDocker()) return;
 		const name = composeName.toLowerCase();
 		if (!isValidAppName(name)) {
@@ -1202,7 +1216,7 @@
 		if (ok) {
 			showCompose = false;
 			editingCompose = null;
-			composeName = ''; composeContent = '';
+			composeName = ''; composeContent = ''; composeTried = false;
 			composeAllowUnsafe = false;
 		}
 		await refresh();
@@ -1236,7 +1250,7 @@
 		volumeMismatches = [];
 		composeTcpPorts = [];
 		newIngressPort = null;
-		composeName = ''; composeContent = '';
+		composeName = ''; composeContent = ''; composeTried = false;
 		composeAllowUnsafe = false;
 	}
 
@@ -1580,9 +1594,14 @@
 					{/if}
 				{/if}
 
-				{@const appNameMissing = !editingApp && !newName}
+				<!-- "Missing required" decoration is gated on installTried so the
+				     form opens clean and only goes amber after the operator
+				     hits Install with an empty field. The invalid-format
+				     check stays always-on (user just typed something wrong,
+				     they want to know immediately). -->
+				{@const appNameMissing = !editingApp && !newName && installTried}
 				{@const appNameInvalid = !!newName && !isValidAppName(newName)}
-				{@const imageMissing = !editingApp && !newImage}
+				{@const imageMissing = !editingApp && !newImage && installTried}
 				<div class="mb-4">
 					<Label for="app-name">App Name {#if appNameMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 					<Input id="app-name" value={newName} oninput={(e) => { newName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="whoami" class="mt-1 {requiredFieldCls(appNameMissing || appNameInvalid)}" disabled={!!editingApp} />
@@ -1765,14 +1784,22 @@
 					{#if editingApp}
 						<Button onclick={updateApp} disabled={!newImage}>Save</Button>
 					{:else}
-						<Button onclick={install} disabled={!newName || !newImage || !isValidAppName(newName) || !!newSubdomainConflict}>Install</Button>
+						<!-- Install stays enabled even when required fields are empty
+						     so clicking it triggers the amber decoration. Real
+						     blockers (invalid name format, subdomain conflict) keep
+						     it disabled — those are user-correctable but should never
+						     reach the server. -->
+						<Button onclick={install} disabled={(!!newName && !isValidAppName(newName)) || !!newSubdomainConflict}>Install</Button>
 					{/if}
 					<Button variant="secondary" onclick={cancelEdit}>Cancel</Button>
 				</div>
 				{:else if installMode === 'compose' && (showCompose || editingCompose)}
-				{@const composeNameMissing = !editingCompose && !composeName}
+				<!-- composeTried gates the amber treatment so the form opens
+				     clean. composeNameInvalid stays always-on because that's
+				     "you typed something invalid", not "you forgot a field". -->
+				{@const composeNameMissing = !editingCompose && !composeName && composeTried}
 				{@const composeNameInvalid = !!composeName && !isValidAppName(composeName)}
-				{@const composeContentMissing = !composeContent.trim()}
+				{@const composeContentMissing = !composeContent.trim() && composeTried}
 				<!-- Compose form: two columns at lg+ — form on the left, warnings + ingress picker on the right. -->
 				<div class="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)]">
 					<div>
@@ -1815,7 +1842,7 @@
 							{/if}
 						</div>
 						<div class="flex gap-2">
-							<Button onclick={installCompose} disabled={!composeName || !composeContent.trim() || (!editingCompose && !isValidAppName(composeName))}>
+							<Button onclick={installCompose} disabled={!editingCompose && !!composeName && !isValidAppName(composeName)}>
 								{editingCompose ? 'Update' : 'Deploy'}
 							</Button>
 							<Button variant="secondary" onclick={cancelCompose}>Cancel</Button>

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -24,6 +24,9 @@
 	// Create form
 	let newName = $state('');
 	let newSources = $state('');
+	/** Has Create been clicked at least once on this open form? Gates
+	 * the amber required-field decoration so the form opens clean. */
+	let createTried = $state(false);
 	let newTargetType: 'local' | 's3' | 'sftp' | 'rest' | 'b2' = $state('local');
 	let newLocalPath = $state('');
 	let newS3Endpoint = $state(''); let newS3Region = $state(''); let newS3Bucket = $state(''); let newS3Key = $state(''); let newS3Secret = $state('');
@@ -58,6 +61,7 @@
 	function resetCreateForm() {
 		newName = '';
 		newSources = '';
+		createTried = false;
 		newTargetType = 'local';
 		newLocalPath = '';
 		newS3Endpoint = '';
@@ -218,6 +222,8 @@
 	}
 
 	async function createProfile() {
+		if (!newName || !newSources || !newPassword) { createTried = true; return; }
+		createTried = false;
 		const target = newTargetType === 'local' ? { type: 'local' as const, path: newLocalPath }
 			: newTargetType === 's3' ? { type: 's3' as const, endpoint: newS3Endpoint, region: newS3Region || undefined, bucket: newS3Bucket, access_key: newS3Key, secret_key: newS3Secret }
 			: newTargetType === 'sftp' ? { type: 'sftp' as const, host: newSftpHost, user: newSftpUser, path: newSftpPath, port: parseInt(newSftpPort) || undefined }
@@ -381,12 +387,12 @@
 				<h3 class="text-lg font-semibold">New Backup Profile</h3>
 
 				<div>
-					<Label for="bk-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-					<Input id="bk-name" bind:value={newName} placeholder="Daily offsite" class="mt-1 max-w-sm {requiredFieldCls(!newName)}" />
+					<Label for="bk-name">Name {#if !newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="bk-name" bind:value={newName} placeholder="Daily offsite" class="mt-1 max-w-sm {requiredFieldCls(!newName, createTried)}" />
 				</div>
 
 				<div>
-					<Label>Sources {#if !newSources}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Label>Sources {#if !newSources && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 					<div class="mt-1 space-y-1">
 						<!-- System config -->
 						<label class="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/30 {selectedSources.has('/var/lib/nasty') ? 'bg-muted/20' : ''}">
@@ -486,8 +492,8 @@
 				{/if}
 
 				<div>
-					<Label for="bk-pass">Encryption Password {#if !newPassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-					<Input id="bk-pass" type="password" bind:value={newPassword} placeholder="strong-password" class="mt-1 {requiredFieldCls(!newPassword)}" />
+					<Label for="bk-pass">Encryption Password {#if !newPassword && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="bk-pass" type="password" bind:value={newPassword} placeholder="strong-password" class="mt-1 {requiredFieldCls(!newPassword, createTried)}" />
 					<p class="mt-1 text-xs text-muted-foreground">Used to encrypt the backup repository. Store this safely — losing it means losing access to backups.</p>
 				</div>
 
@@ -519,7 +525,10 @@
 					</div>
 				</div>
 
-				<Button onclick={createProfile} disabled={!newName || !newSources || !newPassword}>Create</Button>
+				<!-- Stays enabled so clicking Create triggers the amber decoration
+				     on whichever required field is missing. The handler validates
+				     before calling the server. -->
+				<Button onclick={createProfile}>Create</Button>
 			</CardContent>
 		</Card>
 	{/if}

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -123,6 +123,7 @@
 	// Mkdir state
 	let showMkdir = $state(false);
 	let newDirName = $state('');
+	let mkdirTried = $state(false);
 
 	// Delete confirmation
 	let deleteTarget: FileEntry | null = $state(null);
@@ -130,6 +131,7 @@
 	// Rename inline
 	let renameTarget: FileEntry | null = $state(null);
 	let renameValue = $state('');
+	let renameTried = $state(false);
 
 	// Edit (text files in the preview modal)
 	let editing = $state(false);
@@ -248,7 +250,8 @@
 	}
 
 	async function createDir() {
-		if (!newDirName.trim()) return;
+		if (!newDirName.trim()) { mkdirTried = true; return; }
+		mkdirTried = false;
 		const path = currentPath ? `${currentPath}/${newDirName.trim()}` : newDirName.trim();
 		const res = await fetch(`/api/files/mkdir?path=${encodeURIComponent(path)}`, {
 			method: 'POST',
@@ -260,6 +263,7 @@
 		}
 		showMkdir = false;
 		newDirName = '';
+		mkdirTried = false;
 		await browse(currentPath);
 	}
 
@@ -286,9 +290,10 @@
 		if (!renameTarget) return;
 		const newName = renameValue.trim();
 		if (!newName || newName === renameTarget.name) {
-			renameTarget = null;
+			renameTried = true;
 			return;
 		}
+		renameTried = false;
 		if (newName.includes('/')) {
 			alert('Name cannot contain slashes — use this directory only.');
 			return;
@@ -307,6 +312,7 @@
 		}
 		renameTarget = null;
 		renameValue = '';
+		renameTried = false;
 		await browse(currentPath);
 	}
 
@@ -399,9 +405,9 @@
 {#if showMkdir}
 	<div class="mb-4 flex items-center gap-2">
 		<input type="text" bind:value={newDirName} placeholder="Folder name"
-			class="h-9 w-64 rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newDirName.trim())}"
+			class="h-9 w-64 rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newDirName.trim(), mkdirTried)}"
 			onkeydown={(e) => { if (e.key === 'Enter') createDir(); if (e.key === 'Escape') showMkdir = false; }} />
-		<Button size="sm" onclick={createDir} disabled={!newDirName.trim()}>Create</Button>
+		<Button size="sm" onclick={createDir}>Create</Button>
 		<Button variant="secondary" size="sm" onclick={() => showMkdir = false}>Cancel</Button>
 	</div>
 {/if}
@@ -503,12 +509,12 @@
 				<input
 					type="text"
 					bind:value={renameValue}
-					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm font-mono {requiredFieldCls(!renameValue.trim() || renameValue === renameTarget.name)}"
+					class="mb-4 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm font-mono {requiredFieldCls(!renameValue.trim() || renameValue === renameTarget.name, renameTried)}"
 					onkeydown={(e) => { if (e.key === 'Enter') confirmRename(); if (e.key === 'Escape') renameTarget = null; }}
 					autofocus
 				/>
 				<div class="flex gap-2">
-					<Button onclick={confirmRename} disabled={!renameValue.trim() || renameValue === renameTarget.name}>Rename</Button>
+					<Button onclick={confirmRename}>Rename</Button>
 					<Button variant="secondary" onclick={() => { renameTarget = null; renameValue = ''; }}>Cancel</Button>
 				</div>
 			</CardContent>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -65,6 +65,7 @@
 	// VLAN form
 	let showVlanForm = $state(false);
 	let vlanParent = $state('');
+	let vlanTried = $state(false);
 	let vlanId = $state(100);
 	let vlanMtu = $state('');
 	// Bridge form
@@ -456,7 +457,9 @@
 	}
 
 	async function createVlan() {
-		if (!vlanParent || vlanId < 1 || vlanId > 4094 || !network) return;
+		if (!vlanParent) { vlanTried = true; return; }
+		if (vlanId < 1 || vlanId > 4094 || !network) return;
+		vlanTried = false;
 		const mtu = parseMtu(vlanMtu);
 		const payload: NetworkConfig = {
 			interfaces: network.interfaces || [],
@@ -467,7 +470,7 @@
 		};
 		await applyNetworkUpdate(payload, `VLAN ${vlanParent}.${vlanId} created`);
 		networkState = await client.call<NetworkState>('system.network.get');
-		showVlanForm = false; vlanParent = ''; vlanId = 100; vlanMtu = '';
+		showVlanForm = false; vlanParent = ''; vlanId = 100; vlanMtu = ''; vlanTried = false;
 	}
 
 	async function refreshNetworkState() {
@@ -1106,8 +1109,8 @@
 					<p class="text-xs text-muted-foreground">Tag traffic on a physical interface with a VLAN ID.</p>
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label for="vlan-parent" class="text-xs text-muted-foreground">Parent Interface {#if !vlanParent}<span class="text-amber-500">required</span>{/if}</label>
-							<select id="vlan-parent" bind:value={vlanParent} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm {requiredFieldCls(!vlanParent)}">
+							<label for="vlan-parent" class="text-xs text-muted-foreground">Parent Interface {#if !vlanParent && vlanTried}<span class="text-amber-500">required</span>{/if}</label>
+							<select id="vlan-parent" bind:value={vlanParent} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm {requiredFieldCls(!vlanParent, vlanTried)}">
 								<option value="">Select...</option>
 								{#if networkState}
 									{#each networkState.interfaces.filter(i => i.kind === 'physical' || i.kind === 'bond') as iface}
@@ -1125,7 +1128,7 @@
 						<label for="vlan-mtu" class="text-xs text-muted-foreground">MTU (optional)</label>
 						<input id="vlan-mtu" type="number" min="68" max="65535" bind:value={vlanMtu} placeholder="default (1500), 9000 for jumbo frames" class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono" />
 					</div>
-					<Button size="sm" onclick={createVlan} disabled={!vlanParent}>Create VLAN</Button>
+					<Button size="sm" onclick={createVlan}>Create VLAN</Button>
 				</div>
 			{/if}
 

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -20,6 +20,28 @@
 
 	$effect(() => { if (iscsi.showCreate || iscsi.addLunTarget) iscsiLoadSubvolumes(); });
 
+	// Per-form "tried" flags — defer amber required-field decoration
+	// until each submit button is clicked at least once.
+	let createTried = $state(false);
+	let addLunTried = $state(false);
+	let addAclTried = $state(false);
+
+	async function iscsiCreateGuarded() {
+		if (!iscsi.newName || !iscsi.newDevice) { createTried = true; return; }
+		createTried = false;
+		await iscsiCreate();
+	}
+	async function iscsiAddLunGuarded() {
+		if (!iscsi.addLunPath) { addLunTried = true; return; }
+		addLunTried = false;
+		await iscsiAddLun();
+	}
+	async function iscsiAddAclGuarded() {
+		if (!iscsi.addAclIqn) { addAclTried = true; return; }
+		addAclTried = false;
+		await iscsiAddAcl();
+	}
+
 	const iscsiFiltered = $derived(
 		iscsi.search.trim()
 			? iscsi.targets.filter(t =>
@@ -45,8 +67,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Target</h3>
 			<div class="mb-4">
-				<Label for="iscsi-device">Block Subvolume {#if !iscsi.newDevice}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<select id="iscsi-device" bind:value={iscsi.newDevice} onchange={iscsiOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!iscsi.newDevice)}">
+				<Label for="iscsi-device">Block Subvolume {#if !iscsi.newDevice && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="iscsi-device" bind:value={iscsi.newDevice} onchange={iscsiOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!iscsi.newDevice, createTried)}">
 					<option value="">Select a block subvolume...</option>
 					{#each iscsi.blockSubvolumes as sv}
 						<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -57,11 +79,11 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="iscsi-name">Target Name {#if !iscsi.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="iscsi-name" bind:value={iscsi.newName} placeholder="dbserver" class="mt-1 {requiredFieldCls(!iscsi.newName)}" />
+				<Label for="iscsi-name">Target Name {#if !iscsi.newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="iscsi-name" bind:value={iscsi.newName} placeholder="dbserver" class="mt-1 {requiredFieldCls(!iscsi.newName, createTried)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">IQN: iqn.2137-01.com.nasty:{iscsi.newName || '...'}</span>
 			</div>
-			<Button onclick={iscsiCreate} disabled={!iscsi.newName || !iscsi.newDevice}>Create</Button>
+			<Button onclick={iscsiCreateGuarded}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -140,8 +162,8 @@
 									{#if iscsi.addLunTarget === target.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Block Device or Subvolume {#if !iscsi.addLunPath}<span class="text-amber-500">required</span>{/if}</Label>
-												<select bind:value={iscsi.addLunPath} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!iscsi.addLunPath)}">
+												<Label class="text-xs">Block Device or Subvolume {#if !iscsi.addLunPath && addLunTried}<span class="text-amber-500">required</span>{/if}</Label>
+												<select bind:value={iscsi.addLunPath} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!iscsi.addLunPath, addLunTried)}">
 													<option value="">Select...</option>
 													{#each iscsi.blockSubvolumes as sv}
 														<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -157,8 +179,8 @@
 												</select>
 											</div>
 											<div class="flex gap-2">
-												<Button size="xs" onclick={iscsiAddLun} disabled={!iscsi.addLunPath}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { iscsi.addLunTarget = ''; }}>Cancel</Button>
+												<Button size="xs" onclick={iscsiAddLunGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { iscsi.addLunTarget = ''; addLunTried = false; }}>Cancel</Button>
 											</div>
 										</div>
 									{:else}
@@ -187,8 +209,8 @@
 									{#if iscsi.addAclTarget === target.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Initiator IQN {#if !iscsi.addAclIqn}<span class="text-amber-500">required</span>{/if}</Label>
-												<Input bind:value={iscsi.addAclIqn} placeholder="iqn.2024-01.com.client:initiator1" class="mt-1 h-8 text-xs {requiredFieldCls(!iscsi.addAclIqn)}" />
+												<Label class="text-xs">Initiator IQN {#if !iscsi.addAclIqn && addAclTried}<span class="text-amber-500">required</span>{/if}</Label>
+												<Input bind:value={iscsi.addAclIqn} placeholder="iqn.2024-01.com.client:initiator1" class="mt-1 h-8 text-xs {requiredFieldCls(!iscsi.addAclIqn, addAclTried)}" />
 											</div>
 											<div class="grid grid-cols-2 gap-2 mb-2">
 												<div>
@@ -201,8 +223,8 @@
 												</div>
 											</div>
 											<div class="flex gap-2">
-												<Button size="xs" onclick={iscsiAddAcl} disabled={!iscsi.addAclIqn}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { iscsi.addAclTarget = ''; }}>Cancel</Button>
+												<Button size="xs" onclick={iscsiAddAclGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { iscsi.addAclTarget = ''; addAclTried = false; }}>Cancel</Button>
 											</div>
 										</div>
 									{:else}

--- a/webui/src/routes/sharing/NfsPanel.svelte
+++ b/webui/src/routes/sharing/NfsPanel.svelte
@@ -17,6 +17,18 @@
 
 	$effect(() => { if (nfs.showCreate) nfsLoadSubvolumes(); });
 
+	/** Per-panel "tried Add" flag — defers the amber required-field
+	 * decoration until the operator has clicked Add at least once
+	 * with the host field empty. Reset when the Add Client panel
+	 * collapses (showAddClientShare is cleared elsewhere). */
+	let addClientTried = $state(false);
+
+	async function nfsAddClickHost(share: Parameters<typeof nfsAddClient>[0]) {
+		if (!nfs.addClientHost) { addClientTried = true; return; }
+		addClientTried = false;
+		await nfsAddClient(share);
+	}
+
 	const nfsFiltered = $derived(
 		nfs.search.trim()
 			? nfs.shares.filter(s =>
@@ -108,15 +120,15 @@
 							{#if nfs.addClientShare === share.id}
 								<div class="flex items-end gap-2">
 									<div>
-										<Label class="text-xs">Host / Network {#if !nfs.addClientHost}<span class="text-amber-500">required</span>{/if}</Label>
-										<Input bind:value={nfs.addClientHost} placeholder="192.168.1.0/24" class="mt-1 h-8 w-44 text-xs {requiredFieldCls(!nfs.addClientHost)}" />
+										<Label class="text-xs">Host / Network {#if !nfs.addClientHost && addClientTried}<span class="text-amber-500">required</span>{/if}</Label>
+										<Input bind:value={nfs.addClientHost} placeholder="192.168.1.0/24" class="mt-1 h-8 w-44 text-xs {requiredFieldCls(!nfs.addClientHost, addClientTried)}" />
 									</div>
 									<div>
 										<Label class="text-xs">Options</Label>
 										<Input bind:value={nfs.addClientOptions} class="mt-1 h-8 w-56 text-xs" />
 									</div>
-									<Button size="xs" onclick={() => nfsAddClient(share)} disabled={!nfs.addClientHost}>Add</Button>
-									<Button variant="secondary" size="xs" onclick={() => { nfs.addClientShare = null; nfs.addClientHost = ''; }}>Cancel</Button>
+									<Button size="xs" onclick={() => nfsAddClickHost(share)}>Add</Button>
+									<Button variant="secondary" size="xs" onclick={() => { nfs.addClientShare = null; nfs.addClientHost = ''; addClientTried = false; }}>Cancel</Button>
 								</div>
 								{#if nfs.addClientOptions.includes('no_root_squash')}
 									<p class="mt-1 text-xs text-yellow-500">Warning: <code>no_root_squash</code> disables quota enforcement for root NFS clients.</p>

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -23,6 +23,28 @@
 
 	$effect(() => { if (nvme.showCreate || nvme.addNsSubsys) nvmeLoadSubvolumes(); });
 
+	// Per-form "tried" flags — defer amber required-field decoration
+	// until each submit button is clicked at least once.
+	let createTried = $state(false);
+	let addNsTried = $state(false);
+	let addHostTried = $state(false);
+
+	async function nvmeCreateGuarded() {
+		if (!nvme.newName || !nvme.newDevice) { createTried = true; return; }
+		createTried = false;
+		await nvmeCreate();
+	}
+	async function nvmeAddNamespaceGuarded() {
+		if (!nvme.addNsDevice) { addNsTried = true; return; }
+		addNsTried = false;
+		await nvmeAddNamespace();
+	}
+	async function nvmeAddHostGuarded() {
+		if (!nvme.addHostNqn) { addHostTried = true; return; }
+		addHostTried = false;
+		await nvmeAddHost();
+	}
+
 	const nvmeFiltered = $derived(
 		nvme.search.trim()
 			? nvme.subsystems.filter(s => s.nqn.toLowerCase().includes(nvme.search.toLowerCase()))
@@ -46,8 +68,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Share</h3>
 			<div class="mb-4">
-				<Label for="nvme-device">Block Subvolume {#if !nvme.newDevice}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<select id="nvme-device" bind:value={nvme.newDevice} onchange={nvmeOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!nvme.newDevice)}">
+				<Label for="nvme-device">Block Subvolume {#if !nvme.newDevice && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="nvme-device" bind:value={nvme.newDevice} onchange={nvmeOnDeviceSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!nvme.newDevice, createTried)}">
 					<option value="">Select a block subvolume...</option>
 					{#each nvme.blockSubvolumes as sv}
 						<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -58,8 +80,8 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="nvme-name">Share Name {#if !nvme.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="nvme-name" bind:value={nvme.newName} placeholder="faststore" class="mt-1 {requiredFieldCls(!nvme.newName)}" />
+				<Label for="nvme-name">Share Name {#if !nvme.newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="nvme-name" bind:value={nvme.newName} placeholder="faststore" class="mt-1 {requiredFieldCls(!nvme.newName, createTried)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">NQN: nqn.2137.com.nasty:{nvme.newName || '...'}</span>
 			</div>
 			<div class="grid grid-cols-2 gap-4 mb-4">
@@ -72,7 +94,7 @@
 					<Input id="nvme-port" type="number" bind:value={nvme.newPort} class="mt-1" />
 				</div>
 			</div>
-			<Button onclick={nvmeCreate} disabled={!nvme.newName || !nvme.newDevice}>Create</Button>
+			<Button onclick={nvmeCreateGuarded}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -136,8 +158,8 @@
 									{#if nvme.addNsSubsys === subsys.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Block Device {#if !nvme.addNsDevice}<span class="text-amber-500">required</span>{/if}</Label>
-												<select bind:value={nvme.addNsDevice} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!nvme.addNsDevice)}">
+												<Label class="text-xs">Block Device {#if !nvme.addNsDevice && addNsTried}<span class="text-amber-500">required</span>{/if}</Label>
+												<select bind:value={nvme.addNsDevice} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs {requiredFieldCls(!nvme.addNsDevice, addNsTried)}">
 													<option value="">Select...</option>
 													{#each nvme.blockSubvolumes as sv}
 														<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>
@@ -145,8 +167,8 @@
 												</select>
 											</div>
 											<div class="flex gap-2">
-												<Button size="xs" onclick={nvmeAddNamespace} disabled={!nvme.addNsDevice}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { nvme.addNsSubsys = ''; }}>Cancel</Button>
+												<Button size="xs" onclick={nvmeAddNamespaceGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { nvme.addNsSubsys = ''; addNsTried = false; }}>Cancel</Button>
 											</div>
 										</div>
 									{:else}
@@ -225,12 +247,12 @@
 									{#if nvme.addHostSubsys === subsys.id}
 										<div class="mt-3 rounded border p-3">
 											<div class="mb-2">
-												<Label class="text-xs">Host NQN {#if !nvme.addHostNqn}<span class="text-amber-500">required</span>{/if}</Label>
-												<Input bind:value={nvme.addHostNqn} placeholder="nqn.2024-01.com.client:host1" class="mt-1 h-8 text-xs {requiredFieldCls(!nvme.addHostNqn)}" />
+												<Label class="text-xs">Host NQN {#if !nvme.addHostNqn && addHostTried}<span class="text-amber-500">required</span>{/if}</Label>
+												<Input bind:value={nvme.addHostNqn} placeholder="nqn.2024-01.com.client:host1" class="mt-1 h-8 text-xs {requiredFieldCls(!nvme.addHostNqn, addHostTried)}" />
 											</div>
 											<div class="flex gap-2">
-												<Button size="xs" onclick={nvmeAddHost} disabled={!nvme.addHostNqn}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { nvme.addHostSubsys = ''; }}>Cancel</Button>
+												<Button size="xs" onclick={nvmeAddHostGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { nvme.addHostSubsys = ''; addHostTried = false; }}>Cancel</Button>
 											</div>
 										</div>
 									{:else}

--- a/webui/src/routes/sharing/SmbPanel.svelte
+++ b/webui/src/routes/sharing/SmbPanel.svelte
@@ -25,6 +25,16 @@
 
 	const client = getClient();
 
+	/** Gates the amber required-field decoration on the SMB create form
+	 * until the operator has clicked Create at least once with a missing
+	 * field. Without it the form opens "alarmed" before any input. */
+	let createTried = $state(false);
+	async function smbCreateGuarded() {
+		if (!smb.newName || !smb.newSubvolume) { createTried = true; return; }
+		createTried = false;
+		await smbCreate();
+	}
+
 	$effect(() => { if (smb.showCreate) smbLoadSubvolumes(); });
 
 	const smbFiltered = $derived(
@@ -57,8 +67,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New Share</h3>
 			<div class="mb-4">
-				<Label for="smb-subvol">Subvolume {#if !smb.newSubvolume}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<select id="smb-subvol" bind:value={smb.newSubvolume} onchange={smbOnSubvolumeSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!smb.newSubvolume)}">
+				<Label for="smb-subvol">Subvolume {#if !smb.newSubvolume && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<select id="smb-subvol" bind:value={smb.newSubvolume} onchange={smbOnSubvolumeSelect} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!smb.newSubvolume, createTried)}">
 					<option value="">Select a subvolume...</option>
 					{#each smb.subvolumes as sv}
 						<option value={sv.path}>{sv.filesystem}/{sv.name} ({sv.path})</option>
@@ -70,8 +80,8 @@
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="smb-name">Share Name {#if !smb.newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="smb-name" bind:value={smb.newName} placeholder="documents" class="mt-1 {requiredFieldCls(!smb.newName)}" />
+				<Label for="smb-name">Share Name {#if !smb.newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="smb-name" bind:value={smb.newName} placeholder="documents" class="mt-1 {requiredFieldCls(!smb.newName, createTried)}" />
 				<span class="mt-1 block text-xs text-muted-foreground">Name visible to network clients</span>
 			</div>
 			<div class="mb-4">
@@ -86,7 +96,7 @@
 					<input type="checkbox" bind:checked={smb.newGuestOk} class="h-4 w-4" /> Allow guests
 				</label>
 			</div>
-			<Button onclick={smbCreate} disabled={!smb.newName || !smb.newSubvolume}>Create</Button>
+			<Button onclick={smbCreateGuarded}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}

--- a/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
@@ -36,7 +36,14 @@
 	let showInlineGroupCreate = $state(false);
 	let inlineGroupName = $state('');
 
+	// Per-form "tried" flags — defer amber required-field decoration
+	// until each submit button is clicked at least once.
+	let createUserTried = $state(false);
+	let createGroupTried = $state(false);
+
 	async function createInlineGroup() {
+		if (!inlineGroupName.trim()) { createGroupTried = true; return; }
+		createGroupTried = false;
 		await withToast(
 			() => client.call('smb.group.create', { name: inlineGroupName.trim() }),
 			`Group "${inlineGroupName}" created`
@@ -48,6 +55,9 @@
 	}
 
 	async function createInlineUser() {
+		if (!inlineUsername || !inlinePassword || !inlinePasswordConfirm) { createUserTried = true; return; }
+		if (inlinePassword !== inlinePasswordConfirm) { createUserTried = true; return; }
+		createUserTried = false;
 		const ok = await withToast(
 			() => client.call('smb.user.create', { username: inlineUsername, password: inlinePassword }),
 			`User "${inlineUsername}" created`
@@ -120,16 +130,16 @@
 					<h3 class="mb-4 text-lg font-semibold">New System User</h3>
 					{@const inlinePwMismatch = !!inlinePasswordConfirm && inlinePassword !== inlinePasswordConfirm}
 					<div class="mb-4">
-						<Label for="inline-username">Username {#if !inlineUsername}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-						<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!inlineUsername)}" />
+						<Label for="inline-username">Username {#if !inlineUsername && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-username" bind:value={inlineUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!inlineUsername, createUserTried)}" />
 					</div>
 					<div class="mb-4">
-						<Label for="inline-password">Password {#if !inlinePassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-						<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePassword)}" />
+						<Label for="inline-password">Password {#if !inlinePassword && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-password" type="password" bind:value={inlinePassword} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePassword, createUserTried)}" />
 					</div>
 					<div class="mb-4">
-						<Label for="inline-password-confirm">Confirm Password {#if !inlinePasswordConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-						<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePasswordConfirm || inlinePwMismatch)}" />
+						<Label for="inline-password-confirm">Confirm Password {#if !inlinePasswordConfirm && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+						<Input id="inline-password-confirm" type="password" bind:value={inlinePasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!inlinePasswordConfirm, createUserTried) || requiredFieldCls(inlinePwMismatch)}" />
 						{#if inlinePwMismatch}
 							<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 						{/if}
@@ -152,9 +162,9 @@
 							{/each}
 							{#if showInlineGroupCreate}
 								<div class="flex items-center gap-1.5">
-									<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs {requiredFieldCls(!inlineGroupName.trim())}" />
-									<Button size="xs" disabled={!inlineGroupName.trim()} onclick={createInlineGroup}>Create</Button>
-									<Button size="xs" variant="secondary" onclick={() => showInlineGroupCreate = false}>Cancel</Button>
+									<Input bind:value={inlineGroupName} placeholder="Group name" class="h-7 w-32 text-xs {requiredFieldCls(!inlineGroupName.trim(), createGroupTried)}" />
+									<Button size="xs" onclick={createInlineGroup}>Create</Button>
+									<Button size="xs" variant="secondary" onclick={() => { showInlineGroupCreate = false; createGroupTried = false; }}>Cancel</Button>
 								</div>
 							{:else}
 								<Button size="sm" onclick={() => showInlineGroupCreate = true}>Create Group</Button>
@@ -162,10 +172,10 @@
 						</div>
 					</div>
 					<div class="flex gap-2">
-						<Button onclick={createInlineUser} disabled={!inlineUsername || !inlinePassword || inlinePassword !== inlinePasswordConfirm}>
+						<Button onclick={createInlineUser} disabled={inlinePwMismatch}>
 							Create & Add
 						</Button>
-						<Button variant="secondary" onclick={() => { showInlineUserCreate = false; }}>Cancel</Button>
+						<Button variant="secondary" onclick={() => { showInlineUserCreate = false; createUserTried = false; }}>Cancel</Button>
 					</div>
 				</CardContent>
 			</Card>

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -95,6 +95,12 @@
 
 	let wizardStep: 0 | 1 | 2 | 3 = $state(0); // 0=hidden
 	let newName = $state('');
+	/** Per-form "tried" flags. Amber required-field decoration is gated
+	 * on these so each form opens clean and only flags missing fields
+	 * after the operator clicks the submit / next button at least once. */
+	let createTried = $state(false);
+	let snapTried = $state(false);
+	let cloneTried = $state(false);
 	let newType: SubvolumeType = $state('filesystem');
 	let newVolsize = $state('');
 	let newCompression = $state('');
@@ -494,7 +500,9 @@
 	}
 
 	async function createSnapshot() {
-		if (!showSnap || !snapName) return;
+		if (!showSnap) return;
+		if (!snapName) { snapTried = true; return; }
+		snapTried = false;
 		const src = showSnap;
 		const ok = await withToast(
 			() => client.call('snapshot.create', {
@@ -508,6 +516,7 @@
 		if (ok !== undefined) {
 			showSnap = null;
 			snapName = '';
+			snapTried = false;
 		}
 		await refresh();
 		// Update detail view so tab count reflects the new snapshot
@@ -518,7 +527,9 @@
 	}
 
 	async function cloneSubvolume() {
-		if (!showClone || !cloneName) return;
+		if (!showClone) return;
+		if (!cloneName) { cloneTried = true; return; }
+		cloneTried = false;
 		const src = showClone;
 		const ok = src.snapshot
 			? await withToast(() =>
@@ -540,6 +551,7 @@
 		if (ok !== undefined) {
 			showClone = null;
 			cloneName = '';
+			cloneTried = false;
 			await refresh();
 			// Reopen detail if we cloned the detail subvolume
 			if (detailSv) {
@@ -776,8 +788,8 @@
 			{#if wizardStep === 1}
 			{#if mountedFilesystems.length > 1}
 				<div class="mb-4">
-					<Label for="sv-filesystem">Filesystem {#if !newFilesystem}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-					<select id="sv-filesystem" bind:value={newFilesystem} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newFilesystem)}">
+					<Label for="sv-filesystem">Filesystem {#if !newFilesystem && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<select id="sv-filesystem" bind:value={newFilesystem} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm {requiredFieldCls(!newFilesystem, createTried)}">
 						{#each mountedFilesystems as p}
 							<option value={p.name}>{p.name}</option>
 						{/each}
@@ -785,8 +797,8 @@
 				</div>
 			{/if}
 			<div class="mb-4">
-				<Label for="sv-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="sv-name" bind:value={newName} placeholder="documents or projects/web" class="mt-1 {requiredFieldCls(!newName)}" />
+				<Label for="sv-name">Name {#if !newName && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="sv-name" bind:value={newName} placeholder="documents or projects/web" class="mt-1 {requiredFieldCls(!newName, createTried)}" />
 				<p class="mt-1 text-xs text-muted-foreground">Use <span class="font-mono">/</span> for nested subvolumes (e.g. projects/web)</p>
 			</div>
 			<div class="mb-4">
@@ -801,7 +813,7 @@
 				<Input id="sv-comments" bind:value={newComments} placeholder="Optional description" class="mt-1" />
 			</div>
 			<div class="flex gap-2">
-				<Button size="sm" onclick={() => wizardStep = 2} disabled={!newName || !newFilesystem}>Next: Storage →</Button>
+				<Button size="sm" onclick={() => { if (!newName || !newFilesystem) { createTried = true; return; } createTried = false; wizardStep = 2; }}>Next: Storage →</Button>
 			</div>
 
 			<!-- Step 2: Storage -->
@@ -1485,11 +1497,11 @@
 			<p class="text-sm text-muted-foreground">Create a read-only point-in-time copy.</p>
 		</Dialog.Header>
 		<div class="mb-4">
-			<Label for="snap-name">Snapshot Name {#if !snapName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="snap-name" bind:value={snapName} placeholder="snap-2026-03-12" class="mt-1 {requiredFieldCls(!snapName)}" />
+			<Label for="snap-name">Snapshot Name {#if !snapName && snapTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="snap-name" bind:value={snapName} placeholder="snap-2026-03-12" class="mt-1 {requiredFieldCls(!snapName, snapTried)}" />
 		</div>
 		<Dialog.Footer>
-			<Button size="sm" onclick={createSnapshot} disabled={!snapName}>Create</Button>
+			<Button size="sm" onclick={createSnapshot}>Create</Button>
 			<Button variant="secondary" size="sm" onclick={() => showSnap = null}>Cancel</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
@@ -1502,11 +1514,11 @@
 			<p class="text-sm text-muted-foreground">Create a writable copy (COW — instant, shares data until modified).</p>
 		</Dialog.Header>
 		<div class="mb-4">
-			<Label for="clone-name">Clone Name {#if !cloneName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="clone-name" bind:value={cloneName} placeholder="my-clone" class="mt-1 {requiredFieldCls(!cloneName)}" />
+			<Label for="clone-name">Clone Name {#if !cloneName && cloneTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="clone-name" bind:value={cloneName} placeholder="my-clone" class="mt-1 {requiredFieldCls(!cloneName, cloneTried)}" />
 		</div>
 		<Dialog.Footer>
-			<Button size="sm" onclick={cloneSubvolume} disabled={!cloneName}>Create</Button>
+			<Button size="sm" onclick={cloneSubvolume}>Create</Button>
 			<Button variant="secondary" size="sm" onclick={() => showClone = null}>Cancel</Button>
 		</Dialog.Footer>
 	</Dialog.Content>

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -60,6 +60,14 @@
 	let expandedGroup = $state<string | null>(null);
 	let addMemberGroup = $state<string | null>(null);
 	let addMemberUser = $state('');
+	// Per-form "tried" flags. Amber required-field decoration only kicks
+	// in after the operator clicks the submit button at least once on
+	// each form, so a freshly-opened dialog isn't lit up like an alarm.
+	let createUserTried = $state(false);
+	let changePwTried = $state(false);
+	let sysPwTried = $state(false);
+	let newGroupTried = $state(false);
+	let newTokenTried = $state(false);
 
 	// ── Single Sign-On (OIDC) ──────────────────────────────────
 	type OidcRoleMapping = { group: string; role: string };
@@ -163,8 +171,10 @@
 	}
 
 	async function createUser() {
-		if (!newUsername || !newPassword) return;
-		if (newPassword !== newPasswordConfirm) return;
+		if (!newUsername || !newPassword || !newPasswordConfirm) { createUserTried = true; return; }
+		if (newPassword.length < 8) { createUserTried = true; return; }
+		if (newPassword !== newPasswordConfirm) { createUserTried = true; return; }
+		createUserTried = false;
 		const ok = await withToast(
 			() => client.call('auth.create_user', {
 				username: newUsername,
@@ -179,6 +189,7 @@
 			newPassword = '';
 			newPasswordConfirm = '';
 			newRole = 'readonly';
+			createUserTried = false;
 			await refresh();
 		}
 	}
@@ -193,8 +204,11 @@
 	}
 
 	async function changePassword() {
-		if (!pwUser || !pwNew) return;
-		if (pwNew !== pwConfirm) return;
+		if (!pwUser) return;
+		if (!pwNew || !pwConfirm) { changePwTried = true; return; }
+		if (pwNew.length < 8) { changePwTried = true; return; }
+		if (pwNew !== pwConfirm) { changePwTried = true; return; }
+		changePwTried = false;
 		const ok = await withToast(
 			() => client.call('auth.change_password', {
 				username: pwUser,
@@ -206,11 +220,13 @@
 			pwUser = null;
 			pwNew = '';
 			pwConfirm = '';
+			changePwTried = false;
 		}
 	}
 
 	async function createToken() {
-		if (!newTokenName) return;
+		if (!newTokenName) { newTokenTried = true; return; }
+		newTokenTried = false;
 		const expires_in_secs = newTokenExpiry ? parseInt(newTokenExpiry) : null;
 		const allowed_ips = newTokenAllowedIPs.trim()
 			? newTokenAllowedIPs.split(',').map(ip => ip.trim()).filter(Boolean)
@@ -230,6 +246,7 @@
 			showCreateToken = false;
 			newTokenName = '';
 			newTokenRole = 'operator';
+			newTokenTried = false;
 			newTokenFs = '';
 			newTokenExpiry = '';
 			newTokenAllowedIPs = '';
@@ -254,7 +271,8 @@
 	}
 
 	async function createGroup() {
-		if (!newGroupName.trim()) return;
+		if (!newGroupName.trim()) { newGroupTried = true; return; }
+		newGroupTried = false;
 		const ok = await withToast(
 			() => client.call('smb.group.create', { name: newGroupName.trim() }),
 			`Group "${newGroupName}" created`
@@ -262,6 +280,7 @@
 		if (ok !== undefined) {
 			showCreateGroup = false;
 			newGroupName = '';
+			newGroupTried = false;
 			await refresh();
 		}
 	}
@@ -324,7 +343,10 @@
 	}
 
 	async function changeSysPassword() {
-		if (!sysPwUser || !sysPwNew || sysPwNew !== sysPwConfirm) return;
+		if (!sysPwUser) return;
+		if (!sysPwNew || !sysPwConfirm) { sysPwTried = true; return; }
+		if (sysPwNew !== sysPwConfirm) { sysPwTried = true; return; }
+		sysPwTried = false;
 		await withToast(
 			() => client.call('smb.user.set_password', { username: sysPwUser, password: sysPwNew }),
 			`Password changed for "${sysPwUser}"`
@@ -332,6 +354,7 @@
 		sysPwUser = null;
 		sysPwNew = '';
 		sysPwConfirm = '';
+		sysPwTried = false;
 	}
 
 	function formatDate(ts: number): string {
@@ -376,19 +399,19 @@
 			{@const newUserPwTooShort = !!newPassword && newPassword.length < 8}
 			{@const newUserPwMismatch = !!newPasswordConfirm && newPassword !== newPasswordConfirm}
 			<div class="mb-4">
-				<Label for="new-username">Username {#if !newUsername}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="new-username" bind:value={newUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!newUsername)}" />
+				<Label for="new-username">Username {#if !newUsername && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-username" bind:value={newUsername} placeholder="johndoe" autocomplete="off" class="mt-1 {requiredFieldCls(!newUsername, createUserTried)}" />
 			</div>
 			<div class="mb-4">
-				<Label for="new-password">Password {#if !newPassword}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="new-password" type="password" bind:value={newPassword} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPassword || newUserPwTooShort)}" />
+				<Label for="new-password">Password {#if !newPassword && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-password" type="password" bind:value={newPassword} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPassword, createUserTried) || requiredFieldCls(newUserPwTooShort)}" />
 				{#if newUserPwTooShort}
 					<span class="mt-1 block text-xs text-destructive">At least 8 characters required</span>
 				{/if}
 			</div>
 			<div class="mb-4">
-				<Label for="new-password-confirm">Confirm Password {#if !newPasswordConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="new-password-confirm" type="password" bind:value={newPasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPasswordConfirm || newUserPwMismatch)}" />
+				<Label for="new-password-confirm">Confirm Password {#if !newPasswordConfirm && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="new-password-confirm" type="password" bind:value={newPasswordConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!newPasswordConfirm, createUserTried) || requiredFieldCls(newUserPwMismatch)}" />
 				{#if newUserPwMismatch}
 					<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 				{/if}
@@ -401,9 +424,9 @@
 					<option value="operator">Operator</option>
 				</select>
 			</div>
-			<Button onclick={createUser} disabled={!newUsername || !newPassword || newPassword.length < 8 || newPassword !== newPasswordConfirm}>
-				Create
-			</Button>
+			<!-- Stays enabled; createUser validates and triggers the amber
+			     decoration on a missing-field click. -->
+			<Button onclick={createUser}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -582,18 +605,18 @@
 		</Dialog.Header>
 		{@const sysPwMismatch = !!sysPwConfirm && sysPwNew !== sysPwConfirm}
 		<div class="mb-4">
-			<Label for="sys-pw-new">New Password {#if !sysPwNew}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="sys-pw-new" type="password" bind:value={sysPwNew} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwNew)}" />
+			<Label for="sys-pw-new">New Password {#if !sysPwNew && sysPwTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="sys-pw-new" type="password" bind:value={sysPwNew} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwNew, sysPwTried)}" />
 		</div>
 		<div class="mb-4">
-			<Label for="sys-pw-confirm">Confirm Password {#if !sysPwConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="sys-pw-confirm" type="password" bind:value={sysPwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwConfirm || sysPwMismatch)}" />
+			<Label for="sys-pw-confirm">Confirm Password {#if !sysPwConfirm && sysPwTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="sys-pw-confirm" type="password" bind:value={sysPwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!sysPwConfirm, sysPwTried) || requiredFieldCls(sysPwMismatch)}" />
 			{#if sysPwMismatch}
 				<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 			{/if}
 		</div>
 		<Dialog.Footer>
-			<Button size="sm" onclick={changeSysPassword} disabled={!sysPwNew || sysPwNew !== sysPwConfirm}>
+			<Button size="sm" onclick={changeSysPassword}>
 				Change Password
 			</Button>
 			<Button variant="secondary" size="sm" onclick={() => sysPwUser = null}>Cancel</Button>
@@ -617,10 +640,10 @@
 	<Card class="mb-4 max-w-md">
 		<CardContent class="pt-4 space-y-3">
 			<div>
-				<Label for="group-name">Group Name {#if !newGroupName.trim()}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="group-name" bind:value={newGroupName} placeholder="e.g. engineering" class="mt-1 {requiredFieldCls(!newGroupName.trim())}" />
+				<Label for="group-name">Group Name {#if !newGroupName.trim() && newGroupTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="group-name" bind:value={newGroupName} placeholder="e.g. engineering" class="mt-1 {requiredFieldCls(!newGroupName.trim(), newGroupTried)}" />
 			</div>
-			<Button size="sm" onclick={createGroup} disabled={!newGroupName.trim()}>Create</Button>
+			<Button size="sm" onclick={createGroup}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -706,8 +729,8 @@
 		<CardContent class="pt-6">
 			<h3 class="mb-4 text-lg font-semibold">New API Token</h3>
 			<div class="mb-4">
-				<Label for="token-name">Name {#if !newTokenName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="token-name" bind:value={newTokenName} placeholder="e.g. k8s-cluster" autocomplete="off" class="mt-1 {requiredFieldCls(!newTokenName)}" />
+				<Label for="token-name">Name {#if !newTokenName && newTokenTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="token-name" bind:value={newTokenName} placeholder="e.g. k8s-cluster" autocomplete="off" class="mt-1 {requiredFieldCls(!newTokenName, newTokenTried)}" />
 			</div>
 			<div class="mb-4">
 				<Label for="token-role">Role</Label>
@@ -743,7 +766,7 @@
 				<Input id="token-ips" bind:value={newTokenAllowedIPs} placeholder="e.g. 10.10.10.100, 192.168.1.50" autocomplete="off" class="mt-1" />
 				<span class="mt-1 block text-xs text-muted-foreground">Comma-separated. Leave empty to allow any IP.</span>
 			</div>
-			<Button onclick={createToken} disabled={!newTokenName}>Create Token</Button>
+			<Button onclick={createToken}>Create Token</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -803,21 +826,21 @@
 		{@const pwTooShort = !!pwNew && pwNew.length < 8}
 		{@const pwMismatch = !!pwConfirm && pwNew !== pwConfirm}
 		<div class="mb-4">
-			<Label for="pw-new">New Password {#if !pwNew}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="pw-new" type="password" bind:value={pwNew} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwNew || pwTooShort)}" />
+			<Label for="pw-new">New Password {#if !pwNew && changePwTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="pw-new" type="password" bind:value={pwNew} placeholder="Min 8 characters" autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwNew, changePwTried) || requiredFieldCls(pwTooShort)}" />
 			{#if pwTooShort}
 				<span class="mt-1 block text-xs text-destructive">At least 8 characters required</span>
 			{/if}
 		</div>
 		<div class="mb-4">
-			<Label for="pw-confirm">Confirm Password {#if !pwConfirm}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-			<Input id="pw-confirm" type="password" bind:value={pwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwConfirm || pwMismatch)}" />
+			<Label for="pw-confirm">Confirm Password {#if !pwConfirm && changePwTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+			<Input id="pw-confirm" type="password" bind:value={pwConfirm} autocomplete="new-password" class="mt-1 {requiredFieldCls(!pwConfirm, changePwTried) || requiredFieldCls(pwMismatch)}" />
 			{#if pwMismatch}
 				<span class="mt-1 block text-xs text-destructive">Passwords do not match</span>
 			{/if}
 		</div>
 		<Dialog.Footer>
-			<Button size="sm" onclick={changePassword} disabled={!pwNew || pwNew.length < 8 || pwNew !== pwConfirm}>
+			<Button size="sm" onclick={changePassword}>
 				Change Password
 			</Button>
 			<Button variant="secondary" size="sm" onclick={() => pwUser = null}>Cancel</Button>

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -43,6 +43,10 @@
 
 	// Create form
 	let newName = $state('');
+	/** True after the operator clicks Next/Create on the wizard with
+	 * an empty Name — gates the amber decoration so the form opens
+	 * clean and only flags the missing field after a submit attempt. */
+	let vmNameTried = $state(false);
 	let newCpus = $state(1);
 	let newMemory = $state(1024);
 	let newDisk = $state('');
@@ -96,6 +100,7 @@
 	 * automatically. */
 	function resetCreateForm() {
 		newName = '';
+		vmNameTried = false;
 		newCpus = 1;
 		newMemory = 1024;
 		newDisk = '';
@@ -616,7 +621,8 @@
 	}
 
 	async function create() {
-		if (!newName) return;
+		if (!newName) { vmNameTried = true; return; }
+		vmNameTried = false;
 
 		let diskPath = newDisk;
 
@@ -1051,8 +1057,8 @@
 			<!-- Step 1: General -->
 			{:else if wizardStep === 1}
 			<div class="mb-4">
-				<Label for="vm-name">Name {#if !newName}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
-				<Input id="vm-name" bind:value={newName} placeholder="my-vm" class="mt-1 {requiredFieldCls(!newName)}" />
+				<Label for="vm-name">Name {#if !newName && vmNameTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+				<Input id="vm-name" bind:value={newName} placeholder="my-vm" class="mt-1 {requiredFieldCls(!newName, vmNameTried)}" />
 			</div>
 			<div class="mb-4">
 				<Label for="vm-desc">Description</Label>
@@ -1063,7 +1069,7 @@
 				<Label for="vm-autostart">Auto-start on NASty boot</Label>
 			</div>
 			<div class="flex gap-2">
-				<Button size="sm" onclick={() => wizardStep = 2} disabled={!newName}>Next: System →</Button>
+				<Button size="sm" onclick={() => { if (!newName) { vmNameTried = true; return; } vmNameTried = false; wizardStep = 2; }}>Next: System →</Button>
 			</div>
 
 			<!-- Step 2: System -->
@@ -1378,7 +1384,7 @@
 			</div>
 			<div class="flex gap-2">
 				<Button variant="secondary" size="sm" onclick={() => wizardStep = 5}>← Back</Button>
-				<Button size="sm" onclick={create} disabled={!newName}>Create VM</Button>
+				<Button size="sm" onclick={create}>Create VM</Button>
 			</div>
 			{/if}
 		</CardContent>


### PR DESCRIPTION
## Summary
- Forms no longer open "alarmed" — amber required-field decoration is deferred until the operator actually tries to submit with something missing.
- Each create/install form now carries a per-form `tried` boolean; the amber border, ring, and "required" hint are gated on it.
- Button `disabled` no longer blocks missing-field submits — the click reaches the handler, which sets `tried = true`. `disabled` is kept only for genuinely-invalid states (password mismatch, subdomain conflict, name format).

Follow-up to #234, which made the amber treatment always-on the moment a form opened. That was too aggressive — the user shouldn't be scolded for an empty field they haven't had a chance to fill in yet.

`requiredFieldCls(missing, tried = true)` keeps the default at the old behavior so unchanged call sites still light up immediately if any remain.

## Files touched
14 .svelte/.ts files across apps, backups, users, vms, subvolumes, alerts, files, settings, sharing (SMB/NFS/iSCSI/NVMe-oF, SMB wizard).

## Test plan
- [ ] Open each create/install form (Apps → Install, Apps → Compose, Backups → New Profile, Users → Create User / Change Password / Create Group / Create Token, VMs → New VM wizard, Subvolumes → Create/Snapshot/Clone, Alerts → New Rule, Files → mkdir/rename, Settings → New VLAN, Sharing → New SMB/NFS/iSCSI/NVMe target plus their Add LUN/ACL/Namespace/Host sub-forms, SMB Wizard inline user/group create) and confirm no amber on open.
- [ ] Click the submit button with required fields blank: amber appears and stays until they're filled.
- [ ] Cancelling a sub-form (Add LUN, Add Client, etc.) and reopening it should reset back to quiet — no leftover amber.
- [ ] Filling everything and submitting works as before.