### PR TITLE
deps: cargo/npm bump pass for 0.0.8

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1512,9 +1512,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-r0lg1Shu6NSy6l3oILxShv2o/iriJoSTuEfxZ5GjD60=";
+      npmDepsHash = "sha256-eH0wB8PUPzRqjiflIIlxCFyE8Mh9Rl8XbwoQ1J/3e4c=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -435,9 +435,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.132.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+			"integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -452,9 +452,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+			"integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -469,9 +469,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+			"integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -486,9 +486,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+			"integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
 			"cpu": [
 				"x64"
 			],
@@ -503,9 +503,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+			"integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
 			"cpu": [
 				"x64"
 			],
@@ -520,9 +520,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+			"integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
 			"cpu": [
 				"arm"
 			],
@@ -537,13 +537,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+			"integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -554,13 +557,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+			"integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -571,13 +577,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+			"integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -588,13 +597,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+			"integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -605,13 +617,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+			"integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -622,13 +637,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+			"integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -639,9 +657,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+			"integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
 			"cpu": [
 				"arm64"
 			],
@@ -656,9 +674,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+			"integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
 			"cpu": [
 				"wasm32"
 			],
@@ -675,9 +693,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+			"integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -692,9 +710,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+			"integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -723,9 +741,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-			"integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -947,6 +965,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -964,6 +985,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -981,6 +1005,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -998,6 +1025,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1147,16 +1177,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-			"integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+			"integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/spy": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1165,13 +1195,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-			"integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+			"integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.6",
+				"@vitest/spy": "4.1.7",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1192,9 +1222,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-			"integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+			"integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1205,13 +1235,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-			"integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+			"integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.6",
+				"@vitest/utils": "4.1.7",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1219,14 +1249,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-			"integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+			"integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/pretty-format": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1235,9 +1265,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-			"integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+			"integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1245,13 +1275,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-			"integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+			"integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.6",
+				"@vitest/pretty-format": "4.1.7",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1812,9 +1842,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.21.5",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.5.tgz",
-			"integrity": "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==",
+			"version": "5.21.6",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2187,6 +2217,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -2208,6 +2241,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -2229,6 +2265,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -2250,6 +2289,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -2489,13 +2531,13 @@
 			"license": "Unlicense"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+			"integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.130.0",
