### PR TITLE
webui+nixos: recover from silent TLS-reject on WS reconnect after self-signed leaf rotation

### DIFF
--- a/engine/nasty-apps/src/caddy.rs
+++ b/engine/nasty-apps/src/caddy.rs
@@ -31,6 +31,12 @@ const ADMIN_URL: &str = "http://127.0.0.1:2019";
 /// route list is left alone — that's the static Caddyfile content.
 const ROUTE_ID_PREFIX: &str = "nasty-app-";
 
+/// Leaf-cert lifetime for the internal-CA fallback (`nasty.local`).
+/// Caddy duration string format; passed through into the
+/// `automation.policies[].issuers[].lifetime` JSON field. See
+/// `build_tls_automation_json` for the full rationale.
+const INTERNAL_LEAF_LIFETIME: &str = "168h";
+
 /// One ingress rule, ready to be turned into a Caddy route object.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppRoute {
@@ -636,7 +642,37 @@ fn build_tls_automation_json(
     }
     policy_values.push(json!({
         "subjects": fallback_subjects,
-        "issuers": [{ "module": "internal" }],
+        // `lifetime` overrides Caddy's 12-hour default for internal-CA
+        // leaf certs. The short default means Caddy re-issues the
+        // `nasty.local` leaf any time the box is rebooted after more
+        // than ~8 hours of downtime (Caddy renews at ~2/3 lifetime),
+        // which gives the new leaf a fresh SHA-256 fingerprint and
+        // invalidates whatever browser exception the operator had
+        // clicked through — "your connection is not private" returns
+        // on every reboot, and the WebUI WebSocket reconnect hangs
+        // silently because TLS handshake failures don't surface a
+        // prompt for WebSocket connections (the rpc.ts
+        // reload-after-N-failed-reconnects path is the WebUI-side
+        // cover for this; this lifetime bump is the prevention).
+        //
+        // 7 days catches most operator reboot cadences (kernel
+        // updates, power outages) without re-issuing in between.
+        // TLS-hygiene cost: longer-lived leaf, bigger blast radius
+        // if the private key under /var/lib/caddy/ leaks — acceptable
+        // trade for a NAS appliance. Operators who want zero warnings
+        // forever should import the local-CA root (10-year lifetime,
+        // doesn't rotate) via the WebUI's "Download CA Root" button.
+        //
+        // Pushed here rather than in the Caddyfile because Caddy
+        // rejects the long-form `tls { issuer internal { lifetime ... } }`
+        // when it duplicates a hostname covered by an
+        // auto-generated policy (the site-address-derived one for
+        // `nasty.local`) — "hostname appears in more than one
+        // automation policy". The short-form `tls internal` in the
+        // Caddyfile folds into the auto-generated policy; this
+        // admin-API PATCH then replaces it with the lifetime-bearing
+        // version.
+        "issuers": [{ "module": "internal", "lifetime": INTERNAL_LEAF_LIFETIME }],
     }));
     json!({ "policies": policy_values })
 }
@@ -1154,6 +1190,21 @@ mod tests {
         assert_eq!(policies.len(), 1);
         assert_eq!(policies[0]["subjects"][0], "nasty.local");
         assert_eq!(policies[0]["issuers"][0]["module"], "internal");
+    }
+
+    #[test]
+    fn tls_automation_internal_issuer_carries_lifetime_override() {
+        // The internal-CA fallback policy must include `lifetime` on
+        // its issuer block — Caddy's 12 h default rotates the leaf on
+        // most box reboots and blows the operator's stored browser
+        // exception. This admin-API field is the only place we can
+        // set it (the Caddyfile's long-form `tls { issuer internal
+        // { lifetime ... } }` is rejected because it duplicates the
+        // auto-generated automation policy for nasty.local).
+        let body = build_tls_automation_json(&[], &TlsIssuer::default(), &[]);
+        let fallback = &body["policies"][0];
+        assert_eq!(fallback["issuers"][0]["module"], "internal");
+        assert_eq!(fallback["issuers"][0]["lifetime"], INTERNAL_LEAF_LIFETIME);
     }
 
     #[test]

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -10,6 +10,15 @@ let
   # `tls internal` directive — Caddy's "Local Authority" issues a
   # self-signed cert into its own state dir (`/var/lib/caddy/...`) and
   # auto-renews it.
