### PR TITLE
tls: DNS resolver/propagation_wait knobs + Caddy local-CA download

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -78,11 +78,19 @@ pub struct TlsPolicy {
 /// caddy-dns plugin. When `None`, Caddy falls back to its default
 /// challenge order (HTTP-01 then TLS-ALPN-01) — useful when port 80 is
 /// reachable from the internet but DNS automation isn't set up.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TlsIssuer {
     pub email: Option<String>,
     pub dns_provider: Option<String>,
     pub staging: bool,
+    /// External DNS resolvers used during DNS-01 propagation checks.
+    /// `None` ⇒ engine default (`["1.1.1.1", "8.8.8.8"]`). Set when
+    /// the box can't reach those (split-horizon DNS, restricted egress).
+    pub dns_resolvers: Option<Vec<String>>,
+    /// Seconds to wait after creating the TXT record before checking
+    /// propagation. `None` ⇒ engine default (30s). Bump when resolvers
+    /// have unusually long negative-TTL caching.
+    pub dns_propagation_wait_secs: Option<u32>,
 }
 
 /// One row in the Ingress overview page — every route Caddy is serving,
@@ -644,8 +652,9 @@ fn build_acme_issuer_json(issuer: &TlsIssuer) -> Value {
         // resolver (systemd-resolved on most boxes), which in our setup
         // (split-horizon DNS, internal-only resolver, or just a slow
         // ISP cache) may not see the record for minutes — long enough
-        // that Caddy gives up. Pin to Cloudflare + Google so the box's
-        // own resolver setup doesn't block issuance.
+        // that Caddy gives up. Default to Cloudflare + Google so the
+        // box's own resolver setup doesn't block issuance; operators
+        // can override via `tls_dns_resolver` in settings.
         //
         // `propagation_delay` makes Caddy sleep N seconds after the
         // provider's API call before issuing the verification query.
@@ -654,18 +663,20 @@ fn build_acme_issuer_json(issuer: &TlsIssuer) -> Value {
         // is cached for the SOA's MINIMUM TTL — often 1 hour for
         // Cloudflare), sees no record, retries on a backoff that
         // never converges within the propagation timeout. 30s
-        // matches what the lego flow used (`--dns.propagation-wait`).
-        //
-        // Both settings mirror the lego defaults; hardcoded for now
-        // because the settings struct doesn't expose knobs. Easy to
-        // make configurable when a user has a real reason.
+        // matches what the lego flow used (`--dns.propagation-wait`)
+        // and is the default when `tls_dns_propagation_wait` is unset.
+        let resolvers: Vec<String> = issuer
+            .dns_resolvers
+            .clone()
+            .unwrap_or_else(|| vec!["1.1.1.1".to_string(), "8.8.8.8".to_string()]);
+        let propagation_delay = format!("{}s", issuer.dns_propagation_wait_secs.unwrap_or(30));
         obj.insert(
             "challenges".into(),
             json!({
                 "dns": {
                     "provider": dns_provider_json(provider),
-                    "resolvers": ["1.1.1.1", "8.8.8.8"],
-                    "propagation_delay": "30s"
+                    "resolvers": resolvers,
+                    "propagation_delay": propagation_delay,
                 }
             }),
         );
@@ -1112,6 +1123,7 @@ mod tests {
                 email: None,
                 dns_provider: None,
                 staging: false,
+                ..Default::default()
             },
         );
         let policies = body["policies"].as_array().unwrap();
@@ -1135,6 +1147,7 @@ mod tests {
                 email: None,
                 dns_provider: None,
                 staging: false,
+                ..Default::default()
             },
         );
         let policies = body["policies"].as_array().unwrap();
@@ -1153,6 +1166,7 @@ mod tests {
                 email: Some("ops@example.com".into()),
                 dns_provider: Some("cloudflare".into()),
                 staging: false,
+                ..Default::default()
             },
         );
         let p = &body["policies"][0];
@@ -1177,6 +1191,7 @@ mod tests {
                 email: None,
                 dns_provider: None,
                 staging: true,
+                ..Default::default()
             },
         );
         let issuer = &body["policies"][0]["issuers"][0];
@@ -1184,6 +1199,52 @@ mod tests {
             issuer["ca"],
             "https://acme-staging-v02.api.letsencrypt.org/directory"
         );
