### PR TITLE
engine: log when silent-fallthrough Err arms hit, not just degrade

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3327,7 +3327,15 @@ impl AppsService {
                         parent_exists,
                     });
                 }
-                Err(_) => {}
+                Err(e) => {
+                    // Per the doc comment above: stat hiccups other
+                    // than ENOENT are deliberately not flagged to the
+                    // user (don't block a deploy on a transient
+                    // permission error). But the operator should at
+                    // least see WHY a path the WebUI shows as fine
+                    // would fail at docker-run time — log it.
+                    warn!("check_devices: stat({path}) failed: {e}; treating as existing");
+                }
             }
         }
         missing
@@ -3417,7 +3425,16 @@ impl AppsService {
                         line,
                     });
                 }
-                Err(_) => {}
+                Err(e) => {
+                    // Same rationale as check_devices: don't block a
+                    // deploy on a non-ENOENT stat hiccup, but log so
+                    // the operator can correlate a later docker-run
+                    // permission error with the silent skip here.
+                    warn!(
+                        "check_volumes: stat({}) failed: {e}; skipping permission check",
+                        bind.host_path
+                    );
+                }
             }
         }
         out

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2579,7 +2579,15 @@ async fn read_fs_options_show_super(device: Option<&str>) -> FilesystemOptions {
 
     let output = match cmd::run_ok("bcachefs", &["show-super", dev]).await {
         Ok(o) => o,
-        Err(_) => return FilesystemOptions::default(),
+        Err(e) => {
+            // `show-super` failure means the WebUI's "Options" panel
+            // for this filesystem will display all defaults — masking
+            // whatever the real on-disk options are. Worth logging
+            // so the operator can correlate the missing data with a
+            // bcachefs tools / permission issue.
+            warn!("bcachefs show-super {dev} failed: {e}; reporting defaults");
+            return FilesystemOptions::default();
+        }
     };
 
     let mut opts = FilesystemOptions::default();
@@ -2744,7 +2752,13 @@ async fn discover_unmounted_bcachefs(
 ) -> Vec<(String, String, Vec<String>)> {
     let output = match cmd::run_ok("blkid", &["-t", "TYPE=bcachefs", "-o", "export"]).await {
         Ok(o) => o,
-        Err(_) => return Vec::new(),
+        Err(e) => {
+            // blkid failure means we'll silently miss every unmounted
+            // bcachefs filesystem on the box. The WebUI's "import"
+            // flow won't see them. Loud log so the operator notices.
+            warn!("blkid failed: {e}; unmounted bcachefs filesystems will not be discovered");
+            return Vec::new();
+        }
     };
 
     // Parse blkid export format: blocks separated by blank lines

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -1866,7 +1866,14 @@ async fn build_losetup_map() -> HashMap<String, String> {
     .await
     {
         Ok(o) => o,
-        Err(_) => return map,
+        Err(e) => {
+            // Empty loop-device map means the caller (subvolume
+            // enumeration) can't resolve block-subvolume backing
+            // files to /dev/loopN entries. The WebUI sees those
+            // subvolumes as detached even when they aren't.
+            warn!("losetup failed: {e}; loop-device map will be empty");
+            return map;
+        }
     };
 
     for line in output.lines() {
@@ -1906,7 +1913,17 @@ fn find_loop_device_from_map(
 async fn find_child_subvolumes(mount_point: &str, parent_name: &str) -> Vec<String> {
     let output = match cmd::run_ok("bcachefs", &["subvolume", "list", "-R", mount_point]).await {
         Ok(o) => o,
-        Err(_) => return Vec::new(),
+        Err(e) => {
+            // Empty children list means the caller (subvolume delete
+            // path) won't see nested subvolumes that need to be
+            // removed first — the outer delete then fails with a
+            // less actionable error. Surface the real cause here.
+            warn!(
+                "bcachefs subvolume list -R {mount_point} failed: {e}; \
+                 children of {parent_name} will not be discovered"
+            );
+            return Vec::new();
+        }
     };
 
     let prefix = format!("{parent_name}/");


### PR DESCRIPTION
Second pass on the silent-error-swallow audit (PR #257 covered the state-file class). This one fixes a softer class of issue: six call sites where an external command failure was silently degraded to an empty default with no log line — leaving the operator to figure out from WebUI symptoms why their UI was showing partial data.

## Pattern

\`\`\`rust
let output = match cmd::run_ok("…", &[…]).await {
    Ok(o) => o,
    Err(_) => return <empty default>,
};
\`\`\`

Downstream caller sees defaults, continues; operator sees missing data in the WebUI with no breadcrumb back to which subprocess failed.

## Sites

| File:line | Failure | Symptom when silent |
|---|---|---|
| \`nasty-apps/lib.rs:3330\` | \`check_devices\` stat error | Preflight reports "fine" when path is permission-blocked; docker-run later fails confusingly. (Doc comment already justifies the no-block — log is purely for observability.) |
| \`nasty-apps/lib.rs:3420\` | \`check_volumes\` stat error | Same as above for the perms preflight. |
| \`nasty-storage/filesystem.rs:2582\` | \`bcachefs show-super\` | WebUI Options panel for the filesystem displays all defaults, masking real on-disk options. |
| \`nasty-storage/filesystem.rs:2747\` | \`blkid\` | Unmounted bcachefs filesystems silently invisible to the import flow. |
| \`nasty-storage/subvolume.rs:1869\` | \`losetup --list\` | Loop-device map empty → block subvolumes appear detached even when attached. |
| \`nasty-storage/subvolume.rs:1909\` | \`bcachefs subvolume list -R\` | Nested subvolumes go undiscovered before a delete pass; outer delete then fails with a less actionable error. |

## What this does NOT change

Each site **still degrades to the same default** — no aborts, no behaviour change for the happy path. The only diff is a WARN line in \`journalctl -u nasty-engine\` when the subprocess fails. Operator can now correlate UI weirdness with subprocess errors instead of speculating.

## Audit summary for the rest

Every other \`Err(_) => {}\` pattern across the engine codebase was reviewed:

- **Auth rejection paths** (terminal.rs, log_stream.rs, vm_console.rs, app_deploy.rs, vm_disk_import.rs) — already send user-facing error messages over websocket + close. Intentional. Leaving alone.
- **HTTP NotFound returns** (main.rs files-API handlers) — return proper 404 to client. Intentional.
- **Loop termination on EOF** (terminal.rs, log_stream.rs, vm_console.rs read loops) — standard pattern.
- **tokio::time::Elapsed** (docker compose timeout) — already returns a proper timeout error.
- **archive_path_once** (main.rs migration helper) — deferred to post-0.0.8 cleanup pass.

So this PR completes the in-scope silent-Err audit. The remaining categories are intentional or deferred.

## Test plan

- [x] \`cargo test --workspace\` (all tests still pass; no behaviour change).
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [ ] Manual sanity: kill or rename one of the affected binaries (e.g. \`mv $(which blkid) /tmp/\`) and confirm the WARN line appears in journal when the corresponding code path runs.