### PR TITLE
ops: pin Caddy version + extend nasty-report with proxy/net/upgrade info

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1436,7 +1436,7 @@ in {
 
           outputHashMode = "recursive";
           outputHashAlgo = "sha256";
-          outputHash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
+          outputHash = "sha256-Rd7Zh8Y5vxvv1bcUwk4k2tyO6n3j0s5Qb4eSrlEz018=";
         };
 
       in pkgs.buildGoModule {

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -627,17 +627,43 @@ in {
       '')
 
       (writeShellScriptBin "nasty-report" ''
-        set -euo pipefail
+        # `set -e` is intentionally OFF: this script is meant to be run on
+        # broken systems where individual commands will fail. We want each
+        # section to attempt independently and produce as much diagnostic
+        # info as possible even when half the box is down. `pipefail` is
+        # also off — the `tee` at the end shouldn't fail-mask any
+        # diagnostic command upstream of it.
+        set -u
 
         SEP="─────────────────────────────────────────────────────"
 
         section() { echo ""; echo "$SEP"; echo "  $1"; echo "$SEP"; }
+
+        # Persist every report under /var/lib/nasty/reports/. Two reasons:
+        # 1) When the WebUI is dead, the operator may roll back to a
+        #    working generation and want to send us what they had on the
+        #    broken one. /var/lib survives nixos-rebuild rollbacks (it's
+        #    state, not config) so the report survives with it.
+        # 2) Capturing the same machine state across multiple rebuild
+        #    attempts gives us a delta to look at.
+        # Rotate aggressively (keep last 10) so a wedged box doesn't fill
+        # the disk with reports.
+        REPORTS_DIR="/var/lib/nasty/reports"
+        mkdir -p "$REPORTS_DIR" 2>/dev/null
+        TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
+        REPORT_FILE="$REPORTS_DIR/nasty-report-$TIMESTAMP.txt"
+        ls -1t "$REPORTS_DIR"/nasty-report-*.txt 2>/dev/null | tail -n +11 | xargs -r rm -f
+
+        # Tee everything to both stdout (the operator's terminal) and the
+        # persisted file. `exec` redirects the rest of the script.
+        exec > >(tee "$REPORT_FILE") 2>&1
 
         echo ""
         echo "╔═════════════════════════════════════════════════════╗"
         echo "║              NASty Diagnostic Dump                  ║"
         echo "╚═════════════════════════════════════════════════════╝"
         echo "  $(date '+%Y-%m-%d %H:%M:%S %Z')  |  $(hostname)  |  NASty $(cat /etc/nasty-version 2>/dev/null || echo unknown)"
+        echo "  Saved to: $REPORT_FILE"
 
         section "System"
         echo "  OS:      $(nixos-version 2>/dev/null || echo unknown)"
@@ -702,12 +728,124 @@ in {
         section "Recent Engine Logs (last 50 lines)"
         journalctl -u nasty-engine -n 50 --no-pager 2>/dev/null | sed 's/^/  /' || echo "  (unavailable)"
 
+        section "Reverse Proxy — Caddy"
+        # Service state first: covers the "caddy.service could not be
+        # found" case (build evaluated falsy / module skipped) by
+        # distinguishing "not installed" from "installed but failed".
+        if systemctl list-unit-files caddy.service >/dev/null 2>&1; then
+          echo "  Unit:       installed"
+          state=$(systemctl is-active caddy.service 2>/dev/null || true)
+          enabled=$(systemctl is-enabled caddy.service 2>/dev/null || true)
+          echo "  Active:     $state"
+          echo "  Enabled:    $enabled"
+        else
+          echo "  Unit:       NOT INSTALLED (services.caddy probably evaluated to absent)"
+        fi
+        echo ""
+        echo "  Listening sockets on :80 / :443 / :2019 (Caddy admin API):"
+        ss -tlnp 2>/dev/null | awk '/:80\s|:443\s|:2019\s/ {print "    " $0}' || echo "    (ss unavailable)"
+        echo ""
+        # Caddy's admin API is on 127.0.0.1:2019; pulling the runtime
+        # config tells us what TLS automation policies / app routes are
+        # actually live, vs. what we think we pushed. Short timeout so
+        # this doesn't hang on broken systems.
+        echo "  Admin-API runtime config (apps.tls + apps.http servers):"
+        if curl -fsS --max-time 3 http://127.0.0.1:2019/config/apps 2>/dev/null \
+          | ${pkgs.jq}/bin/jq '{tls: .tls, servers: (.http.servers // {} | map_values({listen, route_count: (.routes|length), tls_policy_count: ((.tls_connection_policies // [])|length)}))}' 2>/dev/null \
+          | sed 's/^/    /'; then
+          :
+        else
+          echo "    (admin API not reachable — caddy may not be running)"
+        fi
+        echo ""
+        echo "  Issued certs on disk:"
+        find /var/lib/caddy/.local/share/caddy/certificates -name '*.crt' 2>/dev/null \
+          | sed 's|^|    |' || echo "    (none)"
+        echo ""
+        echo "  Recent Caddy logs (last 30 lines, level=warn or error):"
+        journalctl -u caddy -n 200 --no-pager 2>/dev/null \
+          | grep -iE '"level":"(warn|error)"|^Aug |^May |^Apr |^Jan |^Feb |^Mar |^Jun |^Jul |^Sep |^Oct |^Nov |^Dec ' \
+          | tail -30 \
+          | sed 's/^/    /' || echo "    (unavailable)"
+
+        section "Networking"
+        echo "  Interfaces:"
+        ip -brief addr show 2>/dev/null | sed 's/^/    /' || echo "    (ip unavailable)"
+        echo ""
+        echo "  Routes:"
+        ip route show 2>/dev/null | sed 's/^/    /' || true
+        echo ""
+        echo "  /etc/resolv.conf:"
+        sed 's/^/    /' /etc/resolv.conf 2>/dev/null || echo "    (missing)"
+        echo ""
+        # systemd-resolved is the box's actual stub; resolv.conf above
+        # may just point at 127.0.0.53. Surface the upstream resolvers
+        # resolved is using.
+        if command -v resolvectl >/dev/null 2>&1; then
+          echo "  resolvectl status (DNS servers / search domains):"
+          resolvectl status 2>/dev/null | grep -E 'DNS Servers|DNS Domain|Current DNS' | sed 's/^/    /' || true
+        fi
+        echo ""
+        # The two DNS resolvers our DNS-01 propagation check uses by
+        # default. If they're unreachable, the upgrade migration's cert
+        # issuance will appear to hang for 30+ seconds.
+        echo "  Public-DNS reachability (1.1.1.1, 8.8.8.8, port 53):"
+        for r in 1.1.1.1 8.8.8.8; do
+          if timeout 2 bash -c "echo > /dev/tcp/$r/53" 2>/dev/null; then
+            echo "    $r:53  reachable"
+          else
+            echo "    $r:53  UNREACHABLE"
+          fi
+        done
+        echo ""
+        echo "  Firewall (nftables) summary:"
+        nft list ruleset 2>/dev/null | head -40 | sed 's/^/    /' || echo "    (nft unavailable)"
+
+        section "System Updates — Flake + Generations"
+        echo "  Current NixOS generation:"
+        readlink /run/current-system 2>/dev/null | sed 's/^/    /'
+        echo ""
+        echo "  Last 5 boot generations:"
+        # nix-env -p shows the bootloader's view; nixos-rebuild list-generations is more
+        # human-readable but only exists in newer NixOS. Fall back gracefully.
+        if command -v nixos-rebuild >/dev/null 2>&1 && nixos-rebuild list-generations 2>/dev/null | head -6 | sed 's/^/    /'; then
+          :
+        else
+          nix-env --list-generations --profile /nix/var/nix/profiles/system 2>/dev/null \
+            | tail -5 | sed 's/^/    /' || echo "    (unavailable)"
+        fi
+        echo ""
+        echo "  /etc/nixos/flake.lock (nixpkgs + nasty pins):"
+        if [ -f /etc/nixos/flake.lock ]; then
+          ${pkgs.jq}/bin/jq -r '
+            (.nodes.nixpkgs.locked // {}) as $np
+            | (.nodes.nasty.locked // {}) as $n
+            | (.nodes."bcachefs-tools".locked // {}) as $b
+            | "    nixpkgs:        ref=\($np.ref // "?")  rev=\($np.rev // "?" | .[0:12])  lastModified=\($np.lastModified // "?")",
+              "    nasty:          ref=\($n.ref // "?")  rev=\($n.rev // "?" | .[0:12])  lastModified=\($n.lastModified // "?")",
+              "    bcachefs-tools: ref=\($b.ref // "?")  rev=\($b.rev // "?" | .[0:12])  lastModified=\($b.lastModified // "?")"
+          ' /etc/nixos/flake.lock 2>/dev/null || echo "    (parse failed)"
+        else
+          echo "    (no /etc/nixos/flake.lock — not running from a flake?)"
+        fi
+        echo ""
+        echo "  Recent nixos-rebuild attempts (journal, last 40 lines):"
+        # nixos-rebuild logs as a transient unit; journalctl -u nixos-rebuild won't
+        # work, but we can grep the journal for the activation script's stdout.
+        journalctl --since '2 hours ago' --no-pager 2>/dev/null \
+          | grep -E 'nixos-rebuild|activating the configuration|switching to system configuration|error: builder for|hash mismatch|sha256-' \
+          | tail -40 \
+          | sed 's/^/    /' || echo "    (none)"
+
         section "dmesg — bcachefs / storage errors (last 30)"
         dmesg --level=err,warn -T 2>/dev/null | grep -iE 'bcachefs|nvme|scsi|ata|disk|i/o error' | tail -30 | sed 's/^/  /' || echo "  (none)"
 
         echo ""
         echo "$SEP"
-        echo "  Share full output:  report | nc termbin.com 9999"
+        echo "  Report saved to: $REPORT_FILE"
+        echo "  Older reports:   $REPORTS_DIR/  (keeps last 10)"
+        echo "  Share output:    report | nc termbin.com 9999"
+        echo "  Share saved:     cat $REPORT_FILE | nc termbin.com 9999"
         echo "$SEP"
         echo ""
       '')
@@ -833,6 +971,12 @@ in {
       # engine's archive_path_once migration can find the old files
       # to move them aside without racing the tmpfiles-creation step.
       "d /var/lib/nasty/tls 0750 root caddy -"
+      # /var/lib/nasty/reports/ holds rotated nasty-report dumps.
+      # Surviving boot generation rollbacks is the point — operator
+      # generates a report on a broken system, rolls back to a working
+      # one, then `cat`s the saved report to share. tmpfiles creates
+      # it; the script rotates within it (keep last 10).
+      "d /var/lib/nasty/reports 0750 root root -"
       # acme.env feeds DNS-01 provider creds into Caddy via
       # EnvironmentFile. Seeded empty so Caddy can start before the
       # engine has had a chance to write it. (vhosts.conf is no longer
@@ -1225,7 +1369,28 @@ in {
       # fresh `go build`). To add a provider, append to `plugins`, run
       # `nix build .#nixosConfigurations.nasty-vm.config.services.caddy.package`,
       # and update `hash` from the resulting "got: sha256-…" message.
-      package = pkgs.caddy.withPlugins {
+      # Custom Caddy build with DNS-01 plugins compiled in. Pinned to
+      # a specific version + source hash so the build is deterministic
+      # regardless of which Caddy version the operator's nixpkgs ships.
+      #
+      # Why we don't just use `pkgs.caddy.withPlugins`: that function's
+      # closure captures the original `pkgs.caddy.version`. When the
+      # operator's nixpkgs has Caddy 2.11.2 but our `hash` was computed
+      # against 2.11.3 (because xcaddy's source-tree assembly is
+      # version-dependent), the build fails with a vendor-hash mismatch
+      # — bricking the upgrade for anyone whose nixpkgs hasn't tracked
+      # the same Caddy bumps as the box we developed against. Pinning
+      # everything here makes that class of failure impossible.
+      #
+      # To bump:
+      #   1. Update caddyVersion + caddySrcHash (look up the matching
+      #      hash from nixpkgs's pkgs/by-name/ca/caddy/package.nix).
+      #   2. Run `nix build .#nixosConfigurations.nasty-vm.config.services.caddy.package`.
+      #   3. Copy the "got: sha256-…" from the failure into srcWithPluginsHash.
+      package = let
+        caddyVersion = "2.11.3";
+        caddySrcHash = "sha256-7Hgmo7ldDtbwl/acEY/4RNhSGnK/NNcXn+eIm1I8HKg=";
+
         plugins = [
           # Public-DNS heavyweights — Cloudflare alone covers the
           # majority of selfhost users.
@@ -1244,7 +1409,59 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
+
+        # xcaddy assembles a fresh Caddy source tree that imports each
+        # plugin's module. Fixed-output derivation: the recorded hash
+        # is the SHA256 of the assembled tree (Caddy source + vendored
+        # plugin deps). xcaddy fetches dependencies from upstream
+        # proxies, but the FOD freezes the result.
+        caddySrcWithPlugins = pkgs.stdenv.mkDerivation {
+          pname = "nasty-caddy-src-with-plugins";
+          version = caddyVersion;
+
+          nativeBuildInputs = with pkgs; [ go xcaddy cacert git ];
+          dontUnpack = true;
+
+          buildPhase = ''
+            export GOCACHE=$TMPDIR/go-cache
+            export GOPATH="$TMPDIR/go"
+            XCADDY_SKIP_BUILD=1 TMPDIR="$PWD" xcaddy build v${caddyVersion} \
+              ${lib.concatMapStringsSep " " (p: "--with ${p}") plugins}
+            (cd buildenv* && go mod vendor)
+          '';
+
+          installPhase = ''
+            mv buildenv* $out
+          '';
+
+          outputHashMode = "recursive";
+          outputHashAlgo = "sha256";
+          outputHash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
+        };
+
+      in pkgs.buildGoModule {
+        pname = "nasty-caddy";
+        version = caddyVersion;
+        src = caddySrcWithPlugins;
+        vendorHash = null;
+        subPackages = [ "." ];
+
+        ldflags = [
+          "-s"
+          "-w"
+          "-X github.com/caddyserver/caddy/v2.CustomVersion=${caddyVersion}"
+        ];
+
+        # Match upstream's tag set since v2.8.0: drops Caddy's bundled
+        # KV-store backends we don't use (badger, mysql, pgx). Smaller
+        # binary, faster start.
+        tags = [ "nobadger" "nomysql" "nopgx" ];
+
+        meta = {
+          description = "Caddy with NASty's DNS-01 plugin set (pinned)";
+          mainProgram = "caddy";
+          inherit (pkgs.caddy.meta) homepage license;
+        };
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
Two changes against the failure mode HuxyUK hit in #99: a NASty upgrade that broke his box with no way to gather diagnostics from the broken generation once he'd rolled back, and a Caddy build that failed because his nixpkgs lock pinned a different Caddy version than the one our \`hash\` was computed against.

## 1. Pin Caddy + plugins inside our repo

\`pkgs.caddy.withPlugins\` today resolves \`pkgs.caddy\` against whatever nixpkgs the operator's flake.lock pins. When their nixpkgs ships Caddy 2.11.2 but our hardcoded \`hash\` was generated for 2.11.3, xcaddy produces different bytes than we recorded, and the rebuild fails with:

\`\`\`
specified: sha256-xwt...
got:       sha256-1aS...
\`\`\`

We *did* declare the plugin-bundle hash inside our repo, but the *Caddy version* xcaddy assembled against came from upstream nixpkgs. Different operators on different nixpkgs revisions ⇒ different Caddy versions ⇒ different output bytes ⇒ mismatch. The version is the missing link in the "our repo is the source of truth" story.

Inline our own caddy-with-plugins derivation: pin \`caddyVersion\` and \`caddySrcHash\` in nasty.nix, run xcaddy with that exact version, vendor modules, build via buildGoModule. The whole pipeline is now declared in our repo. nixpkgs's caddy package is no longer in the path. Operators on any nixpkgs revision (as long as it ships \`pkgs.xcaddy\` + Go) build the same Caddy bytes.

**Cost**: bumping Caddy now means a deliberate two-line edit here instead of inheriting nixpkgs's tracking. That's a feature for an appliance — the reverse proxy doesn't change underfoot.

## 2. Extend nasty-report to cover proxy, networking, system upgrades

When HuxyUK's UI died, his only diagnostic channel was running individual commands from the WebUI terminal. Most of what we'd want to see wasn't in \`nasty-report\`.

New sections:
- **Reverse Proxy — Caddy**: unit state (distinguishes "not installed" from "installed but failed"), listening sockets on :80/:443/:2019, live admin-API config summary, issued certs on disk, last 30 warn/error log lines.
- **Networking**: interfaces, routes, /etc/resolv.conf, resolvectl upstream DNS, public-DNS reachability probe (1.1.1.1, 8.8.8.8 on :53), nft ruleset summary.
- **System Updates — Flake + Generations**: current /run/current-system, last 5 boot generations, nixpkgs + nasty + bcachefs-tools pins from flake.lock, last 40 journal lines matching nixos-rebuild / hash mismatch / activation errors.

Reports are now **persisted** under \`/var/lib/nasty/reports/\` (keep last 10, rotated by the script). \`/var/lib\` survives nixos-rebuild rollbacks, so the operator can generate a report on the broken generation, roll back to a working one, then \`cat\` and share the saved file. Footer points at both \`report | nc termbin.com 9999\` and the saved file path.

\`set -e\` is now OFF — broken systems WILL have individual commands fail, and we want each section to attempt independently and produce maximum diagnostic info even when half the box is down.

## Test plan

- [x] \`nix eval '.#nixosConfigurations.nasty-vm.config.services.caddy.package.pname'\` returns \`"nasty-caddy"\`.
- [x] \`nix eval '.#nixosConfigurations.nasty-vm.config.services.caddy.package.src.outputHash'\` returns our pinned hash.
- [x] \`nasty-report\` derivation evaluates cleanly (rendered script reads as expected; CI builds for x86_64-linux validate the actual build).
- [ ] Deploy to a box with a stale nixpkgs lock and confirm Caddy builds without hash mismatch.
- [ ] Run \`report\` on 10.10.20.100, confirm the new sections render correctly and the file lands in /var/lib/nasty/reports/.