### PR TITLE
boot: gate memtest86+ menu entry on x86 (fixes aarch64 rebuild)

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -15,17 +15,26 @@
   # the ESP, no closure-size impact on boxes that never boot into
   # it — but when an operator needs it (flaky RAM, ECC errors, post-
   # hardware-change sanity check) it's right there in the boot
-  # menu instead of requiring a USB stick. Works on x86_64 and
-  # aarch64; the systemd-boot module silently no-ops on architectures
-  # without a memtest86+ build available.
+  # menu instead of requiring a USB stick.
+  #
+  # Gated on x86 because nixpkgs's memtest86+ package declares
+  # `meta.platforms = [ "x86_64-linux" "i686-linux" ]` only — and
+  # the systemd-boot module does NOT silently skip platforms it
+  # can't satisfy, despite earlier comments here implying it would.
+  # Setting `memtest86.enable = true` on aarch64 triggers a hard
+  # eval failure ("Refusing to evaluate package 'memtest86+-8.00'
+  # because it is not available on the requested hostPlatform").
+  # The `pkgs.stdenv.hostPlatform.isx86` check makes the option
+  # value depend on architecture: true on x86_64 / i686, false on
+  # aarch64 et al.
   #
   # Note for future Secure Boot work: memtest86+ isn't signed by
   # NASty's keys, so under SB it will refuse to launch. The
-  # systemd-boot module documents that the entry stays visible but
-  # the boot attempt fails; that's acceptable since SB-protected
-  # boxes are the ones where memtest's "unsigned-but-trusted" model
-  # doesn't fit anyway.
-  boot.loader.systemd-boot.memtest86.enable = true;
+  # systemd-boot module keeps the entry visible but the boot
+  # attempt fails; that's acceptable since SB-protected boxes are
+  # the ones where memtest's "unsigned-but-trusted" model doesn't
+  # fit anyway.
+  boot.loader.systemd-boot.memtest86.enable = pkgs.stdenv.hostPlatform.isx86;
   boot.loader.efi.canTouchEfiVariables = true;
 
   networking.hostName = "nasty";


### PR DESCRIPTION
Reported on a real aarch64 NASty trying to rebuild on top of #330:

\`\`\`
error: Refusing to evaluate package 'memtest86+-8.00' …
  because it is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-linux"
  package.meta.platforms = [ "x86_64-linux" "i686-linux" ]
\`\`\`

My #330 comment claimed the systemd-boot module silently no-ops on
architectures without a memtest86+ build. It doesn't —
\`boot.loader.systemd-boot.memtest86.enable = true\` is unconditional
and nixpkgs refuses to evaluate the package on aarch64. Existing
aarch64 NASties can't rebuild until this lands.

## Fix

\`\`\`nix
boot.loader.systemd-boot.memtest86.enable = pkgs.stdenv.hostPlatform.isx86;
\`\`\`

On x86_64 / i686: nothing changes — the entry appears in the
systemd-boot menu as before. On aarch64 / other arches: option
resolves to false, nixpkgs never tries to evaluate the package,
rebuild succeeds without the menu entry (which they didn't have
anyway under the old config — they just couldn't build).

Comment block corrected so the next person reading the file
doesn't repeat the original mistaken assumption.

## Test plan

- [x] \`nix-instantiate --parse\` clean
- [ ] Manual on aarch64 NASty: \`nasty-rebuild\` succeeds
- [ ] Manual on x86_64 NASty: rebuild succeeds, memtest entry still in boot menu