+    }
+
+    #[test]
+    fn tls_automation_dns_challenge_uses_custom_resolvers_when_set() {
+        // When the operator overrides `tls_dns_resolver`, those values
+        // should make it into the challenge config verbatim instead of
+        // the hardcoded Cloudflare/Google defaults. Useful for boxes
+        // on air-gapped networks where 1.1.1.1 isn't reachable.
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "h.example".into(),
+            }],
+            &TlsIssuer {
+                email: None,
+                dns_provider: Some("cloudflare".into()),
+                staging: false,
+                dns_resolvers: Some(vec!["10.0.0.53".into(), "10.0.0.54".into()]),
+                dns_propagation_wait_secs: None,
+            },
+        );
+        let resolvers = body["policies"][0]["issuers"][0]["challenges"]["dns"]["resolvers"]
+            .as_array()
+            .unwrap();
+        assert_eq!(resolvers.len(), 2);
+        assert_eq!(resolvers[0], "10.0.0.53");
+        assert_eq!(resolvers[1], "10.0.0.54");
+    }
+
+    #[test]
+    fn tls_automation_dns_challenge_uses_custom_propagation_wait_when_set() {
+        // Custom wait overrides the 30s default. Caddy serialises the
+        // duration as "<n>s" — the engine takes a u32 and renders it.
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "h.example".into(),
+            }],
+            &TlsIssuer {
+                email: None,
+                dns_provider: Some("cloudflare".into()),
+                staging: false,
+                dns_resolvers: None,
+                dns_propagation_wait_secs: Some(120),
+            },
+        );
+        let delay = &body["policies"][0]["issuers"][0]["challenges"]["dns"]["propagation_delay"];
+        assert_eq!(delay, "120s");
     }
 
     #[test]
@@ -1203,6 +1264,7 @@ mod tests {
                 email: None,
                 dns_provider: Some("cloudflare".into()),
                 staging: false,
+                ..Default::default()
             },
         );
         let resolvers = &body["policies"][0]["issuers"][0]["challenges"]["dns"]["resolvers"];
@@ -1227,6 +1289,7 @@ mod tests {
                 email: Some("a@b".into()),
                 dns_provider: None,
                 staging: false,
+                ..Default::default()
             },
         );
         let issuer = &body["policies"][0]["issuers"][0];
@@ -1252,6 +1315,7 @@ mod tests {
                 email: None,
                 dns_provider: None,
                 staging: false,
+                ..Default::default()
             },
         );
         let policies = body["policies"].as_array().unwrap();

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -128,6 +128,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.nut.status"
                 | "system.tailscale.get"
                 | "system.acme.status"
+                | "system.tls.local_ca_root"
                 | "system.metrics.history"
                 | "system.metrics.prometheus"
                 | "alert.rules.list"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -358,6 +358,24 @@ pub(super) async fn try_route(
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
         },
