### PR TITLE
hardware: surface Secure Boot state via sbctl

### DIFF
--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cmd;
 pub mod jsonrpc;
 pub mod metrics_types;
+pub mod secure_boot;
 pub mod state;
 pub mod tpm;
 

--- a/engine/nasty-common/src/secure_boot.rs
+++ b/engine/nasty-common/src/secure_boot.rs
@@ -1,0 +1,177 @@
+//! Secure Boot state readout — what does UEFI see right now?
+//!
+//! Single source of truth: `sbctl status --json`. We treat sbctl as a
+//! read-only observability tool here; signing + key enrollment is
+//! lanzaboote's job (declarative at NixOS build time, not a runtime
+//! CLI), so this module never invokes `sbctl enroll-keys`, `sbctl sign`,
+//! `sbctl reset`, etc. — only `status`.
+//!
+//! Why sbctl rather than reading efivars directly: the efivar bytes
+//! cover SB on/off and SetupMode, but not "did our key actually land
+//! in db?" or "is the running shim signed?". Even though we don't act
+//! on those today, the eventual SB UX will ("show me the trust chain
+//! this box is on"), and pinning the engine to one tool keeps the
+//! callsite stable.
+//!
+//! Error model: anything short of a parsed JSON response → `Unknown`,
+//! not an error return. The Hardware page renders this as a status
+//! pill and a missing TPM/SB pill should look the same as one that
+//! says "unavailable" — never as a 500.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// What the host's firmware is currently doing about Secure Boot.
+/// All fields are best-effort: any missing piece collapses to `None`
+/// rather than blocking the rest. Consumers that need a single yes/no
+/// should read [`SecureBootStatus::enabled`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SecureBootStatus {
+    /// Best available answer to "is Secure Boot enforcing right now?".
+    /// `Some(true)` / `Some(false)` come from sbctl; `None` means we
+    /// couldn't determine it (no sbctl, not UEFI, sbctl errored).
+    pub enabled: Option<bool>,
+    /// UEFI Setup Mode — when true the firmware will accept arbitrary
+    /// key enrollment without PK signing. Relevant for enrollment
+    /// flows we don't drive today but will surface later.
+    pub setup_mode: Option<bool>,
+    /// True iff `sbctl`'s own keys / signing artifacts are installed on
+    /// this host. NASty doesn't use sbctl for signing (lanzaboote does
+    /// that), so this is expected to be `false` on every NASty box —
+    /// but it's worth surfacing so an operator who manually installed
+    /// sbctl-managed keys doesn't get a misleading UI claim.
+    pub sbctl_installed: Option<bool>,
+    /// Free-form one-line reason when we couldn't get a definitive
+    /// answer ("sbctl not on PATH", "not booted via UEFI", "sbctl exit
+    /// 1: …"). Surfaced in the WebUI tooltip on the status pill.
+    pub note: Option<String>,
+}
+
+impl SecureBootStatus {
+    fn unknown(note: impl Into<String>) -> Self {
+        Self {
+            enabled: None,
+            setup_mode: None,
+            sbctl_installed: None,
+            note: Some(note.into()),
+        }
+    }
+}
+
+/// Inspect Secure Boot state via `sbctl status --json`. Never returns
+/// `Result::Err` — failure modes (missing tool, BIOS boot, sbctl
+/// exiting non-zero) all collapse into a [`SecureBootStatus`] with
+/// `enabled = None` and a human-readable `note`.
+pub async fn status() -> SecureBootStatus {
+    // Cheap pre-check: if /sys/firmware/efi doesn't exist we're on a
+    // BIOS/legacy boot and there's no point asking sbctl — its first
+    // act would be to bail with the same finding via a noisier
+    // pathway.
+    if tokio::fs::metadata("/sys/firmware/efi").await.is_err() {
+        return SecureBootStatus::unknown("host is not booted via UEFI");
+    }
+
+    let output = match Command::new("sbctl")
+        .arg("status")
+        .arg("--json")
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            debug!(target: "nasty::secure_boot", "sbctl spawn failed: {e}");
+            return SecureBootStatus::unknown(format!("sbctl unavailable: {e}"));
+        }
+    };
+
+    // sbctl currently exits non-zero on some happy paths (e.g. when
+    // SB is disabled and it considers that a "problem") — but the
+    // JSON it prints in those cases is still the source of truth.
+    // So we parse stdout regardless of exit status, and only fall
+    // back to the exit-status branch if parsing fails too.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    match serde_json::from_str::<RawSbctlStatus>(stdout.trim()) {
+        Ok(raw) => SecureBootStatus {
+            enabled: raw.secure_boot,
+            setup_mode: raw.setup_mode,
+            sbctl_installed: raw.installed,
+            note: None,
+        },
+        Err(parse_err) => {
+            warn!(
+                target: "nasty::secure_boot",
+                "sbctl status --json unparseable (exit {}): {parse_err}; stderr={stderr}",
+                output.status
+            );
+            SecureBootStatus::unknown(format!(
+                "sbctl returned unparseable output (exit {})",
+                output.status
+            ))
+        }
+    }
+}
+
+/// Mirror of the subset of `sbctl status --json` fields we care about.
+/// Every field is optional — sbctl has reshaped its output schema
+/// across releases (the `installed` key in particular was added
+/// post-0.10) and we want to keep working under both old and new.
+#[derive(Debug, Deserialize)]
+struct RawSbctlStatus {
+    #[serde(default)]
+    secure_boot: Option<bool>,
+    #[serde(default)]
+    setup_mode: Option<bool>,
+    #[serde(default)]
+    installed: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_modern_sbctl_output() {
+        let payload = r#"{
+            "installed": false,
+            "guid": "00000000-0000-0000-0000-000000000000",
+            "setup_mode": false,
+            "secure_boot": true,
+            "vendors": []
+        }"#;
+        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
+        assert_eq!(raw.secure_boot, Some(true));
+        assert_eq!(raw.setup_mode, Some(false));
+        assert_eq!(raw.installed, Some(false));
+    }
+
+    #[test]
+    fn tolerates_missing_installed_field() {
+        // Older sbctl releases (pre-0.10) don't emit `installed`.
+        let payload = r#"{"setup_mode": false, "secure_boot": false}"#;
+        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
+        assert_eq!(raw.secure_boot, Some(false));
+        assert_eq!(raw.installed, None);
+    }
+
+    #[test]
+    fn tolerates_unknown_fields() {
+        // Future sbctl additions must not break parsing.
+        let payload = r#"{
+            "secure_boot": true,
+            "setup_mode": false,
+            "future_field_xyz": "anything"
+        }"#;
+        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
+        assert_eq!(raw.secure_boot, Some(true));
+    }
+
+    #[test]
+    fn unknown_carries_note() {
+        let s = SecureBootStatus::unknown("test");
+        assert!(s.enabled.is_none());
+        assert_eq!(s.note.as_deref(), Some("test"));
+    }
+}

