### PR TITLE
engine+webui: surface TPM2 presence on the Hardware page

### DIFF
--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -273,6 +273,41 @@ pub struct HardwareSummary {
     pub cpu: Option<CpuSummary>,
     pub memory: MemorySummary,
     pub usb: Vec<UsbDevice>,
+    /// TPM chip presence + usability for the encryption-key sealing
+    /// flows that #102 is building toward. `None` when no TPM device
+    /// is enumerated by the kernel at all (no chip, disabled in
+    /// firmware, missing driver).
+    pub tpm: Option<TpmInfo>,
+}
+
+/// Snapshot of the host's first TPM device — what the kernel sees at
+/// `/sys/class/tpm/tpm0/`. We only inspect index 0 because everything
+/// downstream (sealing, unsealing, auto-unlock) targets the system's
+/// "main" TPM; multi-TPM boxes are out of scope.
+///
+/// The two booleans together answer the question that matters for #102:
+///   - `version_major == 2` AND `rm_available` ⇒ usable for sealing.
+///   - Anything else ⇒ surface as "incompatible" in the WebUI and skip
+///     the bind-to-TPM affordance.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TpmInfo {
+    /// `1` for TPM 1.2 (incompatible with the planned sealing flow),
+    /// `2` for TPM 2.0. Read from `tpm_version_major`.
+    pub version_major: Option<u32>,
+    /// `/dev/tpmrm0` is the resource-manager interface tpm2-tools and
+    /// any sealing code actually talks to. Present on TPM 2.0 systems
+    /// with the in-kernel resource manager enabled (default on every
+    /// modern kernel). When false, the chip exists but the sealing
+    /// path will fail at the device-open step.
+    pub rm_available: bool,
+    /// Free-form vendor / model string from sysfs's `description`
+    /// attribute (e.g. `Infineon SLB 9670`). Empty when sysfs doesn't
+    /// expose it — fall back to the manufacturer field for display.
+    pub description: Option<String>,
+    /// 4-character ASCII manufacturer code from
+    /// `/sys/class/tpm/tpm0/tpm_vendor` / `manufacturer` when
+    /// available (e.g. `IFX`, `STM`, `NTC`, `AMD` for fTPM).
+    pub manufacturer: Option<String>,
 }
 
 /// DMI Type 1 + Type 2 — the "what hardware is this box" basics.
