### PR TITLE
nixos/caddy: refresh withPlugins FOD hash (unblocks v0.0.9 ISO build)

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1857,7 +1857,7 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=";
+        hash = "sha256-DdsEXZczcIgqazKCGebEVrDJ6jEZM1AHZkvJAPAAA9U=";
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
## Summary

The v0.0.9 ISO build ([run #26645763270](https://github.com/nasty-project/nasty/actions/runs/26645763270)) failed at `Caddyfile-formatted.drv` with:

\`\`\`
error: hash mismatch in fixed-output derivation 'caddy-src-with-plugins-…-2.11.3.drv':
         specified: sha256-xwtaYTcoX0ZfAdfNiJG9b3zZrwH9aVhwJoxdDtgtQKU=
            got:    sha256-DdsEXZczcIgqazKCGebEVrDJ6jEZM1AHZkvJAPAAA9U=
\`\`\`

Plugin list at `nixos/modules/nasty.nix:1842-1859` is unchanged from v0.0.8 (which built clean on 2026-05-22), and the Caddy version embedded in the drv name is still `2.11.3`. The drift is from this cycle's nixpkgs auto-bump (#319) — `pkgs.caddy.withPlugins` in the newer nixpkgs computes a slightly different FOD hash for the same plugin set, almost certainly a Go module proxy / metadata byte difference.

Fix is exactly what the comment block at line 1838-1840 prescribes for this situation: paste the hash that Nix's error message reported. One line.

After this lands, re-tag v0.0.9 to point at the merge commit, then re-dispatch [Build NASty ISO](https://github.com/nasty-project/nasty/actions/workflows/build-iso.yml) with `ref=v0.0.9`.

## Test plan

- [x] Diff is the single `hash =` line; comment block already documents the procedure.
- [ ] CI Nix engine build green (it uses the same Caddy derivation transitively).
- [ ] Post-merge: re-tag + re-dispatch the ISO workflow; x86_64 and aarch64 ISOs build and publish to the GitHub release for v0.0.9.