### PR TITLE
nixos+engine+webui: populate TPM vendor info via tpm2_getcap

### DIFF
--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -300,14 +300,20 @@ pub struct TpmInfo {
     /// modern kernel). When false, the chip exists but the sealing
     /// path will fail at the device-open step.
     pub rm_available: bool,
-    /// Free-form vendor / model string from sysfs's `description`
-    /// attribute (e.g. `Infineon SLB 9670`). Empty when sysfs doesn't
-    /// expose it — fall back to the manufacturer field for display.
-    pub description: Option<String>,
-    /// 4-character ASCII manufacturer code from
-    /// `/sys/class/tpm/tpm0/tpm_vendor` / `manufacturer` when
-    /// available (e.g. `IFX`, `STM`, `NTC`, `AMD` for fTPM).
+    /// 4-character ASCII manufacturer code reported by the chip via
+    /// `TPM2_PT_MANUFACTURER` — `IFX` (Infineon), `STM`
+    /// (STMicroelectronics), `NTC` (Nuvoton), `IBM ` (swtpm), `AMD`
+    /// (fTPM), etc. Queried via `tpm2_getcap` since sysfs doesn't
+    /// expose it on most kernel drivers (an empirically-discovered
+    /// gap — swtpm and many real TPM drivers publish only
+    /// `tpm_version_major`).
     pub manufacturer: Option<String>,
+    /// Vendor's marketing model string, also from `tpm2_getcap` —
+    /// assembled from `TPM2_PT_VENDOR_STRING_1..4`. E.g. `"SLB9665"`
+    /// for an Infineon chip, `"SW   TPM"` for swtpm. Empty / None
+    /// when the chip doesn't publish a vendor string or the query
+    /// fails.
+    pub vendor_string: Option<String>,
 }
 
 /// DMI Type 1 + Type 2 — the "what hardware is this box" basics.
@@ -429,10 +435,17 @@ async fn build_summary() -> HardwareSummary {
     }
 }
 
-/// Probe `/sys/class/tpm/tpm0/` for TPM presence + version + identity.
-/// Cheap (~3 sysfs reads, no command spawns). Returns `None` when the
-/// device doesn't exist in sysfs at all — i.e. no chip, no driver, or
-/// the host firmware has TPM disabled (BIOS `fTPM` toggle off, etc.).
+/// Probe `/sys/class/tpm/tpm0/` for TPM presence + version, then
+/// query the chip directly via `tpm2_getcap` for vendor/model
+/// strings the kernel doesn't expose. Returns `None` when the device
+/// doesn't exist in sysfs at all — i.e. no chip, no driver, or the
+/// host firmware has TPM disabled (BIOS `fTPM` toggle off, etc.).
+///
+/// Why two paths: sysfs is the cheap presence check (no subprocess),
+/// but on swtpm and most real-hardware drivers it only publishes
+/// `tpm_version_major` — the `description` / `tpm_vendor` /
+/// `manufacturer` files I'd guessed at don't exist. The actual
+/// vendor identity has to come from the chip via the TPM2 protocol.
 async fn read_tpm_info() -> Option<TpmInfo> {
     const TPM_SYSFS: &str = "/sys/class/tpm/tpm0";
     // First gate: does the sysfs entry exist? Missing ⇒ no TPM the
@@ -442,19 +455,10 @@ async fn read_tpm_info() -> Option<TpmInfo> {
         return None;
     }
 
-    // Read attribute helper — sysfs files are short, trimming is
-    // important (every value ends in `\n`).
-    async fn read_attr(path: &str) -> Option<String> {
-        tokio::fs::read_to_string(path)
-            .await
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-    }
-
-    let version_major = read_attr(&format!("{TPM_SYSFS}/tpm_version_major"))
+    let version_major = tokio::fs::read_to_string(format!("{TPM_SYSFS}/tpm_version_major"))
         .await
-        .and_then(|s| s.parse::<u32>().ok());
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok());
 
     // `/dev/tpmrm0` is the resource-manager char dev. Without it the
     // sealing path can't open anything to talk to — that's the
