### PR TITLE
engine: unblock startup on slow OIDC IdP and slow Caddy

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -275,17 +275,27 @@ async fn main() -> anyhow::Result<()> {
     // Build the OIDC client if SSO is configured. Failures are logged, not
     // fatal — a misconfigured IdP shouldn't block the engine from starting,
     // and admins can fix the config via the WebUI.
+    //
+    // Spawned (not awaited) because OIDC discovery fires an HTTP request
+    // at the IdP, and a slow / unreachable IdP would otherwise block
+    // startup for the full reqwest connect timeout (~75 s by default) —
+    // long enough to push past systemd's TimeoutStartSec. The SSO button
+    // on the login page is gated on the rebuild completing, so the
+    // visible effect of spawning is "button appears a moment late" rather
+    // than "engine stuck on Type=notify ready for over a minute."
     {
         let oidc_settings = state.settings.get().await.oidc;
         if oidc_settings.enabled {
-            if let Err(e) = state.oidc.rebuild(&oidc_settings).await {
-                tracing::warn!("OIDC client init failed at startup: {e}");
-            } else {
-                info!(
-                    "OIDC client initialized (issuer={:?})",
-                    oidc_settings.issuer_url
-                );
-            }
+            let oidc_holder = state.oidc.clone();
+            tokio::spawn(async move {
+                match oidc_holder.rebuild(&oidc_settings).await {
+                    Ok(()) => info!(
+                        "OIDC client initialized (issuer={:?})",
+                        oidc_settings.issuer_url
+                    ),
+                    Err(e) => tracing::warn!("OIDC client init failed at startup: {e}"),
+                }
+            });
         }
     }
 

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -90,6 +90,20 @@ pub async fn retry_acme() -> Result<(), String> {
 /// Best-effort: failures log a warning. The next user-triggered TLS
 /// action (settings change, retry button) reconverges.
 pub async fn reapply_tls_from_disk() {
+    // Wait for Caddy's admin API before pushing the policy set. Engine
+    // startup spawns this concurrently with the rest of restore, and on
+    // a fresh boot Caddy can still be initialising when we get here.
+    // main.rs already does a wait_ready before apps.reconcile_app_routes,
+    // but if that timed out (slow Caddy, journald wedged, etc.) calling
+    // set_tls_automation here would fail silently with no retry until
+    // the next engine restart — leaving the box without the policy set
+    // it should have on disk-state. Re-arming the wait_ready locally
+    // means a Caddy that needed more than 30 s still gets its config.
+    let api = nasty_apps::caddy::CaddyApi::new();
+    if let Err(e) = api.wait_ready(30).await {
+        warn!("Caddy admin API not ready ({e}); skipping TLS reapply at startup");
+        return;
+    }
     let settings = load().await;
     let app_subdomains = load_app_subdomains().await;
     if let Err(e) = apply_caddy_tls_with_apps(&settings, &app_subdomains).await {


### PR DESCRIPTION
Maintenance audit of the engine startup sequence (\`nasty-engine/src/main.rs::main\`) for races and blocking calls that shouldn't block. Two real findings, both in the "comment claims best-effort but code blocks synchronously" class.

## Findings & fixes

### 1. OIDC client init blocks engine startup synchronously

\`main.rs:281\` did:

\`\`\`rust
if oidc_settings.enabled {
    if let Err(e) = state.oidc.rebuild(&oidc_settings).await { … }
}
\`\`\`

The comment three lines up said:

> Failures are logged, not fatal — a misconfigured IdP shouldn't block the engine from starting, and admins can fix the config via the WebUI.

But \`OidcHolder::rebuild\` calls \`OidcClient::from_settings\` which calls \`CoreProviderMetadata::discover_async\` — an HTTP GET to \`<issuer>/.well-known/openid-configuration\`. The reqwest client built in \`auth_oidc.rs:191\` sets \`redirect(Policy::none())\` and **nothing else**, so the connect timeout falls back to reqwest's default (~75 s on Linux).

Failure mode: an IdP that's slow or unreachable at boot (DNS down, firewall blocking, IdP in another region) sits on the await past systemd's default \`TimeoutStartSec=90s\`, and the unit declares start failed. Engine never becomes ready, the operator can't reach the WebUI to fix the IdP URL.

**Fix:** spawn the rebuild instead of awaiting. \`/api/auth/oidc/available\` already gates the SSO button on \`state.oidc.current().is_some()\`, so the visible effect is "SSO button appears a moment after the login page renders" instead of "engine takes 90 s to become ready."

\`OidcHolder\` is \`#[derive(Default, Clone)]\` (an \`Arc<RwLock<…>>\` under the hood), so the clone we hand to \`tokio::spawn\` is just an \`Arc\` bump.

### 2. \`reapply_tls_from_disk\` has no Caddy-ready check

\`main.rs\` runs these in order:

\`\`\`rust
// L212
state.apps.reconcile_app_routes().await;  // does CaddyApi.wait_ready(30)
// L223
tokio::spawn(async {
    nasty_system::settings::reapply_tls_from_disk().await;
});
\`\`\`

On the happy path, \`reconcile_app_routes\` waits for Caddy and returns; by the time the spawn at L223 fires, Caddy is up. But \`apply_caddy_tls_with_apps\` (settings.rs:743) only \`wait_ready\`s after a Caddy restart it triggered itself (line 813) — it does **not** \`wait_ready\` on a no-restart code path. If Caddy was slow enough to time out the L212 wait (>30 s), the spawned \`reapply_tls_from_disk\` proceeds straight to \`set_tls_automation\` and fails silently. No retry until next engine restart, so the box runs without the TLS policy set the operator configured on disk.

**Fix:** add a local \`api.wait_ready(30)\` at the top of \`reapply_tls_from_disk\`. The function is spawned in the background, so this isn't a startup-blocker; it just gives \`reapply_tls_from_disk\` its own retry budget. A Caddy that needed more than 30 s now still gets the policy push.

## What was checked and ruled out

| Site | Concern | Verdict |
|---|---|---|
| \`network.restore_pending_revert\` (L184) | Should run before HTTP listener so a confirm can't race the rollback | ✓ HTTP listener doesn't bind until L356 |
| \`alert_notifier\` background loop | First eval against unwarmed metrics | ✓ Sleeps 30 s before first eval |
| \`alerts_cache\` (Mutex<Option<…>>) | Read-during-init race between WebUI and background notifier | ✓ Mutex-protected |
| \`archive_lego_dir_once\` (L234, spawned) | Could race with concurrent reads of those paths | ✓ Touches only legacy paths nothing else reads |
| \`TailscaleService::restore\` (L177) | \`tailscale up\` can hang on browser auth | ✓ Already has 30 s timeout (tailscale.rs:169) |
| \`apps.restore\` (L176) | \`docker compose up\` can be slow | Intentionally awaited; apps must be ready before the WebUI surfaces them |

## Not in this PR (worth flagging)

Combined worst-case startup time: Tailscale 30 s + Caddy 30 s (in \`reconcile_app_routes\`) + apps compose restore (10–30 s per compose app) could push past 60–90 s. systemd's default \`TimeoutStartSec\` is 90 s. Pre-0.0.8 it's tight but not visibly broken on any reports yet — leaving for a follow-up if anyone hits it. The fix would be either bumping \`TimeoutStartSec=300s\` in the nixos module or spawning some of these.

## Test plan

- [x] \`cargo check --workspace\` clean.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [ ] Manual: block the IdP at the network level (\`iptables -A OUTPUT -d <idp-ip> -j DROP\`) with OIDC enabled in settings, then \`systemctl restart nasty-engine\` — confirm engine reaches "Listening on…" within a few seconds and the warn log appears in journal (instead of the unit going to \`failed\`).
- [ ] Manual: \`systemctl stop caddy\` then \`systemctl restart nasty-engine\` — confirm engine starts, both reconcile_app_routes and reapply_tls_from_disk log "Caddy admin API not ready (...)" warnings, and the engine is otherwise functional.