### PR TITLE
engine: telemetry reports version, commit, vms, apps, arch

### DIFF
--- a/engine/nasty-engine/src/telemetry.rs
+++ b/engine/nasty-engine/src/telemetry.rs
@@ -18,6 +18,23 @@ struct Report {
     drives: usize,
     total_bytes: u64,
     used_bytes: u64,
+    version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit: Option<String>,
+    vms: usize,
+    apps: usize,
+    arch: &'static str,
+}
+
+/// Short git SHA this engine was built from. `None` for dev cargo
+/// builds outside Nix where `NASTY_GIT_SHA` wasn't injected. Matches
+/// the 7-char form used elsewhere (see `nasty-system::update`).
+fn build_commit() -> Option<String> {
+    let raw = option_env!("NASTY_GIT_SHA")?.trim();
+    if raw.is_empty() || raw == "unknown" {
+        return None;
+    }
+    Some(raw[..7.min(raw.len())].to_string())
 }
 
 /// Get or create the persistent instance ID.
@@ -66,11 +83,19 @@ async fn collect_report(state: &AppState) -> Option<Report> {
         used_bytes += fs.used_bytes;
     }
 
+    let vms = state.vms.list().await.map(|v| v.len()).unwrap_or(0);
+    let apps = state.apps.list().await.map(|a| a.len()).unwrap_or(0);
+
     Some(Report {
         instance_id: id,
         drives,
         total_bytes,
         used_bytes,
+        version: env!("CARGO_PKG_VERSION"),
+        commit: build_commit(),
+        vms,
+        apps,
+        arch: std::env::consts::ARCH,
     })
 }
 
@@ -87,8 +112,15 @@ pub async fn send_report(state: &AppState) -> bool {
     };
 
     debug!(
-        "Sending telemetry: drives={}, total={}B, used={}B",
-        report.drives, report.total_bytes, report.used_bytes
+        "Sending telemetry: drives={}, total={}B, used={}B, vms={}, apps={}, arch={}, version={}, commit={:?}",
+        report.drives,
+        report.total_bytes,
+        report.used_bytes,
+        report.vms,
+        report.apps,
+        report.arch,
+        report.version,
+        report.commit
     );
 
     match state


### PR DESCRIPTION
## Summary
- `Report` struct in `nasty-engine/src/telemetry.rs` gains five new fields so the project dashboard can answer real questions about the deployed fleet.
- `version` = `CARGO_PKG_VERSION` (compile-time `env!`).
- `commit` = `option_env!(NASTY_GIT_SHA)`, trimmed to 7 chars; `None` for dev cargo builds outside Nix (where the env isn't injected). `mkEngine` in `flake.nix` already supplies the SHA for all Nix builds.
- `vms`, `apps` = lengths of `state.vms.list()` / `state.apps.list()`, 0 on error.
- `arch` = `std::env::consts::ARCH`.
- Follows the same source-of-truth rule used by engine self-version: embed at compile time, never read back through booted-system or lock-file chains that can lag activation.

The wire fields are optional (`commit` uses `skip_serializing_if`; worker accepts payloads without any of the new fields), so an old engine and a new worker — or vice versa — keep working through rollout.

Companion worker/dashboard PR: nasty-project/nasty-telemetry `telemetry-expand-payload`. That PR must merge first so the D1 schema has the new columns before engines start sending them.

## Test plan
- [ ] `cargo build` succeeds.
- [ ] `cargo clippy --workspace --all-targets --no-deps` clean (per `--all-targets` invariant).
- [ ] Nix engine build: `flake.nix`'s `NASTY_GIT_SHA` env propagates so `option_env!("NASTY_GIT_SHA")` resolves and `commit` is populated.
- [ ] On a test box, enable debug logs and confirm the "Sending telemetry: …" line shows the new fields with sensible values for the box's VM/app inventory.
- [ ] Companion worker PR merged and deployed first; this engine PR's first report round-trips through `/api/report` cleanly and shows up on the dashboard.