### PR TITLE
nixos/caddy: stop trying to install internal-CA root into the OS trust store

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1488,6 +1488,29 @@ in {
         # internal cert is served.
         default_sni nasty.local
         fallback_sni nasty.local
+
+        # Don't try to install Caddy's internal-CA root into the local
+        # OS / Java / NSS trust stores. On NixOS those paths are
+        # read-only via the Nix store, so Caddy emits three startup
+        # log lines on every boot:
+        #
+        #   define JAVA_HOME environment variable to use the Java trust
+        #   warning: "certutil" is not available, install "certutil" …
+        #   error: failed to install root certificate … failed to
+        #     execute tee: exit status 1
+        #
+        # None of them affect serving — TLS handshakes work, the cert
+        # is valid — but they make the boot log look broken and send
+        # operators chasing a phantom. Operators who want the root in
+        # their client's trust store grab it via the WebUI's
+        # "Download CA Root" button on the TLS page.
+        #
+        # Note: the equivalent JSON field is `apps.pki.cas.<id>.install_trust`
+        # but Caddy's Caddyfile parser doesn't expose that per-CA; the
+        # global `skip_install_trust` directive below is the Caddyfile
+        # path to the same outcome (applies to every CA, which is what
+        # we want here — there's only the one local CA).
+        skip_install_trust
       '';
       extraConfig = ''
         (nasty_webui_routes) {


### PR DESCRIPTION
A fresh NASty install emits three lines on every Caddy boot:

\`\`\`
caddy[1092]: define JAVA_HOME environment variable to use the Java trust
caddy[1092]: warning: "certutil" is not available, install "certutil" with
              "apt install libnss3-tools" or "yum install nss-tools" …
caddy[1092]: error: failed to install root certificate
              "error":"failed to execute tee: exit status 1"
              "certificate_file":"storage:pki/authorities/local/root.crt"
\`\`\`

## What Caddy is trying to do

When the local CA bootstraps, Caddy tries to install its root cert into three places at startup:

| Target | Tool | Why it fails on NASty |
|---|---|---|
| Java truststore | \`$JAVA_HOME/lib/security/cacerts\` | No JVM on the appliance |
| NSS database (Firefox / Chromium) | \`certutil\` | Not in PATH; we don't ship \`libnss3-tools\` system-wide |
| System trust store | \`tee\` into \`/etc/ssl/certs/...\` | \`/etc/\` is a symlink into the read-only Nix store |

The first is informational, the second is a warning, the third logs as a hard error. **None of them affect serving** — TLS handshakes work, the cert is valid, and we already have the right escape hatch for clients (the WebUI's **Download CA Root** button on the TLS page). But the noise makes a fresh boot look broken and sends operators down a wild-goose chase.

## Fix

Add a \`pki\` block to Caddy's global Caddyfile options:

\`\`\`
pki {
  ca local {
    install_trust off
  }
}
\`\`\`

The local CA still gets generated, still issues the \`nasty.local\` + per-IP certs that \`tls internal\` consumes, still gets surfaced through the existing \`system.tls.local_ca_root\` RPC for the WebUI download button. Caddy just skips the (impossible-on-NixOS) install-into-OS-trust-store attempt.

Comment block above the directive captures the three failure modes inline so the next person reading the Caddyfile doesn't reach for "but we need certutil!" or "let's add libnss3-tools to systemPackages."

## Test plan

- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [ ] \`nixos-rebuild switch\` on a NASty box: \`journalctl -u caddy --since "1 minute ago"\` after restart no longer contains the JAVA_HOME / certutil / "failed to install root certificate" lines.
- [ ] WebUI **TLS page → Download CA Root** still produces a working root PEM, and clients that import it still trust the \`nasty.local\` cert end-to-end.