### PR TITLE
wrapper-flake template: nixpkgs + bcachefs-tools follow nasty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,33 +100,38 @@ jobs:
           echo "npmDepsHash matches package-lock.json: $ACTUAL"
 
   installer-flake-template:
-    # The installer's system-flake template must reference the same
-    # bcachefs-tools input as the project's flake.nix. The ISO build copies
-    # all transitive nodes from flake.lock into the system flake's lock; if
-    # the template's bcachefs-tools.url drifts from flake.nix, the lock will
-    # hold a different ref than the rendered flake.nix asks for and
-    # nixos-install will bail out with a NAR hash mismatch on first boot.
-    name: Installer template bcachefs-tools URL matches flake.nix
+    # The installer's system-flake template used to own its own
+    # `bcachefs-tools.url` and this job asserted it matched the
+    # project's flake.nix — without that, the ISO's flake.lock would
+    # reference one bcachefs-tools rev while the rendered wrapper
+    # flake.nix asked for another, and nixos-install would bail with
+    # a NAR hash mismatch on first boot.
+    #
+    # That entire failure mode is gone post-#304: the wrapper
+    # template no longer owns bcachefs-tools.url at all, it declares
+    # `bcachefs-tools.follows = "nasty/bcachefs-tools"`. The wrapper
+    # inherits whatever bcachefs-tools rev nasty's flake.lock pins,
+    # transitively — no second URL string, nothing to drift.
+    #
+    # Job retained as a guard the other way: assert the template
+    # really uses `follows` and never quietly grows a `.url` back.
+    name: Installer template bcachefs-tools resolves via follows
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Compare URLs
+      - name: Assert template uses follows for bcachefs-tools
         run: |
-          PROJECT=$(grep -oE 'bcachefs-tools\.url = "[^"]+"' flake.nix | head -1)
-          TEMPLATE=$(grep -oE 'bcachefs-tools\.url = "[^"]+"' nixos/system-flake/flake.nix.template | head -1)
-          if [ -z "$PROJECT" ] || [ -z "$TEMPLATE" ]; then
-            echo "::error::could not extract bcachefs-tools.url from one of the files"
-            echo "  flake.nix:                             $PROJECT"
-            echo "  nixos/system-flake/flake.nix.template: $TEMPLATE"
+          if grep -qE 'bcachefs-tools\.url\s*=' nixos/system-flake/flake.nix.template; then
+            echo "::error::installer template owns its own bcachefs-tools.url — should follow nasty"
+            echo "Template should declare:"
+            echo "  bcachefs-tools.follows = \"nasty/bcachefs-tools\";"
+            echo "instead of:"
+            grep -nE 'bcachefs-tools\.url' nixos/system-flake/flake.nix.template
             exit 1
           fi
-          if [ "$PROJECT" != "$TEMPLATE" ]; then
-            echo "::error::installer template bcachefs-tools URL is stale"
-            echo "  flake.nix:                             $PROJECT"
-            echo "  nixos/system-flake/flake.nix.template: $TEMPLATE"
-            echo
-            echo "When bumping bcachefs-tools, update both files together."
+          if ! grep -qE 'bcachefs-tools\.follows\s*=\s*"nasty/bcachefs-tools"' nixos/system-flake/flake.nix.template; then
+            echo "::error::installer template missing bcachefs-tools.follows = \"nasty/bcachefs-tools\""
             exit 1
           fi
