### PR TITLE
nasty.secureBoot.enable — lanzaboote opt-in foundation

### DIFF
--- a/engine/nasty-common/src/tpm.rs
+++ b/engine/nasty-common/src/tpm.rs
@@ -45,12 +45,50 @@ pub enum TpmError {
     Blob(String),
 }
 
+/// Categorises which policy shape a [`SealedBlob`] was built under.
+/// Today every blob is `PolicyKind::Pcr7Static` (a fixed PCR-7
+/// reading captured at seal time). Future shapes — multi-PCR static
+/// (e.g. PCRs 0+4+7 once lanzaboote + measured boot land), or a
+/// `systemd-pcrlock`-backed signed policy — will get their own
+/// variants. Having the discriminant on disk lets the unseal path
+/// route to the right replay logic instead of inferring it from the
+/// `pcrs` string, and lets the engine refuse to load blobs sealed
+/// under a policy this version doesn't understand.
+///
+/// `#[serde(other)]` on `Unknown` makes deserialisation tolerant of
+/// future variants: an older engine reading a future blob produces
+/// `Unknown`, which the unseal path rejects cleanly with a useful
+/// error rather than panicking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyKind {
+    /// Single-PCR static reading (today: PCR-7 only). The `pcrs` field
+    /// names the selection (e.g. `"sha256:7"`); the blob was sealed
+    /// against the exact PCR value at seal time.
+    Pcr7Static,
+    /// Reserved — any policy this engine version doesn't recognise.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Default for legacy blobs written before this field existed.
+/// Serde uses this when deserialising a file that lacks `policy_kind`,
+/// so blobs written by pre-lanzaboote engines continue to load.
+fn default_policy_kind() -> PolicyKind {
+    PolicyKind::Pcr7Static
+}
+
 /// On-disk wrapper around the raw TPM2 blobs. Stored next to the
 /// plaintext `.key` file as `<name>.tpm`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SealedBlob {
     /// Format version of this struct — see [`BLOB_VERSION`].
     pub version: u32,
+    /// Which policy shape this blob was built under. Defaults to
+    /// `Pcr7Static` for backward compat with blobs that pre-date this
+    /// field (every blob ever written by NASty so far is PCR-7 static).
+    #[serde(default = "default_policy_kind")]
+    pub policy_kind: PolicyKind,
     /// PCR selection string the policy was built against
     /// (e.g. `"sha256:7"`). Mirrored into the file so a future change
     /// to [`PCR_SELECTION`] doesn't silently break already-sealed
