### PR TITLE
boot: add memtest86+ as a systemd-boot menu entry

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -11,6 +11,21 @@
   # Boot loader — systemd-boot (UEFI)
   boot.loader.systemd-boot.enable = true;
   boot.loader.systemd-boot.configurationLimit = 20;
+  # Memtest86+ EFI binary added as a sibling menu entry. ~1 MB on
+  # the ESP, no closure-size impact on boxes that never boot into
+  # it — but when an operator needs it (flaky RAM, ECC errors, post-
+  # hardware-change sanity check) it's right there in the boot
+  # menu instead of requiring a USB stick. Works on x86_64 and
+  # aarch64; the systemd-boot module silently no-ops on architectures
+  # without a memtest86+ build available.
+  #
+  # Note for future Secure Boot work: memtest86+ isn't signed by
+  # NASty's keys, so under SB it will refuse to launch. The
+  # systemd-boot module documents that the entry stays visible but
+  # the boot attempt fails; that's acceptable since SB-protected
+  # boxes are the ones where memtest's "unsigned-but-trusted" model
+  # doesn't fit anyway.
+  boot.loader.systemd-boot.memtest86.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
   networking.hostName = "nasty";


### PR DESCRIPTION
One-line change in \`appliance-base.nix\`. Adds the memtest86+ EFI
binary as a sibling menu entry in systemd-boot.

## Why

- ~1 MB on the ESP, zero closure-size impact on boxes that never
  boot it
- An operator diagnosing flaky RAM, ECC errors, or a fresh hardware
  swap usually wants memtest at exactly the wrong moment to be
  hunting for a USB stick
- The systemd-boot module already supports it as a first-class
  option — we just turn it on

## What it does

- Adds a "Memtest86+" entry to the systemd-boot menu (between
  NixOS generations and the firmware-reboot entry)
- Reuses nixpkgs' \`memtest86plus\` package; no version pinning
  needed from NASty
- No-ops silently on architectures without a memtest86+ build, so
  aarch64 / x86_64 both work without conditionals
- Visible to every NASty install once this lands; not opt-in
  (universally applicable hardware diagnostic, no failure modes)

## Future Secure Boot interaction

Documented inline in the comment block. memtest86+ isn't signed by
NASty's keys, so under lanzaboote-protected SB the entry's boot
attempt will fail (systemd-boot keeps the entry visible but the
firmware refuses to launch it). Acceptable: operators running SB
are the ones who'd refuse an unsigned diag binary on principle.

## Test plan

- [x] \`nix-instantiate --parse nixos/appliance-base.nix\` clean
- [ ] Manual on a real NASty: after upgrade, hold shift / esc at
  boot, confirm the Memtest86+ entry appears and launches