### PR TITLE
flake+ci: include wrapper-flake template in engine Nix src + gate on Nix engine build pre-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,38 @@ jobs:
             exit 1
           fi
           echo "Installer template correctly follows nasty/bcachefs-tools."
+
+  nix-engine-build:
+    # Build the nasty-engine Nix package to catch sandbox-visibility
+    # regressions that `cargo build` alone won't see. The PR-time
+    # `cargo` jobs run against the full repo checkout, so a Rust
+    # `include_str!("../../../somewhere/outside/engine/...")` resolves
+    # fine in cargo but fails inside the Nix build sandbox when the
+    # engine's `src` filter only ships `./engine/`. That class of bug
+    # used to slip past PR CI and only blow up in the post-merge
+    # cachix push (e.g. PR #308's wrapper-flake template embed).
+    #
+    # This job is intentionally not gated by `cachix/cachix-action`
+    # auth — it builds without pushing, so it works on forks and
+    # third-party PRs. The cachix push remains on the integration
+    # workflow.
+    name: Nix engine build (sandbox-visibility gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Read-only Cachix substituter: pull cached deps to speed the
+      # build (a cold Rust compile of the workspace takes ~20 min on
+      # ubuntu-latest), but don't push.
+      - uses: cachix/cachix-action@v17
+        with:
+          name: nasty
+          skipPush: true
+
+      - name: Build engine package
+        run: nix build .#packages.x86_64-linux.engine --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,33 @@
     installerNastyOwner = "nasty-project";
     installerNastyRepo = "nasty";
 
-    mkEngine = system: let pkgs = mkPkgs system; in pkgs.rustPlatform.buildRustPackage {
+    mkEngine = system: let
+      pkgs = mkPkgs system;
+      # The engine source plus the wrapper-flake template the engine
+      # embeds via `include_str!("../../../nixos/system-flake/flake.nix.template")`
+      # in `engine/nasty-system/src/update.rs`. The path-up navigation
+      # walks out of `engine/` into the repo root, so the Nix sandbox
+      # must contain both subtrees at their canonical relative
+      # positions for `cargo build` to compile the engine.
+      #
+      # Why fileset.toSource (not just `src = ./.;`): the engine
+      # source-hash only depends on engine sources + this one template
+      # file. Adding unrelated repo changes (docs, webui, nixos
+      # modules) doesn't invalidate the Rust build cache.
+      engineSrc = pkgs.lib.fileset.toSource {
+        root = ./.;
+        fileset = pkgs.lib.fileset.unions [
+          ./engine
+          ./nixos/system-flake/flake.nix.template
+        ];
+      };
+    in pkgs.rustPlatform.buildRustPackage {
       pname = "nasty-engine";
       version = nasty-version;
-      src = ./engine;
+      src = engineSrc;
+      # `engineSrc` unpacks to `source/`; cargo runs from the engine
+      # subdirectory so it finds the workspace Cargo.toml.
+      sourceRoot = "source/engine";
       cargoLock.lockFile = ./engine/Cargo.lock;
       meta = {
         description = "NASty NAS engine";


### PR DESCRIPTION
## Summary

Fix-forward for the regression that #308 introduced into main.

The Integration / cachix push failed because `include_str!("../../../nixos/system-flake/flake.nix.template")` in `engine/nasty-system/src/update.rs` couldn't resolve the path inside the Nix build sandbox — `src = ./engine` only ships `engine/` into the sandbox, so the path-up walks out and the file isn't there.

**Why every PR gate was green and we still broke main:** the Nix engine build only ran post-merge (Integration → cachix push). Every cargo/npm/clippy/test gate uses the full repo checkout, so the relative path resolves fine. No pre-merge job ever exercised the Nix-packaged build.

Failure run for reference: https://github.com/nasty-project/nasty/actions/runs/26357411684

## Fix

**`flake.nix`** — switch the engine package's `src` from a bare `./engine` to `lib.fileset.toSource` with `./engine` PLUS the single template file at its canonical relative path. `sourceRoot = "source/engine"` keeps cargo running from the engine subdir (workspace Cargo.toml lookup); the template is reachable at `source/nixos/system-flake/flake.nix.template`, which is exactly where the `include_str!` path-up expects it.

Using `lib.fileset.toSource` (not `./.`) keeps the Rust build-cache key narrow — unrelated repo changes (docs, webui, nixos modules) don't invalidate the engine derivation.

Locally verified via `nix eval` that the fileset resolves and includes only the engine subtree plus the one template file (full Linux build needs a remote builder; CI will do the end-to-end build).

**`.github/workflows/ci.yml`** — new `nix-engine-build` job runs `nix build .#packages.x86_64-linux.engine` on every PR. Uses `cachix/cachix-action@v17` with `skipPush: true` so fork PRs (no secrets) can still pull cached closures from nasty.cachix.org without trying to push. Catches the whole regression class: missing files in the sandbox, escaping path navigations, preBuild assumptions that hold on cargo-out-of-repo-checkout but not on Nix-with-narrow-src.

The existing PR cargo gates stay — they're faster and cover clippy/fmt/tests that the Nix build doesn't run; the Nix gate is purely the "is the derivation buildable" assertion.

## Test plan

- [x] `nix eval` confirms src.name = `source`, sourceRoot = `source/engine`
- [x] `nix eval` of the fileset store path confirms `engine/` + `nixos/system-flake/flake.nix.template` are both present, and the rest of `nixos/` is NOT (build-cache narrowing works)
- [ ] CI: the new `nix-engine-build` job on this PR turns green — that's the actual end-to-end verification that the sandbox build resolves the `include_str!`
- [ ] Post-merge: Integration / aarch64 cachix push run goes green again