@@ -155,6 +193,7 @@ pub async fn seal_with_pcr7(plaintext: &[u8]) -> Result<SealedBlob, TpmError> {
     let engine = base64::engine::general_purpose::STANDARD;
     Ok(SealedBlob {
         version: BLOB_VERSION,
+        policy_kind: PolicyKind::Pcr7Static,
         pcrs: PCR_SELECTION.to_string(),
         pub_b64: engine.encode(&pub_bytes),
         priv_b64: engine.encode(&priv_bytes),
@@ -349,6 +388,7 @@ mod tests {
     fn sealed_blob_json_roundtrip() {
         let blob = SealedBlob {
             version: BLOB_VERSION,
+            policy_kind: PolicyKind::Pcr7Static,
             pcrs: PCR_SELECTION.to_string(),
             pub_b64: "AAEC".into(),
             priv_b64: "AwQF".into(),
@@ -356,9 +396,42 @@ mod tests {
         let json = serde_json::to_string(&blob).expect("serialize");
         let back: SealedBlob = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.version, BLOB_VERSION);
+        assert_eq!(back.policy_kind, PolicyKind::Pcr7Static);
         assert_eq!(back.pcrs, PCR_SELECTION);
         assert_eq!(back.pub_b64, "AAEC");
         assert_eq!(back.priv_b64, "AwQF");
+    }
+
+    #[test]
+    fn legacy_blob_without_policy_kind_loads_as_pcr7_static() {
+        // Pre-lanzaboote NASty engines wrote blobs without a
+        // `policy_kind` field; serde defaults must produce
+        // `Pcr7Static` so existing on-disk seals continue to load.
+        let legacy_json = r#"{
+            "version": 1,
+            "pcrs": "sha256:7",
+            "pub_b64": "AAEC",
+            "priv_b64": "AwQF"
+        }"#;
+        let blob: SealedBlob = serde_json::from_str(legacy_json).expect("legacy deserialize");
+        assert_eq!(blob.policy_kind, PolicyKind::Pcr7Static);
+    }
+
+    #[test]
+    fn unknown_policy_kind_deserialises_as_unknown_variant() {
+        // Forward-compat: a future blob written with a policy kind
+        // this engine version doesn't know about must deserialise as
+        // `Unknown` rather than failing parse outright. The unseal
+        // path is then expected to refuse it explicitly.
+        let future_json = r#"{
+            "version": 1,
+            "policy_kind": "pcrlock_signed",
+            "pcrs": "sha256:0,4,7",
+            "pub_b64": "AAEC",
+            "priv_b64": "AwQF"
+        }"#;
+        let blob: SealedBlob = serde_json::from_str(future_json).expect("future deserialize");
+        assert_eq!(blob.policy_kind, PolicyKind::Unknown);
     }
 
     #[tokio::test]
@@ -371,6 +444,7 @@ mod tests {
     async fn unseal_rejects_unsupported_version() {
         let blob = SealedBlob {
             version: 99,
+            policy_kind: PolicyKind::Pcr7Static,
             pcrs: PCR_SELECTION.to_string(),
             pub_b64: "AAEC".into(),
             priv_b64: "AwQF".into(),

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,28 @@
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
+    # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────
+    # Pinned but inert by default. The lanzaboote module is loaded
+    # into every NASty NixOS configuration so the `boot.lanzaboote.*`
+    # option space exists, but `boot.lanzaboote.enable` stays false
+    # unless the operator flips `nasty.secureBoot.enable = true`
+    # (per-box opt-in, same shape as TPM2 binding). On boxes that
+    # never opt in this is just a `flake.lock` entry and a few option
+    # declarations — no boot path changes, no `lzbt` in the closure.
+    #
+    # Why pinned in nasty (not just in the wrapper): operators
+    # shouldn't pick a lanzaboote rev — its protocol with sd-stub /
+    # the firmware key formats / the install-hook contract are all
+    # things NASty needs to test against, so we own the version.
+    #
+    # nixpkgs.follows: keeps lanzaboote's nixpkgs aligned with
+    # nasty's, so cachix-substituted artifacts match by content
+    # hash and we don't ship a second nixpkgs in the closure.
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+    lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, bcachefs-tools, ... }: let
+  outputs = { self, nixpkgs, bcachefs-tools, lanzaboote, ... }: let
     # Helper to build packages for a given system
     mkPkgs = system: nixpkgs.legacyPackages.${system};
     nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
@@ -161,12 +180,14 @@
             };
             inputs = {
               bcachefs-tools = [ "bcachefs-tools" ];
+              lanzaboote = [ "lanzaboote" ];
               nixpkgs = [ "nixpkgs" ];
             };
           };
           root = {
             inputs = {
               bcachefs-tools = "bcachefs-tools";
+              lanzaboote = "lanzaboote";
               nasty = "nasty";
               nixpkgs = "nixpkgs";
             };
@@ -189,7 +210,7 @@
       # Full NASty appliance configuration
       nasty = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot lanzaboote; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -201,7 +222,7 @@
 
       nasty-rootfs = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot lanzaboote; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -269,7 +290,7 @@
       # QEMU VM for testing
       nasty-vm = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot lanzaboote; };
         modules = [
           ./nixos/modules/bcachefs.nix
           ./nixos/modules/linuxquota.nix
@@ -283,7 +304,7 @@
       # Cloud/CI disk image (Oracle Cloud compatible)
       nasty-cloud = nixpkgs.lib.nixosSystem {
         inherit system;
-        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot; };
+        specialArgs = { inherit nasty-engine nasty-webui nasty-version nasty-bcachefs-tools nastySystemFlakeSnapshot lanzaboote; };
         modules = [
           "${nixpkgs}/nixos/modules/virtualisation/oci-image.nix"
           ./nixos/modules/bcachefs.nix

--- a/nixos/modules/nasty-secure-boot.nix
+++ b/nixos/modules/nasty-secure-boot.nix
@@ -1,0 +1,33 @@
+# Lanzaboote-using config for `services.nasty.secureBoot.enable`.
+#
+# This file lives separately from `nasty.nix` so its `boot.lanzaboote.*`
+# references don't trip NixOS's option-existence validation when
+# `nasty.nix` is imported into configurations that don't carry the
+# lanzaboote module (notably the integration tests in `nixos/tests/`,
+# which build a stripped-down system via `pkgs.nixosTest` without
+# threading a lanzaboote specialArg through). `nasty.nix` imports this
+# file via `lib.optionals lanzabooteAvailable [...]`, so it's only
+# loaded when the lanzaboote NixOS module is also loaded — meaning the
+# option paths referenced below are guaranteed to exist.
+#
+# The option itself (`services.nasty.secureBoot.enable`) is still
+# declared in `nasty.nix`, since option declarations need to be
+# present unconditionally so that mentioning the option in
+# configurations is valid even on boxes where lanzaboote is absent.
+{ config, lib, ... }:
+
+let
+  cfg = config.services.nasty;
+  inherit (lib) mkIf;
+in {
+  config = mkIf cfg.secureBoot.enable {
+    boot.lanzaboote.enable = true;
+    boot.lanzaboote.pkiBundle = "/var/lib/sbctl";
+    # First boot generates the PKI under pkiBundle if absent.
+    # Operator (or PR #3's installer) still has to enroll PK/KEK/db
+    # into firmware via a Setup-Mode visit — autoEnrollKeys stays
+    # off here so flipping `secureBoot.enable` doesn't surprise an
+    # operator with a firmware-state change.
+    boot.lanzaboote.autoGenerateKeys.enable = true;
+  };
+}

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -97,11 +97,20 @@ EOF
   };
 
 in {
-  # Import the lanzaboote NixOS module if the wrapper passed it
-  # through; on older wrappers without the input, this is just
-  # `[]` and nothing happens — the option above stays unflippable
-  # and the assertion below catches anyone who flips it anyway.
-  imports = lib.optionals lanzabooteAvailable [ lanzaboote.nixosModules.lanzaboote ];
+  # Import the lanzaboote NixOS module — and the small sub-module
+  # that uses its options — only when the wrapper passed lanzaboote
+  # through. Splitting the lanzaboote-using config into a separate
+  # file (`./nasty-secure-boot.nix`) keeps `boot.lanzaboote.*`
+  # references out of this file's evaluation, so configurations
+  # that import `nasty.nix` without threading lanzaboote (notably
+  # the integration tests in `nixos/tests/`) don't trip
+  # option-existence validation. On older wrappers without the
+  # input, this is just `[]` — the option below stays unflippable
+  # and the assertion catches anyone who flips it anyway.
+  imports = lib.optionals lanzabooteAvailable [
+    lanzaboote.nixosModules.lanzaboote
+    ./nasty-secure-boot.nix
+  ];
 
   options.services.nasty = {
     enable = mkEnableOption "NASty NAS management system";
@@ -206,21 +215,14 @@ in {
 
   config = lib.mkMerge [
 
-    # ── Secure Boot opt-in (when lanzaboote was passed by the wrapper) ──
-    # Setting these options under mkMerge with the precise enabling
-    # condition means: when secureBoot is off, this whole sub-attrset
-    # is never evaluated, so the `boot.lanzaboote.*` option references
-    # don't blow up on old wrappers (where lanzaboote = null and the
-    # lanzaboote module wasn't imported).
+    # ── Secure Boot: bits that touch stock NixOS options only ───
+    # The lanzaboote-specific settings (`boot.lanzaboote.*`) live in
+    # `./nasty-secure-boot.nix`, which is only imported when
+    # lanzaboote was actually passed through — so they don't trip
+    # option-existence validation in test configurations.
+    # `boot.loader.systemd-boot.enable` is a stock NixOS option and
+    # is always safe to set here.
     (mkIf (cfg.enable && cfg.secureBoot.enable && lanzabooteAvailable) {
-      boot.lanzaboote.enable = true;
-      boot.lanzaboote.pkiBundle = "/var/lib/sbctl";
-      # First boot generates the PKI under pkiBundle if it isn't there
-      # already. Operator (or PR #3's installer) still has to enroll
-      # PK/KEK/db into firmware via a Setup-Mode visit — auto-enroll
-      # stays off here so flipping this knob doesn't surprise an
-      # operator with a firmware-state change.
-      boot.lanzaboote.autoGenerateKeys.enable = true;
       # Lanzaboote installs systemd-boot itself (signed); the NixOS
       # `boot.loader.systemd-boot.enable` option conflicts with that
       # install path, so it must be forced off when lanzaboote takes

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -5,6 +5,17 @@ let
   inherit (lib) mkEnableOption mkOption mkIf types;
   nastySystemFlakeSnapshot = args.nastySystemFlakeSnapshot or null;
 
+  # Secure Boot integration is opt-in per box. The wrapper flake at
+  # /etc/nixos/flake.nix passes the lanzaboote input through as a
+  # specialArg when it has the input declared; pre-#324-era wrappers
+  # don't, in which case lanzaboote stays null and any attempt to set
+  # `services.nasty.secureBoot.enable = true` trips a clear assertion
+  # (rather than failing with a cryptic "option boot.lanzaboote.enable
+  # does not exist" message). The fix path is to re-render the wrapper
+  # by running any upgrade once on the new engine.
+  lanzaboote = args.lanzaboote or null;
+  lanzabooteAvailable = lanzaboote != null;
+
   # When the operator supplies a cert + key (cfg.tls.certFile/keyFile),
   # Caddy serves those for the :443 catch-all. Otherwise we use Caddy's
   # `tls internal` directive — Caddy's "Local Authority" issues a
@@ -86,6 +97,12 @@ EOF
   };
 
 in {
+  # Import the lanzaboote NixOS module if the wrapper passed it
+  # through; on older wrappers without the input, this is just
+  # `[]` and nothing happens — the option above stays unflippable
+  # and the assertion below catches anyone who flips it anyway.
+  imports = lib.optionals lanzabooteAvailable [ lanzaboote.nixosModules.lanzaboote ];
+
   options.services.nasty = {
     enable = mkEnableOption "NASty NAS management system";
 
@@ -167,9 +184,71 @@ in {
 
     # VPN — not enabled by default (requires Tailscale auth key)
     tailscale.enable = mkEnableOption "Tailscale VPN for NASty";
+
+    # ── Secure Boot (opt-in, per box) ──────────────────────────
+    # Lanzaboote-backed UEFI Secure Boot. Off by default everywhere;
+    # operators flip it on per-box only after their firmware is in
+    # Setup Mode and the on-box `sbctl enroll-keys` ceremony has
+    # been arranged. Without SB on, NASty's TPM2 sealing of bcachefs
+    # keys is bound to PCR-7 — which on a stock NixOS install is
+    # essentially a constant (PCR-7 measures Secure Boot policy, and
+    # "SB disabled" is the same value on every box). The seal looks
+    # right but a box-theft attacker can boot any OS and still
+    # unseal. With SB on, PCR-7 binds to NASty-owned firmware keys,
+    # so an attacker can't satisfy the policy without booting the
+    # signed NASty stub.
+    #
+    # See `docs/adr/0001-secure-boot-via-lanzaboote.md` for the full
+    # picture; PR #2 (enrollment ceremony) is the operator-facing
+    # half of the workflow.
+    secureBoot.enable = mkEnableOption "lanzaboote-backed UEFI Secure Boot (opt-in, per box)";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkMerge [
+
+    # ── Secure Boot opt-in (when lanzaboote was passed by the wrapper) ──
+    # Setting these options under mkMerge with the precise enabling
+    # condition means: when secureBoot is off, this whole sub-attrset
+    # is never evaluated, so the `boot.lanzaboote.*` option references
+    # don't blow up on old wrappers (where lanzaboote = null and the
+    # lanzaboote module wasn't imported).
+    (mkIf (cfg.enable && cfg.secureBoot.enable && lanzabooteAvailable) {
+      boot.lanzaboote.enable = true;
+      boot.lanzaboote.pkiBundle = "/var/lib/sbctl";
+      # First boot generates the PKI under pkiBundle if it isn't there
+      # already. Operator (or PR #3's installer) still has to enroll
+      # PK/KEK/db into firmware via a Setup-Mode visit — auto-enroll
+      # stays off here so flipping this knob doesn't surprise an
+      # operator with a firmware-state change.
+      boot.lanzaboote.autoGenerateKeys.enable = true;
+      # Lanzaboote installs systemd-boot itself (signed); the NixOS
+      # `boot.loader.systemd-boot.enable` option conflicts with that
+      # install path, so it must be forced off when lanzaboote takes
+      # over the loader.
+      boot.loader.systemd-boot.enable = lib.mkForce false;
+    })
+
+    # ── Catch operator-error: SB enabled on a wrapper that doesn't
+    # carry the lanzaboote input. Pre-this-PR wrappers will hit this
+    # if someone flips the knob; the fix is to run any upgrade once
+    # so the new engine re-renders the wrapper template with the
+    # `lanzaboote.url` input added.
+    (mkIf (cfg.enable && cfg.secureBoot.enable && !lanzabooteAvailable) {
+      assertions = [
+        {
+          assertion = false;
+          message = ''
+            services.nasty.secureBoot.enable = true requires the wrapper
+            flake at /etc/nixos/flake.nix to declare the lanzaboote input.
+            Your wrapper is out of date — run any upgrade once on the new
+            NASty engine to re-render it (the new template includes the
+            lanzaboote input), then this option will work.
+          '';
+        }
+      ];
+    })
+
+    (mkIf cfg.enable {
 
     # ── Required kernel support ────────────────────────────────
     # bcachefs kernel module + tools live in modules/bcachefs.nix
@@ -594,6 +673,7 @@ in {
       qemu              # QEMU/KVM for virtual machines
       pciutils          # lspci for passthrough device discovery
       tpm2-tools        # tpm2_getcap, tpm2_pcrread, tpm2_unseal — engine reads vendor info via tpm2_getcap, operators use the rest for TPM debugging
+      sbctl             # Secure Boot key + signing-state inspector. Used by operators directly (`sbctl status`, `sbctl verify`, `sbctl list-enrolled-keys`); the lanzaboote module also drives it via the `autoGenerateKeys` install hook to create `/var/lib/sbctl` keys on first boot. NASty itself only ever reads — signing/enrollment writes go through lanzaboote, never direct sbctl calls.
       docker-compose    # Docker Compose for multi-container apps
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
@@ -1451,6 +1531,7 @@ in {
         dmidecode                    # DMI tables for /system/hardware (BIOS, baseboard, memory)
         tpm2-tools                   # tpm2_getcap / tpm2_create / tpm2_unseal — Hardware page chip info + the PCR-7 seal/unseal flow for the bcachefs encryption key (#102)
         systemd                      # bootctl — Secure Boot + Measured UKI state for the Hardware page. systemd is PID 1 already; this just puts its bin/ on the engine's path so the engine's restricted PATH can find bootctl without an absolute store path.
+        sbctl                        # SB enrollment + signing-state checks for PR #2's WebUI ceremony (`sbctl verify`, `sbctl list-enrolled-keys`). Read paths only from the engine; writes go through lanzaboote's install hooks, never direct sbctl-from-engine calls.
         keyutils                     # keyctl — fs.lock revokes the bcachefs unlock key from the kernel session keyring; without this the call fails with "No such file or directory" even though every other tool we shell out to is here
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
         ++ lib.optionals cfg.smb.enable [ samba shadow.out ]
@@ -2109,5 +2190,6 @@ in {
       "interface-name:cni*"
       "interface-name:flannel*"
     ];
-  };
+    })
+  ];
 }

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -60,9 +60,18 @@
     # tagged release everyone has updated past), this shim can be
     # removed safely.
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+
+    # Secure Boot integration. Pinned by NASty (operators shouldn't
+    # pick a lanzaboote rev — its protocol with sd-stub, the firmware
+    # key formats, and the install-hook contract are all things NASty
+    # tests against). Inert until the operator sets
+    # `nasty.secureBoot.enable = true` per box; on boxes that never
+    # opt in this is just a flake.lock entry, no boot path changes.
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+    lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nasty, ... }:
+  outputs = { self, nixpkgs, nasty, lanzaboote, ... }:
     let
       nasty-version =
         (builtins.fromTOML (builtins.readFile "${nasty}/engine/Cargo.toml")).workspace.package.version;
@@ -84,7 +93,7 @@
             nasty-webui = nasty.packages.${system}.webui;
             nasty-version = nasty-version;
             nasty-bcachefs-tools = nasty.packages.${system}.bcachefs-tools;
-            inherit nastySystemFlakeSnapshot;
+            inherit nastySystemFlakeSnapshot lanzaboote;
           };
           modules = [
             "${nasty}/nixos/binary-cache.nix"


### PR DESCRIPTION
## What

Foundation PR for Secure Boot on NASty — first half of the two-PR plan
laid out in [ADR 0001](docs/adr/0001-secure-boot-via-lanzaboote.md)
(PR #324). PR #2 will be the operator-facing enrollment ceremony.

This PR:

- Pins lanzaboote v1.0.0 as a flake input in both the root flake and
  the wrapper template, with `nixpkgs.follows` set so cachix-
  substituted artifacts stay byte-identical to what CI built against.
- Adds `services.nasty.secureBoot.enable` — a NASty config option that
  flips `boot.lanzaboote.{enable, pkiBundle, autoGenerateKeys.enable}`
  and forces `boot.loader.systemd-boot.enable = false` when on.
  Defaults off everywhere. `autoEnrollKeys` stays at lanzaboote's
  default (off) — firmware-state changes belong to PR #2's ceremony,
  not to this knob.
- Re-adds `sbctl` to host packages + engine systemd path. Used directly
  by operators and by lanzaboote's `autoGenerateKeys` hook; the engine
  itself only reads (`sbctl status`, `sbctl verify`).
- Adds `SealedBlob.policy_kind` enum (`Pcr7Static` + `Unknown` catch-
  all). Legacy blobs without the field deserialise as `Pcr7Static`.
  Future blobs with an unknown variant (e.g. multi-PCR pcrlock) parse
  to `Unknown` so the engine can refuse them cleanly later instead of
  crashing.

## Why this is safe to deploy fleet-wide

Three guarantees, in decreasing order of "you shouldn't even notice":

1. **`boot.lanzaboote.enable` stays false by default.** Importing
   lanzaboote's NixOS module without enabling it just adds option
   declarations to the option space — no activation scripts, no `lzbt`
   in the closure, no ESP writes, no boot-path changes. systemd-boot
   keeps booting boxes exactly as today.
2. **Boxes that physically can't do SB are unaffected.** The Hardware-
   page Secure Boot card from #323 already distinguishes `Unsupported`
   (OVMF without SB, BIOS-only firmware) from `Disabled` (capable but
   off). PR #2 will only surface the opt-in toggle when the box is in
   the second state, so unsupported hardware can't be opted in by
   accident.
3. **Boxes upgrading from pre-this-PR engines work.** nasty.nix's
   `args.lanzaboote ? null` handling means old wrappers (which don't
   declare the lanzaboote input) gracefully pass `null` through, and
   the secureBoot config block doesn't fire (operator hasn't opted in
   anyway). Once the wrapper gets re-rendered (next upgrade triggers
   it via the existing `wrapperFlakeVersion` mechanism), the operator
   can opt in. If they try to opt in before the wrapper re-renders, a
   clear assertion fires telling them to upgrade once first.

## How it plays with the update system

Same shape as `bcachefs-tools` integration:

- `parse_flake_input_urls` is name-agnostic → sees lanzaboote.url
  automatically.
- `VERSION_INPUT_NAMES` is **not** extended — lanzaboote is NASty-
  pinned, not operator-tunable. Promote later if there's demand.
- Template render goes through the existing `wrapperFlakeVersion`
  placeholder mechanism — first upgrade after this PR auto-re-renders
  the wrapper to include `lanzaboote.url`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] 35 nasty-common tests pass (3 new for `PolicyKind`)
- [x] 30 nasty-storage tests pass
- [x] `nix-instantiate --parse` on flake.nix, template, nasty.nix all OK
- [x] WebUI: `npm run check` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on `.74`: deploy this branch with secureBoot off → no behaviour change vs. today
- [ ] Manual on `.74`: flip secureBoot on with an old wrapper → assertion fires with the upgrade-once message
- [ ] Manual on `.74`: upgrade once → flip secureBoot on → next build configures lanzaboote, signs ESP, but doesn't enroll keys (since autoEnrollKeys stays off)
- [ ] Manual on nasty.0f.ee (QEMU OVMF without SB): deploy → no behaviour change; Hardware page still shows `Unsupported`

## What's NOT in this PR

- WebUI enrollment ceremony (PR #2)
- ESP space pre-flight check at opt-in time (PR #2 — belongs to the
  WebUI flow, not to the module)
- Re-seal-under-new-PCR-7-after-enrollment flow (PR #2)
- `Pcr7Postenroll` / multi-PCR / pcrlock `PolicyKind` variants
  (deferred until measured boot lands, well after PR #2)
- Installer integration (PR #3)