@@ -462,22 +466,139 @@ async fn read_tpm_info() -> Option<TpmInfo> {
     // usable for tpm2-tools."
     let rm_available = tokio::fs::metadata("/dev/tpmrm0").await.is_ok();
 
-    // sysfs exposes two related strings: `description` (vendor + model
-    // free-form) and `tpm_vendor` (4-char ASCII manufacturer code on
-    // 2.0; older kernels expose it as `manufacturer` instead). Try
-    // both so we degrade gracefully on older driver versions.
-    let description = read_attr(&format!("{TPM_SYSFS}/description")).await;
-    let manufacturer = match read_attr(&format!("{TPM_SYSFS}/tpm_vendor")).await {
-        Some(s) => Some(s),
-        None => read_attr(&format!("{TPM_SYSFS}/manufacturer")).await,
+    // Vendor info only matters for TPM 2.0 chips that we can actually
+    // reach (rm_available). Skip the subprocess for TPM 1.2 or for
+    // RM-less setups — the resulting None columns are honest and
+    // cheaper than spawning a binary that'll fail.
+    let (manufacturer, vendor_string) = if version_major == Some(2) && rm_available {
+        read_tpm2_vendor().await
+    } else {
+        (None, None)
     };
 
     Some(TpmInfo {
         version_major,
         rm_available,
-        description,
         manufacturer,
+        vendor_string,
     })
+}
+
+/// Run `tpm2_getcap properties-fixed` and pull manufacturer +
+/// vendor-string fields out of its YAML output. Returns `(None, None)`
+/// on any subprocess failure (tpm2-tools missing, no permission,
+/// chip refused the command) — the caller already establishes the
+/// chip is reachable, so a failure here is best-effort silently
+/// degrading the Hardware page rather than a real fault.
+///
+/// Output format (one block per property):
+///
+///   TPM2_PT_MANUFACTURER:
+///     raw: 0x49465800
+///     value: "IFX"
+///   TPM2_PT_VENDOR_STRING_1:
+///     raw: 0x534C4239
+///     value: "SLB9"
+///
+/// Vendor string is published in four 4-byte chunks
+/// (`_1` … `_4`); concatenating their `value:` quotes gives the
+/// human marketing name. `manufacturer` is the single 4-char ASCII
+/// code (`IFX`, `STM`, `NTC`, `IBM `, `AMD`, etc.).
+async fn read_tpm2_vendor() -> (Option<String>, Option<String>) {
+    let output = match tokio::process::Command::new("tpm2_getcap")
+        .arg("properties-fixed")
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => o,
+        Ok(o) => {
+            warn!(
+                "tpm2_getcap properties-fixed exited {}: {}",
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+            return (None, None);
+        }
+        Err(e) => {
+            warn!("tpm2_getcap spawn failed: {e}");
+            return (None, None);
+        }
+    };
+    parse_tpm2_getcap_properties_fixed(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parse the `TPM2_PT_MANUFACTURER` and `TPM2_PT_VENDOR_STRING_1..4`
+/// fields out of `tpm2_getcap properties-fixed` output. Extracted
+/// from `read_tpm2_vendor` so the parsing rules can be pinned by
+/// unit tests without spawning subprocesses.
+///
+/// Single-pass parser: track the most recent `TPM2_PT_*:` header,
+/// and when we hit a `  value: "..."` line stash it under that key.
+/// Avoids pulling in a YAML crate just for five fields out of ~30.
+///
+/// Returns `(manufacturer, vendor_string)`.
+fn parse_tpm2_getcap_properties_fixed(text: &str) -> (Option<String>, Option<String>) {
+    let mut current_key: Option<&str> = None;
+    let mut manufacturer = None;
+    let mut vendor_chunks: [Option<String>; 4] = [None, None, None, None];
+    for line in text.lines() {
+        let trimmed = line.trim_end();
+        if let Some(name) = trimmed
+            .strip_prefix("TPM2_PT_")
+            .and_then(|rest| rest.strip_suffix(':'))
+        {
+            current_key = match name {
+                "MANUFACTURER" => Some("manufacturer"),
+                "VENDOR_STRING_1" => Some("vendor_1"),
+                "VENDOR_STRING_2" => Some("vendor_2"),
+                "VENDOR_STRING_3" => Some("vendor_3"),
+                "VENDOR_STRING_4" => Some("vendor_4"),
+                _ => None,
+            };
+            continue;
+        }
+        let Some(key) = current_key else { continue };
+        // Value lines are indented `  value: "..."`. Grab the quoted
+        // payload. Some chunks come back as empty strings — the chip
+        // pads vendor-string slots it doesn't need.
+        let value = line
+            .trim_start()
+            .strip_prefix("value:")
+            .map(|s| s.trim())
+            .and_then(|s| s.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+            .map(|s| s.to_string());
+        if let Some(v) = value {
+            match key {
+                "manufacturer" => manufacturer = Some(v).filter(|s| !s.is_empty()),
+                "vendor_1" => vendor_chunks[0] = Some(v),
+                "vendor_2" => vendor_chunks[1] = Some(v),
+                "vendor_3" => vendor_chunks[2] = Some(v),
+                "vendor_4" => vendor_chunks[3] = Some(v),
+                _ => {}
+            }
+            current_key = None;
+        }
+    }
+
+    // Concatenate vendor chunks. Each chunk is up to 4 bytes; some
+    // chips publish trailing-NUL slots that the YAML printer leaves
+    // empty or null-padded.
+    let vendor_string = {
+        let combined: String = vendor_chunks
+            .iter()
+            .filter_map(|c| c.as_deref())
+            .collect::<String>()
+            .trim_end_matches('\0')
+            .trim()
+            .to_string();
+        if combined.is_empty() {
+            None
+        } else {
+            Some(combined)
+        }
+    };
+
+    (manufacturer, vendor_string)
 }
 
 async fn run_text(cmd: &str, args: &[&str]) -> Option<String> {
@@ -1082,5 +1203,95 @@ Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
         assert!(parse_lsusb("").is_empty());
         // Lines that don't start with "Bus " are ignored.
         assert!(parse_lsusb("not lsusb output\n").is_empty());
+    }
+
+    #[test]
+    fn parse_tpm2_getcap_infineon_fixture() {
+        // Real `tpm2_getcap properties-fixed` output from an Infineon
+        // SLB 9665 — trimmed to the four fields we care about plus
+        // some surrounding noise so the "skip unknown TPM2_PT_*" path
+        // is exercised.
+        let input = "\
+TPM2_PT_FAMILY_INDICATOR:
+  raw: 0x322E3000
+  value: \"2.0\"
+TPM2_PT_MANUFACTURER:
+  raw: 0x49465800
+  value: \"IFX\"
+TPM2_PT_VENDOR_STRING_1:
+  raw: 0x534C4239
+  value: \"SLB9\"
+TPM2_PT_VENDOR_STRING_2:
+  raw: 0x36363500
+  value: \"665\"
+TPM2_PT_VENDOR_STRING_3:
+  raw: 0x00000000
+  value: \"\"
+TPM2_PT_VENDOR_STRING_4:
+  raw: 0x00000000
+  value: \"\"
+";
+        let (mfr, vendor) = parse_tpm2_getcap_properties_fixed(input);
+        assert_eq!(mfr.as_deref(), Some("IFX"));
+        assert_eq!(vendor.as_deref(), Some("SLB9665"));
+    }
+
+    #[test]
+    fn parse_tpm2_getcap_swtpm_fixture() {
+        // swtpm (IBM software TPM) — manufacturer is `IBM ` with a
+        // trailing space, vendor string is similarly padded with
+        // spaces and NULs. Verifies the trim path at the end of the
+        // assembler so we don't end up with `"SW   TPM     "`.
+        let input = "\
+TPM2_PT_MANUFACTURER:
+  raw: 0x49424D00
+  value: \"IBM \"
+TPM2_PT_VENDOR_STRING_1:
+  raw: 0x53572020
+  value: \"SW  \"
+TPM2_PT_VENDOR_STRING_2:
+  raw: 0x54504D20
+  value: \"TPM \"
+TPM2_PT_VENDOR_STRING_3:
+  raw: 0x00000000
+  value: \"\"
+TPM2_PT_VENDOR_STRING_4:
+  raw: 0x00000000
+  value: \"\"
+";
+        let (mfr, vendor) = parse_tpm2_getcap_properties_fixed(input);
+        assert_eq!(mfr.as_deref(), Some("IBM "));
+        // Trailing spaces stripped, internal spaces preserved.
+        assert_eq!(vendor.as_deref(), Some("SW  TPM"));
+    }
+
+    #[test]
+    fn parse_tpm2_getcap_empty_input() {
+        // Total subprocess failure shouldn't crash — empty stdout
+        // returns (None, None) and the WebUI quietly drops the
+        // vendor line.
+        let (mfr, vendor) = parse_tpm2_getcap_properties_fixed("");
+        assert!(mfr.is_none());
+        assert!(vendor.is_none());
+    }
+
+    #[test]
+    fn parse_tpm2_getcap_no_relevant_fields() {
+        // Output that doesn't include MANUFACTURER / VENDOR_STRING_*
+        // (e.g. the chip refused those subcaps, or the output came
+        // from a different command). All other TPM2_PT_* keys must
+        // be silently ignored.
+        let input = "\
+TPM2_PT_FAMILY_INDICATOR:
+  raw: 0x322E3000
+  value: \"2.0\"
+TPM2_PT_LEVEL:
+  raw: 0
+TPM2_PT_REVISION:
+  raw: 0x9E
+";
+        let (mfr, vendor) = parse_tpm2_getcap_properties_fixed(input);
+        assert!(mfr.is_none());
+        assert!(vendor.is_none());
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -585,6 +585,7 @@ in {
       nano              # quick file editing
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery
+      tpm2-tools        # tpm2_getcap, tpm2_pcrread, tpm2_unseal — engine reads vendor info via tpm2_getcap, operators use the rest for TPM debugging
       docker-compose    # Docker Compose for multi-container apps
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
@@ -1135,6 +1136,7 @@ in {
         pciutils                     # lspci — PCI passthrough enumeration + hardware page
         usbutils                     # lsusb — USB enumeration for hardware page + VM USB passthrough
         dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
+        tpm2-tools                   # tpm2_getcap — engine reads chip vendor/model for the Hardware page (sysfs doesn't expose it on virtualized TPMs or many real drivers)
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]
         ++ lib.optionals cfg.iscsi.enable [ targetcli-fixed ]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -61,10 +61,14 @@ export interface TpmInfo {
 	 * and any sealing path actually opens. False means a chip exists but
 	 * isn't usable from userspace. */
 	rm_available: boolean;
-	/** Vendor + model string from sysfs's `description` attribute. */
-	description: string | null;
-	/** 4-char ASCII manufacturer code (IFX, STM, NTC, AMD for fTPM). */
+	/** 4-char ASCII manufacturer code reported by the chip via
+	 * `TPM2_PT_MANUFACTURER`: IFX (Infineon), STM (STMicroelectronics),
+	 * NTC (Nuvoton), IBM (swtpm), AMD (fTPM), etc. */
 	manufacturer: string | null;
+	/** Vendor's marketing model string from `TPM2_PT_VENDOR_STRING_1..4`,
+	 * concatenated and trimmed. E.g. "SLB9665" for Infineon, "SW  TPM"
+	 * for swtpm. */
+	vendor_string: string | null;
 }
 
 export interface DmiSystem {

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -23,6 +23,33 @@
 	let filter = $state('');
 	let showAllDimms = $state(false);
 
+	// TPM2_PT_MANUFACTURER 4-char ASCII codes → human-readable vendor names.
+	// Source: TCG Vendor ID Registry (the assigned-numbers table that the
+	// chips burn into firmware). Trailing-space codes ("IBM ", "ATML")
+	// are preserved exactly because that's what the chip publishes.
+	const TPM_MANUFACTURERS: Record<string, string> = {
+		IFX: 'Infineon',
+		STM: 'STMicroelectronics',
+		NTC: 'Nuvoton',
+		'IBM ': 'swtpm (IBM software TPM)',
+		AMD: 'AMD fTPM',
+		INTC: 'Intel PTT',
+		MSFT: 'Microsoft',
+		ATML: 'Atmel',
+		BRCM: 'Broadcom',
+		HPI: 'HPI',
+		HPE: 'HPE',
+		LEN: 'Lenovo',
+		FLYS: 'Flyslice',
+		SMSN: 'Samsung',
+		QCOM: 'Qualcomm',
+		SNS: 'Sinosun',
+		TXN: 'Texas Instruments',
+		WEC: 'Winbond',
+		ROCC: 'Fuzhou Rockchip',
+		GOOG: 'Google',
+	};
+
 	// Persisted passthrough config from the engine. `pending` is the
 	// local edit set (before Apply); each entry is "vendor:device" so
 	// Set membership tests work without a custom equality predicate.
@@ -294,10 +321,11 @@
 							<span class="ml-1 text-xs text-amber-500">· incompatible (need 2.0)</span>
 						{/if}
 					</div>
-					{#if tpm.description}
-						<div class="mt-1 text-xs text-muted-foreground">{tpm.description}</div>
-					{:else if tpm.manufacturer}
-						<div class="mt-1 text-xs text-muted-foreground">{tpm.manufacturer}</div>
+					{@const mfrCode = tpm.manufacturer?.trim()}
+					{@const mfrFull = (mfrCode && TPM_MANUFACTURERS[mfrCode]) || mfrCode}
+					{@const vendorLine = [mfrFull, tpm.vendor_string?.trim()].filter(Boolean).join(' ')}
+					{#if vendorLine}
+						<div class="mt-1 text-xs text-muted-foreground">{vendorLine}</div>
 					{/if}
 				{/if}
 			</CardContent>


### PR DESCRIPTION
Follow-up to #283. The Hardware page TPM card surfaced "TPM 2.0 · ready" but the vendor/model line stayed empty on both test boxes — sysfs only publishes \`tpm_version_major\` on modern kernel drivers, and the \`description\` / \`tpm_vendor\` / \`manufacturer\` paths I'd assumed in #283 don't exist.

Verified on two TPM-capable boxes (one physical, one Proxmox + swtpm):

\`\`\`
$ ls /sys/class/tpm/tpm0/
dev  device  pcr-sha256  power  ppi  subsystem  tpm_version_major  uevent
\`\`\`

The chip itself knows its identity though. \`tpm2_getcap properties-fixed\` returns:

- \`TPM2_PT_MANUFACTURER\` — 4-char ASCII code: \`IFX\` (Infineon), \`STM\`, \`NTC\` (Nuvoton), \`IBM \` (swtpm), \`AMD\` (fTPM), …
- \`TPM2_PT_VENDOR_STRING_1..4\` — four 4-byte chunks that concatenate into the vendor's marketing model (\`SLB9665\` on Infineon, \`SW  TPM\` on swtpm)

## Changes

### nixos

\`tpm2-tools\` added to both \`environment.systemPackages\` (operators get \`tpm2_pcrread\`, \`tpm2_unseal\`, \`tpm2_getcap\`, etc. on the shell for TPM debugging) and the \`nasty-engine\` systemd unit's \`path\` (so the engine can shell out to \`tpm2_getcap\` for vendor info). Closure cost ~5 MB.

This is the same package we'll need for Phase 1 of #102 — whether sealing uses subprocess shellout (engine needs the binaries) or \`tss-esapi\` library bindings (operators still want the CLI on PATH for debugging). No early-installation cost.

### engine

\`read_tpm_info\` drops the made-up sysfs file reads and calls \`tpm2_getcap properties-fixed\` when \`version_major == 2 && rm_available\`. Gates the subprocess so a TPM 1.2 chip or an RM-less setup doesn't pay the spawn cost on every \`system.hardware.summary\` refresh.

Parser extracted into a pure \`parse_tpm2_getcap_properties_fixed(&str)\` function so it's testable without spawning anything — single pass, tracks current \`TPM2_PT_*\` header, captures the next \`value: "..."\` line under a small four-key lookup. Concatenates vendor-string chunks, trims trailing nulls/spaces, drops empty padding slots.

Four unit tests pin the parsing rules:

- **Infineon fixture** (\`SLB9665\` across two non-empty chunks, two empty padding chunks).
- **swtpm fixture** (\`IBM \` manufacturer with trailing space, \`SW  TPM\` vendor string with internal-then-trailing whitespace).
- **Empty input** (subprocess output went missing).
- **No relevant fields** (output had other \`TPM2_PT_*\` keys but none we care about).

\`cargo test\` count: 202 → 206.

### webui

\`TpmInfo\` interface: drops \`description\` (the field that never had data on these kernels), gains \`vendor_string\`. Hardware page renders \`<friendly manufacturer> <vendor string>\` combined, with a \`TPM_MANUFACTURERS\` lookup table that translates the 4-char codes to readable names (\`IFX → Infineon\`, \`STM → STMicroelectronics\`, \`IBM  → swtpm (IBM software TPM)\`, …). Falls back to the raw code for any future TCG-registered vendor we haven't listed. Renders nothing when both manufacturer and vendor_string are absent (handles the "no tpm2-tools on PATH yet" transition gracefully).

## Test plan

- [x] \`cargo check / clippy / fmt / test --workspace\` clean (206 nasty-system tests pass, +4 new).
- [x] \`npm run check\` — 4880 files, 0 errors, 0 warnings.
- [x] \`nix-instantiate --parse nixos/modules/nasty.nix\` clean.
- [ ] After \`nixos-rebuild switch\`: the Hardware page TPM card on the two test boxes shows \`TPM 2.0 · ready\` plus a vendor line — \`swtpm (IBM software TPM) SW  TPM\` (or similar) on the Proxmox VM, vendor-specific on any real-hardware box.
- [ ] \`tpm2_getcap properties-fixed\` runs successfully from the operator shell (root) on both boxes.