+        // Caddy's internal-CA root cert (PEM). The WebUI surfaces this
+        // as a download so operators can import it into their OS or
+        // browser trust store and stop getting fresh "untrusted cert"
+        // warnings for every NASty box served via `tls internal`.
+        // None ⇒ Caddy hasn't bootstrapped the CA yet (fresh box or
+        // not running); return the engine-level error string so the
+        // WebUI can render a clear "try again in a moment" message.
+        "system.tls.local_ca_root" => {
+            match nasty_system::settings::read_caddy_local_ca_root().await {
+                Some(pem) => ok(req, pem),
+                None => err(
+                    req,
+                    "Caddy local-CA root not available yet \
+                 (Caddy may still be starting up). Try again in a moment."
+                        .to_string(),
+                ),
+            }
+        }
         "system.tuning.get" => ok(req, state.tuning.get().await),
         "system.tuning.update" => match parse_params(req) {
             Ok(p) => match state.tuning.update(p).await {

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -97,6 +97,21 @@ pub async fn reapply_tls_from_disk() {
     }
 }
 
+/// Caddy's internal-CA root certificate. Lives in Caddy's state dir
+/// alongside the issued certs; we return its PEM so the WebUI can offer
+/// it as a download, letting operators import the cert into their
+/// OS/browser trust store and have every NASty box that uses
+/// `tls internal` (the default fallback) be trusted without per-host
+/// security warnings.
+///
+/// Returns the PEM string. None on read failure (Caddy not yet
+/// started, file permissions, no internal CA bootstrapped). Caller
+/// surfaces None as a 404-ish "not available yet" to the WebUI.
+pub async fn read_caddy_local_ca_root() -> Option<String> {
+    const ROOT_PATH: &str = "/var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt";
+    tokio::fs::read_to_string(ROOT_PATH).await.ok()
+}
+
 /// Walk `/var/lib/nasty/apps/*.json` and collect every non-empty
 /// `ingress_subdomain` value. Used by [`retry_acme`] and the
 /// settings-change path so the TLS policy set always reflects every
@@ -202,6 +217,24 @@ pub struct Settings {
     /// Use Let's Encrypt staging environment (for testing, avoids rate limits).
     #[serde(default)]
     pub tls_acme_staging: bool,
+    /// External DNS resolvers (comma-separated) to use when verifying
+    /// TXT-record propagation during DNS-01. Defaults to "1.1.1.1,8.8.8.8".
+    /// Set this when the box's authoritative DNS isn't reachable via
+    /// public resolvers (split-horizon zones, air-gapped networks).
+    /// Empty / None ⇒ use the default.
+    #[serde(default)]
+    pub tls_dns_resolver: Option<String>,
+    /// Seconds to wait after creating the TXT record before checking
+    /// propagation. Defaults to 30. The recursive resolvers we use to
+    /// verify propagation often have a long negative TTL on the
+    /// `_acme-challenge.X` name (cached NXDOMAIN from prior lookups);
+    /// without a wait, Caddy queries immediately, sees the cached
+    /// answer, and the timer-based propagation check times out before
+    /// the cache flushes. Bump this when issuance still times out
+    /// after several minutes (slow DNS providers, long SOA MINIMUM
+    /// TTL on the parent zone).
+    #[serde(default)]
+    pub tls_dns_propagation_wait: Option<u32>,
     /// Whether anonymous telemetry is enabled (drive count, storage capacity).
     #[serde(default = "default_telemetry_enabled")]
     pub telemetry_enabled: bool,
@@ -330,6 +363,8 @@ impl Default for Settings {
             tls_dns_provider: None,
             tls_dns_credentials: None,
             tls_acme_staging: false,
+            tls_dns_resolver: None,
+            tls_dns_propagation_wait: None,
             telemetry_enabled: default_telemetry_enabled(),
             oidc: OidcSettings::default(),
         }
@@ -360,6 +395,10 @@ pub struct SettingsUpdate {
     pub tls_dns_credentials: Option<String>,
     /// Use staging environment.
     pub tls_acme_staging: Option<bool>,
+    /// External DNS resolvers (comma-separated). Empty string clears.
+    pub tls_dns_resolver: Option<String>,
+    /// Propagation wait in seconds. 0 clears (engine treats as default).
+    pub tls_dns_propagation_wait: Option<u32>,
     /// Enable/disable anonymous telemetry.
     pub telemetry_enabled: Option<bool>,
 }
@@ -485,6 +524,27 @@ impl SettingsService {
         {
             settings.tls_acme_staging = staging;
             tls_changed = true;
+        }
+        if let Some(resolver) = update.tls_dns_resolver {
+            let resolver = if resolver.trim().is_empty() {
+                None
+            } else {
+                Some(resolver.trim().to_string())
+            };
+            if settings.tls_dns_resolver != resolver {
+                settings.tls_dns_resolver = resolver;
+                tls_changed = true;
+            }
+        }
+        if let Some(wait) = update.tls_dns_propagation_wait {
+            // 0 ⇒ clear (engine falls back to the default 30s). Allows
+            // the WebUI form to express "use default" without needing a
+            // separate null/clear field.
+            let wait = if wait == 0 { None } else { Some(wait) };
+            if settings.tls_dns_propagation_wait != wait {
+                settings.tls_dns_propagation_wait = wait;
+                tls_changed = true;
+            }
         }
         if let Some(telemetry) = update.telemetry_enabled {
             settings.telemetry_enabled = telemetry;
@@ -772,6 +832,17 @@ pub async fn apply_caddy_tls_with_apps(
             None
         },
         staging: settings.tls_acme_staging,
+        dns_resolvers: settings
+            .tls_dns_resolver
+            .as_deref()
+            .map(|s| {
+                s.split(',')
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v| !v.is_empty()),
+        dns_propagation_wait_secs: settings.tls_dns_propagation_wait,
     };
 
     let api = nasty_apps::caddy::CaddyApi::new();

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -577,6 +577,9 @@ export interface Settings {
 	tls_challenge_type: 'tls-alpn' | 'dns';
 	tls_dns_provider: string | null;
 	tls_dns_credentials: string | null;
+	tls_acme_staging: boolean;
+	tls_dns_resolver: string | null;
+	tls_dns_propagation_wait: number | null;
 	telemetry_enabled: boolean;
 }
 

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -16,6 +16,9 @@
 	let tlsChallengeType = $state<'tls-alpn' | 'http' | 'dns'>('tls-alpn');
 	let tlsDnsProvider = $state('');
 	let tlsDnsCredentials = $state('');
+	let tlsDnsResolver = $state('');
+	let tlsDnsPropagationWait = $state(0);
+	let showAdvancedDns = $state(false);
 	let savingTls = $state(false);
 	let tlsChanged = $state(false);
 	let editing = $state(false);
@@ -45,9 +48,37 @@
 		tlsChallengeType = settings?.tls_challenge_type ?? 'tls-alpn';
 		tlsDnsProvider = settings?.tls_dns_provider ?? '';
 		tlsDnsCredentials = settings?.tls_dns_credentials ?? '';
-		tlsAcmeStaging = (settings as any)?.tls_acme_staging ?? false;
+		tlsDnsResolver = settings?.tls_dns_resolver ?? '';
+		tlsDnsPropagationWait = settings?.tls_dns_propagation_wait ?? 0;
+		// Expand the advanced section if the operator has previously
+		// set either knob — they shouldn't have to hunt for the
+		// non-default value they last saved.
+		showAdvancedDns = !!tlsDnsResolver || tlsDnsPropagationWait > 0;
+		tlsAcmeStaging = settings?.tls_acme_staging ?? false;
 		try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
 	});
+
+	let downloadingCaRoot = $state(false);
+
+	async function downloadCaRoot() {
+		downloadingCaRoot = true;
+		try {
+			const pem = await client.call<string>('system.tls.local_ca_root');
+			const blob = new Blob([pem], { type: 'application/x-pem-file' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `nasty-local-ca-${settings?.hostname || 'root'}.crt`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+		} catch (e) {
+			const toast = await import('$lib/toast.svelte');
+			toast.error(String(e));
+		}
+		downloadingCaRoot = false;
+	}
 
 	async function saveTls() {
 		savingTls = true;
@@ -59,6 +90,8 @@
 				tls_challenge_type: tlsChallengeType,
 				tls_dns_provider: tlsDnsProvider || null,
 				tls_dns_credentials: tlsDnsCredentials || null,
+				tls_dns_resolver: tlsDnsResolver || '',
+				tls_dns_propagation_wait: tlsDnsPropagationWait || 0,
 				tls_acme_staging: tlsAcmeStaging,
 			}),
 			tlsAcmeEnabled ? 'Let\'s Encrypt certificate requested — check status below' : 'TLS settings saved'
@@ -225,6 +258,57 @@
 						verification happens via DNS records.
 					</span>
 				</div>
+
+				<div class="mb-4">
+					<button
+						type="button"
+						onclick={() => showAdvancedDns = !showAdvancedDns}
+						class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						<span>{showAdvancedDns ? '▾' : '▸'}</span>
+						<span>Advanced DNS settings</span>
+					</button>
+					{#if showAdvancedDns}
+						<div class="mt-3 space-y-3 rounded-md border border-border p-3">
+							<div>
+								<label for="tls-dns-resolver" class="mb-1 block text-xs text-muted-foreground">
+									Resolvers (comma-separated)
+								</label>
+								<input
+									id="tls-dns-resolver"
+									type="text"
+									bind:value={tlsDnsResolver}
+									oninput={() => tlsChanged = true}
+									class="w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+									placeholder="1.1.1.1, 8.8.8.8"
+								/>
+								<span class="mt-1 block text-xs text-muted-foreground">
+									DNS servers used to verify TXT-record propagation. Default: <code>1.1.1.1, 8.8.8.8</code>.
+									Override when the box can't reach those (split-horizon DNS, air-gapped networks).
+								</span>
+							</div>
+							<div>
+								<label for="tls-dns-wait" class="mb-1 block text-xs text-muted-foreground">
+									Propagation wait (seconds)
+								</label>
+								<input
+									id="tls-dns-wait"
+									type="number"
+									min="0"
+									bind:value={tlsDnsPropagationWait}
+									oninput={() => tlsChanged = true}
+									class="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+									placeholder="30"
+								/>
+								<span class="mt-1 block text-xs text-muted-foreground">
+									Sleep this long after creating the TXT record before checking propagation. Default: 30s.
+									Bump if issuance keeps timing out — some resolvers cache NXDOMAIN aggressively (SOA MINIMUM
+									TTL up to an hour). Set <code>0</code> to use the default.
+								</span>
+							</div>
+						</div>
+					{/if}
+				</div>
 			{/if}
 
 			{#if !tlsDomain.trim() || !tlsAcmeEmail.trim() || (tlsChallengeType === 'dns' && !tlsDnsProvider)}
@@ -323,5 +407,24 @@
 				Dismiss
 			</Button>
 		{/if}
+	</section>
+
+	<!-- Local CA root (always shown — covers the IP-direct / no-ACME case) -->
+	<section class="rounded-lg border border-border p-5 lg:col-span-2">
+		<h3 class="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Local CA Root</h3>
+		<p class="text-sm text-muted-foreground mb-3">
+			Caddy serves a self-signed certificate (issued by Caddy's internal CA) for direct-IP access and any
+			hostname that doesn't have a managed Let's Encrypt cert. Browsers don't trust this CA by default —
+			import this root certificate into your OS or browser trust store once and every NASty service signed
+			by it stops triggering security warnings on this machine.
+		</p>
+		<Button size="sm" variant="secondary" onclick={downloadCaRoot} disabled={downloadingCaRoot}>
+			{downloadingCaRoot ? 'Preparing…' : 'Download root certificate (.crt)'}
+		</Button>
+		<p class="mt-2 text-xs text-muted-foreground">
+			Each NASty box has its own CA root, so you'll need to import one per box. The downloaded file is the
+			PEM-encoded root cert; import via your OS keychain (macOS), <code>certmgr</code> / Group Policy
+			(Windows), <code>update-ca-certificates</code> (Linux), or your browser's Authorities tab.
+		</p>
 	</section>
 </div>


### PR DESCRIPTION
Two polish items from #99 follow-up triage.

## 1. DNS resolver + propagation_wait now configurable

Both were hardcoded after the #240/#241 debugging arc: \`["1.1.1.1", "8.8.8.8"]\` and \`"30s"\`. Lego had these as flags (\`--dns.resolvers\` / \`--dns.propagation-wait\`) so operators on weird DNS setups could tweak. Putting them back as Settings fields:

- \`tls_dns_resolver\` (comma-separated) — null/empty keeps the default Cloudflare+Google pair.
- \`tls_dns_propagation_wait\` (seconds) — 0/null keeps the default 30s.

Both plumbed engine → \`TlsIssuer\` → admin-API PATCH. WebUI exposes them under "Advanced DNS settings" on the TLS page; auto-expands when a non-default value is already saved.

Real cases this unblocks:
- Boxes on networks that can't reach 1.1.1.1 / 8.8.8.8 (locked-down egress, internal resolvers).
- Slow DNS providers where SOA MINIMUM TTL caches NXDOMAIN past our default 30s (some users will need 60–120s).

## 2. Caddy local-CA root download

Every NASty box has its own \`tls internal\` self-signed CA root that signs the cert served for IP-direct access and any hostname without a managed LE cert. Firefox / Chrome don't trust this by default → fresh warning per box. Bartosz hit this on 10.10.10.67 right after the migration.

New RPC \`system.tls.local_ca_root\` returns the PEM from \`/var/lib/caddy/.local/share/caddy/pki/authorities/local/root.crt\`. WebUI adds a "Download root certificate" button on the TLS page. Operator imports it once into their OS/browser trust store and every NASty service signed by it stops triggering warnings on that machine.

Still per-box (each box has its own CA), but the click-through workflow becomes "download → import" instead of "click through Firefox warning every time".

## Test plan

- [x] \`cargo test --workspace\` green (77 tests in nasty-apps including new TlsIssuer-with-custom-resolvers / -with-custom-wait coverage).
- [x] \`cargo clippy -- -D warnings\` clean.
- [x] \`npm run check\` on webui clean.
- [ ] On 10.10.20.100: confirm setting a custom resolver/wait via WebUI propagates through to Caddy's runtime config under \`/config/apps/tls/automation/policies/.../challenges/dns/\`.
- [ ] On 10.10.10.67: click "Download root certificate", import into macOS keychain, confirm \`https://10.10.10.67/\` no longer triggers a security warning.