### PR TITLE
fs.create: optional bind_to_tpm to seal key on creation in one step

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -366,6 +366,14 @@ pub struct CreateFilesystemRequest {
     /// When false, user must enter passphrase via WebUI after every reboot.
     #[serde(default = "default_store_key")]
     pub store_key: Option<bool>,
+    /// Whether to seal the stored key with the host's TPM2 immediately
+    /// after creation (PCR-7 bound, same shape as `fs.tpm.bind`). Saves
+    /// the operator the WebUI "Bind to TPM" round-trip and avoids the
+    /// brief window between FS creation and binding when the plaintext
+    /// `.key` exists alone on disk. Requires `encryption == true`,
+    /// `store_key != false`, and a usable TPM2 on the host — request
+    /// is rejected upfront when any are missing.
+    pub bind_to_tpm: Option<bool>,
     /// Filesystem-wide label (used as default when no per-device labels set).
     pub label: Option<String>,
     /// Tiering targets set at format time.
@@ -889,6 +897,35 @@ impl FilesystemService {
             return Err(FilesystemError::NoDevices);
         }
 
+        // Upfront validation of `bind_to_tpm`. Fails the request before
+        // touching disk when prerequisites aren't met, so the operator
+        // doesn't end up with a half-baked FS (formatted but never
+        // sealed) after picking an inconsistent option set in the
+        // WebUI. The post-format tpm_bind call near the bottom of
+        // create() can still fail at runtime (e.g. tpm2-tools missing
+        // unexpectedly) — in that case the FS exists and the operator
+        // can retry via the WebUI's "Bind to TPM" affordance.
+        if req.bind_to_tpm == Some(true) {
+            if req.encryption != Some(true) {
+                return Err(FilesystemError::InvalidInput(
+                    "bind_to_tpm requires encryption=true (there's nothing to seal otherwise)"
+                        .into(),
+                ));
+            }
+            if req.store_key == Some(false) {
+                return Err(FilesystemError::InvalidInput(
+                    "bind_to_tpm requires store_key=true (the .key file is the input to the TPM seal)"
+                        .into(),
+                ));
+            }
+            if !nasty_common::tpm::is_available().await {
+                return Err(FilesystemError::InvalidInput(
+                    "bind_to_tpm requested but no TPM2 is available on this host (/dev/tpmrm0 missing)"
+                        .into(),
+                ));
+            }
+        }
+
         // Resolve ":free" virtual devices — create a new partition in free space
         for dev in &mut req.devices {
             if let Some(disk_path) = dev.path.strip_suffix(":free") {
@@ -1163,6 +1200,33 @@ impl FilesystemService {
             .collect();
 
         self.invalidate_list_cache().await;
+
+        // Bind the freshly-stored key to the host TPM2 when the
+        // operator asked for it. Prerequisites (encryption,
+        // store_key, TPM availability) were verified upfront so a
+        // failure here is unexpected — log + return error with a
+        // hint to the WebUI's manual Bind affordance rather than
+        // rolling back the format. The FS exists on disk with valid
+        // data either way; the operator just needs to retry the
+        // bind step.
+        if req.bind_to_tpm == Some(true) {
+            if let Err(e) = self.tpm_bind(&req.name).await {
+                warn!(
+                    "Filesystem '{}' was created but TPM bind failed: {e}. \
+                     The plaintext .key remains on disk; retry via the WebUI's \
+                     'Bind to TPM' button on the Filesystems page.",
+                    req.name
+                );
+                return Err(FilesystemError::CommandFailed(format!(
+                    "filesystem '{}' created but TPM seal failed: {e}",
+                    req.name
+                )));
+            }
+            info!(
+                "Filesystem '{}' created with key sealed to TPM2 (PCR-7 bound)",
+                req.name
+            );
+        }
 
         Ok(Filesystem {
             name: req.name.clone(),

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -28,6 +28,12 @@
 	let filesystems: Filesystem[] = $state([]);
 	let devices: BlockDevice[] = $state([]);
 	let tpmStatus: Record<string, TpmBindStatus> = $state({});
+	// Host-level TPM availability — same value across every FS on
+	// this box. Cached at refresh time so the create-wizard's "Bind
+	// to TPM" checkbox can be conditionally shown even before the
+	// first encrypted FS exists. Falls back to `false` until the
+	// first probe completes.
+	let hostTpmAvailable = $state(false);
 	let wizardStep: 0 | 1 | 2 | 3 = $state(0); // 0=hidden, 1=name+devices, 2=profile, 3=review
 	let loading = $state(true);
 
@@ -44,6 +50,7 @@
 	let passphrase = $state('');
 	let passphraseConfirm = $state('');
 	let storeKey = $state(true);
+	let bindToTpm = $state(false);
 	let dataChecksum = $state('');
 	let metadataChecksum = $state('');
 	let bucketSize = $state('');
@@ -177,6 +184,25 @@
 		const next: Record<string, TpmBindStatus> = {};
 		for (const r of results) if (r) next[r[0]] = r[1];
 		tpmStatus = next;
+		// Probe host-level TPM availability: re-use any existing
+		// status if we have one (same value across all FSes), or
+		// fire a one-off `fs.tpm.status` against a sentinel name
+		// when no encrypted FS exists yet (the engine's tpm_status
+		// doesn't actually require the FS to exist — it just reports
+		// the host's `/dev/tpmrm0` presence). Without this, the
+		// create-wizard's "Bind to TPM" checkbox would be hidden on
+		// every fresh box that hasn't created an FS yet.
+		const anyStatus = Object.values(next)[0];
+		if (anyStatus) {
+			hostTpmAvailable = anyStatus.tpm_available;
+		} else {
+			try {
+				const probe = await client.call<TpmBindStatus>('fs.tpm.status', { name: '__host_probe' });
+				hostTpmAvailable = probe.tpm_available;
+			} catch {
+				hostTpmAvailable = false;
+			}
+		}
 	}
 
 	async function bindTpm(fs: Filesystem) {
@@ -415,6 +441,7 @@
 				encryption: encryption || undefined,
 				passphrase: encryption ? passphrase : undefined,
 				store_key: encryption ? storeKey : undefined,
+				bind_to_tpm: encryption && storeKey && bindToTpm ? true : undefined,
 				data_checksum: dataChecksum || undefined,
 				metadata_checksum: metadataChecksum || undefined,
 				bucket_size: bucketSize || undefined,
@@ -441,6 +468,7 @@
 			passphrase = '';
 			passphraseConfirm = '';
 			storeKey = true;
+			bindToTpm = false;
 			dataChecksum = '';
 			metadataChecksum = '';
 			bucketSize = '';
@@ -1224,6 +1252,19 @@
 							{/if}
 						</p>
 						<p class="mt-2 text-xs text-amber-400">Warning: losing the passphrase with no stored key means permanent data loss.</p>
+						{#if hostTpmAvailable && storeKey}
+							<label class="mt-3 flex cursor-pointer items-center gap-2 text-sm">
+								<input type="checkbox" bind:checked={bindToTpm} class="h-4 w-4" />
+								Seal key to TPM2 (PCR-7 bound)
+							</label>
+							<p class="mt-1 text-xs text-muted-foreground">
+								{#if bindToTpm}
+									Key is sealed to this host's TPM right after creation. Auto-unlock on boot prefers the sealed copy; the plaintext key file stays as a recovery fallback (remove later via Export Key → Destroy Key if you want pure TPM-only).
+								{:else}
+									Key stays plaintext on the boot drive. You can still bind it to the TPM later via the row's "Bind to TPM" button on the Filesystems page.
+								{/if}
+							</p>
+						{/if}
 					{:else}
 						<p class="mt-1 text-xs text-muted-foreground">Data at rest will not be encrypted.</p>
 					{/if}


### PR DESCRIPTION
## Why

Creating a TPM-bound encrypted filesystem currently takes two operator
actions: create the FS (writes plaintext `.key`), then click "Bind to TPM"
on the row. The mental model is one decision — "I want the key on the
TPM" — and the UX should match.

## What

### Engine (`nasty-storage`)

- `CreateFilesystemRequest` gains `bind_to_tpm: Option<bool>`.
- Upfront validation rejects the request before touching disk when:
  - `encryption != Some(true)` — can't seal a key that won't exist
  - `store_key == Some(false)` — no on-disk key for the seal step
  - the host has no usable TPM2 (`/dev/tpmrm0` missing)
  - Operator gets a clean error, not a half-baked FS.
- After format + mount + `invalidate_list_cache`, the create path calls
  `self.tpm_bind(&req.name)` to seal the freshly-written `.key`.
- If the seal step fails after format (rare — we validated upfront), the
  FS still exists with valid data; we surface an error pointing at the
  WebUI's manual "Bind to TPM" button rather than rolling back.

### WebUI (filesystems page)

- New "Seal key to TPM2 (PCR-7 bound)" checkbox in the create wizard.
- Visible only when host has a TPM **and** "Store key for auto-unlock"
  is checked.
- Host TPM availability is pre-probed via `fs.tpm.status` against a
  sentinel name (engine's `tpm_status` only checks `/dev/tpmrm0`, not the
  named FS) so the toggle is discoverable on a fresh box with zero FSes.
- Helper text explains both states — on: seal happens automatically,
  plaintext `.key` stays as a recovery fallback. Off: bind later via row
  button.

## What's still manual

The post-bind plaintext `.key` stays on disk by design (documented
recovery path). Operators who want pure TPM-only need Export Key →
Destroy Key as a follow-up. Combined "Bind + destroy plaintext" is the
next obvious UX improvement — separate PR.

Secure Boot integration (lanzaboote) — the PCR-7 binding is theatre
without a measured boot chain — is tracked as a separate follow-up.

## Test plan

- [x] cargo fmt / clippy clean
- [x] 30 storage-crate tests pass
- [x] WebUI: svelte-check 0 errors/warnings, 124 vitest tests pass, build clean
- [ ] Manual: TPM-capable box — create encrypted FS with new toggle → reboot → auto-unlock via sealed key
- [ ] Manual: validation rejects toggle=on with encryption=off (clean error, no half-baked FS)
- [ ] Manual: validation rejects toggle=on on a TPM-less box