### PR TITLE
tls: 30s propagation_delay on DNS-01 challenge

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -647,17 +647,25 @@ fn build_acme_issuer_json(issuer: &TlsIssuer) -> Value {
         // that Caddy gives up. Pin to Cloudflare + Google so the box's
         // own resolver setup doesn't block issuance.
         //
-        // This mirrors what the lego flow did with `--dns.resolvers`
-        // before the Caddy migration. Hardcoded for now because the
-        // settings struct doesn't yet expose a knob; it's reasonable
-        // to make this configurable later, but every realistic box
-        // can reach 1.1.1.1 and 8.8.8.8.
+        // `propagation_delay` makes Caddy sleep N seconds after the
+        // provider's API call before issuing the verification query.
+        // Without this Caddy queries instantly, hits the resolver's
+        // negative cache (the prior NXDOMAIN for `_acme-challenge.X`
+        // is cached for the SOA's MINIMUM TTL — often 1 hour for
+        // Cloudflare), sees no record, retries on a backoff that
+        // never converges within the propagation timeout. 30s
+        // matches what the lego flow used (`--dns.propagation-wait`).
+        //
+        // Both settings mirror the lego defaults; hardcoded for now
+        // because the settings struct doesn't expose knobs. Easy to
+        // make configurable when a user has a real reason.
         obj.insert(
             "challenges".into(),
             json!({
                 "dns": {
                     "provider": dns_provider_json(provider),
-                    "resolvers": ["1.1.1.1", "8.8.8.8"]
+                    "resolvers": ["1.1.1.1", "8.8.8.8"],
+                    "propagation_delay": "30s"
                 }
             }),
         );

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -782,7 +782,62 @@ pub async fn apply_caddy_tls_with_apps(
     }
 
     refresh_acme_status_from_disk(settings).await;
+
+    // Caddy issues asynchronously. The status set above will be
+    // "running" / "Waiting for Caddy to obtain a certificate..." until
+    // the file lands on disk — which could be seconds (HTTP-01 from a
+    // public IP) or a few minutes (DNS-01 with our 30s propagation
+    // delay + ACME finalize round-trip). Without a follow-up poll the
+    // WebUI would stay on the "Provisioning" badge forever; users
+    // would have to refresh the engine to see "success".
+    //
+    // Spawn a polling task that re-runs refresh_acme_status_from_disk
+    // until the cert appears or we hit a 5-minute cap. Cheap (a few
+    // statx calls per tick) and the engine doesn't outlive Caddy's
+    // issuance window in practice. Only spawn when ACME is on and a
+    // managed cert is expected; otherwise there's nothing to wait for.
+    if settings.tls_acme_enabled && !policies.is_empty() {
+        let settings_for_poll = settings.clone();
+        tokio::spawn(async move {
+            poll_until_issued(&settings_for_poll).await;
+        });
+    }
+
     Ok(())
+}
+
+/// Re-run `refresh_acme_status_from_disk` on a fixed cadence until the
+/// status flips to `success` or `MAX_POLL_SECS` elapses. Called from
+/// `apply_caddy_tls_with_apps` after a successful policy push so the
+/// WebUI's "Provisioning" badge transitions to "Active" without the
+/// user having to refresh or restart the engine.
+///
+/// Cadence is 5s — Caddy DNS-01 takes ~30s minimum (our propagation
+/// delay) so we'd never catch a sub-5s issuance anyway, and a tighter
+/// poll would just spin against an empty cert dir.
+async fn poll_until_issued(settings: &Settings) {
+    const MAX_POLL_SECS: u64 = 300;
+    const POLL_INTERVAL_SECS: u64 = 5;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(MAX_POLL_SECS);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(POLL_INTERVAL_SECS)).await;
+        refresh_acme_status_from_disk(settings).await;
+        if get_acme_status().state == "success" {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            // Don't escalate to "error" — Caddy is still retrying in the
+            // background and might succeed minutes later. Leave the
+            // status as-is so the operator can see whatever Caddy's
+            // last reported state was; the next settings change or
+            // retry_acme call will pick it up.
+            warn!(
+                "acme: cert not issued within {MAX_POLL_SECS}s; leaving \
+                 status as-is. Caddy will keep retrying in the background."
+            );
+            return;
+        }
+    }
 }
 
 /// Verify that every `KEY=` line in `env_content` has a matching key


### PR DESCRIPTION
Last step on the deploy-on-10.10.20.100 verification chain. With #240 merged, Caddy was issuing through production LE but the propagation check kept timing out:

\`\`\`
[nas.0f.ee] solving challenges: waiting for solver certmagic.solverWrapper to be ready:
timed out waiting for record to fully propagate; verify DNS provider configuration is correct
\`\`\`

Confirmed via Cloudflare API that Caddy IS creating the TXT records correctly:

\`\`\`
_acme-challenge.haze.0f.ee → "BIRreGuo3GcSABXH18M_13HaIIy_..."
_acme-challenge.nas.0f.ee  → "t1YZvZpmkPOcO3NRwk-zRtdQNoov..."
\`\`\`

And the records ARE visible via the resolvers we pinned:

\`\`\`
$ dig +short TXT _acme-challenge.nas.0f.ee @1.1.1.1
"t1YZvZpmkPOcO3NRwk-zRtdQNoovoHHTyivKxt7WLSk"
\`\`\`

So the issue isn't the resolver, it's the **timing**. Caddy fires the propagation check sub-second after the Cloudflare API call returns. The recursive resolvers (1.1.1.1 / 8.8.8.8) have a cached NXDOMAIN for \`_acme-challenge.X\` from prior queries — the SOA MINIMUM TTL for negative caching is often ~1 hour on Cloudflare-managed zones. Until that cache flushes, the resolvers don't even ask the authoritative servers, so Caddy keeps getting "no record".

Fix: \`propagation_delay: "30s"\` in the DNS-01 challenge config. Same value lego used via \`--dns.propagation-wait\`. Enough time for the negative caches to age out and Caddy's first real lookup to land an answer.

## Live verification

I applied this via admin-API PATCH on the test box before the merge, to verify the theory. Within ~2 minutes both certs issued from LE production:

\`\`\`
/var/lib/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/haze.0f.ee/haze.0f.ee.crt
/var/lib/caddy/.local/share/caddy/certificates/acme-v02.api.letsencrypt.org-directory/nas.0f.ee/nas.0f.ee.crt
\`\`\`

End-to-end:

\`\`\`
$ curl -sI https://nas.0f.ee/  → HTTP/2 200
$ curl -sI https://haze.0f.ee/ → HTTP/2 200
$ openssl s_client … | openssl x509 -subject -issuer
subject=CN=nas.0f.ee
issuer=C=US, O=Let's Encrypt, CN=E7
\`\`\`

After merge + deploy, the engine config will match what's now patched live, so an engine restart won't regress.