### PR TITLE
nixos: use nasty-version as the boot-menu label

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, nasty-engine, nasty-webui ? null, ... }:
+{ config, lib, pkgs, nasty-engine, nasty-webui ? null, nasty-version ? "dev", ... }:
 
 {
   imports = [ ./binary-cache.nix ];
@@ -80,6 +80,12 @@
   # Branding
   system.nixos.distroName = "NASty";
   system.nixos.distroId = "nasty";
+  # Boot menu entries read as `NASty v<release>` instead of the
+  # default `NASty <release>.<commit-date>.<commit-hash>` nixpkgs
+  # blob. Falls back to "dev" when this file is consumed standalone
+  # (no specialArgs from the flake) — typical for nixos-rebuild
+  # tests that import the module without the wrapper.
+  system.nixos.label = "v${nasty-version}";
 
   # Useful tools
   environment.systemPackages = with pkgs; [ vim file binutils git fwupd rsync iotop-c btop ];

--- a/nixos/cloud.nix
+++ b/nixos/cloud.nix
@@ -16,7 +16,7 @@
 # by passing NASTY_CLOUD_TESTING_CREDS=1 in the build environment. Production
 # images must never be built with this flag.
 
-{ config, lib, pkgs, nasty-engine, nasty-webui ? null, ... }:
+{ config, lib, pkgs, nasty-engine, nasty-webui ? null, nasty-version ? "dev", ... }:
 
 let
   # Refuse to bake known-bad credentials unless the operator explicitly opts in
@@ -61,5 +61,8 @@ in
 
   system.nixos.distroName = "NASty";
   system.nixos.distroId = "nasty";
+  # Same boot-menu rename as appliance-base. Falls back to "dev"
+  # when consumed standalone outside the flake's specialArgs.
+  system.nixos.label = "v${nasty-version}";
   system.stateVersion = "24.11";
 }

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nasty-engine, nasty-webui, nixpkgs, nasty-rootfs-toplevel ? null, installerSystemFlake, installerNastySource ? null, ... }:
+{ config, pkgs, lib, nasty-engine, nasty-webui, nasty-version, nixpkgs, nasty-rootfs-toplevel ? null, installerSystemFlake, installerNastySource ? null, ... }:
 
 let
   nasty-grub-theme = pkgs.runCommand "nasty-grub-theme" {
@@ -97,10 +97,20 @@ in
   # ── Branding ──────────────────────────────────────────────
   image.baseName = lib.mkForce "nasty";
   isoImage.volumeID = "NASTY_INSTALLER";
-  isoImage.appendToMenuLabel = " NASty Installer";
+  # `distroName` already supplies the "NASty " prefix and
+  # `system.nixos.label` below supplies the version, so this suffix
+  # only needs to add the "Installer" disambiguator — keeping
+  # "NASty" in here too would produce the awkward `NASty v0.0.8
+  # NASty Installer` we shipped pre-cleanup.
+  isoImage.appendToMenuLabel = " Installer";
 
   system.nixos.distroName = "NASty";
   system.nixos.distroId = "nasty";
+  # Override the default release.commit-date.commit-hash label
+  # (e.g. "26.05.20260515.d233902") with the NASty version. Surfaces
+  # as the middle token in the systemd-boot menu — `NASty v0.0.8
+  # Installer` reads cleaner than the nixpkgs commit blob.
+  system.nixos.label = "v${nasty-version}";
 
   boot.supportedFilesystems = [ "bcachefs" ];
 


### PR DESCRIPTION
Per discussion in chat: systemd-boot menu entries currently read e.g.

\`\`\`
NASty 26.05.20260515.d233902 NASty Installer
\`\`\`

Two pieces wrong with that:

1. **The middle token is NixOS's default \`system.nixos.label\`** — \`\${release}.\${commit-date}.\${commit-hash}\` derived from nixpkgs. Meaningful to a nixpkgs maintainer; noise to a NASty operator. The actual NASty release version doesn't appear anywhere.
2. **\`distroName = "NASty"\` (prefix) and \`appendToMenuLabel = " NASty Installer"\` (suffix) both repeat the brand.** Tolerable when there's a long nixpkgs blob between them; awkward once the blob shrinks to a clean version string.

## Fix

Two changes, both touching only the branding strings:

### Override the label

Set \`system.nixos.label = "v\${nasty-version}"\` in the three files that already set \`distroName = "NASty"\`:

| File | Used for |
|---|---|
| \`nixos/iso.nix\` | ISO installer |
| \`nixos/appliance-base.nix\` | Installed appliances |
| \`nixos/cloud.nix\` | Cloud disk images |

\`nasty-version\` is already in \`specialArgs\` for every NixOS configuration the flake builds (\`flake.nix:151, 191, 210, 231, 245\`); the modules just need to destructure it from their args. \`appliance-base.nix\` and \`cloud.nix\` gain a \`? "dev"\` default so the modules still parse cleanly if anyone imports them outside the wrapper flake (typical for ad-hoc \`nixos-rebuild\` tests). \`iso.nix\` is wrapper-only so the arg stays required.

### Trim the redundant suffix

\`iso.nix:100\` had:

\`\`\`
isoImage.appendToMenuLabel = " NASty Installer";
\`\`\`

Now:

\`\`\`
isoImage.appendToMenuLabel = " Installer";
\`\`\`

\`distroName\` already supplies "NASty ", \`system.nixos.label\` supplies the version, so this suffix only needs the "Installer" disambiguator.

## End result

\`\`\`
NASty v0.0.8 Installer
\`\`\`

vs. the current

\`\`\`
NASty 26.05.20260515.d233902 NASty Installer
\`\`\`

## Lands after v0.0.8

Tag was already cut before this discussion, so this rolls into the next release (0.0.9). Existing v0.0.8 boot menus stay on the old labelling — no upgrade path issue, just a cosmetic change visible on fresh installs / first boot after upgrade.

## Test plan

- [x] \`nix-instantiate --parse\` clean on all three files.
- [ ] After merge: \`nixos-rebuild build\` produces a generation whose systemd-boot entry reads \`NASty v\${current-version}\` (without the extra "NASty " on the suffix side for ISO builds).
- [ ] Boot the resulting ISO in QEMU; confirm the menu entry visually matches \`NASty v0.0.9 Installer\` (or whatever's tagged).