### PR TITLE
nixos: bump nasty-top 0.0.4 → 0.0.5

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -591,14 +591,14 @@ in {
       restic-rest-server # REST API server for receiving backups from other machines
       (pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.4";
+        version = "0.0.5";
         src = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
-          rev = "v0.0.4";
-          hash = "sha256-unm/bc/SjxtISm9wbCMj4ySrTPQUeHtoPpcQUSWKUeE=";
+          rev = "v0.0.5";
+          hash = "sha256-8oefkH5hRIYYuECdmVUsbCtqnTJxC3IgwGoPQppmTYc=";
         };
-        cargoHash = "sha256-1HGu29yMYskUr0IEY9Rtw5V6fGlBu+PKyKFvf+TGBu0=";
+        cargoHash = "sha256-d1gVWeQMLx03/qE62qY4Yk+Xqa/bWfdpIg8sjV4XX50=";
         meta.mainProgram = "nasty-top";
       })
 


### PR DESCRIPTION
[nasty-top v0.0.5](https://github.com/nasty-project/nasty-top/releases/tag/v0.0.5) shipped 2026-05-12. We were one version behind.

## What changed upstream

### User-facing
- **Tuning advisor demoted to informational hints** ([#7](https://github.com/nasty-project/nasty-top/pull/7)). The old one-key-apply suggestions overstated confidence; the footer now shows \`HINT\` lines with trigger reason + an example sysfs command and lets the operator decide whether to run it. Hints persist for at least 15s after first appearing, so single-tick triggers no longer flash by faster than you can read.
- **Device error counts are session-aware** ([#6](https://github.com/nasty-project/nasty-top/pull/6)). The \`Err\` column dims pre-existing counts and turns bold red only when errors grow during the current run — you can tell at a glance whether a number is dead history or actively climbing.
- **\`Ctrl-C\` quits from any mode** ([#8](https://github.com/nasty-project/nasty-top/pull/8)), including option edit.
- **Device list sorts more sensibly** ([#5](https://github.com/nasty-project/nasty-top/pull/5)): grouped by label, then natural-sorted by name (\`sda1 < sdz1 < sdaa1\`, \`nvme0n1 < nvme10n1\`).

### Bcachefs sync
- Dropped advisor rules for upstream-removed options (\`rebalance_enabled\`, \`btree_cache_size_max\`). The latter was actively proposing writes that would have failed silently.

### Docs
- Help popup and README synced with every actual keybinding (\`?\`, \`c\`, \`g\`, \`j/k\`, \`Ctrl-C\` were undocumented).
- Updated screenshots.

## Hashes

Both pinned for reproducibility:

| Hash | Value | How obtained |
|---|---|---|
| \`src.hash\` | \`sha256-8oefkH5hRIYYuECdmVUsbCtqnTJxC3IgwGoPQppmTYc=\` | \`nix run nixpkgs#nix-prefetch-github -- --rev v0.0.5 nasty-project nasty-top\` |
| \`cargoHash\` | \`sha256-d1gVWeQMLx03/qE62qY4Yk+Xqa/bWfdpIg8sjV4XX50=\` | Verified by building on a NixOS box (Mac can't build Linux drvs directly) |

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [x] \`nix-build\` of the package succeeds on \`10.10.10.67\` (NixOS) with both hashes set.
- [ ] After \`nixos-rebuild switch\`: \`nasty-top\` runs, footer shows new \`HINT\` line style (vs the old one-key-apply suggestions), \`Ctrl-C\` quits cleanly from option-edit mode.