### PR TITLE
update: show all three flake inputs + surface GitHub lookup errors

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -192,6 +192,21 @@ pub struct UpdateInfo {
     /// pointing at the target tag, which would otherwise make the check
     /// look like a no-op.
     pub last_attempt: Option<String>,
+    /// Human-readable explanation when the latest-version lookup failed
+    /// (GitHub unreachable, rate-limited, refused token, …). Populated
+    /// by `check()`; `version()` leaves it `None`. Surfaced in the UI
+    /// as an amber banner so operators don't see a silent dash when
+    /// GitHub is misbehaving — previously the failure mode was
+    /// indistinguishable from "no check has ever run".
+    pub error: Option<String>,
+    /// Snapshot of each tracked flake input (`nasty`, `nixpkgs`,
+    /// `bcachefs-tools`) — name, URL, locked rev. Embedded here so the
+    /// Version page can render all three pinned components in the
+    /// summary card without making a second RPC. None when the
+    /// engine can't read the local flake (parse error, fresh install
+    /// pre-bootstrap, etc); the UI falls back to the nasty rev alone
+    /// in that case.
+    pub inputs: Option<Vec<VersionInputInfo>>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -285,6 +300,8 @@ impl UpdateService {
             update_available: None,
             channel: read_channel().await,
             last_attempt: last_upgrade_attempt_result().await,
+            error: None,
+            inputs: self.version_info().await.ok().map(|v| v.inputs),
         }
     }
 
@@ -500,6 +517,15 @@ echo "==> Update complete!"
 
         // Mild/Spicy: find latest matching tag (v* or s*) on the configured repo.
         // Nasty: track the wrapper flake's configured branch/ref.
+        //
+        // We collect every failure into `lookup_error` so the UI can
+        // surface *why* the check came back empty instead of just
+        // dropping the user on a blank "Latest" column. Returning the
+        // sentinel string "unknown" (the previous behaviour) was
+        // indistinguishable from "this is a fresh box and check has
+        // never run", which is exactly the silent-failure mode the
+        // operator on nasty.0f.ee couldn't see through.
+        let mut lookup_error: Option<String> = None;
         let latest = match channel {
             ReleaseChannel::Mild | ReleaseChannel::Spicy => {
                 let pattern = channel.tag_pattern().unwrap(); // "v*" or "s*"
@@ -513,29 +539,44 @@ echo "==> Update complete!"
                 .await
                 {
                     Ok(tag) => tag,
-                    Err(_) => "unknown".to_string(),
-                }
-            }
-            ReleaseChannel::Nasty => {
-                match check_via_github_api_branch(
-                    &nasty_input.owner,
-                    &nasty_input.repo,
-                    &nasty_input.tracked_ref,
-                )
-                .await
-                {
-                    Ok(sha) => sha,
-                    Err(_) => {
-                        let token = read_github_token().await;
-                        check_via_git_ls_remote(
-                            token.as_deref(),
-                            &nasty_input.repo_url(),
-                            &format!("refs/heads/{}", nasty_input.tracked_ref),
-                        )
-                        .await?
+                    Err(e) => {
+                        warn!(target: "nasty::update", "tagged-release check failed: {e}");
+                        lookup_error = Some(e.to_string());
+                        "unknown".to_string()
                     }
                 }
             }
+            ReleaseChannel::Nasty => match check_via_github_api_branch(
+                &nasty_input.owner,
+                &nasty_input.repo,
+                &nasty_input.tracked_ref,
+            )
+            .await
+            {
+                Ok(sha) => sha,
+                Err(api_err) => {
+                    warn!(
+                        target: "nasty::update",
+                        "GitHub API branch check failed ({api_err}); falling back to git ls-remote",
+                    );
+                    let token = read_github_token().await;
+                    match check_via_git_ls_remote(
+                        token.as_deref(),
+                        &nasty_input.repo_url(),
+                        &format!("refs/heads/{}", nasty_input.tracked_ref),
+                    )
+                    .await
+                    {
+                        Ok(sha) => sha,
+                        Err(ls_err) => {
+                            warn!(target: "nasty::update", "git ls-remote also failed: {ls_err}");
+                            lookup_error =
+                                Some(format!("GitHub API: {api_err}; git ls-remote: {ls_err}"));
+                            "unknown".to_string()
+                        }
+                    }
+                }
+            },
         };
 
         // Strip "-dirty" suffix for comparison — the local build has a dirty
@@ -576,12 +617,16 @@ echo "==> Update complete!"
             available = Some(true);
         }
 
