### PR TITLE
template: hardcode bcachefs-tools URL — unblocks v0.0.8 WebUI upgrade path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,17 @@ jobs:
     #    Following nasty here removes that capability for no cachix
     #    win, since nasty's binaries don't depend on it.
     #
-    # The renderer in engine/nasty-system/src/update.rs substitutes
-    # @BCACHEFS_TOOLS_REF@ at template render time; the engine
-    # extracts the canonical default from nasty's own flake.nix.
+    # The bcachefs-tools URL is hardcoded with a real ref (e.g.
+    # "v1.38.3") rather than a `@BCACHEFS_TOOLS_REF@` placeholder.
+    # The placeholder approach (#312) was a forward-compat trap:
+    # pre-#312 engines (notably v0.0.8) don't know about the
+    # placeholder, silently no-op when substituting it, and ship
+    # the literal text into `bcachefs-tools.url` during rebootstrap
+    # — breaking the next `nix flake update`. Hardcoding the ref
+    # means every historical renderer (going back to v0.0.5) writes
+    # a clean wrapper. Per-operator bcachefs-tools customization
+    # happens via a post-render `rewrite_flake_input_urls` pass on
+    # the caller side (see update.rs).
     name: Installer template canonical shape (nixpkgs follows, bcachefs.url)
     runs-on: ubuntu-latest
     steps:
@@ -145,20 +153,28 @@ jobs:
           fi
           echo "Installer template correctly follows nasty/nixpkgs."
 
-      - name: Assert template pins bcachefs-tools with its own .url
+      - name: Assert template pins bcachefs-tools with its own .url (hardcoded ref, no placeholder)
         run: |
           if grep -qE 'bcachefs-tools\.follows\s*=' nixos/system-flake/flake.nix.template; then
             echo "::error::installer template declares bcachefs-tools.follows — should pin its own .url so operators can independently override"
             echo "Template should declare:"
-            echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@\";"
+            echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/<vX.Y.Z>\";"
             echo "instead of:"
             grep -nE 'bcachefs-tools\.follows' nixos/system-flake/flake.nix.template
             exit 1
           fi
-          if ! grep -qE 'bcachefs-tools\.url\s*=\s*"github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@"' nixos/system-flake/flake.nix.template; then
-            echo "::error::installer template missing bcachefs-tools.url with the @BCACHEFS_TOOLS_REF@ placeholder"
-            echo "Template should declare:"
-            echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@\";"
+          if grep -qE 'bcachefs-tools\.url\s*=\s*"[^"]*@[A-Z_]+@' nixos/system-flake/flake.nix.template; then
+            echo "::error::installer template's bcachefs-tools.url contains an @PLACEHOLDER@ — pre-#312 engines (v0.0.8) silently no-op on unknown placeholders and ship the literal text into the wrapper, breaking the next nix flake update"
+            echo "Template should hardcode a real ref:"
+            echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/<vX.Y.Z>\";"
+            echo "Current declaration:"
+            grep -nE 'bcachefs-tools\.url' nixos/system-flake/flake.nix.template
             exit 1
           fi
-          echo "Installer template correctly pins bcachefs-tools.url with @BCACHEFS_TOOLS_REF@ placeholder."
+          if ! grep -qE 'bcachefs-tools\.url\s*=\s*"github:koverstreet/bcachefs-tools/v[0-9]+\.[0-9]+\.[0-9]+"' nixos/system-flake/flake.nix.template; then
+            echo "::error::installer template missing bcachefs-tools.url with a hardcoded semver tag (e.g. v1.38.3)"
+            echo "Template should declare:"
+            echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/v1.38.3\";"
+            exit 1
+          fi
+          echo "Installer template correctly pins bcachefs-tools.url with a hardcoded semver tag."

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1354,10 +1354,26 @@ echo "==> Update complete!"
                 } else {
                     current_flake.clone()
                 };
