### PR TITLE
deps: bump rnix 0.12 → 0.14 and rowan 0.15 → 0.16

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3774,22 +3774,21 @@ dependencies = [
 
 [[package]]
 name = "rnix"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f15e00b0ab43abd70d50b6f8cd021290028f9b7fdd7cdfa6c35997173bc1ba9"
+checksum = "c163bd17372eecdf10d351c34584b7de7c1a33be4e92a32f3fb3f5a7fe3f579b"
 dependencies = [
  "rowan",
 ]
 
 [[package]]
 name = "rowan"
-version = "0.15.18"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
- "memoffset",
  "rustc-hash 1.1.0",
  "text-size",
 ]

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -17,9 +17,9 @@ schemars.workspace = true
 libc.workspace = true
 base64.workspace = true
 sha2 = "0.11"
-rnix = "0.12"
+rnix = "0.14"
 x509-parser = "0.18"
-rowan = "0.15"
+rowan = "0.16"
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 uuid.workspace = true


### PR DESCRIPTION
Pre-tag follow-up to #264. I'd flagged these as "major bump deferred for separate validation" — but the validation turned out to be trivial, so doing it.

## Honest correction on the deferrals

PR #264 listed three deferred majors:

| Crate | Stated reason | Actual situation |
|---|---|---|
| \`schemars\` 0.9 → 1.x | "API rewrite; touches every derive" | **Misread on my part.** Workspace \`Cargo.toml\` already pins \`schemars = "1"\` and our direct usage is on 1.2.1. The 0.9 in \`Cargo.lock\` is a transitive of \`serde_with\` — not actionable from our side, not a bump we owe. |
| \`rnix\` 0.12 → 0.14 | "Engine's NM/flake/configuration.nix mutators need re-validation" | Validation done in this PR. |
| \`rowan\` 0.15 → 0.16 | "Transitive of rnix" | Same. |

## What's in this PR

Just the rnix + rowan bumps in \`nasty-system/Cargo.toml\`, plus the lockfile.

\`nasty-system\` uses rnix/rowan in exactly two places, both in \`update.rs\`:

- \`parse_flake_input_urls\` — reads \`<input>.url\` values from \`/etc/nixos/flake.nix\` for the version-info path.
- \`read_wrapper_flake_version\` — reads the \`wrapperFlakeVersion\` attribute that decides whether to trigger a rebootstrap.

API surface used:

\`\`\`
rnix::Root::parse() + .errors() + .tree()
ast::AttrpathValue::cast + .attrpath() + .value()
rowan::ast::AstNode
syntax().descendants() / .text() / .text_range()
\`\`\`

None of those changed between 0.12 → 0.14 or 0.15 → 0.16. The crate compiles unchanged, and the existing 202-test \`nasty-system\` suite (which includes coverage for both flake parsers) stays green.

## Test plan

- [x] \`cargo check -p nasty-system\` clean.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [x] \`cargo test --workspace\` — full suite green; nasty-system's 202 tests cover the two functions that exercise the rnix API.