### PR TITLE
nixos/nasty-engine: add keyutils to PATH + pin TPM2 TCTI

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1136,7 +1136,8 @@ in {
         pciutils                     # lspci — PCI passthrough enumeration + hardware page
         usbutils                     # lsusb — USB enumeration for hardware page + VM USB passthrough
         dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
-        tpm2-tools                   # tpm2_getcap — engine reads chip vendor/model for the Hardware page (sysfs doesn't expose it on virtualized TPMs or many real drivers)
+        tpm2-tools                   # tpm2_getcap / tpm2_create / tpm2_unseal — Hardware page chip info + the PCR-7 seal/unseal flow for the bcachefs encryption key (#102)
+        keyutils                     # keyctl — fs.lock revokes the bcachefs unlock key from the kernel session keyring; without this the call fails with "No such file or directory" even though every other tool we shell out to is here
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]
         ++ lib.optionals cfg.iscsi.enable [ targetcli-fixed ]
@@ -1146,6 +1147,14 @@ in {
 
       environment = {
         RUST_LOG = cfg.engine.logLevel;
+        # Pin the TPM2 TCTI to /dev/tpmrm0. Without this every tpm2-tools
+        # invocation (Hardware page vendor probe, the seal/unseal flow
+        # for #102) prints a stderr stanza about failing to dlopen
+        # libtss2-tcti-tabrmd.so.0 — the userspace TPM resource-manager
+        # daemon NixOS doesn't ship — before falling through to the
+        # in-kernel RM. Setting TPM2TOOLS_TCTI cuts straight to /dev/tpmrm0
+        # and keeps the journal readable.
+        TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
       };
 
       serviceConfig = {


### PR DESCRIPTION
Two small papercuts spotted while validating the TPM2 seal flow (#102) on 10.10.10.71.

## 1. `fs.lock` is silently broken

The RPC fails with:

```
bcachefs command failed: failed to execute keyctl: No such file or directory (os error 2)
```

because `keyutils` isn't in the `nasty-engine.service` `PATH`, even though every other tool the engine shells out to is. The revocation step (`keyctl unlink <bcachefs key> @s`) is the entire point of the Lock action; without `keyctl` the engine can't revoke the key from the kernel session keyring and the Lock button silently does nothing useful.

Fix: add `keyutils` next to the other CLI deps in the engine's `path = with pkgs; [ ... ]` list.

## 2. tpm2-tools noise in the journal

Every tpm2-tools invocation — the Hardware page vendor probe, every `seal_with_pcr7` / `unseal` call on the engine's TPM path — prints a stderr stanza like:

```
ERROR:tcti:src/tss2-tcti/tctildr-dl.c:159:tcti_from_file() Could not initialize TCTI file: libtss2-tcti-tabrmd.so.0
```

before falling through to `/dev/tpmrm0` and continuing successfully. The dlopen target is the userspace TPM resource-manager daemon (`tpm2-abrmd`) which NixOS doesn't ship; we always use the in-kernel RM at `/dev/tpmrm0`. Pinning `TPM2TOOLS_TCTI=device:/dev/tpmrm0` cuts straight to it.

Fix: add `TPM2TOOLS_TCTI = \"device:/dev/tpmrm0\";` next to `RUST_LOG` in the engine unit's `environment` block.

## Test plan

- [x] Nix-syntax local eval (`nix flake check` equivalents in CI will catch syntax)
- [ ] Manual on 10.10.10.71 after deploy: `fs.lock` RPC succeeds and the kernel keyring loses the `bcachefs:<uuid>` entry
- [ ] Manual on 10.10.10.71: `tpm2_getcap properties-fixed` (run as the engine's user/env) emits no `tcti_from_file` / `libtss2-tcti-tabrmd.so.0` stderr