-                let flake_replacements = url_changes
+                // Preserve operator's existing bcachefs-tools pin
+                // across rebootstrap. Without this, a template-hash
+                // change (e.g., a maintainer-side bcachefs default
+                // bump) would silently overwrite the operator's
+                // custom pin with the template's new default. The
+                // request's bcachefs URL is what the operator
+                // actually wants (the WebUI populates it from
+                // version_info, which read the current wrapper);
+                // ensure it's in the rewrite map even when the
+                // request URL matches current state (so url_changes
+                // is empty for it).
+                let mut flake_replacements: HashMap<String, String> = url_changes
                     .iter()
                     .map(|(name, url)| (name.clone(), url.clone()))
-                    .collect::<HashMap<_, _>>();
+                    .collect();
+                if let Some(bcachefs_input) = requested.get("bcachefs-tools") {
+                    flake_replacements
+                        .entry(String::from("bcachefs-tools"))
+                        .or_insert_with(|| bcachefs_input.url.clone());
+                }
                 if flake_replacements.is_empty() {
                     base
                 } else {

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -679,25 +679,28 @@ impl UpdateService {
             &release_status.latest_tag,
         )
         .await?;
+        // Render is now placeholder-free for bcachefs (template
+        // carries a hardcoded default). The release's actual
+        // bcachefs ref gets baked in via a post-render
+        // `rewrite_flake_input_urls` pass below — works on every
+        // historical engine version because rewrite_flake_input_urls
+        // predates the placeholder mechanism. Same code path
+        // whether we rebootstrapped or just URL-rewrote.
         let next_flake = if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
-            render_system_flake_template(
-                &template,
-                &release_status.latest_tag,
-                &bcachefs_ref,
-                &local_system,
-            )?
+            render_system_flake_template(&template, &release_status.latest_tag, &local_system)?
         } else {
-            rewrite_flake_input_urls(
-                &current_flake,
-                &HashMap::from([
-                    (String::from("nasty"), release_status.latest_url.clone()),
-                    (
-                        String::from("bcachefs-tools"),
-                        format!("github:koverstreet/bcachefs-tools/{bcachefs_ref}"),
-                    ),
-                ]),
-            )?
+            current_flake.clone()
         };
+        let next_flake = rewrite_flake_input_urls(
+            &next_flake,
+            &HashMap::from([
+                (String::from("nasty"), release_status.latest_url.clone()),
+                (
+                    String::from("bcachefs-tools"),
+                    format!("github:koverstreet/bcachefs-tools/{bcachefs_ref}"),
+                ),
+            ]),
+        )?;
 
         // Best-effort cleanup of any prior unit state. `try_run` logs spawn
         // failures and non-zero exits at warn! — a missing-unit "exited 5"
@@ -1339,32 +1342,26 @@ echo "==> Update complete!"
                 )
                 .await?;
 