@@ -383,13 +418,66 @@ async fn build_summary() -> HardwareSummary {
     let (system, bios, memory) = parse_dmidecode(&dmidecode_baseboard);
     let cpu = read_cpu_info().await;
     let usb = read_usb_devices().await;
+    let tpm = read_tpm_info().await;
     HardwareSummary {
         system,
         bios,
         cpu,
         memory,
         usb,
+        tpm,
     }
+}
+
+/// Probe `/sys/class/tpm/tpm0/` for TPM presence + version + identity.
+/// Cheap (~3 sysfs reads, no command spawns). Returns `None` when the
+/// device doesn't exist in sysfs at all — i.e. no chip, no driver, or
+/// the host firmware has TPM disabled (BIOS `fTPM` toggle off, etc.).
+async fn read_tpm_info() -> Option<TpmInfo> {
+    const TPM_SYSFS: &str = "/sys/class/tpm/tpm0";
+    // First gate: does the sysfs entry exist? Missing ⇒ no TPM the
+    // kernel could see. Cheap stat — we read the directory metadata,
+    // not its contents.
+    if tokio::fs::metadata(TPM_SYSFS).await.is_err() {
+        return None;
+    }
+
+    // Read attribute helper — sysfs files are short, trimming is
+    // important (every value ends in `\n`).
+    async fn read_attr(path: &str) -> Option<String> {
+        tokio::fs::read_to_string(path)
+            .await
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
+    let version_major = read_attr(&format!("{TPM_SYSFS}/tpm_version_major"))
+        .await
+        .and_then(|s| s.parse::<u32>().ok());
+
+    // `/dev/tpmrm0` is the resource-manager char dev. Without it the
+    // sealing path can't open anything to talk to — that's the
+    // distinction between "kernel saw a TPM" and "kernel made it
+    // usable for tpm2-tools."
+    let rm_available = tokio::fs::metadata("/dev/tpmrm0").await.is_ok();
+
+    // sysfs exposes two related strings: `description` (vendor + model
+    // free-form) and `tpm_vendor` (4-char ASCII manufacturer code on
+    // 2.0; older kernels expose it as `manufacturer` instead). Try
+    // both so we degrade gracefully on older driver versions.
+    let description = read_attr(&format!("{TPM_SYSFS}/description")).await;
+    let manufacturer = match read_attr(&format!("{TPM_SYSFS}/tpm_vendor")).await {
+        Some(s) => Some(s),
+        None => read_attr(&format!("{TPM_SYSFS}/manufacturer")).await,
+    };
+
+    Some(TpmInfo {
+        version_major,
+        rm_available,
+        description,
+        manufacturer,
+    })
 }
 
 async fn run_text(cmd: &str, args: &[&str]) -> Option<String> {

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -51,6 +51,20 @@ export interface HardwareSummary {
 	cpu: CpuSummary | null;
 	memory: MemorySummary;
 	usb: UsbDevice[];
+	tpm: TpmInfo | null;
+}
+
+export interface TpmInfo {
+	/** 1 = TPM 1.2 (incompatible with planned sealing), 2 = TPM 2.0. */
+	version_major: number | null;
+	/** `/dev/tpmrm0` is present — the resource-manager dev that tpm2-tools
+	 * and any sealing path actually opens. False means a chip exists but
+	 * isn't usable from userspace. */
+	rm_available: boolean;
+	/** Vendor + model string from sysfs's `description` attribute. */
+	description: string | null;
+	/** 4-char ASCII manufacturer code (IFX, STM, NTC, AMD for fTPM). */
+	manufacturer: string | null;
 }
 
 export interface DmiSystem {

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -263,6 +263,45 @@
 				{/if}
 			</CardContent>
 		</Card>
+
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					TPM
+				</h3>
+				{#if !summary?.tpm}
+					<div class="text-sm font-medium">Not present</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						Either no TPM chip is installed, the chip is disabled in
+						firmware (BIOS fTPM / PTT toggle), or the kernel driver
+						isn't loaded.
+					</div>
+				{:else}
+					{@const tpm = summary.tpm}
+					{@const isTpm2 = tpm.version_major === 2}
+					{@const usable = isTpm2 && tpm.rm_available}
+					<div class="text-sm font-medium">
+						{#if tpm.version_major}
+							TPM {tpm.version_major}.0
+						{:else}
+							TPM (version unknown)
+						{/if}
+						{#if usable}
+							<span class="ml-1 text-xs text-emerald-400">· ready</span>
+						{:else if isTpm2}
+							<span class="ml-1 text-xs text-amber-500">· no /dev/tpmrm0</span>
+						{:else}
+							<span class="ml-1 text-xs text-amber-500">· incompatible (need 2.0)</span>
+						{/if}
+					</div>
+					{#if tpm.description}
+						<div class="mt-1 text-xs text-muted-foreground">{tpm.description}</div>
+					{:else if tpm.manufacturer}
+						<div class="mt-1 text-xs text-muted-foreground">{tpm.manufacturer}</div>
+					{/if}
+				{/if}
+			</CardContent>
+		</Card>
 	</div>
 
 	<!-- ── DIMM detail (collapsed by default) ──────────────────────── -->


### PR DESCRIPTION
First piece of the #102 TPM2-encryption-key arc. Before committing to the full seal/unseal pipeline (boot-time auto-unlock, sealed-blob persistence, recovery flows), I wanted you to be able to survey your fleet from the Hardware page and confirm which boxes can host the upcoming work. Detection only.

## Engine

\`HardwareSummary\` gains a \`tpm: Option<TpmInfo>\` field populated by reading \`/sys/class/tpm/tpm0/\`:

| Field | Source | Why it matters for #102 |
|---|---|---|
| \`version_major\` | \`tpm_version_major\` sysfs attr | 1 = TPM 1.2 (incompatible with the planned sealing flow); 2 = TPM 2.0 |
| \`rm_available\` | \`stat /dev/tpmrm0\` | The resource-manager char dev that \`tpm2-tools\` and any sealing path actually opens. Without it the chip exists but can't be used. |
| \`description\` | \`description\` sysfs attr | "Infineon SLB 9670" / "AMD fTPM" / etc., for human-readable display |
| \`manufacturer\` | \`tpm_vendor\` (modern) → \`manufacturer\` (older) | 4-char ASCII code fallback when \`description\` isn't populated |

\`None\` (vs. a populated \`TpmInfo\` with \`version_major=None\`) distinguishes "no TPM at all" — no chip, disabled in firmware, driver not loaded — from "TPM present but not usable for sealing." The UI cases differ.

Pure sysfs reads — no command spawns. The existing 60s \`HardwareSummary\` cache covers TPM info too (TPM presence doesn't flap at runtime).

## WebUI

\`types.ts\` mirrors the new shape; \`routes/hardware/+page.svelte\` gets a TPM card alongside the USB card. Four states:

| State | Render |
|---|---|
| \`tpm == null\` | "Not present" — no chip / disabled in firmware / driver missing |
| TPM 2.0 + \`rm_available\` | "TPM 2.0 · ready" (emerald) |
| TPM 2.0 + no /dev/tpmrm0 | "TPM 2.0 · no /dev/tpmrm0" (amber — chip there, RM dev missing) |
| TPM 1.x | "TPM 1.x · incompatible (need 2.0)" (amber) |

Vendor/model line underneath when sysfs exposes it.

## What this is NOT

- No seal / unseal code yet.
- No state-file changes.
- No \`fs.unlock_tpm\` RPC.
- No boot-time auto-unlock service.
- No tpm2-tools dependency added to \`systemPackages\`.

All of that lands in subsequent PRs as #102 progresses. This one's intentionally tiny so the per-box capability data is available to plan the next steps.

## Test plan

- [x] \`cargo check / clippy / fmt / test --workspace\` clean.
- [x] \`npm run check\` — 4880 files, 0 errors, 0 warnings.
- [ ] After deploy on @fenio's four NASty boxes: confirm the Hardware page TPM card matches what \`ls /sys/class/tpm/ && cat /sys/class/tpm/tpm0/tpm_version_major\` reports from the shell. Of the four, one is expected to land in the "TPM 2.0 · ready" state.