### PR TITLE
engine: report own build commit as 'current version', not booted-system snapshot

### DIFF
--- a/engine/nasty-system/build.rs
+++ b/engine/nasty-system/build.rs
@@ -1,0 +1,38 @@
+// Bakes the git commit this engine was built from into the binary
+// as `NASTY_GIT_SHA`, readable at runtime via `option_env!`. The
+// engine uses this as the authoritative answer to "what nasty rev
+// am I?" — the binary literally was built from this commit, so
+// there's no proxy chain to drift or lag.
+//
+// Priority of sources:
+//   1. `NASTY_GIT_SHA` env var — Nix passes the flake's rev here
+//      (set in `mkEngine` in flake.nix). This is the only source
+//      that works in the Nix sandbox, which doesn't have access to
+//      the .git directory.
+//   2. `git rev-parse HEAD` — works for local cargo builds outside
+//      Nix (developer dev loop). Silently no-ops if there's no git
+//      checkout or git isn't on PATH.
+//
+// On total failure the SHA is just absent — `option_env!` returns
+// None at runtime and the engine falls back to its existing
+// /etc/nixos/flake.lock chain. Builds always succeed.
+
+fn main() {
+    let sha = std::env::var("NASTY_GIT_SHA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+    if let Some(sha) = sha {
+        println!("cargo:rustc-env=NASTY_GIT_SHA={sha}");
+    }
+    println!("cargo:rerun-if-env-changed=NASTY_GIT_SHA");
+}

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -2464,39 +2464,38 @@ async fn check_via_git_ls_remote(
         .unwrap_or_else(|| "unknown".to_string()))
 }
 