-                if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
+                // Render is placeholder-free — the template carries
+                // a hardcoded bcachefs default. The operator's
+                // requested bcachefs URL is applied as a post-render
+                // URL rewrite (same code path that handles the
+                // no-rebootstrap case), which works on every
+                // historical engine version.
+                let base = if should_rebootstrap_wrapper_flake(&current_flake, &template)? {
                     let local_system = detect_local_system().await?;
-                    let bcachefs_ref = requested
-                        .get("bcachefs-tools")
-                        .and_then(|i| i.url.rsplit('/').next())
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.to_string())
-                        .ok_or_else(|| {
-                            UpdateError::CommandFailed(
-                                "version_switch request has no parseable bcachefs-tools URL — \
-                                 expected `github:owner/repo/<ref>` shape"
-                                    .into(),
-                            )
-                        })?;
-                    render_system_flake_template_with_ref(
-                        &template,
-                        &nasty_ref,
-                        &bcachefs_ref,
-                        &local_system,
-                    )?
+                    render_system_flake_template_with_ref(&template, &nasty_ref, &local_system)?
                 } else {
-                    let flake_replacements = url_changes
-                        .iter()
-                        .map(|(name, url)| (name.clone(), url.clone()))
-                        .collect::<HashMap<_, _>>();
-                    rewrite_flake_input_urls(&current_flake, &flake_replacements)?
+                    current_flake.clone()
+                };
+                let flake_replacements = url_changes
+                    .iter()
+                    .map(|(name, url)| (name.clone(), url.clone()))
+                    .collect::<HashMap<_, _>>();
+                if flake_replacements.is_empty() {
+                    base
+                } else {
+                    rewrite_flake_input_urls(&base, &flake_replacements)?
                 }
             }
             None => {
@@ -1954,9 +1951,11 @@ pub async fn bootstrap_system_flake_from_template(
     nasty_version: &str,
     local_system: &str,
 ) -> Result<BootstrapSystemFlakeResult, UpdateError> {
-    let bcachefs_ref = embedded_default_bcachefs_tools_ref()?;
-    let rendered =
-        render_system_flake_template(template, nasty_version, &bcachefs_ref, local_system)?;
+    // Template carries a hardcoded bcachefs-tools URL default; no
+    // per-render substitution needed here. Caller can mutate the
+    // bcachefs ref later via `rewrite_flake_input_urls` if they
+    // need a non-default pin (the tagged-release path does this).
+    let rendered = render_system_flake_template(template, nasty_version, local_system)?;
     tokio::fs::create_dir_all(dest_dir)
         .await
         .map_err(|e| UpdateError::CommandFailed(format!("mkdir {dest_dir}: {e}")))?;
@@ -2006,11 +2005,10 @@ fn embedded_default_bcachefs_tools_ref() -> Result<String, UpdateError> {
 fn render_system_flake_template(
     template: &str,
     nasty_version: &str,
-    bcachefs_tools_ref: &str,
     local_system: &str,
 ) -> Result<String, UpdateError> {
     let nasty_tag = normalize_release_tag(nasty_version)?;
-    render_system_flake_template_with_ref(template, &nasty_tag, bcachefs_tools_ref, local_system)
+    render_system_flake_template_with_ref(template, &nasty_tag, local_system)
 }
 
 /// Render the wrapper-flake template with the nasty ref passed
@@ -2018,10 +2016,20 @@ fn render_system_flake_template(
 /// `render_system_flake_template` would reject them — but they're
 /// valid GitHub refs and we want main-trackers to be able to
 /// rebootstrap too.
+///
+/// **Backwards-compat invariant** (the v0.0.8-strand lesson): the
+/// only placeholders this renderer substitutes are the three below
+/// — `@NASTY_VERSION@`, `@LOCAL_SYSTEM@`, `@WRAPPER_FLAKE_VERSION@`.
+/// Older engines (notably v0.0.8) substitute the same three and
+/// silently no-op on anything else, leaving any unknown `@FOO@`
+/// literal in the wrapper they write to disk. So the canonical
+/// template MUST NOT add a fourth placeholder — operator inputs
+/// that need to vary per render (like the bcachefs-tools ref) are
+/// handled by a post-render `rewrite_flake_input_urls` pass on
+/// the caller side, NOT here.
 fn render_system_flake_template_with_ref(
     template: &str,
     nasty_ref: &str,
-    bcachefs_tools_ref: &str,
     local_system: &str,
 ) -> Result<String, UpdateError> {
     if !template.contains("@NASTY_VERSION@") {
@@ -2039,28 +2047,19 @@ fn render_system_flake_template_with_ref(
             "system flake template is missing @WRAPPER_FLAKE_VERSION@ placeholder".into(),
         ));
     }
-    if !template.contains("@BCACHEFS_TOOLS_REF@") {
-        return Err(UpdateError::CommandFailed(
-            "system flake template is missing @BCACHEFS_TOOLS_REF@ placeholder".into(),
-        ));
-    }
     if nasty_ref.is_empty() {
         return Err(UpdateError::CommandFailed(
             "nasty ref must not be empty".into(),
         ));
     }
-    if bcachefs_tools_ref.is_empty() {
-        return Err(UpdateError::CommandFailed(
-            "bcachefs-tools ref must not be empty".into(),
-        ));
-    }
     let wrapper_version = wrapper_flake_content_hash(template);
 
-    Ok(template
+    let rendered = template
         .replace("@NASTY_VERSION@", nasty_ref)
-        .replace("@BCACHEFS_TOOLS_REF@", bcachefs_tools_ref)
         .replace("@LOCAL_SYSTEM@", local_system)
-        .replace("@WRAPPER_FLAKE_VERSION@", &wrapper_version))
+        .replace("@WRAPPER_FLAKE_VERSION@", &wrapper_version);
+
+    Ok(rendered)
 }
 
 /// Whether the wrapper is in the canonical 0.0.9 shape:
@@ -2138,6 +2137,14 @@ async fn migrate_wrapper_to_canonical_shape(
              want the canonical-shape inputs."
         ))
     })?;
