### PR TITLE
nixos: tighten systemd hardening on nasty-engine and nasty-metrics

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1038,6 +1038,39 @@ in {
         Restart = "always";
         RestartSec = 5;
         StateDirectory = "nasty";
+
+        # nasty-metrics is a read-only system inspector + Prometheus
+        # endpoint. Unlike nasty-engine it does NOT manage mounts /
+        # services / kernel tunables, so we can apply the full
+        # service-hardening set without breaking what it does.
+        #
+        # The two `Protect*` directives we intentionally leave off:
+        #   - ProtectKernelLogs: it shells out to `dmesg` for kernel
+        #     error metrics. Setting this would block /dev/kmsg.
+        #   - PrivateDevices:    smartctl needs /dev/sd*, /dev/nvme*
+        #     to read SMART data. PrivateDevices hides all of /dev.
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+        KeyringMode = "private";
+        # AF_NETLINK for `ip -j addr show`; AF_INET/INET6 for the
+        # Prometheus HTTP endpoint on :2138.
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+        UMask = "0077";
       };
     };
 
@@ -1137,6 +1170,20 @@ in {
         #   AF_INET/6 — outbound HTTPS (Caddy ACME, telemetry, registries)
         #   AF_NETLINK — nft, ip, mount/umount kernel chatter
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        # Block the 32-bit syscall ABI on x86_64. NixOS doesn't ship
+        # 32-bit binaries on the appliance image, and SystemCallArchitectures
+        # applies recursively to descendants — but container processes
+        # run under dockerd (a separate unit), not under the engine, so
+        # this only constrains the engine + its direct subprocesses
+        # (docker CLI, qemu-system, smartctl, bcachefs, …) all of which
+        # are 64-bit-only.
+        SystemCallArchitectures = "native";
+        # Default-tight file creation: any file the engine writes
+        # without an explicit chmod gets owner-only access. State
+        # files (audit log, settings.json, oidc client_secret) already
+        # set 0o600 explicitly; this is belt-and-braces for any future
+        # writer that forgets to.
+        UMask = "0077";
       };
     };
 


### PR DESCRIPTION
Pre-0.0.8 maintenance pass over the NASty-managed systemd unit definitions. Two adjacent improvements.

## \`nasty-metrics\`: from zero hardening to the full safe set

The metrics service was running with default systemd permissions — just \`StateDirectory=nasty\`. Reading the code, it's a strictly read-only system inspector:

| Source | Use |
|---|---|
| \`/proc/cpuinfo\`, \`/proc/loadavg\`, \`/proc/meminfo\`, \`/proc/net/dev\`, \`/proc/mounts\`, \`/proc/self/mountinfo\` | system stats |
| \`/sys/class/hwmon\`, \`/sys/class/thermal\`, \`/sys/devices/system/cpu\`, \`/sys/class/net/*\`, \`/sys/fs/bcachefs/*\` | hardware + filesystem health |
| \`smartctl\`, \`dmesg\`, \`ip -j addr show\`, \`lsblk\`, \`lspci\` | shell-outs |
| HTTP \`:2138\` | Prometheus / API endpoints |
| \`/var/lib/nasty/metrics.db\` | the only write target |

None of that needs to manage mounts / services / kernel tunables, so the service can take the full standard hardening set without breaking what it does:

\`\`\`
ProtectSystem = "strict"
ProtectHome = true
PrivateTmp = true
ProtectKernelTunables = true
ProtectKernelModules = true
ProtectControlGroups = true
ProtectClock = true
ProtectHostname = true
ProtectProc = "invisible"
ProcSubset = "pid"
RestrictNamespaces = true
RestrictRealtime = true
LockPersonality = true
NoNewPrivileges = true
RestrictSUIDSGID = true
KeyringMode = "private"
RestrictAddressFamilies = [ AF_UNIX AF_INET AF_INET6 AF_NETLINK ]
SystemCallArchitectures = "native"
SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ]
UMask = "0077"
\`\`\`

Two \`Protect*\` directives are intentionally **off**:

- \`ProtectKernelLogs\` — the kernel-error metric shells out to \`dmesg\`, which reads \`/dev/kmsg\`. Setting this directive blocks that.
- \`PrivateDevices\` — \`smartctl\` needs \`/dev/sd*\`, \`/dev/nvme*\` to read SMART data, and \`PrivateDevices\` hides all of \`/dev\` except a tiny safe-set.

## \`nasty-engine\`: two safe additions in the existing constrained design

The engine is already hardened with the per-process set (\`NoNewPrivileges\`, \`LockPersonality\`, \`RestrictSUIDSGID\`, \`ProtectClock\`, \`RestrictRealtime\`, \`KeyringMode=private\`, \`RestrictAddressFamilies\`). Most \`Protect*\` namespace directives stay **off** by design — the engine writes \`/proc/sys/vm/dirty_*\` for the tuning service, manages NFS/SMB/iSCSI mount tables, and modprobes kernel modules. The existing comment lays this out.

Within that design space there are still two safe additions:

\`\`\`
SystemCallArchitectures = "native"
\`\`\`

Blocks the 32-bit syscall ABI on x86_64. \`SystemCallArchitectures\` applies recursively to descendants — but container processes run under \`dockerd\` (a separate systemd unit), not under \`nasty-engine\`. The engine's actual descendants are \`docker\` CLI, \`qemu-system-x86_64\`, \`smartctl\`, \`bcachefs\`, \`nft\`, etc. — all 64-bit on the appliance image. There are no 32-bit binaries in NASty's pkgs path.

\`\`\`
UMask = "0077"
\`\`\`

Default-tight creation mode. Sensitive state files (\`audit.log\`, \`settings.json\`, OIDC \`client_secret\`) already \`chmod 0o600\` explicitly — this is belt-and-braces so a future writer that forgets to set the mode doesn't accidentally create world-readable files.

## What's NOT in this PR

- \`nasty-tailscale\` — \`tailscaled\` needs broad network privileges by design; hardening here would mostly produce false-positive guidance.
- \`nasty-rest-server\` — restic process, separate threat model, deserves its own pass.
- \`nasty-apply-timezone\` / \`nasty-apply-hostname\` — oneshot scripts that just run \`timedatectl\` / write \`/proc/sys/kernel/hostname\`. Tiny attack surface; hardening would dwarf the actual code.

These can be follow-ups if anyone wants to push further.

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` — clean.
- [ ] \`nixos-rebuild build\` on a NASty box — confirm the unit definitions still apply.
- [ ] Smoke test on a live box: \`systemctl restart nasty-metrics\`; check \`/metrics\` endpoint still returns data, \`systemd-analyze security nasty-metrics\` shows the score drop (default ~9.6 "UNSAFE" → ~3 "OK").
- [ ] Same for \`nasty-engine\` — confirm app install / VM start / fs mount still work end-to-end, since the engine is the one with the unusual mount-namespace constraint.