### PR TITLE
secure_boot: enrollment ceremony wizard (experimental)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -50,6 +50,13 @@ pub struct AppState {
     pub log_reload: LogReloadHandle,
     pub system: nasty_system::SystemService,
     pub settings: nasty_system::settings::SettingsService,
+    /// Secure Boot enrollment ceremony state (ADR #324). Service
+    /// is stateful — survives engine restarts via a small JSON file
+    /// at /var/lib/nasty/secure-boot-enrollment.json — and auto-
+    /// detects the SB transition on startup (`bootctl status` flips
+    /// from disabled to enabled across a reboot ⇒ phase advances
+    /// to PostEnrollment).
+    pub secure_boot_enrollment: nasty_system::secure_boot_enrollment::SecureBootEnrollmentService,
     pub tuning: nasty_system::tuning::TuningService,
     pub nut: nasty_system::nut::NutService,
     pub alerts: nasty_system::alerts::AlertService,
@@ -155,6 +162,8 @@ async fn main() -> anyhow::Result<()> {
         log_reload: reload_handle,
         system: nasty_system::SystemService::new(None, Some(built.to_string())),
         settings: settings_service,
+        secure_boot_enrollment:
+            nasty_system::secure_boot_enrollment::SecureBootEnrollmentService::new().await,
         tuning: nasty_system::tuning::TuningService::new().await,
         nut: nasty_system::nut::NutService::new().await,
         alerts: nasty_system::alerts::AlertService::new().await,

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -193,6 +193,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.health"
                 | "system.hardware.iommu"
                 | "system.hardware.summary"
+                | "system.secure_boot.enrollment.status"
                 | "system.passthrough.get"
                 | "system.stats"
                 | "system.disks"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -50,6 +50,15 @@ pub(super) async fn try_route(
                 Err(e) => err(req, e.to_string()),
             }
         }
+        "system.secure_boot.enrollment.rebuild" => {
+            if session.role != Role::Admin {
+                return Some(err(req, "admin only".to_string()));
+            }
+            match state.secure_boot_enrollment.rebuild().await {
+                Ok(()) => ok(req, serde_json::json!({ "triggered": true })),
+                Err(e) => err(req, e.to_string()),
+            }
+        }
         "system.secure_boot.enrollment.complete" => {
             if session.role != Role::Admin {
                 return Some(err(req, "admin only".to_string()));

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -22,6 +22,47 @@ pub(super) async fn try_route(
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
         "system.secure_boot.readiness" => ok(req, nasty_system::secure_boot::readiness().await),
+        "system.secure_boot.enrollment.status" => {
+            ok(req, state.secure_boot_enrollment.status().await)
+        }
+        "system.secure_boot.enrollment.begin" => {
+            if session.role != Role::Admin {
+                return Some(err(req, "admin only".to_string()));
+            }
+            match state.secure_boot_enrollment.begin(&session.username).await {
+                Ok(s) => ok(req, s),
+                Err(e) => err(req, e.to_string()),
+            }
+        }
+        "system.secure_boot.enrollment.abort" => {
+            if session.role != Role::Admin {
+                return Some(err(req, "admin only".to_string()));
+            }
+            let reason = str_param(req, "reason")
+                .unwrap_or("operator aborted")
+                .to_string();
+            match state
+                .secure_boot_enrollment
+                .abort(&session.username, &reason)
+                .await
+            {
+                Ok(s) => ok(req, s),
+                Err(e) => err(req, e.to_string()),
+            }
+        }
+        "system.secure_boot.enrollment.complete" => {
+            if session.role != Role::Admin {
+                return Some(err(req, "admin only".to_string()));
+            }
+            match state
+                .secure_boot_enrollment
+                .complete(&session.username)
+                .await
+            {
+                Ok(s) => ok(req, s),
+                Err(e) => err(req, e.to_string()),
+            }
+        }
         "system.passthrough.get" => ok(req, nasty_system::passthrough::load().await),
         "system.passthrough.update" => {
             match parse_params::<nasty_system::passthrough::PassthroughUpdate>(req) {

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -8,6 +8,7 @@ pub mod nut;
 pub mod passthrough;
 pub mod protocol;
 pub mod secure_boot;
+pub mod secure_boot_enrollment;
 pub mod settings;
 pub mod tailscale;
 pub mod tuning;

--- a/engine/nasty-system/src/secure_boot_enrollment.rs
+++ b/engine/nasty-system/src/secure_boot_enrollment.rs
@@ -1,0 +1,438 @@
+//! Secure Boot enrollment ceremony state machine (issue ADR #324).
+//!
+//! Drives the per-box "go from `lanzaboote loaded but inert` to `SB
+//! enforcing with NASty-owned keys`" flow. Highly experimental — the
+//! WebUI wraps every step in a clear EXPERIMENTAL badge. The state
+//! machine survives engine restarts and reboots via a small JSON
+//! file at `/var/lib/nasty/secure-boot-enrollment.json`.
+//!
+//! ## Phases
+//!
+//! ```text
+//! NotStarted
+//!     │ begin(operator)
+//!     ▼
+//! OverlayWritten             ←──── operator runs `nasty-rebuild`,
+//!     │                            then enters BIOS Setup Mode and
+//!     │                            reboots; firmware auto-enrolls
+//!     │                            NASty's keys via systemd-boot
+//!     ▼                            and reboots into SB-on state
+//! PostEnrollment             (detected on engine startup —
+//!     │                       bootctl reports SB now enabled,
+//!     │                       and any TPM-bound bcachefs FSes
+//!     │                       have stale `.tpm` blobs that need
+//!     │                       re-binding from /filesystems)
+//!     │ complete(operator)
+//!     ▼
+//! Complete
+//! ```
+//!
+//! From `NotStarted` or `Aborted`, `begin` is allowed. From any
+//! pre-`PostEnrollment` phase, `abort` is allowed (removes the
+//! overlay file, reverts to NotStarted-equivalent state); after
+//! `PostEnrollment` `abort` becomes a no-op because SB has already
+//! been enrolled into firmware and only a BIOS visit can undo it.
+//!
+//! ## Re-seal
+//!
+//! When SB transitions on, the firmware's PCR-7 reading changes —
+//! existing `.tpm` blobs that sealed the bcachefs key against the
+//! pre-SB PCR-7 will fail to unseal. We don't drive re-seal from
+//! this module; instead `PostEnrollment.stale_tpm_bindings` lists
+//! the affected FSes and the wizard links the operator to the
+//! existing `Bind to TPM` button on /filesystems for each. That
+//! button already re-seals against the current PCR-7 using the
+//! plaintext `.key` file (or the operator's passphrase if they've
+//! gone through `Export Key → Destroy Key`).
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+const STATE_PATH: &str = "/var/lib/nasty/secure-boot-enrollment.json";
+const STATE_DIR: &str = "/var/lib/nasty";
+const NIX_OVERLAY_PATH: &str = "/etc/nixos/secure-boot.nix";
+const NASTY_KEYS_DIR: &str = "/var/lib/nasty/keys";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EnrollmentPhase {
+    /// Default. Operator hasn't started the ceremony, or has been
+    /// reset after a previous abort. The wizard renders the
+    /// "Begin enrollment" button.
+    #[default]
+    NotStarted,
+    /// The overlay file is on disk with both
+    /// `services.nasty.secureBoot.enable` and the lanzaboote auto-
+    /// enroll knobs set. Operator now needs to (a) run
+    /// `nasty-rebuild` to apply the config, (b) reboot into BIOS,
+    /// put firmware in Setup Mode, save, (c) reboot again — auto-
+    /// enroll picks up the staged keys on that boot.
+    OverlayWritten {
+        /// Unix seconds when the overlay was written.
+        overlay_at: u64,
+    },
+    /// Engine detected (on startup, after the operator's reboot
+    /// dance) that Secure Boot has transitioned to enabled. The
+    /// `stale_tpm_bindings` field names every bcachefs filesystem
+    /// whose `.tpm` blob predates the SB transition and now needs
+    /// re-binding under the new PCR-7. Operator works through the
+    /// list via /filesystems → Bind to TPM.
+    PostEnrollment {
+        /// Unix seconds when the engine detected the transition.
+        detected_at: u64,
+        /// FS names with a `.tpm` blob present in `/var/lib/nasty/keys/`.
+        /// Empty list = the box had no TPM-bound filesystems at the
+        /// time of enrollment.
+        stale_tpm_bindings: Vec<String>,
+    },
+    /// Operator has confirmed they're done. Optional terminal
+    /// state — `NotStarted` would also be a sane stopping point,
+    /// but `Complete` lets the wizard render a "you finished this"
+    /// summary on subsequent visits instead of suggesting the
+    /// operator start over.
+    Complete {
+        /// Unix seconds the operator clicked Done.
+        completed_at: u64,
+    },
+    /// Operator cancelled before the firmware-level commit (i.e.
+    /// before `PostEnrollment`). Engine has removed the overlay
+    /// file. State persists so the wizard can render a "previous
+    /// attempt was aborted" hint on the next Begin click.
+    Aborted { aborted_at: u64, reason: String },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct EnrollmentState {
+    pub phase: EnrollmentPhase,
+    /// Username that initiated the most recent ceremony attempt.
+    /// `None` only on a freshly-installed box that's never started
+    /// enrollment.
+    #[serde(default)]
+    pub initiated_by: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EnrollmentError {
+    #[error(
+        "secure-boot enrollment can only begin from NotStarted or Aborted state — current phase blocks it"
+    )]
+    AlreadyInProgress,
+    #[error(
+        "can't abort — firmware enrollment has already committed (phase is past PostEnrollment)"
+    )]
+    PastPointOfNoReturn,
+    #[error("can only complete from PostEnrollment phase")]
+    NotInPostEnrollment,
+    #[error("io: {0}")]
+    Io(String),
+}
+
+impl From<std::io::Error> for EnrollmentError {
+    fn from(e: std::io::Error) -> Self {
+        EnrollmentError::Io(e.to_string())
+    }
+}
+
+pub struct SecureBootEnrollmentService {
+    state: Arc<RwLock<EnrollmentState>>,
+}
+
+impl SecureBootEnrollmentService {
+    pub async fn new() -> Self {
+        let state = load_state().await.unwrap_or_default();
+        let svc = Self {
+            state: Arc::new(RwLock::new(state)),
+        };
+        // One-shot startup check: if the previous state was
+        // `OverlayWritten` and Secure Boot is now reported as
+        // enabled, advance to `PostEnrollment`. Done here (not in
+        // a recurring poll) because the SB transition only happens
+        // across a reboot, and the engine's startup itself is the
+        // signal that we're on the new side of it.
+        svc.maybe_detect_transition().await;
+        svc
+    }
+
+    pub async fn status(&self) -> EnrollmentState {
+        self.state.read().await.clone()
+    }
+
+    /// Start the ceremony: write the Nix overlay that enables
+    /// lanzaboote auto-enroll on next rebuild, persist the state.
+    /// Returns the new state so the WebUI can render the next
+    /// wizard step without a follow-up status call.
+    pub async fn begin(&self, actor: &str) -> Result<EnrollmentState, EnrollmentError> {
+        {
+            let current = self.state.read().await;
+            match current.phase {
+                EnrollmentPhase::NotStarted | EnrollmentPhase::Aborted { .. } => {}
+                _ => return Err(EnrollmentError::AlreadyInProgress),
+            }
+        }
+        write_overlay_file().await?;
+        let new_state = EnrollmentState {
+            phase: EnrollmentPhase::OverlayWritten {
+                overlay_at: unix_now(),
+            },
+            initiated_by: Some(actor.to_string()),
+        };
+        *self.state.write().await = new_state.clone();
+        save_state(&new_state).await?;
+        info!(
+            target: "nasty::secure_boot_enrollment",
+            "enrollment begun by {actor} — overlay written, awaiting operator rebuild + BIOS Setup Mode"
+        );
+        Ok(new_state)
+    }
+
+    /// Abort the ceremony before firmware enrollment. Removes the
+    /// overlay (so the next rebuild reverts to systemd-boot without
+    /// SB), records the abort reason. No-op when already past the
+    /// point where firmware has enrolled keys.
+    pub async fn abort(
+        &self,
+        actor: &str,
+        reason: &str,
+    ) -> Result<EnrollmentState, EnrollmentError> {
+        {
+            let current = self.state.read().await;
+            match current.phase {
+                EnrollmentPhase::NotStarted
+                | EnrollmentPhase::PostEnrollment { .. }
+                | EnrollmentPhase::Complete { .. } => {
+                    // PostEnrollment + Complete: firmware has the keys,
+                    // abort is meaningless. NotStarted: nothing to undo.
+                    return Err(EnrollmentError::PastPointOfNoReturn);
+                }
+                _ => {}
+            }
+        }
+        remove_overlay_file().await?;
+        let new_state = EnrollmentState {
+            phase: EnrollmentPhase::Aborted {
+                aborted_at: unix_now(),
+                reason: reason.to_string(),
+            },
+            initiated_by: Some(actor.to_string()),
+        };
+        *self.state.write().await = new_state.clone();
+        save_state(&new_state).await?;
+        info!(
+            target: "nasty::secure_boot_enrollment",
+            "enrollment aborted by {actor}: {reason}"
+        );
+        Ok(new_state)
+    }
+
+    /// Mark the ceremony done. Only valid from PostEnrollment —
+    /// the wizard's Complete button surfaces after the operator
+    /// has re-bound their TPM filesystems (or explicitly chosen to
+    /// skip).
+    pub async fn complete(&self, actor: &str) -> Result<EnrollmentState, EnrollmentError> {
+        {
+            let current = self.state.read().await;
+            if !matches!(current.phase, EnrollmentPhase::PostEnrollment { .. }) {
+                return Err(EnrollmentError::NotInPostEnrollment);
+            }
+        }
+        let new_state = EnrollmentState {
+            phase: EnrollmentPhase::Complete {
+                completed_at: unix_now(),
+            },
+            initiated_by: Some(actor.to_string()),
+        };
+        *self.state.write().await = new_state.clone();
+        save_state(&new_state).await?;
+        info!(
+            target: "nasty::secure_boot_enrollment",
+            "enrollment marked complete by {actor}"
+        );
+        Ok(new_state)
+    }
+
+    /// Engine-startup check: if we left off in `OverlayWritten`
+    /// and the firmware now reports SB enabled, advance to
+    /// `PostEnrollment`. Idempotent — running again from
+    /// `PostEnrollment` does nothing.
+    async fn maybe_detect_transition(&self) {
+        let current_phase = self.state.read().await.phase.clone();
+        if !matches!(current_phase, EnrollmentPhase::OverlayWritten { .. }) {
+            return;
+        }
+        let sb = nasty_common::secure_boot::status().await;
+        if sb.enabled != Some(true) {
+            // Still pre-enrollment from firmware's perspective.
+            // Operator hasn't completed the BIOS Setup Mode dance
+            // yet (or did and it didn't take). Leave state alone
+            // so the wizard keeps showing the "go to BIOS" hint.
+            return;
+        }
+        let stale = enumerate_tpm_bindings().await;
+        let new_state = EnrollmentState {
+            phase: EnrollmentPhase::PostEnrollment {
+                detected_at: unix_now(),
+                stale_tpm_bindings: stale,
+            },
+            initiated_by: self.state.read().await.initiated_by.clone(),
+        };
+        *self.state.write().await = new_state.clone();
+        if let Err(e) = save_state(&new_state).await {
+            warn!(
+                target: "nasty::secure_boot_enrollment",
+                "could not persist post-enrollment state: {e}"
+            );
+        }
+        info!(
+            target: "nasty::secure_boot_enrollment",
+            "secure boot transitioned to enabled — entering PostEnrollment, {} stale TPM binding(s) to re-seal",
+            match &new_state.phase {
+                EnrollmentPhase::PostEnrollment { stale_tpm_bindings, .. } => stale_tpm_bindings.len(),
+                _ => 0,
+            }
+        );
+    }
+}
+
+async fn load_state() -> Option<EnrollmentState> {
+    let bytes = tokio::fs::read(STATE_PATH).await.ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+async fn save_state(state: &EnrollmentState) -> Result<(), EnrollmentError> {
+    if let Some(parent) = Path::new(STATE_PATH).parent()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        warn!(target: "nasty::secure_boot_enrollment", "create_dir_all({STATE_DIR}): {e}");
+    }
+    let body = serde_json::to_vec_pretty(state).map_err(|e| EnrollmentError::Io(e.to_string()))?;
+    tokio::fs::write(STATE_PATH, body).await?;
+    Ok(())
+}
+
+async fn write_overlay_file() -> Result<(), EnrollmentError> {
+    let nix_dir = Path::new(NIX_OVERLAY_PATH)
+        .parent()
+        .ok_or_else(|| EnrollmentError::Io(format!("{NIX_OVERLAY_PATH}: no parent dir")))?;
+    if !nix_dir.exists() {
+        return Err(EnrollmentError::Io(format!(
+            "{} does not exist — is this a NASty install?",
+            nix_dir.display()
+        )));
+    }
+    tokio::fs::write(NIX_OVERLAY_PATH, OVERLAY_BODY).await?;
+    Ok(())
+}
+
+async fn remove_overlay_file() -> Result<(), EnrollmentError> {
+    match tokio::fs::remove_file(NIX_OVERLAY_PATH).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Enumerate filesystems that currently have a `.tpm` blob in
+/// `/var/lib/nasty/keys/`. After SB transitions, every one of these
+/// has been sealed against the old (pre-SB) PCR-7 reading and needs
+/// re-binding. Returns the bare filesystem names (the part before
+/// `.tpm`). Filenames not matching the expected shape are skipped
+/// silently — keys/ is shared with `.key` and other future per-FS
+/// artifacts.
+async fn enumerate_tpm_bindings() -> Vec<String> {
+    let mut out = Vec::new();
+    let mut entries = match tokio::fs::read_dir(NASTY_KEYS_DIR).await {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(stem) = name.strip_suffix(".tpm")
+            && !stem.is_empty()
+        {
+            out.push(stem.to_string());
+        }
+    }
+    out.sort();
+    out
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The Nix overlay content. Writes both `services.nasty.secureBoot.enable
+/// = true` (which the nasty module then turns into the lanzaboote
+/// enable + systemd-boot disable wired in PR #325) AND the auto-
+/// enroll bits that make next boot under firmware Setup Mode commit
+/// the keys.
+const OVERLAY_BODY: &str = r#"# Generated by nasty-engine — Secure Boot enrollment ceremony.
+# Remove this file (or use Abort in the WebUI wizard) to roll back
+# before firmware enrollment fires. After enrollment has committed,
+# rolling back also requires entering BIOS and disabling Secure Boot.
+{ ... }: {
+  services.nasty.secureBoot.enable = true;
+  # Stage PK / KEK / db on the ESP under /loader/keys/auto/. On the
+  # next boot, systemd-boot enrolls them into firmware — but only
+  # when firmware is in Setup Mode. The wizard tells the operator
+  # to enter Setup Mode before rebooting; if they reboot without it
+  # the keys stay staged and nothing happens, which is fine — they
+  # can try again.
+  boot.lanzaboote.autoEnrollKeys.enable = true;
+  boot.lanzaboote.autoEnrollKeys.autoReboot = true;
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_body_contains_required_lines() {
+        // Render quirks would be invisible until the rebuild fires
+        // and produces a misleading error. Cheap to pin the exact
+        // lines we depend on.
+        assert!(OVERLAY_BODY.contains("services.nasty.secureBoot.enable = true;"));
+        assert!(OVERLAY_BODY.contains("boot.lanzaboote.autoEnrollKeys.enable = true;"));
+        assert!(OVERLAY_BODY.contains("boot.lanzaboote.autoEnrollKeys.autoReboot = true;"));
+    }
+
+    #[test]
+    fn default_phase_is_not_started() {
+        let s = EnrollmentState::default();
+        assert!(matches!(s.phase, EnrollmentPhase::NotStarted));
+        assert!(s.initiated_by.is_none());
+    }
+
+    #[test]
+    fn phase_serde_roundtrip() {
+        // Forward-compat: future variants need this discriminated-
+        // tag shape (`kind: "post_enrollment"`) for `#[serde(other)]`-
+        // style additions to deserialise cleanly.
+        let phase = EnrollmentPhase::PostEnrollment {
+            detected_at: 1234,
+            stale_tpm_bindings: vec!["tank".into(), "data".into()],
+        };
+        let json = serde_json::to_string(&phase).unwrap();
+        let back: EnrollmentPhase = serde_json::from_str(&json).unwrap();
+        match back {
+            EnrollmentPhase::PostEnrollment {
+                detected_at,
+                stale_tpm_bindings,
+            } => {
+                assert_eq!(detected_at, 1234);
+                assert_eq!(stale_tpm_bindings, vec!["tank", "data"]);
+            }
+            other => panic!("expected PostEnrollment, got {other:?}"),
+        }
+    }
+}

--- a/engine/nasty-system/src/secure_boot_enrollment.rs
+++ b/engine/nasty-system/src/secure_boot_enrollment.rs
@@ -51,8 +51,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tokio::process::Command;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
+
+const REBUILD_UNIT: &str = "nasty-secureboot-rebuild";
 
 const STATE_PATH: &str = "/var/lib/nasty/secure-boot-enrollment.json";
 const STATE_DIR: &str = "/var/lib/nasty";
@@ -115,6 +118,61 @@ pub struct EnrollmentState {
     /// enrollment.
     #[serde(default)]
     pub initiated_by: Option<String>,
+    /// Unix seconds when the most recent wizard-driven
+    /// `nasty-rebuild` was triggered. `None` until the operator
+    /// clicks Rebuild from the wizard. Cleared back to `None` on
+    /// every `begin()` / `abort()` so each fresh ceremony starts
+    /// without a stale marker. The Abort copy reads this to
+    /// decide whether "the overlay was never applied" or "you
+    /// need to rebuild once more to revert" is accurate.
+    #[serde(default)]
+    pub rebuild_triggered_at: Option<u64>,
+}
+
+/// Live snapshot of the wizard-driven rebuild, queried via
+/// `systemctl show` on every status call (we don't persist the
+/// status — systemd is the source of truth for what's running).
+/// Returned as a sibling field of `EnrollmentState` from the
+/// `status` RPC.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct RebuildSnapshot {
+    /// `running` / `succeeded` / `failed` / `not_run`. Last
+    /// transition is also visible on the wizard's polled UI.
+    pub status: RebuildStatus,
+    /// Exit code from the last finished run, if any. Useful for
+    /// the failed-rebuild error toast.
+    pub exit_code: Option<i32>,
+    /// Tail of the unit's journal (last ~20 lines), surfaced
+    /// verbatim in the wizard's "rebuild output" expandable.
+    /// Empty when the unit was never started, or when journalctl
+    /// failed (we log + skip rather than abort the status call).
+    pub journal_tail: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RebuildStatus {
+    /// systemd doesn't know the unit (never triggered through this
+    /// engine instance, or `systemctl reset-failed` cleared it).
+    #[default]
+    NotRun,
+    /// `systemctl is-active` says the unit is still doing work.
+    Running,
+    /// Unit exited with status 0.
+    Succeeded,
+    /// Unit exited non-zero. `exit_code` field carries the number.
+    Failed,
+}
+
+/// Combined response from `system.secure_boot.enrollment.status` —
+/// the persistent enrollment state plus the live rebuild snapshot
+/// in a single shape so the wizard doesn't need a second round-
+/// trip on every poll.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct EnrollmentStatusResponse {
+    #[serde(flatten)]
+    pub state: EnrollmentState,
+    pub rebuild: RebuildSnapshot,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -159,8 +217,14 @@ impl SecureBootEnrollmentService {
         svc
     }
 
-    pub async fn status(&self) -> EnrollmentState {
-        self.state.read().await.clone()
+    /// Combined enrollment state + live rebuild snapshot. Wizard
+    /// polls this every few seconds; the rebuild snapshot is
+    /// re-queried from systemd on each call (cheap — two
+    /// `systemctl` / `journalctl` invocations).
+    pub async fn status(&self) -> EnrollmentStatusResponse {
+        let state = self.state.read().await.clone();
+        let rebuild = query_rebuild_snapshot().await;
+        EnrollmentStatusResponse { state, rebuild }
     }
 
     /// Start the ceremony: write the Nix overlay that enables
@@ -176,11 +240,17 @@ impl SecureBootEnrollmentService {
             }
         }
         write_overlay_file().await?;
+        // Best-effort: clear any leftover systemd unit state from a
+        // previous ceremony so the new ceremony's rebuild snapshot
+        // starts from `not_run`. Ignored on failure (unit may not
+        // exist yet on a fresh install).
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", REBUILD_UNIT]).await;
         let new_state = EnrollmentState {
             phase: EnrollmentPhase::OverlayWritten {
                 overlay_at: unix_now(),
             },
             initiated_by: Some(actor.to_string()),
+            rebuild_triggered_at: None,
         };
         *self.state.write().await = new_state.clone();
         save_state(&new_state).await?;
@@ -220,6 +290,13 @@ impl SecureBootEnrollmentService {
                 reason: reason.to_string(),
             },
             initiated_by: Some(actor.to_string()),
+            // Don't clear `rebuild_triggered_at` here — the WebUI's
+            // Abort dialog reads it to decide whether the operator
+            // needs to run nasty-rebuild once more to revert
+            // (rebuild_triggered_at = Some) or whether abort is
+            // clean because the overlay was never applied
+            // (rebuild_triggered_at = None).
+            rebuild_triggered_at: self.state.read().await.rebuild_triggered_at,
         };
         *self.state.write().await = new_state.clone();
         save_state(&new_state).await?;
@@ -246,6 +323,7 @@ impl SecureBootEnrollmentService {
                 completed_at: unix_now(),
             },
             initiated_by: Some(actor.to_string()),
+            rebuild_triggered_at: self.state.read().await.rebuild_triggered_at,
         };
         *self.state.write().await = new_state.clone();
         save_state(&new_state).await?;
@@ -254,6 +332,67 @@ impl SecureBootEnrollmentService {
             "enrollment marked complete by {actor}"
         );
         Ok(new_state)
+    }
+
+    /// Trigger `nasty-rebuild` via systemd-run so the operator
+    /// doesn't have to SSH or use the Terminal page to apply the
+    /// overlay the wizard just wrote. The unit runs detached
+    /// (--no-block --collect), so the engine survives nixos-rebuild
+    /// restarting services mid-switch; the wizard polls
+    /// `status()` to see the rebuild's live state.
+    ///
+    /// Only valid from `OverlayWritten`. Re-runnable (idempotent
+    /// `reset-failed` + new systemd-run) so an operator who hit a
+    /// transient failure can retry without aborting first.
+    pub async fn rebuild(&self) -> Result<(), EnrollmentError> {
+        {
+            let current = self.state.read().await;
+            if !matches!(current.phase, EnrollmentPhase::OverlayWritten { .. }) {
+                return Err(EnrollmentError::AlreadyInProgress);
+            }
+        }
+        // Clear any prior unit state — without this, a previous
+        // failed run leaves the unit in `failed` and systemd-run
+        // rejects the new --unit invocation. `try_run` logs
+        // failures but doesn't propagate, which is exactly what we
+        // want here (the unit might not exist on first use).
+        nasty_common::cmd::try_run("systemctl", &["reset-failed", REBUILD_UNIT]).await;
+        nasty_common::cmd::try_run("systemctl", &["stop", REBUILD_UNIT]).await;
+
+        // `nasty-rebuild` is the shell wrapper in nasty.nix's
+        // systemPackages. Same script the Terminal page invocation
+        // would run; --collect cleans the unit after exit so a
+        // future ceremony starts from a clean state.
+        let output = Command::new("systemd-run")
+            .args([
+                "--unit",
+                REBUILD_UNIT,
+                "--collect",
+                "--no-block",
+                "--description=NASty Secure Boot enrollment rebuild",
+                "/run/current-system/sw/bin/nasty-rebuild",
+            ])
+            .output()
+            .await
+            .map_err(|e| EnrollmentError::Io(format!("systemd-run: {e}")))?;
+        if !output.status.success() {
+            return Err(EnrollmentError::Io(format!(
+                "systemd-run exited {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+
+        let mut state = self.state.write().await;
+        state.rebuild_triggered_at = Some(unix_now());
+        let snapshot = state.clone();
+        drop(state);
+        save_state(&snapshot).await?;
+        info!(
+            target: "nasty::secure_boot_enrollment",
+            "secure-boot enrollment rebuild triggered via systemd-run"
+        );
+        Ok(())
     }
 
     /// Engine-startup check: if we left off in `OverlayWritten`
@@ -280,6 +419,7 @@ impl SecureBootEnrollmentService {
                 stale_tpm_bindings: stale,
             },
             initiated_by: self.state.read().await.initiated_by.clone(),
+            rebuild_triggered_at: self.state.read().await.rebuild_triggered_at,
         };
         *self.state.write().await = new_state.clone();
         if let Err(e) = save_state(&new_state).await {
@@ -344,6 +484,91 @@ async fn remove_overlay_file() -> Result<(), EnrollmentError> {
 /// `.tpm`). Filenames not matching the expected shape are skipped
 /// silently — keys/ is shared with `.key` and other future per-FS
 /// artifacts.
+/// Query systemd for the wizard-driven rebuild's live state.
+/// Always succeeds; failure modes (systemctl missing, unit
+/// unknown, journalctl unhappy) all collapse to `NotRun` /
+/// empty-tail so the wizard always has something to render.
+async fn query_rebuild_snapshot() -> RebuildSnapshot {
+    let show = Command::new("systemctl")
+        .args([
+            "show",
+            REBUILD_UNIT,
+            "--property=ActiveState,Result,ExecMainStatus",
+        ])
+        .output()
+        .await;
+    let mut active_state = String::new();
+    let mut result_field = String::new();
+    let mut exec_status: Option<i32> = None;
+    if let Ok(out) = &show {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            if let Some(v) = line.strip_prefix("ActiveState=") {
+                active_state = v.to_string();
+            } else if let Some(v) = line.strip_prefix("Result=") {
+                result_field = v.to_string();
+            } else if let Some(v) = line.strip_prefix("ExecMainStatus=") {
+                exec_status = v.parse().ok();
+            }
+        }
+    }
+
+    let status = match active_state.as_str() {
+        "" | "inactive" => {
+            // No record of the unit (never run, or fully cleaned up
+            // by --collect). Distinguish "ran and succeeded" from
+            // "never ran" via the Result field — systemd remembers
+            // it briefly even after the unit terminates.
+            if result_field == "success" && exec_status == Some(0) {
+                RebuildStatus::Succeeded
+            } else if result_field == "exit-code" || exec_status.unwrap_or(0) != 0 {
+                RebuildStatus::Failed
+            } else {
+                RebuildStatus::NotRun
+            }
+        }
+        "active" | "activating" | "reloading" | "deactivating" => RebuildStatus::Running,
+        "failed" => RebuildStatus::Failed,
+        _ => RebuildStatus::NotRun,
+    };
+
+    // Tail of the unit's journal — cheap to fetch, surfaces real
+    // error messages when the rebuild failed. Capped at 20 lines
+    // so a runaway rebuild doesn't pump the RPC response full of
+    // log spam.
+    let journal = Command::new("journalctl")
+        .args([
+            "-u",
+            REBUILD_UNIT,
+            "-n",
+            "20",
+            "--no-pager",
+            "--output",
+            "short-iso",
+        ])
+        .output()
+        .await;
+    let journal_tail = match journal {
+        Ok(o) => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter(|l| !l.starts_with("-- "))
+            .map(|s| s.to_string())
+            .collect(),
+        Err(e) => {
+            warn!(
+                target: "nasty::secure_boot_enrollment",
+                "journalctl -u {REBUILD_UNIT}: {e}"
+            );
+            Vec::new()
+        }
+    };
+
+    RebuildSnapshot {
+        status,
+        exit_code: exec_status,
+        journal_tail,
+    }
+}
+
 async fn enumerate_tpm_bindings() -> Vec<String> {
     let mut out = Vec::new();
     let mut entries = match tokio::fs::read_dir(NASTY_KEYS_DIR).await {

--- a/nixos/modules/nasty-secure-boot.nix
+++ b/nixos/modules/nasty-secure-boot.nix
@@ -29,5 +29,27 @@ in {
     # off here so flipping `secureBoot.enable` doesn't surprise an
     # operator with a firmware-state change.
     boot.lanzaboote.autoGenerateKeys.enable = true;
+
+    # ── Defensive disables for known-broken paths under SB ──────
+    #
+    # kexec: lanzaboote-produced UKI stubs aren't PE-loadable by
+    # `kexec --load` (upstream issue lanzaboote#143, open since
+    # 2023). `systemctl kexec` and `kexec -e` would either fail
+    # outright or load garbage and panic. The signed-kernel +
+    # SB-on combination also typically enables kernel lockdown
+    # which blocks the kexec_load syscall on its own, but pinning
+    # the sysctl explicitly makes the disable visible in NixOS
+    # config rather than relying on lockdown's runtime detection.
+    # `kexec_load_disabled` is one-way (settable to 1, never back
+    # to 0 without a reboot) — exactly the property we want.
+    boot.kernel.sysctl."kernel.kexec_load_disabled" = 1;
+
+    # fwupd intentionally NOT disabled. Listing devices / refreshing
+    # metadata still works under SB; what's broken is the EFI-capsule
+    # APPLY path (upstream lanzaboote#591). NASty's Firmware page
+    # uses fwupdmgr for device enumeration and would go blank if
+    # services.fwupd.enable were forced off here. Gating the apply-
+    # update RPC on SB state is a separate WebUI concern — tracked
+    # for a follow-up to this PR.
   };
 }

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -104,7 +104,16 @@
             # Machine-local overlay files live directly under /etc/nixos.
             ./hardware-configuration.nix
             ./networking.nix
-          ] ++ nixpkgs.lib.optional (builtins.pathExists ./passthrough.nix) ./passthrough.nix;
+          ]
+          ++ nixpkgs.lib.optional (builtins.pathExists ./passthrough.nix) ./passthrough.nix
+          # Secure Boot enrollment overlay — written by the engine
+          # when the operator clicks "Begin enrollment" in the
+          # Hardware page's experimental SB wizard. Sets
+          # `services.nasty.secureBoot.enable = true` plus the
+          # lanzaboote auto-enroll knobs. Absent on every fresh
+          # install (the wizard hasn't run); `pathExists` keeps
+          # the import optional so eval doesn't fail.
+          ++ nixpkgs.lib.optional (builtins.pathExists ./secure-boot.nix) ./secure-boot.nix;
         };
     in {
       # Content-hash placeholder substituted at render time by

--- a/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
+++ b/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
@@ -1,0 +1,321 @@
+<!--
+	Highly-experimental Secure Boot enrollment ceremony wizard. Polls
+	`system.secure_boot.enrollment.status` and renders the right step
+	for the current phase. Shown only when the readiness probe is
+	green — the parent decides visibility via the `visible` prop.
+
+	The state machine lives in the engine; this component is a thin
+	view + button driver. Per-vendor BIOS hints are matched on the
+	DMI manufacturer string. The generic block is always visible —
+	vendor hints rot faster than the generic "Erase PK" instruction.
+-->
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { rebootState } from '$lib/reboot.svelte';
+	import type { SecureBootEnrollmentState } from '$lib/types';
+	import { ShieldCheck, ShieldAlert, AlertTriangle } from '@lucide/svelte';
+
+	type Props = {
+		/** Parent gates visibility — typically true when readiness is
+		 * green or when enrollment is already in flight. */
+		visible: boolean;
+		/** `summary.system?.manufacturer` from system.hardware.summary.
+		 * Used to pick the vendor-specific BIOS hint. */
+		manufacturer: string | null | undefined;
+	};
+	const { visible, manufacturer }: Props = $props();
+
+	const client = getClient();
+
+	let enrollment: SecureBootEnrollmentState | null = $state(null);
+	let loading = $state(true);
+	let busy = $state(false);
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	async function refresh() {
+		try {
+			enrollment = await client.call<SecureBootEnrollmentState>(
+				'system.secure_boot.enrollment.status',
+			);
+		} catch {
+			enrollment = null;
+		}
+		loading = false;
+	}
+
+	onMount(() => {
+		refresh();
+		// Light polling so a state transition that happened in another
+		// tab (or after the operator's BIOS dance + reboot) shows up
+		// without manual refresh. 5 s is conservative; the engine call
+		// is just a JSON read so the cost is negligible.
+		pollTimer = setInterval(refresh, 5_000);
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+	});
+
+	async function begin() {
+		const ok = await confirm(
+			'Begin Secure Boot enrollment',
+			'This is highly experimental. NASty will write a Nix overlay that enables lanzaboote + auto-enrollment. Before you commit to firmware-level enrollment you can still abort by clicking Abort below. Continue?',
+			{ confirmLabel: 'Begin' },
+		);
+		if (!ok) return;
+		busy = true;
+		const result = await withToast(
+			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.begin'),
+			'Secure Boot enrollment started — overlay written.',
+		);
+		busy = false;
+		if (result) {
+			enrollment = result;
+			rebootState.set();
+		}
+	}
+
+	async function abort() {
+		const ok = await confirm(
+			'Abort enrollment',
+			'Removes the Nix overlay. You’ll still need to run nasty-rebuild to undo any pending boot-loader changes. OK to abort?',
+			{ confirmLabel: 'Abort' },
+		);
+		if (!ok) return;
+		busy = true;
+		const result = await withToast(
+			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.abort', {
+				reason: 'operator aborted via wizard',
+			}),
+			'Secure Boot enrollment aborted.',
+		);
+		busy = false;
+		if (result) enrollment = result;
+	}
+
+	async function complete() {
+		busy = true;
+		const result = await withToast(
+			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.complete'),
+			'Secure Boot enrollment marked complete.',
+		);
+		busy = false;
+		if (result) enrollment = result;
+	}
+
+	// Per-vendor BIOS hints. Matched case-insensitively on the leading
+	// token of the DMI manufacturer string. New vendors land here as
+	// operators report them. Falling back to the generic block is fine
+	// — vendor steps shouldn't be the only path to enrollment.
+	function vendorHint(mfr: string | null | undefined): { vendor: string; steps: string } | null {
+		if (!mfr) return null;
+		const m = mfr.toLowerCase();
+		if (m.startsWith('supermicro')) {
+			return {
+				vendor: 'Supermicro',
+				steps:
+					'Reboot, press DEL at POST (or use IPMI iKVM). ' +
+					'Security → Secure Boot → Erase All Secure Boot Settings. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('asrock')) {
+			return {
+				vendor: 'ASRock Rack',
+				steps:
+					'Reboot, press DEL at POST. ' +
+					'Security → Secure Boot → Key Management → Reset to Setup Mode. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('asus')) {
+			return {
+				vendor: 'ASUS',
+				steps:
+					'Reboot, press DEL at POST. ' +
+					'Press F7 for Advanced Mode. ' +
+					'Boot → Secure Boot → Key Management → Clear Secure Boot Keys. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('gigabyte')) {
+			return {
+				vendor: 'Gigabyte',
+				steps:
+					'Reboot, press DEL at POST. ' +
+					'Boot → Secure Boot → PK Management → Delete PK. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('lenovo')) {
+			return {
+				vendor: 'Lenovo',
+				steps:
+					'Reboot, press F1 at POST. ' +
+					'Security → Secure Boot → Reset to Setup Mode. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('framework')) {
+			return {
+				vendor: 'Framework',
+				steps:
+					'Reboot, press F2 at POST. ' +
+					'Security → Erase all Secure Boot Settings. ' +
+					'Save & exit. (Some Framework batches have a buggy implementation — if it doesn’t take, clear PK, KEK and db individually.)',
+			};
+		}
+		if (m.startsWith('dell')) {
+			return {
+				vendor: 'Dell',
+				steps:
+					'Reboot, press F2 at POST. ' +
+					'System Security → Secure Boot → Custom Mode → Delete PK. ' +
+					'Save & exit.',
+			};
+		}
+		if (m.startsWith('hewlett packard') || m.startsWith('hp')) {
+			return {
+				vendor: 'HPE / HP',
+				steps:
+					'Reboot, press F9 at POST. ' +
+					'System Configuration → BIOS/Platform → Secure Boot → Reset to Setup Mode. ' +
+					'Save & exit.',
+			};
+		}
+		return null;
+	}
+
+	const hint = $derived(vendorHint(manufacturer));
+</script>
+
+{#if visible}
+	<Card class="mb-6">
+		<CardContent class="pt-4 pb-4">
+			<div class="mb-3 flex items-baseline justify-between">
+				<div class="flex items-center gap-2">
+					<ShieldCheck size={18} class="text-muted-foreground" />
+					<h2 class="text-base font-semibold">Secure Boot enrollment</h2>
+					<span class="rounded bg-amber-950/60 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-300">
+						Experimental
+					</span>
+				</div>
+				{#if enrollment}
+					<span class="text-xs text-muted-foreground">
+						Phase: {enrollment.phase.kind.replace('_', ' ')}
+					</span>
+				{/if}
+			</div>
+
+			<div class="mb-3 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+				<div class="flex items-start gap-2">
+					<AlertTriangle size={14} class="mt-0.5 shrink-0" />
+					<div>
+						<strong>Highly experimental.</strong>
+						This is a multi-step ceremony involving a BIOS visit. Recovery from a bad enrollment requires physical or IPMI access to disable Secure Boot in firmware. Don't run this remotely without a recovery plan. Back up your bcachefs encryption keys before starting.
+					</div>
+				</div>
+			</div>
+
+			{#if loading}
+				<div class="text-sm text-muted-foreground">Loading…</div>
+			{:else if !enrollment}
+				<div class="text-sm text-muted-foreground">Could not load enrollment status.</div>
+			{:else if enrollment.phase.kind === 'not_started' || enrollment.phase.kind === 'aborted'}
+				{#if enrollment.phase.kind === 'aborted'}
+					<p class="mb-3 text-xs text-muted-foreground">
+						Previous attempt was aborted: <em>{enrollment.phase.reason}</em>. You can begin again.
+					</p>
+				{/if}
+				<Button size="sm" disabled={busy} onclick={begin}>
+					{busy ? 'Starting…' : 'Begin enrollment'}
+				</Button>
+			{:else if enrollment.phase.kind === 'overlay_written'}
+				<ol class="mb-4 list-decimal space-y-3 pl-5 text-sm">
+					<li>
+						<strong>Run <code class="rounded bg-muted px-1 font-mono text-xs">nasty-rebuild</code> in a terminal</strong>
+						(or via the Update page). This installs lanzaboote-signed boot artifacts on your ESP and stages the platform keys for firmware enrollment.
+					</li>
+					<li>
+						<strong>Reboot into BIOS / UEFI setup</strong> and put firmware in <em>Setup Mode</em>.
+						{#if hint}
+							<div class="mt-2 rounded border border-border bg-muted/30 p-3 text-xs">
+								<div class="mb-1 font-semibold">For your hardware ({hint.vendor})</div>
+								<div class="text-muted-foreground">{hint.steps}</div>
+							</div>
+						{/if}
+						<div class="mt-2 rounded border border-border bg-muted/10 p-3 text-xs">
+							<div class="mb-1 font-semibold">Generic</div>
+							<div class="text-muted-foreground">
+								Reboot into BIOS/UEFI setup (typically DEL or F2 at POST), find the Secure Boot section, look for <em>Reset to Setup Mode</em>, <em>Erase Platform Key</em>, or <em>Clear Secure Boot Keys</em>. Save and exit. Exact wording varies by vendor and BIOS version.
+							</div>
+						</div>
+					</li>
+					<li>
+						<strong>Reboot back into NASty.</strong>
+						systemd-boot will auto-enroll the staged keys on this boot (Setup Mode is required for the firmware to accept them). NASty's engine detects the transition automatically; this wizard will advance to the post-enrollment step.
+					</li>
+				</ol>
+
+				<div class="flex flex-wrap gap-2">
+					<Button size="sm" variant="secondary" disabled={busy} onclick={refresh}>
+						{busy ? '…' : 'Refresh status'}
+					</Button>
+					<Button size="sm" variant="outline" disabled={busy} onclick={abort}>
+						Abort (still possible)
+					</Button>
+				</div>
+				<p class="mt-2 text-xs text-muted-foreground">
+					<strong>Abort is possible</strong> at this stage — firmware hasn’t enrolled any keys yet. After your next reboot with Setup Mode, the firmware-level commit is irreversible from software.
+				</p>
+			{:else if enrollment.phase.kind === 'post_enrollment'}
+				<div class="mb-3 flex items-start gap-2 rounded border border-emerald-700/40 bg-emerald-950/40 px-3 py-2 text-xs text-emerald-200">
+					<ShieldCheck size={14} class="mt-0.5 shrink-0" />
+					<div>
+						<strong>Secure Boot is now enforcing.</strong>
+						The firmware has accepted NASty's platform keys. Lanzaboote-signed kernel + initrd are loaded on every boot from here on; an unsigned boot artifact (memtest, rescue image, etc.) won't launch unless you disable SB in firmware again.
+					</div>
+				</div>
+
+				{#if enrollment.phase.stale_tpm_bindings.length > 0}
+					<div class="mb-3">
+						<div class="mb-2 text-sm font-semibold">
+							Re-bind your TPM-sealed filesystems
+						</div>
+						<p class="mb-2 text-xs text-muted-foreground">
+							Secure Boot activation changed your firmware’s PCR-7 reading.
+							Filesystems sealed against the old reading can’t auto-unlock until they’re re-bound under the new one.
+							Go to <a href="/filesystems" class="underline">Filesystems</a> and click <em>Bind to TPM</em> on each row:
+						</p>
+						<ul class="mb-2 list-disc pl-5 text-sm font-mono text-amber-200">
+							{#each enrollment.phase.stale_tpm_bindings as fs (fs)}
+								<li>{fs}</li>
+							{/each}
+						</ul>
+					</div>
+				{:else}
+					<p class="mb-3 text-xs text-muted-foreground">
+						No TPM-sealed filesystems to re-bind on this box.
+					</p>
+				{/if}
+
+				<Button size="sm" disabled={busy} onclick={complete}>
+					{busy ? '…' : 'Mark enrollment complete'}
+				</Button>
+				<p class="mt-2 text-xs text-muted-foreground">
+					Marking complete just dismisses the wizard. You can re-run any of the listed re-bindings later from the Filesystems page.
+				</p>
+			{:else if enrollment.phase.kind === 'complete'}
+				<div class="rounded border border-emerald-700/40 bg-emerald-950/40 px-3 py-2 text-xs text-emerald-200">
+					<ShieldCheck size={14} class="mr-1 inline" />
+					Secure Boot enrollment complete on {new Date(enrollment.phase.completed_at * 1000).toLocaleString()}.
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+{/if}

--- a/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
+++ b/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
@@ -379,11 +379,55 @@
 				<p class="mt-2 text-xs text-muted-foreground">
 					Marking complete just dismisses the wizard. You can re-run any of the listed re-bindings later from the Filesystems page.
 				</p>
+
+				<details class="mt-4 rounded border border-border bg-muted/10 p-3 text-xs">
+					<summary class="cursor-pointer font-semibold">Manual unenrollment (if you ever want to back out)</summary>
+					<div class="mt-2 space-y-2 text-muted-foreground">
+						<p>
+							There isn't a one-click un-enroll yet — the engine can revert the Nix side, but it can't disable Secure Boot in firmware on your behalf (that step is physical / IPMI by definition). To roll back:
+						</p>
+						<ol class="list-decimal space-y-1 pl-5">
+							<li><strong>Disable Secure Boot in firmware.</strong> BIOS / UEFI setup → Secure Boot → Disabled. On Proxmox VMs, toggle in the VM's BIOS config. On real hardware that ships with vendor PKs, you may want "Reset to Setup Mode" / "Clear Secure Boot Keys" instead, which leaves the firmware ready to be re-enrolled later.</li>
+							<li>
+								<strong>Drop the overlay + state file</strong> from a terminal:
+								<pre class="mt-1 rounded bg-black/40 p-2 text-[10px] leading-tight">rm /etc/nixos/secure-boot.nix /var/lib/nasty/secure-boot-enrollment.json</pre>
+							</li>
+							<li>
+								<strong>Rebuild:</strong>
+								<pre class="mt-1 rounded bg-black/40 p-2 text-[10px] leading-tight">nasty-rebuild</pre>
+								This flips <code class="rounded bg-muted px-1">services.nasty.secureBoot.enable</code> back to false, disables lanzaboote, restores plain systemd-boot.
+							</li>
+							<li><strong>Re-bind any TPM-sealed filesystems.</strong> PCR-7 changes again when SB flips off, so existing <code class="rounded bg-muted px-1">.tpm</code> blobs are stale a second time — same fix as after enrollment, click <em>Bind to TPM</em> on each row at /filesystems.</li>
+						</ol>
+					</div>
+				</details>
 			{:else if enrollment.phase.kind === 'complete'}
 				<div class="rounded border border-emerald-700/40 bg-emerald-950/40 px-3 py-2 text-xs text-emerald-200">
 					<ShieldCheck size={14} class="mr-1 inline" />
 					Secure Boot enrollment complete on {new Date(enrollment.phase.completed_at * 1000).toLocaleString()}.
 				</div>
+
+				<details class="mt-4 rounded border border-border bg-muted/10 p-3 text-xs">
+					<summary class="cursor-pointer font-semibold">Manual unenrollment (if you ever want to back out)</summary>
+					<div class="mt-2 space-y-2 text-muted-foreground">
+						<p>
+							There isn't a one-click un-enroll yet — the engine can revert the Nix side, but it can't disable Secure Boot in firmware on your behalf (that step is physical / IPMI by definition). To roll back:
+						</p>
+						<ol class="list-decimal space-y-1 pl-5">
+							<li><strong>Disable Secure Boot in firmware.</strong> BIOS / UEFI setup → Secure Boot → Disabled. On Proxmox VMs, toggle in the VM's BIOS config. On real hardware that ships with vendor PKs, you may want "Reset to Setup Mode" / "Clear Secure Boot Keys" instead, which leaves the firmware ready to be re-enrolled later.</li>
+							<li>
+								<strong>Drop the overlay + state file</strong> from a terminal:
+								<pre class="mt-1 rounded bg-black/40 p-2 text-[10px] leading-tight">rm /etc/nixos/secure-boot.nix /var/lib/nasty/secure-boot-enrollment.json</pre>
+							</li>
+							<li>
+								<strong>Rebuild:</strong>
+								<pre class="mt-1 rounded bg-black/40 p-2 text-[10px] leading-tight">nasty-rebuild</pre>
+								This flips <code class="rounded bg-muted px-1">services.nasty.secureBoot.enable</code> back to false, disables lanzaboote, restores plain systemd-boot.
+							</li>
+							<li><strong>Re-bind any TPM-sealed filesystems.</strong> PCR-7 changes again when SB flips off, so existing <code class="rounded bg-muted px-1">.tpm</code> blobs are stale a second time — same fix as after enrollment, click <em>Bind to TPM</em> on each row at /filesystems.</li>
+						</ol>
+					</div>
+				</details>
 			{/if}
 		</CardContent>
 	</Card>

--- a/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
+++ b/webui/src/lib/components/SecureBootEnrollmentWizard.svelte
@@ -17,29 +17,30 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { rebootState } from '$lib/reboot.svelte';
-	import type { SecureBootEnrollmentState } from '$lib/types';
-	import { ShieldCheck, ShieldAlert, AlertTriangle } from '@lucide/svelte';
+	import type { SecureBootEnrollmentStatusResponse } from '$lib/types';
+	import { ShieldCheck, AlertTriangle, RefreshCw } from '@lucide/svelte';
 
-	type Props = {
+	interface Props {
 		/** Parent gates visibility — typically true when readiness is
 		 * green or when enrollment is already in flight. */
 		visible: boolean;
 		/** `summary.system?.manufacturer` from system.hardware.summary.
 		 * Used to pick the vendor-specific BIOS hint. */
 		manufacturer: string | null | undefined;
-	};
+	}
 	const { visible, manufacturer }: Props = $props();
 
 	const client = getClient();
 
-	let enrollment: SecureBootEnrollmentState | null = $state(null);
+	let enrollment: SecureBootEnrollmentStatusResponse | null = $state(null);
 	let loading = $state(true);
 	let busy = $state(false);
+	let showJournal = $state(false);
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 	async function refresh() {
 		try {
-			enrollment = await client.call<SecureBootEnrollmentState>(
+			enrollment = await client.call<SecureBootEnrollmentStatusResponse>(
 				'system.secure_boot.enrollment.status',
 			);
 		} catch {
@@ -70,7 +71,7 @@
 		if (!ok) return;
 		busy = true;
 		const result = await withToast(
-			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.begin'),
+			() => client.call<SecureBootEnrollmentStatusResponse>('system.secure_boot.enrollment.begin'),
 			'Secure Boot enrollment started — overlay written.',
 		);
 		busy = false;
@@ -81,27 +82,50 @@
 	}
 
 	async function abort() {
-		const ok = await confirm(
-			'Abort enrollment',
-			'Removes the Nix overlay. You’ll still need to run nasty-rebuild to undo any pending boot-loader changes. OK to abort?',
-			{ confirmLabel: 'Abort' },
-		);
+		// Abort copy depends on whether a rebuild has actually
+		// happened in this ceremony. Without that distinction the
+		// dialog used to tell every operator they'd need to run
+		// nasty-rebuild again to revert — even when the overlay
+		// file was the only thing written and the running system
+		// was untouched. The engine tracks rebuild_triggered_at;
+		// we just branch on it.
+		const rebuilt = enrollment?.rebuild_triggered_at !== null
+			&& enrollment?.rebuild_triggered_at !== undefined;
+		const msg = rebuilt
+			? 'You already ran the Rebuild step earlier — the running system has lanzaboote-signed boot artifacts on the ESP. Aborting removes the Nix overlay, but you\'ll need to run Rebuild once more (or click Update) to revert those artifacts before they activate at next reboot. OK to abort?'
+			: 'Removes the Nix overlay file. Nothing else was applied yet — the running system is unchanged. OK to abort?';
+		const ok = await confirm('Abort enrollment', msg, { confirmLabel: 'Abort' });
 		if (!ok) return;
 		busy = true;
 		const result = await withToast(
-			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.abort', {
-				reason: 'operator aborted via wizard',
-			}),
+			() => client.call<SecureBootEnrollmentStatusResponse>(
+				'system.secure_boot.enrollment.abort',
+				{ reason: 'operator aborted via wizard' },
+			),
 			'Secure Boot enrollment aborted.',
 		);
 		busy = false;
 		if (result) enrollment = result;
 	}
 
+	async function rebuild() {
+		busy = true;
+		const result = await withToast(
+			() => client.call<{ triggered: boolean }>('system.secure_boot.enrollment.rebuild'),
+			'Rebuild started — this will take several minutes.',
+		);
+		busy = false;
+		if (result) {
+			// Bump the poll immediately so the status flips to
+			// `running` without waiting the 5 s tick.
+			await refresh();
+		}
+	}
+
 	async function complete() {
 		busy = true;
 		const result = await withToast(
-			() => client.call<SecureBootEnrollmentState>('system.secure_boot.enrollment.complete'),
+			() => client.call<SecureBootEnrollmentStatusResponse>('system.secure_boot.enrollment.complete'),
 			'Secure Boot enrollment marked complete.',
 		);
 		busy = false;
@@ -236,12 +260,53 @@
 					{busy ? 'Starting…' : 'Begin enrollment'}
 				</Button>
 			{:else if enrollment.phase.kind === 'overlay_written'}
-				<ol class="mb-4 list-decimal space-y-3 pl-5 text-sm">
+				{@const rebuildStatus = enrollment.rebuild.status}
+				{@const rebuildRunning = rebuildStatus === 'running'}
+				{@const rebuildSucceeded = rebuildStatus === 'succeeded'}
+				{@const rebuildFailed = rebuildStatus === 'failed'}
+
+				<ol class="mb-4 list-decimal space-y-4 pl-5 text-sm">
 					<li>
-						<strong>Run <code class="rounded bg-muted px-1 font-mono text-xs">nasty-rebuild</code> in a terminal</strong>
-						(or via the Update page). This installs lanzaboote-signed boot artifacts on your ESP and stages the platform keys for firmware enrollment.
+						<strong>Apply the overlay.</strong>
+						Engine wrote the Nix overlay during Begin; this step actually runs <code class="rounded bg-muted px-1 font-mono text-xs">nasty-rebuild</code> so lanzaboote-signed boot artifacts land on your ESP and the platform keys get staged for firmware auto-enrollment.
+						<div class="mt-2 flex flex-wrap items-center gap-2">
+							{#if !rebuildRunning && !rebuildSucceeded}
+								<Button size="sm" disabled={busy} onclick={rebuild}>
+									{rebuildFailed ? 'Retry rebuild' : 'Rebuild now'}
+								</Button>
+							{:else if rebuildRunning}
+								<span class="inline-flex items-center gap-2 text-xs text-amber-300">
+									<RefreshCw size={14} class="animate-spin" />
+									Rebuilding… (several minutes; the engine may briefly disconnect during the switch)
+								</span>
+							{:else if rebuildSucceeded}
+								<span class="inline-flex items-center gap-2 text-xs text-emerald-400">
+									<ShieldCheck size={14} />
+									Rebuild succeeded — signed boot artifacts on ESP.
+								</span>
+							{/if}
+							{#if rebuildFailed}
+								<span class="text-xs text-amber-300">
+									Rebuild failed{enrollment.rebuild.exit_code !== null
+										? ` (exit ${enrollment.rebuild.exit_code})`
+										: ''}.
+								</span>
+							{/if}
+							{#if enrollment.rebuild.journal_tail.length > 0}
+								<button
+									type="button"
+									class="text-xs underline text-muted-foreground hover:text-foreground"
+									onclick={() => (showJournal = !showJournal)}
+								>
+									{showJournal ? 'Hide' : 'Show'} rebuild output
+								</button>
+							{/if}
+						</div>
+						{#if showJournal && enrollment.rebuild.journal_tail.length > 0}
+							<pre class="mt-2 max-h-64 overflow-auto rounded border border-border bg-black/50 p-2 text-[10px] leading-tight text-muted-foreground">{enrollment.rebuild.journal_tail.join('\n')}</pre>
+						{/if}
 					</li>
-					<li>
+					<li class:opacity-50={!rebuildSucceeded}>
 						<strong>Reboot into BIOS / UEFI setup</strong> and put firmware in <em>Setup Mode</em>.
 						{#if hint}
 							<div class="mt-2 rounded border border-border bg-muted/30 p-3 text-xs">
@@ -256,7 +321,7 @@
 							</div>
 						</div>
 					</li>
-					<li>
+					<li class:opacity-50={!rebuildSucceeded}>
 						<strong>Reboot back into NASty.</strong>
 						systemd-boot will auto-enroll the staged keys on this boot (Setup Mode is required for the firmware to accept them). NASty's engine detects the transition automatically; this wizard will advance to the post-enrollment step.
 					</li>
@@ -271,7 +336,11 @@
 					</Button>
 				</div>
 				<p class="mt-2 text-xs text-muted-foreground">
-					<strong>Abort is possible</strong> at this stage — firmware hasn’t enrolled any keys yet. After your next reboot with Setup Mode, the firmware-level commit is irreversible from software.
+					{#if enrollment.rebuild_triggered_at === null}
+						<strong>Abort is clean</strong> at this point — nothing has been applied to the running system. Aborting just removes the Nix overlay.
+					{:else}
+						<strong>Abort still possible</strong> — the rebuild has run, so abort + the next reboot are still entirely reversible from software. After your reboot with Setup Mode active, the firmware-level commit becomes irreversible.
+					{/if}
 				</p>
 			{:else if enrollment.phase.kind === 'post_enrollment'}
 				<div class="mb-3 flex items-start gap-2 rounded border border-emerald-700/40 bg-emerald-950/40 px-3 py-2 text-xs text-emerald-200">

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -116,6 +116,23 @@ export interface SecureBootStatus {
 	note: string | null;
 }
 
+/** Wire shape of `system.secure_boot.enrollment.status`. Drives the
+ * highly-experimental SB onboarding wizard on the Hardware page.
+ * `phase.kind` is the discriminator; per-variant fields land
+ * inline alongside it (serde flattens — `OverlayWritten` ships
+ * `{kind: "overlay_written", overlay_at: 12345}`). */
+export type SecureBootEnrollmentPhase =
+	| { kind: 'not_started' }
+	| { kind: 'overlay_written'; overlay_at: number }
+	| { kind: 'post_enrollment'; detected_at: number; stale_tpm_bindings: string[] }
+	| { kind: 'complete'; completed_at: number }
+	| { kind: 'aborted'; aborted_at: number; reason: string };
+
+export interface SecureBootEnrollmentState {
+	phase: SecureBootEnrollmentPhase;
+	initiated_by: string | null;
+}
+
 /** Structured checklist returned by `system.secure_boot.readiness`.
  * Drives the Hardware-page panel that shows whether a box is ready
  * for the lanzaboote opt-in. `ready === true` means every check

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -131,6 +131,32 @@ export type SecureBootEnrollmentPhase =
 export interface SecureBootEnrollmentState {
 	phase: SecureBootEnrollmentPhase;
 	initiated_by: string | null;
+	/** Unix seconds when the wizard's Rebuild button last fired.
+	 * `null` until the operator clicks Rebuild for the first time
+	 * in a given ceremony. The Abort dialog uses this to decide
+	 * whether "you'll need to rebuild once more to revert" applies
+	 * (rebuild_triggered_at = number) or "abort is clean, nothing
+	 * was applied" (null). Cleared on each Begin. */
+	rebuild_triggered_at: number | null;
+}
+
+/** Live snapshot of the wizard-driven `nasty-rebuild` unit, queried
+ * via systemctl on every status call. The wizard polls this every
+ * few seconds while a rebuild is in flight; we don't try to
+ * persist it because systemd is the source of truth and survives
+ * engine restarts on its own. */
+export interface SecureBootRebuildSnapshot {
+	status: 'not_run' | 'running' | 'succeeded' | 'failed';
+	exit_code: number | null;
+	journal_tail: string[];
+}
+
+/** Combined response from `system.secure_boot.enrollment.status`.
+ * `state` carries the persistent enrollment state; `rebuild` is
+ * the live systemd-driven progress that the wizard renders next
+ * to the per-phase step copy. */
+export interface SecureBootEnrollmentStatusResponse extends SecureBootEnrollmentState {
+	rebuild: SecureBootRebuildSnapshot;
 }
 
 /** Structured checklist returned by `system.secure_boot.readiness`.

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -15,6 +15,7 @@
 	import { formatBytes } from '$lib/format';
 	import { rebootState } from '$lib/reboot.svelte';
 	import { ChevronDown, ChevronRight, RefreshCw } from '@lucide/svelte';
+	import SecureBootEnrollmentWizard from '$lib/components/SecureBootEnrollmentWizard.svelte';
 
 	let summary: HardwareSummary | null = $state(null);
 	let groups: IommuGroup[] = $state([]);
@@ -542,6 +543,19 @@
 			</CardContent>
 		</Card>
 	{/if}
+
+	<!-- ── Secure Boot enrollment ceremony (experimental) ─────────────
+		 Renders when readiness is all-green (the SB-capable box can
+		 take the next step) OR when an enrollment is already in flight
+		 (so the wizard remains visible after the operator's reboot
+		 dance even if readiness now reports SB-already-on, which would
+		 hide the readiness card). The component itself decides what
+		 to show per phase. -->
+	<SecureBootEnrollmentWizard
+		visible={sbReadiness?.ready === true
+			|| (summary?.secure_boot.enabled === true)}
+		manufacturer={summary?.system?.manufacturer}
+	/>
 
 	<!-- ── DIMM detail (collapsed by default) ──────────────────────── -->
 	{#if summary && summary.memory.dimms.length > 0}

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -253,6 +253,46 @@
 					summary: 'Append-only record of every action operators take on the box.',
 					detail: 'Lives at /var/lib/nasty/audit.log (mode 0600) and is mirrored to journald with target "audit", so tampering with the file still leaves a trail. Every state-changing RPC the engine accepts is recorded with the username, client IP, method name, and a safelist-filtered parameter summary (secrets like passwords / API tokens / TLS DNS credentials never make it in). Logged in addition to mutations: every login attempt (success and failure), permission denials, terminal / VM-console / log-stream opens, and unsafe app deploys — anything an auditor would want to reconstruct after the fact. Read it via the audit.list RPC or the Logs page in the WebUI; rotated by logrotate at 10 MB.',
 				},
+				{
+					term: 'WebAuthn / Passkey / Security Key',
+					summary: 'A non-password authentication factor — Touch ID, YubiKey, Windows Hello, etc.',
+					detail: 'WebAuthn is a browser standard for proving who you are without a password. The "credential" lives on a device you control: a hardware key (YubiKey, Solo 2, Trezor — sometimes called a security key), a platform authenticator (Touch ID on a Mac, Windows Hello on a PC), or a syncable passkey (iCloud Keychain, 1Password, Bitwarden). NASty supports them as a third login backend alongside local password and SSO. Each credential is bound to one origin (a hostname like nasty.local) — moving NASty to a different hostname silently invalidates registered credentials, and IP-based access can never use them by spec. Register and manage your own under Access Control → Tokens & Keys.',
+				},
+				{
+					term: 'TPM2',
+					summary: 'A small chip on the motherboard that holds secrets and measurements.',
+					detail: 'The Trusted Platform Module v2.0 is a discrete security chip (or firmware-emulated equivalent like Intel PTT, AMD fTPM, swtpm on QEMU) that stores keys in tamper-resistant hardware and can release them only when system state matches what you sealed against. NASty uses it to "seal" the bcachefs encryption key so an encrypted filesystem can auto-unlock at boot without the operator typing a passphrase — but only when the box looks the way it did at seal time. Without a TPM2 chip the auto-unlock can\'t work; manual passphrase entry stays as a fallback.',
+				},
+				{
+					term: 'PCR (Platform Configuration Register)',
+					summary: 'TPM-internal registers that record what booted, in a way that can\'t be rewound or faked.',
+					detail: 'PCRs are 24 (or 32) hash values inside the TPM that accumulate measurements during boot. Every component — firmware, bootloader, kernel, initrd, key databases — gets hashed and "extended" into one of these registers. Once a value is extended you can\'t set it back; the only way for a PCR to read a given value is for the boot chain to produce that exact value organically. NASty seals encryption keys against specific PCRs: PCR-7 covers the Secure Boot policy (which keys the firmware trusts), so the seal opens only when the firmware is still trusting NASty\'s keys. Future work extends to PCR-4 (the bootloader + kernel binaries themselves) so the seal binds the whole boot chain, not just the policy.',
+				},
+				{
+					term: 'Secure Boot',
+					summary: 'Firmware-level signature checking on the bootloader, kernel, and initrd.',
+					detail: 'When Secure Boot is on, the UEFI firmware refuses to launch any boot artifact that isn\'t signed by a key in its trust database. NASty\'s SB integration uses lanzaboote to bundle the kernel + initrd + cmdline into a signed PE stub the firmware verifies before handing off control. Enrollment is a one-time per-box ceremony (BIOS Setup Mode → NASty\'s platform key gets installed → next reboot enforces). Once enrolled, every kernel and initrd update is auto-signed on rebuild; an attacker booting an unsigned rescue image (memtest, live USB) fails at the firmware stage. SB also strengthens TPM2 sealing — without it PCR-7 is constant across stock NixOS installs, so a sealed key would unseal anywhere. Highly experimental in NASty today; see the Hardware page.',
+				},
+				{
+					term: 'Setup Mode',
+					summary: 'A UEFI firmware state where it accepts new platform keys without an existing signing chain.',
+					detail: 'A fresh-from-factory or "PK-cleared" UEFI is in Setup Mode: PK (Platform Key) is empty, and the firmware will accept any key enrolled by the operating system without a higher-trust signature. Once a PK is enrolled the firmware leaves Setup Mode and starts enforcing the full SB chain. NASty\'s enrollment ceremony requires the operator to reset firmware to Setup Mode (via BIOS — vendor-specific path documented in the wizard) so that on the next boot, systemd-boot\'s auto-enrollment can install NASty\'s keys without needing a Microsoft-signed bridge. After enrollment, firmware exits Setup Mode automatically.',
+				},
+				{
+					term: 'Measured UKI',
+					summary: 'A Unified Kernel Image whose load is recorded into a PCR.',
+					detail: 'A UKI bundles the kernel, initrd, and command line into a single PE binary. When the firmware loads it and Secure Boot is on, the firmware records the binary\'s hash into PCR-4 — so a different kernel produces a different PCR-4 reading. lanzaboote produces measured UKIs on every NixOS rebuild; bootctl status reports "Measured UKI: yes" when this is active. This is what lets future work seal keys against PCR-4 to bind the entire boot chain (not just the SB policy in PCR-7).',
+				},
+				{
+					term: 'lanzaboote',
+					summary: 'The NixOS-native Secure Boot toolchain.',
+					detail: 'lanzaboote (https://github.com/nix-community/lanzaboote) replaces systemd-boot\'s normal install with a flow that signs every kernel + initrd + UKI for the firmware to verify. NASty pins lanzaboote v1.0.0 as a flake input and ships sbctl alongside as the read-only inspector. Pin and key management live entirely inside the NASty install — operators don\'t pick a lanzaboote rev (the protocol with sd-stub and the install-hook contract are nasty-test-matrix dependent). See the experimental Secure Boot enrollment wizard on the Hardware page.',
+				},
+				{
+					term: 'sbctl',
+					summary: 'CLI tool for inspecting Secure Boot state — keys, signatures, enrollment status.',
+					detail: 'NASty includes sbctl on the system path so operators can inspect SB state by hand (`sbctl status`, `sbctl verify`, `sbctl list-enrolled-keys`). The engine itself uses it as a read-only inspector — signing and key enrollment go through lanzaboote, never direct sbctl writes. Run it from a terminal if you want raw vendor / key-fingerprint data the WebUI doesn\'t surface.',
+				},
 			],
 		},
 		{


### PR DESCRIPTION
PR #2 from ADR 0001 — turns the lanzaboote foundation (#325) + the
readiness probe (#326) into a usable per-box enrollment ceremony.
**Highly experimental** marker on every render of the wizard;
release notes will repeat the warning.

## Engine

- New \`nasty_system::secure_boot_enrollment\` module owns the state
  machine + persistence. Phases:
  ```
  NotStarted → OverlayWritten → PostEnrollment → Complete
  ```
  plus \`Aborted\` from any pre-PostEnrollment phase. State survives
  engine restarts via \`/var/lib/nasty/secure-boot-enrollment.json\`.
- **Automatic post-enrollment detection.** On engine startup, if SB
  transitioned to enabled across a reboot, the phase advances and
  \`/var/lib/nasty/keys/*.tpm\` files are enumerated as stale bindings
  that need re-sealing under the new PCR-7.
- \`begin()\` writes \`/etc/nixos/secure-boot.nix\` with
  \`services.nasty.secureBoot.enable = true\` + lanzaboote
  \`autoEnrollKeys\` + \`autoReboot\`. Operator does \`nasty-rebuild\`
  → BIOS Setup Mode → reboot; firmware then auto-enrolls.
- \`abort()\` removes the overlay and parks state in \`Aborted\` with
  a reason. **Refused once SB is enrolled** (PostEnrollment or
  Complete) — only a BIOS visit can undo firmware enrollment.
- RPCs: \`system.secure_boot.enrollment.{status, begin, abort,
  complete}\`. \`status\` in the read-only allowlist; the mutating
  three are admin-only.

## Wrapper template

- Optional \`./secure-boot.nix\` import (same \`pathExists\` pattern
  passthrough.nix uses). Engine writes that file during enrollment;
  stays absent on every box that never starts the ceremony.

## WebUI

New \`SecureBootEnrollmentWizard.svelte\` component on the Hardware
page, below the readiness card. Polls \`enrollment.status\` every
5 s so a phase transition (operator's BIOS dance + reboot) shows up
without manual refresh.

**Per-vendor BIOS hints** matched on DMI manufacturer string:

| Vendor match | Hint |
|---|---|
| Supermicro | DEL → Security → Secure Boot → Erase All Secure Boot Settings |
| ASRock Rack | DEL → Security → Secure Boot → Key Management → Reset to Setup Mode |
| ASUS | DEL → F7 (Advanced) → Boot → Secure Boot → Key Management → Clear Secure Boot Keys |
| Gigabyte | DEL → Boot → Secure Boot → PK Management → Delete PK |
| Lenovo | F1 → Security → Secure Boot → Reset to Setup Mode |
| Framework | F2 → Security → Erase all Secure Boot Settings (some batches buggy) |
| Dell | F2 → System Security → Secure Boot → Custom Mode → Delete PK |
| HPE / HP | F9 → System Configuration → BIOS/Platform → Secure Boot → Reset to Setup Mode |

**Generic block always rendered** alongside vendor hint so an
operator on weird hardware or a version skew has the fallback in
the same place.

**"Abort still possible" indicator** on the OverlayWritten step,
with a clear callout that the next reboot into Setup Mode is the
firmware-level point of no return.

**EXPERIMENTAL badge** in the card header + warning banner every
render. Backup-your-keys reminder in the banner.

## Out of scope (deliberate)

- Driving the rebuild from the engine — operator runs
  \`nasty-rebuild\` between phases. Update-page-style detached
  rebuild integration is a follow-up; this PR keeps the operator
  in the loop on the actual rebuild command.
- PCR-7 drift detection for fwupd dbx updates (ADR PR #3 / later).
- Automatic re-seal — wizard links to the existing per-FS Bind to
  TPM button on \`/filesystems\` rather than re-implementing the
  flow.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] 236 nasty-system tests pass (3 new for the module)
- [x] \`npm run check\` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on a real SB-capable NASty:
  - Click Begin → overlay file appears, phase = OverlayWritten
  - Run \`nasty-rebuild\` → lanzaboote-signed artifacts on ESP
  - Enter BIOS Setup Mode → reboot → firmware auto-enrolls
  - Engine detects SB transition on startup → phase = PostEnrollment
  - Stale TPM bindings list correct, links go to /filesystems
  - Re-bind each from /filesystems → click Complete
- [ ] Manual abort path: Begin → Abort → overlay removed, phase = Aborted
- [ ] Manual on a non-SB box (no readiness): wizard not rendered

## Release notes copy (draft)

> **Secure Boot enrollment (experimental).** NASty now ships an
> end-to-end wizard for enabling lanzaboote-backed UEFI Secure
> Boot from the Hardware page. The flow is highly experimental
> — it involves a per-box BIOS visit to put firmware in Setup
> Mode, and recovery from a bad enrollment requires physical
> or IPMI access. Back up your bcachefs encryption keys before
> running the ceremony. Operators on Supermicro / ASRock Rack /
> ASUS / Gigabyte / Lenovo / Framework / Dell / HPE hardware
> get per-vendor BIOS hints; a generic fallback is always
> shown.