--- a/engine/nasty-system/src/hardware.rs
+++ b/engine/nasty-system/src/hardware.rs
@@ -278,6 +278,12 @@ pub struct HardwareSummary {
     /// is enumerated by the kernel at all (no chip, disabled in
     /// firmware, missing driver).
     pub tpm: Option<TpmInfo>,
+    /// Secure Boot state as reported by `sbctl status --json`. Always
+    /// present — failure modes (BIOS boot, sbctl missing, sbctl
+    /// errored) collapse into a struct with `enabled = None` and a
+    /// human-readable `note` rather than an absent field. The WebUI
+    /// renders one of: enabled / disabled / unknown.
+    pub secure_boot: nasty_common::secure_boot::SecureBootStatus,
 }
 
 /// Snapshot of the host's first TPM device — what the kernel sees at
@@ -425,6 +431,7 @@ async fn build_summary() -> HardwareSummary {
     let cpu = read_cpu_info().await;
     let usb = read_usb_devices().await;
     let tpm = read_tpm_info().await;
+    let secure_boot = nasty_common::secure_boot::status().await;
     HardwareSummary {
         system,
         bios,
@@ -432,6 +439,7 @@ async fn build_summary() -> HardwareSummary {
         memory,
         usb,
         tpm,
+        secure_boot,
     }
 }
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -594,6 +594,7 @@ in {
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery
       tpm2-tools        # tpm2_getcap, tpm2_pcrread, tpm2_unseal — engine reads vendor info via tpm2_getcap, operators use the rest for TPM debugging
+      sbctl             # Secure Boot state inspection (sbctl status --json). Read-only use by the engine; signing/enrollment stays lanzaboote's territory.
       docker-compose    # Docker Compose for multi-container apps
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
@@ -1450,6 +1451,7 @@ in {
         usbutils                     # lsusb — USB enumeration for hardware page + VM USB passthrough
         dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
         tpm2-tools                   # tpm2_getcap / tpm2_create / tpm2_unseal — Hardware page chip info + the PCR-7 seal/unseal flow for the bcachefs encryption key (#102)
+        sbctl                        # sbctl status --json — Secure Boot state for Hardware page. Read-only; signing/enrollment is lanzaboote's job, not ours.
         keyutils                     # keyctl — fs.lock revokes the bcachefs unlock key from the kernel session keyring; without this the call fails with "No such file or directory" even though every other tool we shell out to is here
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -52,6 +52,18 @@ export interface HardwareSummary {
 	memory: MemorySummary;
 	usb: UsbDevice[];
 	tpm: TpmInfo | null;
+	secure_boot: SecureBootStatus;
+}
+
+/** Result of `sbctl status --json`. All fields degrade to null when
+ * the box isn't UEFI, sbctl isn't installed, or sbctl errored — those
+ * failure modes surface as `enabled: null` with a human-readable
+ * `note`, not as a missing field. */
+export interface SecureBootStatus {
+	enabled: boolean | null;
+	setup_mode: boolean | null;
+	sbctl_installed: boolean | null;
+	note: string | null;
 }
 
 export interface TpmInfo {

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -330,6 +330,40 @@
 				{/if}
 			</CardContent>
 		</Card>
+
+		<Card>
+			<CardContent class="pt-4 pb-3">
+				<h3 class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					Secure Boot
+				</h3>
+				{#if summary?.secure_boot.enabled === true}
+					<div class="text-sm font-medium">
+						Enabled
+						<span class="ml-1 text-xs text-emerald-400">· enforcing</span>
+					</div>
+					{#if summary.secure_boot.setup_mode === true}
+						<div class="mt-1 text-xs text-amber-500">
+							Firmware in setup mode — accepts unsigned key enrollment.
+						</div>
+					{/if}
+				{:else if summary?.secure_boot.enabled === false}
+					<div class="text-sm font-medium">
+						Disabled
+						<span class="ml-1 text-xs text-amber-500">· not enforcing</span>
+					</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						TPM PCR-7 sealing still works but is significantly weaker
+						without a measured boot chain. Enable Secure Boot in firmware
+						to harden the seal.
+					</div>
+				{:else}
+					<div class="text-sm font-medium">Unknown</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						{summary?.secure_boot.note ?? 'No status reported.'}
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
 	</div>
 
 	<!-- ── DIMM detail (collapsed by default) ──────────────────────── -->


### PR DESCRIPTION
## Why

Step 1 of the Secure Boot story: just *see* what the host's firmware is
doing. No signing, no enrollment, no key management — those belong to a
future lanzaboote integration. This PR adds a read-only pill on the
Hardware page so operators (and us, when debugging) can tell at a glance
whether SB is enforcing, off, or unknown.

## Why sbctl, not efivars

Reading `/sys/firmware/efi/efivars/SecureBoot-*` directly gives us SB
on/off and SetupMode — enough for v1. But the eventual SB UX is "show
me the trust chain this box is on" — enrolled keys in db/KEK/PK,
whether the running bootloader is signed, which vendor's certs are
trusted. sbctl already covers all of that, with a JSON output, and runs
fine alongside lanzaboote (it reads firmware state; it doesn't have to
own signing). Pinning the engine to one tool now means we don't rewrite
the call site when those features land.

## What

### Engine

- **`nasty_common::secure_boot::status()`** — shells out to `sbctl status
  --json`, returns `SecureBootStatus { enabled, setup_mode,
  sbctl_installed, note }`. Every field optional; failure modes collapse
  into `enabled: None` + a human-readable `note`, never `Result::Err`
  (the UI renders this as a pill, not a toast).
- Parses stdout regardless of sbctl's exit status — sbctl 0.x exits
  non-zero on the "SB disabled" happy path but still emits the JSON.
- `RawSbctlStatus` is a tolerant DTO with all-optional fields so older
  (pre-0.10) and newer sbctl releases both deserialise.
- Folded into `HardwareSummary.secure_boot` — same 60s cache as the rest
  of the summary (efivars don't change between reboots).

### NixOS

- `sbctl` added to host `environment.systemPackages` (operator CLI use)
  and to the nasty-engine systemd unit's `path` (engine can shell out
  without an absolute path).

### WebUI

- `types.ts` mirrors the new `SecureBootStatus`.
- New "Secure Boot" card on the Hardware page. Three states:
  - **Enabled** — green pill; amber sub-line if firmware is in setup mode
  - **Disabled** — amber pill, with copy explaining that PCR-7 sealing is
    weakened without a measured boot chain
  - **Unknown** — muted; shows the engine's `note` (BIOS boot / sbctl
    missing / sbctl errored)

## What's deliberately not here

- No `sbctl sign` / `enroll-keys` / `reset` — lanzaboote owns signing.
- No new RPC route — folds into `system.hardware.summary`, so the data
  lands next to TPM / CPU / DIMMs on the same Hardware page render.
- No enrolled-keys / signature-chain display — sbctl exposes that, but
  it's not useful without the enrollment UX, which is the lanzaboote
  PR's job.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] 28 nasty-common tests pass (4 new for sbctl JSON shapes)
- [x] 225 nasty-system tests pass
- [x] WebUI `npm run check` 0 errors / 0 warnings, 124 vitest pass, build clean
- [ ] Manual on a real UEFI+SB-enabled NASty: card shows "Enabled · enforcing"
- [ ] Manual with SB toggled off in firmware: card shows "Disabled · not enforcing"
- [ ] Manual on a legacy-BIOS box (or a SecureBoot-N/A VM): card shows "Unknown" with the engine's note