### PR TITLE
nixos: add openssl and uv to systemPackages

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -574,12 +574,14 @@ in {
       jq                # JSON parsing (used by engine scripts)
       htop
       python3           # scripting and quick data processing
+      uv                # fast Python package manager (uv + uvx — `uvx <tool>` for one-shots)
       file              # file type identification
       tree              # directory structure visualization
       eza               # modern ls replacement (colors, git, tree)
       strace            # system call tracing for debugging
       trace-cmd         # ftrace frontend for kernel tracing
       dig               # DNS debugging
+      openssl           # cert inspection (x509 -text), TLS handshake debugging (s_client)
       nano              # quick file editing
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery


### PR DESCRIPTION
Two small operator-facing additions that were missing.

## openssl

Hit this today while debugging #275's per-IP cert. Trying to inspect the on-disk certs in \`/var/lib/caddy/.local/share/caddy/certificates/local/<name>/<name>.crt\` from the box itself:

\`\`\`
bash: line 1: openssl: command not found
\`\`\`

Had to SCP the .crt down to a workstation that had openssl. Not great.

That class of debugging — \`openssl x509 -text\` to dump a cert, \`openssl s_client -connect ... -servername X\` to walk a TLS handshake against the local box, \`openssl req\` / \`openssl rsa\` / \`openssl pkcs12\` to fiddle with keys — is exactly what an operator reaches for first when TLS breaks. \`openssl\` is already pulled in transitively by half the system (anything linking against curl / samba / nginx / wpa / etc.), so this just exposes the existing binary on PATH.

## uv

Astral's fast Python package manager + \`uvx\` for one-shot tool invocation (\`uvx ruff check .\`, \`uvx httpie ...\`, \`uvx ansible-playbook foo.yml\`, etc).

Pairs with the existing \`python3\` in the same list — \`python3\` alone gets the interpreter, but installing tools into a NixOS read-only Python environment is fiddly (pip refuses, system Python is sealed, \`nix-shell -p python3Packages.X\` requires knowing the nixpkgs attr name). \`uvx\` works around all of that — operators get a one-liner-friendly Python-tool experience without polluting the system.

## Cost

~10 MB total closure addition. One line each, slotted in next to existing related tools (\`openssl\` near \`dig\` / \`tcpdump\`, \`uv\` right after \`python3\`).

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [ ] After \`nixos-rebuild switch\`: \`openssl version\` returns a version string; \`uv --version\` and \`uvx --version\` both work; \`uvx --help\` shows the run-a-tool subcommand surface.