### PR TITLE
secure_boot: readiness probe is read-only, not admin-only

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -194,6 +194,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.hardware.iommu"
                 | "system.hardware.summary"
                 | "system.secure_boot.enrollment.status"
+                | "system.secure_boot.readiness"
                 | "system.passthrough.get"
                 | "system.stats"
                 | "system.disks"


### PR DESCRIPTION
## Summary

`system.secure_boot.readiness` (added in #326) was missing from the `is_read_only` allowlist in `engine/nasty-engine/src/router/mod.rs`. Its name doesn't match the `.list` / `.get` / `.status` suffix heuristic, so the role check fell through to admin-only — Operator and ReadOnly users hit Permission denied when the Hardware page polled it.

The WebUI catches that error silently (`webui/src/routes/hardware/+page.svelte:102` — `} catch { sbReadiness = null; }`) and just renders no checklist, so the bug is invisible from the operator's side. They see a Hardware page where the SB section never appears, with no hint that it's a permission problem rather than "the probe didn't apply to my hardware".

One-line fix: add the method alongside the other Hardware-page probes that already live in the explicit allowlist (`system.hardware.iommu`, `system.hardware.summary`, `system.secure_boot.enrollment.status`). Same pattern, same audience.

Surfaced while auditing role assignments of methods added since v0.0.8.

## Test plan

- [ ] `cargo build` + `cargo clippy --workspace --all-targets --no-deps` clean.
- [ ] On a SB-capable box, log in as a ReadOnly user, open the Hardware page, confirm the SB checklist now renders (where it didn't before).
- [ ] Same page as Admin: behaviour unchanged.
- [ ] Existing role tests still pass (no new tests — single allowlist entry, parallels three existing identically-classified methods).