### PR TITLE
router: extend operator scope to backups, service protocols, VM image import

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -115,6 +115,31 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "apps.compose.remove"
                 | "apps.ingress.set"
                 | "apps.ingress.remove"
+                // Backup lifecycle is operator territory in a NAS
+                // appliance — same role that manages shares + apps
+                // typically manages where the data is copied. The
+                // read paths (`backup.profile.get`/`list`,
+                // `backup.status`, `backup.snapshots`) are already
+                // in `is_read_only`, so credentials in profiles are
+                // already visible to operators; admitting the write
+                // paths doesn't widen secrets exposure.
+                | "backup.profile.create"
+                | "backup.profile.update"
+                | "backup.profile.delete"
+                | "backup.run"
+                | "backup.repo.check"
+                | "backup.repo.init"
+                // Service-protocol toggles (NFS/SMB/iSCSI/NVMe-oF
+                // server services + SSH/mDNS/SMART). Operators were
+                // creating shares for protocols they couldn't turn
+                // on — the share would land on disk but no server
+                // was listening. Same coupling as share CRUD.
+                | "service.protocol.enable"
+                | "service.protocol.disable"
+                // VM disk-image import. Operator already has
+                // `vm.create` etc.; without import they can't
+                // populate the disk to boot from.
+                | "vm.images.ensure"
                 | "firmware.update"
         )
 }


### PR DESCRIPTION
PR B from the role-permission audit. PR #254 handled clear bugs; this PR is the policy decisions for gaps where operator scope was narrower than the day-to-day workflow needed.

## Added to operator

| Method | Why |
|---|---|
| \`backup.profile.create\` / \`update\` / \`delete\` | Backups are core operator work; read paths already exposed credentials at this level |
| \`backup.run\` | Triggering a backup is a routine operation |
| \`backup.repo.check\` / \`init\` | Repo setup is part of backup config |
| \`service.protocol.enable\` / \`disable\` | Operators were creating shares for protocols they couldn't turn on |
| \`vm.images.ensure\` | Operator has \`vm.create\` but couldn't import the disk image — broken workflow |

## Deliberately NOT added

**\`auth.token.create/delete/list\`** — admin-only stays.

Tokens are global with a configurable \`role\` parameter. A non-admin calling \`create\` with \`role: Admin\` would be textbook privilege escalation. The handlers in \`auth.rs\` already enforce \`session.role != Admin → Forbidden\` internally; the router classification stays admin-only for defense in depth (so any future handler refactor doesn't accidentally open the door).

If we want non-admin users to have personal API tokens, the right design is per-user token tables with role clamping ("you can only create tokens with your own role or lower"). Separate feature.

## Risk model

Pattern is consistent across the audit: operators are trusted with day-to-day data operations on the box. They can already delete shares, delete VMs (after PR #254), delete app installs — so adding "delete a backup profile" doesn't fundamentally change the trust assumption. The escalation gate is at the **token/account** layer (admin owns who gets which role), not at individual mutation paths.

## Test plan

- [x] \`cargo test --workspace\` green.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [ ] Manual: create an Operator user, confirm they can: create a backup profile, kick off \`backup.run\`, init a backup repo, enable an NFS protocol, import a VM image. Confirm they still CANNOT: create/list/delete API tokens (admin-only kept).