### PR TITLE
webui/apps: align port form with docker convention (closes #271)

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -1628,20 +1628,25 @@
 						<Button size="xs" variant="outline" onclick={addPort}>+ Add Port</Button>
 					</div>
 					{#if newPorts.length > 0}
-						<div class="grid grid-cols-[1fr_80px_90px_60px_auto] gap-2 mb-1">
+						<!-- Column order matches `docker run -p HOST:CONTAINER` —
+						     Exposed (host) first, Internal (container) second.
+						     The listing and the dropdown elsewhere on this page
+						     also read host:container, so all three surfaces line
+						     up. See issue #271. -->
+						<div class="grid grid-cols-[1fr_90px_80px_60px_auto] gap-2 mb-1">
 							<span class="text-[0.65rem] text-muted-foreground">Name</span>
-							<span class="text-[0.65rem] text-muted-foreground">Internal</span>
 							<span class="text-[0.65rem] text-muted-foreground">Exposed</span>
+							<span class="text-[0.65rem] text-muted-foreground">Internal</span>
 							<span class="text-[0.65rem] text-muted-foreground"></span>
 							<span></span>
 						</div>
 					{/if}
 					{#each newPorts as port, i}
 						{@const hasConflict = portConflicts.some(c => c.port === (parseInt(port.host_port) || port.container_port))}
-						<div class="grid grid-cols-[1fr_80px_90px_60px_auto] gap-2 mt-1 items-center">
+						<div class="grid grid-cols-[1fr_90px_80px_60px_auto] gap-2 mt-1 items-center">
 							<Input bind:value={port.name} placeholder="e.g. http" class="h-8 text-xs" />
-							<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 text-xs" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 							<Input bind:value={port.host_port} placeholder={String(port.container_port)} class="h-8 text-xs {hasConflict ? 'border-amber-500 ring-1 ring-amber-500/50' : ''}" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
+							<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 text-xs" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 							<select bind:value={port.protocol} class="h-8 rounded-md border border-input bg-transparent px-1 text-xs">
 								<option>TCP</option>
 								<option>UDP</option>
@@ -1657,7 +1662,7 @@
 							{/each}
 						</div>
 					{/if}
-					<p class="mt-1 text-[0.6rem] text-muted-foreground">Internal = port inside the container. Exposed = port on the host (defaults to internal port if empty). App is also accessible at /apps/{'{name}'}/ via reverse proxy.</p>
+					<p class="mt-1 text-[0.6rem] text-muted-foreground">Exposed = port on the host (what clients connect to). Internal = port inside the container. Leave Exposed blank to use the same number as Internal. App is also accessible at /apps/{'{name}'}/ via reverse proxy.</p>
 				</div>
 
 				<!-- Environment Variables -->
@@ -1992,7 +1997,7 @@
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap">Memory</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap" title="Cumulative bytes since container start">Net&nbsp;I/O</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap" title="Cumulative block-device read/write since container start">Disk&nbsp;I/O</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Ports</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground" title="host:container — same direction as `docker run -p HOST:CONTAINER`">Ports</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Status</th>
 					<th class="w-px border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground whitespace-nowrap">Actions</th>
 				</tr>


### PR DESCRIPTION
Closes #271.

## The bug

@johnnyq reported the Apps page Ports column showed internal:external "in reverse." Looking at the page, the actual problem is an internal inconsistency:

| Surface | Code | Reads as |
|---|---|---|
| Apps listing column | \`{p.host_port}:{p.container_port}\` (\`+page.svelte:2065\`) | **host:container** ✓ matches Docker |
| Ingress dropdown | \`:{p.host_port} → container :{p.container_port}\` (\`:1858\`) | **host → container** ✓ matches Docker |
| Create / Edit form | \`Name \| Internal \| Exposed \| …\` (\`:1633-1634\`) | **container : host** ✗ reversed |

So when @johnnyq filled in the form left-to-right (Internal, then Exposed) and then read the listing left-to-right (host, then container), the numbers appeared to swap. Two different left-to-right conventions on the same page.

## Why we're not flipping the listing

Every UI built on top of Docker is **host first**:

| Tool | Order |
|---|---|
| \`docker run -p\` | \`HOST:CONTAINER\` |
| \`docker ps\` | \`0.0.0.0:8080->80/tcp\` |
| \`docker-compose ports:\` | \`PUBLISHED:TARGET\` |
| Portainer / TrueNAS / Synology / Unraid / Cockpit / Dockge | host first |

Flipping NASty's listing to internal-first (the literal request in #271) would put us in the minority of one. Aligning the form is the move that preserves cross-UI muscle memory.

## What this PR does

- **Swaps form columns** to \`Name | Exposed | Internal | Protocol | x\`. Reading the form L→R now matches \`docker run -p HOST:CONTAINER\` and the listing.
- **Widens Exposed to 90px** (was 80px) so the auto-fallback placeholder showing the Internal port number stays readable; Internal moves to 80px.
- **Rewrites the hint text** to lead with "Exposed = port on the host (what clients connect to). Internal = port inside the container. Leave Exposed blank to use the same number as Internal."
- **Adds a tooltip on the listing column header**: \`host:container — same direction as docker run -p HOST:CONTAINER\`. Cold readers don't have to remember which side is which.

## What this is NOT

- No engine change.
- No schema change — the underlying \`{ host_port, container_port }\` JSON shape was already correct; only the form's L→R presentation moved.
- No data migration — existing apps render identically in the listing (it was already host:container) and load identically into the form (just with the columns visually swapped).

## Test plan

- [x] \`npm run check\` clean (4880 files, 0 errors, 0 warnings).
- [x] \`npm test\` — vitest 121 tests pass.
- [ ] Manual: open Create App, type 8080 into Exposed, 80 into Internal — confirm the listing shows \`8080:80\` (i.e. same numbers in the same L→R order).
- [ ] Manual: leave Exposed blank, type 80 into Internal — confirm the placeholder shows \`80\` and the resulting listing shows \`80:80\`.
- [ ] Manual: edit an existing app — confirm both columns load with their existing values.