### PR TITLE
release: 0.0.8 (Caddy migration) + glossary updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NASty is a NAS operating system built on NixOS and bcachefs. It turns commodity 
 - **Subvolumes** — filesystem and block subvolumes with quotas, compression, and tiering per subvolume
 - **Snapshots** — instant, space-efficient point-in-time copies
 - **Encryption lifecycle** — lock and unlock encrypted filesystems from the WebUI, with a dependents preview that lists every app, VM, share, and backup that would break before you confirm
-- **File browser** — browse, upload, and manage files from the web UI
+- **File browser** — browse, upload, edit, rename, copy, move, and bulk-manage files from the web UI
 - **Backups** — encrypted, deduplicated, incremental backups to local, S3, SFTP, REST, or Backblaze B2 with per-profile schedules and retention
 
 ### Monitoring & Alerts
@@ -56,7 +56,7 @@ NASty is a NAS operating system built on NixOS and bcachefs. It turns commodity 
 - **Networking** — NetworkManager-based with confirm-or-rollback: edits stage, apply, and auto-revert if you don't confirm in time, so a typo can't lock you out over SSH
 - **Let's Encrypt** — automatic TLS certificates via ACME (TLS-ALPN and DNS challenges)
 - **Tailscale** — built-in VPN with one-click setup
-- **Access control** — local user accounts with role-based permissions, API tokens, and OIDC single sign-on
+- **Access control** — local user accounts with role-based permissions, API tokens, OIDC single sign-on, and an append-only audit log of every mutation, login attempt, and privileged-console open
 - **UPS monitoring** — NUT integration for graceful shutdown on power loss (opt-in)
 - **Atomic updates** — NixOS-based, with one-click rollback to any previous generation
 - **Binary cache** — fast updates via cachix on both x86_64 and aarch64 (engine, webui, bcachefs-tools pre-built — no Rust + npm compile on Pi / Odroid / Rockchip boxes)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-apidoc"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "nasty-sharing",
  "nasty-storage",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-apps"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-backup"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "chrono",
  "jiff",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-common"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-engine"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-metrics"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-sharing"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",
@@ -2589,14 +2589,14 @@ dependencies = [
 
 [[package]]
 name = "nasty-snapshot"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "nasty-storage",
 ]
 
 [[package]]
 name = "nasty-storage"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-system"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-vm"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 license = "GPL-3.0-only"
 

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -204,9 +204,14 @@
 					detail: 'The built-in terminal gives you a bash shell on the NAS, accessible from the web UI. Useful for running bcachefs commands, inspecting logs, or anything the web UI doesn\'t cover. Commands like nasty-top are available here.',
 				},
 				{
+					term: 'Caddy',
+					summary: 'The reverse proxy and TLS terminator running in front of the engine.',
+					detail: 'Caddy serves the web UI on port 443, terminates HTTPS, and proxies /api/* and /ws/* to the engine on 127.0.0.1:2137. Certificates come from either Let\'s Encrypt (ACME) when you\'ve set a real domain, or from Caddy\'s built-in "internal" CA when you haven\'t — that\'s the self-signed cert you\'ll see on nasty.local and on the box\'s IP addresses. The engine talks to Caddy through its admin API on 127.0.0.1:2019 to push per-app routes and TLS automation policies at runtime, so app installs and TLS settings changes apply without restarting anything. Replaced nginx in 0.0.8. Logs: journalctl -u caddy.',
+				},
+				{
 					term: 'ACME / Let\'s Encrypt',
 					summary: 'Automatic TLS certificates for the web UI.',
-					detail: 'NASty can request a free, trusted TLS certificate for your hostname from Let\'s Encrypt and renew it automatically. Two challenge types are supported: TLS-ALPN (works when NASty is reachable on port 443 from the internet) and DNS-01 (works behind a NAT / on a private network, but needs API credentials for your DNS provider). Configure under Settings → TLS.',
+					detail: 'NASty can request a free, trusted TLS certificate for your hostname from Let\'s Encrypt and renew it automatically. Two challenge types are supported: TLS-ALPN (works when NASty is reachable on port 443 from the internet) and DNS-01 (works behind a NAT / on a private network, but needs API credentials for your DNS provider). Issuance is handled by Caddy. Configure under Settings → TLS.',
 				},
 				{
 					term: 'Tailscale',
@@ -242,6 +247,11 @@
 					term: 'SSO / OIDC',
 					summary: 'Sign in to NASty with an external identity provider.',
 					detail: 'OpenID Connect lets you delegate web UI login to a provider like Authentik, Keycloak, Google, or any OIDC-compliant IdP. Users log in once at the provider and are redirected back. Configure under Access Control → Identity Provider; existing local accounts keep working alongside SSO.',
+				},
+				{
+					term: 'Audit Log',
+					summary: 'Append-only record of every action operators take on the box.',
+					detail: 'Lives at /var/lib/nasty/audit.log (mode 0600) and is mirrored to journald with target "audit", so tampering with the file still leaves a trail. Every state-changing RPC the engine accepts is recorded with the username, client IP, method name, and a safelist-filtered parameter summary (secrets like passwords / API tokens / TLS DNS credentials never make it in). Logged in addition to mutations: every login attempt (success and failure), permission denials, terminal / VM-console / log-stream opens, and unsafe app deploys — anything an auditor would want to reconstruct after the fact. Read it via the audit.list RPC or the Logs page in the WebUI; rotated by logrotate at 10 MB.',
 				},
 			],
 		},


