### PR TITLE
tls: per-host issuance status on /tls page + fix misleading 'first request' wording

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -135,9 +135,13 @@ pub struct CaddyRouteSummary {
     /// Populated by the engine binary after `list_all_route_summaries`
     /// returns — nasty-apps doesn't have access to the cert directory
     /// or PEM parser. `None` for non-host routes (`path` / `catch_all`)
-    /// and for host routes Caddy hasn't issued a cert for yet (the
-    /// "pending" state — auto-HTTPS issues asynchronously on first
-    /// request).
+    /// and for host routes whose cert isn't on disk yet — the engine
+    /// pushes automation policies eagerly via `set_tls_automation` so
+    /// issuance starts at policy-push time, not on first request, but
+    /// DNS-01 + propagation_delay can take 30-90s before the cert
+    /// lands. Use `system.tls.host_statuses` for the live state of
+    /// each managed host (issuing / failed / active) with error
+    /// details when issuance is stuck.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cert: Option<HostCert>,
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -129,6 +129,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.tailscale.get"
                 | "system.acme.status"
                 | "system.tls.local_ca_root"
+                | "system.tls.host_statuses"
                 | "system.metrics.history"
                 | "system.metrics.prometheus"
                 | "alert.rules.list"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -358,6 +358,16 @@ pub(super) async fn try_route(
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
         },
+        // Per-host TLS automation status. Returns one entry per
+        // managed hostname Caddy is tracking (from
+        // `apps.tls.certificates.automate`), with state =
+        // active / issuing / failed / pending and the latest log
+        // message attached. Used by the /tls page's "Managed
+        // certificates" section so the operator can see why a cert
+        // is stuck instead of staring at an indefinite "pending".
+        "system.tls.host_statuses" => {
+            ok(req, nasty_system::settings::list_host_tls_statuses().await)
+        }
         // Caddy's internal-CA root cert (PEM). The WebUI surfaces this
         // as a download so operators can import it into their OS or
         // browser trust store and stop getting fresh "untrusted cert"

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -1131,10 +1131,13 @@ pub struct HostCertInfo {
 ///     (`wildcard_.example.com/wildcard_.example.com.crt` covers
 ///     `<anything>.example.com`).
 ///
-/// Returns `None` when no cert is on disk yet — Caddy auto-HTTPS issues
-/// asynchronously on first request, so a freshly-set ingress can spend
-/// a few seconds with no cert. The WebUI renders that as "pending"
-/// rather than treating it as a hard failure.
+/// Returns `None` when no cert is on disk yet. Issuance is eager —
+/// the engine pushes automation policies the moment an ingress is
+/// set, so Caddy starts work immediately — but DNS-01 with our 30s
+/// `propagation_delay` plus the ACME order round-trip can take
+/// 30-90s before the cert lands. See [`host_tls_status`] for the
+/// richer state (issuing / failed / active) including the last error
+/// message when issuance is stuck.
 pub async fn cert_info_for_host(host: &str) -> Option<HostCertInfo> {
     let path = locate_cert_for_host(host).await?;
     let info = read_cert_info(&path).await;
@@ -1153,6 +1156,188 @@ pub async fn cert_info_for_host(host: &str) -> Option<HostCertInfo> {
         expires_in_days,
         path,
     })
+}
+
+/// Per-host TLS state surfaced on the `/tls` page. Distinguishes the
+/// four states a managed hostname can be in:
+///
+/// - `active` — cert on disk, currently being served. `issuer` /
+///   `expires` / `expires_in_days` are populated.
+/// - `issuing` — Caddy is actively working on getting a cert. Tail
+///   of recent log lines for this host showed `obtaining
+///   certificate` or `trying to solve challenge`. `message` carries
+///   the most recent log line so the operator can see how far along
+///   the process is.
+/// - `failed` — Caddy tried and gave up (rate-limit, DNS challenge
+///   timeout, provider auth error). `message` carries the failure
+///   reason verbatim from the log.
+/// - `pending` — policy exists but Caddy hasn't logged any activity
+///   yet (sub-second window between policy push and first work).
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
+pub struct HostTlsStatus {
+    pub host: String,
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issued: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_in_days: Option<i64>,
+    /// `active` ⇒ on-disk cert path. `failed` / `issuing` ⇒ last log
+    /// line, verbatim. `pending` ⇒ None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Build a [`HostTlsStatus`] for one managed hostname.
+///
+/// Decision tree:
+///   1. Cert on disk via [`cert_info_for_host`] ⇒ `active`.
+///   2. Else tail Caddy's journal for the last 10 minutes, find log
+///      lines matching `"identifier":"<host>"`, classify the most
+///      recent one:
+///        - "obtained successfully" ⇒ `active` (race: cert just
+///          landed but cert_info_for_host raced ahead of disk sync)
+///        - "could not get" / "error" / "timed out" ⇒ `failed`
+///          with the error message as `message`
+///        - any other engaged-state phrase ⇒ `issuing` with the line
+///          as `message`
+///   3. No matching log lines ⇒ `pending`.
+pub async fn host_tls_status(host: &str) -> HostTlsStatus {
+    if let Some(info) = cert_info_for_host(host).await {
+        return HostTlsStatus {
+            host: host.to_string(),
+            state: "active".into(),
+            issuer: info.issuer,
+            issued: info.issued,
+            expires: info.expires,
+            expires_in_days: info.expires_in_days,
+            message: Some(info.path),
+        };
+    }
+
+    // Tail Caddy's journal for this host. JSON-formatted logs from
+    // certmagic always carry `"identifier":"<host>"` for ACME events
+    // — that's the field we grep for. 10-minute window covers a
+    // full DNS-01 attempt + a retry, but stays cheap.
+    let output = tokio::process::Command::new("journalctl")
+        .args(["-u", "caddy", "--since", "10 min ago", "--no-pager"])
+        .output()
+        .await;
+    let lines = match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        _ => String::new(),
+    };
+
+    // Walk lines newest-last (journalctl default). Find the most
+    // recent log mentioning this host; classify by content.
+    let needle = format!("\"identifier\":\"{host}\"");
+    let last = lines.lines().rev().find(|l| l.contains(&needle));
+    let Some(line) = last else {
+        return HostTlsStatus {
+            host: host.to_string(),
+            state: "pending".into(),
+            issuer: None,
+            issued: None,
+            expires: None,
+            expires_in_days: None,
+            message: None,
+        };
+    };
+
+    let lower = line.to_lowercase();
+    let state = if lower.contains("could not get") || lower.contains("timed out") {
+        "failed"
+    } else if lower.contains("obtained successfully") {
+        "active"
+    } else {
+        "issuing"
+    };
+
+    HostTlsStatus {
+        host: host.to_string(),
+        state: state.into(),
+        issuer: None,
+        issued: None,
+        expires: None,
+        expires_in_days: None,
+        message: Some(extract_log_message(line)),
+    }
+}
+
+/// Return the list of all managed hostnames Caddy is currently
+/// tracking, with each one's current TLS status. Reads
+/// `apps.tls.certificates.automate` from Caddy's admin API (the
+/// authoritative "what hosts should Caddy be obtaining certs for"
+/// list — set by our `set_tls_automation` flow) and resolves status
+/// per host.
+///
+/// Skips `nasty.local` (the internal-CA fallback) — that one is
+/// always active and not interesting on the /tls page.
+pub async fn list_host_tls_statuses() -> Vec<HostTlsStatus> {
+    let url = "http://127.0.0.1:2019/config/apps/tls/certificates/automate";
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build();
+    let Ok(client) = client else {
+        return Vec::new();
+    };
+    let resp = match client.get(url).send().await {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+    let hosts: Vec<String> = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for host in hosts {
+        if host == "nasty.local" {
+            continue;
+        }
+        out.push(host_tls_status(&host).await);
+    }
+    out
+}
+
+/// Pull the human-readable `msg` field out of a Caddy JSON log line,
+/// falling back to the whole line when the format doesn't match what
+/// we expect. Keeps the WebUI tooltip readable instead of dumping
+/// raw JSON.
+fn extract_log_message(line: &str) -> String {
+    // Look for "msg":"..." (un-escaped naive parse, good enough for
+    // certmagic's well-formed logs). If we find `error` field too,
+    // prefer it (it carries the actual failure detail).
+    if let Some(err) = extract_json_string_field(line, "error")
+        && !err.is_empty()
+    {
+        return err;
+    }
+    if let Some(msg) = extract_json_string_field(line, "msg") {
+        return msg;
+    }
+    line.to_string()
+}
+
+fn extract_json_string_field(line: &str, field: &str) -> Option<String> {
+    let key = format!("\"{field}\":\"");
+    let start = line.find(&key)? + key.len();
+    let rest = &line[start..];
+    let mut end = 0;
+    let bytes = rest.as_bytes();
+    while end < bytes.len() {
+        if bytes[end] == b'\\' {
+            end += 2;
+            continue;
+        }
+        if bytes[end] == b'"' {
+            break;
+        }
+        end += 1;
+    }
+    Some(rest[..end].replace("\\\"", "\"").replace("\\\\", "\\"))
 }
 
 async fn locate_cert_for_host(host: &str) -> Option<String> {

--- a/webui/src/routes/ingress/+page.svelte
+++ b/webui/src/routes/ingress/+page.svelte
@@ -165,11 +165,14 @@
 										{@const cb = certBadge(r.cert)}
 										<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] cursor-help {cb.class}" title={cb.title}>{cb.label}</span>
 									{:else if r.match_kind === "host"}
-										<!-- Host route with no cert on disk yet — auto-HTTPS issues
-										     asynchronously on first request, so a freshly-set ingress can
-										     spend a few seconds in this state. Surface it as "pending"
-										     rather than a hard failure so the operator doesn't panic. -->
-										<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] bg-muted text-muted-foreground border-border" title="No cert on disk yet — Caddy issues asynchronously on first request.">pending</span>
+										<!-- Host route with no cert on disk yet — issuance is
+										     eager (engine pushes automation on ingress set) but
+										     DNS-01 + propagation_delay can take 30-90s. The /tls
+										     page's "Managed certificates" section surfaces the
+										     live state per host (issuing / failed / active) with
+										     the last log message; we just point there from the
+										     tooltip rather than duplicating the polling logic. -->
+										<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] bg-muted text-muted-foreground border-border" title="No cert on disk yet — see Managed certificates on the TLS page for live status.">pending</span>
 									{:else}
 										<span class="text-muted-foreground">—</span>
 									{/if}

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import type { Settings } from '$lib/types';
@@ -56,7 +56,46 @@
 		showAdvancedDns = !!tlsDnsResolver || tlsDnsPropagationWait > 0;
 		tlsAcmeStaging = settings?.tls_acme_staging ?? false;
 		try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
