### PR TITLE
auth: WebAuthn safeguards — fallback-factor + admin recovery (#289 PR #3)

### DIFF
--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -826,6 +826,7 @@ impl AuthService {
             .map(|u| UserInfo {
                 username: u.username.clone(),
                 role: u.role.clone(),
+                webauthn_credential_count: u.webauthn_credentials.len(),
             })
             .collect()
     }
@@ -941,6 +942,65 @@ impl AuthService {
         }
         save_state(&state).await?;
         Ok(())
+    }
+
+    /// True iff the user has at least one non-WebAuthn factor
+    /// (a local password OR an OIDC link). Used as the registration
+    /// precheck: a user with only WebAuthn credentials who loses
+    /// every authenticator is locked out, so we require a
+    /// recoverable fallback before letting them register the first
+    /// security key. Today's user-creation paths always set one of
+    /// the two, but this check guards against future API additions
+    /// that might break that invariant (e.g. an "unlink OIDC" RPC
+    /// without a matching "but the user has WebAuthn-only" check).
+    pub async fn has_non_webauthn_factor(&self, username: &str) -> bool {
+        let state = self.state.read().await;
+        state
+            .users
+            .iter()
+            .find(|u| u.username == username)
+            .map(|u| {
+                u.password_hash.is_some() || (u.oidc_subject.is_some() && u.oidc_issuer.is_some())
+            })
+            .unwrap_or(false)
+    }
+
+    /// Admin recovery for the "lost every WebAuthn authenticator"
+    /// case — wipes every credential under the named user. Audit
+    /// log records the actor + target so a malicious admin can't
+    /// quietly clear someone else's keys without a trail. Returns
+    /// the number of credentials removed (0 when the user existed
+    /// but had no credentials; this is not an error — admin UI
+    /// surfaces it as a no-op).
+    pub async fn reset_webauthn_credentials(
+        &self,
+        actor: &Session,
+        target_username: &str,
+    ) -> Result<usize, AuthError> {
+        if actor.role != Role::Admin {
+            return Err(AuthError::Forbidden);
+        }
+        let mut state = self.state.write().await;
+        let user = state
+            .users
+            .iter_mut()
+            .find(|u| u.username == target_username)
+            .ok_or(AuthError::UserNotFound)?;
+        let removed = user.webauthn_credentials.len();
+        user.webauthn_credentials.clear();
+        save_state(&state).await?;
+        drop(state);
+        audit(
+            "webauthn_reset_for_user",
+            &actor.username,
+            actor.client_ip.as_deref().unwrap_or(""),
+            &format!("target={target_username} removed={removed}"),
+        );
+        info!(
+            "admin '{}' reset {} WebAuthn credential(s) for user '{}'",
+            actor.username, removed, target_username
+        );
+        Ok(removed)
     }
 
     /// Persist the new `sign_count` (and any other counter / backup
@@ -1096,6 +1156,13 @@ impl AuthService {
 pub struct UserInfo {
     pub username: String,
     pub role: Role,
+    /// How many WebAuthn credentials are registered to this user.
+    /// Drives the admin "Reset security keys" affordance on the
+    /// /users page — admins only see the button on rows where
+    /// there are credentials to reset, instead of a no-op button
+    /// on every row.
+    #[serde(default)]
+    pub webauthn_credential_count: usize,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/engine/nasty-engine/src/auth_webauthn.rs
+++ b/engine/nasty-engine/src/auth_webauthn.rs
@@ -87,6 +87,10 @@ pub enum WebauthnError {
     CredentialNotFound,
     #[error("user has no registered security keys")]
     NoCredentials,
+    #[error(
+        "set a password or single sign-on for this account before adding a security key — otherwise losing every authenticator would lock you out permanently"
+    )]
+    NoFallbackFactor,
     #[error("auth state I/O failed: {0}")]
     Auth(String),
 }
@@ -243,6 +247,16 @@ impl WebauthnService {
         }
         if label.len() > MAX_LABEL_LEN {
             return Err(WebauthnError::LabelTooLong);
+        }
+
+        // Fallback-factor precheck (#289 PR #3). Refuse to register
+        // a security key for a user who has neither a local password
+        // nor an OIDC link — without one of those, losing every
+        // authenticator would lock them out permanently with no
+        // recovery path the operator (or even an admin) can take
+        // short of editing auth.json by hand.
+        if !auth.has_non_webauthn_factor(username).await {
+            return Err(WebauthnError::NoFallbackFactor);
         }
 
         // Exclude credentials already registered to this user. Mirrors

--- a/engine/nasty-engine/src/router/auth.rs
+++ b/engine/nasty-engine/src/router/auth.rs
@@ -231,6 +231,22 @@ pub(super) async fn try_route(
                 Err(e) => invalid(req, e),
             }
         }
