### PR TITLE
engine/network: rebind discovery daemons after apply (closes #270)

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -1568,7 +1568,59 @@ async fn apply_config(
             warn!("network apply: connection '{id}' failed: {msg}");
         }
     }
+
+    // LAN-discovery daemons capture the live interface set at start
+    // and don't all react to netlink topology changes. After a bridge
+    // / bond / VLAN appears (or the management IP moves to a newly
+    // enslaved interface), `samba-wsdd` keeps announcing on the old
+    // set and Windows Explorer stops seeing the box; `avahi-daemon`
+    // is more dynamic but a clean restart costs ~1s of disrupted
+    // mDNS and reliably resets the publish list. Best-effort —
+    // discovery is UX, not the data path. Only restarts daemons that
+    // are currently active so we don't accidentally start one a
+    // protocol toggle had left disabled (#270).
+    //
+    // We deliberately do NOT rebind the data-path services here:
+    //
+    //   smbd / nmbd:  `interfaces =` is unset → 0.0.0.0 wildcard
+    //                 bind → picks up new interfaces automatically.
+    //                 Restart would also kick active SMB sessions.
+    //   nfs-server:   nfsd binds 0.0.0.0:2049 → same story; restart
+    //                 causes ESTALE on active mounts.
+    //   target.svc:   LIO portal config defaults to 0.0.0.0:3260;
+    //                 restart drops every initiator's session.
+    //   nvmet:        wildcard portals in configfs; same disruption.
+    //
+    // Discovery is what actually breaks under a bridge change — the
+    // data path is interface-agnostic by default.
+    rebind_discovery_daemons().await;
+
     Ok(outcome)
+}
+
+async fn rebind_discovery_daemons() {
+    for unit in ["samba-wsdd.service", "avahi-daemon.service"] {
+        let is_active = tokio::process::Command::new("systemctl")
+            .args(["is-active", "--quiet", unit])
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !is_active {
+            continue;
+        }
+        match tokio::process::Command::new("systemctl")
+            .args(["restart", unit])
+            .status()
+            .await
+        {
+            Ok(s) if s.success() => {
+                info!("Restarted {unit} to rebind discovery to new interface set");
+            }
+            Ok(s) => warn!("systemctl restart {unit} exited with {s}"),
+            Err(e) => warn!("systemctl restart {unit} failed: {e}"),
+        }
+    }
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #270.

## The bug

After adding a bridge in the WebUI, NASty disappears from the network section of macOS Finder / Windows Explorer / GNOME Files. The **data path** on the new bridge still works — \`\\\\nasty.local\\share\` mounts fine, NFS clients still connect — but **discovery** is broken until \`systemctl restart\` is run manually.

## Root cause

\`samba-wsdd\` captures the live interface list at process startup and does **not** listen on netlink for topology changes. When the engine pushes a new bridge to NetworkManager and the management IP moves onto \`br0\`, wsdd keeps announcing on the pre-bridge interface set, so WS-Discovery on the LAN never sees the box.

\`avahi-daemon\` is more dynamic via netlink, but its publish state can drift in practice — the publish list is built at start, and netlink events don't always reach into it cleanly. A clean restart costs ~1s of disrupted mDNS and reliably resets the publish list, which is the right trade for a UX feature.

## Fix

After a successful \`apply_config\`, restart \`samba-wsdd\` and \`avahi-daemon\` — only when they're currently active, so we don't accidentally start a protocol the operator had disabled.

## Why only the discovery daemons

This was @fenio's question in the comments. Going through the data-path services:

| Service | Bind mode | Picks up new iface? | Restart needed? |
|---|---|---|---|
| \`samba-wsdd\` | Captures interface list at start | **No** | **Yes** — the bug |
| \`avahi-daemon\` | netlink-aware, but publishes snapshot at start | mostly yes, sometimes flaky | **Yes** — cheap, deterministic |
| \`samba-smbd\` / \`nmbd\` | \`interfaces =\` unset → \`0.0.0.0\` wildcard | **Yes** automatically | **No** — restart would kick active SMB sessions |
| \`nfs-server\` | nfsd binds \`0.0.0.0:2049\` | **Yes** automatically | **No** — restart causes ESTALE on active mounts |
| \`target.service\` (LIO) | Default portal \`0.0.0.0:3260\` | **Yes** automatically | **No** — restart drops every initiator's session |
| \`nvmet\` (NVMe-oF) | Wildcard configfs portals | **Yes** automatically | **No** — same data-path disruption as iSCSI |

The comment block in \`network.rs\` captures this table inline so the next person doesn't add them back when they read the function and wonder.

## Test plan

- [x] \`cargo check -p nasty-system\` clean.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo test -p nasty-system\` — 202 tests green.
- [ ] Manual on a NASty box:
  - Confirm box appears in Finder / Explorer before any change.
  - Create a br0 bridge via the Network page.
  - Confirm box still appears in Finder / Explorer (would fail without this PR).
  - Confirm active SMB / NFS mounts on a client survive the apply (they should — neither smbd nor nfs-server is restarted).