### PR TITLE
engine+webui: report the live log filter through system.log.level

### DIFF
--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -532,9 +532,21 @@ pub(super) async fn try_route(
         },
         "system.reboot_required" => ok(req, state.updates.reboot_required().await),
         "system.log.level" => {
-            // Return the current filter as a string — not easily available from reload handle,
-            // so just return a placeholder. The set method is more useful.
-            ok(req, "use system.log.set_level to change")
+            // Return the live filter so the WebUI's Log Level input can be
+            // pre-populated with what's actually running. Without this the
+            // input stays empty and shows a placeholder, which an operator
+            // reasonably mistakes for the current value — and "Normal"
+            // looks like it does something even when the running filter is
+            // already the Normal preset.
+            //
+            // `with_current` returns Err only if the parent dispatcher has
+            // been dropped — never happens in our lifecycle (the reload
+            // handle outlives the dispatcher for the entire engine run),
+            // so the Err arm is a safety surface, not an expected path.
+            match state.log_reload.with_current(|f| f.to_string()) {
+                Ok(s) => ok(req, s),
+                Err(e) => err(req, format!("failed to read current filter: {e}")),
+            }
         }
         "system.log.set_level" => {
             #[derive(Deserialize)]

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -209,13 +209,20 @@
 
 	onMount(async () => {
 		await withToast(async () => {
-			[settings, info, timezones, networkState] = await Promise.all([
+			let liveLogFilter: string;
+			[settings, info, timezones, networkState, liveLogFilter] = await Promise.all([
 				client.call<Settings>('system.settings.get'),
 				client.call<SystemInfo>('system.info'),
 				client.call<string[]>('system.settings.timezones'),
 				client.call<NetworkState>('system.network.get'),
+				// Engine returns the live tracing EnvFilter as a string,
+				// so the Log Level input pre-populates with what's actually
+				// running — the placeholder is now a real suggestion shown
+				// only when the operator clears the field.
+				client.call<string>('system.log.level').catch(() => ''),
 			]);
 			hostnameInput = settings.hostname ?? info.hostname;
+			logFilter = liveLogFilter;
 			syncNetworkForm();
 		});
 	});


### PR DESCRIPTION
The Log Level section on the Settings page displayed its \`<input>\` placeholder text (\`nasty_engine=debug,nasty_system=trace\`) as if it were the running filter. Two bugs stacked:

## What was wrong

1. \`engine/nasty-engine/src/router/system.rs\` — the \`system.log.level\` RPC was a stub:

   \`\`\`rust
   "system.log.level" => {
       // Return the current filter as a string — not easily available from reload handle,
       // so just return a placeholder. The set method is more useful.
       ok(req, "use system.log.set_level to change")
   }
   \`\`\`

2. \`webui/src/routes/settings/+page.svelte\` — \`logFilter\` started as \`''\` and was never set from the engine. The gray text in the box was the \`<input>\`'s HTML placeholder, showing an example debug filter (\`nasty_engine=debug,nasty_system=trace\`) as a syntax hint.

The compound effect: an operator looking at the screen sees what looks like an *active* debug-level filter, clicks "Normal," sees the field switch to a long all-\`info\` string, and reasonably concludes the running filter just dropped from debug to info. In reality the box was at \`info\` the whole time — verified on a deployed box:

\`\`\`
$ tr '\\0' '\\n' < /proc/$(pidof nasty-engine)/environ | grep RUST_LOG
RUST_LOG=nasty_engine=info,nasty_storage=info,nasty_sharing=info,
         nasty_snapshot=info,nasty_system=info,nasty_apps=info,
         tower_http=info
\`\`\`

(That's the NixOS default at \`nasty.nix:99\`, identical to what the "Normal" preset writes.)

## Fix

**Engine** — \`system.log.level\` now reads the live filter:

\`\`\`rust
match state.log_reload.with_current(|f| f.to_string()) {
    Ok(s) => ok(req, s),
    Err(e) => err(req, format!("failed to read current filter: {e}")),
}
\`\`\`

\`tracing_subscriber::reload::Handle::with_current\` accepts a closure that gets a reference to the live layer; \`EnvFilter: Display\` round-trips with \`EnvFilter::try_new\`, so the returned string is directly valid as input to \`system.log.set_level\`. The \`Err\` arm only fires if the parent dispatcher has been dropped, which never happens in our lifecycle.

**WebUI** — \`onMount\` now fetches the filter alongside the other settings in the existing \`Promise.all\`, and assigns it to \`logFilter\` before render. \`.catch(() => '')\` keeps the page working on older engines or RPC errors — the placeholder still serves as a fallback hint.

## End result

- Input pre-populates with the actual running filter.
- Preset chips ("Normal" / "Debug" / "Trace") highlight correctly when one of them matches the running filter (the existing \`logFilter === preset.value\` check).
- Apply with an unchanged value is the no-op it always should have been.

## Test plan

- [x] \`cargo check / clippy / fmt / test -p nasty-engine\` clean.
- [x] \`npm run check\` clean.
- [ ] On a NASty box after deploy: open Settings → Log Level. Confirm the input shows the actual \`RUST_LOG\` from systemd (matches \`/proc/\$(pidof nasty-engine)/environ\`), and the "Normal" chip is highlighted by default since the default IS Normal.
- [ ] Click "Debug" → Apply → reload the page → confirm the input now shows the debug filter, Debug chip is highlighted.