### PR TITLE
update: opt-in bcachefs build-dir spillover for small-rootfs installs

### DIFF
--- a/engine/nasty-apidoc/src/main.rs
+++ b/engine/nasty-apidoc/src/main.rs
@@ -113,7 +113,8 @@ use nasty_system::network::NetworkConfig;
 use nasty_system::protocol::ProtocolStatus;
 use nasty_system::settings::{Settings, SettingsUpdate};
 use nasty_system::update::{
-    UpdateInfo, UpdateStatus, VersionInfo, VersionSwitchRequest, VersionTaggedReleaseStatus,
+    UpdateBuildDirConfig, UpdateInfo, UpdateStatus, VersionInfo, VersionSwitchRequest,
+    VersionTaggedReleaseStatus,
 };
 use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats};
 
@@ -303,6 +304,20 @@ fn methods(generator: &mut SchemaGenerator) -> Vec<(&'static str, Vec<Method>)> 
                     role: "any",
                     params: MethodParams::None,
                     result: Some(gen_schema::<UpdateStatus>(generator)),
+                },
+                Method {
+                    name: "system.update.build_dir.get",
+                    desc: "Return the configured Nix build-dir spillover path (if any) plus the live list of mounted bcachefs pools eligible to host the sandbox. Useful on small-rootfs installs where the default `/tmp` (tmpfs) doesn't have room for kernel-module / Rust compile sandboxes.",
+                    role: "any",
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateBuildDirConfig>(generator)),
+                },
+                Method {
+                    name: "system.update.build_dir.set",
+                    desc: "Set or clear the Nix build-dir spillover path. Pass `{\"path\": \"/fs/<pool>\"}` to enable (must match one of the mounted bcachefs pools reported by `build_dir.get`) or `{\"path\": null}` to disable. When set, the engine runs upgrade scripts with `NIX_REMOTE=local` and `--option build-dir <pool>/.nasty-nix-build` so the sandbox spills onto bcachefs instead of tmpfs/root.",
+                    role: "admin",
+                    params: MethodParams::Literal("`{\"path\": string | null}`"),
+                    result: Some(gen_schema::<UpdateBuildDirConfig>(generator)),
                 },
                 Method {
                     name: "system.version.get",

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -212,6 +212,7 @@ fn is_read_only(method: &str) -> bool {
                 | "service.base_names.get"
                 | "system.update.version"
                 | "system.update.status"
+                | "system.update.build_dir.get"
                 | "system.reboot_required"
                 | "system.generations.list"
                 | "system.version.get"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -513,6 +513,20 @@ pub(super) async fn try_route(
             }
         }
         "system.update.channel.get" => ok(req, state.updates.get_channel().await),
+        "system.update.build_dir.get" => ok(req, state.updates.get_update_build_dir().await),
+        "system.update.build_dir.set" => match parse_params::<serde_json::Value>(req) {
+            Ok(p) => {
+                let path = p
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                match state.updates.set_update_build_dir(path).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
+            Err(e) => invalid(req, e),
+        },
         "firmware.available" => ok(req, state.firmware.is_available().await),
         "firmware.devices" => ok(req, state.firmware.list_devices().await),
         "firmware.check" => ok(req, state.firmware.check_updates().await),

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -10,6 +10,15 @@ use tracing::{info, warn};
 
 /// Primary version path — writable by the update script, not managed by NixOS.
 const VERSION_PATH: &str = "/var/lib/nasty/version";
+/// File holding the operator-chosen path that upgrade scripts should
+/// use as Nix's `build-dir`. Empty or missing = default (sandbox lives
+/// on `/tmp` → tmpfs → root). When set, scripts run with
+/// `NIX_REMOTE=local` and `--option build-dir <path>` so the daemon is
+/// bypassed and the sandbox spills onto the configured path. The
+/// hard-won lesson from `nasty.fenski.pl` (`#293`-class disks): the
+/// option only takes effect in single-user mode; the daemon ignores
+/// client-side `--option build-dir`.
+const UPDATE_BUILD_DIR_PATH: &str = "/var/lib/nasty/update-build-dir";
 /// Fallback version path — baked in by NixOS at build time (may be a local SHA).
 const VERSION_PATH_FALLBACK: &str = "/etc/nasty-version";
 const UPDATE_UNIT: &str = "nasty-update";
@@ -111,6 +120,166 @@ pub async fn read_channel() -> ReleaseChannel {
 
 async fn write_channel(channel: ReleaseChannel) -> Result<(), std::io::Error> {
     tokio::fs::write(RELEASE_CHANNEL_PATH, channel.to_string()).await
+}
+
+/// Read the operator-chosen build-dir spillover path, if any. Trims
+/// whitespace and treats empty / missing as `None`.
+pub async fn read_update_build_dir() -> Option<String> {
+    let raw = tokio::fs::read_to_string(UPDATE_BUILD_DIR_PATH)
+        .await
+        .ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Persist the build-dir spillover path. `None` clears it (the file
+/// is removed so absence is the canonical "unset" state).
+pub async fn write_update_build_dir(path: Option<&str>) -> Result<(), std::io::Error> {
+    match path {
+        Some(p) => tokio::fs::write(UPDATE_BUILD_DIR_PATH, p).await,
+        None => match tokio::fs::remove_file(UPDATE_BUILD_DIR_PATH).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        },
+    }
+}
+
+/// Enumerate mounted bcachefs filesystems under `/fs/`. Used as the
+/// candidate list the WebUI offers in the build-dir dropdown — only
+/// bcachefs pools are surfaced because they're the only filesystems
+/// the engine guarantees are NASty-managed (we don't want to suggest
+/// the operator spill builds onto a random NFS mount they happened
+/// to bind under `/fs/`). Returns mount points (e.g. `/fs/first`),
+/// not the underlying devices.
+pub async fn list_bcachefs_pool_mounts() -> Vec<String> {
+    let content = match tokio::fs::read_to_string("/proc/mounts").await {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    parse_bcachefs_mounts(&content)
+}
+
+/// Pure parser for `/proc/mounts` rows. Each line has six
+/// space-separated columns: `<source> <mountpoint> <fstype> <options>
+/// <freq> <passno>`. We want column 2 where column 3 is `bcachefs`
+/// and column 2 starts with `/fs/`. Extracted so the parsing rules
+/// can be pinned by unit tests without touching the real /proc.
+fn parse_bcachefs_mounts(proc_mounts: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in proc_mounts.lines() {
+        let mut cols = line.split_whitespace();
+        let _source = cols.next();
+        let mountpoint = match cols.next() {
+            Some(m) => m,
+            None => continue,
+        };
+        let fstype = match cols.next() {
+            Some(f) => f,
+            None => continue,
+        };
+        if fstype == "bcachefs" && mountpoint.starts_with("/fs/") {
+            out.push(mountpoint.to_string());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Default subdirectory the spillover lands under so we never write
+/// to the root of a bcachefs pool that may host user data. Kept as a
+/// helper rather than a const so the rendered path is visible in the
+/// API surface (`<pool>/.nasty-nix-build`) and operators recognize it.
+fn build_dir_under_pool(pool: &str) -> String {
+    format!("{}/.nasty-nix-build", pool.trim_end_matches('/'))
+}
+
+/// Resolve the stored build-dir value into the actual path scripts
+/// should use. The stored value may be a bare pool mountpoint
+/// (`/fs/first`) or a fully-qualified spillover dir
+/// (`/fs/first/.nasty-nix-build`); the former is rewritten to the
+/// latter so `.nasty-nix-build` always wraps Nix's sandbox traffic.
+fn resolve_build_dir(stored: &str) -> String {
+    let trimmed = stored.trim();
+    if trimmed.contains("/.nasty-nix-build") || trimmed.ends_with("/.nasty-nix-build") {
+        trimmed.to_string()
+    } else {
+        build_dir_under_pool(trimmed)
+    }
+}
+
+/// Script fragments rendered into the upgrade bash template when a
+/// build-dir spillover is configured. All four strings are empty when
+/// no spillover is configured, so unconditional `{...}` interpolation
+/// stays a no-op for default installs.
+struct BuildDirFragments {
+    /// Multi-line bash block, run once before the rebuild, that
+    /// ensures the spillover directory exists with the strict 0755
+    /// perms Nix demands (it refuses world-writable build-dirs).
+    /// Empty when no spillover is configured.
+    setup: String,
+    /// Inline env prefix for the `nixos-rebuild` line, including the
+    /// trailing space — e.g. `"NIX_REMOTE=local "`. Empty otherwise.
+    /// Needed because client-side `--option build-dir` is only honored
+    /// in single-user mode; the daemon ignores it.
+    env_prefix: String,
+    /// CLI suffix for the `nixos-rebuild` line, including the leading
+    /// space — e.g. `" --option build-dir /fs/first/.nasty-nix-build"`.
+    opt_suffix: String,
+    /// Cleanup block run after the rebuild (regardless of outcome) to
+    /// reclaim the spillover space once the build is done. Empty
+    /// otherwise.
+    cleanup: String,
+}
+
+fn build_dir_fragments(stored: Option<&str>) -> BuildDirFragments {
+    match stored {
+        None => BuildDirFragments {
+            setup: String::new(),
+            env_prefix: String::new(),
+            opt_suffix: String::new(),
+            cleanup: String::new(),
+        },
+        Some(stored) => {
+            let path = resolve_build_dir(stored);
+            BuildDirFragments {
+                setup: format!(
+                    "echo \"==> Preparing build-dir spillover at {path}...\"\n\
+                     mkdir -p \"{path}\"\n\
+                     chmod 0755 \"{path}\"\n"
+                ),
+                env_prefix: "NIX_REMOTE=local ".to_string(),
+                opt_suffix: format!(" --option build-dir \"{path}\""),
+                cleanup: format!("rm -rf \"{path}\"/* 2>/dev/null || true\n"),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct UpdateBuildDirConfig {
+    /// Persisted spillover path (`None` = unset, builds use the
+    /// default `/tmp` → tmpfs → root path). Returned verbatim from
+    /// the on-disk setting, **not** the auto-resolved
+    /// `<pool>/.nasty-nix-build` derivation — the WebUI dropdown
+    /// stores pool roots, the engine resolves at script-render time.
+    pub path: Option<String>,
+    /// Mounted bcachefs pool roots under `/fs/` discovered live from
+    /// `/proc/mounts`. Used by the WebUI to populate the dropdown of
+    /// viable spillover targets. Empty on single-disk (mode-1)
+    /// installs that don't have a separate data pool — the feature
+    /// can't help those boxes and the UI hides the option.
+    pub available_pools: Vec<String>,
+    /// Resolved sandbox path the engine would actually pass to
+    /// `nixos-rebuild` (i.e. `<pool>/.nasty-nix-build`). Surfaced so
+    /// the WebUI can show operators where the spillover will land
+    /// without re-implementing the derivation rule.
+    pub resolved: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -398,6 +567,7 @@ impl UpdateService {
             .map_err(|e| UpdateError::CommandFailed(format!("write {flake_temp_path}: {e}")))?;
 
         let local_flake = local_flake();
+        let bd = build_dir_fragments(read_update_build_dir().await.as_deref());
         let script = format!(
             r#"#!/bin/bash
 set -euo pipefail
@@ -414,6 +584,7 @@ _PROXY_CONF_BEFORE=$(_proxy_conf)
 WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
 echo "false" > {UPDATE_WEBUI_CHANGED}
 
+{bd_setup}
 echo "==> Updating local system flake..."
 cd {NIXOS_FLAKE_DIR}
 cp {flake_temp_path} flake.nix
@@ -426,7 +597,8 @@ nix flake update nasty
 
 echo "==> Rebuilding system..."
 _RC=0
-NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake} || _RC=$?
+{bd_env}NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}{bd_opt} || _RC=$?
+{bd_cleanup}
 if [ "$_RC" -ne 0 ]; then
     echo
     echo "==> nixos-rebuild switch failed (exit $_RC)."
@@ -449,6 +621,10 @@ echo "{latest_tag}" > {VERSION_PATH}
 echo "==> Update complete!"
 "#,
             latest_tag = release_status.latest_tag,
+            bd_setup = bd.setup,
+            bd_env = bd.env_prefix,
+            bd_opt = bd.opt_suffix,
+            bd_cleanup = bd.cleanup,
         );
 
         let script_path = "/tmp/nasty-upgrade-tagged-release.sh";
@@ -510,6 +686,60 @@ echo "==> Update complete!"
             .map_err(|e| UpdateError::CommandFailed(format!("write channel: {e}")))?;
         info!("Release channel set to {}", channel.display_name());
         Ok(channel)
+    }
+
+    /// Snapshot the upgrade-script build-dir setting + the live list
+    /// of bcachefs pools the operator could spill to.
+    pub async fn get_update_build_dir(&self) -> UpdateBuildDirConfig {
+        let path = read_update_build_dir().await;
+        UpdateBuildDirConfig {
+            resolved: path.as_deref().map(resolve_build_dir),
+            path,
+            available_pools: list_bcachefs_pool_mounts().await,
+        }
+    }
+
+    /// Persist the operator's build-dir choice. The stored value is
+    /// validated lightly: it must be either `None` (unset) or one of
+    /// the currently-mounted bcachefs pool roots. We don't accept
+    /// arbitrary paths because the upgrade script will `chmod 0755`
+    /// the directory and clean it after the build — pointing it at
+    /// `/etc` would be a disaster.
+    pub async fn set_update_build_dir(
+        &self,
+        path: Option<String>,
+    ) -> Result<UpdateBuildDirConfig, UpdateError> {
+        if let Some(ref p) = path {
+            let trimmed = p.trim();
+            if trimmed.is_empty() {
+                write_update_build_dir(None)
+                    .await
+                    .map_err(|e| UpdateError::CommandFailed(format!("clear build-dir: {e}")))?;
+            } else {
+                let pools = list_bcachefs_pool_mounts().await;
+                if !pools.iter().any(|m| m == trimmed) {
+                    return Err(UpdateError::CommandFailed(format!(
+                        "build-dir must be one of the mounted bcachefs pools \
+                         ({}); got `{trimmed}`",
+                        if pools.is_empty() {
+                            "none currently mounted".to_string()
+                        } else {
+                            pools.join(", ")
+                        }
+                    )));
+                }
+                write_update_build_dir(Some(trimmed))
+                    .await
+                    .map_err(|e| UpdateError::CommandFailed(format!("write build-dir: {e}")))?;
+                info!("Update build-dir spillover set to {trimmed}");
+            }
+        } else {
+            write_update_build_dir(None)
+                .await
+                .map_err(|e| UpdateError::CommandFailed(format!("clear build-dir: {e}")))?;
+            info!("Update build-dir spillover cleared");
+        }
+        Ok(self.get_update_build_dir().await)
     }
 
     /// Check if an update is available by comparing local rev to GitHub
@@ -705,6 +935,7 @@ echo "==> Update complete!"
         };
 
         let local_flake = local_flake();
+        let bd = build_dir_fragments(read_update_build_dir().await.as_deref());
         let script = format!(
             r#"#!/bin/bash
 set -euo pipefail
@@ -724,6 +955,7 @@ _proxy_conf() {{
 }}
 _PROXY_CONF_BEFORE=$(_proxy_conf)
 WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
+{bd_setup}
 echo "==> Updating local system flake..."
 cd {LOCAL_REPO}
 {update_step}
@@ -733,7 +965,8 @@ cd {LOCAL_REPO}
 
 echo "==> Rebuilding system..."
 _RC=0
-NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake} || _RC=$?
+{bd_env}NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}{bd_opt} || _RC=$?
+{bd_cleanup}
 if [ "$_RC" -ne 0 ]; then
     echo
     echo "==> nixos-rebuild switch failed (exit $_RC)."
@@ -760,7 +993,11 @@ fi
 {installed_version_expr}
 
 echo "==> Update complete!"
-"#
+"#,
+            bd_setup = bd.setup,
+            bd_env = bd.env_prefix,
+            bd_opt = bd.opt_suffix,
+            bd_cleanup = bd.cleanup,
         );
 
         // Write script to a temp file
@@ -981,6 +1218,7 @@ echo "==> Update complete!"
             .join("\n");
 
         let local_flake = local_flake();
+        let bd = build_dir_fragments(read_update_build_dir().await.as_deref());
         let script = format!(
             r#"#!/bin/bash
 set -euo pipefail
@@ -997,6 +1235,7 @@ _PROXY_CONF_BEFORE=$(_proxy_conf)
 WEBUI_BEFORE=$([ -n "$_PROXY_CONF_BEFORE" ] && grep 'nasty-webui' "$_PROXY_CONF_BEFORE" 2>/dev/null | head -1 || echo "")
 echo "false" > {UPDATE_WEBUI_CHANGED}
 
+{bd_setup}
 echo "==> Updating local system flake..."
 cd {NIXOS_FLAKE_DIR}
 LOCK_BEFORE=$(sha256sum flake.lock 2>/dev/null | awk '{{print $1}}' || true)
@@ -1007,10 +1246,12 @@ LOCK_AFTER=$(sha256sum flake.lock 2>/dev/null | awk '{{print $1}}' || true)
 if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
     echo "==> Rebuilding system..."
     cp flake.lock flake.lock.pre-rebuild
-    if NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}; then
+    if {bd_env}NIXOS_INSTALL_BOOTLOADER=0 nixos-rebuild switch --flake {local_flake}{bd_opt}; then
         rm -f flake.lock.pre-rebuild
+        {bd_cleanup}
     else
         RC=$?
+        {bd_cleanup}
         echo "==> Rebuild failed (exit $RC). Restoring previous flake.lock so update can be retried."
         cp flake.lock.pre-rebuild flake.lock
         rm -f flake.lock.pre-rebuild
@@ -1034,7 +1275,11 @@ else
     echo "==> No flake.lock changes detected; skipping rebuild."
 fi
 echo "==> Update complete!"
-"#
+"#,
+            bd_setup = bd.setup,
+            bd_env = bd.env_prefix,
+            bd_opt = bd.opt_suffix,
+            bd_cleanup = bd.cleanup,
         );
 
         let script_path = "/tmp/nasty-version-switch.sh";
@@ -2616,6 +2861,83 @@ outputs = { nixpkgs, nasty, ... }: {
             classify_last_upgrade_attempt("failed", "timeout"),
             Some("failed")
         );
+    }
+
+    // ── build-dir spillover ────────────────────────────────────────
+
+    #[test]
+    fn parse_bcachefs_mounts_filters_to_fs_prefixed_bcachefs() {
+        // Realistic /proc/mounts excerpt with mixed fstypes. Only the
+        // two bcachefs rows under /fs/ should survive — the bcachefs
+        // mounted at /mnt/external is filtered out (we don't want to
+        // suggest random mountpoints as spillover targets), and the
+        // ext4/tmpfs/proc rows are noise.
+        let mounts = "\
+/dev/sda2 / ext4 rw,relatime 0 0\n\
+tmpfs /tmp tmpfs rw 0 0\n\
+proc /proc proc rw 0 0\n\
+/dev/sda3 /fs/first bcachefs rw,relatime 0 0\n\
+/dev/sdb1 /fs/archive bcachefs rw 0 0\n\
+/dev/sdc1 /mnt/external bcachefs rw 0 0\n\
+";
+        assert_eq!(
+            super::parse_bcachefs_mounts(mounts),
+            vec!["/fs/archive".to_string(), "/fs/first".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_bcachefs_mounts_returns_empty_when_no_bcachefs() {
+        let mounts = "/dev/sda2 / ext4 rw 0 0\ntmpfs /tmp tmpfs rw 0 0\n";
+        assert!(super::parse_bcachefs_mounts(mounts).is_empty());
+    }
+
+    #[test]
+    fn resolve_build_dir_appends_subdir_to_bare_pool() {
+        assert_eq!(
+            super::resolve_build_dir("/fs/first"),
+            "/fs/first/.nasty-nix-build"
+        );
+        assert_eq!(
+            super::resolve_build_dir("/fs/first/"),
+            "/fs/first/.nasty-nix-build"
+        );
+    }
+
+    #[test]
+    fn resolve_build_dir_passes_fully_qualified_path_through() {
+        // Already a spillover dir — don't double-wrap.
+        assert_eq!(
+            super::resolve_build_dir("/fs/first/.nasty-nix-build"),
+            "/fs/first/.nasty-nix-build"
+        );
+    }
+
+    #[test]
+    fn build_dir_fragments_are_empty_when_unset() {
+        let bd = super::build_dir_fragments(None);
+        assert!(bd.setup.is_empty());
+        assert!(bd.env_prefix.is_empty());
+        assert!(bd.opt_suffix.is_empty());
+        assert!(bd.cleanup.is_empty());
+    }
+
+    #[test]
+    fn build_dir_fragments_render_single_user_mode_when_set() {
+        // The empirically-proven combo: NIX_REMOTE=local + --option
+        // build-dir <path>. Anything else (TMPDIR alone, daemon-side
+        // build-dir, --option without single-user mode) was tested
+        // live on .59 and didn't actually divert sandbox traffic.
+        let bd = super::build_dir_fragments(Some("/fs/first"));
+        assert!(bd.setup.contains("/fs/first/.nasty-nix-build"));
+        assert!(bd.setup.contains("mkdir -p"));
+        assert!(bd.setup.contains("chmod 0755")); // Nix refuses world-writable build-dirs
+        assert_eq!(bd.env_prefix, "NIX_REMOTE=local ");
+        assert!(
+            bd.opt_suffix
+                .contains("--option build-dir \"/fs/first/.nasty-nix-build\"")
+        );
+        assert!(bd.cleanup.contains("rm -rf"));
     }
 
     // ── booted-generation comparison ───────────────────────────────

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -542,6 +542,15 @@ export interface VersionInputInfo {
 	rev: string | null;
 }
 
+export interface UpdateBuildDirConfig {
+	/** Persisted pool root (e.g. `/fs/first`); null when unset. */
+	path: string | null;
+	/** Mounted bcachefs pools discovered live from `/proc/mounts`. */
+	available_pools: string[];
+	/** Where the sandbox will actually land (`<pool>/.nasty-nix-build`). */
+	resolved: string | null;
+}
+
 export interface VersionInfo {
 	inputs: VersionInputInfo[];
 }

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -65,6 +65,7 @@
 	let startingSwitch = $state(false);
 	let startingUpgrade = $state(false);
 	let upstreamExpanded = $state(false);
+	let buildDirExpanded = $state(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	let logEl: HTMLPreElement | undefined = $state();
 	let logCollapsed = $state(true);
@@ -812,34 +813,53 @@
 				</div>
 
 				{#if buildDir && buildDir.available_pools.length > 0}
-					<div class="mt-3 rounded-lg border border-border/60 p-4">
-						<div class="mb-1 font-medium">Build space</div>
-						<p class="mb-3 text-xs text-muted-foreground">
-							Default is <code class="font-mono">/tmp</code> (tmpfs in RAM, spilling to root). On a 20&nbsp;GB-class rootfs that's often not enough room for a kernel/bcachefs build; pointing the sandbox at a bcachefs pool with headroom lets the upgrade complete. The engine runs the rebuild in single-user mode (<code class="font-mono">NIX_REMOTE=local</code>) with <code class="font-mono">--option build-dir &lt;pool&gt;/.nasty-nix-build</code> when this is set.
-						</p>
-						<div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-							<select
-								bind:value={buildDirDraft}
-								disabled={savingBuildDir || status?.state === 'running'}
-								class="h-9 flex-1 rounded-md border border-input bg-transparent px-2 text-sm"
-							>
-								<option value="">Default (tmpfs / root)</option>
-								{#each buildDir.available_pools as pool}
-									<option value={pool}>{pool}</option>
-								{/each}
-							</select>
-							<Button
-								size="sm"
-								onclick={saveBuildDir}
-								disabled={savingBuildDir || status?.state === 'running' || buildDirDraft === (buildDir.path ?? '')}
-							>
-								{savingBuildDir ? 'Saving...' : 'Save'}
-							</Button>
-						</div>
-						{#if buildDir.resolved}
-							<p class="mt-2 text-xs text-muted-foreground">
-								Active spillover: <code class="font-mono">{buildDir.resolved}</code>
-							</p>
+					<div class="mt-3 rounded-lg border border-border/60">
+						<button
+							onclick={() => { buildDirExpanded = !buildDirExpanded; }}
+							class="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-muted/20"
+						>
+							{#if buildDirExpanded}
+								<ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{:else}
+								<ChevronRight class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{/if}
+							<div class="flex-1">
+								<div class="font-medium">Recovery: build space override</div>
+								<div class="text-xs text-muted-foreground">
+									{#if buildDir.path}
+										Spillover active — sandbox lives on <code class="font-mono">{buildDir.resolved}</code>.
+									{:else}
+										Last-resort knob. Only useful when upgrades fail with ENOSPC on a tight rootfs.
+									{/if}
+								</div>
+							</div>
+						</button>
+
+						{#if buildDirExpanded}
+							<div class="space-y-3 border-t border-border/60 p-4">
+								<p class="text-xs text-muted-foreground">
+									Normally the Nix sandbox lives on <code class="font-mono">/tmp</code> (tmpfs in RAM, spilling to root) — that's where it belongs. <strong>Don't change this unless upgrades are failing with ENOSPC.</strong> When enabled, the engine runs the rebuild in single-user mode (<code class="font-mono">NIX_REMOTE=local</code>) with <code class="font-mono">--option build-dir &lt;pool&gt;/.nasty-nix-build</code> so the sandbox spills onto the chosen bcachefs pool. Trade-off: build is slower than tmpfs and writes wear on the pool's SSDs during every upgrade.
+								</p>
+								<div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+									<select
+										bind:value={buildDirDraft}
+										disabled={savingBuildDir || status?.state === 'running'}
+										class="h-9 flex-1 rounded-md border border-input bg-transparent px-2 text-sm"
+									>
+										<option value="">Default (tmpfs / root) — recommended</option>
+										{#each buildDir.available_pools as pool}
+											<option value={pool}>Spill to {pool}</option>
+										{/each}
+									</select>
+									<Button
+										size="sm"
+										onclick={saveBuildDir}
+										disabled={savingBuildDir || status?.state === 'running' || buildDirDraft === (buildDir.path ?? '')}
+									>
+										{savingBuildDir ? 'Saving...' : 'Save'}
+									</Button>
+								</div>
+							</div>
 						{/if}
 					</div>
 				{/if}

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -11,7 +11,8 @@
 		FirmwareUpdateResult,
 		VersionInfo,
 		VersionInputInfo,
-		VersionTaggedReleaseStatus
+		VersionTaggedReleaseStatus,
+		UpdateBuildDirConfig
 	} from '$lib/types';
 	import { Tag, Trash2, ArrowRightLeft, X, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
@@ -49,6 +50,9 @@
 
 	let info = $state<UpdateInfo | null>(null);
 	let checkInfo = $state<UpdateInfo | null>(null);
+	let buildDir = $state<UpdateBuildDirConfig | null>(null);
+	let buildDirDraft = $state<string>('');
+	let savingBuildDir = $state(false);
 	const summaryInputs: VersionInputInfo[] | null = $derived(
 		checkInfo?.inputs ?? info?.inputs ?? null
 	);
@@ -258,11 +262,14 @@
 
 	async function loadVersionPage() {
 		await withToast(async () => {
-			const [nextInfo, nextVersion] = await Promise.all([
+			const [nextInfo, nextVersion, nextBuildDir] = await Promise.all([
 				client.call<VersionInfo>('system.version.get'),
-				client.call<UpdateInfo>('system.update.version')
+				client.call<UpdateInfo>('system.update.version'),
+				client.call<UpdateBuildDirConfig>('system.update.build_dir.get')
 			]);
 			info = nextVersion;
+			buildDir = nextBuildDir;
+			buildDirDraft = nextBuildDir.path ?? '';
 			syncVersionRows(nextInfo);
 			if (readVersionPageAction() === 'version-switch') {
 				taggedReleaseBanner = { kind: 'switching' };
@@ -384,6 +391,23 @@
 			checkInfo = null;
 		}
 		checking = false;
+	}
+
+	async function saveBuildDir() {
+		savingBuildDir = true;
+		const next = await withToast(
+			() => client.call<UpdateBuildDirConfig>('system.update.build_dir.set', {
+				path: buildDirDraft || null
+			}),
+			buildDirDraft
+				? `Build spillover set to ${buildDirDraft}.`
+				: 'Build spillover disabled.'
+		);
+		if (next) {
+			buildDir = next;
+			buildDirDraft = next.path ?? '';
+		}
+		savingBuildDir = false;
 	}
 
 	async function upgradeDevBuild() {
@@ -786,6 +810,39 @@
 						</div>
 					{/if}
 				</div>
+
+				{#if buildDir && buildDir.available_pools.length > 0}
+					<div class="mt-3 rounded-lg border border-border/60 p-4">
+						<div class="mb-1 font-medium">Build space</div>
+						<p class="mb-3 text-xs text-muted-foreground">
+							Default is <code class="font-mono">/tmp</code> (tmpfs in RAM, spilling to root). On a 20&nbsp;GB-class rootfs that's often not enough room for a kernel/bcachefs build; pointing the sandbox at a bcachefs pool with headroom lets the upgrade complete. The engine runs the rebuild in single-user mode (<code class="font-mono">NIX_REMOTE=local</code>) with <code class="font-mono">--option build-dir &lt;pool&gt;/.nasty-nix-build</code> when this is set.
+						</p>
+						<div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+							<select
+								bind:value={buildDirDraft}
+								disabled={savingBuildDir || status?.state === 'running'}
+								class="h-9 flex-1 rounded-md border border-input bg-transparent px-2 text-sm"
+							>
+								<option value="">Default (tmpfs / root)</option>
+								{#each buildDir.available_pools as pool}
+									<option value={pool}>{pool}</option>
+								{/each}
+							</select>
+							<Button
+								size="sm"
+								onclick={saveBuildDir}
+								disabled={savingBuildDir || status?.state === 'running' || buildDirDraft === (buildDir.path ?? '')}
+							>
+								{savingBuildDir ? 'Saving...' : 'Save'}
+							</Button>
+						</div>
+						{#if buildDir.resolved}
+							<p class="mt-2 text-xs text-muted-foreground">
+								Active spillover: <code class="font-mono">{buildDir.resolved}</code>
+							</p>
+						{/if}
+					</div>
+				{/if}
 			</CardContent>
 		</Card>
 


### PR DESCRIPTION
NASty's mode-2 installer carves a 20 GiB ext4 root next to a much larger bcachefs data pool. That's enough room for one system closure but not for the temporary \"old + new + build sandbox\" peak a NixOS upgrade needs — kernel-module compiles routinely push past 13 GiB of `/nix/store` + `/tmp` churn and ENOSPC partway through. The 90+ GiB sitting idle on `/fs/<pool>` right next to it goes unused.

This PR adds an opt-in **\"Use bcachefs pool for upgrade build space\"** toggle in **System → Updates**. When set, the engine renders all three upgrade scripts (`upgrade_tagged_release`, the Nasty-channel branch of `apply`, and `version_switch`) with three extra fragments around the `nixos-rebuild` invocation:

```
mkdir -p <pool>/.nasty-nix-build && chmod 0755 <pool>/.nasty-nix-build
NIX_REMOTE=local nixos-rebuild switch ... --option build-dir <pool>/.nasty-nix-build
rm -rf <pool>/.nasty-nix-build/*   # after build returns, success or fail
```

Empirically validated by upgrading 10.10.10.59 — a box that ENOSPC'd three times in a row on its 20 GiB root — to v0.0.8 cleanly with `/fs/first` sitting next to it.

## Two non-obvious bits worth flagging

- **The daemon ignores client-side `--option build-dir`.** Setting it via `nix-daemon`'s env or via `NIX_CONFIG` does *not* propagate to builds in any version I tested. The spillover only catches sandbox traffic in **single-user mode**, which is why the engine prefixes `NIX_REMOTE=local`.
- **Nix refuses world-writable build-dirs** with `error: Path ... is world-writable or a symlink. That's not allowed for security.` The setup snippet explicitly `chmod 0755`s before invoking.

## Safety

The persisted path is validated against the live `/proc/mounts` list — only currently-mounted bcachefs pools under `/fs/` are accepted. The script's cleanup step then targets `<pool>/.nasty-nix-build/*`, never the pool root, so a misconfigured input can't wipe user data.

## API

| Method | Role | Returns |
| --- | --- | --- |
| `system.update.build_dir.get` | any | `{path, available_pools, resolved}` |
| `system.update.build_dir.set` | admin | same, after persisting `path` |

## Test plan

- [x] `cargo test -p nasty-system` — 216 passed (6 new tests covering the `/proc/mounts` parser, path resolution, and the rendered script fragments)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check`
- [x] **Live test on 10.10.10.59 today**: previously stuck box upgraded successfully end-to-end with the exact recipe encoded here
- [ ] Manual after merge: flip the toggle in WebUI on a box with a `/fs/*` pool, click Upgrade, observe `/fs/<pool>/.nasty-nix-build` grow while `/` stays mostly flat
- [ ] Manual: confirm the dropdown is *hidden* on a mode-1 single-disk install (no `/fs/*` mount) so the feature doesn't clutter inapplicable boxes