### PR TITLE
update: run wrapper-shape migration at the top of version_switch too

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1215,6 +1215,29 @@ echo "==> Update complete!"
             return Err(UpdateError::AlreadyRunning);
         }
 
+        // Migrate the wrapper to the canonical 0.0.9 shape before
+        // anything else — the input-presence checks below (and
+        // rewrite_flake_input_urls deeper in the call chain) demand
+        // `.url` declarations for both editable inputs. Without this
+        // upfront migration a post-#308 follows-shape wrapper (no
+        // `bcachefs-tools.url`) would error "missing bcachefs-tools.url"
+        // on the very first WebUI dev-build click — the same
+        // self-update strand that #312 set out to fix for nixpkgs but
+        // missed for bcachefs-tools. apply() and upgrade_tagged_release()
+        // already do this migration up-front; doing it here too closes
+        // the third edge of the triangle.
+        //
+        // Best-effort: failure logged as warn, doesn't abort the
+        // request. If the wrapper can't be migrated (fork URL, parse
+        // failure, etc.) the operator gets a clearer error from the
+        // input-presence check below.
+        if let Err(e) = self.maybe_migrate_wrapper_shape().await {
+            warn!(
+                target: "nasty::update",
+                "wrapper migration to canonical shape skipped during version_switch: {e}"
+            );
+        }
+
         let current_urls = read_flake_input_urls().await?;
         let mut seen = HashSet::new();
         let mut requested = HashMap::new();


### PR DESCRIPTION
## Summary

`apply()` and `upgrade_tagged_release()` both call `maybe_migrate_wrapper_shape` up-front so a post-#308 follows-shape wrapper gets canonicalized before the input-presence checks downstream demand `.url` declarations. **`version_switch()` was missing the same call** — which meant the WebUI's dev-build "Upgrade" button (the one path that routes through `version_switch`) still stranded any operator on a follows-shape wrapper:

```
command failed: missing bcachefs-tools.url in /etc/nixos/flake.nix
```

Same self-update-strand shape #312 set out to fix for nixpkgs, just hitting bcachefs-tools instead because the migration only runs in two of the three RPC paths. Caught immediately post-#312 on .71 after deploying the fixed engine; the next click on Upgrade hit the same wall just one layer in.

## Fix

Add the migration call at the top of `version_switch`, mirroring `apply()` and `upgrade_tagged_release()`. Best-effort: failure logs a warn and the request continues. Genuinely-unmigratable wrappers (fork URLs, parse failures) get the existing input-presence error a few lines down — same outcome as before this patch, with the side effect that successfully-migratable wrappers no longer trip on the first WebUI dev-build click.

## Test plan

- [x] `cargo fmt`, `cargo clippy`, `cargo test -p nasty-system` all pass (226 tests, no new ones — the change is purely defensive plumbing covered by the existing migration tests)
- [ ] Smoke on a stranded box: deploy this, click Upgrade in the WebUI, confirm the wrapper migrates and the build proceeds.

## Follow-up

A `nasty-sync` CLI on the box would give operators a permanent "WebUI is broken, rescue path" recovery hatch — separate PR.