+  #
+  # The internal-CA leaf TTL is overridden to 7 days via the engine's
+  # `apps.tls.automation` admin-API push (see `build_tls_automation_json`
+  # in engine/nasty-apps/src/caddy.rs) — Caddyfile's long-form
+  # `tls { issuer internal { lifetime ... } }` creates a second
+  # automation policy for `nasty.local` and conflicts with the one
+  # auto-generated from the site address, so we keep the Caddyfile in
+  # its short-form `tls internal` shape and lift the lifetime override
+  # into the engine's runtime PATCH instead.
   useUserCert = cfg.tls.certFile != null && cfg.tls.keyFile != null;
   caddyTlsDirective =
     if useUserCert

--- a/webui/src/lib/rpc.test.ts
+++ b/webui/src/lib/rpc.test.ts
@@ -243,6 +243,124 @@ describe('connection lifecycle', () => {
 		expect(mockInstances).toHaveLength(1);
 	});
 
+	test('forces page reload after enough consecutive failed reconnects', async () => {
+		// The escape hatch for the silent-TLS-reject case: when Caddy
+		// re-issues a self-signed leaf with a new fingerprint after a
+		// reboot, the browser silently refuses the WS handshake (no
+		// cert-warning UI for WebSockets — that's gated to full-page
+		// navigations). Without this reload, the reconnect loop spins
+		// forever. The full HTML reload that this triggers does surface
+		// the cert UI, so the operator can click through and the next
+		// connection succeeds.
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		vi.stubGlobal('location', { reload });
+		try {
+			const client = new NastyClient('ws://localhost/api');
+			const initial = client.connect();
+			mockInstances[0].open();
+			mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await initial;
+
+			// Drop the connection to enter the reconnect loop.
+			mockInstances[0].fireClose();
+
+			// Drive 10 consecutive failed reconnect attempts. Each cycle:
+			// advance past the (capped) backoff to fire the timer, then
+			// fail the freshly-constructed WS to simulate the silent TLS
+			// reject. Microtask flush happens inside advanceTimersByTimeAsync.
+			for (let attempt = 1; attempt <= 10; attempt++) {
+				await vi.advanceTimersByTimeAsync(30_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				// Let the connect()'s catch handler run.
+				await vi.advanceTimersByTimeAsync(0);
+			}
+
+			expect(reload).toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.useRealTimers();
+		}
+	});
+
+	test('does not force reload while under the failed-reconnect threshold', async () => {
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		vi.stubGlobal('location', { reload });
+		try {
+			const client = new NastyClient('ws://localhost/api');
+			const initial = client.connect();
+			mockInstances[0].open();
+			mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await initial;
+
+			mockInstances[0].fireClose();
+
+			// Five failed attempts — well under the 10-attempt threshold.
+			for (let attempt = 1; attempt <= 5; attempt++) {
+				await vi.advanceTimersByTimeAsync(30_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+
+			expect(reload).not.toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.useRealTimers();
+		}
+	});
+
+	test('successful reconnect resets the failed-attempt counter', async () => {
+		// After a streak of failures, a successful reconnect must clear
+		// the counter so a later, unrelated streak doesn't trip reload
+		// before reaching the full threshold.
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		vi.stubGlobal('location', { reload });
+		try {
+			const client = new NastyClient('ws://localhost/api');
+			const initial = client.connect();
+			mockInstances[0].open();
+			mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await initial;
+
+			// Drop, then fail 8 times (just under the threshold).
+			mockInstances[0].fireClose();
+			for (let attempt = 1; attempt <= 8; attempt++) {
+				await vi.advanceTimersByTimeAsync(30_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+			expect(reload).not.toHaveBeenCalled();
+
+			// The next attempt succeeds — this should reset the counter.
+			await vi.advanceTimersByTimeAsync(30_000);
+			const reconnected = mockInstances[mockInstances.length - 1];
+			reconnected.open();
+			reconnected.receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Drop again, fail 9 times — with a working reset, this is
+			// also under the threshold and shouldn't reload. (Without
+			// the reset, we'd be at 8+9=17 ≥ 10 and reload would fire.)
+			reconnected.fireClose();
+			for (let attempt = 1; attempt <= 9; attempt++) {
+				await vi.advanceTimersByTimeAsync(30_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+
+			expect(reload).not.toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.useRealTimers();
+		}
+	});
+
 	test('reconnect is scheduled on drop and onReconnect fires on re-auth', async () => {
 		vi.useFakeTimers();
 		try {

--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -36,6 +36,32 @@ export class NastyClient {
 	private reconnectDelayMs = 1000;
 	private static readonly RECONNECT_DELAY_FLOOR_MS = 1000;
 	private static readonly RECONNECT_DELAY_CEIL_MS = 30_000;
+	/** Number of consecutive failed reconnect attempts since the last
+	 *  successful auth. Drives the page-reload escape hatch below. */
+	private consecutiveFailedReconnects = 0;
+	/** After this many consecutive failed reconnect attempts, force a
+	 *  full page reload instead of scheduling yet another retry.
+	 *
+	 *  Why this exists: a WebSocket TLS handshake can fail silently in
+	 *  the browser (most commonly when the box rebooted and Caddy
+	 *  re-issued a self-signed leaf with a new fingerprint — the prior
+	 *  browser exception is keyed to the old fingerprint and the new
+	 *  one is silently rejected with no cert-warning UI, because the
+	 *  WebSocket API doesn't surface that prompt). The reconnect loop
+	 *  then spins forever — "Reconnecting..." with no progress.
+	 *  `location.reload()` does a full HTML navigation which DOES
+	 *  surface the cert-warning UI; once the operator clicks through,
+	 *  the WS connects fine on the reloaded page. The same escape
+	 *  hatch also unblocks "box has moved to a new IP", "server
+	 *  config changed in a way that breaks the WS endpoint", and any
+	 *  other persistent reconnect failure — the user gets a clear
+	 *  browser-level error state instead of a spinner.
+	 *
+	 *  Threshold sized so a normal reboot (~30–90 s downtime) recovers
+	 *  via the normal reconnect path without ever tripping reload, but
+	 *  a stuck state unblocks within ~3 minutes. Backoff totals at
+	 *  the 10th attempt: 1+2+4+8+16+30+30+30+30+30 = 181 s. */
+	private static readonly MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD = 10;
 	private _authenticated = false;
 	/** Set to true after the first successful auth; cleared by disconnect(). */
 	private _shouldReconnect = false;
@@ -76,8 +102,11 @@ export class NastyClient {
 						this._authenticated = true;
 						this._shouldReconnect = true;
 						// Successful connect — reset the backoff so the next
-						// disconnect retries quickly.
+						// disconnect retries quickly, and clear the
+						// failed-reconnect counter so the reload escape hatch
+						// only fires after a fresh streak of failures.
 						this.reconnectDelayMs = NastyClient.RECONNECT_DELAY_FLOOR_MS;
+						this.consecutiveFailedReconnects = 0;
 						this._readyResolve?.();
 						this._readyResolve = null;
 						if (wasReconnect) {
@@ -198,8 +227,19 @@ export class NastyClient {
 					location.reload();
 					return;
 				}
-				// Connection failed (server still down) — schedule another attempt
+				// Connection failed (server still down, or silent TLS reject
+				// after leaf-cert rotation, or any other persistent failure).
+				// After enough attempts, reload the page — see
+				// MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD for the rationale.
 				if (this._shouldReconnect) {
+					this.consecutiveFailedReconnects += 1;
+					if (
+						this.consecutiveFailedReconnects
+						>= NastyClient.MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD
+					) {
+						location.reload();
+						return;
+					}
 					this._scheduleReconnect();
 				}
 			});


### PR DESCRIPTION
## Summary

Two complementary fixes for "the WebUI sits forever on **Reconnecting…** after a reboot, and only `cmd+R` unblocks it."

### Root cause

Caddy's `tls internal` issues leaf certs with a 12-hour TTL by default and renews at ~2/3 lifetime (~8 h). Any reboot following >8 h of downtime mints a new leaf with a new SHA-256 fingerprint. The operator's prior browser exception (which pins by fingerprint) is invalidated.

For HTTP navigations this re-prompts the cert-warning UI — annoying but recoverable. For **WebSocket** reconnects the handshake fails silently — the WebSocket API has no surface for cert errors, and the browser doesn't show a cert-warning UI for WS handshakes (it's gated to full-page navigations). The reconnect loop in `rpc.ts` retries forever with no escape hatch. `cmd+R` works because the reload triggers a real navigation, which shows the cert UI, the operator clicks through, and on page load the WS connects fine.

### Fix A — `webui/src/lib/rpc.ts`

Add an escape hatch: after `MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD` (10) consecutive failed reconnect attempts, force `location.reload()` instead of scheduling yet another retry. The full HTML navigation triggers the browser's cert-warning UI; the operator clicks through; the reloaded page reconnects on the new fingerprint. Same escape hatch unblocks any other persistent reconnect failure (server moved IP, WS endpoint changed, etc.).

Threshold sized so a normal reboot (~30–90 s downtime) recovers via the normal reconnect path without ever tripping the reload. With exponential backoff capped at 30 s, the 10th attempt fires at ~181 s elapsed — generous enough for slow boots, bounded enough that a stuck state unblocks within ~3 minutes.

Counter resets on successful auth so a later unrelated failure streak doesn't trip reload prematurely.

### Fix B — `nixos/modules/nasty.nix`

Change `tls internal` to the long-form `tls { issuer internal { lifetime 168h } }` so the leaf rotates weekly rather than twice daily. Most operator reboot cadences (kernel updates, power outages) now fall inside one leaf lifetime, so the cert the browser accepted last time is still valid.

TLS-hygiene cost: longer-lived self-signed leaf, bigger blast radius if `/var/lib/caddy/`'s private key leaks. For a NAS appliance threat model this is an acceptable trade. Operators who want zero warnings forever should still import the local-CA root (10-year lifetime, doesn't rotate) via the WebUI's **Download CA Root** button on the TLS page — that's the strictly-better fix but requires explicit operator action.

### Why both fixes

A prevents the situation in the common case; B recovers cleanly when it happens anyway (some other cert change, the leaf does eventually rotate after 7 days, or anything else that breaks WS reconnect persistently). Neither replaces the other.

## Test plan

Three new tests in `rpc.test.ts` cover the reload threshold:

- [x] `forces page reload after enough consecutive failed reconnects` — drives 10 failed attempts via fake timers + fireError; asserts `location.reload` was called.
- [x] `does not force reload while under the failed-reconnect threshold` — 5 failed attempts; asserts `location.reload` was NOT called.
- [x] `successful reconnect resets the failed-attempt counter` — 8 fails, then success, then 9 more fails; asserts reload doesn't fire (8+9=17 ≥ 10 would falsely trip without the reset).

Gates:

- [x] `npm run check` — clean (0 errors, 0 warnings)
- [x] `npm test` — 124 passed across 11 files (3 new, all passing)
- [x] `npm run build` — clean
- [ ] Smoke on .71: reboot the box, watch the WebUI; without this PR it hangs on "Reconnecting…" forever; with this PR + B's lifetime bump in place, leaf shouldn't rotate at all on a reboot within 7 days of the last issuance.