+        // Admin recovery for the "user lost every authenticator"
+        // case. AuthService re-checks the admin role; we also gate
+        // here so a non-admin call doesn't even reach the state
+        // mutation path. Audit log written by AuthService.
+        "auth.webauthn.reset_for_user" => {
+            if session.role != Role::Admin {
+                return Some(err(req, "admin only".to_string()));
+            }
+            match require_str(req, "username") {
+                Ok(target) => match state.auth.reset_webauthn_credentials(session, target).await {
+                    Ok(removed) => ok(req, serde_json::json!({ "removed": removed })),
+                    Err(e) => err(req, e),
+                },
+                Err(r) => r,
+            }
+        }
         _ => return None,
     })
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1,5 +1,13 @@
 // Mirrors engine Rust types
 
+/** Error code emitted by `auth.webauthn.register.start` when the
+ * caller has no fallback factor (no local password and no OIDC
+ * link). Surfaced verbatim by the engine so the WebUI can match on
+ * it without re-translating the user-facing message. Kept as a
+ * substring check on the engine's full error string because the
+ * engine returns a String, not a structured error code. */
+export const WEBAUTHN_NO_FALLBACK_HINT = 'set a password or single sign-on';
+
 /** One registered WebAuthn credential under the current user. Wire
  * shape returned by `auth.webauthn.list` and (on a single-row form)
  * `auth.webauthn.register.finish`. The credential_id is the
@@ -491,6 +499,10 @@ export interface NvmeofPort {
 export interface UserInfo {
 	username: string;
 	role: 'admin' | 'readonly' | 'operator';
+	/** Number of registered WebAuthn credentials. Defaults to 0 for
+	 * compat with engines that pre-date the field. Drives the admin
+	 * "Reset security keys" button visibility on the /users page. */
+	webauthn_credential_count?: number;
 }
 
 export interface ApiTokenInfo {

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -64,6 +64,8 @@
 	let webauthnLabel = $state('');
 	let webauthnRegistering = $state(false);
 	let webauthnDeleting = $state<string | null>(null);
+	let webauthnResetting = $state<string | null>(null);
+	let webauthnRegisterError = $state<string | null>(null);
 	const webauthnBrowserSupported = $derived(
 		typeof window !== 'undefined'
 			&& 'PublicKeyCredential' in window
@@ -231,6 +233,7 @@
 		const label = webauthnLabel.trim();
 		if (!label) return;
 		webauthnRegistering = true;
+		webauthnRegisterError = null;
 		try {
 			const start = await client.call<WebauthnRegisterStart>(
 				'auth.webauthn.register.start',
@@ -255,16 +258,37 @@
 			webauthnShowAdd = false;
 			await refresh();
 		} catch (err) {
-			// Most common failure: operator dismissed the browser
-			// prompt (NotAllowedError / AbortError). Short toast is
-			// kinder than a stack trace.
-			const msg = err instanceof Error ? err.message : String(err);
-			await withToast(
-				() => Promise.reject(msg),
-				'Security key registration failed',
-			).catch(() => {});
+			// Surface inline so the message is read where the operator
+			// is looking. The fallback-factor error (no password +
+			// no OIDC) and the user-dismissed-prompt error read very
+			// differently; the inline panel gives both room to be
+			// informative without truncating into a toast.
+			webauthnRegisterError = err instanceof Error ? err.message : String(err);
 		} finally {
 			webauthnRegistering = false;
+		}
+	}
+
+	async function webauthnResetForUser(target: UserInfo) {
+		const ok = await confirm(
+			'Reset security keys',
+			`Remove every registered security key for "${target.username}"? They'll need to sign in via password or SSO and re-register a key.`,
+			{ confirmLabel: 'Reset' },
+		);
+		if (!ok) return;
+		webauthnResetting = target.username;
+		try {
+			const result = await withToast(
+				() => client.call<{ removed: number }>('auth.webauthn.reset_for_user', {
+					username: target.username,
+				}),
+				`Security keys for "${target.username}" reset`,
+			);
+			if (result !== undefined) {
+				await refresh();
+			}
+		} finally {
+			webauthnResetting = null;
 		}
 	}
 
@@ -590,6 +614,22 @@
 							<Button variant="secondary" size="xs" onclick={() => { pwUser = user.username; pwNew = ''; pwConfirm = ''; }}>
 								Change Password
 							</Button>
+							{#if (user.webauthn_credential_count ?? 0) > 0}
+								<!-- Admin recovery for the "lost every security key"
+									 case. Visible only on rows that actually have
+									 keys to reset; the button is a no-op otherwise
+									 and clutters the row. Engine enforces admin-
+									 only on the server side. -->
+								<Button
+									variant="secondary"
+									size="xs"
+									disabled={webauthnResetting === user.username}
+									onclick={() => webauthnResetForUser(user)}
+									title="Remove all WebAuthn credentials for this user"
+								>
+									{webauthnResetting === user.username ? 'Resetting…' : `Reset Keys (${user.webauthn_credential_count})`}
+								</Button>
+							{/if}
 							{#if !(user.role === 'admin' && users.filter(u => u.role === 'admin').length === 1)}
 								<Button variant="destructive" size="xs" onclick={() => deleteUser(user.username)}>Delete</Button>
 							{/if}
@@ -1051,6 +1091,15 @@
 			maxlength={128}
 			autocomplete="off"
 		/>
+		{#if webauthnRegisterError}
+			<!-- Engine-side errors that the operator needs to see in
+				 context: the fallback-factor refusal, label-too-long,
+				 in-flight cap, etc. Toast wouldn't give them room to be
+				 useful. -->
+			<div class="mt-3 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+				{webauthnRegisterError}
+			</div>
+		{/if}
 		<div class="mt-3 flex gap-2">
 			<Button type="submit" size="sm" disabled={webauthnRegistering || !webauthnLabel.trim()}>
 				{#if webauthnRegistering}Tap your key…{:else}Register{/if}
@@ -1063,6 +1112,7 @@
 				onclick={() => {
 					webauthnShowAdd = false;
 					webauthnLabel = '';
+					webauthnRegisterError = null;
 				}}
 			>
 				Cancel


### PR DESCRIPTION
Closes out the WebAuthn series. Two distinct safeguards added on top
of PR #1's registration (#327) and PR #2's login (#328).

## 1. Fallback-factor enforcement

Refuse to register a security key for a user who has neither a
local password nor an OIDC link — without one of those, losing
every authenticator locks them out permanently with no recovery
path short of editing \`auth.json\` by hand.

**Engine**
- \`AuthService::has_non_webauthn_factor(username) -> bool\` checks
  for at least one of \`password_hash.is_some()\` or
  \`(oidc_subject.is_some() && oidc_issuer.is_some())\`.
- \`WebauthnService::register_start\` now refuses with the new
  \`WebauthnError::NoFallbackFactor\` variant when that check
  fails. Error message: *"set a password or single sign-on for this
  account before adding a security key — otherwise losing every
  authenticator would lock you out permanently."*
- Today's user-creation paths always seed one of the two factors,
  so this check is *implicit* in current flows; it's belt-and-
  suspenders against a future API that might remove either factor
  without checking WebAuthn-only state.

**WebUI**
- \`/users\` registration form surfaces the engine's error inline
  in an amber panel under the label input, instead of just as a
  toast. The fallback-factor message and the user-dismissed-prompt
  message read very differently — inline gives both room to be
  actionable.

## 2. Admin recovery RPC

Solves the *"user lost every YubiKey and forgot their password"*
case. An admin clicks a button on the target user's row;
credentials are wiped; user logs in via password/SSO and
re-enrolls.

**Engine**
- New \`auth.webauthn.reset_for_user(username)\` RPC, **admin-only**
  (enforced both in router and in \`AuthService\`). Returns
  \`{ removed: usize }\`. Audit log records actor + target + count
  under \`webauthn_reset_for_user\`.

**WebUI**
- WebUI Users table grows a per-row "Reset Keys (N)" button next
  to Change Password / Delete. Visible only when the target user
  has at least one credential, so most rows on most installs stay
  uncluttered.
- Confirmation dialog warns the user will need password/SSO and
  will have to re-register a key.

## Shape changes

- \`UserInfo\` (returned by \`auth.list_users\`) gains
  \`webauthn_credential_count: usize\`. Additive,
  \`#[serde(default)]\` on the engine side and optional on the TS
  side. Old WebUI builds ignore the field; old engines return
  responses without it (TS defaults to 0).

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] 16 existing engine auth tests still pass
- [x] \`npm run check\` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on a real NASty:
  - Try to register a key on an account with no password and no
    OIDC → see the fallback-factor message inline on the Add form.
  - Add password / link OIDC → retry → registration succeeds.
  - Admin clicks Reset Keys on another user's row → confirm
    dialog → row's count badge disappears → that user attempting
    WebAuthn login gets "no security keys registered" until
    re-enrol.
  - Non-admin attempts \`auth.webauthn.reset_for_user\` via direct
    RPC → engine returns "admin only".

## Not in this PR (out of scope for #289)

- Discoverable-credential / conditional-UI sign-in (Apple's
  "autofill from passwords" prompt on the username field).
- Webauthn-as-second-factor (currently only first-factor).
- Volume unlock via PRF — that's #17 / #288.

Closes #289.