### PR TITLE
tls: drive automation through Caddy admin API, drop lego + vhosts.conf

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2616,6 +2616,7 @@ dependencies = [
  "chrono",
  "lettre",
  "libc",
+ "nasty-apps",
  "nasty-common",
  "reqwest 0.13.3",
  "rnix",

--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -11,6 +11,12 @@
 //!
 //! Each app's route is tagged with `@id = nasty-app-<name>` so we
 //! can manipulate it without traversing the JSON config tree.
+//!
+//! TLS automation is driven through the same admin API: `set_tls_automation`
+//! PUTs the full `apps.tls.automation` block, replacing whatever was there.
+//! The caller (engine startup + settings/ingress mutations) builds the
+//! desired policy set from settings + per-app subdomains and pushes it in
+//! one shot. No file rewrite, no reload — Caddy issues the certs.
 
 use std::time::Duration;
 
@@ -47,6 +53,36 @@ pub struct AppRoute {
     /// via DNS-01, or per-name via HTTP-01/TLS-ALPN-01) handles cert
     /// acquisition. V1 doesn't add per-app ACME knobs.
     pub subdomain: Option<String>,
+}
+
+/// One hostname that Caddy should auto-provision a certificate for.
+/// The caller assembles a `Vec<TlsPolicy>` from settings (main domain) +
+/// per-app subdomains and passes it to [`CaddyApi::set_tls_automation`].
+///
+/// All policies share the same issuer config — they differ only in
+/// `subjects` — so we don't carry per-host email/provider knobs. If a
+/// future use case wants that (e.g. one app on Cloudflare DNS, another
+/// on Route 53), grow the struct then.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsPolicy {
+    /// Fully-qualified hostname Caddy should issue a cert for.
+    pub host: String,
+}
+
+/// Issuer configuration shared by every policy emitted in one
+/// `set_tls_automation` call. Mirrors the user's settings (email + DNS
+/// provider + staging flag) and gets folded into the ACME issuer block
+/// of each policy.
+///
+/// When `dns_provider` is `Some`, the policy uses DNS-01 with the named
+/// caddy-dns plugin. When `None`, Caddy falls back to its default
+/// challenge order (HTTP-01 then TLS-ALPN-01) — useful when port 80 is
+/// reachable from the internet but DNS automation isn't set up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsIssuer {
+    pub email: Option<String>,
+    pub dns_provider: Option<String>,
+    pub staging: bool,
 }
 
 /// One row in the Ingress overview page — every route Caddy is serving,
@@ -401,6 +437,61 @@ impl CaddyApi {
         }
         Ok(())
     }
+
+    /// Replace Caddy's `apps.tls.automation` block with the policies
+    /// derived from `policies` + `issuer`. Empty `policies` is the
+    /// "ACME-off" state: PUT clears any prior automation config so
+    /// Caddy stops trying to renew certs we no longer want.
+    ///
+    /// One policy per host, all sharing the same issuer. Caddy issues
+    /// a separate cert per subject — we don't try to SAN-combine
+    /// because not every DNS provider supports the wildcards that would
+    /// make combining worthwhile, and per-host certs make revocation /
+    /// renewal failures isolated.
+    ///
+    /// Idempotent: identical input ⇒ identical PUT body ⇒ Caddy
+    /// no-ops internally. Failures (Caddy not running, JSON shape
+    /// rejected) are returned for the caller to log and surface in
+    /// `acme_status`.
+    pub async fn set_tls_automation(
+        &self,
+        policies: &[TlsPolicy],
+        issuer: &TlsIssuer,
+    ) -> Result<(), String> {
+        let body = build_tls_automation_json(policies, issuer);
+        // PUT `/config/apps/tls/automation` replaces the entire
+        // automation object. The parent `apps.tls` is always present
+        // because the static-cert :443 block in the Caddyfile creates
+        // `apps.tls.certificates.load_files` — so we never have to
+        // bootstrap `apps.tls` itself, just its automation child.
+        let url = format!("{}/config/apps/tls/automation", self.base_url);
+        let resp = self
+            .client
+            .put(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("PUT {url}: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(format!("PUT {url}: status {status} body={text}"));
+        }
+        if policies.is_empty() {
+            info!("caddy: cleared TLS automation policies");
+        } else {
+            info!(
+                "caddy: set TLS automation for {} host(s): {}",
+                policies.len(),
+                policies
+                    .iter()
+                    .map(|p| p.host.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Build the Caddy JSON route object for one app ingress.  Mirror
@@ -456,6 +547,124 @@ fn build_route_json(route: &AppRoute) -> Value {
         }],
         "terminal": true
     })
+}
+
+/// Build the JSON body for `PUT /config/apps/tls/automation`. One policy
+/// per host so a failure on one cert doesn't take down the others — and
+/// so the WebUI's per-host cert-status view (`cert_info_for_host`)
+/// matches one-to-one with Caddy's storage layout.
+///
+/// `policies` empty ⇒ `{ "policies": [] }` (Caddy stops auto-issuing).
+fn build_tls_automation_json(policies: &[TlsPolicy], issuer: &TlsIssuer) -> Value {
+    let policy_values: Vec<Value> = policies
+        .iter()
+        .map(|p| {
+            json!({
+                "subjects": [p.host.clone()],
+                "issuers": [build_acme_issuer_json(issuer)],
+            })
+        })
+        .collect();
+    json!({ "policies": policy_values })
+}
+
+/// Build one ACME issuer block for an automation policy. Shape mirrors
+/// `caddy adapt`'s output for a `tls EMAIL { dns PROVIDER ... }` block —
+/// emitted by hand here because the admin API takes JSON, not Caddyfile.
+///
+/// DNS-01 vs HTTP-01/TLS-ALPN-01 split: when `dns_provider` is None we
+/// omit the `challenges` field entirely and let Caddy use its default
+/// challenge order (HTTP-01 then TLS-ALPN-01). When DNS is set, we emit
+/// only the `dns` challenge — pinning matters because some users pick
+/// DNS specifically because port 80 isn't reachable from the public
+/// internet, and falling back to HTTP-01 in that case would just rack
+/// up failed attempts at the ACME server.
+fn build_acme_issuer_json(issuer: &TlsIssuer) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("module".into(), json!("acme"));
+    if let Some(email) = issuer.email.as_deref()
+        && !email.is_empty()
+    {
+        obj.insert("email".into(), json!(email));
+    }
+    if issuer.staging {
+        // Staging directory URL — accepts any caller, doesn't count
+        // against Let's Encrypt's production rate limits. Used for
+        // testing changes to the cert pipeline without burning quota.
+        obj.insert(
+            "ca".into(),
+            json!("https://acme-staging-v02.api.letsencrypt.org/directory"),
+        );
+    }
+    if let Some(provider) = issuer.dns_provider.as_deref() {
+        obj.insert(
+            "challenges".into(),
+            json!({ "dns": { "provider": dns_provider_json(provider) } }),
+        );
+    }
+    Value::Object(obj)
+}
+
+/// Map a DNS provider code to its caddy-dns plugin JSON shape. Each
+/// plugin exposes the credentials it needs as named JSON fields; the
+/// values are `{env.NAME}` placeholders that Caddy expands at request
+/// time from its EnvironmentFile (sourced from `tls_dns_credentials`).
+///
+/// Env var names mirror what users typically write in the credentials
+/// textarea: `CLOUDFLARE_DNS_API_TOKEN=…`, `PORKBUN_API_KEY=…`, etc.
+/// They don't necessarily match what each plugin's README suggests as
+/// a convention — but matching what's already saved in 0.0.7 boxes'
+/// `settings.json` matters more than matching upstream docs.
+///
+/// Unknown providers get a stub object with just the name; Caddy will
+/// reject the PUT with "unknown module" if the plugin isn't compiled
+/// in, and the engine surfaces that through `acme_status`.
+fn dns_provider_json(provider: &str) -> Value {
+    match provider {
+        "cloudflare" => json!({
+            "name": "cloudflare",
+            "api_token": "{env.CLOUDFLARE_DNS_API_TOKEN}"
+        }),
+        "duckdns" => json!({
+            "name": "duckdns",
+            "api_token": "{env.DUCKDNS_TOKEN}"
+        }),
+        "linode" => json!({
+            "name": "linode",
+            "api_token": "{env.LINODE_TOKEN}"
+        }),
+        "desec" => json!({
+            "name": "desec",
+            "token": "{env.DESEC_TOKEN}"
+        }),
+        "hetzner" => json!({
+            "name": "hetzner",
+            "api_token": "{env.HETZNER_API_TOKEN}"
+        }),
+        // route53 plugin reads AWS_REGION / AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN) from env on its
+        // own. Empty config object lets it self-configure.
+        "route53" => json!({ "name": "route53" }),
+        "porkbun" => json!({
+            "name": "porkbun",
+            "api_key": "{env.PORKBUN_API_KEY}",
+            "api_secret_key": "{env.PORKBUN_SECRET_API_KEY}"
+        }),
+        "namecheap" => json!({
+            "name": "namecheap",
+            "user": "{env.NAMECHEAP_USER}",
+            "api_key": "{env.NAMECHEAP_API_KEY}",
+            "client_ip": "{env.NAMECHEAP_CLIENT_IP}"
+        }),
+        "rfc2136" => json!({
+            "name": "rfc2136",
+            "key_name": "{env.RFC2136_KEY_NAME}",
+            "key": "{env.RFC2136_KEY}",
+            "key_alg": "{env.RFC2136_KEY_ALG}",
+            "server": "{env.RFC2136_SERVER}"
+        }),
+        other => json!({ "name": other }),
+    }
 }
 
 /// Pull the first hostname out of the route's `match[].host[]` array,
