### PR TITLE
nixos: drop SystemCallFilter from nasty-metrics (SIGSYS at startup)

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1041,14 +1041,22 @@ in {
 
         # nasty-metrics is a read-only system inspector + Prometheus
         # endpoint. Unlike nasty-engine it does NOT manage mounts /
-        # services / kernel tunables, so we can apply the full
+        # services / kernel tunables, so we can apply most of the
         # service-hardening set without breaking what it does.
         #
-        # The two `Protect*` directives we intentionally leave off:
+        # The Protect* directives we intentionally leave off:
         #   - ProtectKernelLogs: it shells out to `dmesg` for kernel
         #     error metrics. Setting this would block /dev/kmsg.
         #   - PrivateDevices:    smartctl needs /dev/sd*, /dev/nvme*
         #     to read SMART data. PrivateDevices hides all of /dev.
+        #   - SystemCallFilter:  the original `@system-service
+        #     ~@privileged ~@resources` set fatally SIGSYS'd the
+        #     service in <50ms at startup. `~@resources` strips
+        #     `sched_setaffinity` (and the rest of the sched_set*
+        #     family), which tokio's multi-thread runtime calls when
+        #     pinning worker threads. The other Protect* directives
+        #     below still cover the same threat model without the
+        #     seccomp-filter fragility.
         ProtectSystem = "strict";
         ProtectHome = true;
         PrivateTmp = true;
@@ -1069,7 +1077,6 @@ in {
         # Prometheus HTTP endpoint on :2138.
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
         SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
         UMask = "0077";
       };
     };


### PR DESCRIPTION
Hotfix for #263.

## What broke

After the upgrade activated:

\`\`\`
May 21 16:23:04 nasty bash: Failed to start nasty-metrics.service
May 21 16:23:04 nasty bash:    Process: 376665 ExecStart=/.../bin/nasty-metrics (code=dumped, signal=SYS)
May 21 16:23:04 nasty bash:    Mem peak: 2.6M
May 21 16:23:04 nasty bash:    CPU: 49ms
May 21 16:23:04 nasty bash: nasty-metrics.service: Failed with result 'core-dump'.
\`\`\`

\`signal=SYS\` = seccomp violation. 2.6M peak / 49ms CPU = died during runtime init, before reaching \`sd_notify_ready\`. The only directive #263 added that emits SIGSYS (rather than EPERM / EAFNOSUPPORT) is \`SystemCallFilter\`.

## Why it broke

\`\`\`
SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
\`\`\`

The \`~@resources\` subtractor strips the \`sched_set*\` family (\`setaffinity\` / \`setattr\` / \`setparam\` / \`setscheduler\` / \`setpriority\`). tokio's multi-thread runtime calls \`sched_setaffinity\` when pinning worker threads during startup. The seccomp filter killed it before the runtime could even spawn its scheduler.

## The fix

Drop \`SystemCallFilter\` entirely. The remaining 18 hardening directives still cover the same threat model:

- \`ProtectSystem=strict\` — filesystem read-only outside StateDirectory.
- \`ProtectKernelTunables\` / \`ProtectKernelModules\` / \`ProtectControlGroups\` — block kernel mutation.
- \`RestrictNamespaces\` / \`RestrictAddressFamilies\` — namespace + socket family lockdown (these use seccomp but return EPERM / EAFNOSUPPORT, not SIGSYS).
- \`NoNewPrivileges\` / \`LockPersonality\` / \`RestrictSUIDSGID\` / \`KeyringMode=private\` — per-process state.
- \`ProtectClock\` / \`ProtectHostname\` / \`RestrictRealtime\` — capability subsets.
- \`ProtectProc=invisible\` / \`ProcSubset=pid\` — /proc visibility.
- \`SystemCallArchitectures=native\` — block 32-bit ABI on x86_64.
- \`UMask=0077\` — default-tight file creation mode.

The seccomp filter was belt-and-braces; the belt broke. Added a comment in nasty.nix explaining why so the next contributor doesn't reach for \`SystemCallFilter\` without remembering to exclude \`~@resources\`.

## Alternatives considered

1. **Drop just \`~@resources\`, keep \`@system-service ~@privileged\`.** Less restrictive but still seccomp-based — the next time a transitive dep adds an unusual syscall we'd be back here. Skipped.
2. **Replace with explicit \`~@mount ~@reboot ~@swap ~@privileged\`.** More targeted but fiddlier to keep in sync as systemd's group definitions evolve across releases. Could revisit post-0.0.8 if we want extra tightening.

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [ ] \`nixos-rebuild switch\` on the affected box — confirm \`nasty-metrics.service\` reaches \`active (running)\` and \`/metrics\` returns data.
- [ ] \`systemd-analyze security nasty-metrics\` — confirm the score is still in the OK range (it'll be a hair higher than #263 produced, but should still beat the default of ~9.6).