### PR TITLE
firmware: gate apply path when Secure Boot is enforcing

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -259,6 +259,7 @@ fn is_read_only(method: &str) -> bool {
                 | "vm.capabilities"
                 | "vm.images.import_info"
                 | "firmware.available"
+                | "firmware.constraints"
                 | "firmware.check"
                 | "firmware.devices"
                 | "notifications.config.get"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -579,6 +579,7 @@ pub(super) async fn try_route(
             Err(e) => invalid(req, e),
         },
         "firmware.available" => ok(req, state.firmware.is_available().await),
+        "firmware.constraints" => ok(req, state.firmware.constraints().await),
         "firmware.devices" => ok(req, state.firmware.list_devices().await),
         "firmware.check" => ok(req, state.firmware.check_updates().await),
         "firmware.update" => match require_str(req, "device_id") {

--- a/engine/nasty-system/src/firmware.rs
+++ b/engine/nasty-system/src/firmware.rs
@@ -36,6 +36,29 @@ pub struct FirmwareUpdateResult {
     pub reboot_required: bool,
 }
 
+/// Constraints on firmware updates from the surrounding system —
+/// today, just whether Secure Boot is blocking the apply path.
+/// Returned by `firmware.constraints` so the WebUI can disable the
+/// per-row Apply button (with an explanatory tooltip) instead of
+/// letting the operator click and surface the error in a toast.
+///
+/// SB-blocking exists because of upstream lanzaboote#591: the
+/// EFI-capsule shim fwupd uses to apply updates can't be launched
+/// from a lanzaboote-managed boot chain under enforcing Secure Boot.
+/// Listing devices / refreshing metadata still works — only the
+/// final `fwupdmgr update` step breaks.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct FirmwareConstraints {
+    /// True when the engine has detected Secure Boot is enforcing.
+    /// The Apply UI surfaces a banner + per-row disable when set;
+    /// `firmware.update` itself rejects the call as well.
+    pub sb_blocks_apply: bool,
+    /// Operator-facing reason string, suitable for surfacing
+    /// verbatim in a tooltip or banner. Empty when
+    /// `sb_blocks_apply` is false (the WebUI hides the banner).
+    pub sb_blocks_apply_reason: String,
+}
+
 pub struct FirmwareService;
 
 impl Default for FirmwareService {
@@ -152,7 +175,52 @@ impl FirmwareService {
     }
 
     /// Apply a firmware update to a specific device.
+    /// Snapshot of update-blocking constraints. Today only Secure
+    /// Boot is in play (upstream lanzaboote#591 breaks fwupd's
+    /// capsule-apply path); future constraints — pending reboot
+    /// already queued, disk-space gates, etc. — would slot in
+    /// here so the WebUI gets them in one call.
+    pub async fn constraints(&self) -> FirmwareConstraints {
+        let sb = nasty_common::secure_boot::status().await;
+        if sb.enabled == Some(true) {
+            FirmwareConstraints {
+                sb_blocks_apply: true,
+                sb_blocks_apply_reason:
+                    "Firmware updates can't be applied while Secure Boot is enforcing — \
+                     fwupd's EFI-capsule shim isn't compatible with lanzaboote's \
+                     boot chain (upstream issue lanzaboote#591). Disable Secure \
+                     Boot in firmware to apply updates, then re-enroll afterward."
+                        .to_string(),
+            }
+        } else {
+            FirmwareConstraints {
+                sb_blocks_apply: false,
+                sb_blocks_apply_reason: String::new(),
+            }
+        }
+    }
+
     pub async fn update_device(&self, device_id: &str) -> FirmwareUpdateResult {
+        // Belt-and-suspenders: the WebUI disables the Apply button when
+        // SB blocks updates, but a direct RPC client (curl, scripted
+        // automation) wouldn't see that gate. Refuse here too with the
+        // same message so the failure mode is consistent and the
+        // operator doesn't waste time chasing a fwupd error that's
+        // actually upstream-broken.
+        let constraints = self.constraints().await;
+        if constraints.sb_blocks_apply {
+            warn!(
+                target: "nasty::firmware",
+                "firmware.update refused for {device_id}: Secure Boot enforcing (lanzaboote#591)"
+            );
+            return FirmwareUpdateResult {
+                device_name: device_id.to_string(),
+                success: false,
+                message: constraints.sb_blocks_apply_reason,
+                reboot_required: false,
+            };
+        }
+
         info!("Applying firmware update to device {device_id}");
 
         let output = Command::new("fwupdmgr")

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -650,6 +650,17 @@ export interface FirmwareUpdateResult {
 	reboot_required: boolean;
 }
 
+/** Returned by `firmware.constraints`. Today only Secure Boot is
+ * tracked — the EFI-capsule shim fwupd uses to apply updates
+ * doesn't work under enforcing SB (upstream lanzaboote#591), so
+ * the Apply button gates on `sb_blocks_apply` and renders the
+ * `sb_blocks_apply_reason` string verbatim in a tooltip / banner
+ * (no client-side translation; the engine owns the copy). */
+export interface FirmwareConstraints {
+	sb_blocks_apply: boolean;
+	sb_blocks_apply_reason: string;
+}
+
 export type ReleaseChannel = 'mild' | 'spicy' | 'nasty';
 
 export interface UpdateInfo {

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -9,6 +9,7 @@
 		Generation,
 		FirmwareDevice,
 		FirmwareUpdateResult,
+		FirmwareConstraints,
 		VersionInfo,
 		VersionInputInfo,
 		VersionTaggedReleaseStatus,
@@ -99,6 +100,11 @@
 	let firmwareLoading = $state(false);
 	let firmwareLoaded = $state(false);
 	let firmwareUpdating: Record<string, boolean> = $state({});
+	// Apply-side blockers (today: Secure Boot enforcing — upstream
+	// lanzaboote#591 breaks fwupd's EFI-capsule shim). Engine owns
+	// the reason string; we render it verbatim in the banner and
+	// tooltip so the wording stays consistent across surfaces.
+	let firmwareConstraints: FirmwareConstraints | null = $state(null);
 
 	const phases = [
 		{ label: 'Fetch', marker: '==> Updating local system flake' },
@@ -564,7 +570,12 @@
 		try {
 			firmwareAvailable = await client.call<boolean>('firmware.available');
 			if (firmwareAvailable) {
-				firmwareDevices = await client.call<FirmwareDevice[]>('firmware.check');
+				const [devices, constraints] = await Promise.all([
+					client.call<FirmwareDevice[]>('firmware.check'),
+					client.call<FirmwareConstraints>('firmware.constraints'),
+				]);
+				firmwareDevices = devices;
+				firmwareConstraints = constraints;
 			}
 		} catch {
 			// Ignore fwupd errors in the page shell.
@@ -1142,6 +1153,17 @@
 						</Button>
 					</div>
 
+					{#if firmwareConstraints?.sb_blocks_apply}
+						<!-- Apply path is broken under Secure Boot (upstream
+							 lanzaboote#591). Listing + check still work, so
+							 the table renders normally; only the Apply button
+							 is replaced with a tooltip explaining why. -->
+						<div class="mb-4 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+							<strong>Firmware apply is blocked.</strong>
+							<div class="mt-1">{firmwareConstraints.sb_blocks_apply_reason}</div>
+						</div>
+					{/if}
+
 					{#if firmwareDevices.length === 0}
 						<p class="text-sm text-muted-foreground">No firmware-capable devices detected.</p>
 					{:else}
@@ -1173,7 +1195,14 @@
 										</td>
 										<td class="p-3">
 											{#if dev.update_available}
-												<Button size="xs" onclick={() => updateFirmware(dev.device_id)} disabled={firmwareUpdating[dev.device_id]}>
+												<Button
+													size="xs"
+													onclick={() => updateFirmware(dev.device_id)}
+													disabled={firmwareUpdating[dev.device_id] || firmwareConstraints?.sb_blocks_apply}
+													title={firmwareConstraints?.sb_blocks_apply
+														? firmwareConstraints.sb_blocks_apply_reason
+														: undefined}
+												>
 													{firmwareUpdating[dev.device_id] ? 'Updating...' : 'Update'}
 												</Button>
 											{/if}


### PR DESCRIPTION
Resolves the TODO left in \`nasty-secure-boot.nix\` (#331).

fwupd's EFI-capsule shim can't be launched from a lanzaboote-managed
boot chain under enforcing Secure Boot — upstream
[lanzaboote#591](https://github.com/nix-community/lanzaboote/issues/591).
Listing devices and refreshing metadata still works, so the Firmware
section of the Update page renders as before; only the Apply step
is gated.

## Engine

- New \`firmware.constraints\` RPC returning
  \`{ sb_blocks_apply, sb_blocks_apply_reason }\`. Engine owns the
  operator-facing reason string so wording stays consistent across
  banner, tooltip, and defensive RPC refusal.
- \`firmware.update\` precheck refuses with the same reason when SB
  blocks apply — defense in depth so a scripted client (curl,
  automation) gets the same explicit refusal the WebUI button does.
- \`firmware.constraints\` in the read-only allowlist so the Update
  page (rendered to any authenticated user) can poll it without a
  role gate.

## WebUI

- \`FirmwareConstraints\` interface in \`types.ts\`.
- Update page's \`loadFirmware()\` fetches devices + constraints in
  parallel.
- When \`sb_blocks_apply\` is true:
  - Amber banner above the device table with the engine's reason
    string verbatim.
  - Per-row Update buttons disabled + \`title=\` carries the reason
    on hover.
- When false: behaviour identical to before.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --all-targets --no-deps -- -D warnings\`
- [x] \`npm run check\` 0 errors / 0 warnings, 126 vitest pass, build clean
- [ ] Manual on .74 (SB enforcing): Update page → firmware section
  shows the banner; per-row Update buttons disabled with tooltip
- [ ] Manual on .20.100 (SB off): Update page unchanged
- [ ] Manual via direct RPC: \`firmware.update\` with SB on returns
  \`success=false\` + the reason string instead of running fwupdmgr