### PR TITLE
files: add copy, move, and bulk actions (closes #88)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -340,6 +340,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/files/mkdir", post(files_mkdir_handler))
         .route("/api/files/rename", post(files_rename_handler))
+        .route("/api/files/copy", post(files_copy_handler))
         .route(
             "/api/files/content",
             get(files_content_handler)
@@ -1427,6 +1428,214 @@ async fn files_rename_handler(
         )
             .into_response(),
     }
+}
+
+/// Copy a file or directory to a new location under /fs. The source
+/// and destination safety rules mirror `files_rename_handler`: both
+/// ends must canonicalize under /fs, neither may target a filesystem
+/// root, and the destination must not exist (we never silently
+/// overwrite — bulk-copying a folder of media onto an existing folder
+/// of the same name has bitten us before).
+///
+/// Unlike rename, copy isn't kernel-atomic. For files we use
+/// `tokio::fs::copy` directly; for directories we walk iteratively
+/// with a stack — recursion depth on a populated photo / media tree
+/// can otherwise blow the default stack.
+///
+/// POST /api/files/copy with body `{ from, to }` — same shape as
+/// rename so the WebUI can reuse its existing request builder.
+async fn files_copy_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RenameRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_bearer(&headers, &state.auth).await {
+        return e.into_response();
+    }
+
+    let from = match safe_path(&req.from) {
+        Ok(p) => p,
+        Err(status) => {
+            return (
+                status,
+                Json(serde_json::json!({"error": "Invalid source path"})),
+            )
+                .into_response();
+        }
+    };
+    let from_rel = from.strip_prefix(FILES_ROOT).unwrap_or(&from);
+    if from_rel.components().count() <= 1 {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot copy filesystem root directories — use the Subvolumes page"})),
+        )
+            .into_response();
+    }
+    if is_inside_block_subvolume(&from) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot copy block subvolume contents — manage via the Subvolumes page"})),
+        )
+            .into_response();
+    }
+
+    let clean_to = req.to.replace("\\", "/");
+    let trimmed_to = clean_to.trim_start_matches('/');
+    let (parent_req, leaf) = match trimmed_to.rsplit_once('/') {
+        Some((p, l)) => (p, l),
+        None => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "Destination must include a filesystem path component"})),
+            )
+                .into_response();
+        }
+    };
+    if leaf.is_empty() || leaf == "." || leaf == ".." || leaf.contains('/') {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid destination name"})),
+        )
+            .into_response();
+    }
+    let parent = match safe_path(parent_req) {
+        Ok(p) => p,
+        Err(status) => {
+            return (
+                status,
+                Json(serde_json::json!({"error": "Invalid destination parent"})),
+            )
+                .into_response();
+        }
+    };
+    if is_inside_block_subvolume(&parent) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Cannot copy into block subvolume contents"})),
+        )
+            .into_response();
+    }
+    let to = parent.join(leaf);
+    if !to.starts_with(FILES_ROOT) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "Invalid destination path"})),
+        )
+            .into_response();
+    }
+    if to == from {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Source and destination are the same"})),
+        )
+            .into_response();
+    }
+    // Refuse copying a directory into itself or any of its descendants
+    // — that's an infinite walk and produces nonsense even when
+    // bounded. `to.starts_with(&from)` catches both cases.
+    if to.starts_with(&from) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Cannot copy a directory into itself"})),
+        )
+            .into_response();
+    }
+    if to.exists() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "Destination already exists"})),
+        )
+            .into_response();
+    }
+
+    let from_meta = match tokio::fs::symlink_metadata(&from).await {
+        Ok(m) => m,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("stat source: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let result = if from_meta.is_dir() {
+        copy_dir_recursive(&from, &to).await
+    } else {
+        tokio::fs::copy(&from, &to)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    };
+
+    match result {
+        Ok(()) => {
+            info!("Copied {} -> {}", from.display(), to.display());
+            (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        )
+            .into_response(),
+    }
+}
+
+/// Recursively copy `src` to `dst`. Iterative (stack-based) so a deep
+/// tree can't blow the default tokio task stack. Plain files use
+/// `tokio::fs::copy`; symlinks are recreated with `symlink` rather
+/// than dereferenced (matches `cp -a` semantics — losing a relative
+/// symlink to absolute, or vice versa, would silently change what the
+/// user expects to be a literal link).
+///
+/// Permissions and timestamps follow the kernel's default behaviour
+/// for `copy`/`mkdir` — we don't preserve mtime/atime explicitly.
+/// That's fine for the WebUI's "copy this folder" affordance, which
+/// is treated by users as "new copy made now," not "snapshot of
+/// the original at this point in time."
+async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    // (current source path, current destination path) tuples.
+    let mut stack: Vec<(std::path::PathBuf, std::path::PathBuf)> =
+        vec![(src.to_path_buf(), dst.to_path_buf())];
+    while let Some((src_dir, dst_dir)) = stack.pop() {
+        tokio::fs::create_dir(&dst_dir)
+            .await
+            .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?;
+        let mut entries = tokio::fs::read_dir(&src_dir)
+            .await
+            .map_err(|e| format!("read_dir {}: {e}", src_dir.display()))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?
+        {
+            let entry_src = entry.path();
+            let entry_dst = dst_dir.join(entry.file_name());
+            let meta = entry
+                .metadata()
+                .await
+                .map_err(|e| format!("metadata {}: {e}", entry_src.display()))?;
+            if meta.is_dir() {
+                stack.push((entry_src, entry_dst));
+            } else if meta.file_type().is_symlink() {
+                let target = tokio::fs::read_link(&entry_src)
+                    .await
+                    .map_err(|e| format!("read_link {}: {e}", entry_src.display()))?;
+                tokio::fs::symlink(&target, &entry_dst)
+                    .await
+                    .map_err(|e| format!("symlink {}: {e}", entry_dst.display()))?;
+            } else {
+                tokio::fs::copy(&entry_src, &entry_dst).await.map_err(|e| {
+                    format!(
+                        "copy {} -> {}: {e}",
+                        entry_src.display(),
+                        entry_dst.display()
+                    )
+                })?;
+            }
+        }
+    }
+    Ok(())
 }
 
 // ── File content/download endpoint ─────────────────────────────

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -3,8 +3,9 @@
 	import { goto } from '$app/navigation';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil } from '@lucide/svelte';
