### PR TITLE
engine: add local IPs as SANs on the self-signed cert

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -478,6 +478,7 @@ impl CaddyApi {
         &self,
         policies: &[TlsPolicy],
         issuer: &TlsIssuer,
+        extra_internal_subjects: &[String],
     ) -> Result<(), String> {
         // Single PATCH against `/config/apps/tls` that replaces both
         // `automation` and `certificates` at once.
@@ -504,8 +505,9 @@ impl CaddyApi {
             .iter()
             .map(|p| p.host.as_str())
             .chain(std::iter::once("nasty.local"))
+            .chain(extra_internal_subjects.iter().map(String::as_str))
             .collect();
-        let automation = build_tls_automation_json(policies, issuer);
+        let automation = build_tls_automation_json(policies, issuer, extra_internal_subjects);
         let body = json!({
             "automation": automation,
             "certificates": { "automate": automate },
@@ -606,7 +608,11 @@ fn build_route_json(route: &AppRoute) -> Value {
 ///
 /// Order matters: managed hosts first, so Caddy's SNI matching hits
 /// them before falling through to nasty.local.
-fn build_tls_automation_json(policies: &[TlsPolicy], issuer: &TlsIssuer) -> Value {
+fn build_tls_automation_json(
+    policies: &[TlsPolicy],
+    issuer: &TlsIssuer,
+    extra_internal_subjects: &[String],
+) -> Value {
     let mut policy_values: Vec<Value> = policies
         .iter()
         .map(|p| {
@@ -616,8 +622,20 @@ fn build_tls_automation_json(policies: &[TlsPolicy], issuer: &TlsIssuer) -> Valu
             })
         })
         .collect();
+    // Subjects on the internal-CA fallback: `nasty.local` is always
+    // there (the Caddyfile's `default_sni nasty.local` substitutes it
+    // for SNI-less or unknown-SNI connections, and the cert needs a
+    // matching subject), plus every local IP the caller hands in.
+    // Adding IPs as SANs lets `https://10.x.x.x` and `https://[fd00::1]`
+    // skip the CN-mismatch warning — only the "self-signed CA"
+    // warning remains, and that goes away once the operator imports
+    // Caddy's root via the existing "download CA root" button.
+    let mut fallback_subjects = vec![Value::String("nasty.local".into())];
+    for s in extra_internal_subjects {
+        fallback_subjects.push(Value::String(s.clone()));
+    }
     policy_values.push(json!({
-        "subjects": ["nasty.local"],
+        "subjects": fallback_subjects,
         "issuers": [{ "module": "internal" }],
     }));
     json!({ "policies": policy_values })
@@ -1131,11 +1149,69 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let policies = body["policies"].as_array().unwrap();
         assert_eq!(policies.len(), 1);
         assert_eq!(policies[0]["subjects"][0], "nasty.local");
         assert_eq!(policies[0]["issuers"][0]["module"], "internal");
+    }
+
+    #[test]
+    fn tls_automation_extra_subjects_attach_to_internal_policy() {
+        // Local IPs flow into the internal-CA fallback policy's
+        // `subjects` array alongside `nasty.local`, so the cert
+        // Caddy auto-issues covers direct-IP access without a
+        // CN-mismatch warning. Order: nasty.local first (default_sni
+        // target — keep it as the policy's leading subject), IPs
+        // after.
+        let body = build_tls_automation_json(
+            &[],
+            &TlsIssuer {
+                email: None,
+                dns_provider: None,
+                staging: false,
+                ..Default::default()
+            },
+            &["10.10.10.67".to_string(), "fd00::1".to_string()],
+        );
+        let policies = body["policies"].as_array().unwrap();
+        assert_eq!(policies.len(), 1);
+        let subjects = policies[0]["subjects"].as_array().unwrap();
+        assert_eq!(subjects.len(), 3);
+        assert_eq!(subjects[0], "nasty.local");
+        assert_eq!(subjects[1], "10.10.10.67");
+        assert_eq!(subjects[2], "fd00::1");
+        assert_eq!(policies[0]["issuers"][0]["module"], "internal");
+    }
+
+    #[test]
+    fn tls_automation_extra_subjects_do_not_leak_into_acme_policies() {
+        // ACME policies must NOT include the local IPs — those go
+        // only on the internal-CA fallback. Otherwise Let's Encrypt
+        // would refuse the order (LE doesn't issue for IPs / private
+        // names).
+        let body = build_tls_automation_json(
+            &[TlsPolicy {
+                host: "nas.example.com".into(),
+            }],
+            &TlsIssuer {
+                email: Some("ops@example.com".into()),
+                dns_provider: None,
+                staging: false,
+                ..Default::default()
+            },
+            &["10.10.10.67".to_string()],
+        );
+        let policies = body["policies"].as_array().unwrap();
+        assert_eq!(policies.len(), 2);
+        // Managed-host policy: subjects = [host] only.
+        assert_eq!(policies[0]["subjects"][0], "nas.example.com");
+        assert_eq!(policies[0]["subjects"].as_array().unwrap().len(), 1);
+        // Internal fallback: nasty.local + IP.
+        let fallback = policies[1]["subjects"].as_array().unwrap();
+        assert_eq!(fallback[0], "nasty.local");
+        assert_eq!(fallback[1], "10.10.10.67");
     }
 
     #[test]
@@ -1155,6 +1231,7 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let policies = body["policies"].as_array().unwrap();
         assert_eq!(policies.len(), 2);
@@ -1174,6 +1251,7 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let p = &body["policies"][0];
         assert_eq!(p["subjects"][0], "nas.example.com");
@@ -1199,6 +1277,7 @@ mod tests {
                 staging: true,
                 ..Default::default()
             },
+            &[],
         );
         let issuer = &body["policies"][0]["issuers"][0];
         assert_eq!(
@@ -1224,6 +1303,7 @@ mod tests {
                 dns_resolvers: Some(vec!["10.0.0.53".into(), "10.0.0.54".into()]),
                 dns_propagation_wait_secs: None,
             },
+            &[],
         );
         let resolvers = body["policies"][0]["issuers"][0]["challenges"]["dns"]["resolvers"]
             .as_array()
@@ -1248,6 +1328,7 @@ mod tests {
                 dns_resolvers: None,
                 dns_propagation_wait_secs: Some(120),
             },
+            &[],
         );
         let delay = &body["policies"][0]["issuers"][0]["challenges"]["dns"]["propagation_delay"];
         assert_eq!(delay, "120s");
@@ -1272,6 +1353,7 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let resolvers = &body["policies"][0]["issuers"][0]["challenges"]["dns"]["resolvers"];
         let resolvers = resolvers.as_array().expect("resolvers array present");
@@ -1297,6 +1379,7 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let issuer = &body["policies"][0]["issuers"][0];
         assert!(issuer.get("challenges").is_none());
@@ -1323,6 +1406,7 @@ mod tests {
                 staging: false,
                 ..Default::default()
             },
+            &[],
         );
         let policies = body["policies"].as_array().unwrap();
         assert_eq!(policies.len(), 3);

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -970,6 +970,61 @@ async fn load_config() -> NetworkConfig {
 
 // ── Interface enumeration ──────────────────────────────────────
 
+/// Local IPs to include as additional SANs on the internal-CA cert
+/// (alongside the always-present `nasty.local`). Hitting the box at
+/// `https://10.x.x.x` or `https://[fd00::1]` should not throw a
+/// CN-mismatch warning just because the user didn't type the .local
+/// name.
+///
+/// Filters applied:
+///   - loopback (127.0.0.1, ::1): never useful as a cert SAN.
+///   - IPv4 link-local (169.254.0.0/16, APIPA): only meaningful when
+///     DHCP failed; would just bloat the SAN list.
+///   - IPv6 link-local (fe80::/10): already filtered by
+///     `get_addresses`, but kept here as a belt-and-braces guard.
+///   - the loopback interface itself (`lo`): already skipped by
+///     `enumerate_interfaces`.
+///
+/// Tailscale CGNAT addresses (100.64/10) are NOT filtered — those
+/// are real reachable addresses for tailnet clients and want to be
+/// on the cert.
+///
+/// Returns bare IP strings without the CIDR `/prefix` suffix that
+/// `ip addr show` emits. Deduplicated.
+pub async fn local_tls_subjects() -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for iface in enumerate_interfaces().await {
+        for cidr in iface
+            .ipv4_addresses
+            .iter()
+            .chain(iface.ipv6_addresses.iter())
+        {
+            let ip = cidr.split('/').next().unwrap_or(cidr).trim();
+            if ip.is_empty() {
+                continue;
+            }
+            if ip == "127.0.0.1" || ip == "::1" {
+                continue;
+            }
+            // IPv4 link-local (APIPA)
+            if ip.starts_with("169.254.") {
+                continue;
+            }
+            // IPv6 link-local (defence in depth — get_addresses already filters)
+            if ip.starts_with("fe80:") || ip.starts_with("FE80:") {
+                continue;
+            }
+            // Strip any IPv6 zone identifier (`fd00::1%eth0`).
+            let bare = ip.split('%').next().unwrap_or(ip).to_string();
+            if seen.insert(bare.clone()) {
+                out.push(bare);
+            }
+        }
+    }
+    out
+}
+
 async fn enumerate_interfaces() -> Vec<LiveInterface> {
     let mut result = Vec::new();
     let sys_net = std::path::Path::new("/sys/class/net");
@@ -1594,6 +1649,17 @@ async fn apply_config(
     // Discovery is what actually breaks under a bridge change — the
     // data path is interface-agnostic by default.
     rebind_discovery_daemons().await;
+
+    // Re-issue the internal-CA cert so its SAN list matches the box's
+    // current IP set. Without this, a freshly-added bridge / VLAN / IP
+    // would not be on the cert until the next ACME settings change or
+    // engine restart, and `https://<new-ip>/` would throw a
+    // CN-mismatch warning the operator already paid for. Cheap when
+    // nothing changed — Caddy compares the PATCH body against the
+    // running config and no-ops if identical.
+    tokio::spawn(async {
+        crate::settings::reapply_tls_from_disk().await;
+    });
 
     Ok(outcome)
 }

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -856,8 +856,20 @@ pub async fn apply_caddy_tls_with_apps(
         dns_propagation_wait_secs: settings.tls_dns_propagation_wait,
     };
 
+    // Local IP SANs for the internal-CA fallback policy. Adding the
+    // box's reachable IPs to the cert means `https://10.x.x.x` and
+    // `https://[fd00::1]` don't trip a browser CN-mismatch warning
+    // — only the "self-signed CA" warning remains, which goes away
+    // once the operator imports Caddy's root via the TLS page's
+    // existing "download CA root" button. Refreshed every time TLS
+    // is reapplied (engine startup, settings change, and after every
+    // network apply via the hook in network.rs::apply_config).
+    let extra_subjects = crate::network::local_tls_subjects().await;
     let api = nasty_apps::caddy::CaddyApi::new();
-    if let Err(e) = api.set_tls_automation(&policies, &issuer).await {
+    if let Err(e) = api
+        .set_tls_automation(&policies, &issuer, &extra_subjects)
+        .await
+    {
         warn!("caddy: set_tls_automation failed: {e}");
         set_acme_status("error", &e, domain_for_status.as_deref());
         return Err(e);


### PR DESCRIPTION
Per discussion: \`https://10.x.x.x\` and \`https://[fd00::1]\` used to hit a CN-mismatch warning because the internal-CA cert's SAN list was hardcoded to \`["nasty.local"]\`. Importing Caddy's root via the existing "Download CA Root" button in the TLS page already cleared the "untrusted issuer" warning, but the CN warning stuck around forever.

## What's in the cert now

Caddy's internal CA happily issues certs with IP SANs (smallstep's CA library supports them). The internal-CA fallback policy in the admin-API config gets `subjects: ["nasty.local", "10.10.10.67", "fd00::1", ...]` — Caddy auto-issues one cert covering everything in that list.

## How direct-IP access lines up

1. Browser opens \`https://10.10.10.67\` — sends ClientHello with **no SNI** (IP literals don't go in SNI by browser convention).
2. Caddy hits the existing \`default_sni nasty.local\` directive, substitutes \`nasty.local\` as the SNI.
3. Matches the internal-CA fallback policy.
4. That policy's cert now has \`10.10.10.67\` in its SAN list.
5. Browser checks: cert SAN includes \`10.10.10.67\` → ✓ no CN-mismatch warning.

Only the "untrusted issuer" warning remains; same fix as today (import the root via the TLS page).

## Filters applied to the local-IP list

| Address class | Include? | Why |
|---|---|---|
| Regular IPv4 (10/8, 192.168/16, public) | yes | What users actually type |
| Regular IPv6 (global, ULA fc00::/7) | yes | Same |
| Tailscale CGNAT (100.64/10) | **yes** | Real reachable address for tailnet clients |
| Loopback (127.0.0.1, ::1) | no | Never useful as a cert SAN |
| IPv4 link-local (169.254/16 APIPA) | no | Only meaningful when DHCP failed; bloat |
| IPv6 link-local (fe80::/10) | no | Already filtered by \`get_addresses()\` — defence in depth |
| Loopback iface (\`lo\`) | no | Already skipped by \`enumerate_interfaces()\` |

CIDR \`/prefix\` suffixes and IPv6 zone identifiers (\`fd00::1%eth0\`) are stripped; results are deduped.

## Refresh triggers

| Trigger | Already fired before this PR? | Now picks up IPs |
|---|---|---|
| Engine startup (\`reapply_tls_from_disk\`) | yes | yes |
| WebUI TLS settings update | yes | yes |
| **Network apply** (bridge / bond / VLAN / IP change) | **no** | **yes** — new hook |

The new hook lives at the end of \`apply_config\` in \`network.rs\`, right after the discovery-daemon rebind landed in #273. Fired via \`tokio::spawn\` so a slow Caddy can't pin the network-apply RPC; \`reapply_tls_from_disk\` already has its own \`wait_ready\` and idempotent PATCH semantics (no-ops if body is identical to running config).

## Importantly: IPs go ONLY on the internal-CA policy

Two unit tests pin this invariant. Let's Encrypt refuses ACME orders for IP literals / private names, so leaking the LAN IPs into a per-domain ACME policy's \`subjects\` would crater issuance. The new \`extra_internal_subjects\` argument is funneled exclusively to the trailing internal-issuer policy; the managed-host ACME policies stay \`subjects: [host]\` only.

## Test plan

- [x] \`cargo check -p nasty-system -p nasty-apps -p nasty-engine\` clean.
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo test -p nasty-apps\` — 79 pass (was 77; +2 new tests).
- [x] \`cargo test -p nasty-system\` — 202 pass.
- [ ] Manual on the test box: \`nixos-rebuild switch\`, then \`curl -v --cacert <downloaded-root> https://<box-ip>/\` — confirm no CN-mismatch warning, only trust still vs. unimported root.
- [ ] Manual: create a new bridge / bond / VLAN with an IP — confirm the cert reissues to cover the new IP within ~1s (look for the \`caddy: set TLS automation\` log line).