### PR TITLE
apps: persist ingress_subdomain for compose apps too (closes #247 reboot bug)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -829,10 +829,18 @@ async fn save_ingress_subdomain(app_name: &str, subdomain: Option<&str>) -> Resu
     let mut manifest: serde_json::Value = match tokio::fs::read_to_string(&manifest_path).await {
         Ok(s) => serde_json::from_str(&s)
             .map_err(|e| AppsError::CommandFailed(format!("manifest parse: {e}")))?,
-        // Compose apps don't have a flat manifest; we silently no-op
-        // in that case rather than create a stub that masks the real
-        // compose dir layout. V1 subdomain mode is simple-only anyway.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        // Compose apps don't have a flat manifest (their storage lives
+        // under `<COMPOSE_DIR>/<name>/docker-compose.yml`), but we
+        // still need a place to persist their ingress_subdomain so it
+        // survives a reboot — without that, set_app_route puts the
+        // host-match route in Caddy and `compute_desired_routes` then
+        // forgets the choice on restart (the "subdomain ingress
+        // reverts on reboot" half of #247 for compose apps). Create
+        // a stub `<name>.json` next to the compose dir to hold the
+        // field; the on-remove path (lib.rs ~2015) already deletes
+        // it, so no leak. Mirrors how `save_proxy_disabled_reason`
+        // handles the same NotFound case.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
         Err(e) => return Err(AppsError::CommandFailed(format!("manifest read: {e}"))),
     };
     let map = match manifest.as_object_mut() {


### PR DESCRIPTION
**Yes, we missed something.** HuxyUK's still-broken state after deploying #248 is because that PR fixed the wrong half of the bug.

## What's actually wrong

\`save_ingress_subdomain\` has this:

\`\`\`rust
async fn save_ingress_subdomain(app_name: &str, subdomain: Option<&str>) -> Result<(), AppsError> {
    let manifest_path = format!("{}/{}.json", COMPOSE_DIR, app_name);
    let mut manifest: serde_json::Value = match tokio::fs::read_to_string(&manifest_path).await {
        Ok(s) => serde_json::from_str(&s)...,
        // Compose apps don't have a flat manifest; we silently no-op
        // in that case rather than create a stub that masks the real
        // compose dir layout. V1 subdomain mode is simple-only anyway.
        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
        ...
\`\`\`

The "V1 subdomain mode is simple-only anyway" was a design constraint the WebUI never enforced — the ingress form lets you set a subdomain on any app, compose or simple. For compose apps, the route gets pushed to Caddy correctly (in-session it works), but **the subdomain is never persisted to disk** because there's no flat manifest to write to. On reboot, \`compute_desired_routes\` calls \`load_ingress_subdomain\` → no file → returns None → defaults back to path-prefix.

#248 fixed the path where the manifest exists but \`proxy_disabled_reason\` shadows the subdomain. That's the simple-app case. For compose apps (which is what Jellyfin would be installed as), the manifest doesn't exist at all and #248 has nothing to act on.

Meanwhile \`save_proxy_disabled_reason\` (right above \`save_ingress_subdomain\` in the same file) handles the same NotFound case differently — it falls back to \`serde_json::json!({})\` and creates the file. So compose apps DO get a \`<name>.json\` stub from the path-prefix probe failure, but never from a manual subdomain set.

## Fix

One-line behavioural change: \`save_ingress_subdomain\` now mirrors \`save_proxy_disabled_reason\`'s NotFound fallback. Creates the stub manifest if it doesn't exist, writes the field, done.

Safe because the app-remove path (lib.rs ~2015) already \`rm -f\`s this exact file on uninstall, so no leak. The compose directory layout (\`<name>/docker-compose.yml\`) is untouched — the new file is a sibling, not nested.

## Combined effect with #248

| | Pre-#248 | Post-#248 | Post-this PR |
|---|---|---|---|
| Simple app, path-prefix probe fails, subdomain set later | reverts on reboot | survives | survives |
| Compose app, subdomain set | reverts on reboot | reverts on reboot | survives |

## Test plan

- [x] \`cargo test --workspace\` green (77 nasty-apps tests).
- [x] \`cargo clippy -- -D warnings\` clean.
- [ ] HuxyUK to install a compose app, set subdomain, reboot, confirm subdomain persists. Same repro as the original #247 report.