### PR TITLE
caddy: single PATCH for TLS config (fixes whoami-style stuck pending)

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -475,10 +475,38 @@ impl CaddyApi {
         policies: &[TlsPolicy],
         issuer: &TlsIssuer,
     ) -> Result<(), String> {
-        // 1) PATCH the policies array. This says HOW to issue each
-        //    hostname's cert (ACME issuer + DNS provider config).
-        let body = build_tls_automation_json(policies, issuer);
-        let url = format!("{}/config/apps/tls/automation", self.base_url);
+        // Single PATCH against `/config/apps/tls` that replaces both
+        // `automation` and `certificates` at once.
+        //
+        // Why one PATCH instead of two: each PATCH triggers a Caddy
+        // config reload, which CANCELS any in-flight ACME job. With
+        // separate PATCHes — first automation, then automate — the
+        // first PATCH starts issuance for a newly-added hostname, the
+        // second PATCH cancels it mid-flight, the in-flight DNS-01
+        // Present call gets aborted, and the TXT record never lands on
+        // the provider. Then Caddy retries with a fresh order/token,
+        // but some DNS providers (including caddy-dns/cloudflare in
+        // 2.11) handle rapid Present/CleanUp cycles poorly and fail
+        // silently — the next provider call sees the prior cleanup
+        // state and skips. Observed on 10.10.20.100 with whoami.0f.ee:
+        // Caddy logged "obtaining certificate" then "context canceled"
+        // sub-second apart, and no TXT record ever appeared on
+        // Cloudflare for the challenge.
+        //
+        // `automation.policies` says HOW to issue; `certificates.automate`
+        // says WHICH names to obtain. Both need to be set together;
+        // setting just one is incomplete state Caddy shouldn't see.
+        let automate: Vec<&str> = policies
+            .iter()
+            .map(|p| p.host.as_str())
+            .chain(std::iter::once("nasty.local"))
+            .collect();
+        let automation = build_tls_automation_json(policies, issuer);
+        let body = json!({
+            "automation": automation,
+            "certificates": { "automate": automate },
+        });
+        let url = format!("{}/config/apps/tls", self.base_url);
         let resp = self
             .client
             .patch(&url)
@@ -490,32 +518,6 @@ impl CaddyApi {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
             return Err(format!("PATCH {url}: status {status} body={text}"));
-        }
-
-        // 2) PATCH `certificates.automate` with the same hostname set.
-        //    This is the list Caddy walks to *trigger* issuance — without
-        //    it the policies sit there describing how to issue certs
-        //    Caddy never tries to obtain. The Caddyfile populates this
-        //    from `tls internal` on the fallback site (nasty.local
-        //    only); ACME-managed hosts are admin-API-only so they have
-        //    to be added here explicitly.
-        let automate: Vec<&str> = policies
-            .iter()
-            .map(|p| p.host.as_str())
-            .chain(std::iter::once("nasty.local"))
-            .collect();
-        let automate_url = format!("{}/config/apps/tls/certificates/automate", self.base_url);
-        let resp = self
-            .client
-            .patch(&automate_url)
-            .json(&automate)
-            .send()
-            .await
-            .map_err(|e| format!("PATCH {automate_url}: {e}"))?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(format!("PATCH {automate_url}: status {status} body={text}"));
         }
 
         if policies.is_empty() {


### PR DESCRIPTION
Bug 1 from #247 reproduces here as: adding a new subdomain ingress while other subdomain ingresses already exist leaves the new one stuck on "pending" forever.

## Root cause

\`set_tls_automation\` (in nasty-apps/src/caddy.rs) was doing two sequential PATCHes:
1. \`PATCH /config/apps/tls/automation\` — adds the new policy
2. \`PATCH /config/apps/tls/certificates/automate\` — adds the host to the issuance list

Each PATCH triggers a full Caddy config reload, which cancels any in-flight ACME job. With the two patches firing sub-second apart, the sequence on the box becomes:

1. First PATCH lands → Caddy starts issuance for the new host, calls Cloudflare provider's Present, TXT record gets created on Cloudflare.
2. Second PATCH arrives → Caddy reloads → in-flight job gets \`context canceled\`. Cleanup deletes the TXT.
3. Caddy retries with a fresh ACME order. The Cloudflare provider's Present is called again for the new token, but caddy-dns/cloudflare 2.11.x handles rapid Present/CleanUp cycles poorly — no error returned, but no record actually lands.
4. Propagation check polls 1.1.1.1 for 2 minutes, sees nothing, times out with \`last error: <nil>\`.

Confirmed on 10.10.20.100 — Caddy logs show:
\`\`\`
19:06:14 ... obtaining certificate ... whoami.0f.ee
19:06:14 ... could not get certificate from issuer ... context canceled
19:06:14 ... obtaining certificate ... whoami.0f.ee   (retry)
19:06:16 ... trying to solve challenge dns-01 ...
19:08:48 ... timed out waiting for record to fully propagate; last error: <nil>
\`\`\`

Cloudflare API confirms \`_acme-challenge.whoami.0f.ee\` was never present in the zone. Meanwhile \`nas.0f.ee\` and \`haze.0f.ee\` (set up earlier, one at a time) worked fine — they didn't hit the cancellation race because their PATCHes weren't interleaved with each other's in-flight jobs.

## Fix

Single PATCH against \`/config/apps/tls\` that carries both \`automation\` and \`certificates\` together. One reload, one synchronisation point, no mid-flight cancellation.

## Test plan

- [x] \`cargo test --workspace\` green (77 tests in nasty-apps).
- [x] \`cargo clippy -- -D warnings\` clean.
- [ ] Deploy to 10.10.20.100, remove whoami's stuck policy (Ingress → set whoami to path-prefix → set back to subdomain), confirm the new attempt succeeds within ~90 seconds and \`whoami.0f.ee.crt\` lands in Caddy's cert dir.