+        let inputs = self.version_info().await.ok().map(|v| v.inputs);
+
         Ok(UpdateInfo {
             current_version: current,
             latest_version: Some(latest),
             update_available: available,
             channel,
             last_attempt,
+            error: lookup_error,
+            inputs,
         })
     }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -530,6 +530,10 @@ export interface UpdateInfo {
 	channel: ReleaseChannel;
 	/** "success" | "failed" | null — result of the most recent upgrade-unit run. */
 	last_attempt: string | null;
+	/** Engine-side error message when the latest-version lookup failed (GH unreachable, rate-limited, …). */
+	error: string | null;
+	/** Snapshot of every tracked flake input — populated by both system.update.version and system.update.check. */
+	inputs: VersionInputInfo[] | null;
 }
 
 export interface VersionInputInfo {

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -10,6 +10,7 @@
 		FirmwareDevice,
 		FirmwareUpdateResult,
 		VersionInfo,
+		VersionInputInfo,
 		VersionTaggedReleaseStatus
 	} from '$lib/types';
 	import { Tag, Trash2, ArrowRightLeft, X, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
@@ -46,8 +47,11 @@
 		: 'version'
 	);
 
-	let info: UpdateInfo | null = $state(null);
-	let checkInfo: UpdateInfo | null = $state(null);
+	let info = $state<UpdateInfo | null>(null);
+	let checkInfo = $state<UpdateInfo | null>(null);
+	const summaryInputs: VersionInputInfo[] | null = $derived(
+		checkInfo?.inputs ?? info?.inputs ?? null
+	);
 	let checking = $state(false);
 	let startingDevUpgrade = $state(false);
 	let taggedReleaseBanner: TaggedReleaseBannerState = $state({ kind: 'loading' });
@@ -192,6 +196,21 @@
 			case 'nasty': return 'nasty';
 			default: return name;
 		}
