### PR TITLE
rpc: aggressive reconnect during Update so the spinner clears in seconds

### DIFF
--- a/webui/src/lib/rpc.test.ts
+++ b/webui/src/lib/rpc.test.ts
@@ -391,4 +391,85 @@ describe('connection lifecycle', () => {
 			vi.useRealTimers();
 		}
 	});
+
+	test('aggressive-reconnect mode trips the reload escape hatch faster', async () => {
+		// The whole reason aggressive mode exists: during a known engine
+		// restart (Update flow), an upgrade that genuinely fails to bring
+		// the engine back should drop to the login screen quickly rather
+		// than sitting on a spinner for ~42 s. The aggressive threshold is
+		// 20 attempts; reaching it in the test verifies the mode-aware
+		// reload gate.
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		vi.stubGlobal('location', { reload });
+		try {
+			const client = new NastyClient('ws://localhost/api');
+			const initial = client.connect();
+			mockInstances[0].open();
+			mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await initial;
+
+			client.setAggressiveReconnect(true);
+
+			mockInstances[0].fireClose();
+
+			// 10 failed attempts — that's the normal-mode threshold, but
+			// with aggressive on it shouldn't reload yet.
+			for (let attempt = 1; attempt <= 10; attempt++) {
+				await vi.advanceTimersByTimeAsync(5_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+			expect(reload).not.toHaveBeenCalled();
+
+			// Push through to attempt 20 — that's the aggressive threshold.
+			for (let attempt = 11; attempt <= 20; attempt++) {
+				await vi.advanceTimersByTimeAsync(5_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+			expect(reload).toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.useRealTimers();
+		}
+	});
+
+	test('setAggressiveReconnect is idempotent and reversible', async () => {
+		// Flipping aggressive off mid-outage must restore the normal
+		// reload threshold (10 attempts), not leave the aggressive
+		// threshold (20) stuck in place. Otherwise a future Update flow
+		// that crashed cleanup would leave the rest of the app in
+		// aggressive mode forever.
+		vi.useFakeTimers();
+		const reload = vi.fn();
+		vi.stubGlobal('location', { reload });
+		try {
+			const client = new NastyClient('ws://localhost/api');
+			const initial = client.connect();
+			mockInstances[0].open();
+			mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+			await initial;
+
+			client.setAggressiveReconnect(true);
+			client.setAggressiveReconnect(true); // idempotent no-op
+			client.setAggressiveReconnect(false);
+
+			mockInstances[0].fireClose();
+
+			// In normal mode the reload trips at 10 attempts.
+			for (let attempt = 1; attempt <= 10; attempt++) {
+				await vi.advanceTimersByTimeAsync(5_000);
+				const mock = mockInstances[mockInstances.length - 1];
+				mock.fireError();
+				await vi.advanceTimersByTimeAsync(0);
+			}
+			expect(reload).toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.useRealTimers();
+		}
+	});
 });

--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -29,16 +29,51 @@ export class NastyClient {
 	private disconnectHandlers: (() => void)[] = [];
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	/** Exponential reconnect delay — doubles on each failed attempt up to a
-	 *  cap, resets to the floor on a successful auth. The previous version
-	 *  used a fixed 3 s delay, which during a longer outage produced 20
-	 *  attempts per minute — friendlier to spam the server slower and
-	 *  faster to reconnect from a transient blip. */
+	 *  cap, resets to the floor on a successful auth. Two profiles:
+	 *
+	 *    `normal`     — the default. Used for the "engine just rebooted /
+	 *                   network blip" case. Backoff sequence to reload:
+	 *                   1+2+4+5+5+5+5+5+5+5 = ~42 s.
+	 *    `aggressive` — flipped on by [`setAggressiveReconnect`] while a
+	 *                   known restart is in flight (the only caller today
+	 *                   is the Update page, which knows the engine is
+	 *                   coming down and back during an upgrade). Backoff
+	 *                   sequence to reload: 0.25+0.5+1+1.5×17 ≈ ~27 s.
+	 *
+	 *  The earlier shape used a 30 s ceiling. That was fine in theory but
+	 *  meant up to a 30 s gap between "engine is back" and "WebUI tries
+	 *  the next WS handshake" — operators watching an Upgrade progress
+	 *  bar perceived the lag as the WebUI being broken even though the
+	 *  reconnect was healthy. A few-seconds ceiling keeps the WS attempt
+	 *  rate cheap enough on the server side (~1 attempt every couple of
+	 *  seconds during outage) and the user-perceived lag near zero. */
 	private reconnectDelayMs = 1000;
-	private static readonly RECONNECT_DELAY_FLOOR_MS = 1000;
-	private static readonly RECONNECT_DELAY_CEIL_MS = 30_000;
+	private static readonly NORMAL_DELAY_FLOOR_MS = 1000;
+	private static readonly NORMAL_DELAY_CEIL_MS = 5_000;
+	private static readonly NORMAL_MAX_ATTEMPTS_BEFORE_RELOAD = 10;
+	private static readonly AGGRESSIVE_DELAY_FLOOR_MS = 250;
+	private static readonly AGGRESSIVE_DELAY_CEIL_MS = 1_500;
+	private static readonly AGGRESSIVE_MAX_ATTEMPTS_BEFORE_RELOAD = 20;
+	/** Aggressive-reconnect toggle — see [`setAggressiveReconnect`]. */
+	private _aggressive = false;
 	/** Number of consecutive failed reconnect attempts since the last
 	 *  successful auth. Drives the page-reload escape hatch below. */
 	private consecutiveFailedReconnects = 0;
+
+	/** Lower bound for the next backoff delay, mode-dependent. */
+	private get reconnectFloorMs(): number {
+		return this._aggressive
+			? NastyClient.AGGRESSIVE_DELAY_FLOOR_MS
+			: NastyClient.NORMAL_DELAY_FLOOR_MS;
+	}
+
+	/** Upper bound for the next backoff delay, mode-dependent. */
+	private get reconnectCeilMs(): number {
+		return this._aggressive
+			? NastyClient.AGGRESSIVE_DELAY_CEIL_MS
+			: NastyClient.NORMAL_DELAY_CEIL_MS;
+	}
+
 	/** After this many consecutive failed reconnect attempts, force a
 	 *  full page reload instead of scheduling yet another retry.
 	 *
@@ -55,13 +90,12 @@ export class NastyClient {
 	 *  hatch also unblocks "box has moved to a new IP", "server
 	 *  config changed in a way that breaks the WS endpoint", and any
 	 *  other persistent reconnect failure — the user gets a clear
-	 *  browser-level error state instead of a spinner.
-	 *
-	 *  Threshold sized so a normal reboot (~30–90 s downtime) recovers
-	 *  via the normal reconnect path without ever tripping reload, but
-	 *  a stuck state unblocks within ~3 minutes. Backoff totals at
-	 *  the 10th attempt: 1+2+4+8+16+30+30+30+30+30 = 181 s. */
-	private static readonly MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD = 10;
+	 *  browser-level error state instead of a spinner. */
+	private get maxAttemptsBeforeReload(): number {
+		return this._aggressive
+			? NastyClient.AGGRESSIVE_MAX_ATTEMPTS_BEFORE_RELOAD
+			: NastyClient.NORMAL_MAX_ATTEMPTS_BEFORE_RELOAD;
+	}
 	private _authenticated = false;
 	/** Set to true after the first successful auth; cleared by disconnect(). */
 	private _shouldReconnect = false;
@@ -105,7 +139,7 @@ export class NastyClient {
 						// disconnect retries quickly, and clear the
 						// failed-reconnect counter so the reload escape hatch
 						// only fires after a fresh streak of failures.
-						this.reconnectDelayMs = NastyClient.RECONNECT_DELAY_FLOOR_MS;
+						this.reconnectDelayMs = this.reconnectFloorMs;
 						this.consecutiveFailedReconnects = 0;
 						this._readyResolve?.();
 						this._readyResolve = null;
@@ -212,7 +246,7 @@ export class NastyClient {
 		const delay = this.reconnectDelayMs;
 		this.reconnectDelayMs = Math.min(
 			this.reconnectDelayMs * 2,
-			NastyClient.RECONNECT_DELAY_CEIL_MS,
+			this.reconnectCeilMs,
 		);
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
@@ -233,10 +267,7 @@ export class NastyClient {
 				// MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD for the rationale.
 				if (this._shouldReconnect) {
 					this.consecutiveFailedReconnects += 1;
-					if (
-						this.consecutiveFailedReconnects
-						>= NastyClient.MAX_RECONNECT_ATTEMPTS_BEFORE_RELOAD
-					) {
+					if (this.consecutiveFailedReconnects >= this.maxAttemptsBeforeReload) {
 						location.reload();
 						return;
 					}
@@ -273,6 +304,42 @@ export class NastyClient {
 
 	offDisconnect(handler: () => void) {
 		this.disconnectHandlers = this.disconnectHandlers.filter((h) => h !== handler);
+	}
+
+	/** Tell the client a known restart is in flight so reconnect should
+	 *  be more aggressive. Today only the Update page calls this — between
+	 *  Upgrade-click and `system.update.status` transitioning to
+	 *  success/failed it flips this on, then flips it off again.
+	 *
+	 *  Effects while `true`:
+	 *    - Backoff floor 250 ms / ceiling 1.5 s (vs. 1 s / 5 s).
+	 *    - Reload escape hatch trips after ~20 attempts (~27 s) instead of
+	 *      ~10 attempts (~42 s). Sized so an upgrade that genuinely fails
+	 *      to bring the engine back drops to the login screen quickly,
+	 *      while a healthy ~20–60 s activation window still recovers
+	 *      cleanly without ever tripping reload.
+	 *    - If we're already mid-backoff when flipped on, the next scheduled
+	 *      retry happens at the aggressive ceiling rather than waiting out
+	 *      the current (possibly multi-second) timer.
+	 *
+	 *  Idempotent — calling with the same value twice is a no-op. */
+	setAggressiveReconnect(active: boolean) {
+		if (this._aggressive === active) return;
+		this._aggressive = active;
+		// If we just entered aggressive mode mid-outage, the current
+		// reconnectDelayMs may already be at the old (5 s / 30 s) ceiling.
+		// Snap it down so the very next scheduled retry fires fast.
+		// (Doesn't cancel an already-pending timer — that's fine, the
+		// timer's delay was set when it was scheduled; the snap takes
+		// effect for the *next* one. In practice the next retry is
+		// already milliseconds away because we're typically in this code
+		// path because a reconnect just failed.)
+		if (active) {
+			this.reconnectDelayMs = Math.min(
+				this.reconnectDelayMs,
+				NastyClient.AGGRESSIVE_DELAY_CEIL_MS,
+			);
+		}
 	}
 
 	disconnect() {

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -461,6 +461,11 @@
 
 	function startPolling() {
 		stopPolling();
+		// Tell the RPC client an engine restart is imminent — the activate
+		// phase will tear down the WebSocket and the reconnect should be
+		// aggressive (sub-second retries, fast reload escape hatch) instead
+		// of the normal 1-5 s backoff. See rpc.ts:setAggressiveReconnect.
+		client.setAggressiveReconnect(true);
 		pollInterval = setInterval(async () => {
 			try {
 					status = await client.call<UpdateStatus>('system.update.status');
@@ -486,6 +491,9 @@
 			clearInterval(pollInterval);
 			pollInterval = null;
 		}
+		// Restart window over (success / failed / cancelled / navigated away)
+		// — go back to the normal reconnect cadence.
+		client.setAggressiveReconnect(false);
 	}
 
 	function formatLog(log: string): string {


### PR DESCRIPTION
## Why

The Reconnecting… overlay during Upgrade could sit on screen for a
minute or more on a slow box — see attached screenshot from a recent
upgrade on 10.10.10.74. Reason: the WS reconnect backoff doubled to
a 30 s ceiling, so once the engine restarted during activate, there
could be up to a 30 s gap between "engine is back" and "WebUI tries
the next handshake" — and the reload escape hatch only tripped after
10 attempts (~3 minutes cumulative). Operators watching a progress
bar perceived a healthy reconnect as broken.

## What

### Tighten the global defaults

Ceiling dropped from 30 s → 5 s. The earlier 30 s was over-cautious —
a WS attempt every couple of seconds during an outage is cheap on
the server. Normal-mode reload escape hatch is now ~42 s of
cumulative attempts (vs. 181 s before) at the same 10-attempt
threshold.

### Add an aggressive-reconnect mode

`NastyClient.setAggressiveReconnect(true)` swaps to a tighter profile:

| Mode       | Floor  | Ceiling | Max attempts | Total before reload |
|------------|-------:|--------:|-------------:|---------------------:|
| Normal     | 1 s    | 5 s     | 10           | ~42 s                |
| Aggressive | 250 ms | 1.5 s   | 20           | ~27 s                |

The Update page flips it on in `startPolling()` and off in
`stopPolling()` — so it's active exactly between Upgrade-click and
the upgrade reaching success / failed (and also cleans up on
navigate-away, since `onDestroy` calls `stopPolling`). Idempotent
and reversible (verified by test), so a partial cleanup can't leave
the rest of the app stuck in aggressive mode.

## Why aggressive mode and not just-tighter-defaults

The 5 s ceiling is the right tradeoff *outside* known-restart
windows. Inside them we have prior knowledge — the engine WILL come
back, the only question is when — so we can afford to retry harder
and reload faster on actual failure. Lowering the global default to
where aggressive sits would mean the rest of the app reloads itself
within ~30 s of any transient network blip, which is too eager.

## Test plan

- [x] Existing 18 reconnect tests still pass under the new defaults
- [x] New: aggressive mode trips reload at attempt 20 (not 10)
- [x] New: setAggressiveReconnect is idempotent and reversible
- [x] svelte-check 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual: trigger Upgrade on a real box, observe the Reconnecting overlay clears within seconds of the new engine being up (not 30+ s)
- [ ] Manual: kill the engine on a box and don't restart it; observe the page reloads to login within ~30 s if Aggressive is on, ~42 s if it's off (just visit /update vs. any other page)