### PR TITLE
router: fix permission classifications (logout, change_password, smb.group.*, vm.delete, apps.disable, apps.stats)

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -20,9 +20,28 @@ mod vm;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
-/// Methods an operator token is allowed to call (in addition to all read-only methods)
-fn is_operator_allowed(method: &str) -> bool {
+/// Methods every authenticated user can call regardless of role.
+/// Two categories:
+///   1. Pure reads (`is_read_only`).
+///   2. Mutations that only affect the caller's own session/account —
+///      logging out, changing your own password. Putting these in
+///      `is_read_only` would be misleading (they DO write), so the
+///      role-check pipes through this wider predicate instead.
+fn is_universally_allowed(method: &str) -> bool {
     is_read_only(method)
+        || matches!(
+            method,
+            // Without these, ReadOnly and Operator users literally
+            // couldn't log out or change their own password — the
+            // engine would deny them with "Permission denied".
+            "auth.logout" | "auth.change_password"
+        )
+}
+
+/// Methods an operator token is allowed to call (in addition to
+/// everything in `is_universally_allowed`).
+fn is_operator_allowed(method: &str) -> bool {
+    is_universally_allowed(method)
         || matches!(
             method,
             "subvolume.create"
@@ -46,7 +65,14 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "smb.user.create"
                 | "smb.user.delete"
                 | "smb.user.set_password"
+                // Operator can create, delete, AND manage members of
+                // SMB groups — the old list only had `delete`, which
+                // meant operators could tear groups down they had no
+                // way to build up.
+                | "smb.group.create"
                 | "smb.group.delete"
+                | "smb.group.add_member"
+                | "smb.group.remove_member"
                 | "share.iscsi.create"
                 | "share.iscsi.delete"
                 | "share.iscsi.add_lun"
@@ -63,12 +89,19 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "share.nvmeof.remove_host"
                 | "vm.create"
                 | "vm.update"
+                // `vm.delete` was admin-only; operator could spin up
+                // VMs they had no way to tear down. Closes the same
+                // create-vs-delete asymmetry as smb.group above.
+                | "vm.delete"
                 | "vm.start"
                 | "vm.stop"
                 | "vm.kill"
                 | "vm.snapshot"
                 | "vm.clone"
                 | "apps.enable"
+                // `apps.disable` was admin-only — same asymmetry: an
+                // operator could turn the apps runtime on but not off.
+                | "apps.disable"
                 | "apps.install"
                 | "apps.update"
                 | "apps.remove"
@@ -165,6 +198,11 @@ fn is_read_only(method: &str) -> bool {
                 | "apps.check_devices"
                 | "apps.check_volumes"
                 | "apps.status"
+                // Live CPU / mem / network stats per container.
+                // Pure read; the WebUI polls it from the Apps page
+                // and ReadOnly users need it for the dashboard to
+                // populate.
+                | "apps.stats"
                 | "apps.logs"
                 | "apps.compose.logs"
                 | "apps.container.logs"
@@ -265,10 +303,17 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
         return serde_json::to_string(&resp).unwrap();
     }
 
-    // Enforce role permissions
+    // Enforce role permissions.
+    //
+    // ReadOnly used to map to `is_read_only` directly, which meant
+    // ReadOnly users couldn't log out or change their own password —
+    // both are mutations and so didn't qualify as "read-only". The
+    // wider `is_universally_allowed` predicate handles the read-set
+    // plus the small set of self-only mutations every authenticated
+    // user is allowed.
     let denied = match session.role {
         Role::Admin => false,
-        Role::ReadOnly => !is_read_only(&request.method),
+        Role::ReadOnly => !is_universally_allowed(&request.method),
         Role::Operator => !is_operator_allowed(&request.method),
     };
     if denied {


### PR DESCRIPTION
PR A from the role-permission audit. All clear bugs / omissions — no policy decisions in this one.

## What was wrong

| Method | Old | New | Why |
|---|---|---|---|
| \`auth.logout\` | admin only | universal | ReadOnly / Operator users literally couldn't log out |
| \`auth.change_password\` | admin only | universal | …or change their own password |
| \`smb.group.create\` | admin only | operator | \`smb.group.delete\` was operator → asymmetry |
| \`smb.group.add_member\` | admin only | operator | Operators created SMB shares with groups they couldn't add members to |
| \`smb.group.remove_member\` | admin only | operator | Same as above |
| \`vm.delete\` | admin only | operator | \`vm.create\` was operator → asymmetry |
| \`apps.disable\` | admin only | operator | \`apps.enable\` was operator → asymmetry |
| \`apps.stats\` | admin only | read-only | Pure live-stats poll; ReadOnly's Apps page chart needs it |

## How the auth/logout fix works

`auth.logout` and `auth.change_password` mutate state (session / user record), so they don't match `is_read_only`. They also weren't in `is_operator_allowed`. So non-admin users got "Permission denied" trying to log out.

Adding them to `is_read_only` would be misleading (the name implies no writes). Instead, this PR adds a new predicate `is_universally_allowed` that covers `is_read_only` + a small set of self-only mutations (currently just those two). The ReadOnly role check uses this wider predicate; `is_operator_allowed` builds on it too, so operators inherit the same access.

## What's NOT in this PR (deliberate)

These are policy questions, not bugs — kept separate per yesterday's audit discussion:

- Should operators manage backups? (\`backup.profile.*\`, \`backup.run\`, \`backup.repo.*\`)
- Should operators toggle service protocols? (\`service.protocol.enable/disable\`)
- Should operators import VM disk images? (\`vm.images.ensure\`)
- Should operators create/delete their own API tokens? Depends on whether the handler restricts to self — needs to be verified before opening that gate.

## Test plan

- [x] \`cargo test --workspace\` (everything green, no role-specific tests changed but build verifies the predicates).
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [ ] Manual: create an Operator user, confirm they can now: log out, change password, create+delete an SMB group with members, delete a VM they created, disable the apps runtime, view live container stats.
- [ ] Manual: create a ReadOnly user, confirm they can log out and change password (other methods should still be denied).