+    // Resolve the bcachefs ref to PRESERVE across migration. Three
+    // sources, in priority:
+    //   1. operator's existing `bcachefs-tools.url` (legacy / pre-#304
+    //      wrappers that had their own pin),
+    //   2. `flake.lock`'s `nodes["bcachefs-tools"].original.ref`
+    //      (post-#308 follows-shape wrappers — Nix wrote the
+    //      resolved ref on the followed node),
+    //   3. embedded default (lock-less fresh installs).
     let bcachefs_ref = if let Some(input) = urls.get("bcachefs-tools") {
         input
             .url
@@ -2159,11 +2166,18 @@ async fn migrate_wrapper_to_canonical_shape(
             None => embedded_default_bcachefs_tools_ref()?,
         }
     };
-    render_system_flake_template_with_ref(
-        EMBEDDED_WRAPPER_TEMPLATE,
-        &nasty_ref,
-        &bcachefs_ref,
-        local_system,
+    // Render is placeholder-free (template has a hardcoded bcachefs
+    // default). Then rewrite the bcachefs URL to the operator's
+    // preserved ref — same rewrite-after-render pattern as
+    // upgrade_tagged_release and version_switch.
+    let rendered =
+        render_system_flake_template_with_ref(EMBEDDED_WRAPPER_TEMPLATE, &nasty_ref, local_system)?;
+    rewrite_flake_input_urls(
+        &rendered,
+        &HashMap::from([(
+            String::from("bcachefs-tools"),
+            format!("github:koverstreet/bcachefs-tools/{bcachefs_ref}"),
+        )]),
     )
 }
 
@@ -3173,7 +3187,7 @@ body = true;
         let template = r#"
 inputs = {
   nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
-  bcachefs-tools.url = "github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@";
+  bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
 };
 wrapperFlakeVersion = "@WRAPPER_FLAKE_VERSION@";
 "#
@@ -3183,37 +3197,28 @@ outputs = { nixpkgs, nasty, ... }: {
   nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "@LOCAL_SYSTEM@"; };
 };
 "#;
-        let rendered =
-            super::render_system_flake_template(&template, "0.0.3", "v1.38.3", "x86_64-linux")
-                .expect("rendered");
+        let rendered = super::render_system_flake_template(&template, "0.0.3", "x86_64-linux")
+            .expect("rendered");
         assert!(rendered.contains("github:nasty-project/nasty/v0.0.3"));
+        // bcachefs-tools URL is hardcoded in the template (no
+        // placeholder) — passes through unchanged.
         assert!(rendered.contains("github:koverstreet/bcachefs-tools/v1.38.3"));
         assert!(rendered.contains("\"x86_64-linux\""));
-        // The placeholder must be substituted with a content hash.
+        // The hash placeholder must be substituted with a content hash.
         assert!(!rendered.contains("@WRAPPER_FLAKE_VERSION@"));
