### PR TITLE
nixos: drop ProcSubset=pid from nasty-metrics (no system /proc stats)

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1044,19 +1044,25 @@ in {
         # services / kernel tunables, so we can apply most of the
         # service-hardening set without breaking what it does.
         #
-        # The Protect* directives we intentionally leave off:
+        # The directives we intentionally leave off:
         #   - ProtectKernelLogs: it shells out to `dmesg` for kernel
         #     error metrics. Setting this would block /dev/kmsg.
         #   - PrivateDevices:    smartctl needs /dev/sd*, /dev/nvme*
         #     to read SMART data. PrivateDevices hides all of /dev.
-        #   - SystemCallFilter:  the original `@system-service
-        #     ~@privileged ~@resources` set fatally SIGSYS'd the
-        #     service in <50ms at startup. `~@resources` strips
-        #     `sched_setaffinity` (and the rest of the sched_set*
-        #     family), which tokio's multi-thread runtime calls when
-        #     pinning worker threads. The other Protect* directives
-        #     below still cover the same threat model without the
-        #     seccomp-filter fragility.
+        #   - ProcSubset:        the whole *point* of metrics is to
+        #     read /proc/loadavg, /proc/meminfo, /proc/stat,
+        #     /proc/net/dev, /proc/diskstats. ProcSubset=pid hides
+        #     everything except /proc/<pid>/* — leaving the service
+        #     up but reading zeros for every CPU / memory / network
+        #     stat. ProtectProc=invisible stays on because it only
+        #     hides other users' processes (a separate concern).
+        #   - SystemCallFilter:  the original
+        #     `@system-service ~@privileged ~@resources` set fatally
+        #     SIGSYS'd the service in <50ms at startup. The hot path
+        #     was SQLite's WAL init calling `fchown()` (which is in
+        #     @privileged); the runtime / tokio paths were close
+        #     behind. Re-add as additive-only (`@system-service`
+        #     alone, no `~@` subtractors) if you want it back.
         ProtectSystem = "strict";
         ProtectHome = true;
         PrivateTmp = true;
@@ -1066,7 +1072,6 @@ in {
         ProtectClock = true;
         ProtectHostname = true;
         ProtectProc = "invisible";
-        ProcSubset = "pid";
         RestrictNamespaces = true;
         RestrictRealtime = true;
         LockPersonality = true;


### PR DESCRIPTION
Follow-up to #267. With \`SystemCallFilter\` removed in #267 the service stays *up*, but the dashboard's CPU and Memory graphs were flat zero. Same shape of bug as the seccomp filter: a hardening directive I added in #263 without checking what the service actually reads.

## Symptom

[Image #2 in this thread] — Dashboard shows OK / Engine / Metrics dots green, but CPU LOAD reads \`0.00 / 1 cores\`, MEMORY reads \`0% — 0 B / 0 B\`, and the CPU USAGE / MEMORY USAGE history graphs are flat zero lines.

(Storage works because it's served by the engine, not metrics.)

## Cause

\`ProcSubset = "pid"\` restricts \`/proc\` to PID subdirectories only. Every non-PID entry — \`/proc/loadavg\`, \`/proc/meminfo\`, \`/proc/stat\`, \`/proc/cpuinfo\`, \`/proc/net/dev\`, \`/proc/diskstats\` — becomes invisible.

Verified from the box's existing mount namespace:

\`\`\`
$ nsenter -t $(pidof nasty-metrics) -m cat /proc/loadavg
cat: /proc/loadavg: No such file or directory

$ nsenter -t $(pidof nasty-metrics) -m head -3 /proc/meminfo
head: cannot open '/proc/meminfo' for reading: No such file or directory
\`\`\`

\`nasty-metrics\` reads those paths in \`collect_system::system_stats()\` and friends, gets zeros across the board, serves them via \`/api/stats\`, and the WebUI renders the flat lines we're seeing.

## Fix

Drop \`ProcSubset = "pid"\`. Keep \`ProtectProc = "invisible"\` — that one only hides *other users'* processes from this unit, which is fine.

Comment in nasty.nix now spells out that ProcSubset is fundamentally incompatible with a metrics-style service that reads global \`/proc\` files, so the next contributor doesn't add it back.

## Bonus correction

While here, fixed the \`SystemCallFilter\` comment that #267 left behind. The actual kill site shown in the older coredumps is SQLite's WAL init calling \`fchown()\` — \`fchown\` is in \`@privileged\`. The \`#267\` commit blamed \`~@resources\` / \`sched_setaffinity\`; that group was being stripped too, but \`fchown\` fired first. The fix (drop the filter) was correct; the attribution was wrong.

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [ ] \`nixos-rebuild switch\` on the affected box — confirm \`nsenter -t $(pidof nasty-metrics) -m cat /proc/loadavg\` returns content, and the dashboard CPU / Memory graphs populate.