+	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput } from '@lucide/svelte';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import PathPicker from '$lib/components/PathPicker.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 
 	interface FileEntry {
@@ -132,6 +133,125 @@
 	let renameTarget: FileEntry | null = $state(null);
 	let renameValue = $state('');
 	let renameTried = $state(false);
+
+	// Multi-select for bulk actions. Keyed by entry.name within the
+	// current directory — clears automatically on browse() since
+	// `selected` is reset whenever currentPath changes.
+	let selected: Set<string> = $state(new Set());
+	$effect(() => { void currentPath; selected = new Set(); });
+
+	// Copy / Move picker. `pickerMode` controls which API the chosen
+	// destination is fed into; `pickerTargets` is the list of entries
+	// the action will iterate (either a single-row click or the
+	// current multi-select). Using a list keeps the single and bulk
+	// flows on one code path.
+	let pickerOpen = $state(false);
+	let pickerMode: 'copy' | 'move' = $state('copy');
+	let pickerTargets: FileEntry[] = $state([]);
+	let bulkActionRunning = $state(false);
+	let bulkActionStatus = $state('');
+	let bulkDeleteConfirm = $state(false);
+
+	function isSelected(name: string): boolean { return selected.has(name); }
+	function toggleSelected(name: string) {
+		const next = new Set(selected);
+		if (next.has(name)) next.delete(name); else next.add(name);
+		selected = next;
+	}
+	function clearSelection() { selected = new Set(); }
+	function toggleSelectAll() {
+		if (selected.size === visibleEntries.length && visibleEntries.length > 0) {
+			selected = new Set();
+		} else {
+			selected = new Set(visibleEntries.map(e => e.name));
+		}
+	}
+	function selectedEntries(): FileEntry[] {
+		return visibleEntries.filter(e => selected.has(e.name));
+	}
+
+	function openPicker(targets: FileEntry[], mode: 'copy' | 'move') {
+		if (targets.length === 0) return;
+		pickerTargets = targets;
+		pickerMode = mode;
+		pickerOpen = true;
+	}
+
+	// PathPicker returns absolute paths like "/fs/tank/photos". The
+	// files API takes paths relative to /fs, so we strip that prefix
+	// before issuing the per-entry request.
+	function relFromHostPath(abs: string): string {
+		const stripped = abs.replace(/^\/fs\/?/, '');
+		return stripped;
+	}
+
+	async function runPickerAction(destAbs: string) {
+		pickerOpen = false;
+		const destRel = relFromHostPath(destAbs);
+		const endpoint = pickerMode === 'copy' ? '/api/files/copy' : '/api/files/rename';
+		const verb = pickerMode === 'copy' ? 'copy' : 'move';
+		const targets = pickerTargets.slice();
+		pickerTargets = [];
+
+		bulkActionRunning = true;
+		const errors: string[] = [];
+		for (let i = 0; i < targets.length; i++) {
+			const entry = targets[i];
+			bulkActionStatus = `${verb} ${i + 1}/${targets.length}: ${entry.name}`;
+			const from = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+			const to = destRel ? `${destRel}/${entry.name}` : entry.name;
+			if (from === to) continue; // copying/moving onto self → skip silently
+			try {
+				const res = await fetch(endpoint, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ from, to }),
+				});
+				if (!res.ok) {
+					const data = await res.json().catch(() => ({}));
+					errors.push(`${entry.name}: ${data.error || res.statusText}`);
+				}
+			} catch (e) {
+				errors.push(`${entry.name}: ${e instanceof Error ? e.message : String(e)}`);
+			}
+		}
+		bulkActionRunning = false;
+		bulkActionStatus = '';
+		if (errors.length > 0) {
+			alert(`${verb} finished with ${errors.length} error(s):\n\n${errors.join('\n')}`);
+		}
+		clearSelection();
+		await browse(currentPath);
+	}
+
+	async function runBulkDelete() {
+		bulkDeleteConfirm = false;
+		const targets = selectedEntries();
+		if (targets.length === 0) return;
+		bulkActionRunning = true;
+		const errors: string[] = [];
+		for (let i = 0; i < targets.length; i++) {
+			const entry = targets[i];
+			bulkActionStatus = `delete ${i + 1}/${targets.length}: ${entry.name}`;
+			const path = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+			try {
+				const res = await fetch(`/api/files?path=${encodeURIComponent(path)}`, { method: 'DELETE' });
+				if (!res.ok) {
+					const data = await res.json().catch(() => ({}));
+					errors.push(`${entry.name}: ${data.error || res.statusText}`);
+				}
+			} catch (e) {
+				errors.push(`${entry.name}: ${e instanceof Error ? e.message : String(e)}`);
+			}
+		}
+		bulkActionRunning = false;
+		bulkActionStatus = '';
+		if (errors.length > 0) {
+			alert(`Delete finished with ${errors.length} error(s):\n\n${errors.join('\n')}`);
+		}
+		clearSelection();
+		await browse(currentPath);
+	}
 
 	// Edit (text files in the preview modal)
 	let editing = $state(false);