-        assert!(!rendered.contains("@BCACHEFS_TOOLS_REF@"));
         assert!(rendered.contains("wrapperFlakeVersion = \"sha256-"));
         // Rendering twice yields the same hash (deterministic).
-        let rendered2 =
-            super::render_system_flake_template(&template, "0.0.3", "v1.38.3", "x86_64-linux")
-                .expect("rendered");
+        let rendered2 = super::render_system_flake_template(&template, "0.0.3", "x86_64-linux")
+            .expect("rendered");
         assert_eq!(rendered, rendered2);
     }
 
     #[test]
     fn render_fails_without_wrapper_placeholder() {
-        let template = "inputs = {\n  nasty.url = \"github:nasty-project/nasty/@NASTY_VERSION@\";\n  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@\";\n};\nsystem = \"@LOCAL_SYSTEM@\";\n";
-        let err = super::render_system_flake_template(template, "0.0.3", "v1.38.3", "x86_64-linux")
+        let template = "inputs = {\n  nasty.url = \"github:nasty-project/nasty/@NASTY_VERSION@\";\n  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/v1.38.3\";\n};\nsystem = \"@LOCAL_SYSTEM@\";\n";
+        let err = super::render_system_flake_template(template, "0.0.3", "x86_64-linux")
             .expect_err("placeholder enforcement");
         assert!(format!("{err:?}").contains("@WRAPPER_FLAKE_VERSION@"));
-    }
-
-    #[test]
-    fn render_fails_without_bcachefs_tools_placeholder() {
-        let template = "inputs = { nasty.url = \"github:nasty-project/nasty/@NASTY_VERSION@\"; };\nwrapperFlakeVersion = \"@WRAPPER_FLAKE_VERSION@\";\nsystem = \"@LOCAL_SYSTEM@\";\n";
-        let err = super::render_system_flake_template(template, "0.0.3", "v1.38.3", "x86_64-linux")
-            .expect_err("placeholder enforcement");
-        assert!(format!("{err:?}").contains("@BCACHEFS_TOOLS_REF@"));
     }
 
     // ── systemd state mapping ──────────────────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -29,7 +29,21 @@
     # on their hardware.
     nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
     nixpkgs.follows = "nasty/nixpkgs";
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/@BCACHEFS_TOOLS_REF@";
+    # bcachefs-tools defaults to the same rev nasty's CI is tested
+    # against; operators retain the right to pin a different version
+    # by editing this line (or via the WebUI's Upstream editor, which
+    # calls `version_switch` → `rewrite_flake_input_urls` to mutate
+    # this URL surgically without re-rendering the template).
+    #
+    # Intentionally NOT a `@BCACHEFS_TOOLS_REF@` placeholder: an
+    # earlier iteration tried that, and pre-#312 engines (notably
+    # the v0.0.8 release) silently no-op on unknown placeholders
+    # during rebootstrap — so when they fetched main's template and
+    # re-rendered the wrapper, the literal text `@BCACHEFS_TOOLS_REF@`
+    # ended up in `bcachefs-tools.url`, breaking the next
+    # `nix flake update`. The hardcoded default below renders cleanly
+    # under any historical renderer.
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
   };
 
   outputs = { self, nixpkgs, nasty, ... }:

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -43,6 +43,22 @@
     # ended up in `bcachefs-tools.url`, breaking the next
     # `nix flake update`. The hardcoded default below renders cleanly
     # under any historical renderer.
