### PR TITLE
flake: send identifying User-Agent on fetchurl (crates.io 403 workaround)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,30 @@
   };
 
   outputs = { self, nixpkgs, bcachefs-tools, lanzaboote, ... }: let
-    # Helper to build packages for a given system
-    mkPkgs = system: nixpkgs.legacyPackages.${system};
+    # Helper to build packages for a given system.
+    #
+    # The overlay wraps `fetchurl` so every curl invocation sends an
+    # identifying User-Agent. crates.io enforces its long-standing
+    # crawler policy (https://crates.io/policies) by rejecting
+    # unidentifying UAs — `curl/X.Y.Z` is on the blocklist as of early
+    # 2026, which makes `rustPlatform.importCargoLock` fail with HTTP
+    # 403 for any crate tarball not already in the binary cache.
+    # nixpkgs has a fix in flight (NixOS/nixpkgs#512735) but it will
+    # take weeks to propagate; until then this overlay keeps every
+    # PR that bumps a crate version unblocked.
+    #
+    # The UA matches the policy's recommended shape
+    # (`appname (contact)`) so we don't need to dodge enforcement
+    # again next time it tightens.
+    mkPkgs = system: import nixpkgs {
+      inherit system;
+      overlays = [ (final: prev: {
+        fetchurl = args: prev.fetchurl (args // {
+          curlOptsList = (args.curlOptsList or []) ++
+            [ "-A" "nasty-engine-build (github.com/nasty-project/nasty)" ];
+        });
+      }) ];
+    };
     nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
     rootLock = builtins.fromJSON (builtins.readFile ./flake.lock);
     installerNastyOwner = "nasty-project";

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,19 @@
     mkPkgs = system: import nixpkgs {
       inherit system;
       overlays = [ (final: prev: {
-        fetchurl = args: prev.fetchurl (args // {
-          curlOptsList = (args.curlOptsList or []) ++
-            [ "-A" "nasty-engine-build (github.com/nasty-project/nasty)" ];
-        });
+        fetchurl = args:
+          # Guard with isAttrs because some callers in nixpkgs (e.g.
+          # makeOverridable wrappers / callPackage auto-call) pass a
+          # function-shaped value here at evaluation time; only
+          # actual fetch requests (attribute sets carrying url + hash)
+          # get the User-Agent injection.
+          if builtins.isAttrs args then
+            prev.fetchurl (args // {
+              curlOptsList = (args.curlOptsList or []) ++
+                [ "-A" "nasty-engine-build (github.com/nasty-project/nasty)" ];
+            })
+          else
+            prev.fetchurl args;
       }) ];
     };
     nasty-version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;


### PR DESCRIPTION
## Summary

crates.io has long had a [crawler policy](https://crates.io/policies) requiring an identifying `User-Agent` header. The policy was formalised in [RFC 3463](https://rust-lang.github.io/rfcs/3463-crates-io-policy-update.html). What changed early 2026 is **enforcement**: the default `curl/X.Y.Z` UA that Nix's `fetchurl` sends started getting actively rejected with `HTTP 403`, alongside default `python-requests/*` ([rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482)).

The bite is silent on `main` because the Nix binary cache covers every crate that's been built before — only PRs that introduce a *new* crate version hit a live crates.io download and fail. PR #336 (`http`/`jiff` patch bump) tripped it; every future dep bump will too until this is fixed.

This overlay wraps `pkgs.fetchurl` so every curl invocation appends an identifying UA of the shape the policy [recommends](https://crates.io/policies) (`appname (contact)`). It's an umbrella workaround until [NixOS/nixpkgs#512735](https://github.com/NixOS/nixpkgs/pull/512735) — which addresses `fetchCargoVendor` directly — propagates through our channel (estimated weeks).

After this lands, retrying #336's CI run should turn the Nix engine job green.

## Test plan

- [x] `nix flake check --no-build` — all outputs evaluate clean.
- [ ] CI Nix engine build on this PR — passes (the binary cache will serve everything anyway, but at least confirms the overlay doesn't break eval at build time).
- [ ] Rerun #336's failed Nix engine job after this lands — `http 1.4.1`, `jiff 0.2.27`, `jiff-static 0.2.27` tarballs fetch successfully.
- [ ] Manual sanity: in the CI logs for any subsequent build that hits crates.io live, confirm no more `curl: (22) ... error: 403`.

## Risks / scope

- The overlay touches every `fetchurl` call, not just `rustPlatform.importCargoLock`. Effect on other fetchers: they get a `-A "nasty-engine-build (...)"` appended, which servers almost universally ignore. The one corner is fetchers that deliberately set their own UA — curl uses the last `-A`, so ours would override theirs. No known callers in our derivation tree do that, but worth knowing.
- Remove this overlay once nixpkgs#512735 propagates so we're not maintaining a workaround past its shelf life.