### PR TITLE
webui/ingress: link the Value column to the route's live destination

### DIFF
--- a/webui/src/routes/ingress/+page.svelte
+++ b/webui/src/routes/ingress/+page.svelte
@@ -155,7 +155,23 @@
 								<td class="p-2">
 									<span class="inline-flex items-center whitespace-nowrap rounded-md border px-2 py-0.5 text-[0.65rem] {mb.class}">{mb.label}</span>
 								</td>
-								<td class="p-2 font-mono text-xs break-all">{r.match_value}</td>
+								<td class="p-2 font-mono text-xs break-all">
+									<!-- Make the value clickable when it resolves to a real URL.
+									     `host`-match: full https://<host>/ (the cert serves it; new
+									     tab keeps the operator on the WebUI). `path`-match: relative
+									     path on the current origin with the trailing `*` glob
+									     stripped (so /apps/haze/* becomes /apps/haze/ which Caddy
+									     proxies to the container). Catch-all stays plain text — no
+									     meaningful destination. -->
+									{#if r.match_kind === 'host'}
+										<a class="text-blue-400 hover:text-blue-300" href={`https://${r.match_value}/`} target="_blank" rel="noopener noreferrer">{r.match_value}</a>
+									{:else if r.match_kind === 'path'}
+										{@const pathHref = r.match_value.replace(/\/\*+$/, '/').replace(/\*+$/, '')}
+										<a class="text-blue-400 hover:text-blue-300" href={pathHref} target="_blank" rel="noopener noreferrer">{r.match_value}</a>
+									{:else}
+										{r.match_value}
+									{/if}
+								</td>
 								<td class="p-2 text-xs text-muted-foreground">{r.handler_kind}</td>
 								<td class="p-2 font-mono text-xs">
 									{#if r.upstream}{r.upstream}{:else}<span class="text-muted-foreground">—</span>{/if}


### PR DESCRIPTION
Small QoL change. The Ingress overview's Value column was plain text — operators saw \`haze.0f.ee\` but had to manually copy/retype to actually visit it. Now each value is a link where it makes sense:

| match_kind | Link target | New tab? |
|---|---|---|
| \`host\` | \`https://<host>/\` | yes (keeps operator on the WebUI) |
| \`path\` | relative path on current origin, with \`/*\` glob stripped (\`/apps/haze/*\` → \`/apps/haze/\`) | yes |
| \`catch_all\` | plain text (no meaningful destination) | — |

The existing **App** column link (which jumps to \`/apps\` for *managing* the ingress) is unchanged — the new Value link is for *visiting* the destination.

## Test plan

- [x] \`npm run check\` clean.
- [ ] Manual on a box with mixed ingress: click a host row → opens \`https://<subdomain>/\` in new tab. Click a path-prefix row → opens the path in new tab. Catch-all row stays uninteractive.