### PR TITLE
update: default upgrade flow refreshes only the nasty input

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -400,8 +400,11 @@ echo "false" > {UPDATE_WEBUI_CHANGED}
 echo "==> Updating local system flake..."
 cd {NIXOS_FLAKE_DIR}
 cp {flake_temp_path} flake.nix
-nix flake update nixpkgs
-nix flake update bcachefs-tools
+# Only refresh the `nasty` input by default. Operators who want a
+# kernel / system bump pin nixpkgs and bcachefs-tools explicitly
+# via the Version page (system.version.switch RPC) — the upgrade
+# flow is NASty-only so a small release tag doesn't drag the whole
+# distro along with it.
 nix flake update nasty
 
 echo "==> Rebuilding system..."
@@ -634,17 +637,18 @@ echo "==> Update complete!"
                 )
             }
             ReleaseChannel::Nasty => (
-                // Refresh every flake input the wrapper owns, not just
-                // `nasty`. Without this, the weekly nixpkgs bump never
-                // reaches `main`-tracking users — they'd see only the
-                // new nasty commits while their kernel + system
-                // packages stayed pinned to whatever the wrapper's
-                // lock had at install time. Mirrors the tagged-release
-                // upgrade path which already refreshes all three.
+                // Only refresh the `nasty` input. We used to also pull
+                // fresh nixpkgs and bcachefs-tools here so main-tracking
+                // users would get the weekly nixpkgs bump, but that
+                // turned a "ship the latest NASty commits" click into
+                // an unscheduled distro upgrade — exactly the kind of
+                // surprise that ate a /boot's worth of space on more
+                // than one box. Operators who want a kernel / system
+                // bump pin those inputs explicitly via the Version
+                // page (system.version.switch RPC); for everyone else
+                // a small NASty bump now means a small NASty bump.
                 format!(
-                    "echo \"==> Updating wrapper flake inputs (nixpkgs, bcachefs-tools, nasty[{}])...\"\n\
-                     nix flake update nixpkgs\n\
-                     nix flake update bcachefs-tools\n\
+                    "echo \"==> Updating nasty input ({})...\"\n\
                      nix flake update nasty",
                     nasty_input.tracked_ref
                 ),


### PR DESCRIPTION
Both the tagged-release path (`upgrade_tagged_release`) and the Nasty-channel branch of `apply` used to `nix flake update` all three wrapper inputs — nixpkgs, bcachefs-tools, and nasty — on every click. That turned a \"ship the latest NASty commits\" gesture into an unscheduled distro upgrade. On one of my test boxes today it pulled a kernel bump alongside a small NASty release, the new initrd ran `/boot` out of space mid-`switch-to-configuration`, and the rollback story got more interesting than anyone wanted.

This PR drops the implicit refreshes. The default Upgrade button now only refreshes the `nasty` input — both for tagged-release upgrades and for Nasty-channel (main-tracking) builds.

Operators who *do* want a kernel/system bump still have the **Version** page (`system.version.switch` RPC), which is unchanged: it lets you pick which inputs to refresh and what URLs to point them at. That's the explicit path for distro upgrades from here on.

## Test plan
- [x] `cargo test -p nasty-system` — 210 passed
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: click Upgrade on a tagged-release box, confirm the journal shows only `==> Updating nasty input` (no `nixpkgs` / `bcachefs-tools` lines) and `flake.lock` only mutates the `nasty` node