### PR TITLE
webui/types: close drift between engine settings and shared TS types

### DIFF
--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -566,6 +566,24 @@ export interface ProtocolStatus {
 
 export type TempUnit = 'celsius' | 'fahrenheit';
 
+export interface OidcRoleMapping {
+	group: string;
+	role: string;
+}
+
+export interface OidcSettings {
+	enabled: boolean;
+	issuer_url: string | null;
+	client_id: string | null;
+	client_secret: string | null;
+	redirect_uri: string | null;
+	scopes: string[];
+	groups_claim: string;
+	role_mappings: OidcRoleMapping[];
+	default_role: string | null;
+	auto_provision: boolean;
+}
+
 export interface Settings {
 	timezone: string;
 	hostname: string | null;
@@ -574,13 +592,24 @@ export interface Settings {
 	tls_domain: string | null;
 	tls_acme_email: string | null;
 	tls_acme_enabled: boolean;
-	tls_challenge_type: 'tls-alpn' | 'dns';
+	tls_challenge_type: 'tls-alpn' | 'http' | 'dns';
 	tls_dns_provider: string | null;
 	tls_dns_credentials: string | null;
 	tls_acme_staging: boolean;
 	tls_dns_resolver: string | null;
 	tls_dns_propagation_wait: number | null;
 	telemetry_enabled: boolean;
+	oidc: OidcSettings;
+}
+
+export interface TailscaleStatus {
+	enabled: boolean;
+	daemon_running: boolean;
+	connected: boolean;
+	ip?: string;
+	hostname?: string;
+	version?: string;
+	has_auth_key: boolean;
 }
 
 export type NutMode = 'local' | 'remote';

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -4,7 +4,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
-	import type { UserInfo, ApiTokenInfo, ApiTokenCreated, Filesystem, SmbGroup } from '$lib/types';
+	import type { UserInfo, ApiTokenInfo, ApiTokenCreated, Filesystem, SmbGroup, OidcSettings } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
@@ -70,19 +70,6 @@
 	let newTokenTried = $state(false);
 
 	// ── Single Sign-On (OIDC) ──────────────────────────────────
-	type OidcRoleMapping = { group: string; role: string };
-	type OidcSettings = {
-		enabled: boolean;
-		issuer_url: string | null;
-		client_id: string | null;
-		client_secret: string | null;
-		redirect_uri: string | null;
-		scopes: string[];
-		groups_claim: string;
-		role_mappings: OidcRoleMapping[];
-		default_role: string | null;
-		auto_provision: boolean;
-	};
 	let oidc: OidcSettings | null = $state(null);
 	let oidcSecretSet = $state(false);
 	let oidcSecretInput = $state('');

--- a/webui/src/routes/vpn/+page.svelte
+++ b/webui/src/routes/vpn/+page.svelte
@@ -3,18 +3,9 @@
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
 	import { Button } from '$lib/components/ui/button';
+	import type { TailscaleStatus } from '$lib/types';
 
 	const client = getClient();
-
-	interface TailscaleStatus {
-		enabled: boolean;
-		daemon_running: boolean;
-		connected: boolean;
-		ip?: string;
-		hostname?: string;
-		version?: string;
-		has_auth_key: boolean;
-	}
 
 	let tsStatus: TailscaleStatus | null = $state(null);
 	let tsAuthKey = $state('');


### PR DESCRIPTION
Maintenance pass on the engine ↔ WebUI type boundary. Three discrete drifts, one bundle.

## Drifts

### 1. `Settings.oidc` was silently discarded by TS
\`engine/nasty-system/src/settings.rs:243\` declares \`pub oidc: OidcSettings\` with \`#[serde(default)]\`, so \`system.settings.get\` always returns it. \`webui/src/lib/types.ts\` had no \`oidc\` field, so the TS Settings interface was lying about the payload. Anything that wanted OIDC config still had to call \`auth.oidc.config_status\` separately — but that wasn't *because* OIDC is intentionally separate from Settings; it was a duplication driven by the missing field.

### 2. \`tls_challenge_type\` was too narrow in TS
Engine accepts three values (\`settings.rs:202-207\`):
\`\`\`
"tls-alpn"  → TLS-ALPN-01 (port 443)
"http"      → HTTP-01 (port 80)
"dns"       → DNS-01 via a DNS-provider plugin compiled into Caddy
\`\`\`
TS had \`'tls-alpn' | 'dns'\`. The TLS page's local string union (\`tls/+page.svelte:16\`) already had \`'http'\`, just not the shared one. The buttons in the UI don't offer \`'http'\` yet, but if a future migration or hand-edit stores it, code reading \`Settings.tls_challenge_type\` would silently mis-narrow.

### 3. Two locally-defined types should live in \`types.ts\`
- \`OidcSettings\` / \`OidcRoleMapping\` were inline in \`users/+page.svelte:73-85\`.
- \`TailscaleStatus\` was inline in \`vpn/+page.svelte:9-17\`.

Both engine-side structs are derived via \`schemars\`, so future field additions would need to land in two places. Moved into \`types.ts\` and imported.

## What's not in this PR
- \`HostTlsStatus\` (\`tls/+page.svelte\`) — still local, but tightly scoped to one page and not drifting from \`settings.rs:1174\`.
- \`TailscaleConfig\` / \`TailscaleConnectRequest\` — only used as RPC payloads, never read into a typed state slot in TS; no value in surfacing them.
- The \`SettingsUpdate\` partial — engine has it as a struct, TS passes loose object literals to \`system.settings.update\`. Adding a \`Partial<Settings>\` alias would help, but the current call sites all type-narrow at the literal, so this would be churn without payoff. Leaving for a future pass.

## Test plan
- [x] \`npm run check\` clean (svelte-check 4880 files, 0 errors, 0 warnings).
- [x] No engine changes — no Rust rebuild needed.