+	}
+
+	/**
+	 * Pull the human-meaningful ref out of a `github:owner/repo/ref` URL.
+	 * For nixpkgs this lands on the branch name (`nixos-unstable`); for
+	 * bcachefs-tools on a tag (`v1.38.3`); for nasty on either depending
+	 * on channel. Fallback: the trailing path segment, or the raw URL
+	 * if we can't parse it (e.g. git+https forks). Used to fill the
+	 * "Tracking / Latest" column on the Current Version summary card.
+	 */
+	function trackingRef(url: string | null | undefined): string {
+		if (!url) return '—';
+		const match = url.match(/^github:[^/]+\/[^/]+\/(.+)$/);
+		if (match) return match[1];
+		return url;
 	}
 
 	function syncVersionRows(next: VersionInfo) {
@@ -560,6 +579,27 @@
 				</CardContent>
 			</Card>
 		{/if}
+		{#if checkInfo?.error}
+			<Card class="mb-4 border-amber-500/50 bg-amber-500/5">
+				<CardContent class="py-3">
+					<div class="flex items-start gap-3 text-sm">
+						<span class="mt-0.5 text-amber-400">⚠</span>
+						<div class="flex-1">
+							<div class="flex flex-wrap items-center justify-between gap-2">
+								<div class="font-medium text-amber-200">Couldn't reach GitHub</div>
+								<Button size="xs" variant="secondary" onclick={checkForUpdates} disabled={checking}>
+									{checking ? 'Retrying...' : 'Retry'}
+								</Button>
+							</div>
+							<p class="mt-1 break-words font-mono text-xs text-muted-foreground">{checkInfo.error}</p>
+							<p class="mt-2 text-muted-foreground">
+								The "Tracking / Latest" column shows the last successful check (may be stale).
+							</p>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+		{/if}
 		<Card class="mb-6">
 			<CardContent class="pt-6">
 				<div class="rounded-lg border border-border/60 text-sm">
@@ -574,41 +614,48 @@
 								{/if}
 							</div>
 							<div class="px-4 py-3">
-								<table class="text-sm">
+								<table class="w-full text-sm">
+									<thead>
+										<tr class="text-left text-[0.65rem] uppercase tracking-wide text-muted-foreground">
+											<th class="pb-1 pr-4 font-medium">Input</th>
+											<th class="pb-1 pr-4 font-medium">Locked</th>
+											<th class="pb-1 font-medium">Tracking / Latest</th>
+										</tr>
+									</thead>
 									<tbody>
-									<tr>
-										<td class="pr-4 text-muted-foreground">Installed</td>
-										<td class="font-mono font-semibold">{info?.current_version ?? '—'}</td>
-									</tr>
-									{#if isDevBuild}
-										<tr>
-											<td class="pr-4 text-muted-foreground">Available</td>
-											<td class="font-mono font-semibold">
-												{#if checkInfo?.update_available === true}
-													<span class="text-blue-400">{checkInfo.latest_version}</span>
-												{:else if checkInfo?.update_available === false}
-													<span class="text-muted-foreground">up to date</span>
-												{:else}
-													<span class="text-muted-foreground">—</span>
-												{/if}
-											</td>
-										</tr>
-									{:else}
-										<tr>
-											<td class="pr-4 text-muted-foreground">Latest</td>
-											<td class="font-mono font-semibold">
-												{#if taggedReleaseBanner.kind === 'ready'}
-													{#if taggedReleaseBanner.current_is_latest_standard_url}
-														<span class="text-muted-foreground">up to date</span>
-													{:else}
-														<span class="text-emerald-400">{taggedReleaseBanner.latest_tag}</span>
-													{/if}
-												{:else}
-													<span class="text-muted-foreground">—</span>
-												{/if}
-											</td>
-										</tr>
-									{/if}
+										{#if summaryInputs}
+											{#each summaryInputs as input}
+												<tr>
+													<td class="pr-4 align-top text-muted-foreground">{versionLabel(input.name)}</td>
+													<td class="pr-4 align-top font-mono font-semibold">{input.rev ?? '—'}</td>
+													<td class="align-top font-mono">
+														{#if input.name === 'nasty'}
+															{#if !isDevBuild && taggedReleaseBanner.kind === 'ready'}
+																{#if taggedReleaseBanner.current_is_latest_standard_url}
+																	{taggedReleaseBanner.latest_tag} <span class="text-xs text-muted-foreground">(up to date)</span>
+																{:else}
+																	<span class="text-emerald-400">{taggedReleaseBanner.latest_tag}</span> <span class="text-xs text-muted-foreground">(new)</span>
+																{/if}
+															{:else if isDevBuild && checkInfo?.update_available === true}
+																<span class="text-blue-400">{checkInfo.latest_version}</span>
+															{:else if isDevBuild && checkInfo?.update_available === false}
+																<span class="text-muted-foreground">{trackingRef(input.url)} <span class="text-xs">(up to date)</span></span>
+															{:else}
+																<span class="text-muted-foreground">{trackingRef(input.url)}</span>
+															{/if}
+														{:else}
+															<span class="text-muted-foreground">{trackingRef(input.url)}</span>
+														{/if}
+													</td>
+												</tr>
+											{/each}
+										{:else}
+											<tr>
+												<td class="pr-4 text-muted-foreground">nasty</td>
+												<td class="pr-4 font-mono font-semibold">{info?.current_version ?? '—'}</td>
+												<td class="font-mono text-muted-foreground">—</td>
+											</tr>
+										{/if}
 									</tbody>
 								</table>
 								<div class="mt-3 flex gap-2">


### PR DESCRIPTION
Two complaints driving this PR:

1. **The Current Version card showed only the nasty rev.** A NASty install is actually three pinned things — `nasty`, `nixpkgs`, and `bcachefs-tools` — but the operator had to expand the advanced Upstream drawer to see the other two. Now they're all on the summary card.
2. **`system.update.check` swallowed GitHub errors.** Every failure path mapped to the literal string `"unknown"` and `update_available = None`. On the WebUI side that's indistinguishable from \"no check has ever run\" — exactly the silent state we caught on `nasty.0f.ee` this morning, where 11s GitHub calls were happening with zero visibility.

## Engine
- `UpdateInfo` gains two fields: `inputs: Option<Vec<VersionInputInfo>>` (populated by both `version()` and `check()` so the summary card never needs a second RPC) and `error: Option<String>`.
- `check()` now keeps the underlying tag-lookup / GitHub API / git-ls-remote error strings instead of throwing them away, and `warn!`s each one so the journal has the cause when GitHub flakes.

## WebUI
- Current Version card replaced with a 3-row table: **Input · Locked · Tracking / Latest**.
   - The Latest cell stays empty for nixpkgs/bcachefs-tools (no automatic upstream comparison yet), but the URL ref (`nixos-unstable`, `v1.38.3`, …) gets pulled out via a small `trackingRef` helper so the column is still useful at a glance.
   - For `nasty` the cell shows the latest tag from `system.version.tagged_release_status` with an `(up to date)` / `(new)` annotation.
- New amber **\"Couldn't reach GitHub\"** banner, sibling to the existing \"Last upgrade attempt failed\" one. Carries the full engine error message and a Retry button that re-runs `system.update.check`.

## Test plan
- [x] `cargo test -p nasty-system` — 210 passed
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check`
- [ ] Manual on a box: confirm the new 3-row table renders correctly with all three inputs locked + their tracking refs
- [ ] Manual on `nasty.0f.ee` (or any box with slow GitHub): trigger Check for Updates, confirm the amber banner appears with the actual error message and the Retry button re-runs the check