### PR TITLE
ci: speed up slow Nix jobs via paths filter + Magic Nix Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,38 +135,3 @@ jobs:
             exit 1
           fi
           echo "Installer template correctly follows nasty/bcachefs-tools."
-
-  nix-engine-build:
-    # Build the nasty-engine Nix package to catch sandbox-visibility
-    # regressions that `cargo build` alone won't see. The PR-time
-    # `cargo` jobs run against the full repo checkout, so a Rust
-    # `include_str!("../../../somewhere/outside/engine/...")` resolves
-    # fine in cargo but fails inside the Nix build sandbox when the
-    # engine's `src` filter only ships `./engine/`. That class of bug
-    # used to slip past PR CI and only blow up in the post-merge
-    # cachix push (e.g. PR #308's wrapper-flake template embed).
-    #
-    # This job is intentionally not gated by `cachix/cachix-action`
-    # auth — it builds without pushing, so it works on forks and
-    # third-party PRs. The cachix push remains on the integration
-    # workflow.
-    name: Nix engine build (sandbox-visibility gate)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      # Read-only Cachix substituter: pull cached deps to speed the
-      # build (a cold Rust compile of the workspace takes ~20 min on
-      # ubuntu-latest), but don't push.
-      - uses: cachix/cachix-action@v17
-        with:
-          name: nasty
-          skipPush: true
-
-      - name: Build engine package
-        run: nix build .#packages.x86_64-linux.engine --print-build-logs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,9 @@ on:
       - 'flake.lock'
 
 permissions:
+  # `id-token: write` required by Magic Nix Cache for OIDC auth against
+  # the GitHub Actions cache (the per-branch incremental Nix cache).
+  id-token: write
   contents: read
 
 concurrency:
@@ -30,6 +33,15 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+
+      # Magic Nix Cache uses GitHub Actions' cache as a Nix binary
+      # cache, layered on top of cachix. Cachix carries main-branch
+      # closures; Magic Nix Cache adds per-branch incremental caching
+      # across PR runs. On a PR that touches one Rust crate, only that
+      # crate + downstream rebuild — the rest substitutes from Actions
+      # cache. Realistic win on this job: ~36 min cold → ~15 min warm
+      # (VM-boot overhead is still ~10 min and uncacheable).
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
 
       # Read-only on PRs and workflow_dispatch; the conditional push step
       # below populates the cache when this run is a push to main. Folding

--- a/.github/workflows/nix-engine-build.yml
+++ b/.github/workflows/nix-engine-build.yml
@@ -1,0 +1,66 @@
+name: Nix engine build
+
+# Sandbox-visibility gate for the engine derivation. Catches the class
+# of regression where a Rust `include_str!("../../../somewhere")`
+# resolves fine in cargo (which sees the full repo checkout) but fails
+# inside the Nix build sandbox when the engine's `src` filter only
+# ships `./engine/`. PR #308 hit exactly this; the gate was added in
+# #310 alongside the fix.
+#
+# Lives in its own workflow file (not ci.yml) so the `paths:` filter
+# below can skip the slow Nix build entirely for PRs that touch only
+# WebUI, docs, or other unrelated files. ci.yml stays as the
+# always-on cargo+npm gate.
+
+on:
+  pull_request:
+    paths:
+      - 'engine/**'
+      - 'nixos/system-flake/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/nix-engine-build.yml'
+  push:
+    branches: [main]
+
+permissions:
+  # `id-token: write` is required by Magic Nix Cache to authenticate
+  # against the GitHub Actions cache via OIDC.
+  id-token: write
+  contents: read
+
+concurrency:
+  group: nix-engine-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-engine-build:
+    name: Nix engine build (sandbox-visibility gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Magic Nix Cache uses the GitHub Actions cache as a Nix binary
+      # cache. Layered on top of cachix (which holds main-branch
+      # closures) to give per-branch incremental caching across PR
+      # runs: when only one Rust crate changes, only that crate +
+      # downstream rebuild, the rest substitutes from Actions cache.
+      # Realistic win on this job: ~17 min cold → ~5-8 min warm.
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      # Read-only Cachix substituter: pull cached deps to speed cold
+      # builds (rustc, openssl, etc. all come from cachix), but don't
+      # push. Works on forks and PRs without secrets.
+      - uses: cachix/cachix-action@v17
+        with:
+          name: nasty
+          skipPush: true
+
+      - name: Build engine package
+        run: nix build .#packages.x86_64-linux.engine --print-build-logs


### PR DESCRIPTION
## Summary

Two compounding speedups for the two slow Nix-based CI jobs (Nix engine build ~17 min, bcachefs smoke ~36 min).

### (1) Paths filter on the Nix engine build

Moved the job out of `ci.yml` into its own `nix-engine-build.yml` with `paths:` triggering only on engine sources, the embedded flake template, `flake.nix`/`flake.lock`, the Rust toolchain pin, or this workflow itself. PRs that touch only WebUI, docs, or other unrelated files now skip the ~17-min Nix build entirely.

The job's display name stays **"Nix engine build (sandbox-visibility gate)"** so any branch-protection rules matching on the check name keep working.

`integration.yml`'s bcachefs-smoke already has an equivalent `paths:` filter (engine, nixos modules, nixos tests, `flake.nix`, `flake.lock`) — no change there.

### (2) Magic Nix Cache on both Nix-running jobs

`DeterminateSystems/magic-nix-cache-action@v13` uses the GitHub Actions cache as a Nix binary cache, layered on top of cachix. Cachix carries main-branch closures; Magic Nix Cache adds **per-branch incremental caching** across PR runs: when one Rust crate changes, only that crate + its downstream rebuilds, the rest substitutes from the Actions cache.

Free, no third-party service, works on forks (uses GHA's built-in OIDC for cache auth — `id-token: write` permission added on both workflows). Doesn't replace cachix — they serve different purposes (cachix: published main-branch closures available outside CI; Magic Nix Cache: PR-time incremental).

Realistic wins:

| Job | Cold | Warm |
|---|---|---|
| Nix engine build | ~17 min | ~5–8 min |
| bcachefs smoke | ~36 min | ~15 min (VM-boot ~10 min uncacheable) |

These two together should drop a typical engine-touching PR from ~36 min of wall-clock CI down to ~15 min, and a docs-only PR from ~17 min down to the cargo+npm gates (~2 min).

## Test plan

- [ ] On this PR itself: docs-only diff wouldn't normally trigger nix-engine-build, but this PR touches `.github/workflows/nix-engine-build.yml`, so the job DOES run once. After this merges, a follow-up docs-only PR should skip it cleanly.
- [ ] Magic Nix Cache first-run on this PR: no warm cache yet, so build time should be similar to today. The win shows up on the SECOND PR run (rebase, force-push, etc.) — the slow jobs should drop noticeably.
- [ ] Verify the job display name is unchanged (branch protection on "Nix engine build (sandbox-visibility gate)" still resolves).