-          echo "Installer template matches flake.nix: $PROJECT"
+          echo "Installer template correctly follows nasty/bcachefs-tools."

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -476,17 +476,32 @@ impl UpdateService {
 
     /// Read the exact upstream input URLs and locked revs from the live
     /// `/etc/nixos` flake on the installed system.
+    ///
+    /// Inputs the wrapper *owns* a `.url` for (today: just `nasty`,
+    /// historically all three) are reported with their literal URL.
+    /// Inputs the wrapper *follows* from nasty (today: `nixpkgs` and
+    /// `bcachefs-tools`) are reported with a synthetic
+    /// `follows:nasty/<name>` marker so the WebUI can distinguish
+    /// "operator owns this version" from "this just tracks nasty."
+    /// In either case `rev` comes from `flake.lock`, which carries
+    /// resolved revs for followed inputs too.
     pub async fn version_info(&self) -> Result<VersionInfo, UpdateError> {
         let urls = read_flake_input_urls().await?;
         let revs = read_flake_lock_revs().await;
 
         let mut inputs = Vec::with_capacity(VERSION_INPUT_NAMES.len());
         for name in VERSION_INPUT_NAMES {
-            let url = urls.get(name).cloned().ok_or_else(|| {
-                UpdateError::CommandFailed(format!(
-                    "missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"
-                ))
-            })?;
+            let url = match urls.get(name) {
+                Some(u) => u.clone(),
+                None if *name == *"nasty" => {
+                    // `nasty.url` is the one input the wrapper must
+                    // own — there's nothing to follow it from.
+                    return Err(UpdateError::CommandFailed(format!(
+                        "missing nasty.url in {NIXOS_FLAKE_DIR}/flake.nix"
+                    )));
+                }
+                None => format!("follows:nasty/{name}"),
+            };
             inputs.push(VersionInputInfo {
                 name: name.to_string(),
                 url,
@@ -2243,12 +2258,19 @@ fn parse_flake_input_urls(content: &str) -> Result<HashMap<String, ParsedFlakeIn
         );
     }
 
-    for name in VERSION_INPUT_NAMES {
-        if !urls.contains_key(name) {
-            return Err(UpdateError::CommandFailed(format!(
-                "missing {name}.url in {NIXOS_FLAKE_DIR}/flake.nix"
-            )));
-        }
+    // `nasty.url` is the one input the wrapper *must* own — it's what
+    // pins the release the operator is tracking. `nixpkgs.url` and
+    // `bcachefs-tools.url` used to also be required, but the modern
+    // template (post wrapper-follows refactor) declares them as
+    // `nixpkgs.follows = "nasty/nixpkgs"` instead — the wrapper no
+    // longer owns those URLs, it inherits whatever nasty's flake.lock
+    // pins. Their absence here just means "this wrapper uses the
+    // follows pattern"; callers handle that explicitly by checking
+    // the returned map for presence.
+    if !urls.contains_key("nasty") {
+        return Err(UpdateError::CommandFailed(format!(
+            "missing nasty.url in {NIXOS_FLAKE_DIR}/flake.nix"
+        )));
     }
 
     Ok(urls)
@@ -3000,6 +3022,29 @@ proc /proc proc rw 0 0\n\
 }"#;
         let err = parse_flake_input_urls(missing_nasty).unwrap_err();
         assert!(format!("{err:?}").contains("nasty"));
+    }
+
+    /// The current wrapper-flake shape (post wrapper-follows refactor)
+    /// declares only `nasty.url`; nixpkgs and bcachefs-tools come in
+    /// via `follows`. The parser must accept that shape — returning
+    /// just the nasty entry, no error.
+    #[test]
+    fn parse_flake_input_urls_accepts_follows_only_wrapper() {
+        let follows_shape = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.follows = "nasty/bcachefs-tools";
+  };
+}"#;
+        let parsed = parse_flake_input_urls(follows_shape).expect("follows-shape parses");
+        assert_eq!(parsed.len(), 1, "only nasty.url is present");
+        assert_eq!(
+            parsed.get("nasty").map(|p| p.url.as_str()),
+            Some("github:nasty-project/nasty/v0.0.9")
+        );
+        assert!(parsed.get("nixpkgs").is_none());
+        assert!(parsed.get("bcachefs-tools").is_none());
     }
 
     #[test]

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -3043,8 +3043,8 @@ proc /proc proc rw 0 0\n\
             parsed.get("nasty").map(|p| p.url.as_str()),
             Some("github:nasty-project/nasty/v0.0.9")
         );
-        assert!(parsed.get("nixpkgs").is_none());
-        assert!(parsed.get("bcachefs-tools").is_none());
+        assert!(!parsed.contains_key("nixpkgs"));
+        assert!(!parsed.contains_key("bcachefs-tools"));
     }
 
     #[test]

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -2,16 +2,26 @@
   description = "NASty local system configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
-    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
-
-    # Installer payload template. Bootstrap substitutes the tagged release
-    # and local system placeholders when writing /etc/nixos/flake.nix.
+    # The wrapper owns exactly one input: nasty. The blessed nixpkgs
+    # and bcachefs-tools revs for any given NASty release are recorded
+    # in nasty's own flake.lock at that ref, and we follow them from
+    # there. That way the maintainer controls all three versions
+    # through nasty's lock alone, the operator's single
+    # `nix flake update nasty` atomically advances all three on the
+    # wrapper, and the wrapper's resolved closure is byte-identical
+    # to what CI built against — so `nasty.cachix.org` actually
+    # substitutes instead of triggering a full local engine recompile.
+    #
+    # Before this template shape (everything before #304-ish), the
+    # wrapper owned its own `nixpkgs.url` and `bcachefs-tools.url`,
+    # and `nasty.inputs.nixpkgs.follows = "nixpkgs"` forced nasty
+    # to use whatever the wrapper had. Any drift in the wrapper's
+    # nixpkgs invalidated cachix coverage — caused every nasty bump
+    # to recompile ~92 Rust crates locally on every box that had
+    # ever run an `nix flake update nixpkgs`.
     nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
