### PR TITLE
state: stop silently wiping state files on parse failure

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/engine/nasty-common/Cargo.toml
+++ b/engine/nasty-common/Cargo.toml
@@ -12,3 +12,6 @@ tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 schemars.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -4,4 +4,4 @@ pub mod metrics_types;
 pub mod state;
 
 pub use jsonrpc::{Error as RpcError, ErrorCode, Notification, Request, Response};
-pub use state::{HasId, StateDir};
+pub use state::{HasId, StateDir, load_singleton_or_recover};

--- a/engine/nasty-common/src/state.rs
+++ b/engine/nasty-common/src/state.rs
@@ -4,9 +4,85 @@
 //! identified by its ID. Writes use write-to-temp-then-rename
 //! for crash safety.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Serialize, de::DeserializeOwned};
+
+/// Load a JSON-serialized state file, returning `Default::default()` if
+/// the file is missing OR corrupted — with critical differences from
+/// the naive pattern `from_str(&s).unwrap_or_default()`:
+///
+/// 1. **Loud logging on corruption.** A parse failure means the
+///    on-disk file existed but couldn't be deserialized — typically a
+///    disk error, partial write, or hand-edit gone wrong. Silently
+///    falling back to defaults is data loss in disguise; this helper
+///    emits a `WARN` so the operator sees it.
+///
+/// 2. **Side-saves the corrupt content.** The bad file is moved to
+///    `<path>.corrupt.<unix-ts>` before defaults take over. That
+///    keeps a forensic copy for manual recovery and prevents the
+///    engine from re-reading the same corruption next boot. A failed
+///    rename is itself logged but doesn't block startup.
+///
+/// 3. **Missing file is silently OK** — first-boot is normal.
+///
+/// Use this anywhere a singleton JSON state file is loaded into a
+/// `T: Default + DeserializeOwned`. Replaces patterns like:
+///
+/// ```ignore
+/// match tokio::fs::read_to_string(PATH).await {
+///     Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
+///     Err(_) => Default::default(),
+/// }
+/// ```
+pub async fn load_singleton_or_recover<T>(path: impl AsRef<Path>) -> T
+where
+    T: Default + DeserializeOwned,
+{
+    let path = path.as_ref();
+    let content = match tokio::fs::read_to_string(path).await {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return T::default(),
+        Err(e) => {
+            // Read failed for a non-missing reason (permission denied,
+            // I/O error). Same downside as a parse failure — we have no
+            // way to recover the data — so log loudly and fall through.
+            tracing::warn!(
+                "state read failed for {}: {e}; using defaults",
+                path.display()
+            );
+            return T::default();
+        }
+    };
+    match serde_json::from_str::<T>(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "state file at {} is corrupt: {e}; backing up and using defaults",
+                path.display()
+            );
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs().to_string())
+                .unwrap_or_else(|_| "unknown".into());
+            let backup = path.with_extension(format!(
+                "{}.corrupt.{}",
+                path.extension().and_then(|s| s.to_str()).unwrap_or("dat"),
+                ts
+            ));
+            if let Err(e) = tokio::fs::rename(path, &backup).await {
+                tracing::warn!(
+                    "could not move corrupt {} aside to {}: {e}",
+                    path.display(),
+                    backup.display()
+                );
+            } else {
+                tracing::warn!("corrupt {} saved as {}", path.display(), backup.display());
+            }
+            T::default()
+        }
+    }
+}
 
 /// A directory-based state store where each item is a separate JSON file.
 pub struct StateDir {
@@ -88,4 +164,75 @@ impl StateDir {
 /// Trait for items that have an ID field.
 pub trait HasId {
     fn id(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Default, PartialEq, Eq, Deserialize)]
+    struct Sample {
+        name: String,
+        count: i64,
+    }
+
+    #[tokio::test]
+    async fn load_singleton_returns_default_when_file_missing() {
+        // Missing file is the "fresh install" case — no warning, just
+        // defaults. (We do log on other errors, but absence shouldn't
+        // be alarming.)
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let got: Sample = load_singleton_or_recover(&path).await;
+        assert_eq!(got, Sample::default());
+    }
+
+    #[tokio::test]
+    async fn load_singleton_reads_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ok.json");
+        tokio::fs::write(&path, br#"{"name":"hi","count":3}"#)
+            .await
+            .unwrap();
+        let got: Sample = load_singleton_or_recover(&path).await;
+        assert_eq!(
+            got,
+            Sample {
+                name: "hi".into(),
+                count: 3
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn load_singleton_backs_up_corrupt_file_and_returns_default() {
+        // This is the property we care about most: a corrupt state
+        // file must NOT silently degrade to defaults — it must be
+        // moved aside so the operator can recover it, and the
+        // engine continues with defaults. Without the backup, the
+        // next save would overwrite the corrupt-but-recoverable
+        // content with a fresh `Default::default()`-serialised file,
+        // and the original data would be unrecoverable.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        tokio::fs::write(&path, b"this is not json").await.unwrap();
+        let got: Sample = load_singleton_or_recover(&path).await;
+        assert_eq!(got, Sample::default());
+        assert!(!path.exists(), "corrupt file should be renamed away");
+        let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+        let mut found_backup = false;
+        while let Ok(Some(e)) = entries.next_entry().await {
+            let name = e.file_name();
+            let n = name.to_string_lossy();
+            if n.starts_with("bad.json.corrupt.") {
+                found_backup = true;
+                // Sanity: the backup carries the original bytes
+                // verbatim — otherwise it's useless for recovery.
+                let content = tokio::fs::read_to_string(e.path()).await.unwrap();
+                assert_eq!(content, "this is not json");
+            }
+        }
+        assert!(found_backup, "expected bad.json.corrupt.<ts> backup file");
+    }
 }

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -1032,10 +1032,7 @@ fn generate_id() -> String {
 }
 
 async fn load_state() -> AuthState {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => AuthState::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save_state(state: &AuthState) -> Result<(), AuthError> {
@@ -1048,10 +1045,7 @@ async fn save_state(state: &AuthState) -> Result<(), AuthError> {
 }
 
 async fn load_rate_limit() -> RateLimitState {
-    match tokio::fs::read_to_string(RATE_LIMIT_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => RateLimitState::default(),
-    }
+    nasty_common::load_singleton_or_recover(RATE_LIMIT_PATH).await
 }
 
 async fn save_rate_limit(state: &RateLimitState) -> Result<(), AuthError> {

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -868,10 +868,7 @@ fn uuid_v4() -> String {
 }
 
 async fn load_state() -> AlertState {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => AlertState::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save_state(state: &AlertState) -> Result<(), std::io::Error> {

--- a/engine/nasty-system/src/nut.rs
+++ b/engine/nasty-system/src/nut.rs
@@ -544,10 +544,7 @@ pub async fn load_config() -> NutConfig {
 }
 
 async fn load() -> NutConfig {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => NutConfig::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save(config: &NutConfig) -> Result<(), std::io::Error> {

--- a/engine/nasty-system/src/passthrough.rs
+++ b/engine/nasty-system/src/passthrough.rs
@@ -72,10 +72,7 @@ static STATE_LOCK: Mutex<()> = Mutex::const_new(());
 
 pub async fn load() -> PassthroughConfig {
     let _guard = STATE_LOCK.lock().await;
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => PassthroughConfig::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 /// Apply a request: validate against the management interface

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -649,10 +649,7 @@ async fn apply_timezone(tz: &str) -> Result<(), String> {
 }
 
 async fn load() -> Settings {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => Settings::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save(settings: &Settings) -> Result<(), std::io::Error> {

--- a/engine/nasty-system/src/tailscale.rs
+++ b/engine/nasty-system/src/tailscale.rs
@@ -252,10 +252,7 @@ async fn query_status() -> (bool, Option<String>, Option<String>, Option<String>
 // ── Persistence ─────────────────────────────────────────────────
 
 async fn load_config() -> TailscaleConfig {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => TailscaleConfig::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save_config(config: &TailscaleConfig) -> Result<(), std::io::Error> {

--- a/engine/nasty-system/src/tuning.rs
+++ b/engine/nasty-system/src/tuning.rs
@@ -463,10 +463,7 @@ async fn apply_iscsi_login_timeout(timeout: u32) -> Result<(), String> {
 // ── Persistence ──────────────────────────────────────────────
 
 async fn load() -> TuningConfig {
-    match tokio::fs::read_to_string(STATE_PATH).await {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => TuningConfig::default(),
-    }
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
 }
 
 async fn save(config: &TuningConfig) -> Result<(), std::io::Error> {


### PR DESCRIPTION
First finding from the silent-error-swallow audit and the biggest one I've seen all session. Eight separate singleton-state files share this load pattern:

\`\`\`rust
match tokio::fs::read_to_string(PATH).await {
    Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
    Err(_) => Default::default(),
}
\`\`\`

If the file exists but parses badly — disk error, partial write during a crash, hand-edit gone wrong, schema mismatch after a botched upgrade — the engine silently falls back to \`Default::default()\` and keeps going. Worst case scenarios:

- \`auth.json\` corruption ⇒ **entire user database silently erased**, box looks like a fresh install.
- \`settings.json\` corruption ⇒ TLS / OIDC / hostname / ACME config silently reset to factory defaults.
- \`alerts.json\` corruption ⇒ all alert rules vanish.
- (plus rate-limit, nut, passthrough, tailscale, tuning.)

In each case the engine logs nothing, returns "ready", and lets the user (or upgrade process) overwrite the now-defaults-only file on the next save — making the original corruption unrecoverable.

## Fix

New \`nasty_common::load_singleton_or_recover<T>\` does the right thing per failure mode:

| Case | Behaviour |
|---|---|
| Missing file (fresh install) | defaults, no log |
| Read error (perm / I/O) | WARN log, defaults |
| Parse error (corrupt content) | WARN log, **rename file to \`<path>.corrupt.<unix-ts>\`**, defaults |

The rename is the key. It preserves the original bytes for forensic recovery (\`cat /var/lib/nasty/auth.json.corrupt.1234567890\` to inspect what was there) AND prevents the engine from overwriting the corruption with a fresh defaults-file on the next save. Loss is now recoverable instead of silent.

## Files

- New helper: \`engine/nasty-common/src/state.rs\` + 3 unit tests (missing / valid / corrupt).
- 8 call sites updated:
  - \`nasty-engine/src/auth.rs\`: \`auth.json\`, \`rate-limit.json\`
  - \`nasty-system/src/settings.rs\`: \`settings.json\`
  - \`nasty-system/src/alerts.rs\`: alert rules
  - \`nasty-system/src/nut.rs\`: UPS config
  - \`nasty-system/src/passthrough.rs\`: VM passthrough
  - \`nasty-system/src/tailscale.rs\`: Tailscale config
  - \`nasty-system/src/tuning.rs\`: tuning config

## What this does NOT change

- Behaviour on first boot (missing file) is identical.
- Behaviour with a valid file is identical.
- Behaviour on a successful save is identical (atomic write was already in place).

The only behavioural diff is: present-but-unreadable file now produces a loud log line and a backup, instead of silent data loss.

## Test plan

- [x] \`cargo test --workspace\` green (3 new tests in nasty-common cover missing / valid / corrupt cases; existing tests still pass).
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [ ] Manual: \`echo "garbage" > /var/lib/nasty/settings.json && systemctl restart nasty-engine\`. Expect:
  1. \`journalctl -u nasty-engine\` shows a WARN about corrupt settings.json.
  2. \`/var/lib/nasty/settings.json.corrupt.<ts>\` exists with the literal "garbage" string.
  3. \`/var/lib/nasty/settings.json\` does NOT exist (will be re-created on next setting save).
  4. WebUI loads cleanly with default settings.