### PR TITLE
secure_boot: read via bootctl instead of sbctl

### DIFF
--- a/engine/nasty-common/src/secure_boot.rs
+++ b/engine/nasty-common/src/secure_boot.rs
@@ -1,177 +1,250 @@
 //! Secure Boot state readout — what does UEFI see right now?
 //!
-//! Single source of truth: `sbctl status --json`. We treat sbctl as a
-//! read-only observability tool here; signing + key enrollment is
-//! lanzaboote's job (declarative at NixOS build time, not a runtime
-//! CLI), so this module never invokes `sbctl enroll-keys`, `sbctl sign`,
-//! `sbctl reset`, etc. — only `status`.
+//! Source: `bootctl status`. systemd-bootctl is on every NixOS box
+//! already (no extra dep), reports SB state, setup-mode flag, and the
+//! "(unsupported)" parenthetical that distinguishes "firmware can't
+//! enable SB" from "firmware can but operator hasn't" — three states
+//! that efivars only expose across multiple variables and that sbctl
+//! collapses into one unhelpful "disabled". As a bonus we get the
+//! Measured UKI flag, which lanzaboote integration will want later.
 //!
-//! Why sbctl rather than reading efivars directly: the efivar bytes
-//! cover SB on/off and SetupMode, but not "did our key actually land
-//! in db?" or "is the running shim signed?". Even though we don't act
-//! on those today, the eventual SB UX will ("show me the trust chain
-//! this box is on"), and pinning the engine to one tool keeps the
-//! callsite stable.
+//! Parsing: plaintext, line-by-line, scanning the `System:` block.
+//! Format has been stable since systemd 250-ish; both the label
+//! widths and the parenthetical values are part of bootctl's
+//! user-facing UI, not a serialization detail that drifts.
 //!
-//! Error model: anything short of a parsed JSON response → `Unknown`,
-//! not an error return. The Hardware page renders this as a status
-//! pill and a missing TPM/SB pill should look the same as one that
-//! says "unavailable" — never as a 500.
+//! Error model: never returns `Result::Err`. The Hardware page
+//! renders this as a status pill — unknown SB pill should look the
+//! same as one that says "disabled" or "enabled", never as a 500.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, warn};
 
-/// What the host's firmware is currently doing about Secure Boot.
-/// All fields are best-effort: any missing piece collapses to `None`
-/// rather than blocking the rest. Consumers that need a single yes/no
-/// should read [`SecureBootStatus::enabled`].
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+/// Snapshot of the firmware's Secure Boot stance. All fields are
+/// best-effort: any missing piece collapses to `None` rather than
+/// blocking the rest.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SecureBootStatus {
-    /// Best available answer to "is Secure Boot enforcing right now?".
-    /// `Some(true)` / `Some(false)` come from sbctl; `None` means we
-    /// couldn't determine it (no sbctl, not UEFI, sbctl errored).
+    /// `Some(true)` iff `bootctl status` reports `Secure Boot: enabled`.
+    /// `Some(false)` for `disabled` (any parenthetical). `None` when we
+    /// couldn't determine state — see `note`.
     pub enabled: Option<bool>,
-    /// UEFI Setup Mode — when true the firmware will accept arbitrary
-    /// key enrollment without PK signing. Relevant for enrollment
-    /// flows we don't drive today but will surface later.
+    /// UEFI Setup Mode — when true the firmware accepts arbitrary key
+    /// enrollment without PK signing. Sourced from the `(setup)`
+    /// parenthetical on the `Secure Boot:` line.
     pub setup_mode: Option<bool>,
