### PR TITLE
storage+webui: fix encrypted-FS boot mount hang + distinguish login failures

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1173,28 +1173,46 @@ impl FilesystemService {
 
         let first_device = fs.devices.first().map(|d| d.path.as_str()).unwrap_or("");
 
-        // Unlock encrypted filesystem before mounting. Three paths:
+        // Unlock decision matrix:
         // 1. Stored key (TPM-sealed `.tpm` or plaintext `.key`) exists
-        //    (auto-unlock-on-boot setup) → load it into the session
-        //    keyring via `bcachefs unlock`.
+        //    → load it into the session keyring via `bcachefs unlock`.
+        //    The key file's existence is itself the authoritative
+        //    signal that this filesystem is encrypted; opts.encrypted
+        //    is unreliable at boot (see below) and we must NOT gate
+        //    on it.
         // 2. No stored key BUT the keyring already has the key (user
         //    clicked Unlock with a passphrase earlier this session)
         //    → nothing to do, kernel uses the loaded key at mount.
-        // 3. Neither → genuinely locked, ask user to unlock first.
+        //    Path 2 was missing before — a passphrase-unlocked FS would
+        //    hit the else-error even though the keyring was ready.
+        // 3. Encrypted but neither key file nor keyring entry exists
+        //    → genuinely locked, ask user to unlock first.
         //
-        // Path 2 was missing before — a passphrase-unlocked FS would
-        // hit the else-error even though the keyring was ready, and
-        // the UI would show the FS as Unmounted (correctly: the
-        // `locked` flag is keyring-aware) but Mount would fail.
-        if opts.encrypted == Some(true) {
-            if let Some(bytes) = read_unlock_key(name).await? {
-                bcachefs_unlock_with_key(first_device, &bytes).await?;
-            } else if !is_bcachefs_key_loaded(&fs.uuid).await {
-                return Err(FilesystemError::CommandFailed(format!(
-                    "encrypted filesystem '{name}' is locked — unlock it first, then mount."
-                )));
-            }
-        }
+        // Why key-file-presence is the source of truth, not opts.encrypted:
+        // `opts` is derived from `bcachefs show-super` at runtime, but
+        // show-super needs the encrypted superblock decrypted to report
+        // its options — and that requires the key to already be in the
+        // keyring. At boot the key isn't loaded yet, show-super fails
+        // with "error reading passphrase", and we report defaults
+        // (i.e. opts.encrypted = None). Gating the unlock branch on
+        // `opts.encrypted == Some(true)` therefore SKIPS the auto-unlock
+        // at boot for every encrypted FS, and `bcachefs mount` falls
+        // through to its built-in `systemd-ask-password` prompt which
+        // blocks for 90 s until systemd kills the engine for hitting
+        // TimeoutStartSec. Live regression on 10.10.10.71 after a
+        // reboot; trivial to reproduce on any encrypted FS whose
+        // fs-state.json doesn't carry `encrypted: true` (e.g. ones
+        // created by an older NASty before the field was persisted).
+        let unlocked_via_key_file = if let Some(bytes) = read_unlock_key(name).await? {
+            bcachefs_unlock_with_key(first_device, &bytes).await?;
+            true
+        } else if opts.encrypted == Some(true) && !is_bcachefs_key_loaded(&fs.uuid).await {
+            return Err(FilesystemError::CommandFailed(format!(
+                "encrypted filesystem '{name}' is locked — unlock it first, then mount."
+            )));
+        } else {
+            false
+        };
 
         let device_arg = fs
             .devices
@@ -1217,10 +1235,20 @@ impl FilesystemService {
             warn!("Failed to set I/O scheduler: {e}");
         }
 
-        // Track mount state with identity info for boot reconciliation
+        // Track mount state with identity info for boot reconciliation.
+        // If we successfully unlocked via a stored key, force the
+        // persisted `encrypted` flag to true: opts.encrypted may have
+        // been None (e.g. older NASty versions didn't always persist
+        // it, or a previous boot's show-super failed and the recorded
+        // value got cleared), and we want next boot's auto-unlock
+        // branch to have the right signal without depending on a
+        // possibly-failing show-super.
         let mut saved_opts = opts.clone();
         saved_opts.uuid = Some(fs.uuid.clone());
         saved_opts.devices = fs.devices.iter().map(|d| d.path.clone()).collect();
+        if unlocked_via_key_file {
+            saved_opts.encrypted = Some(true);
+        }
         save_fs_mounted_with_opts(name, saved_opts).await;
 
         self.invalidate_list_cache().await;

--- a/webui/src/lib/auth.ts
+++ b/webui/src/lib/auth.ts
@@ -5,19 +5,55 @@
 // JS-visible token to thread through requests.
 
 export async function login(username: string, password: string): Promise<void> {
-	const res = await fetch('/api/login', {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ username, password }),
-	});
-
-	if (!res.ok) {
-		const body = await res.json().catch(() => ({}));
-		throw new Error(body.error || 'Login failed');
+	let res: Response;
+	try {
+		res = await fetch('/api/login', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ username, password }),
+		});
+	} catch (e) {
+		// Network-layer failure (DNS, TLS, server unreachable) — the
+		// browser couldn't even get a response. Distinct from a 5xx
+		// because nothing on the other end answered at all.
+		const msg = e instanceof Error ? e.message : String(e);
+		throw new Error(`Can't reach server: ${msg}`);
 	}