### PR DESCRIPTION
Version bump for 0.0.8. Codename: **nginx → Caddy migration**.

## Version

\`engine/Cargo.toml\` workspace.package.version: \`0.0.7\` → \`0.0.8\`. \`flake.nix\` reads this single TOML field for \`nasty-version\`, so:

- All 11 workspace crates flip in \`Cargo.lock\` (cargo refreshed it automatically on \`cargo check\`).
- The installer tag (\`v\${nasty-version}\`) becomes \`v0.0.8\`.
- The NixOS module label, the engine's built-in version string (\`env!("CARGO_PKG_VERSION")\`), and the WebUI dashboard footer all stay in lockstep.

## Glossary (\`webui/src/routes/help\`)

Two concept-level additions, scoped to what 0.0.8 actually introduced or materially expanded:

- **Caddy** (Networking & Services). Replaced nginx as the TLS terminator + reverse proxy. Slotted in just before the existing ACME entry; ACME's \`detail\` now cross-references Caddy so the relationship is obvious. Covers what Caddy does, where it gets certs (Let's Encrypt + the built-in "internal" CA — explaining the self-signed certs on \`nasty.local\` and on box IPs), how the engine drives it (admin API on \`:2019\`), and where to read its logs.
- **Audit Log** (Security & Access). The audit-completeness pass (#262) made the audit log substantially more comprehensive — \`permission_denied\` on role-denied RPCs, \`terminal_opened\` / \`vm_console_opened\` / \`log_stream_opened\` on privileged WS opens, threaded session identity into unsafe-deploy records. The new entry points operators at the file + journald mirror, summarizes what's recorded, and tells them how to read it.

## README

Two small features-list updates to reflect new-or-expanded 0.0.8 content:

- File browser line now lists the new copy / move / bulk-manage operations from #269 (was: just "browse, upload, and manage files").
- Access control line now mentions the audit log alongside the existing local-users / tokens / OIDC bullets, matching the glossary addition above.

The rest of the README is intentionally version-agnostic — no "current version" tag, no changelog section (those live in GitHub Releases) — so nothing else needs touching for the tag.

## What's NOT updated, and why

Everything else shipped between 0.0.7 and 0.0.8 was internal refinement:

| Change | User-facing? | Worth surfacing in README/Glossary? |
|---|---|---|
| State-corruption recovery (#257) | no — silent | no |
| systemd hardening (#263) | no | no |
| Engine startup races (#261) | no | no |
| Cargo / npm bumps (#264, #266) | no | no |
| Subvolume cascade delete (#272) | yes, but dialog UX | no — too niche |
| Self-signed IP SANs (#275) | yes, behind-the-scenes | covered by the new Caddy entry |
| \`fallback_sni\` (#276) | implementation | no |
| Port form swap (#274) | yes, cosmetic | no — already covered by \`App\` |
| openssl + uv (#277) | yes, but operator tools | no — they're just on PATH |

FAQ.md has no version-specific content and didn't need changes.

## Test plan

- [x] \`cargo check --workspace\` clean after bump.
- [x] \`cargo test --workspace\` — ~440 tests pass.
- [x] \`cargo clippy --workspace -- -D warnings\` clean.
- [x] \`npm run check\` — 4880 files, 0 errors, 0 warnings.
- [x] \`npm test\` — vitest 121 pass.
- [ ] After merge: tag \`v0.0.8\`, GitHub release notes, \`nixos-rebuild switch\` on \`nasty.0f.ee\` and the dev box.