### PR TITLE
auth: WebAuthn sign-in (#289 PR #2)

### DIFF
--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -942,6 +942,154 @@ impl AuthService {
         save_state(&state).await?;
         Ok(())
     }
+
+    /// Persist the new `sign_count` (and any other counter / backup
+    /// state) into the matching credential after a successful
+    /// assertion. Without this, every subsequent assertion would
+    /// be rejected by webauthn-rs's `finish_passkey_authentication`
+    /// — that function checks the incoming sign_count is strictly
+    /// greater than the stored value as replay protection.
+    pub async fn update_webauthn_sign_count(
+        &self,
+        username: &str,
+        auth_result: &webauthn_rs::prelude::AuthenticationResult,
+    ) -> Result<(), AuthError> {
+        let mut state = self.state.write().await;
+        let user = state
+            .users
+            .iter_mut()
+            .find(|u| u.username == username)
+            .ok_or(AuthError::UserNotFound)?;
+        let cred = user
+            .webauthn_credentials
+            .iter_mut()
+            .find(|c| c.passkey.cred_id() == auth_result.cred_id())
+            .ok_or(AuthError::NotFound)?;
+        // `update_credential` consumes the auth result's counter +
+        // backup-state and returns whether anything actually changed.
+        // We persist regardless of the return value — saving an
+        // unchanged record is cheap and avoids a branch for
+        // "credential is identical, skip the disk write" that's
+        // hard to verify.
+        cred.passkey.update_credential(auth_result);
+        save_state(&state).await?;
+        Ok(())
+    }
+
+    /// Mint a fresh session for a user whose identity has already
+    /// been verified out-of-band (today: WebAuthn assertion; PR #2
+    /// of issue #289). Mirrors the lockout + session-pruning logic
+    /// from `login` so a WebAuthn-only attacker spamming bad
+    /// assertions hits the same per-IP / per-username limits the
+    /// password path uses. The username **must** be one this engine
+    /// has already authenticated (the caller's job, not this
+    /// function's) — there's no credential check here.
+    pub async fn mint_session_for_webauthn(
+        &self,
+        username: &str,
+        client_ip: &str,
+    ) -> Result<String, AuthError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // Same per-IP lockout as `login` — a WebAuthn-only attacker
+        // can't get around it by switching from password to webauthn
+        // attempts.
+        if client_ip != "unknown" {
+            let rl = self.rate_limit.read().await;
+            let ip_fails = rl.ip_failures(client_ip, now);
+            if ip_fails >= MAX_IP_FAILED_ATTEMPTS {
+                tracing::warn!(
+                    "WebAuthn login blocked from {client_ip}: {ip_fails} failed attempts in the last hour"
+                );
+                audit(
+                    "login_webauthn_ip_locked",
+                    username,
+                    client_ip,
+                    &format!("{ip_fails} failed attempts"),
+                );
+                return Err(AuthError::AccountLocked);
+            }
+        }
+
+        // Per-username lockout — same suppression rule for the
+        // last-admin case as `login`, since locking the last admin
+        // out of every login path would brick the appliance.
+        let only_admin = self.is_only_local_admin(username).await;
+        {
+            let rl = self.rate_limit.read().await;
+            let user_fails = rl.user_failures(username, now);
+            if user_fails >= MAX_FAILED_ATTEMPTS && !only_admin {
+                tracing::warn!(
+                    "WebAuthn login blocked for '{}': {} failed attempts in last {} minutes",
+                    username,
+                    user_fails,
+                    LOCKOUT_WINDOW_SECS / 60
+                );
+                audit(
+                    "login_webauthn_locked",
+                    username,
+                    client_ip,
+                    &format!("{user_fails} failed attempts"),
+                );
+                return Err(AuthError::AccountLocked);
+            }
+        }
+
+        let mut state = self.state.write().await;
+        let user = state
+            .users
+            .iter()
+            .find(|u| u.username == username)
+            .ok_or(AuthError::UserNotFound)?;
+
+        let token = generate_token();
+        let session = Session {
+            token: token.clone(),
+            username: user.username.clone(),
+            role: user.role.clone(),
+            filesystem: None,
+            owner: None,
+            created_at: now,
+            // WebAuthn-verified sessions don't trigger the
+            // password-change wall — the operator already proved
+            // possession of a registered credential. If their local
+            // password is still flagged for change they can do it
+            // from /users when they want to.
+            must_change_password: false,
+            client_ip: Some(client_ip.to_string()),
+        };
+
+        state
+            .sessions
+            .retain(|s| now - s.created_at <= SESSION_TTL_SECS);
+        state.sessions.push(session);
+        save_state(&state).await?;
+
+        // Webauthn success clears the per-username failure bucket
+        // (mirrors the password path); per-IP failures stay so a
+        // single redeemed username doesn't whitewash an attacker's
+        // spray across other accounts.
+        self.clear_failed_attempts(username).await;
+        audit("login_webauthn_success", username, client_ip, "");
+        info!("User '{}' logged in via WebAuthn", username);
+        Ok(token)
+    }
+
+    /// Counterpart to `mint_session_for_webauthn` for the failure
+    /// case — bumps the per-user + per-IP lockout counters so a
+    /// stream of bad WebAuthn assertions feeds the same rate limit
+    /// as a stream of bad passwords. Exposed publicly so the REST
+    /// handler can call it after `login_finish` fails.
+    pub async fn record_webauthn_failure(&self, username: &str, client_ip: &str) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        self.record_failed_attempt(username, client_ip, now).await;
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/engine/nasty-engine/src/auth_webauthn.rs
+++ b/engine/nasty-engine/src/auth_webauthn.rs
@@ -426,10 +426,7 @@ impl WebauthnService {
         let auth_id = base64_token();
         let mut pending = self.pending_auth.lock().await;
         prune_expired_auth(&mut pending);
-        let same_user_count = pending
-            .values()
-            .filter(|p| p.username == username)
-            .count();
+        let same_user_count = pending.values().filter(|p| p.username == username).count();
         if same_user_count >= MAX_IN_FLIGHT_PER_USER {
             warn!(
                 target: "nasty::webauthn",

--- a/engine/nasty-engine/src/auth_webauthn.rs
+++ b/engine/nasty-engine/src/auth_webauthn.rs
@@ -44,7 +44,8 @@ use uuid::Uuid;
 use webauthn_rs::Webauthn;
 use webauthn_rs::WebauthnBuilder;
 use webauthn_rs::prelude::{
-    CreationChallengeResponse, CredentialID, PasskeyRegistration, RegisterPublicKeyCredential,
+    CreationChallengeResponse, CredentialID, PasskeyAuthentication, PasskeyRegistration,
+    PublicKeyCredential, RegisterPublicKeyCredential, RequestChallengeResponse,
 };
 
 use crate::auth::{AuthService, WebauthnCredential};
@@ -76,12 +77,16 @@ pub enum WebauthnError {
     Backend(#[from] webauthn_rs::prelude::WebauthnError),
     #[error("no in-flight registration for id {0}")]
     UnknownRegistration(String),
+    #[error("no in-flight authentication for id {0}")]
+    UnknownAuthentication(String),
     #[error("label is empty")]
     EmptyLabel,
     #[error("label too long (max {MAX_LABEL_LEN} chars)")]
     LabelTooLong,
     #[error("credential not found")]
     CredentialNotFound,
+    #[error("user has no registered security keys")]
+    NoCredentials,
     #[error("auth state I/O failed: {0}")]
     Auth(String),
 }
@@ -98,12 +103,24 @@ pub struct WebauthnService {
     webauthn: Webauthn,
     rp_id: String,
     pending: Arc<Mutex<HashMap<String, PendingRegistration>>>,
+    /// In-flight authentication challenges, keyed by the per-request
+    /// `auth_id` the WebUI round-trips between login.start and
+    /// login.finish. Same TTL + per-user cap as the registration cache;
+    /// kept separate because the lifecycle and `PasskeyAuthentication`
+    /// shape differ from registration.
+    pending_auth: Arc<Mutex<HashMap<String, PendingAuthentication>>>,
 }
 
 struct PendingRegistration {
     username: String,
     label: String,
     state: PasskeyRegistration,
+    started_at: Instant,
+}
+
+struct PendingAuthentication {
+    username: String,
+    state: PasskeyAuthentication,
     started_at: Instant,
 }
 
@@ -135,6 +152,17 @@ pub struct WebauthnConfig {
     pub rp_id: String,
 }
 
+/// Wire shape returned by `/api/auth/webauthn/login/start`. The
+/// `request_options` goes straight into `@simplewebauthn/browser`'s
+/// `startAuthentication`; the `auth_id` round-trips back via
+/// `login/finish` so we can pair the browser's response with the
+/// matching server-side `PasskeyAuthentication` state.
+#[derive(Debug, Serialize)]
+pub struct LoginStartResponse {
+    pub auth_id: String,
+    pub request_options: RequestChallengeResponse,
+}
+
 /// Wire shape for `auth.webauthn.list`. Each row is the metadata
 /// the operator sees in account settings — no public key, no
 /// internal webauthn-rs state.
@@ -164,6 +192,7 @@ impl WebauthnService {
             webauthn,
             rp_id: rp_id.to_string(),
             pending: Arc::new(Mutex::new(HashMap::new())),
+            pending_auth: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -370,9 +399,117 @@ impl WebauthnService {
                 other => WebauthnError::Auth(other.to_string()),
             })
     }
+
+    /// Step 1 of WebAuthn login: build an assertion challenge bound to
+    /// the named user's existing credentials. The `allowCredentials`
+    /// list (built from the user's registered passkeys) tells the
+    /// browser which keys are acceptable for this assertion; the
+    /// authenticator that the operator taps must own one of them.
+    ///
+    /// `NoCredentials` when the user has no registered keys — caller
+    /// surfaces this as "this account has no security key set up,
+    /// use a password." We could mask it to avoid user enumeration
+    /// but `/api/login` already enumerates via its 401 response so
+    /// the added information here is negligible.
+    pub async fn login_start(
+        &self,
+        auth: &AuthService,
+        username: &str,
+    ) -> Result<LoginStartResponse, WebauthnError> {
+        let stored = auth.webauthn_credentials_for(username).await;
+        if stored.is_empty() {
+            return Err(WebauthnError::NoCredentials);
+        }
+        let passkeys: Vec<_> = stored.iter().map(|c| c.passkey.clone()).collect();
+        let (request_options, state) = self.webauthn.start_passkey_authentication(&passkeys)?;
+
+        let auth_id = base64_token();
+        let mut pending = self.pending_auth.lock().await;
+        prune_expired_auth(&mut pending);
+        let same_user_count = pending
+            .values()
+            .filter(|p| p.username == username)
+            .count();
+        if same_user_count >= MAX_IN_FLIGHT_PER_USER {
+            warn!(
+                target: "nasty::webauthn",
+                "user '{username}' has {same_user_count} pending authentications; refusing new one"
+            );
+            return Err(WebauthnError::Auth(format!(
+                "too many in-flight authentications for {username} (limit {MAX_IN_FLIGHT_PER_USER})",
+            )));
+        }
+        pending.insert(
+            auth_id.clone(),
+            PendingAuthentication {
+                username: username.to_string(),
+                state,
+                started_at: Instant::now(),
+            },
+        );
+        debug!(
+            target: "nasty::webauthn",
+            "started authentication {auth_id} for user '{username}'"
+        );
+        Ok(LoginStartResponse {
+            auth_id,
+            request_options,
+        })
+    }
+
+    /// Step 2 of WebAuthn login: verify the browser's assertion
+    /// against the stored credential. On success, persists the
+    /// updated `sign_count` (replay protection — webauthn-rs's
+    /// `finish_passkey_authentication` rejects assertions whose
+    /// sign_count is ≤ the stored value, so we must save the new
+    /// one or every subsequent assertion on the same credential
+    /// would fail) and returns the verified username so the REST
+    /// handler can mint a session token.
+    pub async fn login_finish(
+        &self,
+        auth: &AuthService,
+        auth_id: &str,
+        response: &PublicKeyCredential,
+    ) -> Result<String, WebauthnError> {
+        let pending_entry = {
+            let mut pending = self.pending_auth.lock().await;
+            prune_expired_auth(&mut pending);
+            pending.remove(auth_id)
+        };
+        let pending_entry = pending_entry
+            .ok_or_else(|| WebauthnError::UnknownAuthentication(auth_id.to_string()))?;
+
+        let auth_result = self
+            .webauthn
+            .finish_passkey_authentication(response, &pending_entry.state)?;
+
+        // Update the matching credential's sign_count in place. The
+        // operator's other credentials are untouched. Failure here
+        // (concurrent delete, state corruption) is logged but not
+        // fatal — the assertion itself was valid, so we proceed with
+        // session minting; the next assertion will simply hit the
+        // sign_count check freshly.
+        if let Err(e) = auth
+            .update_webauthn_sign_count(&pending_entry.username, &auth_result)
+            .await
+        {
+            warn!(
+                target: "nasty::webauthn",
+                "post-assertion sign_count update for '{}' failed: {e}",
+                pending_entry.username,
+            );
+        }
+
+        Ok(pending_entry.username)
+    }
 }
 
 fn prune_expired(pending: &mut HashMap<String, PendingRegistration>) {
+    let now = Instant::now();
+    pending.retain(|_, p| now.duration_since(p.started_at) < REGISTRATION_TTL);
+}
+
+fn prune_expired_auth(pending: &mut HashMap<String, PendingAuthentication>) {
     let now = Instant::now();
     pending.retain(|_, p| now.duration_since(p.started_at) < REGISTRATION_TTL);
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -502,6 +502,14 @@ async fn main() -> anyhow::Result<()> {
         .merge(ws_routes)
         .route("/api/login", post(login_handler))
         .route("/api/logout", post(logout_handler))
+        .route(
+            "/api/auth/webauthn/login/start",
+            post(webauthn_login_start_handler),
+        )
+        .route(
+            "/api/auth/webauthn/login/finish",
+            post(webauthn_login_finish_handler),
+        )
         .route("/api/auth/oidc/available", get(oidc_available_handler))
         .route("/api/boot_status", get(boot_status_handler))
         .route("/api/auth/oidc/start", get(oidc_start_handler))
@@ -1995,6 +2003,151 @@ async fn files_content_put_handler(
 struct LoginRequest {
     username: String,
     password: String,
+}
+
+#[derive(Deserialize)]
+struct WebauthnLoginStartRequest {
+    username: String,
+}
+
+#[derive(Deserialize)]
+struct WebauthnLoginFinishRequest {
+    username: String,
+    auth_id: String,
+    response: webauthn_rs::prelude::PublicKeyCredential,
+}
+
+/// Build the assertion challenge for a WebAuthn login. Pre-auth —
+/// the WebUI hits this before any session exists. Echoes the
+/// per-IP lockout from `AuthService::login`, so an attacker hosing
+/// the box with bad assertions hits the same per-IP cap as a
+/// password sprayer.
+async fn webauthn_login_start_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<WebauthnLoginStartRequest>,
+) -> impl IntoResponse {
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    match state
+        .webauthn
+        .login_start(&state.auth, &req.username)
+        .await
+    {
+        Ok(resp) => (StatusCode::OK, Json(serde_json::to_value(&resp).unwrap())).into_response(),
+        Err(e) => {
+            tracing::warn!(
+                "WebAuthn login.start failed for '{}' from {}: {e}",
+                req.username,
+                client_ip
+            );
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Verify the browser's WebAuthn assertion and mint a session. The
+/// username in the body has to match the one bound to the
+/// in-flight `auth_id` — `WebauthnService::login_finish` enforces
+/// that. On any failure we audit + record the per-IP / per-user
+/// failure so the assertion path can't be used to dodge lockouts.
+async fn webauthn_login_finish_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<WebauthnLoginFinishRequest>,
+) -> impl IntoResponse {
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    let verified_username = match state
+        .webauthn
+        .login_finish(&state.auth, &req.auth_id, &req.response)
+        .await
+    {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(
+                "WebAuthn login.finish failed for '{}' from {}: {e}",
+                req.username,
+                client_ip
+            );
+            state
+                .auth
+                .record_webauthn_failure(&req.username, client_ip)
+                .await;
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    // Defense in depth: the body's claimed username must match the
+    // one bound to the `auth_id` server-side. login_finish already
+    // returns the verified username; we just confirm equality so a
+    // browser bug or replay can't end up minting a session for a
+    // different account than the client thinks.
+    if verified_username != req.username {
+        tracing::warn!(
+            "WebAuthn login.finish: body username '{}' != session username '{}' from {}",
+            req.username,
+            verified_username,
+            client_ip
+        );
+        state
+            .auth
+            .record_webauthn_failure(&req.username, client_ip)
+            .await;
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "username mismatch" })),
+        )
+            .into_response();
+    }
+
+    match state
+        .auth
+        .mint_session_for_webauthn(&verified_username, client_ip)
+        .await
+    {
+        Ok(token) => {
+            info!(
+                "WebAuthn login successful: user '{}' from {}",
+                verified_username, client_ip
+            );
+            let mut resp_headers = axum::http::HeaderMap::new();
+            resp_headers.insert(
+                axum::http::header::SET_COOKIE,
+                build_session_cookie(&token).parse().unwrap(),
+            );
+            (
+                StatusCode::OK,
+                resp_headers,
+                Json(serde_json::json!({ "token": token, "username": verified_username })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::warn!(
+                "WebAuthn session mint failed for '{}' from {}: {e}",
+                verified_username,
+                client_ip
+            );
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
 }
 
 async fn login_handler(

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -2031,11 +2031,7 @@ async fn webauthn_login_start_handler(
         .get("x-real-ip")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown");
-    match state
-        .webauthn
-        .login_start(&state.auth, &req.username)
-        .await
-    {
+    match state.webauthn.login_start(&state.auth, &req.username).await {
         Ok(resp) => (StatusCode::OK, Json(serde_json::to_value(&resp).unwrap())).into_response(),
         Err(e) => {
             tracing::warn!(

--- a/webui/src/lib/auth.ts
+++ b/webui/src/lib/auth.ts
@@ -62,3 +62,65 @@ export async function logout(): Promise<void> {
 	// Set-Cookie with Max-Age=0 to drop the cookie.
 	await fetch('/api/logout', { method: 'POST' }).catch(() => {});
 }
+
+/** Sign in via a registered WebAuthn credential (issue #289 PR #2).
+ * The browser side of the ceremony — fetch a challenge from the
+ * engine, hand it to @simplewebauthn's `startAuthentication`, post
+ * the resulting assertion back to the engine, which mints a
+ * `nasty_session` cookie just like the password path. On any
+ * failure (no creds registered, user dismissed the prompt, wrong
+ * key, etc.) the caller catches and surfaces the message. */
+export async function loginWebauthn(username: string): Promise<void> {
+	const { startAuthentication } = await import('@simplewebauthn/browser');
+	let startRes: Response;
+	try {
+		startRes = await fetch('/api/auth/webauthn/login/start', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ username }),
+		});
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		throw new Error(`Can't reach server: ${msg}`);
+	}
+	if (!startRes.ok) {
+		const body = await startRes.json().catch(() => ({}));
+		const detail = (body as { error?: string }).error;
+		throw new Error(
+			detail
+				?? (startRes.status === 401 || startRes.status === 403
+					? 'No security keys registered for this account.'
+					: `Login failed (HTTP ${startRes.status}).`),
+		);
+	}
+	const { auth_id, request_options } = await startRes.json();
+
+	// simplewebauthn handles the JSON ↔ ArrayBuffer dance. The
+	// engine sends webauthn-rs's `RequestChallengeResponse` shape
+	// directly; same JSON form simplewebauthn accepts.
+	let response;
+	try {
+		response = await startAuthentication({
+			optionsJSON: (request_options as { publicKey?: unknown }).publicKey ?? request_options,
+		} as Parameters<typeof startAuthentication>[0]);
+	} catch (e) {
+		// Most common: NotAllowedError (user dismissed prompt, wrong
+		// key, no matching credential on the authenticator). Short
+		// message is friendlier than the raw DOMException string.
+		const msg = e instanceof Error ? e.message : String(e);
+		throw new Error(`Security key prompt failed: ${msg}`);
+	}
+
+	const finishRes = await fetch('/api/auth/webauthn/login/finish', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ username, auth_id, response }),
+	});
+	if (!finishRes.ok) {
+		const body = await finishRes.json().catch(() => ({}));
+		const detail = (body as { error?: string }).error;
+		throw new Error(detail ?? `Login failed (HTTP ${finishRes.status}).`);
+	}
+	// Session cookie is set by the engine. Caller's job is to refresh
+	// the connection.
+}

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { getClient, resetClient } from '$lib/client';
-	import { login as doLogin, logout as doLogout } from '$lib/auth';
+	import { login as doLogin, logout as doLogout, loginWebauthn as doLoginWebauthn } from '$lib/auth';
 	import { error as showError, isBusy } from '$lib/toast.svelte';
 	import Toasts from '$lib/components/Toasts.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
@@ -480,6 +480,38 @@
 		}
 	}
 
+	// WebAuthn sign-in (issue #289 PR #2). Visible alongside the
+	// password form when the browser exposes the WebAuthn API and
+	// the operator has typed a username. Same lockout/audit machinery
+	// on the server side as the password path, so this isn't an
+	// alternative "bypass" — just a credential-only login flow.
+	let webauthnPending = $state(false);
+	const webauthnLoginSupported = $derived(
+		typeof window !== 'undefined'
+			&& 'PublicKeyCredential' in window
+			&& typeof navigator !== 'undefined'
+			&& !!navigator.credentials?.get,
+	);
+
+	async function handleWebauthnLogin() {
+		loginError = '';
+		const username = loginUser.trim();
+		if (!username) {
+			loginError = 'Enter your username first.';
+			return;
+		}
+		webauthnPending = true;
+		try {
+			await doLoginWebauthn(username);
+			loginPass = '';
+			await tryConnect();
+		} catch (e) {
+			loginError = e instanceof Error ? e.message : 'Sign-in failed';
+		} finally {
+			webauthnPending = false;
+		}
+	}
+
 	async function handlePasswordChange() {
 		passwordError = '';
 		if (newPassword.length < 8) {
@@ -727,14 +759,27 @@
 					<Label for="password">Password</Label>
 					<Input id="password" type="password" bind:value={loginPass} autocomplete="current-password" class="mt-1" />
 				</div>
-				<Button type="submit" class="w-full">Sign In</Button>
+				<Button type="submit" class="w-full" disabled={webauthnPending}>Sign In</Button>
 			</form>
-			{#if ssoEnabled}
+			{#if webauthnLoginSupported || ssoEnabled}
 				<div class="my-4 flex items-center gap-3 text-xs text-muted-foreground">
 					<div class="h-px flex-1 bg-border"></div>
 					<span>or</span>
 					<div class="h-px flex-1 bg-border"></div>
 				</div>
+			{/if}
+			{#if webauthnLoginSupported}
+				<Button
+					type="button"
+					variant="outline"
+					class="w-full {ssoEnabled ? 'mb-2' : ''}"
+					disabled={webauthnPending}
+					onclick={handleWebauthnLogin}
+				>
+					{#if webauthnPending}Tap your security key…{:else}Sign in with security key{/if}
+				</Button>
+			{/if}
+			{#if ssoEnabled}
 				<Button type="button" variant="outline" class="w-full" onclick={startSso}>Sign in with SSO</Button>
 			{/if}
 		</div>


### PR DESCRIPTION
Adds the actual login flow on top of PR #1's (#327, now merged in main)
registration scaffolding. Registered keys from #327 don't sign anyone
in yet; this PR makes them.

## Engine

- `WebauthnService` gains `login_start` / `login_finish` + a 5-min
  `pending_auth` cache (mirrors the registration cache: same TTL,
  4-per-user cap).
- `login_finish` persists the new sign_count after every successful
  assertion. webauthn-rs's verifier rejects any assertion whose
  sign_count is not strictly greater than the stored one (replay
  protection), so saving after each success is load-bearing.
- `AuthService::mint_session_for_webauthn(username, client_ip)`
  mirrors `login()` — same per-IP and per-username lockouts (with
  the last-admin suppression rule), same session pruning, same audit
  events under `login_webauthn_*`. The webauthn path can't be used
  to dodge rate limits the password path enforces.
- `AuthService::update_webauthn_sign_count` writes the new counter
  back to `auth.json` under the same lock that protects every other
  user-record write.
- REST: `POST /api/auth/webauthn/login/{start,finish}` mirror
  `/api/login`'s cookie + JSON shape. `finish` includes a
  defence-in-depth check: body's claimed username must match the
  one bound to the `auth_id` server-side.

## WebUI

- `loginWebauthn(username)` in `$lib/auth.ts` runs the assertion
  ceremony via `@simplewebauthn/browser`'s `startAuthentication`
  (dynamic import so the chunk only loads when the button is
  clicked).
- Login screen grows a "Sign in with security key" button next to
  the existing SSO one. Visible only when the browser exposes
  `PublicKeyCredential.get`. Disables / flips to "Tap your security
  key…" while the prompt is in flight; the password Sign-In button
  disables in parallel so double-submits can't race.

## What's not in this PR (PR #3)

- Fallback-factor enforcement — refuse to delete the last password
  / OIDC link when the user has only WebAuthn credentials.
- Admin "reset webauthn for user" recovery RPC for the locked-out-
  admin case.
- Discoverable-credential / conditional-UI sign-in (the
  "autofill from passwords" prompt on the username field).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- [x] 5 existing auth_webauthn unit tests pass (no behaviour change
  to registration)
- [x] `npm run check` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on a real NASty:
  - register a key under /users → log out → "Sign in with security
    key" with same username → tap → logged back in
  - same flow with the wrong key → friendly browser-prompt rejection
  - try the button with a username that has no keys → "No security
    keys registered for this account."
  - spam bad assertions → per-username lockout fires (same threshold
    as password path)