### PR TITLE
nixos/caddy: add fallback_sni so unknown SNI falls back to nasty.local

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1462,16 +1462,30 @@ in {
         # collide.
         auto_https disable_redirects
 
-        # When a TLS connection arrives with no SNI (direct-IP access,
-        # `curl https://10.x.x.x/`) or an SNI we don't recognise,
-        # Caddy substitutes this value before site routing. Pairs with
-        # the `nasty.local:443 { tls internal }` block below — every
-        # such connection ends up served by the internal-CA cert
-        # instead of TLS-handshake-failing. Without this, port-only
-        # `:443 { tls internal }` had no hostname to issue against and
-        # every IP-direct curl got `tlsv1 alert internal error`
-        # (caught by appliance-smoke CI).
+        # SNI substitution rules. Both pair with the
+        # `nasty.local:443 { tls internal }` block below so every
+        # otherwise-unmatchable connection ends up served by the
+        # internal-CA cert instead of TLS-handshake-failing.
+        #
+        # `default_sni` only fires when the ClientHello has NO SNI at
+        # all — the direct-IP-literal case (`curl https://10.x.x.x/`).
+        # Without it, a port-only `:443 { tls internal }` listener has
+        # no hostname for the internal CA to bind to and IP-direct
+        # connections get `tlsv1 alert internal error` (originally
+        # caught by appliance-smoke CI).
+        #
+        # `fallback_sni` covers the other case: ClientHello DOES send
+        # an SNI but no `automation.policies` entry has it in
+        # `subjects` (typical for tailnet hostnames in the CSI E2E
+        # rig — the QEMU VM curls the box at its `*.ts.net` MagicDNS
+        # name, which we deliberately don't put on the cert). Without
+        # it, Caddy has no policy to apply, doesn't issue on-demand
+        # (we don't want arbitrary-SNI cert issuance), and emits
+        # `internal_error`. With it, the unknown SNI is rewritten to
+        # `nasty.local`, the internal-CA policy matches, and the
+        # internal cert is served.
         default_sni nasty.local
+        fallback_sni nasty.local
       '';
       extraConfig = ''
         (nasty_webui_routes) {


### PR DESCRIPTION
Unblocks the [nasty-csi integration suite](https://github.com/nasty-project/nasty-csi/actions/runs/26267338603) — all 5 E2E jobs (NVMe-oF / NFS / iSCSI / SMB / Shared) were failing on the connectivity check with:

\`\`\`
* TLSv1.3 (IN), TLS alert, internal error (592)
* OpenSSL/3.0.13: error:0A000438:SSL routines::tlsv1 alert internal error
curl: (35) ...
##[error]NASty is NOT reachable from VM
\`\`\`

## What happened

The K3s VMs in CI reach the test box (\`nasty.0f.ee\`) by its **tailnet MagicDNS name** (\`*.ts.net\`). curl puts that hostname in the TLS ClientHello SNI. Caddy on the box has no \`automation.policies\` entry for that name — only \`nasty.0f.ee\` (ACME) and \`nasty.local\` (internal CA).

The Caddyfile had:

\`\`\`
default_sni nasty.local
\`\`\`

with a comment claiming it handled both no-SNI and unknown-SNI cases. The unknown-SNI half is wrong: in Caddy, \`default_sni\` only substitutes when the ClientHello has **no SNI at all** (the IP-literal case). For **non-empty but unmatched** SNI there's a separate directive: \`fallback_sni\`.

Since \`on_demand_tls\` isn't configured (we don't want arbitrary cert issuance for any SNI a client requests), Caddy has no policy to apply, can't load a cert for the requested name, and emits TLS \`internal_error\` — exactly what the CSI rig saw.

## Reproduced from the box itself

Before:

\`\`\`
$ curl -vk --resolve dummy.ts.net:443:127.0.0.1 https://dummy.ts.net/
* TLSv1.3 (IN), TLS alert, internal error (592)
curl: (35) error:0A000438:SSL routines::tlsv1 alert internal error
\`\`\`

After live-patching \`fallback_sni\` into the running policy via the Caddy admin API:

\`\`\`
$ curl -s -X PATCH http://127.0.0.1:2019/config/apps/http/servers/srv0/tls_connection_policies/0 \\
    -H 'Content-Type: application/json' \\
    -d '{"default_sni":"nasty.local","fallback_sni":"nasty.local"}'

$ curl -vk --resolve dummy.ts.net:443:127.0.0.1 https://dummy.ts.net/
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
\`\`\`

Full TLS 1.3 handshake completes. CSI E2E unblocked.

## Fix

One line in the Caddyfile global block, plus a rewritten comment that spells out which directive fires when so the next reader doesn't have to dig into Caddy's source to figure it out.

\`\`\`
default_sni nasty.local
fallback_sni nasty.local
\`\`\`

## Independent of #275

[#275](https://github.com/nasty-project/nasty/pull/275) (just merged) adds local IPs as SANs on the self-signed cert, which fixes **direct-IP access** (`curl https://10.x.x.x`). This PR fixes **direct-hostname access where the hostname isn't on any cert** (the CSI / tailnet case). Both are complementary; neither subsumes the other.

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [x] Live admin-API patch of the equivalent JSON on \`nasty.0f.ee\` resolves the curl error — confirms the directive is the right fix.
- [ ] \`nixos-rebuild switch\` on \`nasty.0f.ee\` to persist (live patch is volatile, gone on Caddy restart).
- [ ] Re-run the CSI integration workflow — connectivity step should pass, downstream E2E should run.