+		refreshHostStatuses();
+		// Poll every 10s so the operator sees state transitions
+		// (issuing → active) without manually refreshing. Cheap
+		// (admin-API read + journalctl tail).
+		hostStatusPollHandle = setInterval(refreshHostStatuses, 10_000) as unknown as number;
 	});
+
+	type HostTlsStatus = {
+		host: string;
+		state: 'active' | 'issuing' | 'failed' | 'pending';
+		issuer?: string;
+		issued?: string;
+		expires?: string;
+		expires_in_days?: number;
+		message?: string;
+	};
+
+	let hostStatuses: HostTlsStatus[] = $state([]);
+	let hostStatusPollHandle: number | null = $state(null);
+
+	async function refreshHostStatuses() {
+		try {
+			hostStatuses = await client.call<HostTlsStatus[]>('system.tls.host_statuses');
+		} catch {
+			// engine restart / transient network — keep prior list, retry next tick
+		}
+	}
+
+	onDestroy(() => {
+		if (hostStatusPollHandle !== null) clearInterval(hostStatusPollHandle);
+	});
+
+	function badgeForState(s: string): { label: string; cls: string } {
+		switch (s) {
+			case 'active': return { label: 'active', cls: 'bg-green-500/15 text-green-400 border-green-500/40' };
+			case 'issuing': return { label: 'issuing…', cls: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/40' };
+			case 'failed': return { label: 'failed', cls: 'bg-red-500/15 text-red-400 border-red-500/40' };
+			default: return { label: 'pending', cls: 'bg-muted text-muted-foreground border-border' };
+		}
+	}
 
 	let downloadingCaRoot = $state(false);
 
@@ -406,6 +445,64 @@
 			<Button size="xs" variant="secondary" class="mt-3" onclick={async () => { await client.call('system.acme.reset'); acmeStatus = await client.call('system.acme.status'); }}>
 				Dismiss
 			</Button>
+		{/if}
+	</section>
+
+	<!-- Managed certificates — per-host issuance state from Caddy.
+	     Auto-refreshes every 10s. Replaces the operator's previous
+	     workflow of "ssh in and grep journalctl" when an ingress sits
+	     on `pending` for longer than expected. -->
+	<section class="rounded-lg border border-border p-5 lg:col-span-2">
+		<div class="flex items-baseline justify-between gap-3 mb-3">
+			<h3 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Managed Certificates</h3>
+			<span class="text-xs text-muted-foreground">Updates every 10s</span>
+		</div>
+		{#if hostStatuses.length === 0}
+			<p class="text-sm text-muted-foreground">
+				No managed hostnames yet. Hosts appear here once you enable Let's Encrypt above or assign a
+				subdomain ingress to an app — the engine pushes each one to Caddy and tracks issuance.
+			</p>
+		{:else}
+			<table class="w-full text-sm">
+				<thead>
+					<tr class="text-left text-xs uppercase text-muted-foreground">
+						<th class="pb-2 font-medium">Host</th>
+						<th class="pb-2 font-medium">State</th>
+						<th class="pb-2 font-medium">Issuer / Expires</th>
+						<th class="pb-2 font-medium">Detail</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each hostStatuses as h}
+						{@const badge = badgeForState(h.state)}
+						<tr class="border-t border-border">
+							<td class="py-2 pr-3 font-mono text-xs">{h.host}</td>
+							<td class="py-2 pr-3">
+								<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] {badge.cls}">{badge.label}</span>
+							</td>
+							<td class="py-2 pr-3 text-xs">
+								{#if h.state === 'active'}
+									<div>{h.issuer || '—'}</div>
+									{#if h.expires}
+										<div class="text-muted-foreground">{h.expires}{#if h.expires_in_days !== undefined && h.expires_in_days !== null} ({h.expires_in_days}d){/if}</div>
+									{/if}
+								{:else}
+									<span class="text-muted-foreground">—</span>
+								{/if}
+							</td>
+							<td class="py-2 text-xs">
+								{#if h.message}
+									<span class="text-muted-foreground break-all">{h.message}</span>
+								{:else if h.state === 'pending'}
+									<span class="text-muted-foreground">Waiting for Caddy to start issuance…</span>
+								{:else}
+									<span class="text-muted-foreground">—</span>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
 		{/if}
 	</section>
 


### PR DESCRIPTION
Your point about the tooltip was right — it was leftover wording from a much earlier draft where we'd intended to rely on Caddy's on-demand TLS. The current design pushes automation policies eagerly via \`set_tls_automation\`, so issuance starts at policy-push time, not on first request. The stale wording showed up in three places (corrected in this PR):
- Ingress page pending tooltip
- \`cert_info_for_host\` doc comment
- \`CaddyRouteSummary.cert\` doc comment

## New per-host status surface

RPC \`system.tls.host_statuses\` returns per-host state for every managed hostname Caddy is tracking (\`apps.tls.certificates.automate\` is the authoritative list we push). Four states:

- **active** — cert on disk, served. Includes issuer + expires + days-remaining.
- **issuing** — Caddy is currently working. \`message\` = the latest journal line for that host so the operator can see how far along.
- **failed** — Caddy gave up. \`message\` = the error verbatim (DNS-01 timeout, rate limit, provider auth error).
- **pending** — sub-second window between policy push and first work.

Classification: cert dir check first; on miss, tails \`journalctl -u caddy --since '10 min ago'\` and matches \`"identifier":"<host>"\`.

New "Managed Certificates" table on \`/tls\`, auto-refreshing every 10s. Operator sees \`issuing → active\` live, or the failure reason when stuck — no more "ssh + journalctl" needed.

## What this would have given us during the whoami debugging

Instead of \`pending\` sitting for 5+ minutes with no explanation, the table would have shown:

\`\`\`
whoami.0f.ee    failed    —    timed out waiting for record to fully propagate; verify DNS provider configuration is correct - last error: <nil>
\`\`\`

— the exact failure mode, surfaced in the WebUI, without manual log digging.

## Test plan

- [x] \`cargo test --workspace\` (77 nasty-apps + 202 nasty-engine tests passing).
- [x] \`cargo clippy -- -D warnings\` clean.
- [x] \`npm run check\` on webui clean.
- [ ] Deploy on 10.10.20.100: open /tls, see managed certs section with nas/haze/whoami rows. Trigger a known-bad issuance (e.g. set ingress for a subdomain whose DNS isn't propagated yet) and confirm the row flips through pending → issuing → failed with the actual error.