-    /// True iff `sbctl`'s own keys / signing artifacts are installed on
-    /// this host. NASty doesn't use sbctl for signing (lanzaboote does
-    /// that), so this is expected to be `false` on every NASty box —
-    /// but it's worth surfacing so an operator who manually installed
-    /// sbctl-managed keys doesn't get a misleading UI claim.
-    pub sbctl_installed: Option<bool>,
-    /// Free-form one-line reason when we couldn't get a definitive
-    /// answer ("sbctl not on PATH", "not booted via UEFI", "sbctl exit
-    /// 1: …"). Surfaced in the WebUI tooltip on the status pill.
+    /// `Some(true)` when bootctl reports `disabled (unsupported)` —
+    /// the firmware lacks SB support entirely (e.g. OVMF without the
+    /// SB build option, common on default QEMU). Distinct from a
+    /// firmware that supports SB but has it switched off, so the
+    /// WebUI can show "Unsupported" instead of nudging the operator
+    /// to enable a feature they can't.
+    pub unsupported: Option<bool>,
+    /// `Some(true)` when bootctl reports `Measured UKI: yes` — kernel
+    /// and initrd are loaded as a measured Unified Kernel Image.
+    /// Useful signal for the future lanzaboote integration where SB
+    /// and measured boot together strengthen the PCR-7 seal.
+    pub measured_uki: Option<bool>,
+    /// Free-form one-line reason when we couldn't determine the
+    /// state ("bootctl unavailable: …", "bootctl status returned no
+    /// System: block", etc.). Surfaced under the Hardware card's
+    /// status pill.
     pub note: Option<String>,
 }
 
 impl SecureBootStatus {
-    fn unknown(note: impl Into<String>) -> Self {
+    fn note(text: impl Into<String>) -> Self {
         Self {
-            enabled: None,
-            setup_mode: None,
-            sbctl_installed: None,
-            note: Some(note.into()),
+            note: Some(text.into()),
+            ..Self::default()
         }
     }
 }
 
-/// Inspect Secure Boot state via `sbctl status --json`. Never returns
-/// `Result::Err` — failure modes (missing tool, BIOS boot, sbctl
-/// exiting non-zero) all collapse into a [`SecureBootStatus`] with
-/// `enabled = None` and a human-readable `note`.
+/// Inspect Secure Boot state via `bootctl status`. Never returns
+/// `Result::Err`; every failure mode (bootctl missing, no System:
+/// block, mangled line) collapses to a [`SecureBootStatus`] with
+/// `enabled = None` and a human-readable note.
 pub async fn status() -> SecureBootStatus {
-    // Cheap pre-check: if /sys/firmware/efi doesn't exist we're on a
-    // BIOS/legacy boot and there's no point asking sbctl — its first
-    // act would be to bail with the same finding via a noisier
-    // pathway.
-    if tokio::fs::metadata("/sys/firmware/efi").await.is_err() {
-        return SecureBootStatus::unknown("host is not booted via UEFI");
-    }
-
-    let output = match Command::new("sbctl")
-        .arg("status")
-        .arg("--json")
-        .output()
-        .await
-    {
+    let output = match Command::new("bootctl").arg("status").output().await {
         Ok(o) => o,
         Err(e) => {
-            debug!(target: "nasty::secure_boot", "sbctl spawn failed: {e}");
-            return SecureBootStatus::unknown(format!("sbctl unavailable: {e}"));
+            debug!(target: "nasty::secure_boot", "bootctl spawn failed: {e}");
+            return SecureBootStatus::note(format!("bootctl unavailable: {e}"));
         }
     };
 
-    // sbctl currently exits non-zero on some happy paths (e.g. when
-    // SB is disabled and it considers that a "problem") — but the
-    // JSON it prints in those cases is still the source of truth.
-    // So we parse stdout regardless of exit status, and only fall
-    // back to the exit-status branch if parsing fails too.
+    // bootctl status can exit non-zero on systems where it can't find
+    // an ESP, but it still prints the System: block first if it got
+    // far enough to read EFI variables — so parse stdout regardless
+    // of exit code and only fall back to the error path if the parser
+    // sees nothing useful.
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    match serde_json::from_str::<RawSbctlStatus>(stdout.trim()) {
-        Ok(raw) => SecureBootStatus {
-            enabled: raw.secure_boot,
-            setup_mode: raw.setup_mode,
-            sbctl_installed: raw.installed,
-            note: None,
-        },
-        Err(parse_err) => {
-            warn!(
-                target: "nasty::secure_boot",
-                "sbctl status --json unparseable (exit {}): {parse_err}; stderr={stderr}",
-                output.status
-            );
-            SecureBootStatus::unknown(format!(
-                "sbctl returned unparseable output (exit {})",
-                output.status
-            ))
-        }
+    let parsed = parse_bootctl_status(&stdout);
+    if parsed.enabled.is_some() {
+        return parsed;
     }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    warn!(
+        target: "nasty::secure_boot",
+        "bootctl status missing Secure Boot line ({}); stderr={stderr}",
+        output.status
+    );
+    SecureBootStatus::note(if stderr.is_empty() {
+        format!("bootctl produced no Secure Boot line ({})", output.status)
+    } else {
+        format!("bootctl: {stderr}")
+    })
 }
 
-/// Mirror of the subset of `sbctl status --json` fields we care about.
-/// Every field is optional — sbctl has reshaped its output schema
-/// across releases (the `installed` key in particular was added
-/// post-0.10) and we want to keep working under both old and new.
-#[derive(Debug, Deserialize)]
-struct RawSbctlStatus {
-    #[serde(default)]
-    secure_boot: Option<bool>,
-    #[serde(default)]
-    setup_mode: Option<bool>,
-    #[serde(default)]
-    installed: Option<bool>,
+/// Parse the plaintext body of `bootctl status`. Picks out:
+///   - `Secure Boot: <state> (<parenthetical>)?`
+///   - `Measured UKI: yes/no`
+///
+/// Resilient to leading whitespace (the labels are right-aligned in
+/// bootctl's output, so each line has varying indent), to extra lines
+/// before/after the System: block, and to unknown parentheticals
+/// (logged at debug and ignored).
+fn parse_bootctl_status(body: &str) -> SecureBootStatus {
+    let mut out = SecureBootStatus::default();
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("Secure Boot:") {
+            let (state, paren) = split_state_and_paren(rest.trim());
+            out.enabled = match state {
+                "enabled" => Some(true),
+                "disabled" => Some(false),
+                other => {
+                    debug!(target: "nasty::secure_boot", "unknown Secure Boot value: {other:?}");
+                    None
+                }
+            };
+            match paren {
+                Some("setup") => out.setup_mode = Some(true),
+                Some("unsupported") => out.unsupported = Some(true),
+                Some(other) => {
+                    debug!(target: "nasty::secure_boot", "unknown SB parenthetical: {other:?}")
+                }
+                None => {}
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("Measured UKI:") {
+            out.measured_uki = match rest.trim() {
+                "yes" => Some(true),
+                "no" => Some(false),
+                _ => None,
+            };
+        }
+    }
+    out
+}
+
+/// Split `"disabled (unsupported)"` into `("disabled", Some("unsupported"))`.
+/// Returns `("disabled", None)` for a bare `"disabled"`. Whitespace-tolerant.
+fn split_state_and_paren(s: &str) -> (&str, Option<&str>) {
+    match s.find(" (") {
+        Some(idx) => {
+            let state = s[..idx].trim();
+            let rest = s[idx + 2..].trim_end_matches(')').trim();
+            (state, Some(rest))
+        }
+        None => (s, None),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn parses_modern_sbctl_output() {
-        let payload = r#"{
-            "installed": false,
-            "guid": "00000000-0000-0000-0000-000000000000",
-            "setup_mode": false,
-            "secure_boot": true,
-            "vendors": []
-        }"#;
-        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
-        assert_eq!(raw.secure_boot, Some(true));
-        assert_eq!(raw.setup_mode, Some(false));
-        assert_eq!(raw.installed, Some(false));
+    fn fixture(line: &str) -> String {
+        format!(
+            "System:\n      Firmware: UEFI 2.70 (vendor)\n Firmware Arch: x64\n   Secure Boot: {line}\n  TPM2 Support: yes\n  Measured UKI: no\n  Boot into FW: supported\n"
+        )
     }
 
     #[test]
-    fn tolerates_missing_installed_field() {
-        // Older sbctl releases (pre-0.10) don't emit `installed`.
-        let payload = r#"{"setup_mode": false, "secure_boot": false}"#;
-        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
-        assert_eq!(raw.secure_boot, Some(false));
-        assert_eq!(raw.installed, None);
+    fn parses_enabled() {
+        let s = parse_bootctl_status(&fixture("enabled"));
+        assert_eq!(s.enabled, Some(true));
+        assert_eq!(s.setup_mode, None);
+        assert_eq!(s.unsupported, None);
     }
 
     #[test]
-    fn tolerates_unknown_fields() {
-        // Future sbctl additions must not break parsing.
-        let payload = r#"{
-            "secure_boot": true,
-            "setup_mode": false,
-            "future_field_xyz": "anything"
-        }"#;
-        let raw: RawSbctlStatus = serde_json::from_str(payload).unwrap();
-        assert_eq!(raw.secure_boot, Some(true));
+    fn parses_disabled_plain() {
+        let s = parse_bootctl_status(&fixture("disabled"));
+        assert_eq!(s.enabled, Some(false));
+        assert_eq!(s.unsupported, None);
+        assert_eq!(s.setup_mode, None);
     }
 
     #[test]
-    fn unknown_carries_note() {
-        let s = SecureBootStatus::unknown("test");
+    fn parses_disabled_unsupported() {
+        // The case that prompted this whole rewrite: nasty.0f.ee's
+        // OVMF build can't do Secure Boot, and we need to distinguish
+        // that from "disabled but supported" so the UI doesn't nudge
+        // the operator toward a firmware setting that doesn't exist.
+        let s = parse_bootctl_status(&fixture("disabled (unsupported)"));
+        assert_eq!(s.enabled, Some(false));
+        assert_eq!(s.unsupported, Some(true));
+        assert_eq!(s.setup_mode, None);
+    }
+
+    #[test]
+    fn parses_disabled_setup() {
+        let s = parse_bootctl_status(&fixture("disabled (setup)"));
+        assert_eq!(s.enabled, Some(false));
+        assert_eq!(s.setup_mode, Some(true));
+        assert_eq!(s.unsupported, None);
+    }
+
+    #[test]
+    fn parses_measured_uki() {
+        let body = "System:\n   Secure Boot: enabled\n  Measured UKI: yes\n";
+        let s = parse_bootctl_status(body);
+        assert_eq!(s.measured_uki, Some(true));
+    }
+
+    #[test]
+    fn missing_system_block_yields_no_signal() {
+        let s = parse_bootctl_status("Some unrelated output\nWithout any System block\n");
         assert!(s.enabled.is_none());
-        assert_eq!(s.note.as_deref(), Some("test"));
+        assert!(s.setup_mode.is_none());
+        assert!(s.unsupported.is_none());
+    }
+
+    #[test]
+    fn unknown_parenthetical_is_ignored_not_fatal() {
+        // bootctl in some future systemd release could add new
+        // parentheticals — we want the primary enabled flag to still
+        // parse, with the unknown value silently dropped.
+        let s = parse_bootctl_status(&fixture("disabled (audit)"));
+        assert_eq!(s.enabled, Some(false));
+        assert_eq!(s.setup_mode, None);
+        assert_eq!(s.unsupported, None);
+    }
+
+    #[test]
+    fn split_state_and_paren_handles_both_shapes() {
+        assert_eq!(split_state_and_paren("enabled"), ("enabled", None));
+        assert_eq!(
+            split_state_and_paren("disabled (setup)"),
+            ("disabled", Some("setup"))
+        );
+        assert_eq!(
+            split_state_and_paren("disabled (unsupported)"),
+            ("disabled", Some("unsupported"))
+        );
+    }
+
+    #[test]
+    fn note_helper_clears_signal_fields() {
+        let s = SecureBootStatus::note("test reason");
+        assert!(s.enabled.is_none());
+        assert!(s.setup_mode.is_none());
+        assert!(s.unsupported.is_none());
+        assert!(s.measured_uki.is_none());
+        assert_eq!(s.note.as_deref(), Some("test reason"));
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -594,7 +594,6 @@ in {
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery
       tpm2-tools        # tpm2_getcap, tpm2_pcrread, tpm2_unseal — engine reads vendor info via tpm2_getcap, operators use the rest for TPM debugging
-      sbctl             # Secure Boot state inspection (sbctl status --json). Read-only use by the engine; signing/enrollment stays lanzaboote's territory.
       docker-compose    # Docker Compose for multi-container apps
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
@@ -1451,7 +1450,7 @@ in {
         usbutils                     # lsusb — USB enumeration for hardware page + VM USB passthrough
         dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
         tpm2-tools                   # tpm2_getcap / tpm2_create / tpm2_unseal — Hardware page chip info + the PCR-7 seal/unseal flow for the bcachefs encryption key (#102)
-        sbctl                        # sbctl status --json — Secure Boot state for Hardware page. Read-only; signing/enrollment is lanzaboote's job, not ours.
+        systemd                      # bootctl — Secure Boot + Measured UKI state for the Hardware page. systemd is PID 1 already; this just puts its bin/ on the engine's path so the engine's restricted PATH can find bootctl without an absolute store path.
         keyutils                     # keyctl — fs.lock revokes the bcachefs unlock key from the kernel session keyring; without this the call fails with "No such file or directory" even though every other tool we shell out to is here
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -55,14 +55,19 @@ export interface HardwareSummary {
 	secure_boot: SecureBootStatus;
 }
 
-/** Result of `sbctl status --json`. All fields degrade to null when
- * the box isn't UEFI, sbctl isn't installed, or sbctl errored — those
- * failure modes surface as `enabled: null` with a human-readable
- * `note`, not as a missing field. */
+/** Sourced from `bootctl status` on the engine. All fields degrade
+ * to null when the box isn't UEFI, bootctl is missing, or its output
+ * lacks the Secure Boot line — those failure modes surface as
+ * `enabled: null` with a human-readable `note`, never as a missing
+ * field. `unsupported = true` distinguishes "firmware can't do SB"
+ * from "firmware can but operator hasn't enabled it", so the WebUI
+ * doesn't nudge the operator toward a firmware setting that isn't
+ * there. */
 export interface SecureBootStatus {
 	enabled: boolean | null;
 	setup_mode: boolean | null;
-	sbctl_installed: boolean | null;
+	unsupported: boolean | null;
+	measured_uki: boolean | null;
 	note: string | null;
 }
 

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -346,6 +346,21 @@
 							Firmware in setup mode — accepts unsigned key enrollment.
 						</div>
 					{/if}
+					{#if summary.secure_boot.measured_uki === true}
+						<div class="mt-1 text-xs text-emerald-400">
+							Measured UKI · kernel and initrd measured into the PCR chain.
+						</div>
+					{/if}
+				{:else if summary?.secure_boot.unsupported === true}
+					<div class="text-sm font-medium">
+						Unsupported
+						<span class="ml-1 text-xs text-muted-foreground">· firmware lacks SB</span>
+					</div>
+					<div class="mt-1 text-xs text-muted-foreground">
+						This UEFI build doesn't support Secure Boot (common on default
+						QEMU OVMF). Nothing to enable in firmware — TPM PCR-7 sealing
+						still works, just without the measured-boot reinforcement.
+					</div>
 				{:else if summary?.secure_boot.enabled === false}
 					<div class="text-sm font-medium">
 						Disabled


### PR DESCRIPTION
## Why

#321 added sbctl as the Secure Boot reader. On `nasty.0f.ee` it broke
in an interesting way: the VM has `/sys/firmware/efi` (so my pre-check
passed) but no usable efivars, so sbctl exited non-zero with **empty
stdout** and JSON-parse blew up. The Hardware card displayed:

> Unknown — sbctl returned unparseable output (exit exit status: 1)

Uninformative, and `exit exit` was my format-string bug doubling
`output.status.Display`'s own `"exit status: N"`. But the bigger
mistake was the tool choice: **`bootctl` is already on every NixOS box
(systemd ships it), distinguishes more firmware states than sbctl
does, and the official NixOS docs point operators at it for SB
checks**. I anchored on sbctl because of its JSON output and
advertised "future" features (enrolled-keys, signature verification)
without checking that (a) we'd never use them — lanzaboote owns
signing — or (b) bootctl's plaintext was actually harder to parse. It
isn't.

## What

### Engine (`nasty-common`)

`secure_boot::status()` now shells out to `bootctl status` and scans
the `Secure Boot:` and `Measured UKI:` lines from the System: block.
Resilient to leading whitespace (bootctl right-aligns labels), unknown
parentheticals (logged debug, primary flag still set), extra lines,
and non-zero exit codes.

`SecureBootStatus` shape changes:

| Field             | Before                | After                      |
|-------------------|-----------------------|----------------------------|
| `enabled`         | from sbctl JSON       | from `Secure Boot:` line   |
| `setup_mode`      | from sbctl JSON       | from `(setup)` parenthetical |
| `sbctl_installed` | from sbctl JSON       | **removed** (no consumer)  |
| `unsupported`     | —                     | **new** — from `(unsupported)` parenthetical |
| `measured_uki`    | —                     | **new** — from `Measured UKI:` line |
| `note`            | unchanged             | unchanged                  |

9 unit tests cover all four bootctl SB states, Measured UKI parsing,
unknown parentheticals (forward-compat with future bootctl additions),
missing System: block, and the state/parenthetical splitter.

### NixOS

- `sbctl` removed from `environment.systemPackages`.
- `sbctl` removed from the nasty-engine systemd unit's `path`.
- `pkgs.systemd` added to the engine systemd unit's `path` — `bootctl`
  lives at `${pkgs.systemd}/bin/bootctl`. systemd is PID 1 already;
  this just makes its `bin/` findable from the engine's restricted
  PATH.

### WebUI

- `SecureBootStatus` mirror updated: drop `sbctl_installed`, add
  `unsupported` + `measured_uki`.
- Hardware page card gains an **Unsupported** state (muted, copy
  explains there's nothing to enable in firmware — so the QEMU OVMF
  operator doesn't get nudged toward a setting that doesn't exist).
- When SB is `enabled` AND Measured UKI is `yes`, an emerald sub-line
  highlights the reinforced boot chain.

## What this means for nasty.0f.ee

Card will now read:

> **Secure Boot — Unsupported**
> · firmware lacks SB
> This UEFI build doesn't support Secure Boot (common on default QEMU
> OVMF). Nothing to enable in firmware — TPM PCR-7 sealing still works,
> just without the measured-boot reinforcement.

Distinct from the "Unknown" bucket, no misleading "fix me" prompt.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] 9 secure_boot unit tests cover all parser branches
- [x] 33 nasty-common tests pass overall
- [x] WebUI `npm run check` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on `nasty.0f.ee`: card reads "Unsupported · firmware lacks SB"
- [ ] Manual on a real SB-capable box: card reads "Enabled · enforcing"
- [ ] Manual on the other test VM (SB-capable, disabled): "Disabled · not enforcing"