@@ -388,6 +508,34 @@
 	</div>
 </div>
 
+<!-- Bulk action bar (visible only when at least one row is selected) -->
+{#if selected.size > 0 && !isRoot}
+	<div class="mb-3 flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+		<span class="text-sm font-medium">{selected.size} selected</span>
+		<div class="ml-auto flex items-center gap-2">
+			<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'copy')} disabled={bulkActionRunning}>
+				<Copy size={14} class="mr-1" /> Copy
+			</Button>
+			<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'move')} disabled={bulkActionRunning}>
+				<FolderInput size={14} class="mr-1" /> Move
+			</Button>
+			<Button size="sm" variant="destructive" onclick={() => bulkDeleteConfirm = true} disabled={bulkActionRunning}>
+				<Trash2 size={14} class="mr-1" /> Delete
+			</Button>
+			<Button size="sm" variant="ghost" onclick={clearSelection} disabled={bulkActionRunning}>
+				Clear
+			</Button>
+		</div>
+	</div>
+{/if}
+
+<!-- Bulk action progress strip -->
+{#if bulkActionRunning}
+	<div class="mb-3 rounded-md border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+		{bulkActionStatus || 'Working…'}
+	</div>
+{/if}
+
 <!-- Upload progress -->
 {#if uploading}
 	<div class="mb-4 rounded-md border border-border p-3">
@@ -426,6 +574,17 @@
 	<table class="w-full text-sm">
 		<thead>
 			<tr>
+				{#if !isRoot}
+					<th class="w-10 border-b-2 border-border p-3">
+						<input
+							type="checkbox"
+							class="h-3.5 w-3.5"
+							aria-label="Select all"
+							checked={selected.size > 0 && selected.size === visibleEntries.length}
+							indeterminate={selected.size > 0 && selected.size < visibleEntries.length}
+							onchange={toggleSelectAll} />
+					</th>
+				{/if}
 				<SortTh label="Name" active={sortKey === 'name'} dir={sortDir} onclick={() => toggleSort('name')} />
 				<SortTh label="Size" active={sortKey === 'size'} dir={sortDir} onclick={() => toggleSort('size')} align="right" />
 				<SortTh label="Modified" active={sortKey === 'modified'} dir={sortDir} onclick={() => toggleSort('modified')} align="right" />
@@ -436,7 +595,17 @@
 		</thead>
 		<tbody>
 			{#each visibleEntries as entry}
-				<tr class="border-b border-border hover:bg-muted/30 transition-colors group">
+				<tr class="border-b border-border hover:bg-muted/30 transition-colors group {isSelected(entry.name) ? 'bg-muted/20' : ''}">
+					{#if !isRoot}
+						<td class="p-3">
+							<input
+								type="checkbox"
+								class="h-3.5 w-3.5"
+								aria-label={`Select ${entry.name}`}
+								checked={isSelected(entry.name)}
+								onchange={() => toggleSelected(entry.name)} />
+						</td>
+					{/if}
 					<td class="p-3">
 						{#if entry.is_dir}
 							<button class="flex items-center gap-2 hover:text-primary transition-colors" onclick={() => navigateTo(entry)}>
@@ -480,6 +649,18 @@
 									onclick={() => startRename(entry)}
 									title="Rename">
 									<Pencil size={14} />
+								</button>
+								<button
+									class="text-muted-foreground/40 hover:text-foreground transition-colors"
+									onclick={() => openPicker([entry], 'copy')}
+									title="Copy to…">
+									<Copy size={14} />
+								</button>
+								<button
+									class="text-muted-foreground/40 hover:text-foreground transition-colors"
+									onclick={() => openPicker([entry], 'move')}
+									title="Move to…">
+									<FolderInput size={14} />
 								</button>
 								<button
 									class="text-muted-foreground/40 hover:text-destructive transition-colors"
@@ -615,3 +796,32 @@
 		</div>
 	</div>
 {/if}
+
+<!-- Bulk delete confirm modal -->
+{#if bulkDeleteConfirm}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<Card class="w-full max-w-sm">
+			<CardContent class="pt-6">
+				<h3 class="mb-2 text-lg font-semibold">Delete {selected.size} item{selected.size === 1 ? '' : 's'}?</h3>
+				<p class="mb-4 text-sm text-muted-foreground">
+					This cannot be undone. Directories are removed with their contents.
+				</p>
+				<div class="flex gap-2">
+					<Button variant="destructive" onclick={runBulkDelete}>Delete {selected.size}</Button>
+					<Button variant="secondary" onclick={() => bulkDeleteConfirm = false}>Cancel</Button>
+				</div>
+			</CardContent>
+		</Card>
+	</div>
+{/if}
+
+<!-- Copy / Move destination picker -->
+<PathPicker
+	open={pickerOpen}
+	initialPath={currentPath}
+	title={pickerMode === 'copy'
+		? `Copy ${pickerTargets.length} item${pickerTargets.length === 1 ? '' : 's'} to…`
+		: `Move ${pickerTargets.length} item${pickerTargets.length === 1 ? '' : 's'} to…`}
+	onPick={runPickerAction}
+	onClose={() => { pickerOpen = false; pickerTargets = []; }}
+/>


### PR DESCRIPTION
Closes #88.

## What #88 asked for, and what was already done

> Copy, Move, rename along with Bulk actions
> Click Column to Sort
> Ability to Edit files with a standard text editor.

Click-column sort and inline text edit landed earlier (the existing \`SortTh\` columns at \`+page.svelte:577-579\` and the edit button on the preview modal). The remaining gaps were **Copy**, **Move**, and **Bulk actions** — this PR finishes them.

## Backend: \`POST /api/files/copy\`

New handler mirrors the safety model of \`files_rename_handler\`:

- Source canonicalises under \`/fs\`, isn't a filesystem root, isn't inside a block subvolume.
- Destination parent canonicalises under \`/fs\`; leaf is a single safe filename (no slashes, not \`.\`/\`..\`); full destination doesn't already exist (we never silently overwrite — bulk-copying onto an existing dir of the same name has bitten me before).
- **Extra rule beyond rename**: refuse copying a directory into itself or any descendant (\`to.starts_with(&from)\`) — that would be an infinite walk and produces nonsense even when bounded.

Files go through \`tokio::fs::copy\`. Directories use a **stack-based iterative walk** (not recursion) so a deep media tree can't blow the default tokio task stack; symlinks are recreated with \`symlink()\` rather than dereferenced, matching \`cp -a\` semantics for relative links.

Cross-filesystem copy *just works* now because we're reading + writing, not calling \`rename(2)\` — so the operator can finally copy across bcachefs filesystems mounted under \`/fs\`, which the existing EXDEV-fails rename path used to suggest as a workaround.

## WebUI: per-row Copy/Move + multi-select bulk action bar

- Two new per-row icons (\`Copy\`, \`FolderInput\`/move) next to the existing rename + delete. Both open the existing \`PathPicker\` component with the current directory as starting point.
- **Checkbox column** in the table header (select-all + indeterminate when partial) and on each row. Selection is a \`Set<string>\` keyed by entry name; clears automatically when \`currentPath\` changes via \`\$effect\`.
- **Sticky bulk action bar** appears once anything is selected: Copy / Move / Delete / Clear. Copy and Move reuse the same PathPicker as the single-row flow — single and bulk are one code path, the only difference is how many entries get iterated.
- **Bulk delete** routes through a confirm modal because the per-row Delete already does — skipping confirmation for the multi-action case would be a footgun.
- **Progress strip** during long-running bulk ops so the UI doesn't look frozen on a 100-file move; per-item errors are collected and surfaced together at the end rather than aborting the whole batch on the first failure.

Implementation detail worth pointing out: \`PathPicker\` returns absolute \`/fs/...\` paths but the files API expects \`/fs\`-relative. New \`relFromHostPath()\` strips the prefix at the boundary.

## Not in this PR (deliberately)

- Drag-and-drop reordering — the icon-button affordance is the same shape as Rename/Delete, which the codebase already uses elsewhere; adding DnD would be a separate UX pass.
- Restic-style copy progress (bytes/sec, ETA). The progress strip shows item N/M, which is the right granularity for "did the bulk op finish?"; bytes-level progress per item would need streaming through a WebSocket like \`/ws/apps/deploy\`. Big chunk on its own.

## Test plan

- [x] \`cargo check / clippy / fmt / test --workspace\` clean.
- [x] \`svelte-check\` clean (4880 files, 0 errors, 0 warnings).
- [x] \`npm test\` — vitest 121 tests pass.
- [ ] Manual on a NASty box:
  - Copy a file across filesystems (would have failed as rename).
  - Copy a deep directory (verifies the iterative walk).
  - Bulk-move 10+ files via the action bar.
  - Bulk-delete a mix of files and dirs.
  - Confirm select-all checkbox + indeterminate state work as expected.