+				"@oxc-project/types": "=0.132.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -2505,21 +2547,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.1",
-				"@rolldown/binding-darwin-arm64": "1.0.1",
-				"@rolldown/binding-darwin-x64": "1.0.1",
-				"@rolldown/binding-freebsd-x64": "1.0.1",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
-				"@rolldown/binding-linux-arm64-musl": "1.0.1",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-musl": "1.0.1",
-				"@rolldown/binding-openharmony-arm64": "1.0.1",
-				"@rolldown/binding-wasm32-wasi": "1.0.1",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
-				"@rolldown/binding-win32-x64-msvc": "1.0.1"
+				"@rolldown/binding-android-arm64": "1.0.2",
+				"@rolldown/binding-darwin-arm64": "1.0.2",
+				"@rolldown/binding-darwin-x64": "1.0.2",
+				"@rolldown/binding-freebsd-x64": "1.0.2",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.2",
+				"@rolldown/binding-linux-arm64-musl": "1.0.2",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.2",
+				"@rolldown/binding-linux-x64-gnu": "1.0.2",
+				"@rolldown/binding-linux-x64-musl": "1.0.2",
+				"@rolldown/binding-openharmony-arm64": "1.0.2",
+				"@rolldown/binding-wasm32-wasi": "1.0.2",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.2",
+				"@rolldown/binding-win32-x64-msvc": "1.0.2"
 			}
 		},
 		"node_modules/runed": {
@@ -2644,15 +2686,15 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.8",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
-			"integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
+			"version": "5.55.9",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
+			"integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.10",
 				"@types/estree": "^1.0.5",
 				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
@@ -2661,7 +2703,7 @@
 				"clsx": "^2.1.1",
 				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.4",
+				"esrap": "^2.2.9",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -2868,16 +2910,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.0.13",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+			"version": "8.0.14",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+			"integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.14",
-				"rolldown": "1.0.1",
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.2",
 				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
@@ -2966,19 +3008,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+			"integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.6",
-				"@vitest/mocker": "4.1.6",
-				"@vitest/pretty-format": "4.1.6",
-				"@vitest/runner": "4.1.6",
-				"@vitest/snapshot": "4.1.6",
-				"@vitest/spy": "4.1.6",
-				"@vitest/utils": "4.1.6",
+				"@vitest/expect": "4.1.7",
+				"@vitest/mocker": "4.1.7",
+				"@vitest/pretty-format": "4.1.7",
+				"@vitest/runner": "4.1.7",
+				"@vitest/snapshot": "4.1.7",
+				"@vitest/spy": "4.1.7",
+				"@vitest/utils": "4.1.7",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -3006,12 +3048,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.6",
-				"@vitest/browser-preview": "4.1.6",
-				"@vitest/browser-webdriverio": "4.1.6",
-				"@vitest/coverage-istanbul": "4.1.6",
-				"@vitest/coverage-v8": "4.1.6",
-				"@vitest/ui": "4.1.6",
+				"@vitest/browser-playwright": "4.1.7",
+				"@vitest/browser-preview": "4.1.7",
+				"@vitest/browser-webdriverio": "4.1.7",
+				"@vitest/coverage-istanbul": "4.1.7",
+				"@vitest/coverage-v8": "4.1.7",
+				"@vitest/ui": "4.1.7",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"


### PR DESCRIPTION
Pre-tag dependency refresh covering Rust workspace and WebUI. Final item on the pre-0.0.8 maintenance list.

## Cargo

\`cargo update\` brought two minor bumps:

| Crate | From | To |
|---|---|---|
| either | 1.15.0 | 1.16.0 |
| futures-timer | 3.0.3 | 3.0.4 |

### Major bumps available, deliberately deferred

| Crate | Project | Latest | Reason for deferral |
|---|---|---|---|
| schemars | 0.9.0 | 1.2.1 | API rewrite; touches every \`#[derive(JsonSchema)]\` in the engine. Wrong scope for a pre-tag bump — separate PR. |
| rnix | 0.12 | 0.14 | NixOS config parsing path. Major bump means the engine's NM/flake/configuration.nix mutators need re-validation. |
| rowan | 0.15 | 0.16 | Transitive of rnix. Comes with the rnix bump. |

Four other crates show as "available" newer but are pinned by constraints in parents (generic-array, matchit, plus the rnix/rowan above). Not actionable without parent bumps.

## NPM

\`npm update\` bumped three to the latest within the declared semver range:

| Package | From | To |
|---|---|---|
| svelte | 5.55.8 | 5.55.9 |
| vite | 8.0.13 | 8.0.14 |
| vitest | 4.1.6 | 4.1.7 |

\`layerchart\` stays at \`2.0.0-next.46\`. The registry's \`latest\` tag points at the 1.x stable line; we're intentionally on the 2.0 pre-release for new chart features. Not stale — flagged that way by \`npm outdated\` because of the dist-tag direction.

### One known low-severity advisory, not actionable here

\`npm audit\` reports \`cookie<0.7.0\` (GHSA-pxg6-pf52-xh8x) reaching us via \`@sveltejs/kit\`. We're on the latest kit (2.60.1), which still pins \`cookie@^0.6\`. The only "fix" \`npm audit fix --force\` offers is a downgrade to \`@sveltejs/kit@0.0.30\` — that's a regression, not a fix.

Exploit shape: cookie name / path / domain accepting out-of-bounds characters. SvelteKit sets all three statically in the session-cookie config — no untrusted input flows into them — so this CVE doesn't apply to this WebUI. Wait-on-upstream is the correct response.

Could force the fix via npm \`overrides\`, but that risks breaking SvelteKit if there's an actual API difference between cookie 0.6 and 0.7+. Not worth the risk for a low-severity advisory that doesn't affect us.

## Nix flake

Already fresh. \`nix flake update\` is a no-op:

- \`nixpkgs\` → \`d233902\` (2026-05-15, 6 days ago).
- \`bcachefs-tools\` → \`ff765d6\` = \`v1.38.3\` (intentional pin via \`ref = "v1.38.3"\`).

## npmDepsHash

Old hash invalidated by \`package-lock.json\` changes. Recomputed via \`nix run nixpkgs#prefetch-npm-deps -- webui/package-lock.json\`:

\`\`\`
sha256-r0lg1Shu6NSy6l3oILxShv2o/iriJoSTuEfxZ5GjD60= →
sha256-eH0wB8PUPzRqjiflIIlxCFyE8Mh9Rl8XbwoQ1J/3e4c=
\`\`\`

This keeps the "npmDepsHash freshness" CI job green and lets \`nixos-rebuild build\` resolve the lock against the new tree.

## Test plan

- [x] \`cargo test --workspace\` — clean, full suite green (≈400 tests).
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [x] \`npm run check\` (svelte-check 4880 files, 0 errors, 0 warnings).
- [x] \`npm run build\` — Vite build succeeds.
- [x] \`npm test\` — vitest 121 tests pass.
- [ ] CI: npmDepsHash freshness job passes.