### PR TITLE
engine + nixos: drop nginx → Caddy / lego → Caddy-ACME migration paths

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -686,9 +686,8 @@ fn build_acme_issuer_json(issuer: &TlsIssuer) -> Value {
         // negative cache (the prior NXDOMAIN for `_acme-challenge.X`
         // is cached for the SOA's MINIMUM TTL — often 1 hour for
         // Cloudflare), sees no record, retries on a backoff that
-        // never converges within the propagation timeout. 30s
-        // matches what the lego flow used (`--dns.propagation-wait`)
-        // and is the default when `tls_dns_propagation_wait` is unset.
+        // never converges within the propagation timeout. 30s is the
+        // default when `tls_dns_propagation_wait` is unset.
         let resolvers: Vec<String> = issuer
             .dns_resolvers
             .clone()
@@ -1341,8 +1340,7 @@ mod tests {
         // resolver list, certmagic queries 127.0.0.53, may not see the
         // freshly-set TXT record for minutes, and gives up. Pin to
         // Cloudflare + Google so issuance doesn't depend on whatever
-        // DNS the operator has wired up locally. Mirrors what the
-        // lego flow did with `--dns.resolvers` before the switch.
+        // DNS the operator has wired up locally.
         let body = build_tls_automation_json(
             &[TlsPolicy {
                 host: "h.example".into(),

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3045,13 +3045,6 @@ impl AppsService {
     /// makes Docker / labelled-container state the source of truth
     /// and pushes the resulting set to Caddy.
     ///
-    /// Also folds in the v0.0.7 → v0.0.8 migration: if the engine
-    /// has no live containers (e.g. apps service was never enabled)
-    /// but the legacy `/var/lib/nasty/apps-proxy.conf` exists with
-    /// `# app:X port:Y` comments from the nginx era, recover the
-    /// list from there.  Once Caddy has routes, future installs
-    /// keep them in sync directly.
-    ///
     /// Best-effort: log and continue on failure.  Engine startup
     /// must not block on Caddy being healthy.
     pub async fn reconcile_app_routes(&self) {
@@ -3079,21 +3072,11 @@ impl AppsService {
         }
     }
 
-    /// Source-of-truth resolver for what app ingresses should exist.
-    /// Prefer live state (managed containers from Docker); fall back
-    /// to the legacy nginx-era file on first-boot-after-upgrade.
+    /// Source-of-truth resolver for what app ingresses should exist:
+    /// ask Docker about managed-labelled containers and derive the
+    /// route set from their host-port mappings.
     async fn compute_desired_routes(&self) -> Vec<AppRoute> {
-        const LEGACY_PROXY_CONF: &str = "/var/lib/nasty/apps-proxy.conf";
-
-        // Live state: ask Docker about labelled containers with a
-        // TCP port mapping, then look up the host port for each.
-        // If we successfully enumerated *any* managed apps, treat the
-        // resulting route set as authoritative — even when it's empty
-        // after filtering (e.g. all apps have proxy_disabled_reason
-        // set). Falling back to the legacy file in that case would
-        // resurrect routes the probe explicitly killed.
         if let Ok(apps) = self.list().await {
-            let saw_managed_apps = !apps.is_empty();
             let mut routes = Vec::new();
             for app in apps {
                 // The post-install probe disables path-prefix ingress
@@ -3135,33 +3118,7 @@ impl AppsService {
                     subdomain,
                 });
             }
-            if saw_managed_apps {
-                return routes;
-            }
-        }
-
-        // Legacy file fallback: v0.0.7 → v0.0.8 upgrade where
-        // Docker is up but apps haven't been re-listed yet, or
-        // an installation method that bypassed the apps service.
-        if let Ok(legacy) = tokio::fs::read_to_string(LEGACY_PROXY_CONF).await {
-            let rules = parse_ingress_comments(&legacy);
-            if !rules.is_empty() {
-                info!(
-                    "apps: recovered {} ingress rule(s) from legacy {}",
-                    rules.len(),
-                    LEGACY_PROXY_CONF
-                );
-                return rules
-                    .into_iter()
-                    .map(|r| AppRoute {
-                        name: r.name,
-                        host_port: r.host_port,
-                        // Legacy nginx-era config doesn't encode subdomain
-                        // mode — recovered routes default to path-prefix.
-                        subdomain: None,
-                    })
-                    .collect();
-            }
+            return routes;
         }
         Vec::new()
     }
@@ -4003,38 +3960,6 @@ async fn find_container_shell(container: &str) -> Option<&'static str> {
         }
     }
     None
-}
-
-/// Pull `AppIngress` rules out of a proxy-config file's `# app:X port:Y`
-/// comments.  Same parser for the legacy nginx-era `apps-proxy.conf`
-/// and the current `apps-proxy.caddy`, since `write_proxy_conf` emits
-/// the same comment header for both formats.
-fn parse_ingress_comments(content: &str) -> Vec<AppIngress> {
-    let mut rules = Vec::new();
-    for line in content.lines() {
-        let Some(comment) = line.strip_prefix("# app:") else {
-            continue;
-        };
-        let parts: Vec<&str> = comment.split_whitespace().collect();
-        if parts.len() < 2 {
-            continue;
-        }
-        let name = parts[0].to_string();
-        let Some(port_str) = parts[1].strip_prefix("port:") else {
-            continue;
-        };
-        let Ok(port) = port_str.parse::<u16>() else {
-            continue;
-        };
-        rules.push(AppIngress {
-            path: format!("/apps/{name}/"),
-            name,
-            host_port: port,
-            // Legacy nginx-era format never recorded subdomain mode.
-            subdomain: None,
-        });
-    }
-    rules
 }
 
 /// One row parsed from `ss -tlnp` output.

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use serde::Deserialize;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use tracing_subscriber::{prelude::*, reload};
 
 mod app_deploy;
@@ -336,10 +336,7 @@ async fn main() -> anyhow::Result<()> {
     // Push the engine-known set of app ingresses into Caddy's
     // admin-API config.  Caddy holds these in memory, so a fresh
     // boot or `systemctl restart caddy` would otherwise drop every
-    // `/apps/<name>/` route.  Also folds in the v0.0.7 → v0.0.8
-    // recovery: when no live containers exist but the nginx-era
-    // /var/lib/nasty/apps-proxy.conf does, the rules are parsed
-    // from there.
+    // `/apps/<name>/` route.
     state
         .boot_status
         .run_phase(
@@ -360,17 +357,6 @@ async fn main() -> anyhow::Result<()> {
     // catches up.
     tokio::spawn(async {
         nasty_system::settings::reapply_tls_from_disk().await;
-    });
-
-    // Migration: archive `/var/lib/nasty/lego/` once on the first boot
-    // after upgrading to admin-API TLS. The lego tree carried the
-    // pre-Caddy ACME account + issued cert, both of which are now
-    // managed by Caddy itself. We MOVE (not delete) so a NixOS
-    // generation rollback can recover by symlinking it back, per the
-    // operator guidance that nothing should be destroyed irreversibly
-    // during an upgrade. Idempotent via a flag file.
-    tokio::spawn(async {
-        archive_lego_dir_once().await;
     });
 
     // Initialize firewall based on current protocol states
@@ -574,107 +560,6 @@ fn required_flag_value(args: &[String], flag: &str) -> anyhow::Result<String> {
 }
 
 /// Notify systemd that the service is ready (Type=notify).
-/// First-boot-after-upgrade cleanup for state files made obsolete by
-/// the admin-API TLS migration. Currently:
-///   1. `/var/lib/nasty/lego/` → archive (carried the pre-Caddy ACME
-///      account key + issued cert).
-///   2. `/var/lib/nasty/caddy/vhosts.conf` → archive when non-empty
-///      (engine used to render the per-domain ACME vhost into this
-///      file; the Caddyfile no longer imports it).
-///
-/// All moves use rename to a timestamped sibling path. The operator
-/// rule is that nothing irreversible happens during an upgrade — a
-/// rollback to the previous NixOS generation can recover by renaming
-/// the archive back in place.
-///
-/// Each step is independently gated by its own flag file so a partial
-/// failure (one archive succeeded, the next didn't) is correctly
-/// retried on the next boot.
-async fn archive_lego_dir_once() {
-    archive_path_once(
-        "/var/lib/nasty/lego",
-        "/var/lib/nasty/.lego-archived-v1",
-        "lego",
-    )
-    .await;
-    archive_path_once(
-        "/var/lib/nasty/caddy/vhosts.conf",
-        "/var/lib/nasty/.vhosts-archived-v1",
-        "caddy vhosts.conf",
-    )
-    .await;
-    // The static cert.pem / key.pem at /var/lib/nasty/tls/ are
-    // obsolete now that the Caddyfile uses `tls internal`. They
-    // carry the user's old LE cert content for ACME-enabled 0.0.7
-    // boxes, so archive (not delete) so a rollback can recover.
-    archive_path_once(
-        "/var/lib/nasty/tls/cert.pem",
-        "/var/lib/nasty/.tls-cert-archived-v1",
-        "static tls cert",
-    )
-    .await;
-    archive_path_once(
-        "/var/lib/nasty/tls/key.pem",
-        "/var/lib/nasty/.tls-key-archived-v1",
-        "static tls key",
-    )
-    .await;
-}
-
-/// Move `path` to a timestamped sibling (`<path>.archived.<unix-ts>`)
-/// the first time we observe it post-upgrade, recording the action in
-/// `flag`. Best-effort; any failure logs a warning and leaves state
-/// for the next boot to retry.
-///
-/// `label` is a short human-readable name used in the log line.
-async fn archive_path_once(path: &str, flag: &str, label: &str) {
-    if tokio::fs::metadata(flag).await.is_ok() {
-        return;
-    }
-    let meta = match tokio::fs::metadata(path).await {
-        Ok(m) => m,
-        Err(_) => {
-            // Path absent — write the flag so we don't keep
-            // re-stating it every boot.
-            let _ = tokio::fs::write(
-                flag,
-                format!("{label}: no {path} found on first run\n").as_bytes(),
-            )
-            .await;
-            return;
-        }
-    };
-    // Skip empty files — vhosts.conf is created empty by the NixOS
-    // tmpfiles entry on every boot, and archiving an empty file would
-    // be noise. The flag write still records the migration as done.
-    if meta.is_file() && meta.len() == 0 {
-        let _ = tokio::fs::write(
-            flag,
-            format!("{label}: {path} was empty, nothing to archive\n").as_bytes(),
-        )
-        .await;
-        return;
-    }
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs().to_string())
-        .unwrap_or_else(|_| "unknown".into());
-    let archive_path = format!("{path}.archived.{ts}");
-    match tokio::fs::rename(path, &archive_path).await {
-        Ok(()) => {
-            info!(
-                "{label} migration: moved {path} → {archive_path}. \
-                 Safe to delete once Caddy admin-API TLS is confirmed working."
-            );
-            let _ =
-                tokio::fs::write(flag, format!("archived to {archive_path}\n").as_bytes()).await;
-        }
-        Err(e) => {
-            warn!("{label} migration: rename {path} → {archive_path} failed: {e}");
-        }
-    }
-}
-
 fn sd_notify_ready() {
     let Some(sock_path) = std::env::var_os("NOTIFY_SOCKET") else {
         return;

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -679,8 +679,7 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 //
 // Caddy's built-in ACME issuer handles HTTP-01, TLS-ALPN-01 and
 // (with the right plugin compiled in) DNS-01 — including renewals,
-// retries, OCSP stapling, and the multi-stepped state machine that
-// used to live in this file as a 250-line `lego` subprocess wrapper.
+// retries, OCSP stapling, and the full issuance state machine.
 //
 // The engine's job here is reduced to:
 //   1. Write the user's DNS-provider credentials to the
@@ -1109,10 +1108,10 @@ pub async fn refresh_acme_status_from_disk(settings: &Settings) {
     }
 }
 
-/// Engine-startup hook (replaces the old lego-driven `check_acme_renewal`).
-/// Caddy auto-renews internally — there's nothing for us to *do* here, just
-/// seed the cached status so the WebUI shows cert details immediately rather
-/// than after the first user-triggered apply.
+/// Engine-startup hook. Caddy auto-renews internally — there's nothing
+/// for us to *do* here, just seed the cached status so the WebUI shows
+/// cert details immediately rather than after the first user-triggered
+/// apply.
 pub async fn check_acme_renewal() {
     let settings = load().await;
     refresh_acme_status_from_disk(&settings).await;

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -9,8 +9,7 @@ let
   # Caddy serves those for the :443 catch-all. Otherwise we use Caddy's
   # `tls internal` directive — Caddy's "Local Authority" issues a
   # self-signed cert into its own state dir (`/var/lib/caddy/...`) and
-  # auto-renews it. No more `nasty-selfsigned-cert.service`, no more
-  # cert.pem at /var/lib/nasty/tls/.
+  # auto-renews it.
   useUserCert = cfg.tls.certFile != null && cfg.tls.keyFile != null;
   caddyTlsDirective =
     if useUserCert
@@ -968,17 +967,9 @@ in {
 
     systemd.tmpfiles.rules = [
       "d /var/lib/nasty 0751 root root -"
-      # /var/lib/nasty/tls/ used to hold the static self-signed cert.
-      # `tls internal` in the Caddyfile now puts that under Caddy's
-      # own state dir; the directory entry below is kept so the
-      # engine's archive_path_once migration can find the old files
-      # to move them aside without racing the tmpfiles-creation step.
-      "d /var/lib/nasty/tls 0750 root caddy -"
       # acme.env feeds DNS-01 provider creds into Caddy via
       # EnvironmentFile. Seeded empty so Caddy can start before the
-      # engine has had a chance to write it. (vhosts.conf is no longer
-      # written — TLS automation is driven through the admin API; the
-      # engine's first-boot migration archives any leftover file.)
+      # engine has had a chance to write it.
       # /var/lib/nasty/reports/ holds rotated nasty-report dumps.
       # Surviving boot-generation rollbacks is the point — operator
       # generates a report on a broken system, rolls back to a working
@@ -994,8 +985,8 @@ in {
       "d /var/lib/nasty/shares/iscsi 0750 root root -"
       "d /var/lib/nasty/shares/nvmeof 0750 root root -"
       "d /var/lib/nasty/vms 0750 root root -"
-      # Note: no `apps-proxy.caddy` tmpfile — apps ingress lives in
-      # Caddy's admin-API config, not on disk.  The engine PATCHes
+      # No apps-proxy tmpfile: apps ingress lives in Caddy's admin-API
+      # config, not on disk. The engine PATCHes
       # `/config/apps/http/servers/.../routes` directly on install /
       # remove.
       "C /var/lib/nasty/sshd_override.conf 0644 root root - ${pkgs.writeText "sshd-default" "PasswordAuthentication yes\n"}"
@@ -1007,14 +998,6 @@ in {
       "d /var/lib/nasty/nut 0750 root root -"
       "d /var/state/ups 0750 root root -"
     ];
-
-    # The static `:443` fallback is now `tls internal` by default
-    # (Caddy's Local Authority issues + auto-renews a self-signed cert
-    # into its own state dir). The old `nasty-selfsigned-cert.service`
-    # that generated /var/lib/nasty/tls/cert.pem on first boot is gone.
-    # Existing boxes carry the old cert.pem until the engine's first-
-    # boot migration archives it (see `archive_lego_dir_once` in
-    # nasty-engine).
 
     # ── NASty Metrics service ────────────────────────────────
 
@@ -1581,11 +1564,9 @@ in {
           # engine WS route that might be added without a
           # corresponding nasty.nix update — without it, a new
           # `/ws/foo` route would silently 404 through the SPA
-          # fallback (the exact bug that broke `/ws/apps/deploy` and
-          # `/ws/system/logs` after the nginx → Caddy swap).  Caddy
-          # evaluates routes in declaration order, so the specific
-          # handlers above still win for their paths; this one only
-          # catches what nothing else claimed.
+          # fallback.  Caddy evaluates routes in declaration order,
+          # so the specific handlers above still win for their paths;
+          # this one only catches what nothing else claimed.
           handle /ws/terminal {
             reverse_proxy 127.0.0.1:${toString cfg.engine.port} {
               header_up X-Real-IP {remote_host}


### PR DESCRIPTION
## Summary

The runtime migrations that carried 0.0.7 boxes across the nginx → Caddy and lego → Caddy-ACME architecture changes ran on first boot after upgrading to 0.0.8 and are now redundant: every deployed box has either run them already or was installed fresh on 0.0.8+. With 0.0.8 out, 0.0.9 doesn't need them.

Net: 5 files, +21 / -233 lines.

## Removed (runtime)

- **`archive_lego_dir_once` + `archive_path_once`** — first-boot flag-gated rename of `/var/lib/nasty/lego/`, `caddy/vhosts.conf`, and the static `tls/cert.pem|key.pem` to `*.archived.<ts>` siblings — and its spawn from `nasty-engine`'s `boot()`. Boxes already carrying the archived siblings keep them; nothing reads them.
- **`compute_desired_routes` legacy fallback** that parsed the nginx-era `/var/lib/nasty/apps-proxy.conf` `# app:X port:Y` comments when Docker had no managed containers but the file existed. Live container state is the only source of truth now. The `saw_managed_apps` discriminator (introduced so an empty managed-app list wouldn't trigger the fallback) goes with it.
- **`parse_ingress_comments`** — the legacy fallback was its only caller.
- **`/var/lib/nasty/tls` tmpfile entry** in `nasty.nix` — existed solely so the migration's rename had a directory to find files in. Tmpfiles doesn't delete on entry removal, so any existing dirs on operator boxes sit untouched.

## Removed (comments only — no behaviour change)

- `settings.rs`: "used to live in this file as a 250-line `lego` subprocess wrapper" and "replaces the old lego-driven `check_acme_renewal`" — pure historical narrative.
- `caddy.rs`: "matches what the lego flow used" / "Mirrors what the lego flow did with `--dns.resolvers` before the switch". Load-bearing reasoning (resolver negative-cache, systemd-resolved stub bypass) stays.
- `nasty.nix`: the "no more `nasty-selfsigned-cert.service`, no more cert.pem at `/var/lib/nasty/tls/`" block and the paragraph telling operators their old cert.pem will get archived on first boot. Drops the "after the nginx → Caddy swap" tag from the catch-all `/ws/*` route comment; the actual rationale (a new `/ws/foo` would silently 404 through the SPA fallback) stands on its own.
- `main.rs`: drops the unused `warn` from `use tracing::{...}` — only the archive helpers used it.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --workspace --no-fail-fast` — all green (no test deleted, no behaviour changed for live code paths)
- [ ] Smoke: deploy on a 0.0.8 box, confirm `nasty-engine` boots, app ingresses reconcile from Docker state, TLS still issues. The migration paths haven't fired on any 0.0.8+ box since they're gated on first-boot flag files — removing them is purely dead-code-deletion for boxes upgraded through 0.0.8.