### PR TITLE
webui: PathPicker descent no longer reverts to root on click (#252)

### DIFF
--- a/webui/src/lib/components/PathPicker.svelte
+++ b/webui/src/lib/components/PathPicker.svelte
@@ -64,12 +64,22 @@
 
 	$effect(() => {
 		if (open) {
-			currentPath = normalizeRel(initialPath);
+			// Snapshot the starting path into a local before writing
+			// to the reactive `currentPath` — passing `currentPath`
+			// itself to `browse()` here would make it a dependency of
+			// this effect (Svelte 5 tracks reactive reads regardless of
+			// any prior write in the same run). When `browse()` later
+			// async-updates `currentPath` after a fetch, the effect
+			// would re-run, reset `currentPath` back to `initialPath`,
+			// and re-fetch the root — wiping the descent and producing
+			// the "click does nothing but blink" behaviour from #252.
+			const start = normalizeRel(initialPath);
+			currentPath = start;
 			mkdirOpen = false;
 			subvolOpen = false;
 			mkdirName = '';
 			subvolName = '';
-			browse(currentPath);
+			browse(start);
 		}
 	});
 


### PR DESCRIPTION
## What

Fixes [#252](https://github.com/nasty-project/nasty/issues/252) — clicking a folder in the Path Picker "did nothing but blink" instead of descending into the directory.

## Cause (Svelte 5 reactivity foot-gun)

The \`$effect\` that initializes the picker when \`open\` flips to true was reading \`currentPath\` reactively:

\`\`\`ts
$effect(() => {
    if (open) {
        currentPath = normalizeRel(initialPath);
        ...
        browse(currentPath);   // ← reads currentPath
    }
});
\`\`\`

Svelte 5 tracks reactive reads regardless of whether a write to the same variable happened earlier in the same effect run. So \`currentPath\` ended up as a dependency of the effect.

Sequence on click:

1. \`descend('first')\` calls \`browse('first')\`
2. \`browse()\` async-fetches, writes \`currentPath = 'first'\`, \`entries = [...]\`
3. State change re-runs the effect because \`currentPath\` is a dep
4. Effect body resets \`currentPath\` back to \`normalizeRel(initialPath)\` (empty string), then \`browse('')\` re-fetches the root listing
5. UI shows the descended content for one frame, then snaps back to root → the "blink"

## Fix

Snapshot the start value into a local before writing, then pass the local to \`browse()\` so the effect never reads \`currentPath\`:

\`\`\`ts
$effect(() => {
    if (open) {
        const start = normalizeRel(initialPath);
        currentPath = start;
        ...
        browse(start);   // local, not reactive
    }
});
\`\`\`

Effect now re-runs only when \`open\` or \`initialPath\` actually changes — both of which only happen on open/close, not on descent.

## Test plan

- [x] \`npm run check\` clean.
- [ ] Manual: open Apps page → "+ Install" → add a Volume → click the browse (folder) button → modal opens → click a folder → confirm it descends and breadcrumb updates to show the descended path.
- [ ] Same with Backups → Create Profile → Browse for a source folder.

## Same component, three call sites

PathPicker is used in:
- \`routes/apps/+page.svelte\` (install-volume browse)
- \`routes/backups/+page.svelte\` (create + edit profile source pickers)

The single fix covers all three.