@@ -818,6 +1027,126 @@ mod tests {
         assert_eq!(s.handler_kind, "file_server");
         assert_eq!(s.upstream, None);
         assert_eq!(s.source, "static");
+    }
+
+    // ── build_tls_automation_json ──
+
+    #[test]
+    fn tls_automation_empty_policies_clears_caddy() {
+        // The "ACME off" PUT body. Caddy treats an empty policies array
+        // as "stop trying to auto-issue anything" — distinct from
+        // *missing* automation (which would inherit defaults). Asserts
+        // the shape stays exactly `{policies: []}` so future refactors
+        // can't accidentally re-enable defaults by emitting `null`.
+        let body = build_tls_automation_json(
+            &[],
+            &TlsIssuer {
+                email: None,
+                dns_provider: None,
+                staging: false,
+            },
+        );
+        assert_eq!(body, json!({"policies": []}));
+    }
+
+    #[test]
+    fn tls_automation_cloudflare_dns_shape() {
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "nas.example.com".into(),
+            }],
+            &TlsIssuer {
+                email: Some("ops@example.com".into()),
+                dns_provider: Some("cloudflare".into()),
+                staging: false,
+            },
+        );
+        let p = &body["policies"][0];
+        assert_eq!(p["subjects"][0], "nas.example.com");
+        let issuer = &p["issuers"][0];
+        assert_eq!(issuer["module"], "acme");
+        assert_eq!(issuer["email"], "ops@example.com");
+        // No staging CA → no `ca` override field at all (Caddy uses prod).
+        assert!(issuer.get("ca").is_none());
+        let prov = &issuer["challenges"]["dns"]["provider"];
+        assert_eq!(prov["name"], "cloudflare");
+        assert_eq!(prov["api_token"], "{env.CLOUDFLARE_DNS_API_TOKEN}");
+    }
+
+    #[test]
+    fn tls_automation_staging_sets_ca_url() {
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "h.example".into(),
+            }],
+            &TlsIssuer {
+                email: None,
+                dns_provider: None,
+                staging: true,
+            },
+        );
+        let issuer = &body["policies"][0]["issuers"][0];
+        assert_eq!(
+            issuer["ca"],
+            "https://acme-staging-v02.api.letsencrypt.org/directory"
+        );
+    }
+
+    #[test]
+    fn tls_automation_no_dns_provider_omits_challenges() {
+        // Without a DNS provider Caddy uses its default challenge order
+        // (HTTP-01, TLS-ALPN-01). Asserting the `challenges` field is
+        // absent — not present-but-empty — because Caddy treats
+        // `challenges: {}` as "no challenge modules enabled" which
+        // would block all issuance.
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "h.example".into(),
+            }],
+            &TlsIssuer {
+                email: Some("a@b".into()),
+                dns_provider: None,
+                staging: false,
+            },
+        );
+        let issuer = &body["policies"][0]["issuers"][0];
+        assert!(issuer.get("challenges").is_none());
+    }
+
+    #[test]
+    fn tls_automation_one_policy_per_host() {
+        // Per-host policies isolate failures and match `cert_info_for_host`'s
+        // one-cert-per-hostname assumption. Two subjects in → two policies
+        // out, not one combined-SAN policy.
+        let body = build_tls_automation_json(
+            &[
+                TlsPolicy {
+                    host: "a.example".into(),
+                },
+                TlsPolicy {
+                    host: "b.example".into(),
+                },
+            ],
+            &TlsIssuer {
+                email: None,
+                dns_provider: None,
+                staging: false,
+            },
+        );
+        let policies = body["policies"].as_array().unwrap();
+        assert_eq!(policies.len(), 2);
+        assert_eq!(policies[0]["subjects"][0], "a.example");
+        assert_eq!(policies[1]["subjects"][0], "b.example");
+    }
+
+    #[test]
+    fn dns_provider_json_unknown_provider_is_stub() {
+        // A provider name we don't have a hand-rolled shape for (e.g. a
+        // newly-added plugin) gets a bare `{name: <code>}` object.
+        // Caddy will reject if the plugin isn't compiled in; we don't
+        // try to be smart at the engine layer.
+        let v = dns_provider_json("freenom");
+        assert_eq!(v, json!({"name": "freenom"}));
     }
 
     #[test]

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 use tokio::process::Command;
 use tracing::{error, info, warn};
 
-mod caddy;
+pub mod caddy;
 
 use caddy::{AppRoute, CaddyApi};
 pub use caddy::{CaddyRouteSummary, HostCert};

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -492,11 +492,8 @@ async fn archive_path_once(path: &str, flag: &str, label: &str) {
                 "{label} migration: moved {path} → {archive_path}. \
                  Safe to delete once Caddy admin-API TLS is confirmed working."
             );
-            let _ = tokio::fs::write(
-                flag,
-                format!("archived to {archive_path}\n").as_bytes(),
-            )
-            .await;
+            let _ =
+                tokio::fs::write(flag, format!("archived to {archive_path}\n").as_bytes()).await;
         }
         Err(e) => {
             warn!("{label} migration: rename {path} → {archive_path} failed: {e}");

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, reload};
 
 mod app_deploy;