+    #
+    # ⚠ FORWARD-COMPAT SHIM — DO NOT REMOVE the literal string
+    # `@BCACHEFS_TOOLS_REF@` from the comments above. Post-#312
+    # pre-#317 engines have an explicit `template.contains
+    # ("@BCACHEFS_TOOLS_REF@")` presence check in their renderer
+    # and refuse to render any template missing it. Those engines
+    # exist in the wild on every box that updated to main HEAD
+    # between #312 merging (2026-05-24) and #317 merging (TBD).
+    # Their `template.contains(...)` check finds the placeholder
+    # in the comment block above and is satisfied; their
+    # `.replace("@BCACHEFS_TOOLS_REF@", ref)` call then mangles
+    # those comments cosmetically (no functional effect — comments
+    # aren't read by anything). When the broken-engine cohort has
+    # aged out of the fleet (likely never matters again after a
+    # tagged release everyone has updated past), this shim can be
+    # removed safely.
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
   };
 


### PR DESCRIPTION
## Summary

The `@BCACHEFS_TOOLS_REF@` placeholder added in #312 is a forward-compat trap: pre-#312 engines (notably v0.0.8) don't know about it, silently no-op when substituting, and leak the literal text into `bcachefs-tools.url` when they rebootstrap the wrapper from main's template. The corrupted wrapper then breaks the next `nix flake update bcachefs-tools` with a 422 from GitHub:

```
error: unable to download 'https://api.github.com/repos/koverstreet/bcachefs-tools/commits/@BCACHEFS_TOOLS_REF@': HTTP error 422
{ "message": "No commit found for SHA: @BCACHEFS_TOOLS_REF@", "status": "422" }
```

This stranded today's fresh-v0.0.8 install (.72) on the first WebUI Upgrade click. There was no in-WebUI recovery possible because v0.0.8's engine is already shipped — it can't be retroactively taught the placeholder.

## Fix

Drop the placeholder from the template; hardcode `v1.38.3`. v0.0.8's renderer now sees a template it can substitute cleanly, the corruption never happens, and **v0.0.8 users can upgrade to main via the WebUI without SSH**.

The bcachefs-pinning feature from #312 stays alive — operator customization and tagged-release atomic-bundling now go through a post-render `rewrite_flake_input_urls` pass instead of template substitution. `rewrite_flake_input_urls` predates the placeholder mechanism by many versions, so it works on every historical engine.

## Touched call sites

- `render_system_flake_template_with_ref`: drops the `bcachefs_tools_ref` parameter, drops the `@BCACHEFS_TOOLS_REF@` presence check, drops the substitution call.
- `render_system_flake_template`: parameter dropped to match.
- `upgrade_tagged_release`: render (without bcachefs ref) then `rewrite_flake_input_urls`. Same atomic-bundle outcome.
- `version_switch`: same render-then-rewrite pattern; consolidates the rebootstrap and no-rebootstrap branches that previously diverged on how they applied `url_changes`.
- `migrate_wrapper_to_canonical_shape`: render then rewrite to preserve the operator's existing bcachefs pin.

## Out of scope (deliberately, to keep the change small)

Bartosz called out: *"I'm a bit scared by the number of changes... I'm afraid we will introduce another bunch of corner cases we will have to untangle later on."*

Dropped from the initial draft:

- **Placeholder-leak validator** (a generic `@WORD@`-detector that would catch future templates adding new placeholders before they ship corruption). Useful guard but adds complexity for a failure mode we're now removing.
- Function renames / further consolidation.

## What it does NOT fix

Boxes that have ALREADY been corrupted by today's strand (`.72` and friends) — they still need a one-time SSH rescue (`nasty-sync -r` once #314 is everywhere, or the inline `sed` recipe). This PR prevents the trap going forward; it doesn't reach back in time to a wrapper that already has `@BCACHEFS_TOOLS_REF@` literally written to disk.

## Test plan

- [x] 5 logical changes verified locally (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p nasty-system` — 225 pass)
- [ ] **Critical**: re-install fresh v0.0.8 on a new box, click Upgrade in the WebUI ONCE without SSH. Should rebuild cleanly to current main HEAD with no corruption. That's the test that proves the v0.0.8 → main path actually works now.
- [ ] Tagged-release switch on a post-#312 box: verify the target release's bcachefs ref is still applied to the wrapper (rewrite-after-render path).