-    nasty.inputs.nixpkgs.follows = "nixpkgs";
-    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.follows = "nasty/bcachefs-tools";
   };
 
   outputs = { self, nixpkgs, nasty, ... }:


### PR DESCRIPTION
The structural fix discussed for #303. Supersedes the per-upgrade realignment scripting I was about to ship.

## The problem (in one diagram)

**Before:**
```
wrapper inputs = { nixpkgs.url,         # owned ← drifts on every update nixpkgs
                   bcachefs-tools.url,  # owned ← drifts independently
                   nasty.url,
                   nasty.inputs.nixpkgs.follows = \"nixpkgs\" }  # ← BACKWARDS
                   nasty.inputs.bcachefs-tools.follows = \"bcachefs-tools\"
```
Maintainer's blessed (nixpkgs, bcachefs-tools, nasty) tuple → overridden by the wrapper's choices → cachix coverage useless once wrapper diverges → ~92 Rust crates recompiled locally on every nasty bump.

**After:**
```
wrapper inputs = { nasty.url,                                 # operator owns just this one
                   nixpkgs.follows = \"nasty/nixpkgs\",         # tracks whatever nasty pins
                   bcachefs-tools.follows = \"nasty/bcachefs-tools\" }
```
Maintainer controls all three via nasty's own `flake.lock`. Operator's `nix flake update nasty` atomically advances all three on the wrapper. Resolved closure is byte-identical to what CI built ⇒ cachix substitutes properly ⇒ engine binary and Rust deps come down as pre-built nars rather than being recompiled.

## Why this is strictly better than realignment scripting

- **Structural, not procedural.** Nothing to drift; nothing to realign. No conditional logic about \"should we also bump nixpkgs?\" — there's literally nothing to bump separately.
- **Cachix becomes useful by construction.** The wrapper's resolved nixpkgs/bcachefs revs are identical to what CI used by definition, not by recipe.
- **Single knob: `nix flake update nasty`** is the entire operator-side upgrade. Mild/Spicy and Nasty channels collapse to the same flow.

## Maintainer workflow (unchanged conceptually, now structurally honored)

```bash
# In nasty repo: bless a new nixpkgs rev
nix flake update nixpkgs
git commit -am \"bump nixpkgs to 26.05.20260601\"
git push    # CI pushes engine + webui to nasty.cachix.org
# User on wrapper: nix flake update nasty — picks up nasty + nixpkgs + bcachefs in one shot
```

## Engine-side fallout

- **`parse_flake_input_urls`** used to require all three `.url` entries — now requires only `nasty.url`. Returns whatever's present.
- **`version_info`** reports `follows:nasty/<name>` as a synthetic URL for followed inputs so the WebUI can distinguish \"operator owns this version\" from \"this just tracks nasty.\" Lock revs still come from `flake.lock` (which carries resolved revs for followed inputs).
- **New unit test** (`parse_flake_input_urls_accepts_follows_only_wrapper`) covers the new shape. Existing legacy-shape tests stay green — parser handles both during the migration window.

## What this PR does NOT do

- **Doesn't auto-migrate existing wrappers.** The template content-hash change will trigger the rebootstrap path on next tagged-release upgrade for Mild/Spicy boxes, but Nasty-channel boxes don't go through rebootstrap. A follow-up PR adds an explicit migration so every existing box gets reshaped on its next engine-driven upgrade regardless of channel.
- **Doesn't update the WebUI** to render \"follows nasty\" specially for the followed inputs. They'll show the synthetic URL string as-is for now; a UI polish pass is a separate small change.
- **`version_switch` for nixpkgs / bcachefs-tools URLs** will return \"missing nixpkgs.url\" errors on a follows-shape wrapper, since there's no `.url` to rewrite. That's the right error semantically — overriding a `follows` requires actually adding a `.url` line, which the engine doesn't synthesise today. Acceptable regression for the advanced override page; operators who need that path edit the wrapper by hand.

## Test plan

- [x] `cargo test -p nasty-system` — 217 passed (1 new)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual on a fresh ISO build: confirm new wrapper has the `follows` shape
- [ ] Manual on a tagged-release box: trigger upgrade, observe rebootstrap re-renders the wrapper to the new shape, then `nix build --dry-run` shows ≤ ~20 derivations (per-machine glue only)