### PR TITLE
engine: per-phase boot status tracker + /api/boot_status REST endpoint

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bollard",
+ "chrono",
  "futures-util",
  "http",
  "nasty-apps",

--- a/engine/nasty-engine/Cargo.toml
+++ b/engine/nasty-engine/Cargo.toml
@@ -37,6 +37,7 @@ tokio-util = { workspace = true, features = ["io"] }
 openidconnect = { version = "4", default-features = false, features = ["accept-rfc3339-timestamps", "accept-string-booleans"] }
 http = "1"
 url = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 
 [dev-dependencies]
 # `test-util` enables tokio::time::pause/start_paused for fs_lock's

--- a/engine/nasty-engine/src/boot_status.rs
+++ b/engine/nasty-engine/src/boot_status.rs
@@ -1,0 +1,331 @@
+//! Per-phase boot status tracker shared between `main`'s restoration
+//! sequence and the `/api/boot_status` REST endpoint.
+//!
+//! Part of #299. PR 1 made each startup phase non-fatal by wrapping
+//! it in a `tokio::time::timeout`. This module captures the result
+//! of each phase in a snapshot the WebUI can poll **without
+//! authenticating** so it can render the "NASty is starting up"
+//! overlay on the login screen — exactly when the engine isn't yet
+//! ready to accept logins. After READY fires the same snapshot is
+//! the source of truth for "did anything go wrong at boot" badges
+//! in the dashboard.
+
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tracing::{error, info};
+
+/// Per-phase lifecycle state. The WebUI maps these to icons (clock /
+/// spinner / check / cross) on the boot screen and on dashboard
+/// badges. Order matters: `Pending → Running → {Ok | Failed}` is
+/// the only legal transition path; nothing un-finishes.
+#[derive(Debug, Clone, Copy, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PhaseState {
+    /// Hasn't started yet. All phases begin here when the tracker
+    /// is built so the WebUI sees the complete checklist even
+    /// before the engine has visited any of them.
+    Pending,
+    /// Currently executing.
+    Running,
+    /// Completed within its budget without an error.
+    Ok,
+    /// Hit its `tokio::time::timeout` ceiling, or — if we ever wire
+    /// in panic capture — crashed. The `error` field carries the
+    /// reason for display in the UI.
+    Failed,
+}
+
+/// One row in the boot checklist. Timestamps are milliseconds since
+/// the engine process started — chosen over wall-clock so the UI
+/// renders the same `1.2 s` regardless of system clock skew, and
+/// because `Instant` already gives us a monotonic baseline that's
+/// trivial to subtract.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BootPhase {
+    /// Machine-readable name (`filesystems.restore_mounts`, etc.).
+    /// Stable across releases so the WebUI can attach phase-specific
+    /// remediation hints (e.g. "click for the Storage tab") by name.
+    pub name: String,
+    pub state: PhaseState,
+    /// Milliseconds since process start when this phase entered
+    /// `Running`. `None` while `Pending`.
+    pub started_at_ms: Option<u64>,
+    /// Milliseconds since process start when this phase transitioned
+    /// to `Ok` or `Failed`. `None` while `Pending` or `Running`.
+    pub finished_at_ms: Option<u64>,
+    /// `finished_at_ms - started_at_ms` once the phase completes.
+    /// Convenience field so the UI doesn't have to subtract.
+    pub duration_ms: Option<u64>,
+    /// The engine-side message when `state == Failed`. For the
+    /// current timeout-only failure mode this looks like
+    /// `"exceeded 60 s budget"`; future panic capture would surface
+    /// the panic message here too.
+    pub error: Option<String>,
+}
+
+/// What state the engine *as a whole* is in. The WebUI gates the
+/// login screen on this: `Booting` → show the overlay; either
+/// `Ready` value → show the login form (and stash the
+/// `ReadyWithErrors` badge for after auth).
+#[derive(Debug, Clone, Copy, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OverallState {
+    Booting,
+    /// All phases finished `Ok` (or were never registered).
+    Ready,
+    /// At least one phase ended in `Failed`. The engine is still
+    /// accepting requests — the operator just needs to know
+    /// something didn't come up cleanly.
+    ReadyWithErrors,
+}
+
+/// Snapshot returned by `/api/boot_status`. Cheap to clone — the
+/// tracker rebuilds this on every read by holding the RwLock briefly.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BootStatus {
+    pub overall: OverallState,
+    pub phases: Vec<BootPhase>,
+    /// Unix seconds at which the engine process started. Lets the
+    /// UI render absolute wall-clock times if it wants to.
+    pub process_started_at_unix: i64,
+    /// Milliseconds from process start to the call that flipped
+    /// `overall` away from `Booting`. `None` while still booting.
+    pub ready_at_ms: Option<u64>,
+}
+
+/// Shared handle. `Clone` is cheap — internally an `Arc` to the
+/// `RwLock` so every component (the `run_phase` helper, the REST
+/// handler, future RPC handlers) can hold its own copy without
+/// fighting over ownership.
+#[derive(Clone)]
+pub struct BootStatusTracker {
+    inner: Arc<RwLock<BootStatus>>,
+    process_start: Instant,
+}
+
+impl BootStatusTracker {
+    /// Build a fresh tracker with every phase pre-registered as
+    /// `Pending`. Pre-registration matters for the UX: the WebUI
+    /// can show the complete checklist immediately rather than
+    /// having rows pop in as each phase starts.
+    pub fn new(phase_names: &[&str]) -> Self {
+        let phases = phase_names
+            .iter()
+            .map(|name| BootPhase {
+                name: (*name).to_string(),
+                state: PhaseState::Pending,
+                started_at_ms: None,
+                finished_at_ms: None,
+                duration_ms: None,
+                error: None,
+            })
+            .collect();
+        let now_unix = chrono::Utc::now().timestamp();
+        Self {
+            inner: Arc::new(RwLock::new(BootStatus {
+                overall: OverallState::Booting,
+                phases,
+                process_started_at_unix: now_unix,
+                ready_at_ms: None,
+            })),
+            process_start: Instant::now(),
+        }
+    }
+
+    pub async fn snapshot(&self) -> BootStatus {
+        self.inner.read().await.clone()
+    }
+
+    /// Run a phase under its timeout budget, recording state
+    /// transitions in the snapshot as they happen. The return value
+    /// of the wrapped future is passed through on success;
+    /// `T::default()` is returned on timeout (caller continues).
+    ///
+    /// Replaces the standalone `run_phase` helper PR 1 shipped; the
+    /// behavioural contract is identical (logs match, defaults
+    /// returned the same way) so the existing test plan still
+    /// applies. The new bit is the snapshot write-through.
+    pub async fn run_phase<T, F>(&self, name: &str, max: Duration, fut: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+        T: Default,
+    {
+        self.mark_running(name).await;
+        let started = Instant::now();
+        match tokio::time::timeout(max, fut).await {
+            Ok(v) => {
+                let elapsed = started.elapsed();
+                info!(
+                    "boot phase '{name}' completed in {} ms",
+                    elapsed.as_millis()
+                );
+                self.mark_finished(name, elapsed, None).await;
+                v
+            }
+            Err(_) => {
+                let elapsed = started.elapsed();
+                let msg = format!("exceeded {} s budget", max.as_secs());
+                error!(
+                    "boot phase '{name}' {msg} — continuing without it; \
+                     check the prior log lines for what stalled"
+                );
+                self.mark_finished(name, elapsed, Some(msg)).await;
+                T::default()
+            }
+        }
+    }
+
+    async fn mark_running(&self, name: &str) {
+        let now_ms = self.elapsed_ms();
+        let mut snap = self.inner.write().await;
+        if let Some(p) = snap.phases.iter_mut().find(|p| p.name == name) {
+            p.state = PhaseState::Running;
+            p.started_at_ms = Some(now_ms);
+        } else {
+            // Phase wasn't pre-registered. Append it instead of
+            // dropping the update — the alternative would be a
+            // silent gap in the snapshot whenever main.rs and the
+            // tracker's expected-phase list drift apart.
+            snap.phases.push(BootPhase {
+                name: name.to_string(),
+                state: PhaseState::Running,
+                started_at_ms: Some(now_ms),
+                finished_at_ms: None,
+                duration_ms: None,
+                error: None,
+            });
+        }
+    }
+
+    async fn mark_finished(&self, name: &str, elapsed: Duration, error: Option<String>) {
+        let finished_ms = self.elapsed_ms();
+        let duration_ms = elapsed.as_millis() as u64;
+        let mut snap = self.inner.write().await;
+        if let Some(p) = snap.phases.iter_mut().find(|p| p.name == name) {
+            p.state = if error.is_some() {
+                PhaseState::Failed
+            } else {
+                PhaseState::Ok
+            };
+            p.finished_at_ms = Some(finished_ms);
+            p.duration_ms = Some(duration_ms);
+            p.error = error;
+        }
+    }
+
+    /// Call this exactly once after every phase has been awaited.
+    /// Flips `overall` to `Ready` if all phases ended `Ok`, or to
+    /// `ReadyWithErrors` if any ended `Failed`. Records the
+    /// millisecond timestamp so the WebUI can show "engine reached
+    /// READY at +14.2 s".
+    pub async fn mark_ready(&self) {
+        let now_ms = self.elapsed_ms();
+        let mut snap = self.inner.write().await;
+        let any_failed = snap.phases.iter().any(|p| p.state == PhaseState::Failed);
+        snap.overall = if any_failed {
+            OverallState::ReadyWithErrors
+        } else {
+            OverallState::Ready
+        };
+        snap.ready_at_ms = Some(now_ms);
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.process_start.elapsed().as_millis() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pre_registered_phases_start_pending() {
+        let t = BootStatusTracker::new(&["a", "b", "c"]);
+        let snap = t.snapshot().await;
+        assert_eq!(snap.overall, OverallState::Booting);
+        assert_eq!(snap.phases.len(), 3);
+        for p in &snap.phases {
+            assert_eq!(p.state, PhaseState::Pending);
+            assert!(p.started_at_ms.is_none());
+            assert!(p.finished_at_ms.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_phase_transitions_pending_to_ok() {
+        let t = BootStatusTracker::new(&["x"]);
+        let result: u32 = t.run_phase("x", Duration::from_secs(5), async { 42 }).await;
+        assert_eq!(result, 42);
+        let snap = t.snapshot().await;
+        let p = &snap.phases[0];
+        assert_eq!(p.state, PhaseState::Ok);
+        assert!(p.started_at_ms.is_some());
+        assert!(p.finished_at_ms.is_some());
+        assert!(p.duration_ms.is_some());
+        assert!(p.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn timed_out_phase_transitions_pending_to_failed() {
+        let t = BootStatusTracker::new(&["slow"]);
+        // tokio time pausing isn't enabled by default for the test
+        // binary; use a real (very short) sleep and a tiny budget.
+        let result: u32 = t
+            .run_phase("slow", Duration::from_millis(20), async {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                7
+            })
+            .await;
+        // T::default() returned on timeout.
+        assert_eq!(result, 0);
+        let snap = t.snapshot().await;
+        let p = &snap.phases[0];
+        assert_eq!(p.state, PhaseState::Failed);
+        assert!(p.error.as_ref().unwrap().contains("exceeded"));
+    }
+
+    #[tokio::test]
+    async fn unregistered_phase_is_appended_not_dropped() {
+        // We could panic on an unknown phase, but the engine running
+        // in production beats "lost a status update because the
+        // tracker's expected-phase list got out of sync." Append it.
+        let t = BootStatusTracker::new(&[]);
+        let _: () = t
+            .run_phase("surprise", Duration::from_secs(5), async {})
+            .await;
+        let snap = t.snapshot().await;
+        assert_eq!(snap.phases.len(), 1);
+        assert_eq!(snap.phases[0].name, "surprise");
+        assert_eq!(snap.phases[0].state, PhaseState::Ok);
+    }
+
+    #[tokio::test]
+    async fn mark_ready_picks_overall_state_from_phase_outcomes() {
+        let t = BootStatusTracker::new(&["a", "b"]);
+        let _: () = t.run_phase("a", Duration::from_secs(5), async {}).await;
+        let _: () = t.run_phase("b", Duration::from_secs(5), async {}).await;
+        t.mark_ready().await;
+        assert_eq!(t.snapshot().await.overall, OverallState::Ready);
+
+        let t = BootStatusTracker::new(&["a", "b"]);
+        let _: () = t.run_phase("a", Duration::from_secs(5), async {}).await;
+        let _: u32 = t
+            .run_phase("b", Duration::from_millis(10), async {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                0
+            })
+            .await;
+        t.mark_ready().await;
+        assert_eq!(t.snapshot().await.overall, OverallState::ReadyWithErrors);
+    }
+
+    #[tokio::test]
+    async fn snapshot_before_ready_is_booting() {
+        let t = BootStatusTracker::new(&["a"]);
+        assert_eq!(t.snapshot().await.overall, OverallState::Booting);
+    }
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::{prelude::*, reload};
 mod app_deploy;
 mod auth;
 mod auth_oidc;
+mod boot_status;
 mod fs_dependents;
 mod fs_lock;
 mod ingress_conflict;
@@ -72,6 +73,11 @@ pub struct AppState {
     /// Cached alerts result (timestamp, json value). Avoids re-evaluating
     /// all alert checks on every WebUI poll (called every few seconds).
     pub alerts_cache: tokio::sync::Mutex<Option<(std::time::Instant, serde_json::Value)>>,
+    /// Boot-time per-phase status. Populated by main()'s restoration
+    /// sequence; read by `/api/boot_status` so the WebUI can render
+    /// a TrueNAS-style "starting up" overlay on the login screen
+    /// while phases are still running. See #299.
+    pub boot_status: boot_status::BootStatusTracker,
 }
 
 /// Base URL for the nasty-metrics service.
@@ -142,6 +148,30 @@ async fn main() -> anyhow::Result<()> {
         backups: nasty_backup::BackupService::new(),
         firmware: nasty_system::firmware::FirmwareService::new(),
         alerts_cache: tokio::sync::Mutex::new(None),
+        // Pre-register every phase name we'll feed into `run_phase`
+        // below. Pre-registering makes the WebUI's checklist fully
+        // visible from the moment the engine starts answering
+        // /api/boot_status — rows transition Pending → Running →
+        // Ok/Failed in place, no popping-into-existence reflow.
+        // Keep this list in sync with the `run_phase` calls below.
+        boot_status: boot_status::BootStatusTracker::new(&[
+            "filesystems.restore_mounts",
+            "subvolumes.restore_block_devices",
+            "nvmeof.remap_device_paths",
+            "iscsi.remap_device_paths",
+            "protocols.restore",
+            "nvmeof.restore",
+            "vms.restore",
+            "apps.restore",
+            "tailscale.restore",
+            "network.restore_pending_revert",
+            "network.reconcile_orphans",
+            "subvolumes.reconcile_project_ids",
+            "apps.reconcile_app_routes",
+            "firewall.init",
+            "nvmeof.ensure_tailscale_ports",
+            "caches.warm",
+        ]),
     });
 
     // Restore state from previous session:
@@ -166,12 +196,14 @@ async fn main() -> anyhow::Result<()> {
     use std::time::Duration;
     let secs = Duration::from_secs;
 
-    let mount_failures = run_phase(
-        "filesystems.restore_mounts",
-        secs(300), // per-FS 60s device-wait × multi-disk pools, plus mount + possible fsck
-        state.filesystems.restore_mounts(),
-    )
-    .await;
+    let mount_failures = state
+        .boot_status
+        .run_phase(
+            "filesystems.restore_mounts",
+            secs(300), // per-FS 60s device-wait × multi-disk pools, plus mount + possible fsck
+            state.filesystems.restore_mounts(),
+        )
+        .await;
     if !mount_failures.is_empty() {
         error!(
             "CRITICAL: {} filesystem(s) failed to mount: {}",
@@ -183,72 +215,90 @@ async fn main() -> anyhow::Result<()> {
     // Re-attach loop devices and get the current name→device mapping.
     // Loop device numbers change across reboots, so NVMe-oF and iSCSI state
     // files must be patched before their respective restore steps run.
-    let dev_map = run_phase(
-        "subvolumes.restore_block_devices",
-        secs(30), // losetup per block subvolume + state-file write
-        state.subvolumes.restore_block_devices(),
-    )
-    .await;
+    let dev_map = state
+        .boot_status
+        .run_phase(
+            "subvolumes.restore_block_devices",
+            secs(30), // losetup per block subvolume + state-file write
+            state.subvolumes.restore_block_devices(),
+        )
+        .await;
     if !dev_map.is_empty() {
-        run_phase(
-            "nvmeof.remap_device_paths",
-            secs(15), // string substitution + state-file save
-            state.nvmeof.remap_device_paths(&dev_map),
-        )
-        .await;
-        run_phase(
-            "iscsi.remap_device_paths",
-            secs(15),
-            state.iscsi.remap_device_paths(&dev_map),
-        )
-        .await;
+        state
+            .boot_status
+            .run_phase(
+                "nvmeof.remap_device_paths",
+                secs(15), // string substitution + state-file save
+                state.nvmeof.remap_device_paths(&dev_map),
+            )
+            .await;
+        state
+            .boot_status
+            .run_phase(
+                "iscsi.remap_device_paths",
+                secs(15),
+                state.iscsi.remap_device_paths(&dev_map),
+            )
+            .await;
     }
-    run_phase(
-        "protocols.restore",
-        secs(90), // 9 systemd services × up to ~10s each on a bursty box
-        state.protocols.restore(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "protocols.restore",
+            secs(90), // 9 systemd services × up to ~10s each on a bursty box
+            state.protocols.restore(),
+        )
+        .await;
 
     // SSH password auth is managed via /var/lib/nasty/sshd_override.conf
     // (created by tmpfiles with default "yes", toggled by the WebUI).
 
-    run_phase(
-        "nvmeof.restore",
-        secs(30), // configfs writes — fast unless many subsystems
-        state.nvmeof.restore(),
-    )
-    .await;
-    run_phase(
-        "vms.restore",
-        secs(300), // 10-20s per autostart VM × N
-        state.vms.restore(),
-    )
-    .await;
-    run_phase(
-        "apps.restore",
-        secs(300), // `docker compose up -d` per autostart app, may pull layers
-        state.apps.restore(),
-    )
-    .await;
-    run_phase(
-        "tailscale.restore",
-        secs(60), // network round-trip to login.tailscale.com
-        state.tailscale.restore(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "nvmeof.restore",
+            secs(30), // configfs writes — fast unless many subsystems
+            state.nvmeof.restore(),
+        )
+        .await;
+    state
+        .boot_status
+        .run_phase(
+            "vms.restore",
+            secs(300), // 10-20s per autostart VM × N
+            state.vms.restore(),
+        )
+        .await;
+    state
+        .boot_status
+        .run_phase(
+            "apps.restore",
+            secs(300), // `docker compose up -d` per autostart app, may pull layers
+            state.apps.restore(),
+        )
+        .await;
+    state
+        .boot_status
+        .run_phase(
+            "tailscale.restore",
+            secs(60), // network round-trip to login.tailscale.com
+            state.tailscale.restore(),
+        )
+        .await;
 
     // If the engine was killed mid-apply (or restarted before the user
     // confirmed a risky network change), restore the prior config from
     // /var/lib/nasty/networking.json.pending-revert. No-op if the file
     // doesn't exist. Runs before the HTTP server starts accepting calls
     // so a confirm can't race the rollback.
-    run_phase(
-        "network.restore_pending_revert",
-        secs(60), // file check is instant; revert path runs nmcli
-        state.network.restore_pending_revert(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "network.restore_pending_revert",
+            secs(60), // file check is instant; revert path runs nmcli
+            state.network.restore_pending_revert(),
+        )
+        .await;
 
     // Idempotent sweep: drop networking.json `interfaces[]` entries
     // that no longer correspond to any live device or virtual
@@ -259,12 +309,14 @@ async fn main() -> anyhow::Result<()> {
     // engine's apply path doesn't garbage-collect dead profiles
     // otherwise.  Runs before firewall.init so the firewall mirrors
     // the cleaned-on-disk state.
-    run_phase(
-        "network.reconcile_orphans",
-        secs(30), // a handful of NM connection deletes at most
-        state.network.reconcile_orphans(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "network.reconcile_orphans",
+            secs(30), // a handful of NM connection deletes at most
+            state.network.reconcile_orphans(),
+        )
+        .await;
 
     // Backfill project quota IDs on filesystem subvolumes that
     // predate the always-assign change (#176). Without this, those
@@ -272,12 +324,14 @@ async fn main() -> anyhow::Result<()> {
     // `None` and the WebUI shows `—` forever. Idempotent: scans
     // repquota output and only writes for subvolumes that lack a
     // row. Best-effort; failures are logged and don't block startup.
-    run_phase(
-        "subvolumes.reconcile_project_ids",
-        secs(90), // repquota scan + setproject per subvolume, scales with subvol count
-        state.subvolumes.reconcile_project_ids(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "subvolumes.reconcile_project_ids",
+            secs(90), // repquota scan + setproject per subvolume, scales with subvol count
+            state.subvolumes.reconcile_project_ids(),
+        )
+        .await;
 
     // Push the engine-known set of app ingresses into Caddy's
     // admin-API config.  Caddy holds these in memory, so a fresh
@@ -286,12 +340,14 @@ async fn main() -> anyhow::Result<()> {
     // recovery: when no live containers exist but the nginx-era
     // /var/lib/nasty/apps-proxy.conf does, the rules are parsed
     // from there.
-    run_phase(
-        "apps.reconcile_app_routes",
-        secs(30), // localhost HTTP to Caddy admin :2019
-        state.apps.reconcile_app_routes(),
-    )
-    .await;
+    state
+        .boot_status
+        .run_phase(
+            "apps.reconcile_app_routes",
+            secs(30), // localhost HTTP to Caddy admin :2019
+            state.apps.reconcile_app_routes(),
+        )
+        .await;
 
     // TLS automation reconcile — push the policy set (main domain +
     // every app subdomain) so Caddy issues certs after a fresh boot or
@@ -318,44 +374,50 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Initialize firewall based on current protocol states
-    run_phase("firewall.init", secs(15), {
-        let state = state.clone();
-        async move {
-            use nasty_system::protocol::Protocol;
-            let mut proto_states = Vec::new();
-            for p in Protocol::ALL {
-                let enabled = state.protocols.is_enabled(*p).await;
-                proto_states.push((*p, enabled));
+    state
+        .boot_status
+        .run_phase("firewall.init", secs(15), {
+            let state = state.clone();
+            async move {
+                use nasty_system::protocol::Protocol;
+                let mut proto_states = Vec::new();
+                for p in Protocol::ALL {
+                    let enabled = state.protocols.is_enabled(*p).await;
+                    proto_states.push((*p, enabled));
+                }
+                state.firewall.init(&proto_states).await;
             }
-            state.firewall.init(&proto_states).await;
-        }
-    })
-    .await;
+        })
+        .await;
 
     // Sync NVMe-oF ports with Tailscale IP (if Tailscale reconnected on boot)
-    run_phase("nvmeof.ensure_tailscale_ports", secs(15), {
-        let state = state.clone();
-        async move {
-            let ts_status = state.tailscale.get().await;
-            if ts_status.connected
-                && let Some(ref ip) = ts_status.ip
-            {
-                state.nvmeof.ensure_tailscale_ports(ip).await;
+    state
+        .boot_status
+        .run_phase("nvmeof.ensure_tailscale_ports", secs(15), {
+            let state = state.clone();
+            async move {
+                let ts_status = state.tailscale.get().await;
+                if ts_status.connected
+                    && let Some(ref ip) = ts_status.ip
+                {
+                    state.nvmeof.ensure_tailscale_ports(ip).await;
+                }
             }
-        }
-    })
-    .await;
+        })
+        .await;
 
     // Pre-warm caches so first page loads are fast.
     // Runs before sd_notify_ready() — Caddy won't serve until this completes.
     info!("Warming caches...");
-    run_phase("caches.warm", secs(30), {
-        let state = state.clone();
-        async move {
-            state.system.info().await;
-        }
-    })
-    .await;
+    state
+        .boot_status
+        .run_phase("caches.warm", secs(30), {
+            let state = state.clone();
+            async move {
+                state.system.info().await;
+            }
+        })
+        .await;
 
     // Seed the cached ACME status from whatever cert Caddy is already
     // serving so the WebUI shows the issuer/expiry on first page load
@@ -399,6 +461,12 @@ async fn main() -> anyhow::Result<()> {
     // Background alert evaluation + notifications
     spawn_alert_notifier(state.clone());
 
+    // Flip boot_status.overall from Booting → Ready / ReadyWithErrors
+    // BEFORE notifying systemd — once we're READY the WebUI is going
+    // to start polling /api/boot_status and we want it to immediately
+    // see the post-boot state, not catch the snapshot mid-transition.
+    state.boot_status.mark_ready().await;
+
     // Signal systemd that startup is complete
     sd_notify_ready();
 
@@ -420,6 +488,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/login", post(login_handler))
         .route("/api/logout", post(logout_handler))
         .route("/api/auth/oidc/available", get(oidc_available_handler))
+        .route("/api/boot_status", get(boot_status_handler))
         .route("/api/auth/oidc/start", get(oidc_start_handler))
         .route("/api/auth/oidc/callback", get(oidc_callback_handler))
         .route(
@@ -618,41 +687,18 @@ fn sd_notify_ready() {
     info!("Notified systemd: READY");
 }
 
-/// Run one boot-time restoration phase with a hard wall-clock cap.
+/// Boot-status snapshot, unauthenticated. Surfaces what the
+/// `boot_status::BootStatusTracker` recorded for every restoration
+/// phase + an overall state the WebUI uses to decide between
+/// rendering the boot overlay or the login form.
 ///
-/// On timeout: log an error and return `default()`. Caller continues
-/// to the next phase. The point is to guarantee `sd_notify_ready()`
-/// eventually fires even if a single restoration step (a hung mount,
-/// an unreachable IdP, a stuck Caddy admin API call, …) misbehaves.
-/// Pre-fix any awaited phase that didn't return on its own took the
-/// whole engine down via systemd's `TimeoutStartSec` — and with it
-/// the WebUI, since nothing was serving on 127.0.0.1:2137.
-///
-/// Phase 1 of #299. Per-phase status aggregation for the WebUI
-/// (`system.boot_status` RPC + booting screen) lands in follow-ups.
-async fn run_phase<T, F>(name: &str, max: std::time::Duration, fut: F) -> T
-where
-    F: std::future::Future<Output = T>,
-    T: Default,
-{
-    let started = std::time::Instant::now();
-    match tokio::time::timeout(max, fut).await {
-        Ok(v) => {
-            info!(
-                "boot phase '{name}' completed in {} ms",
-                started.elapsed().as_millis()
-            );
-            v
-        }
-        Err(_) => {
-            error!(
-                "boot phase '{name}' exceeded {} s budget — continuing without it; \
-                 check the prior log lines for what stalled",
-                max.as_secs()
-            );
-            T::default()
-        }
-    }
+/// No auth on purpose: the operator can't authenticate yet when the
+/// engine is mid-boot, and we still want them to see *what's*
+/// holding things up. The snapshot only exposes phase names,
+/// timestamps relative to process start, and tokio-timeout error
+/// strings — no secrets, no per-user data.
+async fn boot_status_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(state.boot_status.snapshot().await)
 }
 
 async fn health() -> impl IntoResponse {


### PR DESCRIPTION
Second slice of #299. PR #300 (now landed) wrapped each startup restoration phase in a `run_phase` helper so a single hang couldn't take down `sd_notify_ready()`. The phase results were only visible in the journal; the WebUI had no way to render TrueNAS-style \"NASty is starting up\" UX or to surface \"filesystem X failed to auto-mount\" badges after the engine reached READY.

## What changed

Promote `run_phase` to a method on a new `BootStatusTracker`:

- Tracker is **pre-registered with every phase name** at construction time so the WebUI sees the full checklist immediately — rows transition `Pending` → `Running` → `Ok` / `Failed` in place rather than popping into existence as each phase starts.
- Each phase write-throughs its state transitions to the snapshot.
- `mark_ready()` flips `overall` from `Booting` → `Ready` or `ReadyWithErrors` based on whether any phase ended `Failed`; called right before `sd_notify_ready()` so the snapshot is post-boot by the time the WebUI starts polling.

The snapshot is exposed via a new REST endpoint:

```
GET /api/boot_status -> {
  overall: \"booting\" | \"ready\" | \"ready_with_errors\",
  phases: [{name, state, started_at_ms, finished_at_ms, duration_ms, error}],
  process_started_at_unix,
  ready_at_ms,
}
```

No auth on purpose — the operator can't authenticate yet while the engine is mid-boot, and we still want them to see what's holding things up. The snapshot only exposes phase names, monotonic timestamps, and tokio-timeout error strings (no secrets, no per-user data).

PR 3 (WebUI booting overlay + dashboard health badges) will consume this endpoint.

## Test plan

- [x] `cargo test -p nasty-engine boot_status::` — 6 passed:
  - `pre_registered_phases_start_pending`
  - `successful_phase_transitions_pending_to_ok`
  - `timed_out_phase_transitions_pending_to_failed`
  - `unregistered_phase_is_appended_not_dropped`
  - `mark_ready_picks_overall_state_from_phase_outcomes`
  - `snapshot_before_ready_is_booting`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual on .71 after merge + deploy: `curl http://127.0.0.1:2137/api/boot_status` immediately after `systemctl restart nasty-engine` to catch the transition through `booting`; eventually shows `ready` or `ready_with_errors` with per-phase timings