### PR TITLE
webui: cancel page-scoped pollers on SPA navigation

### DIFF
--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { page } from '$app/stores';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
@@ -192,6 +192,14 @@
 	let snapshots: BackupSnapshot[] = $state([]);
 	let snapshotsLoading = $state(false);
 
+	// Page-scoped handle for the post-runBackup status poll so onDestroy can
+	// cancel it on SPA navigation — otherwise the 3-second interval keeps
+	// running until the backup finishes server-side, which can be minutes.
+	let runBackupPoll: ReturnType<typeof setInterval> | null = null;
+	function stopRunBackupPoll() {
+		if (runBackupPoll !== null) { clearInterval(runBackupPoll); runBackupPoll = null; }
+	}
+
 	onMount(async () => {
 		await refresh();
 		loading = false;
@@ -204,6 +212,10 @@
 			selectedSources = new Set(['/var/lib/nasty']);
 			loadSourceData();
 		}
+	});
+
+	onDestroy(() => {
+		stopRunBackupPoll();
 	});
 
 	let snapshotCounts: Record<string, number> = $state({});
@@ -272,11 +284,13 @@
 
 	async function runBackup(id: string) {
 		await withToast(() => client.call('backup.run', { id }), 'Backup started');
-		// Poll status
-		const poll = setInterval(async () => {
+		// Poll status until the backup finishes — onDestroy cancels this on
+		// SPA navigation so we don't keep polling after the user leaves.
+		stopRunBackupPoll();
+		runBackupPoll = setInterval(async () => {
 			backupStatus = await client.call<BackupStatus>('backup.status');
 			if (!backupStatus?.running) {
-				clearInterval(poll);
+				stopRunBackupPoll();
 				await refresh();
 			}
 		}, 3000);

--- a/webui/src/routes/services/+page.svelte
+++ b/webui/src/routes/services/+page.svelte
@@ -200,6 +200,15 @@
 		if (p?.collection === 'protocol') refresh();
 	}
 
+	// Page-scoped handles for the post-enable Docker-status poll so onDestroy
+	// can cancel them on SPA navigation.
+	let dockerEnablePoll: ReturnType<typeof setInterval> | null = null;
+	let dockerEnableTimeout: ReturnType<typeof setTimeout> | null = null;
+	function stopDockerEnablePoll() {
+		if (dockerEnablePoll !== null) { clearInterval(dockerEnablePoll); dockerEnablePoll = null; }
+		if (dockerEnableTimeout !== null) { clearTimeout(dockerEnableTimeout); dockerEnableTimeout = null; }
+	}
+
 	onMount(async () => {
 		client.onEvent(handleEvent);
 		await refresh();
@@ -210,7 +219,10 @@
 		if (target) toggleConfig(target);
 	});
 
-	onDestroy(() => client.offEvent(handleEvent));
+	onDestroy(() => {
+		client.offEvent(handleEvent);
+		stopDockerEnablePoll();
+	});
 
 	async function refresh() {
 		await withToast(async () => {
@@ -235,12 +247,13 @@
 			'Docker enabled — starting runtime'
 		);
 		dockerEnabling = false;
-		// Poll until running
-		const poll = setInterval(async () => {
+		// Poll until running.
+		stopDockerEnablePoll();
+		dockerEnablePoll = setInterval(async () => {
 			dockerStatus = await client.call<AppsStatus>('apps.status').catch(() => null);
-			if (dockerStatus?.running) { clearInterval(poll); }
+			if (dockerStatus?.running) stopDockerEnablePoll();
 		}, 3000);
-		setTimeout(() => clearInterval(poll), 60000);
+		dockerEnableTimeout = setTimeout(stopDockerEnablePoll, 60_000);
 	}
 
 	async function disableDocker() {

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -75,6 +75,12 @@
 
 	let hostStatuses: HostTlsStatus[] = $state([]);
 	let hostStatusPollHandle: number | null = $state(null);
+	// Page-scoped handles for the post-save / Retry ACME-status pollers so
+	// onDestroy can cancel them on SPA navigation — otherwise the 2-second
+	// interval (plus its 5-min setTimeout backstop) keeps hammering
+	// system.acme.status long after the user has left the page.
+	let acmePollHandle: ReturnType<typeof setInterval> | null = null;
+	let acmePollTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	async function refreshHostStatuses() {
 		try {
@@ -84,8 +90,27 @@
 		}
 	}
 
+	function stopAcmePolling() {
+		if (acmePollHandle !== null) { clearInterval(acmePollHandle); acmePollHandle = null; }
+		if (acmePollTimeout !== null) { clearTimeout(acmePollTimeout); acmePollTimeout = null; }
+	}
+
+	function startAcmePolling() {
+		stopAcmePolling();
+		acmePollHandle = setInterval(async () => {
+			try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
+			if (acmeStatus && (acmeStatus.state === 'success' || acmeStatus.state === 'error')) {
+				stopAcmePolling();
+			}
+		}, 2000);
+		// 5 min backstop: DNS propagation can be slow, but at some point
+		// the poller stops being useful and just costs RPC traffic.
+		acmePollTimeout = setTimeout(stopAcmePolling, 300_000);
+	}
+
 	onDestroy(() => {
 		if (hostStatusPollHandle !== null) clearInterval(hostStatusPollHandle);
+		stopAcmePolling();
 	});
 
 	function badgeForState(s: string): { label: string; cls: string } {
@@ -139,15 +164,7 @@
 			settings = result;
 			tlsChanged = false;
 			editing = false;
-			if (tlsAcmeEnabled) {
-				const poll = setInterval(async () => {
-					try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
-					if (acmeStatus && (acmeStatus.state === 'success' || acmeStatus.state === 'error')) {
-						clearInterval(poll);
-					}
-				}, 2000);
-				setTimeout(() => clearInterval(poll), 300000); // 5 min (DNS propagation can be slow)
-			}
+			if (tlsAcmeEnabled) startAcmePolling();
 		}
 		savingTls = false;
 	}
@@ -368,13 +385,7 @@
 			{#if tlsAcmeEnabled && acmeStatus?.state !== 'running'}
 				<Button size="sm" variant="secondary" onclick={async () => {
 					await withToast(() => client.call('system.acme.retry'), 'Provisioning started');
-					const poll = setInterval(async () => {
-						try { acmeStatus = await client.call('system.acme.status'); } catch { /* ignore */ }
-						if (acmeStatus && (acmeStatus.state === 'success' || acmeStatus.state === 'error')) {
-							clearInterval(poll);
-						}
-					}, 2000);
-					setTimeout(() => clearInterval(poll), 300000);
+					startAcmePolling();
 				}}>
 					Retry
 				</Button>

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -566,6 +566,15 @@
 		loading = false;
 	});
 
+	// Tear down any open WS / xterm / noVNC instances on SPA navigation —
+	// closeConsole() handles consoleWs, consoleTerm and vncRfb; importWs is
+	// owned by the disk-import dialog so we close it explicitly.
+	onDestroy(() => {
+		closeConsole();
+		importWs?.close();
+		importWs = null;
+	});
+
 	async function loadNetwork() {
 		try {
 			networkState = await client.call<NetworkState>('system.network.get');


### PR DESCRIPTION
Maintenance audit of \`setInterval\` / \`setTimeout\` / WebSocket cleanup across the WebUI routes. Five leaks, one bundle.

## The pattern

Every leak had the same shape: a poll started inside an event handler with the handle stored in a local \`const\`:

\`\`\`ts
const poll = setInterval(async () => { … }, 2000);
setTimeout(() => clearInterval(poll), 300_000); // optional backstop
\`\`\`

If the user navigated away (SvelteKit SPA nav, not full reload) before \`poll\` self-terminated, neither the interval nor the backstop \`setTimeout\` was reachable to cancel. The interval kept hammering its RPC until the backstop fired — or, in one case, forever.

## Five sites

| File | Leak | Worst case |
|---|---|---|
| \`routes/tls/+page.svelte:143\` (saveTls) | ACME status poll, 2 s, 5 min backstop | 150 wasted \`system.acme.status\` RPCs |
| \`routes/tls/+page.svelte:371\` (Retry button) | same | same |
| \`routes/services/+page.svelte:239\` (enableDocker) | Docker status poll, 3 s, 60 s backstop | 20 wasted \`apps.status\` RPCs |
| \`routes/backups/+page.svelte:276\` (runBackup) | Backup status poll, 3 s, **no backstop** | Polls every 3 s until backup completes server-side (minutes) |
| \`routes/vms/+page.svelte\` | \`consoleWs\` / \`importWs\` / \`vncRfb\` / \`consoleTerm\` held in \$state, no \`onDestroy\` | Active WebSocket and xterm/noVNC instance leak across nav |

## Fix

For the four poll sites — promote the handle (and any backstop \`setTimeout\`) into a page-scoped variable and add a \`stopXPoll()\` helper called from both the self-terminating path and \`onDestroy\`. The \`tls\` and \`services\` pages already had \`onDestroy\`; \`backups\` didn't, so this PR adds one.

For the VMs page — add \`onDestroy\` that calls the existing \`closeConsole()\` (which already handles \`consoleWs\` + \`consoleTerm\` + \`vncRfb\`) and closes \`importWs\` directly.

## Not in this PR

A handful of single-shot \`setTimeout\` callbacks that just write a \$state bool (\`tokenCopied = false\`, \`metricsCopied = false\`, \`logCollapsed = true\`) survive SPA-nav technically, but the post-unmount assignment is a no-op in Svelte 5 — not worth restructuring.

Debounce \`setTimeout\` handles inside the apps page input handlers (\`portCheckTimer\`, \`subdomainCheckTimer\`, \`newSubdomainCheckTimer\`) — fire one wasted RPC if the user navigates mid-debounce. Low impact, leaving.

## Verified clean (already had matching cleanup)

\`+layout.svelte\` (tick / rebootPoll / authPoll / sshPoll / backupPoll), routes/+page.svelte (refreshTimer), routes/disks, routes/ingress, routes/ups, routes/filesystems, routes/update, routes/terminal, routes/logs, routes/apps (startupPoll / statsPoll / listPoll + document visibilitychange listener), \`lib/components/BcachefsDiagnostics.svelte\` (four intervals, all stopped in \`onDestroy\`).

## Test plan

- [x] \`npm run check\` clean (svelte-check 4880 files, 0 errors, 0 warnings).
- [ ] Manual: open /backups, click Run on any profile, navigate to /apps before it finishes — confirm \`backup.status\` RPC stops in the network panel.
- [ ] Manual: open /tls, save with ACME enabled, navigate away before \`acmeStatus.state\` reaches success/error — confirm \`system.acme.status\` RPC stops.
- [ ] Manual: open /vms, open a VNC or serial console, navigate to /dashboard — confirm WS in network panel goes to CLOSED.