### PR TITLE
engine: close audit-log gaps for permission denials and console opens

### DIFF
--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -155,8 +155,8 @@ async fn handle_deploy(
 
     // Authenticate — admin only. Compose deploys can mount host paths and run
     // privileged containers, so this is effectively root-equivalent.
-    match state.auth.validate(&token, &client_ip).await {
-        Ok(s) if s.role == crate::auth::Role::Admin => {}
+    let session = match state.auth.validate(&token, &client_ip).await {
+        Ok(s) if s.role == crate::auth::Role::Admin => s,
         Ok(s) => {
             crate::auth::audit(
                 "app_deploy_denied",
@@ -177,7 +177,7 @@ async fn handle_deploy(
             report_error(&mut socket, &req.name, "auth", "invalid token").await;
             return;
         }
-    }
+    };
 
     info!(
         "Deploy stream started for '{}' (kind: {})",
@@ -185,8 +185,8 @@ async fn handle_deploy(
     );
 
     match req.kind.as_str() {
-        "simple" => deploy_simple(&mut socket, &state, &req).await,
-        "compose" => deploy_compose(&mut socket, &state, &req).await,
+        "simple" => deploy_simple(&mut socket, &state, &req, &session, &client_ip).await,
+        "compose" => deploy_compose(&mut socket, &state, &req, &session, &client_ip).await,
         "pull" => deploy_pull(&mut socket, &state, &req).await,
         _ => {
             report_error(&mut socket, &req.name, "dispatch", "unknown deploy kind").await;
@@ -194,7 +194,13 @@ async fn handle_deploy(
     }
 }
 
-async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployRequest) {
+async fn deploy_simple(
+    socket: &mut WebSocket,
+    state: &AppState,
+    req: &DeployRequest,
+    session: &crate::auth::Session,
+    client_ip: &str,
+) {
     let image = match &req.image {
         Some(img) => img.clone(),
         None => {
@@ -268,8 +274,8 @@ async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployReq
     if req.allow_unsafe {
         crate::auth::audit(
             "simple_unsafe_deploy",
-            "<websocket>",
-            "<websocket>",
+            &session.username,
+            client_ip,
             &format!("app={}", req.name),
         );
         let _ = socket
@@ -296,7 +302,13 @@ async fn deploy_simple(socket: &mut WebSocket, state: &AppState, req: &DeployReq
     }
 }
 
-async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRequest) {
+async fn deploy_compose(
+    socket: &mut WebSocket,
+    state: &AppState,
+    req: &DeployRequest,
+    session: &crate::auth::Session,
+    client_ip: &str,
+) {
     let compose_content = match &req.compose_file {
         Some(c) => c.clone(),
         None => {
@@ -324,8 +336,8 @@ async fn deploy_compose(socket: &mut WebSocket, state: &AppState, req: &DeployRe
     if req.allow_unsafe {
         crate::auth::audit(
             "compose_unsafe_deploy",
-            "<websocket>",
-            "<websocket>",
+            &session.username,
+            client_ip,
             &format!("app={}", req.name),
         );
         let _ = socket

--- a/engine/nasty-engine/src/log_stream.rs
+++ b/engine/nasty-engine/src/log_stream.rs
@@ -105,12 +105,7 @@ async fn handle_logs(
             // Comment above says journals can leak secrets / IPs /
             // audit detail — so a live stream of them is sensitive and
             // every open deserves an audit entry, not just denials.
-            crate::auth::audit(
-                "log_stream_opened",
-                &s.username,
-                &client_ip,
-                "",
-            );
+            crate::auth::audit("log_stream_opened", &s.username, &client_ip, "");
         }
         Ok(s) => {
             crate::auth::audit(

--- a/engine/nasty-engine/src/log_stream.rs
+++ b/engine/nasty-engine/src/log_stream.rs
@@ -101,7 +101,17 @@ async fn handle_logs(
 
     // Admin only — system journals can leak secrets, IPs, and audit detail.
     match state.auth.validate(&token, &client_ip).await {
-        Ok(s) if s.role == crate::auth::Role::Admin => {}
+        Ok(s) if s.role == crate::auth::Role::Admin => {
+            // Comment above says journals can leak secrets / IPs /
+            // audit detail — so a live stream of them is sensitive and
+            // every open deserves an audit entry, not just denials.
+            crate::auth::audit(
+                "log_stream_opened",
+                &s.username,
+                &client_ip,
+                "",
+            );
+        }
         Ok(s) => {
             crate::auth::audit(
                 "log_stream_denied",

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -342,6 +342,18 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
         Role::Operator => !is_operator_allowed(&request.method),
     };
     if denied {
+        // Record role-based denials so an attempted role-escalation
+        // (or a misconfigured client) leaves a trail. Read methods are
+        // never denied here (is_universally_allowed covers them), so
+        // this can't fire on routine browser polling — every entry
+        // represents an intentional mutation the session role couldn't
+        // perform.
+        crate::auth::audit(
+            "permission_denied",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or("unknown"),
+            &format!("method={} role={:?}", request.method, session.role),
+        );
         let resp = Response::error(request.id, ErrorCode::InternalError, "Permission denied");
         return serde_json::to_string(&resp).unwrap();
     }

--- a/engine/nasty-engine/src/terminal.rs
+++ b/engine/nasty-engine/src/terminal.rs
@@ -267,6 +267,20 @@ async fn wait_for_terminal_auth(
 
     match state.auth.validate(&token, client_ip).await {
         Ok(session) if session.role == crate::auth::Role::Admin => {
+            // Opening an interactive root shell on the host is the
+            // single highest-stakes admin action — record every open,
+            // not just denials, so the audit trail can answer "who had
+            // a shell at 03:42?" later.
+            crate::auth::audit(
+                "terminal_opened",
+                &session.username,
+                client_ip,
+                &auth
+                    .cmd
+                    .as_deref()
+                    .map(|c| format!("cmd={}", c.join(" ")))
+                    .unwrap_or_default(),
+            );
             let _ = socket
                 .send(Message::Text(r#"{"authenticated":true}"#.into()))
                 .await;

--- a/engine/nasty-engine/src/vm_console.rs
+++ b/engine/nasty-engine/src/vm_console.rs
@@ -106,7 +106,17 @@ async fn proxy_unix_socket(
 
     // Admin or Operator — VM console is interactive root inside the guest.
     match state.auth.validate(&token, &client_ip).await {
-        Ok(s) if s.role == crate::auth::Role::Admin || s.role == crate::auth::Role::Operator => {}
+        Ok(s) if s.role == crate::auth::Role::Admin || s.role == crate::auth::Role::Operator => {
+            // Console is interactive root in the guest — record opens
+            // so the audit log can show who attached to which VM and
+            // when, not just rejected attempts.
+            crate::auth::audit(
+                "vm_console_opened",
+                &s.username,
+                &client_ip,
+                &format!("vm={vm_id} type={console_type}"),
+            );
+        }
         Ok(s) => {
             crate::auth::audit(
                 "vm_console_denied",


### PR DESCRIPTION
Maintenance audit of the engine's audit log (\`auth::audit\` → \`/var/lib/nasty/audit.log\` + journald with target=audit). The existing coverage was solid for auth events and for successful mutations (\`router/mod.rs:369\` audits everything that's not read-only and not \`auth.*\`), but three gaps remained where the denial side was logged and the corresponding success side wasn't, or where the wrong user/IP was recorded.

## Findings

### 1. Permission-denied RPCs were not audited

\`router/mod.rs:344-347\`:

\`\`\`rust
if denied {
    let resp = Response::error(request.id, ErrorCode::InternalError, "Permission denied");
    return serde_json::to_string(&resp).unwrap();
}
\`\`\`

A ReadOnly or Operator account trying to call an admin-only mutation got a 403 response and nothing else. A stolen token being probed for escalation would generate dozens of these — no entry in the audit log. \`is_universally_allowed\` covers all the read methods, so adding an audit here can't create routine-polling noise: every entry represents an actual mutation attempt the session role couldn't perform.

Now logs \`event=permission_denied\` with \`method=<rpc> role=<role>\` in the detail field.

### 2. Terminal / VM-console / log-stream WebSocket opens

Each of these three handlers already audited the *denial* path (\`terminal_denied\`, \`vm_console_denied\`, \`log_stream_denied\`) but the *success* path dropped the session without logging anything. These are the three highest-stakes operator actions on the box:

| Handler | What it gives the user |
|---|---|
| \`terminal.rs\` | Interactive root shell on the host |
| \`vm_console.rs\` | Interactive root console (serial / VNC) in a guest |
| \`log_stream.rs\` | Live \`journalctl\` tail — the existing comment says journals "can leak secrets, IPs, and audit detail" |

When a security review asks "who had a root shell at 03:42?", the audit log should answer that. Now logs \`terminal_opened\`, \`vm_console_opened\` (with vm + console type), and \`log_stream_opened\` on the admin-success path.

### 3. \`simple_unsafe_deploy\` / \`compose_unsafe_deploy\` recorded \`user=\"<websocket>\"\`

\`app_deploy.rs\` did:

\`\`\`rust
match state.auth.validate(&token, &client_ip).await {
    Ok(s) if s.role == Admin => {}    // session immediately dropped
    …
}
…
deploy_simple(&mut socket, &state, &req).await;  // no session arg
\`\`\`

The session was authenticated at the top of \`deploy_handler\` and then dropped, because the success arm bound nothing. So inside \`deploy_simple\`/\`deploy_compose\`, the only way to call \`audit()\` was to hardcode \`user=\"<websocket>\"\`, \`ip=\"<websocket>\"\` — losing the identity of the admin who actually authorised the unsafe deploy.

Bind the session, thread \`(&session, &client_ip)\` into both deploy paths, use real values in the audit call. \`deploy_pull\` doesn't audit so it didn't need the signature change.

## What was already good (and intentionally not touched)

- Auth events (login_success / login_failed / login_ip_locked, oidc_*, user/token create/delete, password_changed, session_ip_mismatch) — covered in \`auth.rs\`.
- General mutation audit at \`router/mod.rs:369\` — covers fs.*, subvolume.*, snapshot.*, share.*, service.protocol.*, system.settings.*, system.tuning.*, system.nut.*, system.tailscale.*, alert.rules.*. Every successful state change goes in the log.
- \`audit_detail()\` uses a safelist (name, username, filesystem, target, id, path, device) — so secrets in params (e.g. \`tls_dns_credentials\`, \`remote_password\`, Tailscale auth keys) can't accidentally leak into the audit log. Verified by grepping which param keys make it through.
- File mode is 0o600 on creation; journald mirror provides tamper-resistance.

## Verified silent (no audit needed)

- \`must_change_password\` gate (\`router/mod.rs:317\`) — fires on every RPC a constrained user makes, which would create polling noise. The auth side already logs \`login_success\` + the eventual \`password_changed\`.
- Read-only RPC denials don't happen — the role predicate accepts all reads for every role.

## Test plan

- [x] \`cargo check -p nasty-engine\` clean.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [x] \`cargo test -p nasty-engine\` — 50 passed, 0 failed.
- [ ] Manual: open WebUI as a ReadOnly user, click any mutation button — confirm \`permission_denied\` entry appears in \`/var/lib/nasty/audit.log\` with method + role.
- [ ] Manual: open Terminal as admin — confirm \`terminal_opened\` entry appears.
- [ ] Manual: deploy a compose app with allow_unsafe — confirm the \`compose_unsafe_deploy\` entry shows the actual admin username, not \`<websocket>\`.