### PR TITLE
secure_boot: readiness probe (RPC + Hardware-page checklist)

### DIFF
--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -21,6 +21,7 @@ pub(super) async fn try_route(
         "system.health" => ok(req, state.system.health().await),
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
+        "system.secure_boot.readiness" => ok(req, nasty_system::secure_boot::readiness().await),
         "system.passthrough.get" => ok(req, nasty_system::passthrough::load().await),
         "system.passthrough.update" => {
             match parse_params::<nasty_system::passthrough::PassthroughUpdate>(req) {

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -7,6 +7,7 @@ pub mod notifications;
 pub mod nut;
 pub mod passthrough;
 pub mod protocol;
+pub mod secure_boot;
 pub mod settings;
 pub mod tailscale;
 pub mod tuning;

--- a/engine/nasty-system/src/secure_boot.rs
+++ b/engine/nasty-system/src/secure_boot.rs
@@ -1,0 +1,357 @@
+//! Readiness probe for the lanzaboote-backed Secure Boot opt-in.
+//!
+//! This is the engine half of PR #2a (the WebUI half is the
+//! Hardware-page panel that renders a checklist from this struct).
+//! Returns a structured [`ReadinessReport`] so the WebUI can render
+//! each check independently with its own state — pass, fail, or
+//! not-applicable — rather than burying the result in a single
+//! pass/fail boolean. The blocker string is the operator-facing
+//! "what's stopping me right now" summary.
+//!
+//! Read-only: this module does not flip any switches, does not
+//! invoke `sbctl create-keys`, does not touch firmware state. The
+//! enrollment ceremony itself (which writes `nasty.secureBoot.enable
+//! = true` to /etc/nixos/configuration.nix and triggers the
+//! rebuild + reboot) belongs to PR #2b.
+
+use std::path::Path;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+use tracing::warn;
+
+/// Minimum free space we want on the ESP before enabling lanzaboote.
+/// Lanzaboote stores ~50 MB per NixOS generation (signed stub +
+/// kernel + initrd, deduplicated where possible); 200 MB gives an
+/// operator headroom for ~4 generations of rollback while leaving
+/// space for the next upgrade's working set. Hard-coded here rather
+/// than configurable because the operator-facing answer to "is my
+/// ESP big enough" is binary and shouldn't be customisable via the
+/// readiness probe.
+pub const ESP_HEADROOM_REQUIRED_BYTES: u64 = 200 * 1024 * 1024;
+
+const WRAPPER_FLAKE_PATH: &str = "/etc/nixos/flake.nix";
+const SBCTL_KEY_PATH: &str = "/var/lib/sbctl/keys/db/db.key";
+
+/// Per-check status the UI can render uniformly. The "checklist"
+/// shape ("UEFI? yes ✓ / no ✗") with mixed `Option<bool>` semantics
+/// (some checks aren't applicable on certain hosts — e.g. "Secure
+/// Boot currently off" is `None` when the box isn't UEFI at all)
+/// lets the WebUI distinguish "blocked" from "not applicable" from
+/// "passed."
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ReadinessReport {
+    /// Top-level answer: can the operator flip
+    /// `services.nasty.secureBoot.enable = true` right now and
+    /// have it succeed end-to-end? `false` while any blocker
+    /// remains.
+    pub ready: bool,
+    /// Human-readable one-line summary of why `ready == false`. The
+    /// WebUI surfaces this next to a disabled "Enable Secure Boot"
+    /// button.
+    pub blocker: Option<String>,
+    /// True iff `/sys/firmware/efi` exists — i.e. the kernel sees a
+    /// UEFI boot environment. BIOS / legacy boots return false and
+    /// every downstream check collapses to `None`.
+    pub uefi_boot: bool,
+    /// `Some(true)` when bootctl reports SB support. `Some(false)`
+    /// when bootctl reports `disabled (unsupported)` — the firmware
+    /// itself lacks SB. `None` when we couldn't determine (BIOS
+    /// boot, bootctl missing).
+    pub sb_supported_by_firmware: Option<bool>,
+    /// `Some(true)` when SB is currently off — i.e. ready to enable.
+    /// `Some(false)` when SB is already on (this readiness probe
+    /// doesn't apply to that path). `None` on BIOS boots / when
+    /// bootctl can't read the state.
+    pub sb_currently_off: Option<bool>,
+    /// True iff `/dev/tpmrm0` is present — TPM2 sealing of bcachefs
+    /// keys requires it. Without TPM the SB opt-in still works, but
+    /// the bcachefs-binding part of NASty's TPM story has nothing
+    /// to seal to, so we treat this as a hard requirement for the
+    /// ceremony.
+    pub tpm2_available: bool,
+    /// Free bytes on `/boot` as reported by `statvfs`. `None` when
+    /// `/boot` isn't a separate mount or `statvfs` fails (rare).
+    pub esp_free_bytes: Option<u64>,
+    /// Threshold the WebUI compares `esp_free_bytes` against. Echoed
+    /// in the response so the UI doesn't have to hard-code the same
+    /// number on its side.
+    pub esp_required_bytes: u64,
+    /// `Some(true)` when `/etc/nixos/flake.nix` declares
+    /// `lanzaboote.url = ...` at top level. `Some(false)` on pre-
+    /// this-PR wrappers (operator needs to upgrade once so the
+    /// engine re-renders the template). `None` when we couldn't
+    /// read /etc/nixos/flake.nix (operator running an unusual
+    /// install or read failed).
+    pub wrapper_has_lanzaboote_input: Option<bool>,
+    /// True iff `/var/lib/sbctl/keys/db/db.key` exists. Purely
+    /// informational — when lanzaboote turns on with
+    /// `autoGenerateKeys.enable = true`, the keys get generated on
+    /// the first SB-enabled boot, so `false` here is the expected
+    /// state pre-enrollment. The WebUI surfaces this so an operator
+    /// who manually pre-generated keys sees that NASty noticed.
+    pub sbctl_keys_already_generated: bool,
+}
+
+/// Compute the readiness checklist. Never returns `Result::Err` —
+/// failure modes (bootctl missing, /etc/nixos unreadable, ESP not
+/// mounted) collapse to `None`/`false` fields rather than an error,
+/// so the WebUI always has something to render.
+pub async fn readiness() -> ReadinessReport {
+    let sb = nasty_common::secure_boot::status().await;
+    let uefi_boot = tokio::fs::metadata("/sys/firmware/efi").await.is_ok();
+    let sb_supported_by_firmware = if sb.enabled.is_some() {
+        // bootctl reported a definitive state. `unsupported = Some(true)`
+        // (i.e., the `(unsupported)` parenthetical) ⇒ firmware can't
+        // do SB. Anything else (including `None` from the parser)
+        // means SB is supported.
+        Some(sb.unsupported != Some(true))
+    } else {
+        None
+    };
+    let sb_currently_off = sb.enabled.map(|e| !e);
+    let tpm2_available = nasty_common::tpm::is_available().await;
+    let esp_free_bytes = statvfs_free_bytes("/boot");
+    let wrapper_has_lanzaboote_input = check_wrapper_has_lanzaboote().await;
+    let sbctl_keys_already_generated = Path::new(SBCTL_KEY_PATH).exists();
+
+    let report_without_overall = ReadinessReport {
+        ready: false,
+        blocker: None,
+        uefi_boot,
+        sb_supported_by_firmware,
+        sb_currently_off,
+        tpm2_available,
+        esp_free_bytes,
+        esp_required_bytes: ESP_HEADROOM_REQUIRED_BYTES,
+        wrapper_has_lanzaboote_input,
+        sbctl_keys_already_generated,
+    };
+
+    let blocker = compute_blocker(&report_without_overall);
+    let ready = blocker.is_none();
+
+    ReadinessReport {
+        ready,
+        blocker,
+        ..report_without_overall
+    }
+}
+
+/// Walks the checks in order and returns the first that's failing.
+/// Order matters for UX: the blocker the operator sees should be the
+/// one closest to the start of the boot stack — fixing it might
+/// cascade.
+fn compute_blocker(r: &ReadinessReport) -> Option<String> {
+    if !r.uefi_boot {
+        return Some("host is not booted via UEFI".into());
+    }
+    match r.sb_supported_by_firmware {
+        Some(false) => {
+            return Some(
+                "firmware does not support Secure Boot (common on default QEMU OVMF)".into(),
+            );
+        }
+        None => {
+            return Some("Secure Boot state could not be read from firmware".into());
+        }
+        Some(true) => {}
+    }
+    match r.sb_currently_off {
+        Some(false) => return Some("Secure Boot is already enabled in firmware".into()),
+        None => return Some("Secure Boot state could not be read from firmware".into()),
+        Some(true) => {}
+    }
+    if !r.tpm2_available {
+        return Some(
+            "TPM2 not available (/dev/tpmrm0 missing) — SB without TPM sealing isn't useful on NASty"
+                .into(),
+        );
+    }
+    match r.esp_free_bytes {
+        Some(free) if free < r.esp_required_bytes => {
+            return Some(format!(
+                "ESP (/boot) has {} MB free; lanzaboote needs ≥{} MB headroom",
+                free / 1_048_576,
+                r.esp_required_bytes / 1_048_576,
+            ));
+        }
+        None => {
+            return Some(
+                "/boot is not a separate mount — lanzaboote needs a real ESP partition mounted at /boot".into(),
+            );
+        }
+        Some(_) => {}
+    }
+    match r.wrapper_has_lanzaboote_input {
+        Some(false) => {
+            return Some(
+                "wrapper flake at /etc/nixos/flake.nix doesn't declare the lanzaboote input — \
+                 run any upgrade once on the new engine to re-render it"
+                    .into(),
+            );
+        }
+        None => {
+            return Some(
+                "could not read /etc/nixos/flake.nix to check for the lanzaboote input".into(),
+            );
+        }
+        Some(true) => {}
+    }
+    None
+}
+
+/// `statvfs(path)` → free bytes. Returns `None` when the syscall
+/// fails (path doesn't exist, not a mount point, EACCES). Matches
+/// the helper used in `alerts.rs` so behavior is consistent across
+/// the codebase.
+fn statvfs_free_bytes(path: &str) -> Option<u64> {
+    use std::ffi::CString;
+    use std::mem::MaybeUninit;
+    let path = CString::new(path).ok()?;
+    let mut buf = MaybeUninit::<libc::statvfs>::uninit();
+    let ret = unsafe { libc::statvfs(path.as_ptr(), buf.as_mut_ptr()) };
+    if ret != 0 {
+        return None;
+    }
+    let stat = unsafe { buf.assume_init() };
+    // f_bavail is u32 in the libc bindings on this target; f_frsize is
+    // already u64 (the alerts.rs path multiplies as f64 so it dodges
+    // the type mismatch). One explicit widen is enough.
+    Some(stat.f_bavail as u64 * stat.f_frsize)
+}
+
+/// Scan `/etc/nixos/flake.nix` for a top-level `lanzaboote.url`
+/// declaration. Returns `None` when the file can't be read,
+/// `Some(false)` when the file exists but the input isn't declared,
+/// `Some(true)` otherwise.
+///
+/// Uses a plain prefix match rather than rnix because the input
+/// declaration in NASty's template is always at the start of a
+/// line (per `nixos/system-flake/flake.nix.template`'s shape) and a
+/// false positive from a comment line would require an operator to
+/// have hand-written `lanzaboote.url ...` in a comment, which they
+/// haven't. PR #2b's actual enrollment trigger will use rnix for
+/// the same reason `update.rs` does — there it's load-bearing.
+async fn check_wrapper_has_lanzaboote() -> Option<bool> {
+    let content = match tokio::fs::read_to_string(WRAPPER_FLAKE_PATH).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                target: "nasty::secure_boot",
+                "could not read {WRAPPER_FLAKE_PATH} for readiness check: {e}",
+            );
+            return None;
+        }
+    };
+    Some(content.lines().any(|line| {
+        let trimmed = line.trim_start();
+        // Require the actual setter shape — `lanzaboote.url = "..."` or
+        // `lanzaboote.url="..."`. Bare mentions in comments don't match.
+        trimmed.starts_with("lanzaboote.url ") || trimmed.starts_with("lanzaboote.url=")
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_report() -> ReadinessReport {
+        ReadinessReport {
+            ready: false,
+            blocker: None,
+            uefi_boot: true,
+            sb_supported_by_firmware: Some(true),
+            sb_currently_off: Some(true),
+            tpm2_available: true,
+            esp_free_bytes: Some(500 * 1024 * 1024),
+            esp_required_bytes: ESP_HEADROOM_REQUIRED_BYTES,
+            wrapper_has_lanzaboote_input: Some(true),
+            sbctl_keys_already_generated: false,
+        }
+    }
+
+    #[test]
+    fn no_blocker_when_all_checks_pass() {
+        let r = base_report();
+        assert!(compute_blocker(&r).is_none());
+    }
+
+    #[test]
+    fn blocker_uefi_first() {
+        let r = ReadinessReport {
+            uefi_boot: false,
+            ..base_report()
+        };
+        assert!(compute_blocker(&r).unwrap().contains("UEFI"));
+    }
+
+    #[test]
+    fn blocker_unsupported_firmware() {
+        let r = ReadinessReport {
+            sb_supported_by_firmware: Some(false),
+            ..base_report()
+        };
+        assert!(
+            compute_blocker(&r)
+                .unwrap()
+                .contains("firmware does not support Secure Boot")
+        );
+    }
+
+    #[test]
+    fn blocker_sb_already_on() {
+        let r = ReadinessReport {
+            sb_currently_off: Some(false),
+            ..base_report()
+        };
+        assert!(compute_blocker(&r).unwrap().contains("already enabled"));
+    }
+
+    #[test]
+    fn blocker_no_tpm() {
+        let r = ReadinessReport {
+            tpm2_available: false,
+            ..base_report()
+        };
+        assert!(compute_blocker(&r).unwrap().contains("TPM2 not available"));
+    }
+
+    #[test]
+    fn blocker_esp_too_small() {
+        let r = ReadinessReport {
+            esp_free_bytes: Some(50 * 1024 * 1024),
+            ..base_report()
+        };
+        let msg = compute_blocker(&r).unwrap();
+        assert!(msg.contains("ESP"));
+        assert!(msg.contains("50 MB"));
+    }
+
+    #[test]
+    fn blocker_no_lanzaboote_in_wrapper() {
+        let r = ReadinessReport {
+            wrapper_has_lanzaboote_input: Some(false),
+            ..base_report()
+        };
+        assert!(
+            compute_blocker(&r)
+                .unwrap()
+                .contains("doesn't declare the lanzaboote input")
+        );
+    }
+
+    #[test]
+    fn blocker_walks_in_order_uefi_before_firmware() {
+        // Both checks failing → operator should see UEFI message
+        // first (the more fundamental issue).
+        let r = ReadinessReport {
+            uefi_boot: false,
+            sb_supported_by_firmware: Some(false),
+            sb_currently_off: None,
+            tpm2_available: false,
+            ..base_report()
+        };
+        assert!(compute_blocker(&r).unwrap().contains("UEFI"));
+    }
+}

--- a/engine/nasty-system/src/secure_boot.rs
+++ b/engine/nasty-system/src/secure_boot.rs
@@ -215,10 +215,11 @@ fn statvfs_free_bytes(path: &str) -> Option<u64> {
         return None;
     }
     let stat = unsafe { buf.assume_init() };
-    // f_bavail is u32 in the libc bindings on this target; f_frsize is
-    // already u64 (the alerts.rs path multiplies as f64 so it dodges
-    // the type mismatch). One explicit widen is enough.
-    Some(stat.f_bavail as u64 * stat.f_frsize)
+    // libc::statvfs's `f_bavail` is `u64` on Linux glibc but `u32` on
+    // macOS — `u64::from(_)` widens portably (identity on u64,
+    // infallible widen on u32) without tripping clippy's
+    // unnecessary-cast lint either way. `f_frsize` is u64 on both.
+    Some(u64::from(stat.f_bavail) * stat.f_frsize)
 }
 
 /// Scan `/etc/nixos/flake.nix` for a top-level `lanzaboote.url`

--- a/engine/nasty-system/src/secure_boot.rs
+++ b/engine/nasty-system/src/secure_boot.rs
@@ -205,6 +205,15 @@ fn compute_blocker(r: &ReadinessReport) -> Option<String> {
 /// fails (path doesn't exist, not a mount point, EACCES). Matches
 /// the helper used in `alerts.rs` so behavior is consistent across
 /// the codebase.
+///
+/// `#[allow(clippy::unnecessary_cast)]` is load-bearing here. The
+/// `libc::statvfs` struct layout is target-dependent: on Linux glibc
+/// (CI's clippy target) `f_bavail` is already `u64`, so `as u64` is
+/// flagged as unnecessary; on macOS (the dev target) it's `u32`, so
+/// dropping the cast breaks the multiplication. Neither `u64::from`
+/// nor an explicit `if cfg!(target_os = …)` is cleaner than naming
+/// the lint we're knowingly suppressing.
+#[allow(clippy::unnecessary_cast)]
 fn statvfs_free_bytes(path: &str) -> Option<u64> {
     use std::ffi::CString;
     use std::mem::MaybeUninit;
@@ -215,11 +224,7 @@ fn statvfs_free_bytes(path: &str) -> Option<u64> {
         return None;
     }
     let stat = unsafe { buf.assume_init() };
-    // libc::statvfs's `f_bavail` is `u64` on Linux glibc but `u32` on
-    // macOS — `u64::from(_)` widens portably (identity on u64,
-    // infallible widen on u32) without tripping clippy's
-    // unnecessary-cast lint either way. `f_frsize` is u64 on both.
-    Some(u64::from(stat.f_bavail) * stat.f_frsize)
+    Some(stat.f_bavail as u64 * stat.f_frsize)
 }
 
 /// Scan `/etc/nixos/flake.nix` for a top-level `lanzaboote.url`

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -71,6 +71,26 @@ export interface SecureBootStatus {
 	note: string | null;
 }
 
+/** Structured checklist returned by `system.secure_boot.readiness`.
+ * Drives the Hardware-page panel that shows whether a box is ready
+ * for the lanzaboote opt-in. `ready === true` means every check
+ * passes and the (PR #2b) "Enable Secure Boot" affordance is
+ * available; otherwise `blocker` names the obstacle. Each individual
+ * field exposes the underlying signal so the UI can render an
+ * itemised checklist with pass/fail/not-applicable per row. */
+export interface SecureBootReadinessReport {
+	ready: boolean;
+	blocker: string | null;
+	uefi_boot: boolean;
+	sb_supported_by_firmware: boolean | null;
+	sb_currently_off: boolean | null;
+	tpm2_available: boolean;
+	esp_free_bytes: number | null;
+	esp_required_bytes: number;
+	wrapper_has_lanzaboote_input: boolean | null;
+	sbctl_keys_already_generated: boolean;
+}
+
 export interface TpmInfo {
 	/** 1 = TPM 1.2 (incompatible with planned sealing), 2 = TPM 2.0. */
 	version_major: number | null;

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -10,6 +10,7 @@
 		IommuGroup,
 		PassthroughConfig,
 		PciDevice,
+		SecureBootReadinessReport,
 	} from '$lib/types';
 	import { formatBytes } from '$lib/format';
 	import { rebootState } from '$lib/reboot.svelte';
@@ -22,6 +23,12 @@
 	let expanded = $state(new Set<number>());
 	let filter = $state('');
 	let showAllDimms = $state(false);
+	// Readiness probe for the lanzaboote opt-in. Fetched lazily — only
+	// when the SB card resolves to a state where opting in could be
+	// possible (UEFI + SB currently off + supported). Boxes that
+	// can't do SB never trigger this call.
+	let sbReadiness: SecureBootReadinessReport | null = $state(null);
+	let sbReadinessLoading = $state(false);
 
 	// TPM2_PT_MANUFACTURER 4-char ASCII codes → human-readable vendor names.
 	// Source: TCG Vendor ID Registry (the assigned-numbers table that the
@@ -75,6 +82,28 @@
 			groups = [];
 			passthroughConfig = { ids: [] };
 			pending = new Set();
+		}
+		// Only probe SB readiness when the firmware-state read suggests
+		// it's worth showing the checklist — i.e. SB is currently off
+		// and the firmware can do SB at all. Boxes in `Enabled`,
+		// `Unsupported`, or `Unknown` states skip the call entirely,
+		// keeping the Hardware page cheap on hardware that can never
+		// opt in.
+		const sb = summary?.secure_boot;
+		const shouldProbe =
+			sb?.enabled === false && sb?.unsupported !== true;
+		if (shouldProbe) {
+			sbReadinessLoading = true;
+			try {
+				sbReadiness = await client.call<SecureBootReadinessReport>(
+					'system.secure_boot.readiness',
+				);
+			} catch {
+				sbReadiness = null;
+			}
+			sbReadinessLoading = false;
+		} else {
+			sbReadiness = null;
 		}
 		loading = false;
 	}
@@ -368,9 +397,19 @@
 					</div>
 					<div class="mt-1 text-xs text-muted-foreground">
 						TPM PCR-7 sealing still works but is significantly weaker
-						without a measured boot chain. Enable Secure Boot in firmware
-						to harden the seal.
+						without a measured boot chain.
 					</div>
+					{#if sbReadinessLoading}
+						<div class="mt-2 text-xs text-muted-foreground">Checking readiness…</div>
+					{:else if sbReadiness?.ready}
+						<div class="mt-2 text-xs text-emerald-400">
+							✓ Ready to enable — see checklist below.
+						</div>
+					{:else if sbReadiness}
+						<div class="mt-2 text-xs text-amber-500">
+							Not ready — see checklist below.
+						</div>
+					{/if}
 				{:else}
 					<div class="text-sm font-medium">Unknown</div>
 					<div class="mt-1 text-xs text-muted-foreground">
@@ -380,6 +419,129 @@
 			</CardContent>
 		</Card>
 	</div>
+
+	<!-- ── Secure Boot readiness checklist (only when SB is currently off + capable) ─── -->
+	{#if sbReadiness}
+		<Card class="mb-6">
+			<CardContent class="pt-4 pb-3">
+				<div class="mb-3 flex items-baseline justify-between">
+					<h3 class="text-sm font-semibold">Secure Boot · readiness</h3>
+					{#if sbReadiness.ready}
+						<span class="text-xs text-emerald-400">All checks pass</span>
+					{:else}
+						<span class="text-xs text-amber-500">Not ready</span>
+					{/if}
+				</div>
+
+				{#if !sbReadiness.ready && sbReadiness.blocker}
+					<div class="mb-3 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+						<strong>Blocker:</strong> {sbReadiness.blocker}
+					</div>
+				{/if}
+
+				<!-- Per-check rows. Each row is one of ✓ (pass), ✗ (fail),
+					 or — (not applicable / unknown). Inlined rather than
+					 abstracted into a snippet because each row's params
+					 are short and the local repetition is more readable
+					 than a typed snippet helper. -->
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.uefi_boot}<span class="text-emerald-400">✓</span>
+						{:else}<span class="text-amber-500">✗</span>{/if}
+					</span>
+					<span class="flex-1">UEFI boot</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.sb_supported_by_firmware === true}<span class="text-emerald-400">✓</span>
+						{:else if sbReadiness.sb_supported_by_firmware === false}<span class="text-amber-500">✗</span>
+						{:else}<span class="text-muted-foreground">—</span>{/if}
+					</span>
+					<span class="flex-1">Firmware supports Secure Boot</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.sb_currently_off === true}<span class="text-emerald-400">✓</span>
+						{:else if sbReadiness.sb_currently_off === false}<span class="text-amber-500">✗</span>
+						{:else}<span class="text-muted-foreground">—</span>{/if}
+					</span>
+					<span class="flex-1">Secure Boot currently off (ready to enable)</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.tpm2_available}<span class="text-emerald-400">✓</span>
+						{:else}<span class="text-amber-500">✗</span>{/if}
+					</span>
+					<span class="flex-1">TPM2 available</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.esp_free_bytes === null}<span class="text-muted-foreground">—</span>
+						{:else if sbReadiness.esp_free_bytes >= sbReadiness.esp_required_bytes}<span class="text-emerald-400">✓</span>
+						{:else}<span class="text-amber-500">✗</span>{/if}
+					</span>
+					<span class="flex-1">
+						ESP headroom
+						{#if sbReadiness.esp_free_bytes !== null}
+							<span class="ml-1 text-muted-foreground">
+								· {formatBytes(sbReadiness.esp_free_bytes)} free ·
+								{formatBytes(sbReadiness.esp_required_bytes)} required
+							</span>
+						{:else}
+							<span class="ml-1 text-muted-foreground">· /boot not a separate mount</span>
+						{/if}
+					</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.wrapper_has_lanzaboote_input === true}<span class="text-emerald-400">✓</span>
+						{:else if sbReadiness.wrapper_has_lanzaboote_input === false}<span class="text-amber-500">✗</span>
+						{:else}<span class="text-muted-foreground">—</span>{/if}
+					</span>
+					<span class="flex-1">
+						Wrapper flake declares lanzaboote input
+						{#if sbReadiness.wrapper_has_lanzaboote_input === false}
+							<span class="ml-1 text-muted-foreground">
+								· run any upgrade once to re-render /etc/nixos/flake.nix
+							</span>
+						{/if}
+					</span>
+				</div>
+
+				<div class="flex items-start gap-3 py-1 text-xs">
+					<span class="w-4 shrink-0 font-mono">
+						{#if sbReadiness.sbctl_keys_already_generated}<span class="text-emerald-400">✓</span>
+						{:else}<span class="text-muted-foreground">—</span>{/if}
+					</span>
+					<span class="flex-1">
+						sbctl keys already generated
+						{#if !sbReadiness.sbctl_keys_already_generated}
+							<span class="ml-1 text-muted-foreground">
+								· will be created on first SB-enabled boot
+							</span>
+						{/if}
+					</span>
+				</div>
+
+				<div class="mt-3 border-t border-border/40 pt-3 text-xs text-muted-foreground">
+					{#if sbReadiness.ready}
+						This box meets every prerequisite for enabling Secure Boot via
+						lanzaboote. The "Enable Secure Boot" action that walks operators
+						through the BIOS Setup-Mode visit and re-seal will land in a
+						follow-up PR.
+					{:else}
+						Once the blockers above are resolved, the "Enable Secure Boot"
+						action will become available here.
+					{/if}
+				</div>
+			</CardContent>
+		</Card>
+	{/if}
 
 	<!-- ── DIMM detail (collapsed by default) ──────────────────────── -->
 	{#if summary && summary.memory.dimms.length > 0}


### PR DESCRIPTION
## What

PR #2a of the lanzaboote enrollment series. Read-only — adds a
checklist showing whether a NASty box is ready for the (PR #2b)
"Enable Secure Boot" ceremony. No state mutation, no firmware
contact, no sbctl writes.

Operator value: deploy this to the fleet, look at the Hardware page on
each box, you see immediately which ones are SB-ready vs. which ones
need (e.g.) a wrapper re-render or a bigger ESP. Before any real
state-mutating PR lands.

## Engine

- New module `nasty-system::secure_boot` with `pub async fn readiness()`
  returning `ReadinessReport`. Each check is its own field so the UI
  can render them independently:
  - `uefi_boot` — `/sys/firmware/efi` present
  - `sb_supported_by_firmware: Option<bool>` — `None` = couldn't read,
    `Some(false)` = bootctl says `disabled (unsupported)`, `Some(true)`
    = firmware can do SB
  - `sb_currently_off: Option<bool>` — `Some(true)` means ready to flip
  - `tpm2_available` — `/dev/tpmrm0` present
  - `esp_free_bytes: Option<u64>` + `esp_required_bytes: u64` (200 MB,
    ~4 lanzaboote generations of headroom)
  - `wrapper_has_lanzaboote_input: Option<bool>` — scans
    `/etc/nixos/flake.nix` for `lanzaboote.url = …` declaration
  - `sbctl_keys_already_generated` — `/var/lib/sbctl/keys/db/db.key`
    present (informational; expected `false` pre-enrollment)
  - `blocker: Option<String>` — first failing check in boot-stack
    order, so an operator with multiple obstacles sees the most
    fundamental one first

- `statvfs()` for `/boot` matches the pattern already used in
  `alerts.rs::statvfs_free_bytes`.

- Plain-prefix scan of `lanzaboote.url` is fine for the readiness
  signal — PR #2b will use rnix parsing when it actually has to
  write the input.

- 8 unit tests covering the all-green path, each blocker condition,
  and the boot-stack-priority ordering.

- New RPC: `system.secure_boot.readiness` wired in `router/system.rs`.

## WebUI

- `SecureBootReadinessReport` interface mirrors the engine struct
  (manually maintained, matching the existing pattern in `types.ts`).

- Hardware page probes readiness lazily — only when SB resolves to
  `disabled` AND `unsupported: false`. Boxes in `Enabled`,
  `Unsupported`, or `Unknown` states skip the RPC entirely, keeping
  the page cheap on hardware that can never opt in.

- The existing SB card's "Disabled" branch gains a one-line summary
  ("✓ Ready to enable — see below" or "✗ Not ready — see below").

- New full-width "Secure Boot · readiness" card below the hardware
  grid renders the seven-row checklist. Each row shows ✓ / ✗ / —
  with a per-row detail line on the rows where details help (ESP
  bytes free vs. required, "run upgrade once" hint when wrapper is
  stale).

- Closing copy makes it explicit: the "Enable Secure Boot"
  affordance arrives in PR #2b. Operators with a green checklist see
  they're not blocked — just waiting on the next PR.

## What's deliberately not here

- The "Enable Secure Boot" button + ceremony (PR #2b — engine writes
  `nasty.secureBoot.enable = true` to `configuration.nix`, triggers
  rebuild, walks operator through Setup-Mode entry, then re-seals
  existing TPM-bound filesystems against the new PCR-7).
- Post-reboot reseal + PCR-7 drift detection (PR #2c — for the
  fwupd-pushes-dbx-update case in the ADR's risk list).
- Detailed inspection of `/var/lib/sbctl` contents (key fingerprints,
  enrolled-keys diff vs. firmware DB, signed-binary list). Belongs to
  PR #2b's actual enrollment UX.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] 233 nasty-system tests pass (8 new for readiness)
- [x] WebUI `npm run check` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on a fresh `.74` after merging PR #325: card should show all green
- [ ] Manual on `nasty.0f.ee` (QEMU OVMF no SB): readiness card should not render at all (SB card shows `Unsupported` from PR #323; readiness probe is skipped client-side)
- [ ] Manual on a box that hasn't been upgraded post-#325: wrapper-input check should fail with "run any upgrade once" hint