### PR TITLE
storage: seal bcachefs encryption keys to TPM2

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2509,6 +2509,7 @@ dependencies = [
 name = "nasty-common"
 version = "0.0.8"
 dependencies = [
+ "base64 0.22.1",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -101,7 +101,7 @@ use nasty_sharing::smb::{CreateSmbShareRequest, SmbShare, UpdateSmbShareRequest}
 use nasty_storage::filesystem::{
     BlockDevice, CreateFilesystemRequest, DestroyFilesystemRequest, DeviceActionRequest,
     DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem, FsUsage,
-    ReconcileStatus, ScrubStatus, UpdateFilesystemOptionsRequest,
+    ReconcileStatus, ScrubStatus, TpmBindStatus, UpdateFilesystemOptionsRequest,
 };
 use nasty_storage::subvolume::{
     CloneSnapshotRequest, CreateSnapshotRequest, CreateSubvolumeRequest, DeleteSnapshotRequest,
@@ -545,6 +545,27 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
                     role: "any",
                     params: MethodParams::Literal("`{\"name\": string}`"),
                     result: Some(gen_schema::<FsUsage>(generator)),
+                },
+                Method {
+                    name: "fs.tpm.status",
+                    desc: "Report TPM2 host capability and per-filesystem bind state. `tpm_available` reflects whether `/dev/tpmrm0` is present; `bound` reflects whether a sealed-key blob exists for this filesystem.",
+                    role: "any",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<TpmBindStatus>(generator)),
+                },
+                Method {
+                    name: "fs.tpm.bind",
+                    desc: "Seal the filesystem's stored encryption key with the host TPM2 (PCR-7 bound). Writes the sealed blob next to the plaintext `.key`; the plaintext is retained as a recovery path until `fs.key.delete` is invoked. Errors when the host has no usable TPM2 or no stored `.key` exists.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<TpmBindStatus>(generator)),
+                },
+                Method {
+                    name: "fs.tpm.unbind",
+                    desc: "Remove the TPM2-sealed copy of the encryption key. The plaintext `.key` is unaffected. No-op success when no sealed blob exists.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"name\": string}`"),
+                    result: Some(gen_schema::<TpmBindStatus>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-common/Cargo.toml
+++ b/engine/nasty-common/Cargo.toml
@@ -12,6 +12,8 @@ tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 schemars.workspace = true
+base64.workspace = true
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cmd;
 pub mod jsonrpc;
 pub mod metrics_types;
 pub mod state;
+pub mod tpm;
 
 pub use jsonrpc::{Error as RpcError, ErrorCode, Notification, Request, Response};
 pub use state::{HasId, StateDir, load_singleton_or_recover};

--- a/engine/nasty-common/src/tpm.rs
+++ b/engine/nasty-common/src/tpm.rs
@@ -1,0 +1,389 @@
+//! TPM2 sealing primitives for the dataset-key auto-unlock flow (#102).
+//!
+//! Shells out to the `tpm2-tools` family — same shape as the rest of the
+//! engine's hardware integrations. The blob is bound to **PCR 7**
+//! (Secure Boot configuration) so:
+//!
+//!   - Kernel / initrd / bootloader / userspace updates still unseal —
+//!     none of those touch PCR 7.
+//!   - Booting alternate media, disabling Secure Boot, or moving the
+//!     drive to a different host voids the seal.
+//!
+//! The blob format on disk is a small JSON wrapper containing base64
+//! TPM2B_PUBLIC and TPM2B_PRIVATE bytes. The Storage Root primary used
+//! to load it is re-derived on every call from the owner hierarchy
+//! seed (deterministic per TPM until the chip is cleared) — we never
+//! persist a primary handle.
+
+use std::path::Path;
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// PCR selection the sealing policy binds to. PCR 7 is the Secure Boot
+/// state — keys, db, dbx, MOK — extended by EDK2/shim/grub during boot.
+/// Keep this stable: changing it invalidates every sealed blob on every
+/// host running NASty, with no migration path.
+pub const PCR_SELECTION: &str = "sha256:7";
+
+/// Schema version for the on-disk JSON. Bump if the field layout
+/// changes incompatibly; never reuse an old number.
+const BLOB_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum TpmError {
+    #[error("TPM2 not available on this host (/dev/tpmrm0 missing)")]
+    Unavailable,
+    #[error("tpm2-tools `{step}` failed: {message}")]
+    ToolFailed { step: &'static str, message: String },
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("sealed blob malformed: {0}")]
+    Blob(String),
+}
+
+/// On-disk wrapper around the raw TPM2 blobs. Stored next to the
+/// plaintext `.key` file as `<name>.tpm`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SealedBlob {
+    /// Format version of this struct — see [`BLOB_VERSION`].
+    pub version: u32,
+    /// PCR selection string the policy was built against
+    /// (e.g. `"sha256:7"`). Mirrored into the file so a future change
+    /// to [`PCR_SELECTION`] doesn't silently break already-sealed
+    /// blobs — we replay this exact selection during unseal.
+    pub pcrs: String,
+    /// TPM2B_PUBLIC, base64-standard.
+    pub pub_b64: String,
+    /// TPM2B_PRIVATE, base64-standard.
+    pub priv_b64: String,
+}
+
+/// Cheap usability check — does the kernel expose the TPM2 resource
+/// manager? If yes, tpm2-tools have a device to talk to. Doesn't
+/// verify the binaries exist; a missing tool surfaces as a clear
+/// `ToolFailed { step: "createprimary", … }` on the first seal/unseal.
+pub async fn is_available() -> bool {
+    tokio::fs::metadata("/dev/tpmrm0").await.is_ok()
+}
+
+/// Seal `plaintext` under a PCR-7 policy. The returned blob can be
+/// JSON-serialised to disk and later passed to [`unseal`].
+pub async fn seal_with_pcr7(plaintext: &[u8]) -> Result<SealedBlob, TpmError> {
+    if !is_available().await {
+        return Err(TpmError::Unavailable);
+    }
+
+    let dir = tempfile::tempdir()?;
+    let dir_path = dir.path();
+
+    let plaintext_path = dir_path.join("plain.bin");
+    tokio::fs::write(&plaintext_path, plaintext).await?;
+
+    let primary_ctx = dir_path.join("primary.ctx");
+    run_tool(
+        "createprimary",
+        &[
+            "tpm2_createprimary",
+            "-Q",
+            "-C",
+            "o",
+            "-G",
+            "ecc",
+            "-c",
+            path_str(&primary_ctx)?,
+        ],
+    )
+    .await?;
+
+    let session_ctx = dir_path.join("trial.ctx");
+    let policy_dat = dir_path.join("policy.dat");
+    run_tool(
+        "startauthsession",
+        &["tpm2_startauthsession", "-Q", "-S", path_str(&session_ctx)?],
+    )
+    .await?;
+    run_tool(
+        "policypcr",
+        &[
+            "tpm2_policypcr",
+            "-Q",
+            "-S",
+            path_str(&session_ctx)?,
+            "-l",
+            PCR_SELECTION,
+            "-L",
+            path_str(&policy_dat)?,
+        ],
+    )
+    .await?;
+    run_tool(
+        "flushcontext",
+        &["tpm2_flushcontext", "-Q", path_str(&session_ctx)?],
+    )
+    .await?;
+
+    let pub_path = dir_path.join("sealed.pub");
+    let priv_path = dir_path.join("sealed.priv");
+    run_tool(
+        "create",
+        &[
+            "tpm2_create",
+            "-Q",
+            "-C",
+            path_str(&primary_ctx)?,
+            "-u",
+            path_str(&pub_path)?,
+            "-r",
+            path_str(&priv_path)?,
+            "-L",
+            path_str(&policy_dat)?,
+            "-a",
+            "fixedtpm|fixedparent|adminwithpolicy",
+            "-i",
+            path_str(&plaintext_path)?,
+        ],
+    )
+    .await?;
+
+    let pub_bytes = tokio::fs::read(&pub_path).await?;
+    let priv_bytes = tokio::fs::read(&priv_path).await?;
+
+    let engine = base64::engine::general_purpose::STANDARD;
+    Ok(SealedBlob {
+        version: BLOB_VERSION,
+        pcrs: PCR_SELECTION.to_string(),
+        pub_b64: engine.encode(&pub_bytes),
+        priv_b64: engine.encode(&priv_bytes),
+    })
+}
+
+/// Unseal a blob previously produced by [`seal_with_pcr7`]. Fails if
+/// the PCR state at the time of the call doesn't match what the seal
+/// was bound to (e.g. Secure Boot disabled, host swapped, TPM cleared).
+pub async fn unseal(blob: &SealedBlob) -> Result<Vec<u8>, TpmError> {
+    if !is_available().await {
+        return Err(TpmError::Unavailable);
+    }
+    if blob.version != BLOB_VERSION {
+        return Err(TpmError::Blob(format!(
+            "unsupported blob version {} (expected {})",
+            blob.version, BLOB_VERSION
+        )));
+    }
+
+    let engine = base64::engine::general_purpose::STANDARD;
+    let pub_bytes = engine
+        .decode(&blob.pub_b64)
+        .map_err(|e| TpmError::Blob(format!("pub_b64: {e}")))?;
+    let priv_bytes = engine
+        .decode(&blob.priv_b64)
+        .map_err(|e| TpmError::Blob(format!("priv_b64: {e}")))?;
+
+    let dir = tempfile::tempdir()?;
+    let dir_path = dir.path();
+
+    let pub_path = dir_path.join("sealed.pub");
+    let priv_path = dir_path.join("sealed.priv");
+    tokio::fs::write(&pub_path, &pub_bytes).await?;
+    tokio::fs::write(&priv_path, &priv_bytes).await?;
+
+    let primary_ctx = dir_path.join("primary.ctx");
+    run_tool(
+        "createprimary",
+        &[
+            "tpm2_createprimary",
+            "-Q",
+            "-C",
+            "o",
+            "-G",
+            "ecc",
+            "-c",
+            path_str(&primary_ctx)?,
+        ],
+    )
+    .await?;
+
+    let sealed_ctx = dir_path.join("sealed.ctx");
+    run_tool(
+        "load",
+        &[
+            "tpm2_load",
+            "-Q",
+            "-C",
+            path_str(&primary_ctx)?,
+            "-u",
+            path_str(&pub_path)?,
+            "-r",
+            path_str(&priv_path)?,
+            "-c",
+            path_str(&sealed_ctx)?,
+        ],
+    )
+    .await?;
+
+    let session_ctx = dir_path.join("session.ctx");
+    run_tool(
+        "startauthsession",
+        &[
+            "tpm2_startauthsession",
+            "-Q",
+            "--policy-session",
+            "-S",
+            path_str(&session_ctx)?,
+        ],
+    )
+    .await?;
+    run_tool(
+        "policypcr",
+        &[
+            "tpm2_policypcr",
+            "-Q",
+            "-S",
+            path_str(&session_ctx)?,
+            "-l",
+            &blob.pcrs,
+        ],
+    )
+    .await?;
+
+    let session_arg = format!("session:{}", path_str(&session_ctx)?);
+    let plaintext = capture_tool(
+        "unseal",
+        &[
+            "tpm2_unseal",
+            "-c",
+            path_str(&sealed_ctx)?,
+            "-p",
+            &session_arg,
+        ],
+    )
+    .await?;
+
+    // Best-effort flush — the dir gets dropped right after but the
+    // TPM keeps the session slot until told otherwise. Failure here
+    // doesn't invalidate the unseal we already got.
+    let _ = run_tool(
+        "flushcontext",
+        &["tpm2_flushcontext", "-Q", path_str(&session_ctx)?],
+    )
+    .await;
+
+    Ok(plaintext)
+}
+
+/// Run a tpm2-tools invocation that returns no useful stdout. `step`
+/// is a short label used only for error messages; `cmd` is `[binary,
+/// ...args]`.
+async fn run_tool(step: &'static str, cmd: &[&str]) -> Result<(), TpmError> {
+    let (program, args) = cmd
+        .split_first()
+        .expect("run_tool called with empty cmd slice");
+    debug!(target: "nasty::tpm", "exec: {} {}", program, args.join(" "));
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| TpmError::ToolFailed {
+            step,
+            message: format!("spawn {program}: {e}"),
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        warn!(
+            target: "nasty::tpm",
+            "{program} exit {}: {stderr}",
+            output.status
+        );
+        return Err(TpmError::ToolFailed {
+            step,
+            message: format!("exit {}: {stderr}", output.status),
+        });
+    }
+    Ok(())
+}
+
+/// Same as [`run_tool`] but returns stdout bytes — used for
+/// `tpm2_unseal`, whose payload is the plaintext.
+async fn capture_tool(step: &'static str, cmd: &[&str]) -> Result<Vec<u8>, TpmError> {
+    let (program, args) = cmd
+        .split_first()
+        .expect("capture_tool called with empty cmd slice");
+    debug!(target: "nasty::tpm", "exec: {} {}", program, args.join(" "));
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| TpmError::ToolFailed {
+            step,
+            message: format!("spawn {program}: {e}"),
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        warn!(
+            target: "nasty::tpm",
+            "{program} exit {}: {stderr}",
+            output.status
+        );
+        return Err(TpmError::ToolFailed {
+            step,
+            message: format!("exit {}: {stderr}", output.status),
+        });
+    }
+    Ok(output.stdout)
+}
+
+fn path_str(p: &Path) -> Result<&str, TpmError> {
+    p.to_str()
+        .ok_or_else(|| TpmError::Blob(format!("non-utf8 path: {p:?}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sealed_blob_json_roundtrip() {
+        let blob = SealedBlob {
+            version: BLOB_VERSION,
+            pcrs: PCR_SELECTION.to_string(),
+            pub_b64: "AAEC".into(),
+            priv_b64: "AwQF".into(),
+        };
+        let json = serde_json::to_string(&blob).expect("serialize");
+        let back: SealedBlob = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.version, BLOB_VERSION);
+        assert_eq!(back.pcrs, PCR_SELECTION);
+        assert_eq!(back.pub_b64, "AAEC");
+        assert_eq!(back.priv_b64, "AwQF");
+    }
+
+    #[tokio::test]
+    async fn is_available_returns_bool_without_panic() {
+        // Just exercises the syscall — value depends on host.
+        let _ = is_available().await;
+    }
+
+    #[tokio::test]
+    async fn unseal_rejects_unsupported_version() {
+        let blob = SealedBlob {
+            version: 99,
+            pcrs: PCR_SELECTION.to_string(),
+            pub_b64: "AAEC".into(),
+            priv_b64: "AwQF".into(),
+        };
+        // Skip when /dev/tpmrm0 is missing — version check runs after
+        // the availability gate.
+        if !is_available().await {
+            return;
+        }
+        let err = unseal(&blob).await.expect_err("should reject");
+        match err {
+            TpmError::Blob(msg) => assert!(msg.contains("version"), "got: {msg}"),
+            other => panic!("expected Blob, got {other:?}"),
+        }
+    }
+}

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -122,6 +122,24 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
+        "fs.tpm.status" => match require_str(req, "name") {
+            Ok(name) => ok(req, state.filesystems.tpm_status(name).await),
+            Err(r) => r,
+        },
+        "fs.tpm.bind" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.tpm_bind(name).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "fs.tpm.unbind" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.tpm_unbind(name).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         "device.list" => match state.filesystems.list_devices().await {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -16,6 +16,13 @@ const FS_STATE_PATH: &str = "/var/lib/nasty/fs-state.json";
 const KEYS_DIR: &str = "/var/lib/nasty/keys";
 const PROC_KEYS_PATH: &str = "/proc/keys";
 
+/// Suffix for a TPM2-sealed copy of the encryption key (#102). Lives
+/// alongside the plaintext `.key` in [`KEYS_DIR`]; `read_unlock_key`
+/// prefers the sealed copy when both are present and falls back to
+/// the plaintext on unseal failure so a cleared TPM or Secure-Boot
+/// toggle can't strand the user.
+const TPM_SEALED_SUFFIX: &str = "tpm";
+
 /// Parse /proc/keys output and return true if the session keyring (or any
 /// keyring visible to this process) holds a `bcachefs:<uuid>` key.
 /// `bcachefs unlock -k session` lands the FS encryption key here; the kernel
@@ -79,6 +86,69 @@ fn parse_bcachefs_key_id(contents: &str, uuid: &str) -> Option<String> {
 async fn find_bcachefs_key_id(uuid: &str) -> Option<String> {
     let contents = tokio::fs::read_to_string(PROC_KEYS_PATH).await.ok()?;
     parse_bcachefs_key_id(&contents, uuid)
+}
+
+/// Resolve the auto-unlock material for filesystem `name`. Returns
+/// the raw passphrase bytes that should be fed to `bcachefs unlock`
+/// via stdin.
+///
+/// Resolution order (#102 — TPM2 sealing):
+///   1. `<KEYS_DIR>/<name>.tpm` — TPM-sealed blob, PCR-7 bound. We
+///      unseal it and use the result.
+///   2. `<KEYS_DIR>/<name>.key` — plaintext fallback. Kept around as
+///      the designated recovery path when binding to a TPM, and the
+///      only on-disk material for systems without TPM2.
+///   3. None — the caller must prompt for a passphrase.
+///
+/// A sealed blob that fails to unseal (TPM cleared, Secure Boot
+/// disabled, blob corrupt) is logged and treated as missing so the
+/// `.key` fallback kicks in. We do not surface the unseal error to
+/// the caller — a stale `.tpm` shouldn't block a mount that the
+/// `.key` would otherwise handle.
+async fn read_unlock_key(name: &str) -> Result<Option<Vec<u8>>, FilesystemError> {
+    let sealed_path = format!("{KEYS_DIR}/{name}.{TPM_SEALED_SUFFIX}");
+    if Path::new(&sealed_path).exists() {
+        match unseal_key_file(&sealed_path).await {
+            Ok(bytes) => return Ok(Some(bytes)),
+            Err(e) => warn!(
+                "TPM unseal for '{name}' at {sealed_path} failed ({e}); falling back to plaintext .key"
+            ),
+        }
+    }
+    let key_path = format!("{KEYS_DIR}/{name}.key");
+    if Path::new(&key_path).exists() {
+        let bytes = tokio::fs::read(&key_path).await.map_err(|e| {
+            FilesystemError::CommandFailed(format!("read key for '{name}' at {key_path}: {e}"))
+        })?;
+        return Ok(Some(bytes));
+    }
+    Ok(None)
+}
+
+async fn unseal_key_file(path: &str) -> Result<Vec<u8>, String> {
+    let data = tokio::fs::read(path)
+        .await
+        .map_err(|e| format!("read {path}: {e}"))?;
+    let blob: nasty_common::tpm::SealedBlob =
+        serde_json::from_slice(&data).map_err(|e| format!("parse {path}: {e}"))?;
+    nasty_common::tpm::unseal(&blob)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Pipe `key_bytes` into `bcachefs unlock` via stdin. The trailing
+/// newline matches the existing passphrase-stdin form — bcachefs
+/// reads up to the first newline as the passphrase.
+async fn bcachefs_unlock_with_key(device: &str, key_bytes: &[u8]) -> Result<(), FilesystemError> {
+    let mut stdin = Vec::with_capacity(key_bytes.len() + 1);
+    stdin.extend_from_slice(key_bytes);
+    if !key_bytes.ends_with(b"\n") {
+        stdin.push(b'\n');
+    }
+    cmd::run_ok_stdin("bcachefs", &["unlock", "-k", "session", device], &stdin)
+        .await
+        .map_err(FilesystemError::CommandFailed)?;
+    Ok(())
 }
 
 #[derive(Debug, Error)]
@@ -362,6 +432,16 @@ pub struct DeviceSetStateRequest {
     pub device: String,
     /// One of: rw, ro, failed, spare
     pub state: String,
+}
+
+/// Host + per-FS TPM2 bind state returned from `fs.tpm.status`,
+/// `fs.tpm.bind`, and `fs.tpm.unbind`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TpmBindStatus {
+    /// Host has a usable TPM 2.0 resource manager (`/dev/tpmrm0`).
+    pub tpm_available: bool,
+    /// A `<KEYS_DIR>/<name>.tpm` sealed blob exists for this filesystem.
+    pub bound: bool,
 }
 
 /// Detailed filesystem usage from `bcachefs fs usage`.
@@ -924,21 +1004,8 @@ impl FilesystemService {
 
         // Unlock encrypted filesystem before mounting
         if is_encrypted {
-            let key_path = format!("{KEYS_DIR}/{}.key", req.name);
-            if Path::new(&key_path).exists() {
-                cmd::run_ok(
-                    "bcachefs",
-                    &[
-                        "unlock",
-                        "-k",
-                        "session",
-                        "-f",
-                        &key_path,
-                        &req.devices[0].path,
-                    ],
-                )
-                .await
-                .map_err(FilesystemError::CommandFailed)?;
+            if let Some(bytes) = read_unlock_key(&req.name).await? {
+                bcachefs_unlock_with_key(&req.devices[0].path, &bytes).await?;
             } else if let Some(ref passphrase) = req.passphrase {
                 let stdin = format!("{passphrase}\n");
                 cmd::run_ok_stdin(
@@ -1107,12 +1174,12 @@ impl FilesystemService {
         let first_device = fs.devices.first().map(|d| d.path.as_str()).unwrap_or("");
 
         // Unlock encrypted filesystem before mounting. Three paths:
-        // 1. Stored key file exists (auto-unlock-on-boot setup) → use
-        //    it to load the key into the session keyring.
-        // 2. No stored key file BUT the keyring already has the key
-        //    (user clicked Unlock with a passphrase earlier this
-        //    session) → nothing to do, kernel will use the loaded
-        //    key when we call `bcachefs mount`.
+        // 1. Stored key (TPM-sealed `.tpm` or plaintext `.key`) exists
+        //    (auto-unlock-on-boot setup) → load it into the session
+        //    keyring via `bcachefs unlock`.
+        // 2. No stored key BUT the keyring already has the key (user
+        //    clicked Unlock with a passphrase earlier this session)
+        //    → nothing to do, kernel uses the loaded key at mount.
         // 3. Neither → genuinely locked, ask user to unlock first.
         //
         // Path 2 was missing before — a passphrase-unlocked FS would
@@ -1120,14 +1187,8 @@ impl FilesystemService {
         // the UI would show the FS as Unmounted (correctly: the
         // `locked` flag is keyring-aware) but Mount would fail.
         if opts.encrypted == Some(true) {
-            let key_path = format!("{KEYS_DIR}/{name}.key");
-            if Path::new(&key_path).exists() {
-                cmd::run_ok(
-                    "bcachefs",
-                    &["unlock", "-k", "session", "-f", &key_path, first_device],
-                )
-                .await
-                .map_err(FilesystemError::CommandFailed)?;
+            if let Some(bytes) = read_unlock_key(name).await? {
+                bcachefs_unlock_with_key(first_device, &bytes).await?;
             } else if !is_bcachefs_key_loaded(&fs.uuid).await {
                 return Err(FilesystemError::CommandFailed(format!(
                     "encrypted filesystem '{name}' is locked — unlock it first, then mount."
@@ -1246,6 +1307,84 @@ impl FilesystemService {
         tokio::fs::remove_file(&key_path).await.map_err(|e| {
             FilesystemError::CommandFailed(format!("delete key for '{name}' at {key_path}: {e}"))
         })
+    }
+
+    /// TPM2 bind status for filesystem `name`.
+    ///
+    /// `tpm_available` is the host capability (`/dev/tpmrm0` present);
+    /// `bound` is per-FS (a `<name>.tpm` sealed blob exists). The two
+    /// are independent — a host can lose its TPM (firmware downgrade,
+    /// chip swap) and still have a stale `.tpm` file from before.
+    pub async fn tpm_status(&self, name: &str) -> TpmBindStatus {
+        let sealed_path = format!("{KEYS_DIR}/{name}.{TPM_SEALED_SUFFIX}");
+        TpmBindStatus {
+            tpm_available: nasty_common::tpm::is_available().await,
+            bound: Path::new(&sealed_path).exists(),
+        }
+    }
+
+    /// Seal the stored plaintext key with the host TPM and write it
+    /// next to the existing `<name>.key` as `<name>.tpm`. The plaintext
+    /// `.key` is **kept** as a recovery path — wiping it is a separate
+    /// explicit step the user invokes via `delete_key` after they've
+    /// satisfied themselves the bind works.
+    ///
+    /// Errors when:
+    ///   - the host has no usable TPM2 (`/dev/tpmrm0` missing);
+    ///   - no plaintext `.key` exists to seal (caller must create the
+    ///     FS with `store_key=true` first);
+    ///   - the FS isn't encrypted at all (programming bug — surfaced
+    ///     so it doesn't silently no-op).
+    pub async fn tpm_bind(&self, name: &str) -> Result<TpmBindStatus, FilesystemError> {
+        let fs = self.get(name).await?;
+        if fs.options.encrypted != Some(true) {
+            return Err(FilesystemError::InvalidInput(format!(
+                "filesystem '{name}' is not encrypted"
+            )));
+        }
+        if !nasty_common::tpm::is_available().await {
+            return Err(FilesystemError::CommandFailed(
+                "TPM2 not available on this host".into(),
+            ));
+        }
+
+        let key_path = format!("{KEYS_DIR}/{name}.key");
+        let plaintext = tokio::fs::read(&key_path).await.map_err(|e| {
+            FilesystemError::CommandFailed(format!(
+                "no stored key for '{name}' at {key_path}: {e} — bind requires an existing .key"
+            ))
+        })?;
+
+        let blob = nasty_common::tpm::seal_with_pcr7(&plaintext)
+            .await
+            .map_err(|e| FilesystemError::CommandFailed(format!("tpm seal: {e}")))?;
+        let json = serde_json::to_vec_pretty(&blob)
+            .map_err(|e| FilesystemError::CommandFailed(format!("serialize sealed blob: {e}")))?;
+
+        let sealed_path = format!("{KEYS_DIR}/{name}.{TPM_SEALED_SUFFIX}");
+        tokio::fs::write(&sealed_path, &json)
+            .await
+            .map_err(|e| FilesystemError::CommandFailed(format!("write {sealed_path}: {e}")))?;
+        info!("Filesystem '{name}' key sealed to TPM at {sealed_path}");
+
+        Ok(self.tpm_status(name).await)
+    }
+
+    /// Remove the TPM-sealed copy of the key. The plaintext `.key`
+    /// (if present) is unaffected — auto-unlock continues working off
+    /// it. No-op (success) when no sealed blob exists.
+    pub async fn tpm_unbind(&self, name: &str) -> Result<TpmBindStatus, FilesystemError> {
+        let sealed_path = format!("{KEYS_DIR}/{name}.{TPM_SEALED_SUFFIX}");
+        match tokio::fs::remove_file(&sealed_path).await {
+            Ok(()) => info!("Filesystem '{name}' TPM seal removed ({sealed_path})"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(FilesystemError::CommandFailed(format!(
+                    "remove {sealed_path}: {e}"
+                )));
+            }
+        }
+        Ok(self.tpm_status(name).await)
     }
 
     /// Update runtime-mutable options on a mounted filesystem via sysfs.


### PR DESCRIPTION
Part one of #102. Adds a TPM2-bound storage path for the dataset encryption keys so an encrypted bcachefs filesystem can auto-unlock at boot without keeping the passphrase in cleartext on the boot disk.

## How it works
- A new sealing primitive in `nasty-common::tpm` shells out to `tpm2-tools` (same pattern as the rest of the engine's hardware integrations — no new C/FFI deps). The blob is bound to **PCR 7** (Secure Boot state): kernel/initrd/bootloader/userspace updates still unseal; disabling Secure Boot or moving the disk to another host doesn't.
- On disk: `<KEYS_DIR>/<name>.tpm` is a small JSON wrapper holding the base64-encoded `TPM2B_PUBLIC` and `TPM2B_PRIVATE` blobs, plus the PCR selection used.
- The unlock path (`mount`, and the unlock step right after `create`) now resolves the auto-unlock key in this order:
  1. `<name>.tpm` — unseal via TPM.
  2. `<name>.key` — plaintext fallback.
  3. None → caller must prompt for a passphrase.
- A sealed blob that fails to unseal is logged and treated as missing, so the `.key` fallback always kicks in. This means a cleared TPM / Secure-Boot toggle never strands the user; they keep the plaintext `.key` as the designated recovery path until they explicitly remove it via `fs.key.delete`.

## API
- `fs.tpm.status` — `{tpm_available, bound}`
- `fs.tpm.bind` — reads the existing `.key`, seals it, writes `.tpm`. Errors if the host has no usable TPM2 or no plaintext key exists yet.
- `fs.tpm.unbind` — removes the sealed blob; plaintext `.key` is untouched.

WebUI integration (bind/unbind button on the FS detail panel) is intentionally a separate change.

## Test plan
- [x] `cargo test -p nasty-common` — 24 passed (new `tpm::tests` exercise the JSON roundtrip and version gating)
- [x] `cargo test -p nasty-storage` — 25 passed
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p nasty-apidoc` produces an updated `docs/api.md` listing the three new methods
- [ ] Manual on a TPM2 host: `fs.tpm.bind` an encrypted FS, reboot, observe auto-unlock via the sealed blob; disable Secure Boot in firmware, reboot, observe graceful fallback to `.key`