@@ -211,6 +211,30 @@ async fn main() -> anyhow::Result<()> {
     // from there.
     state.apps.reconcile_app_routes().await;
 
+    // TLS automation reconcile — push the policy set (main domain +
+    // every app subdomain) so Caddy issues certs after a fresh boot or
+    // restart, the same way ingress routes get re-pushed above.
+    //
+    // Spawned so a failing admin-API call (Caddy slow to start, ACME
+    // server unreachable) doesn't block the engine from finishing
+    // startup. The static-cert :443 block in the Caddyfile serves a
+    // valid cert in the meantime; users keep working while Caddy
+    // catches up.
+    tokio::spawn(async {
+        nasty_system::settings::reapply_tls_from_disk().await;
+    });
+
+    // Migration: archive `/var/lib/nasty/lego/` once on the first boot
+    // after upgrading to admin-API TLS. The lego tree carried the
+    // pre-Caddy ACME account + issued cert, both of which are now
+    // managed by Caddy itself. We MOVE (not delete) so a NixOS
+    // generation rollback can recover by symlinking it back, per the
+    // operator guidance that nothing should be destroyed irreversibly
+    // during an upgrade. Idempotent via a flag file.
+    tokio::spawn(async {
+        archive_lego_dir_once().await;
+    });
+
     // Initialize firewall based on current protocol states
     {
         use nasty_system::protocol::Protocol;
@@ -376,6 +400,110 @@ fn required_flag_value(args: &[String], flag: &str) -> anyhow::Result<String> {
 }
 
 /// Notify systemd that the service is ready (Type=notify).
+/// First-boot-after-upgrade cleanup for state files made obsolete by
+/// the admin-API TLS migration. Currently:
+///   1. `/var/lib/nasty/lego/` → archive (carried the pre-Caddy ACME
+///      account key + issued cert).
+///   2. `/var/lib/nasty/caddy/vhosts.conf` → archive when non-empty
+///      (engine used to render the per-domain ACME vhost into this
+///      file; the Caddyfile no longer imports it).
+///
+/// All moves use rename to a timestamped sibling path. The operator
+/// rule is that nothing irreversible happens during an upgrade — a
+/// rollback to the previous NixOS generation can recover by renaming
+/// the archive back in place.
+///
+/// Each step is independently gated by its own flag file so a partial
+/// failure (one archive succeeded, the next didn't) is correctly
+/// retried on the next boot.
+async fn archive_lego_dir_once() {
+    archive_path_once(
+        "/var/lib/nasty/lego",
+        "/var/lib/nasty/.lego-archived-v1",
+        "lego",
+    )
+    .await;
+    archive_path_once(
+        "/var/lib/nasty/caddy/vhosts.conf",
+        "/var/lib/nasty/.vhosts-archived-v1",
+        "caddy vhosts.conf",
+    )
+    .await;
+    // The static cert.pem / key.pem at /var/lib/nasty/tls/ are
+    // obsolete now that the Caddyfile uses `tls internal`. They
+    // carry the user's old LE cert content for ACME-enabled 0.0.7
+    // boxes, so archive (not delete) so a rollback can recover.
+    archive_path_once(
+        "/var/lib/nasty/tls/cert.pem",
+        "/var/lib/nasty/.tls-cert-archived-v1",
+        "static tls cert",
+    )
+    .await;
+    archive_path_once(
+        "/var/lib/nasty/tls/key.pem",
+        "/var/lib/nasty/.tls-key-archived-v1",
+        "static tls key",
+    )
+    .await;
+}
+
+/// Move `path` to a timestamped sibling (`<path>.archived.<unix-ts>`)
+/// the first time we observe it post-upgrade, recording the action in
+/// `flag`. Best-effort; any failure logs a warning and leaves state
+/// for the next boot to retry.
+///
+/// `label` is a short human-readable name used in the log line.
+async fn archive_path_once(path: &str, flag: &str, label: &str) {
+    if tokio::fs::metadata(flag).await.is_ok() {
+        return;
+    }
+    let meta = match tokio::fs::metadata(path).await {
+        Ok(m) => m,
+        Err(_) => {
+            // Path absent — write the flag so we don't keep
+            // re-stating it every boot.
+            let _ = tokio::fs::write(
+                flag,
+                format!("{label}: no {path} found on first run\n").as_bytes(),
+            )
+            .await;
+            return;
+        }
+    };
+    // Skip empty files — vhosts.conf is created empty by the NixOS
+    // tmpfiles entry on every boot, and archiving an empty file would
+    // be noise. The flag write still records the migration as done.
+    if meta.is_file() && meta.len() == 0 {
+        let _ = tokio::fs::write(
+            flag,
+            format!("{label}: {path} was empty, nothing to archive\n").as_bytes(),
+        )
+        .await;
+        return;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|_| "unknown".into());
+    let archive_path = format!("{path}.archived.{ts}");
+    match tokio::fs::rename(path, &archive_path).await {
+        Ok(()) => {
+            info!(
+                "{label} migration: moved {path} → {archive_path}. \
+                 Safe to delete once Caddy admin-API TLS is confirmed working."
+            );
+            let _ = tokio::fs::write(
+                flag,
+                format!("archived to {archive_path}\n").as_bytes(),
+            )
+            .await;
+        }
+        Err(e) => {
+            warn!("{label} migration: rename {path} → {archive_path} failed: {e}");
+        }
+    }
+}
+
 fn sd_notify_ready() {
     let Some(sock_path) = std::env::var_os("NOTIFY_SOCKET") else {
         return;

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -100,7 +100,15 @@ pub(super) async fn try_route(
         },
         "apps.remove" => match require_str(req, "name") {
             Ok(name) => match state.apps.remove(name).await {
-                Ok(()) => ok(req, "ok"),
+                Ok(()) => {
+                    // Cover the case where the removed app had a
+                    // subdomain ingress — Caddy stops trying to renew
+                    // the now-orphaned cert. The internal remove path
+                    // in nasty-apps clears the route via the admin API
+                    // but doesn't know about the TLS-automation layer.
+                    tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                    ok(req, "ok")
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,
@@ -273,7 +281,14 @@ pub(super) async fn try_route(
                     err(req, format!("subdomain conflict: {reason}"))
                 } else {
                     match state.apps.ingress_set(p).await {
-                        Ok(v) => ok(req, v),
+                        Ok(v) => {
+                            // Refresh Caddy's TLS automation so a new
+                            // subdomain gets a cert immediately. Spawn
+                            // so the RPC reply isn't blocked by the
+                            // admin-API round-trip.
+                            tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                            ok(req, v)
+                        }
                         Err(e) => err(req, e),
                     }
                 }
@@ -300,7 +315,13 @@ pub(super) async fn try_route(
         }
         "apps.ingress.remove" => match require_str(req, "name") {
             Ok(name) => match state.apps.ingress_remove(name).await {
-                Ok(()) => ok(req, "ok"),
+                Ok(()) => {
+                    // Reapply so Caddy stops trying to renew the cert
+                    // for the now-orphaned subdomain. Same fire-and-
+                    // forget pattern as the set arm above.
+                    tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                    ok(req, "ok")
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }
+nasty-apps = { path = "../nasty-apps" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -795,7 +795,10 @@ async fn env_matches_running(expected: &str) -> bool {
 /// Build the `Vec<TlsPolicy>` to push for the current settings + app
 /// subdomain set. Returns empty when ACME is disabled — the caller
 /// PUTs that empty list to clear Caddy's automation.
-fn build_policy_set(settings: &Settings, app_subdomains: &[String]) -> Vec<nasty_apps::caddy::TlsPolicy> {
+fn build_policy_set(
+    settings: &Settings,
+    app_subdomains: &[String],
+) -> Vec<nasty_apps::caddy::TlsPolicy> {
     if !settings.tls_acme_enabled {
         return Vec::new();
     }
@@ -868,8 +871,7 @@ pub async fn refresh_acme_status_from_disk(settings: &Settings) {
         let status = ACME_STATUS.get_or_init(|| std::sync::Mutex::new(AcmeStatus::default()));
         if let Ok(mut s) = status.lock() {
             s.state = "idle".into();
-            s.message =
-                "ACME disabled; Caddy's internal CA is serving the :443 fallback.".into();
+            s.message = "ACME disabled; Caddy's internal CA is serving the :443 fallback.".into();
             s.domain = domain;
             s.expires = None;
             s.issued = None;

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -66,31 +66,88 @@ pub fn reset_acme_status() {
     set_acme_status("idle", "", None);
 }
 
-/// Re-apply the Caddy TLS snippet. Useful after a transient failure
-/// (Caddy briefly down, ACME server flaking, etc.) — the user can hit
-/// "retry" in the WebUI and we re-render + reload, which kicks Caddy's
-/// internal ACME state machine back into action.
+/// Re-apply the Caddy TLS automation policy. Useful after a transient
+/// failure (Caddy briefly down, ACME server flaking, etc.) — the user
+/// can hit "retry" in the WebUI and we push the same policies again,
+/// which kicks Caddy's issuance state machine back into action.
 pub async fn retry_acme() -> Result<(), String> {
     let settings = load().await;
+    let app_subdomains = load_app_subdomains().await;
     tokio::spawn(async move {
-        if let Err(e) = apply_caddy_tls(&settings).await {
-            warn!("Caddy TLS reload failed: {e}");
+        if let Err(e) = apply_caddy_tls_with_apps(&settings, &app_subdomains).await {
+            warn!("Caddy TLS reapply failed: {e}");
         }
     });
     Ok(())
 }
 
+/// Fire-and-forget TLS automation reapply. Called by router-level
+/// ingress mutations (set / remove with a subdomain) so a newly-added
+/// hostname gets a cert immediately, and a removed one stops being
+/// renewed. Cheap when nothing changed — Caddy compares the PUT body
+/// against the running config and no-ops if identical.
+///
+/// Best-effort: failures log a warning. The next user-triggered TLS
+/// action (settings change, retry button) reconverges.
+pub async fn reapply_tls_from_disk() {
+    let settings = load().await;
+    let app_subdomains = load_app_subdomains().await;
+    if let Err(e) = apply_caddy_tls_with_apps(&settings, &app_subdomains).await {
+        warn!("Caddy TLS reapply failed: {e}");
+    }
+}
+
+/// Walk `/var/lib/nasty/apps/*.json` and collect every non-empty
+/// `ingress_subdomain` value. Used by [`retry_acme`] and the
+/// settings-change path so the TLS policy set always reflects every
+/// hostname Caddy needs to serve, not just the main domain.
+///
+/// nasty-system reads these manifests as raw JSON (rather than via
+/// the nasty-apps type) to keep the dep direction one-way: apps
+/// already depends on system via the AppRoute / CaddyApi flow, and
+/// pulling apps's typed reader in would close that loop. Best-effort:
+/// any read or parse failure is logged at debug and skipped — a
+/// malformed app.json shouldn't block the main-domain cert refresh.
+async fn load_app_subdomains() -> Vec<String> {
+    let dir = "/var/lib/nasty/apps";
+    let mut out = Vec::new();
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(d) => d,
+        Err(_) => return out,
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = match tokio::fs::read(&path).await {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let v: serde_json::Value = match serde_json::from_slice(&bytes) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(host) = v.get("ingress_subdomain").and_then(|s| s.as_str())
+            && !host.trim().is_empty()
+        {
+            out.push(host.trim().to_string());
+        }
+    }
+    out
+}
+
 const STATE_PATH: &str = "/var/lib/nasty/settings.json";
 const STATE_DIR: &str = "/var/lib/nasty";
-const TLS_CERT_PATH: &str = "/var/lib/nasty/tls/cert.pem";
-
-// Caddy reads this snippet from its main Caddyfile via `import` to add a
-// hostname-bound vhost when ACME is enabled. Empty file = no extra vhost,
-// Caddy serves the static-cert `:8443` block from the NixOS-managed config.
-const CADDY_VHOSTS_PATH: &str = "/var/lib/nasty/caddy/vhosts.conf";
 
 // Caddy reads DNS-01 provider credentials from this EnvironmentFile (the
-// caddy.service unit references it). One KEY=VAL per line.
+// caddy.service unit references it). One KEY=VAL per line. We still
+// write this even though the rest of the TLS pipeline moved to the
+// admin API — Caddy resolves `{env.X}` references in admin-pushed
+// config from the process env, which is populated from this file at
+// service start. No way to push secrets directly through the admin API
+// without baking them into the JSON, which would leak them into the
+// Caddy storage on disk.
 const CADDY_ACME_ENV_PATH: &str = "/var/lib/nasty/caddy/acme.env";
 
 /// Display unit for temperatures rendered in the WebUI. Internal storage
@@ -435,12 +492,13 @@ impl SettingsService {
         save(&settings).await.map_err(|e| e.to_string())?;
         if tls_changed {
             // Always re-apply on a TLS change — even when ACME is now
-            // disabled the snippet must flip back to the static-cert
-            // form so Caddy stops serving the old ACME-issued cert.
+            // disabled, the automation policy must be cleared so Caddy
+            // stops renewing certs we no longer want.
             let s = settings.clone();
+            let app_subdomains = load_app_subdomains().await;
             tokio::spawn(async move {
-                if let Err(e) = apply_caddy_tls(&s).await {
-                    warn!("Caddy TLS reload failed: {e}");
+                if let Err(e) = apply_caddy_tls_with_apps(&s, &app_subdomains).await {
+                    warn!("Caddy TLS reapply failed: {e}");
                 }
             });
         }
@@ -554,12 +612,13 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 // used to live in this file as a 250-line `lego` subprocess wrapper.
 //
 // The engine's job here is reduced to:
-//   1. Render a Caddy snippet from `Settings` describing the desired
-//      TLS state (static cert vs hostname-bound ACME vhost).
-//   2. Write it to `CADDY_VHOSTS_PATH`, where the NixOS-managed
-//      Caddyfile imports it.
-//   3. Reload Caddy (`systemctl reload`) so it picks up the snippet.
-//   4. Read back what Caddy ends up serving so the WebUI can show
+//   1. Write the user's DNS-provider credentials to the
+//      `CADDY_ACME_ENV_PATH` EnvironmentFile so Caddy can resolve
+//      `{env.X}` references in admin-pushed config.
+//   2. Push a `tls.automation.policies[]` block to Caddy's admin API
+//      describing every hostname we want a cert for (main domain +
+//      per-app subdomains). Caddy issues + renews + staples.
+//   3. Read back what Caddy ends up serving so the WebUI can show
 //      issuer / expiry / status.
 //
 // Caddy stores ACME-issued certs under
@@ -571,157 +630,21 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 
 const CADDY_DATA_DIR: &str = "/var/lib/caddy";
 
-/// Render the `dns <provider>` directive body for a DNS-01 challenge.
-///
-/// Each plugin's Caddyfile syntax is slightly different:
-///   - Single-token plugins (cloudflare, duckdns, linode, hetzner, desec)
-///     take the credential as the first positional argument; we render it
-///     as a `{env.NAME}` placeholder so Caddy reads it from the
-///     `EnvironmentFile` written from `tls_dns_credentials`.
-///   - Two-token plugins (porkbun) take both as positional args.
-///   - Multi-arg plugins (namecheap, rfc2136) require a sub-block.
-///   - route53 reads AWS_* env vars automatically; the empty form works.
-///   - Anything not in this table falls back to a bare `dns <name>` and
-///     hopes the plugin can self-configure from environment. If the
-///     plugin isn't compiled into the Caddy binary at all, Caddy's
-///     reload will reject the config with a clear "unknown module"
-///     message — caller surfaces that error through the WebUI.
-///
-/// The result may be multi-line; the caller is responsible for
-/// indenting each line to the enclosing `tls { ... }` block.
-fn dns_directive_for(provider: &str) -> String {
-    match provider {
-        "cloudflare" => "dns cloudflare {env.CF_API_TOKEN}".to_string(),
-        "duckdns" => "dns duckdns {env.DUCKDNS_TOKEN}".to_string(),
-        "linode" => "dns linode {env.LINODE_TOKEN}".to_string(),
-        "desec" => "dns desec {env.DESEC_TOKEN}".to_string(),
-        "hetzner" => "dns hetzner {env.HETZNER_API_TOKEN}".to_string(),
-        // route53 plugin reads AWS_REGION / AWS_ACCESS_KEY_ID /
-        // AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN) from env on its
-        // own when given no positional args.
-        "route53" => "dns route53".to_string(),
-        // porkbun takes two positional args (api_key, secret_api_key).
-        "porkbun" => "dns porkbun {env.PORKBUN_API_KEY} {env.PORKBUN_SECRET_API_KEY}".to_string(),
-        "namecheap" => "dns namecheap {\n    \
-                        user {env.NAMECHEAP_USER}\n    \
-                        api_key {env.NAMECHEAP_API_KEY}\n    \
-                        api_endpoint https://api.namecheap.com/xml.response\n    \
-                        client_ip {env.NAMECHEAP_CLIENT_IP}\n\
-                        }"
-        .to_string(),
-        "rfc2136" => "dns rfc2136 {\n    \
-                      key_name {env.RFC2136_KEY_NAME}\n    \
-                      key {env.RFC2136_KEY}\n    \
-                      key_alg {env.RFC2136_KEY_ALG}\n    \
-                      server {env.RFC2136_SERVER}\n\
-                      }"
-        .to_string(),
-        _ => format!("dns {provider}"),
-    }
-}
-
-/// Render the Caddy snippet that should live at `CADDY_VHOSTS_PATH`.
-///
-/// When ACME is disabled or no domain is set, returns the empty string —
-/// the NixOS-managed `:8443` block (with the static self-signed cert)
-/// is the only vhost in play. When ACME is enabled, returns a single
-/// hostname-bound vhost that Caddy will issue + serve a real cert for,
-/// while the static `:8443` block stays as the IP-fallback for users
-/// hitting the box by address.
-fn caddy_vhosts_snippet(settings: &Settings, https_port: u16) -> String {
-    if !settings.tls_acme_enabled {
-        return String::new();
-    }
-    let Some(domain) = settings.tls_domain.as_deref() else {
-        return String::new();
-    };
-    if domain.trim().is_empty() {
-        return String::new();
-    }
-
-    // Email is optional for Caddy's ACME issuer (Let's Encrypt requires
-    // one for renewal notices but won't reject without). Render an empty
-    // arg if missing rather than failing the whole reload.
-    let email = settings
-        .tls_acme_email
-        .as_deref()
-        .unwrap_or("")
-        .trim()
-        .to_string();
-
-    let mut out = String::new();
-    out.push_str(&format!("{domain}:{https_port} {{\n"));
-
-    // The `tls` directive's first form is `tls EMAIL` (or just `tls`)
-    // and triggers Caddy's automatic ACME flow for the matched
-    // hostname(s). Anything inside `{ ... }` overrides the defaults.
-    let needs_block = settings.tls_acme_staging
-        || settings.tls_challenge_type == "dns"
-        || settings.tls_challenge_type == "tls-alpn"
-        || settings.tls_challenge_type == "http";
-
-    if !needs_block {
-        if email.is_empty() {
-            out.push_str("    tls\n");
-        } else {
-            out.push_str(&format!("    tls {email}\n"));
-        }
-    } else {
-        if email.is_empty() {
-            out.push_str("    tls {\n");
-        } else {
-            out.push_str(&format!("    tls {email} {{\n"));
-        }
-
-        // Restrict the challenge mechanism. Caddy defaults to trying
-        // both HTTP-01 and TLS-ALPN-01; pinning lets the user pick one
-        // when their network only allows one (e.g. port 80 firewalled).
-        match settings.tls_challenge_type.as_str() {
-            "http" => out.push_str("        protocols tls1.2 tls1.3\n"),
-            "tls-alpn" => out.push_str("        protocols tls1.2 tls1.3\n"),
-            _ => {}
-        }
-
-        // DNS-01 needs a `dns` directive whose shape varies per
-        // plugin: single-token plugins take the credential as the
-        // first positional arg, multi-arg plugins want a sub-block
-        // with named keys. Either way, we render `{env.X}` placeholders
-        // that Caddy expands at request time from its EnvironmentFile
-        // (sourced from `tls_dns_credentials`). Caller is responsible
-        // for pasting matching KEY=VAL lines into credentials.
-        if settings.tls_challenge_type == "dns"
-            && let Some(provider) = settings.tls_dns_provider.as_deref()
-        {
-            for line in dns_directive_for(provider).lines() {
-                out.push_str("        ");
-                out.push_str(line);
-                out.push('\n');
-            }
-        }
-
-        // Issuer block: only needed for the staging override. Without
-        // it, Caddy uses the production Let's Encrypt directory (its
-        // default).
-        if settings.tls_acme_staging {
-            out.push_str("        issuer acme {\n");
-            out.push_str("            ca https://acme-staging-v02.api.letsencrypt.org/directory\n");
-            out.push_str("        }\n");
-            out.push_str("        issuer zerossl {\n");
-            out.push_str("            ca https://acme-staging-v02.api.letsencrypt.org/directory\n");
-            out.push_str("        }\n");
-        }
-
-        out.push_str("    }\n");
-    }
-
-    out.push_str("    import nasty_webui_routes\n");
-    out.push_str("}\n");
-    out
-}
+/// Per-app subdomain ingresses the engine knows about, used to extend
+/// the TLS automation policy beyond just the main `tls_domain`.
+/// Sourced by the engine binary (it has the apps service) and passed
+/// to [`apply_caddy_tls_with_apps`]. Settings code stays decoupled
+/// from the apps crate's storage layer.
+pub type AppSubdomains = Vec<String>;
 
 /// Render the Caddy `EnvironmentFile` content from `tls_dns_credentials`.
 /// Empty when ACME-DNS is off — the file is recreated empty so a stale
 /// value from a previous provider doesn't leak into the next run.
+///
+/// The env vars referenced from `dns_provider_json` in nasty-apps' caddy
+/// module (e.g. `CLOUDFLARE_DNS_API_TOKEN`) must be present in this file
+/// for Caddy to resolve them at request time. We trust the operator to
+/// write KEY=VAL lines matching what the chosen provider expects.
 fn caddy_acme_env(settings: &Settings) -> String {
     if !settings.tls_acme_enabled
         || settings.tls_challenge_type != "dns"
@@ -738,45 +661,54 @@ fn caddy_acme_env(settings: &Settings) -> String {
         + "\n"
 }
 
-/// Apply current settings to Caddy: render the snippet + env file,
-/// write them, reload Caddy, then refresh the cached ACME status from
-/// whatever Caddy ends up serving.
+/// Apply current TLS settings to Caddy via the admin API: write the
+/// EnvironmentFile (so Caddy can resolve `{env.X}` placeholders), then
+/// push the automation policy set.
+///
+/// `app_subdomains` is the list of additional hostnames per-app ingress
+/// has registered. Empty when the caller is settings-only (the engine
+/// binary will pass the real list during startup reconcile and on
+/// ingress mutations).
+///
+/// File-vs-admin-API split: secrets stay file-based because pushing
+/// them through the admin API would land them in `/var/lib/caddy/...`
+/// alongside the cert storage. EnvironmentFile is the standard
+/// systemd-managed secrets path; mode 0640 + group caddy keeps it out
+/// of unprivileged hands.
 pub async fn apply_caddy_tls(settings: &Settings) -> Result<(), String> {
+    apply_caddy_tls_with_apps(settings, &[]).await
+}
+
+/// Variant of [`apply_caddy_tls`] that takes the per-app subdomain list
+/// explicitly. The engine binary knows about apps; settings doesn't, so
+/// we keep the dep direction clean by funnelling everything through
+/// this helper.
+pub async fn apply_caddy_tls_with_apps(
+    settings: &Settings,
+    app_subdomains: &[String],
+) -> Result<(), String> {
     let domain_for_status = settings.tls_domain.clone();
 
     if settings.tls_acme_enabled {
         set_acme_status(
             "running",
-            "Reloading Caddy with ACME configuration...",
+            "Applying TLS automation via Caddy admin API...",
             domain_for_status.as_deref(),
         );
     }
 
-    // Both files live in the same dir, owned by the caddy user/group so
-    // Caddy can read them. Engine runs as root, so the create + chown
-    // here are guaranteed to succeed even on first apply — but log any
-    // failure anyway per the workspace-wide rule (see CONTRIBUTING.md).
-    if let Some(parent) = std::path::Path::new(CADDY_VHOSTS_PATH).parent()
+    // EnvironmentFile lives next to the (now-vestigial) caddy state
+    // dir. Owned by root:caddy so the unit can read it.
+    if let Some(parent) = std::path::Path::new(CADDY_ACME_ENV_PATH).parent()
         && let Err(e) = tokio::fs::create_dir_all(parent).await
     {
         warn!("create_dir_all({}) failed: {e}", parent.display());
-    }
-
-    let snippet = caddy_vhosts_snippet(settings, 8443);
-    tokio::fs::write(CADDY_VHOSTS_PATH, &snippet)
-        .await
-        .map_err(|e| format!("write {CADDY_VHOSTS_PATH}: {e}"))?;
-    if let Err(e) =
-        tokio::fs::set_permissions(CADDY_VHOSTS_PATH, std::fs::Permissions::from_mode(0o644)).await
-    {
-        warn!("chmod 644 {CADDY_VHOSTS_PATH} failed: {e}");
     }
 
     let env_content = caddy_acme_env(settings);
     tokio::fs::write(CADDY_ACME_ENV_PATH, &env_content)
         .await
         .map_err(|e| format!("write {CADDY_ACME_ENV_PATH}: {e}"))?;
-    // 0640 + chown caddy: secrets, not world-readable.
     if let Err(e) =
         tokio::fs::set_permissions(CADDY_ACME_ENV_PATH, std::fs::Permissions::from_mode(0o640))
             .await
@@ -785,56 +717,140 @@ pub async fn apply_caddy_tls(settings: &Settings) -> Result<(), String> {
     }
     nasty_common::cmd::try_run("chown", &["root:caddy", CADDY_ACME_ENV_PATH]).await;
 
-    // `systemctl reload caddy` directly rather than through try_run so
-    // we can surface stderr to the caller (the WebUI shows it as an
-    // error toast). Spawn / non-zero-exit logging happens here inline.
-    let reload = tokio::process::Command::new("systemctl")
-        .args(["reload", "caddy"])
-        .output()
-        .await
-        .map_err(|e| {
-            let m = format!("systemctl reload caddy: spawn failed: {e}");
-            warn!("{m}");
-            m
-        })?;
-    if !reload.status.success() {
-        let stderr = String::from_utf8_lossy(&reload.stderr).to_string();
-        let msg = format!("caddy reload failed: {stderr}");
-        warn!("{msg}");
-        set_acme_status("error", &msg, domain_for_status.as_deref());
-        return Err(msg);
+    // Restart Caddy if the env file changed — admin-API config can
+    // reference `{env.X}` but those references are resolved against the
+    // process environment, populated from EnvironmentFile at unit
+    // start. Updates to the file don't reach the running process until
+    // it's restarted. Skip when ACME is off (no env to refresh) or
+    // when creds match what's already loaded (env_matches_running).
+    if settings.tls_acme_enabled
+        && settings.tls_challenge_type == "dns"
+        && !env_matches_running(&env_content).await
+    {
+        let restart = tokio::process::Command::new("systemctl")
+            .args(["restart", "caddy"])
+            .output()
+            .await
+            .map_err(|e| {
+                let m = format!("systemctl restart caddy: spawn failed: {e}");
+                warn!("{m}");
+                m
+            })?;
+        if !restart.status.success() {
+            let stderr = String::from_utf8_lossy(&restart.stderr).to_string();
+            let msg = format!("caddy restart failed: {stderr}");
+            warn!("{msg}");
+            set_acme_status("error", &msg, domain_for_status.as_deref());
+            return Err(msg);
+        }
+        info!("caddy restarted (EnvironmentFile refreshed)");
+        // Wait for admin API to come back up before pushing config.
+        let api = nasty_apps::caddy::CaddyApi::new();
+        if let Err(e) = api.wait_ready(30).await {
+            warn!("caddy admin API not ready after restart: {e}");
+            set_acme_status("error", &e, domain_for_status.as_deref());
+            return Err(e);
+        }
     }
-    info!("caddy reloaded");
 
-    // Push the status forward best-effort. A successful reload doesn't
-    // mean the ACME issuance is complete — Caddy issues asynchronously
-    // — so we fall back to "running" if no cert is on disk yet.
+    // Build the desired policy set: main domain (when ACME enabled) +
+    // every app subdomain. Empty ⇒ Caddy clears automation and falls
+    // back to the static-cert :443 block.
+    let policies = build_policy_set(settings, app_subdomains);
+    let issuer = nasty_apps::caddy::TlsIssuer {
+        email: settings.tls_acme_email.clone(),
+        dns_provider: if settings.tls_acme_enabled && settings.tls_challenge_type == "dns" {
+            settings.tls_dns_provider.clone()
+        } else {
+            None
+        },
+        staging: settings.tls_acme_staging,
+    };
+
+    let api = nasty_apps::caddy::CaddyApi::new();
+    if let Err(e) = api.set_tls_automation(&policies, &issuer).await {
+        warn!("caddy: set_tls_automation failed: {e}");
+        set_acme_status("error", &e, domain_for_status.as_deref());
+        return Err(e);
+    }
+
     refresh_acme_status_from_disk(settings).await;
     Ok(())
 }
 
-/// Locate the cert Caddy is currently serving for `domain`, falling back
-/// to the static-cert path used when ACME is off.
-async fn locate_serving_cert(settings: &Settings) -> Option<String> {
-    if settings.tls_acme_enabled
-        && let Some(domain) = settings.tls_domain.as_deref()
+/// Cheap check: read the running Caddy unit's EnvironmentFile contents
+/// via systemd and see whether they match `expected`. Used to skip an
+/// expensive restart when the operator hits "save" without actually
+/// changing credentials. Returns true on any read failure so we err on
+/// the side of NOT restarting (safer to leave running than to bounce
+/// for no reason).
+async fn env_matches_running(expected: &str) -> bool {
+    let current = match tokio::fs::read_to_string(CADDY_ACME_ENV_PATH).await {
+        Ok(s) => s,
+        Err(_) => return true,
+    };
+    current.trim() == expected.trim()
+}
+
+/// Build the `Vec<TlsPolicy>` to push for the current settings + app
+/// subdomain set. Returns empty when ACME is disabled — the caller
+/// PUTs that empty list to clear Caddy's automation.
+fn build_policy_set(settings: &Settings, app_subdomains: &[String]) -> Vec<nasty_apps::caddy::TlsPolicy> {
+    if !settings.tls_acme_enabled {
+        return Vec::new();
+    }
+    let mut policies = Vec::new();
+    if let Some(domain) = settings.tls_domain.as_deref()
+        && !domain.trim().is_empty()
     {
-        // `/var/lib/caddy/.local/share/caddy/certificates/<endpoint>/<domain>/<domain>.crt`
-        // Endpoint dir name varies (production vs staging vs zerossl
-        // fallback), so glob one level deep.
-        let base = format!("{CADDY_DATA_DIR}/.local/share/caddy/certificates");
-        if let Ok(mut endpoints) = tokio::fs::read_dir(&base).await {
-            while let Ok(Some(ep)) = endpoints.next_entry().await {
-                let candidate = format!("{}/{domain}/{domain}.crt", ep.path().display());
-                if tokio::fs::metadata(&candidate).await.is_ok() {
-                    return Some(candidate);
-                }
-            }
+        policies.push(nasty_apps::caddy::TlsPolicy {
+            host: domain.trim().to_string(),
+        });
+    }
+    for sub in app_subdomains {
+        let sub = sub.trim();
+        if sub.is_empty() {
+            continue;
         }
+        // Deduplicate against the main domain.
+        if policies.iter().any(|p| p.host == sub) {
+            continue;
+        }
+        policies.push(nasty_apps::caddy::TlsPolicy {
+            host: sub.to_string(),
+        });
+    }
+    policies
+}
+
+/// Locate the cert Caddy is currently serving for `domain` when ACME
+/// is on. Returns None when no managed cert is on disk yet — caller
+/// surfaces that as "still issuing".
+///
+/// We only look under Caddy's ACME-issuer subtrees
+/// (`certificates/acme-v02.*` etc.) — NOT under the internal-CA
+/// subtree, because a managed-cert-not-yet-issued shouldn't be masked
+/// by Caddy's local-authority cert. The internal CA's cert is what
+/// the `:443` fallback serves, and the WebUI's "active certificate"
+/// view is about the *managed* cert.
+async fn locate_serving_cert(settings: &Settings) -> Option<String> {
+    if !settings.tls_acme_enabled {
         return None;
     }
-    if tokio::fs::metadata(TLS_CERT_PATH).await.is_ok() {
-        return Some(TLS_CERT_PATH.to_string());
+    let domain = settings.tls_domain.as_deref()?;
+    let base = format!("{CADDY_DATA_DIR}/.local/share/caddy/certificates");
+    let mut endpoints = tokio::fs::read_dir(&base).await.ok()?;
+    while let Ok(Some(ep)) = endpoints.next_entry().await {
+        let name = ep.file_name().to_string_lossy().into_owned();
+        // Skip the internal-CA dir — those certs are for the fallback,
+        // not for the managed hostname.
+        if name.starts_with("local") {
+            continue;
+        }
+        let candidate = format!("{}/{domain}/{domain}.crt", ep.path().display());
+        if tokio::fs::metadata(&candidate).await.is_ok() {
+            return Some(candidate);
+        }
     }
     None
 }
@@ -845,25 +861,25 @@ async fn locate_serving_cert(settings: &Settings) -> Option<String> {
 pub async fn refresh_acme_status_from_disk(settings: &Settings) {
     let domain = settings.tls_domain.clone();
     if !settings.tls_acme_enabled {
-        // Static-cert mode. Show the cert details if we have any so the
-        // WebUI's "Active certificate" panel still has something to
-        // render, but flag the state as idle so the page doesn't claim
-        // ACME succeeded.
-        let cert_info = read_cert_info(TLS_CERT_PATH).await;
+        // No ACME. The :443 fallback is Caddy's internal-CA cert,
+        // managed entirely by Caddy. Surface that as `idle` rather
+        // than parsing a specific file — there's no "static cert"
+        // path the operator can point at anymore.
         let status = ACME_STATUS.get_or_init(|| std::sync::Mutex::new(AcmeStatus::default()));
         if let Ok(mut s) = status.lock() {
             s.state = "idle".into();
-            s.message = "Static certificate (ACME disabled)".into();
+            s.message =
+                "ACME disabled; Caddy's internal CA is serving the :443 fallback.".into();
             s.domain = domain;
-            s.expires = cert_info.expires;
-            s.issued = cert_info.issued;
-            s.issuer = cert_info.issuer;
+            s.expires = None;
+            s.issued = None;
+            s.issuer = None;
         }
         return;
     }
 
     let Some(path) = locate_serving_cert(settings).await else {
-        // ACME enabled but no cert on disk yet — still issuing.
+        // ACME enabled but no managed cert on disk yet — still issuing.
         set_acme_status(
             "running",
             "Waiting for Caddy to obtain a certificate...",
@@ -1036,7 +1052,7 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::{Settings, caddy_acme_env, caddy_vhosts_snippet, dns_directive_for, to_nix_string};
+    use super::{Settings, build_policy_set, caddy_acme_env, to_nix_string};
 
     fn acme_enabled_settings(challenge: &str) -> Settings {
         Settings {
@@ -1048,137 +1064,71 @@ mod tests {
         }
     }
 
-    #[test]
-    fn dns_directive_for_known_single_token_plugins() {
-        // Single-token plugins (Cloudflare et al.) take the credential as
-        // the first positional arg; we render `{env.NAME}` so Caddy reads
-        // it from the EnvironmentFile we write at apply time. Pin the
-        // exact env-var name per plugin — getting it wrong here means
-        // users paste the right secret under the wrong key and the
-        // plugin silently fails to authenticate.
-        assert_eq!(
-            dns_directive_for("cloudflare"),
-            "dns cloudflare {env.CF_API_TOKEN}"
-        );
-        assert_eq!(
-            dns_directive_for("duckdns"),
-            "dns duckdns {env.DUCKDNS_TOKEN}"
-        );
-        assert_eq!(dns_directive_for("linode"), "dns linode {env.LINODE_TOKEN}");
-        assert_eq!(dns_directive_for("desec"), "dns desec {env.DESEC_TOKEN}");
-        assert_eq!(
-            dns_directive_for("hetzner"),
-            "dns hetzner {env.HETZNER_API_TOKEN}"
-        );
-    }
+    // ── build_policy_set ──
 
     #[test]
-    fn dns_directive_for_route53_relies_on_aws_env_discovery() {
-        // route53 plugin reads AWS_REGION / AWS_ACCESS_KEY_ID /
-        // AWS_SECRET_ACCESS_KEY directly from process env when given no
-        // positional args — exactly what we want for the
-        // EnvironmentFile-driven flow.
-        assert_eq!(dns_directive_for("route53"), "dns route53");
-    }
-
-    #[test]
-    fn dns_directive_for_porkbun_takes_two_positional_tokens() {
-        assert_eq!(
-            dns_directive_for("porkbun"),
-            "dns porkbun {env.PORKBUN_API_KEY} {env.PORKBUN_SECRET_API_KEY}"
-        );
-    }
-
-    #[test]
-    fn dns_directive_for_namecheap_emits_sub_block_with_four_keys() {
-        // Namecheap needs user, api_key, api_endpoint, and client_ip —
-        // a positional form doesn't exist. The api_endpoint is fixed at
-        // the v2 XML endpoint (the only one the Caddy plugin supports).
-        let directive = dns_directive_for("namecheap");
-        assert!(directive.starts_with("dns namecheap {"));
-        assert!(directive.contains("user {env.NAMECHEAP_USER}"));
-        assert!(directive.contains("api_key {env.NAMECHEAP_API_KEY}"));
-        assert!(directive.contains("api_endpoint https://api.namecheap.com/xml.response"));
-        assert!(directive.contains("client_ip {env.NAMECHEAP_CLIENT_IP}"));
-        assert!(directive.trim_end().ends_with('}'));
-    }
-
-    #[test]
-    fn dns_directive_for_rfc2136_emits_sub_block_with_four_keys() {
-        let directive = dns_directive_for("rfc2136");
-        assert!(directive.starts_with("dns rfc2136 {"));
-        assert!(directive.contains("key_name {env.RFC2136_KEY_NAME}"));
-        assert!(directive.contains("key {env.RFC2136_KEY}"));
-        assert!(directive.contains("key_alg {env.RFC2136_KEY_ALG}"));
-        assert!(directive.contains("server {env.RFC2136_SERVER}"));
-    }
-
-    #[test]
-    fn dns_directive_for_unknown_provider_falls_through_to_bare_name() {
-        // Unknown / not-yet-baked-in providers get a bare `dns <name>`.
-        // Caddy will reject the reload with a clear "unknown module"
-        // error if the plugin isn't compiled into the binary, which is
-        // what we want — the caller surfaces that error via the WebUI.
-        assert_eq!(dns_directive_for("madeup"), "dns madeup");
-    }
-
-    #[test]
-    fn vhosts_snippet_empty_when_acme_disabled() {
-        // The static-cert `:8443` vhost in nasty.nix is the only one
-        // active; no hostname-bound block.
+    fn policy_set_empty_when_acme_disabled() {
+        // ACME off ⇒ no policies ⇒ engine PUTs an empty array ⇒ Caddy
+        // stops renewing. Per-app subdomains are ignored in this state
+        // because the user has opted out of cert automation entirely.
         let s = Settings::default();
-        assert!(caddy_vhosts_snippet(&s, 8443).is_empty());
+        assert!(
+            build_policy_set(&s, &["app.example.com".into()]).is_empty(),
+            "subdomains must be skipped when ACME is disabled"
+        );
     }
 
     #[test]
-    fn vhosts_snippet_tls_alpn_emits_short_form() {
-        // The simplest happy path: TLS-ALPN-01 with no DNS provider and
-        // no staging server. Caddy's automatic HTTP-01/TLS-ALPN-01 flow
-        // kicks in from a bare `tls EMAIL` directive (inside a block
-        // because we pin protocols).
-        let s = acme_enabled_settings("tls-alpn");
-        let out = caddy_vhosts_snippet(&s, 8443);
-        assert!(out.contains("nas.example.com:8443 {"));
-        assert!(out.contains("tls admin@example.com {"));
-        assert!(out.contains("import nasty_webui_routes"));
-        // No DNS plugin directive, no staging-CA override.
-        assert!(!out.contains("dns "));
-        assert!(!out.contains("acme-staging"));
+    fn policy_set_includes_main_domain() {
+        let s = acme_enabled_settings("dns");
+        let policies = build_policy_set(&s, &[]);
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].host, "nas.example.com");
     }
 
     #[test]
-    fn vhosts_snippet_dns_challenge_inlines_directive_at_indent() {
-        // The DNS directive needs to land inside the `tls { … }` block
-        // at the 8-space indent level the caller adds, so a sub-block
-        // (e.g., namecheap) ends up correctly nested. Verifying the
-        // structure here means a future plugin-table edit can't sneak
-        // a malformed Caddyfile past CI.
+    fn policy_set_appends_app_subdomains() {
+        let s = acme_enabled_settings("dns");
+        let policies = build_policy_set(&s, &["a.example.com".into(), "b.example.com".into()]);
+        assert_eq!(policies.len(), 3);
+        // Main domain comes first so it gets issued first on cold boot.
+        assert_eq!(policies[0].host, "nas.example.com");
+        assert_eq!(policies[1].host, "a.example.com");
+        assert_eq!(policies[2].host, "b.example.com");
+    }
+
+    #[test]
+    fn policy_set_dedupes_subdomain_matching_main_domain() {
+        // Edge case where an app's subdomain happens to equal the main
+        // domain (operator misconfiguration). Without the dedupe Caddy
+        // would receive two policies with the same subject and reject
+        // the PUT — fail open by collapsing.
+        let s = acme_enabled_settings("dns");
+        let policies = build_policy_set(&s, &["nas.example.com".into()]);
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].host, "nas.example.com");
+    }
+
+    #[test]
+    fn policy_set_skips_blank_subdomain_entries() {
+        // The on-disk app.json may carry an empty or whitespace
+        // `ingress_subdomain` field when the operator cleared it.
+        // load_app_subdomains skips blanks; this is the second line of
+        // defence.
+        let s = acme_enabled_settings("dns");
+        let policies = build_policy_set(&s, &["".into(), "   ".into()]);
+        assert_eq!(policies.len(), 1, "only the main domain should remain");
+    }
+
+    #[test]
+    fn policy_set_skips_main_domain_when_empty_string() {
+        // Operator enabled ACME but didn't (yet) fill in the domain
+        // field — only the apps' subdomains end up in the policy set.
         let mut s = acme_enabled_settings("dns");
-        s.tls_dns_provider = Some("cloudflare".into());
-        let out = caddy_vhosts_snippet(&s, 8443);
-        assert!(out.contains("        dns cloudflare {env.CF_API_TOKEN}"));
-    }
-
-    #[test]
-    fn vhosts_snippet_dns_sub_block_provider_keeps_inner_indent() {
-        let mut s = acme_enabled_settings("dns");
-        s.tls_dns_provider = Some("namecheap".into());
-        let out = caddy_vhosts_snippet(&s, 8443);
-        // First line of the sub-block at 8-space indent…
-        assert!(out.contains("        dns namecheap {"));
-        // …and the inner keys at 12 (the directive itself uses 4 spaces
-        // of internal indent, the caller adds 8).
-        assert!(out.contains("            user {env.NAMECHEAP_USER}"));
-        assert!(out.contains("            api_key {env.NAMECHEAP_API_KEY}"));
-    }
-
-    #[test]
-    fn vhosts_snippet_staging_emits_issuer_ca_override() {
-        let mut s = acme_enabled_settings("tls-alpn");
-        s.tls_acme_staging = true;
-        let out = caddy_vhosts_snippet(&s, 8443);
-        assert!(out.contains("issuer acme {"));
-        assert!(out.contains("ca https://acme-staging-v02.api.letsencrypt.org/directory"));
+        s.tls_domain = Some("   ".into());
+        let policies = build_policy_set(&s, &["only.example.com".into()]);
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].host, "only.example.com");
     }
 
     #[test]

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -5,9 +5,17 @@ let
   inherit (lib) mkEnableOption mkOption mkIf types;
   nastySystemFlakeSnapshot = args.nastySystemFlakeSnapshot or null;
 
-  useSelfSigned = cfg.tls.selfSigned && cfg.tls.certFile == null && cfg.tls.keyFile == null;
-  tlsCertFile = if cfg.tls.certFile != null then cfg.tls.certFile else "/var/lib/nasty/tls/cert.pem";
-  tlsKeyFile = if cfg.tls.keyFile != null then cfg.tls.keyFile else "/var/lib/nasty/tls/key.pem";
+  # When the operator supplies a cert + key (cfg.tls.certFile/keyFile),
+  # Caddy serves those for the :443 catch-all. Otherwise we use Caddy's
+  # `tls internal` directive — Caddy's "Local Authority" issues a
+  # self-signed cert into its own state dir (`/var/lib/caddy/...`) and
+  # auto-renews it. No more `nasty-selfsigned-cert.service`, no more
+  # cert.pem at /var/lib/nasty/tls/.
+  useUserCert = cfg.tls.certFile != null && cfg.tls.keyFile != null;
+  caddyTlsDirective =
+    if useUserCert
+    then "tls ${cfg.tls.certFile} ${cfg.tls.keyFile}"
+    else "tls internal";
 
   # targetcli-fb 3.0.2 passes `exclusive=` to rtslib-fb, but nixpkgs ships
   # rtslib-fb 2.2.3 which lacks that parameter.  Bump rtslib to 2.2.4+.
@@ -819,14 +827,18 @@ in {
 
     systemd.tmpfiles.rules = [
       "d /var/lib/nasty 0751 root root -"
+      # /var/lib/nasty/tls/ used to hold the static self-signed cert.
+      # `tls internal` in the Caddyfile now puts that under Caddy's
+      # own state dir; the directory entry below is kept so the
+      # engine's archive_path_once migration can find the old files
+      # to move them aside without racing the tmpfiles-creation step.
       "d /var/lib/nasty/tls 0750 root caddy -"
-      # Engine-managed Caddy snippets — vhosts.conf is imported by the
-      # main Caddyfile (hostname-bound ACME vhost when enabled, empty
-      # otherwise); acme.env feeds DNS-01 provider creds into Caddy via
+      # acme.env feeds DNS-01 provider creds into Caddy via
       # EnvironmentFile. Seeded empty so Caddy can start before the
-      # engine has had a chance to write either.
+      # engine has had a chance to write it. (vhosts.conf is no longer
+      # written — TLS automation is driven through the admin API; the
+      # engine's first-boot migration archives any leftover file.)
       "d /var/lib/nasty/caddy 0750 root caddy -"
-      "f /var/lib/nasty/caddy/vhosts.conf 0644 root caddy -"
       "f /var/lib/nasty/caddy/acme.env 0640 root caddy -"
       "d /var/lib/nasty/subvolumes 0750 root root -"
       "d /var/lib/nasty/shares 0750 root root -"
@@ -849,44 +861,13 @@ in {
       "d /var/state/ups 0750 root root -"
     ];
 
-    # ── Self-signed TLS certificate ───────────────────────────
-
-    systemd.services.nasty-selfsigned-cert = mkIf useSelfSigned {
-      description = "Generate NASty self-signed TLS certificate";
-      wantedBy = [ "multi-user.target" ];
-      before = [ "caddy.service" ];
-      requiredBy = [ "caddy.service" ];
-
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        ExecStart = pkgs.writeShellScript "nasty-selfsigned-cert" ''
-          set -euo pipefail
-          CERT="${tlsCertFile}"
-          KEY="${tlsKeyFile}"
-
-          if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
-            echo "Generating self-signed TLS certificate for NASty..."
-            ${pkgs.openssl}/bin/openssl req -x509 -newkey ec \
-              -pkeyopt ec_paramgen_curve:prime256v1 \
-              -keyout "$KEY" -out "$CERT" \
-              -days 3650 -nodes \
-              -subj "/CN=nasty.local/O=NASty NAS" \
-              -addext "subjectAltName=DNS:nasty.local,DNS:localhost,IP:127.0.0.1"
-            echo "Self-signed certificate generated at $CERT"
-          else
-            echo "TLS certificate already exists; re-applying ownership"
-          fi
-
-          # Always re-apply ownership / mode so an upgrade from the
-          # nginx era (where the key was group `nginx`) gets the key
-          # readable by Caddy without forcing a regeneration.
-          chmod 640 "$KEY"
-          chown root:caddy "$KEY"
-          chmod 644 "$CERT"
-        '';
-      };
-    };
+    # The static `:443` fallback is now `tls internal` by default
+    # (Caddy's Local Authority issues + auto-renews a self-signed cert
+    # into its own state dir). The old `nasty-selfsigned-cert.service`
+    # that generated /var/lib/nasty/tls/cert.pem on first boot is gone.
+    # Existing boxes carry the old cert.pem until the engine's first-
+    # boot migration archives it (see `archive_lego_dir_once` in
+    # nasty-engine).
 
     # ── NASty Metrics service ────────────────────────────────
 
@@ -1222,16 +1203,16 @@ in {
     # Caddy is configured as a single named snippet (`nasty_webui_routes`)
     # that holds every reverse-proxy / file-server / websocket / header
     # rule, plus a static `:<port>` vhost that mounts the snippet with the
-    # self-signed (or user-supplied) cert. The engine then optionally
-    # writes a hostname-bound ACME vhost to `/var/lib/nasty/caddy/vhosts.conf`
-    # which the main Caddyfile imports — Caddy issues + serves a real cert
-    # for that hostname while the static `:<port>` block stays as the IP
-    # fallback. Both vhosts share routes through the snippet, so we don't
-    # have to keep them in sync by hand.
+    # self-signed (or user-supplied) cert.
     #
-    # `auto_https off` because we never want Caddy enrolling for IP-bound
-    # vhosts; the engine-managed snippet drives ACME explicitly via the
-    # `tls EMAIL` form on a hostname-bound block.
+    # TLS automation (Let's Encrypt / ZeroSSL / staging) is pushed through
+    # the same admin API as ingress routes: on startup and after every
+    # settings/ingress mutation, the engine PUTs `apps.tls.automation`
+    # with a policy per managed hostname (main domain + each app
+    # subdomain). Caddy then issues + renews each cert, and SNI matching
+    # serves the right one. The static-cert `:<port>` block below stays
+    # as the IP / unknown-SNI fallback. No `vhosts.conf` file, no
+    # `systemctl reload caddy` on every settings change.
     services.caddy = mkIf (cfg.webui.package != null) {
       enable = true;
       # Rebuild Caddy with DNS-01 plugins compiled in. Stock `pkgs.caddy`
@@ -1266,7 +1247,17 @@ in {
         hash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
       };
       globalConfig = ''
-        auto_https off
+        # auto_https stays ON so Caddy generates the per-hostname
+        # `tls_connection_policies` entries that route a given SNI to
+        # the right managed cert. The engine still drives issuance
+        # explicitly through `apps.tls.automation` PUTs over the admin
+        # API — auto_https only adds the listener-level glue.
+        #
+        # `disable_redirects` because we already declare an explicit
+        # `:<httpPort> { redir ... }` block below; without this, Caddy
+        # tries to add its own redirect server on :80 and the two
+        # collide.
+        auto_https disable_redirects
       '';
       extraConfig = ''
         (nasty_webui_routes) {
@@ -1433,18 +1424,17 @@ in {
           redir https://{host}{uri} permanent
         }
 
-        # Always-on static-cert vhost. Serves the self-signed (or
-        # user-supplied) cert on the IP path. When ACME is enabled,
-        # Caddy prefers the hostname-bound vhost from the import below
-        # for matching SNI, and this block becomes the IP fallback.
+        # Fallback :443 vhost for unknown SNIs and direct-IP access.
+        # Either Caddy's internal CA (default, `tls internal`) or a
+        # user-supplied cert/key pair. When ACME is enabled, the engine
+        # pushes `tls.automation.policies` per managed hostname via the
+        # admin API and `auto_https` adds per-SNI connection policies
+        # in front of this fallback. Both share routes through the
+        # named snippet above.
         :${toString cfg.webui.port} {
-          tls ${tlsCertFile} ${tlsKeyFile}
+          ${caddyTlsDirective}
           import nasty_webui_routes
         }
-
-        # Engine-managed: hostname-bound ACME vhost when the user has
-        # enabled Let's Encrypt in Settings → TLS. Empty otherwise.
-        import /var/lib/nasty/caddy/vhosts.conf
       '';
     };
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1258,6 +1258,17 @@ in {
         # tries to add its own redirect server on :80 and the two
         # collide.
         auto_https disable_redirects
+
+        # When a TLS connection arrives with no SNI (direct-IP access,
+        # `curl https://10.x.x.x/`) or an SNI we don't recognise,
+        # Caddy substitutes this value before site routing. Pairs with
+        # the `nasty.local:443 { tls internal }` block below — every
+        # such connection ends up served by the internal-CA cert
+        # instead of TLS-handshake-failing. Without this, port-only
+        # `:443 { tls internal }` had no hostname to issue against and
+        # every IP-direct curl got `tlsv1 alert internal error`
+        # (caught by appliance-smoke CI).
+        default_sni nasty.local
       '';
       extraConfig = ''
         (nasty_webui_routes) {
@@ -1424,14 +1435,26 @@ in {
           redir https://{host}{uri} permanent
         }
 
-        # Fallback :443 vhost for unknown SNIs and direct-IP access.
-        # Either Caddy's internal CA (default, `tls internal`) or a
-        # user-supplied cert/key pair. When ACME is enabled, the engine
-        # pushes `tls.automation.policies` per managed hostname via the
-        # admin API and `auto_https` adds per-SNI connection policies
-        # in front of this fallback. Both share routes through the
-        # named snippet above.
-        :${toString cfg.webui.port} {
+        # Fallback site bound to `nasty.local` AND the port-only
+        # catch-all on :${toString cfg.webui.port}. The hostname is
+        # what `tls internal` issues the self-signed cert against (a
+        # port-only listener alone has no hostname for the internal CA
+        # to bind to). The port-only address makes the same site catch
+        # any TLS connection on this listener — combined with the
+        # `default_sni nasty.local` global directive, every SNI-less
+        # or unmatched-SNI connection ends up here and gets served the
+        # `nasty.local` cert.
+        #
+        # When ACME is enabled, the engine pushes
+        # `tls.automation.policies` per managed hostname via the admin
+        # API; `auto_https` adds per-SNI connection policies in front
+        # of this fallback so SNI=<managed-host> wins. Both share
+        # routes through the named snippet above.
+        #
+        # User-supplied cert + key still honoured via
+        # `cfg.tls.certFile/keyFile`; we pick that path instead of
+        # `tls internal` when both are set.
+        nasty.local, :${toString cfg.webui.port} {
           ${caddyTlsDirective}
           import nasty_webui_routes
         }


### PR DESCRIPTION
## Summary

The TLS layer was two half-flows pretending to be one. lego managed the main-domain cert; Caddy was supposed to manage per-app subdomain certs but couldn't because \`auto_https off\` was set globally and the \`:443\` connection policy pinned the file-cert tag exclusively. Per-app subdomain ingresses got their route added via admin API but never a cert — the "pending" UI state operators were seeing was literal: nothing was trying to issue.

This collapses both flows into one. Every managed hostname (main domain + each app's \`ingress_subdomain\`) gets a \`tls.automation\` policy pushed through Caddy's admin API. Caddy issues, renews, and staples. lego is gone. The static \`:443\` fallback is now \`tls internal\` — Caddy's Local Authority owns the self-signed cert and auto-renews it.

## What this fixes

- \`haze.0f.ee\` (and any other per-app subdomain) now actually gets a cert.
- The latent bug where \`vhosts.conf\` was empty on every box because the engine startup hook only refreshed status, never re-applied.
- The env-var-name mismatch between what the engine wrote (\`CLOUDFLARE_DNS_API_TOKEN=\`) and what the Caddyfile referenced (\`{env.CF_API_TOKEN}\`).

## Migration

Engine startup, idempotent via flag files. Archive (not delete) is the rule:

- \`/var/lib/nasty/lego/\` → \`lego.archived.<unix-ts>/\` (carries the user's ACME account private key)
- \`/var/lib/nasty/caddy/vhosts.conf\` → archived if non-empty
- \`/var/lib/nasty/tls/cert.pem\` + \`key.pem\` → archived (holds the lego-issued LE cert content on 0.0.7-with-ACME boxes)

A rollback to the previous NixOS generation can recover by renaming the archives back and removing the flag files; old engine then sees the original state.

## Test plan

- [ ] \`cargo build && cargo test --workspace\` — currently green, 400+ tests pass.
- [ ] \`cargo clippy --workspace --no-deps -- -D warnings\` — clean.
- [ ] Deploy to a 0.0.7-with-ACME box and confirm: (a) main domain cert re-issues via Caddy admin-API, (b) per-app subdomain cert (\`haze.0f.ee\`) issues for the first time, (c) HTTPS for the subdomain proxies to the container, (d) lego dir archived, (e) cert.pem archived, (f) direct-IP access shows Caddy Local Authority self-signed (no longer the stale LE cert).
- [ ] Roll back via \`nixos-rebuild switch --rollback\`, manually restore archives, confirm old engine + lego flow recovers.
- [ ] Fresh-install path: \`tls internal\` produces a working self-signed on \`:443\` from first boot, no \`nasty-selfsigned-cert.service\` involved.

## Risk

This is a TLS-layer refactor on the cert hot path. Failure modes are eventually-consistent (next engine restart re-pushes); the static-cert fallback keeps the box reachable during a botched cutover. But the cutover itself touches every existing box, so I'd want to land it on the test fleet first before tagging a release.

Fixes #99.