-	// Token is in the response body (for CLI tools that don't have a cookie
-	// jar) but the WebUI doesn't read it — the Set-Cookie header is the
-	// source of truth for the browser.
+
+	if (res.ok) {
+		// Token is in the response body (for CLI tools that don't have
+		// a cookie jar) but the WebUI doesn't read it — the Set-Cookie
+		// header is the source of truth for the browser.
+		return;
+	}
+
+	// Map status classes onto messages an operator can act on. Without
+	// this split, an engine that's down/timing out looked identical to
+	// a typo'd password — both surfaced as a bare "Login failed."
+	if (res.status >= 500) {
+		throw new Error(
+			`NASty engine unavailable (HTTP ${res.status}). The backend isn't responding — check 'systemctl status nasty-engine' on the box.`
+		);
+	}
+	if (res.status === 503 || res.status === 504) {
+		// Caddy uses these when the upstream is unreachable / slow.
+		// (Covered by the >=500 branch above too, but keep the specific
+		// hint for the common gateway cases.)
+		throw new Error(`NASty engine isn't accepting requests yet (HTTP ${res.status}). Retry in a moment.`);
+	}
+
+	// 4xx — the request reached the engine and was refused. Honor the
+	// engine's error message when present (e.g. "invalid credentials"),
+	// otherwise fall back to a status-aware default.
+	const body = await res.json().catch(() => ({}));
+	const detail = (body as { error?: string }).error;
+	if (detail) {
+		throw new Error(detail);
+	}
+	if (res.status === 401 || res.status === 403) {
+		throw new Error('Invalid username or password.');
+	}
+	throw new Error(`Login failed (HTTP ${res.status}).`);
 }
 
 export async function logout(): Promise<void> {


### PR DESCRIPTION
Two fixes from chasing #102's reboot validation on 10.10.10.71.

## storage: source-of-truth for \"this FS needs unlock\" is the key file

The mount path gated the auto-unlock branch on `opts.encrypted == Some(true)`. That's read from `fs-state.json`, and the entry can lose `encrypted` two ways:

1. **`bcachefs show-super` fails when the key isn't loaded yet.** At boot the key isn't in the keyring, show-super returns `error reading passphrase`, the engine reports defaults (`encrypted = None`), and any subsequent state write persists `None`.
2. **`save_fs_unmounted` removes the entire state entry.** Filed as a separate fix in a follow-up PR — for now: an unmount/mount cycle clears `encrypted` (and every other tuned mount option), and the next mount runs with `FsMountOptions::default()`.

Either path lands on `opts.encrypted = None` → **unlock branch silently skipped** → `bcachefs mount` falls through to its built-in `systemd-ask-password` prompt → blocks 90 s → systemd hits `TimeoutStartSec` and kills the engine. Live regression on 10.10.10.71 after a fresh-yesterday encrypted FS went through one unmount/mount cycle.

**Key fix**: presence of a `.key` or `.tpm` file in `KEYS_DIR` is itself the authoritative signal that the FS is encrypted and we have its unlock material. Gate on file presence, not on the (boot-unreliable) `opts.encrypted`. The \"encrypted + no key + no keyring entry → error\" branch is preserved for the genuine \"user must enter passphrase\" case.

**Belt-and-suspenders**: when a successful unlock comes from a key file, force `encrypted: Some(true)` into the persisted state so stale state heals on the next save.

## webui: distinguish \"engine down\" from \"wrong password\" on login

Login UX collapsed both into a bare \"Login failed\" — surfaced when the .71 engine was timing out at boot, leaving no hint that the backend was the problem rather than a typo. Map status classes onto actionable messages:

| Status | Message |
| --- | --- |
| network error | `Can't reach server: <reason>` |
| 5xx | `NASty engine unavailable (HTTP <n>). The backend isn't responding — check 'systemctl status nasty-engine' on the box.` |
| 401 / 403 | `Invalid username or password` (or the engine's specific error string from the body when present) |
| Other 4xx | `Login failed (HTTP <n>)` |

## Follow-ups (separate PRs)

- The `save_fs_unmounted` behaviour (\"unmount wipes all tuned options\") is its own bug, fix in flight.
- Engine startup blocking on filesystem mounts is a broader architectural fix — one stuck FS shouldn't take the whole API down for 90 s.

## Test plan

- [x] `cargo test -p nasty-storage` — 25 passed
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check`
- [x] **Root cause confirmed live** on 10.10.10.71: `fs-state.json` lacked `\"encrypted\": true` after our remount test, `bcachefs show-super` returned `error reading passphrase`, mount hung on `systemd-ask-password`
- [ ] Manual on .71 after merge + deploy: reboot, observe `/fs/first` auto-mount without 90 s timeout, fs-state.json gets backfilled with `encrypted: true` on the next mount
- [ ] Manual: stop nasty-engine, try to log into the WebUI, observe the new \"engine unavailable\" message instead of the old \"Login failed\"