+/// The git commit this engine binary was built from, baked in at
+/// build time by `engine/nasty-system/build.rs`. `None` when the
+/// build environment couldn't determine the SHA (no Nix-set env var
+/// AND no usable git checkout — extremely unusual but possible for
+/// dev-loop builds in weird sandboxes).
+const ENGINE_BUILD_REV: Option<&str> = option_env!("NASTY_GIT_SHA");
+
 async fn read_current_version() -> String {
-    // Priority is "closest to ground truth first":
+    // The engine binary's own embedded build commit is the ground
+    // truth: this binary literally was built from that commit, so
+    // by definition that's what's running. No proxy chain to drift
+    // or lag — in particular, no waiting on `/run/booted-system` to
+    // refresh after a reboot (which used to be the top priority
+    // here and caused the "Upgrade keeps being available even after
+    // I clicked it" loop: the operator activates a new generation,
+    // engine restarts on the new closure, but `/run/booted-system`
+    // still points at the previously-booted closure until reboot →
+    // engine reports the OLD rev as "current" → check() says
+    // upgrade available → forever).
     //
-    // 1. `/run/booted-system/etc/nasty-system-flake/flake.lock` —
-    //    the wrapper-flake snapshot baked into the NixOS generation
-    //    we actually booted. recover-generation-flake.service copies
-    //    the wrapper flake.nix + flake.lock that produced the system
-    //    into this path at activation; reading the `nasty` rev from
-    //    that lock answers "what nasty are we ACTUALLY running"
-    //    without any side-effect-driven sync. Independent of
-    //    `/var/lib/nasty/version` stamps, safe across manual
-    //    `nixos-rebuild` invocations (we hit this repeatedly during
-    //    debug sessions — the stamp drifted, UI lied), and immune
-    //    to the half-applied-upgrade case where flake.lock holds
-    //    the target rev but the running system is on the prior one.
-    //
-    // 2. `/var/lib/nasty/version` — kept for backward compat with
-    //    older boxes whose booted system doesn't carry the
-    //    nasty-system-flake snapshot. Written by the upgrade
-    //    script's final line, so reflects intentional state when
-    //    present.
-    //
-    // 3. `/etc/nasty-version` — the literal `nasty-version` arg the
-    //    wrapper passed to the NixOS module. Usually the release
-    //    tag string like "0.0.8" rather than a commit SHA, but
-    //    matches the active generation.
-    //
-    // 4. `flake.lock` of `/etc/nixos` — aspirational. `nix flake
-    //    update` rewrites this BEFORE the rebuild runs, so on a
-    //    half-applied upgrade the lock points at the new tag while
-    //    the running system is still on the old one.
-    //
-    // 5. `"dev"` — last-resort sentinel for unmanaged builds.
+    // The fallback chain below is kept for boxes whose engine was
+    // built without the SHA bake (dev-loop cargo builds in weird
+    // sandboxes, or pre-fix engine binaries doing a self-update).
+    // None of the fallback sources is as good as the bake — they
+    // all drift in one direction or another — but they're better
+    // than "dev" sentinel.
+    if let Some(rev) = ENGINE_BUILD_REV {
+        let trimmed = rev.trim();
+        if !trimmed.is_empty() && trimmed != "unknown" {
+            return trimmed[..7.min(trimmed.len())].to_string();
+        }
+    }
     if let Some(rev) = read_booted_nasty_rev().await {
         return rev;
     }

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,16 @@
       # subdirectory so it finds the workspace Cargo.toml.
       sourceRoot = "source/engine";
       cargoLock.lockFile = ./engine/Cargo.lock;
+      # Bake the flake's source rev into the engine binary as
+      # NASTY_GIT_SHA, picked up by engine/nasty-system/build.rs and
+      # exposed at runtime via option_env!. The engine uses this as
+      # the authoritative answer to "what nasty rev am I" — see the
+      # check() flow in update.rs. `self.rev` is set when the flake
+      # tree is clean (committed); `self.dirtyRev` is set when
+      # uncommitted changes are present (cargo / dev iteration); the
+      # final "unknown" fallback is for flakes evaluated without git
+      # at all (extremely unusual but possible).
+      NASTY_GIT_SHA = self.rev or self.dirtyRev or "unknown";
       meta = {
         description = "NASty NAS engine";
         license = pkgs.lib.licenses.gpl3Only;


### PR DESCRIPTION
## Summary

The engine binary knows its own git commit by construction — it was literally built from that commit. Reporting anything else as "what nasty rev am I" is a proxy chain prone to lag and drift. Today demonstrated the consequence painfully:

1. Operator runs SSH rescue on a stranded box
2. `nix flake update nasty` + `nixos-rebuild switch`
3. Activation succeeds: `/etc/nixos/flake.lock` has new rev, new closure activated, new engine binary running
4. But `/run/booted-system` still points at the BOOTED closure (only refreshes on actual reboot)
5. `read_current_version` reads `/run/booted-system/etc/nasty-system-flake/flake.lock` first → returns OLD rev
6. `check()` compares OLD vs upstream main HEAD → "update available"
7. Operator clicks Upgrade → new closure activates (no-op since already on main), `/run/booted-system` still stale, repeat
8. **"I can upgrade dozen times and it keeps saying upgradable"**

## Fix

Bake the source rev into the binary at build time and read it back via `option_env!`.

- **`engine/nasty-system/build.rs`** (new): writes `cargo:rustc-env=NASTY_GIT_SHA=<rev>` using either the `NASTY_GIT_SHA` env var (Nix passes this) or `git rev-parse HEAD` (local cargo dev loop).
- **`flake.nix`**: `mkEngine` sets `NASTY_GIT_SHA = self.rev or self.dirtyRev or "unknown"` on the derivation. `self.rev` works for clean trees; `self.dirtyRev` for in-progress dev iteration.
- **`update.rs read_current_version`**: prefers `ENGINE_BUILD_REV` (the `option_env!` reader) over the existing `/run/booted-system → stamp → /etc/nasty-version → live lock → "dev"` chain. The chain stays as a fallback for binaries that somehow lost their bake.

Verified by inspecting the produced `nasty-engine` binary: the full SHA appears in the data section right next to `/etc/nasty-version`.

## Why the previous priority order was wrong

- **`/run/booted-system`** answers "what kernel am I actually booted into" — useful for "do I need to reboot" semantics (which `lib.rs`'s `bcachefs_is_custom` already handles separately). Wrong answer for "what engine binary am I." This is the source of today's strand.
- **`/var/lib/nasty/version`** stamp drifts on out-of-band rebuilds (and today the upgrade script wasn't even reaching the stamp write on the stranded boxes).
- **`/etc/nasty-version`** is just the version STRING (`0.0.8`), not a commit — useless for rev comparison.
- **`/etc/nixos/flake.lock`** (live) drifts ahead during a half-applied upgrade: lock has new rev, engine binary is old.

The baked SHA has none of these failure modes. The binary running the check IS the binary built from the reported SHA, period.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p nasty-system` (226 passed)
- [x] Local release build inspected — full SHA `0584505cd12f7816d4b517885fad6eb0416e6250` appears in the binary's data section
- [ ] Smoke on a stranded box once #314's `nasty-sync -r` is also out: rescue + verify the WebUI's Update page shows current = upstream main = "up to date" without needing a reboot
- [ ] CI's nix-engine-build job confirms the Nix path works (the env-var hand-off from flake.nix to build.rs)