### PR TITLE
secure_boot: lanzaboote is truly per-box opt-in (unblocks v0.0.9 ISO)

### DIFF
--- a/engine/nasty-system/src/secure_boot_enrollment.rs
+++ b/engine/nasty-system/src/secure_boot_enrollment.rs
@@ -316,7 +316,8 @@ impl SecureBootEnrollmentService {
         // update prunes it). Surface the failure so the wizard can
         // show it, but don't bounce the abort back — the operator's
         // intent (cancel) succeeded at the SB-config level.
-        if let Err(e) = crate::update::remove_lanzaboote_input_from_wrapper(WRAPPER_FLAKE_PATH).await
+        if let Err(e) =
+            crate::update::remove_lanzaboote_input_from_wrapper(WRAPPER_FLAKE_PATH).await
         {
             warn!(
                 target: "nasty::secure_boot_enrollment",

--- a/engine/nasty-system/src/secure_boot_enrollment.rs
+++ b/engine/nasty-system/src/secure_boot_enrollment.rs
@@ -60,6 +60,8 @@ const REBUILD_UNIT: &str = "nasty-secureboot-rebuild";
 const STATE_PATH: &str = "/var/lib/nasty/secure-boot-enrollment.json";
 const STATE_DIR: &str = "/var/lib/nasty";
 const NIX_OVERLAY_PATH: &str = "/etc/nixos/secure-boot.nix";
+const WRAPPER_FLAKE_PATH: &str = "/etc/nixos/flake.nix";
+const NIXOS_FLAKE_DIR: &str = "/etc/nixos";
 const NASTY_KEYS_DIR: &str = "/var/lib/nasty/keys";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -240,6 +242,29 @@ impl SecureBootEnrollmentService {
             }
         }
         write_overlay_file().await?;
+        // Lanzaboote is per-box opt-in: the wrapper-flake template
+        // does NOT declare it. Inject it now (and lock it below) so
+        // the upcoming `nasty-rebuild` can actually evaluate
+        // `boot.lanzaboote.*` options. If injection or lock fails,
+        // roll the overlay back so the box doesn't end up half-
+        // configured (overlay says "enable SB" but the input that
+        // provides the option space is missing → eval error on
+        // rebuild). Rollback is best-effort; if it fails the
+        // operator sees the original error and a stale overlay,
+        // which `abort()` can clean up.
+        if let Err(e) = crate::update::add_lanzaboote_input_to_wrapper(WRAPPER_FLAKE_PATH).await {
+            let _ = remove_overlay_file().await;
+            return Err(EnrollmentError::Io(format!(
+                "inject lanzaboote input into wrapper: {e}"
+            )));
+        }
+        if let Err(e) = run_nix_flake_lock().await {
+            let _ = crate::update::remove_lanzaboote_input_from_wrapper(WRAPPER_FLAKE_PATH).await;
+            let _ = remove_overlay_file().await;
+            return Err(EnrollmentError::Io(format!(
+                "lock lanzaboote input (network required): {e}"
+            )));
+        }
         // Best-effort: clear any leftover systemd unit state from a
         // previous ceremony so the new ceremony's rebuild snapshot
         // starts from `not_run`. Ignored on failure (unit may not
@@ -284,6 +309,22 @@ impl SecureBootEnrollmentService {
             }
         }
         remove_overlay_file().await?;
+        // Strip the lanzaboote input that `begin()` injected. Best-
+        // effort: a failure here leaves the input declaration in
+        // place but the overlay gone, so SB stays off (the lanzaboote
+        // closure remains in the lock until the next operator-driven
+        // update prunes it). Surface the failure so the wizard can
+        // show it, but don't bounce the abort back — the operator's
+        // intent (cancel) succeeded at the SB-config level.
+        if let Err(e) = crate::update::remove_lanzaboote_input_from_wrapper(WRAPPER_FLAKE_PATH).await
+        {
+            warn!(
+                target: "nasty::secure_boot_enrollment",
+                "abort: failed to strip lanzaboote input from wrapper: {e} \
+                 (overlay removed, SB will not engage on next rebuild — \
+                 lanzaboote lock entries persist until next update)"
+            );
+        }
         let new_state = EnrollmentState {
             phase: EnrollmentPhase::Aborted {
                 aborted_at: unix_now(),
@@ -475,6 +516,33 @@ async fn remove_overlay_file() -> Result<(), EnrollmentError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e.into()),
     }
+}
+
+/// Run `nix flake lock` against the wrapper at `/etc/nixos`. Used
+/// after injecting the lanzaboote input so the new declaration
+/// actually pulls a locked rev (and its transitive deps) into
+/// `/etc/nixos/flake.lock`. Network-bound — fails when the box is
+/// offline; the caller surfaces the failure to the operator.
+async fn run_nix_flake_lock() -> Result<(), EnrollmentError> {
+    let out = Command::new("nix")
+        .args([
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "flake",
+            "lock",
+            NIXOS_FLAKE_DIR,
+        ])
+        .output()
+        .await
+        .map_err(|e| EnrollmentError::Io(format!("spawn nix flake lock: {e}")))?;
+    if !out.status.success() {
+        return Err(EnrollmentError::Io(format!(
+            "nix flake lock exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
 }
 
 /// Enumerate filesystems that currently have a `.tpm` blob in

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -2347,7 +2347,10 @@ fn inject_lanzaboote_input(content: &str) -> Result<String, UpdateError> {
         // (single-line `inputs = { ... };`) we fall back to
         // inserting just before the `}` — produces ugly formatting
         // but stays correct.
-        let insert_at = content[..end - 1].rfind('\n').map(|n| n + 1).unwrap_or(end - 1);
+        let insert_at = content[..end - 1]
+            .rfind('\n')
+            .map(|n| n + 1)
+            .unwrap_or(end - 1);
         let mut out = String::with_capacity(content.len() + LANZABOOTE_INPUT_BLOCK.len());
         out.push_str(&content[..insert_at]);
         out.push_str(LANZABOOTE_INPUT_BLOCK);
@@ -2366,9 +2369,7 @@ fn strip_lanzaboote_input(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.split_inclusive('\n') {
         let trimmed = line.trim_start();
-        if trimmed.starts_with("lanzaboote.url")
-            || trimmed.starts_with("lanzaboote.inputs.")
-        {
+        if trimmed.starts_with("lanzaboote.url") || trimmed.starts_with("lanzaboote.inputs.") {
             continue;
         }
         out.push_str(line);

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -25,6 +25,13 @@ const UPDATE_UNIT: &str = "nasty-update";
 const LOCAL_FLAKE_TARGET: &str = "/etc/nixos#nasty";
 const LOCAL_REPO: &str = "/etc/nixos";
 const NIXOS_FLAKE_DIR: &str = "/etc/nixos";
+/// Per-box opt-in Secure Boot overlay written by the SB enrollment
+/// ceremony (see `secure_boot_enrollment`). Its on-disk presence is
+/// the signal that the wrapper-flake should also carry a lanzaboote
+/// input — `wrapper_is_canonical_shape` rejects either-or drift,
+/// `migrate_wrapper_to_canonical_shape` reconciles by re-injecting
+/// lanzaboote during a re-render when the overlay is present.
+const SECURE_BOOT_OVERLAY_PATH: &str = "/etc/nixos/secure-boot.nix";
 const UPDATE_WEBUI_CHANGED: &str = "/var/lib/nasty/update-webui-changed";
 const RELEASE_CHANNEL_PATH: &str = "/var/lib/nasty/release-channel";
 const DEFAULT_NASTY_OWNER: &str = "nasty-project";
@@ -604,11 +611,15 @@ impl UpdateService {
         let current = tokio::fs::read_to_string(&path)
             .await
             .map_err(|e| UpdateError::CommandFailed(format!("read {path}: {e}")))?;
-        if wrapper_is_canonical_shape(&current) {
+        let overlay_present = tokio::fs::try_exists(SECURE_BOOT_OVERLAY_PATH)
+            .await
+            .unwrap_or(false);
+        if wrapper_is_canonical_shape(&current, overlay_present) {
             return Ok(false);
         }
         let local_system = detect_local_system().await?;
-        let migrated = migrate_wrapper_to_canonical_shape(&current, &local_system).await?;
+        let migrated =
+            migrate_wrapper_to_canonical_shape(&current, &local_system, overlay_present).await?;
         tokio::fs::write(&path, &migrated)
             .await
             .map_err(|e| UpdateError::CommandFailed(format!("write {path}: {e}")))?;
@@ -2080,14 +2091,17 @@ fn render_system_flake_template_with_ref(
 
 /// Whether the wrapper is in the canonical 0.0.9 shape:
 /// `nixpkgs.follows = "nasty/nixpkgs"` (no `.url`) AND
-/// `bcachefs-tools.url = "..."` (no `.follows`).
+/// `bcachefs-tools.url = "..."` (no `.follows`) AND lanzaboote's
+/// presence matches the SB overlay's presence (declared iff
+/// `secure-boot.nix` exists on disk, since lanzaboote is engine-
+/// injected per-box at enrollment).
 ///
-/// Returns true when both invariants hold, OR when the content
+/// Returns true when all invariants hold, OR when the content
 /// fails to parse, OR when no inputs are declared at all. The two
 /// "can't reason" cases are conservative on purpose: don't rewrite
 /// a wrapper we can't make sense of, leave operator customizations
 /// alone.
-fn wrapper_is_canonical_shape(content: &str) -> bool {
+fn wrapper_is_canonical_shape(content: &str, overlay_present: bool) -> bool {
     let Ok(urls) = parse_flake_input_urls(content) else {
         return true;
     };
@@ -2102,6 +2116,14 @@ fn wrapper_is_canonical_shape(content: &str) -> bool {
     }
     // bcachefs-tools must have a .url.
     if !urls.contains_key("bcachefs-tools") {
+        return false;
+    }
+    // Lanzaboote must be present iff the SB overlay is on disk.
+    // Drift in either direction (overlay without input, or input
+    // without overlay) is non-canonical and needs reconciliation
+    // by `migrate_wrapper_to_canonical_shape`.
+    let lanzaboote_present = urls.contains_key("lanzaboote");
+    if overlay_present != lanzaboote_present {
         return false;
     }
     true
@@ -2136,8 +2158,9 @@ fn wrapper_is_canonical_shape(content: &str) -> bool {
 async fn migrate_wrapper_to_canonical_shape(
     current_content: &str,
     local_system: &str,
+    overlay_present: bool,
 ) -> Result<String, UpdateError> {
-    if wrapper_is_canonical_shape(current_content) {
+    if wrapper_is_canonical_shape(current_content, overlay_present) {
         return Ok(current_content.to_string());
     }
     let urls = parse_flake_input_urls(current_content)?;
@@ -2188,13 +2211,169 @@ async fn migrate_wrapper_to_canonical_shape(
     // upgrade_tagged_release and version_switch.
     let rendered =
         render_system_flake_template_with_ref(EMBEDDED_WRAPPER_TEMPLATE, &nasty_ref, local_system)?;
-    rewrite_flake_input_urls(
+    let after_bcachefs = rewrite_flake_input_urls(
         &rendered,
         &HashMap::from([(
             String::from("bcachefs-tools"),
             format!("github:koverstreet/bcachefs-tools/{bcachefs_ref}"),
         )]),
-    )
+    )?;
+    // Lanzaboote reconciliation: the wrapper template no longer
+    // declares lanzaboote unconditionally (per-box opt-in — engine
+    // injects on enrollment, strips on abort). If the SB overlay is
+    // present on this box, re-inject the input here so a re-render
+    // doesn't strip the enrolled box's SB stack out from under it.
+    // If the overlay is absent and a stale lanzaboote.url somehow
+    // survives from an earlier wrapper shape, the freshly-rendered
+    // template won't carry it forward (the template's inputs block
+    // has no lanzaboote line to preserve). So the symmetric "strip
+    // when no overlay" branch is implicit in the render itself.
+    if overlay_present {
+        inject_lanzaboote_input(&after_bcachefs)
+    } else {
+        Ok(after_bcachefs)
+    }
+}
+
+/// Lanzaboote input lines as injected into the wrapper-flake
+/// `inputs` block by `add_lanzaboote_input_to_wrapper`. Pinned to
+/// `v1.0.0` here (same rev nasty's own flake.nix pins) so the lock
+/// stays consistent across nasty/wrapper. The `.inputs.nixpkgs.follows`
+/// keeps lanzaboote on nasty's pinned nixpkgs so cachix substitution
+/// hits.
+const LANZABOOTE_INPUT_BLOCK: &str = "\
+    lanzaboote.url = \"github:nix-community/lanzaboote/v1.0.0\";\n\
+    lanzaboote.inputs.nixpkgs.follows = \"nasty/nixpkgs\";\n";
+
+/// Inject lanzaboote as a top-level flake input into the wrapper at
+/// `wrapper_path`. Called by the SecureBoot enrollment ceremony when
+/// the operator begins enrollment; pair with
+/// `remove_lanzaboote_input_from_wrapper` on abort.
+///
+/// Idempotent: returns `Ok(())` with no change when lanzaboote is
+/// already declared. Does NOT run `nix flake lock` — caller is
+/// responsible (typically immediately after this, so the lanzaboote
+/// sources actually get fetched).
+pub async fn add_lanzaboote_input_to_wrapper(wrapper_path: &str) -> Result<(), UpdateError> {
+    let content = tokio::fs::read_to_string(wrapper_path)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("read {wrapper_path}: {e}")))?;
+    let urls = parse_flake_input_urls(&content)?;
+    if urls.contains_key("lanzaboote") {
+        return Ok(());
+    }
+    let mutated = inject_lanzaboote_input(&content)?;
+    tokio::fs::write(wrapper_path, mutated)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("write {wrapper_path}: {e}")))
+}
+
+/// Strip lanzaboote from the wrapper at `wrapper_path`. Removes the
+/// `lanzaboote.url` line and any `lanzaboote.inputs.*` lines.
+/// Called by the SecureBoot enrollment ceremony on abort.
+///
+/// Idempotent: returns `Ok(())` with no change when lanzaboote is
+/// already absent. Does NOT run `nix flake lock` — the dead lock
+/// entries get pruned on the operator's next update; eager pruning
+/// here would add a network requirement to abort, which we'd rather
+/// keep best-effort.
+pub async fn remove_lanzaboote_input_from_wrapper(wrapper_path: &str) -> Result<(), UpdateError> {
+    let content = tokio::fs::read_to_string(wrapper_path)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("read {wrapper_path}: {e}")))?;
+    let urls = parse_flake_input_urls(&content)?;
+    if !urls.contains_key("lanzaboote") {
+        return Ok(());
+    }
+    let mutated = strip_lanzaboote_input(&content);
+    tokio::fs::write(wrapper_path, mutated)
+        .await
+        .map_err(|e| UpdateError::CommandFailed(format!("write {wrapper_path}: {e}")))
+}
+
+/// Locate the wrapper's `inputs = { ... };` attrset and splice the
+/// two lanzaboote lines in just before the closing brace. Uses the
+/// same rnix-based parsing as `parse_flake_input_urls` so the
+/// insertion point is robust to whatever the operator did to the
+/// inputs block (extra comments, reordering, etc.).
+fn inject_lanzaboote_input(content: &str) -> Result<String, UpdateError> {
+    let parsed = rnix::Root::parse(content);
+    if !parsed.errors().is_empty() {
+        let first = parsed.errors()[0].to_string();
+        return Err(UpdateError::CommandFailed(format!(
+            "failed to parse flake.nix: {first}"
+        )));
+    }
+    let root = parsed.tree();
+    // Find the top-level `inputs = { ... };` attrset's closing
+    // brace position. The inputs attrset is the AttrSet value of an
+    // AttrpathValue whose attrpath is literally "inputs".
+    for node in root
+        .syntax()
+        .descendants()
+        .filter_map(ast::AttrpathValue::cast)
+    {
+        let Some(attrpath) = node.attrpath() else {
+            continue;
+        };
+        let normalized_path = attrpath
+            .syntax()
+            .text()
+            .to_string()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
+        if normalized_path != "inputs" {
+            continue;
+        }
+        let Some(value) = node.value() else { continue };
+        // The value is the `{ ... }` AttrSet. We want to insert
+        // immediately before the line that holds the closing `}`,
+        // so the existing indentation of that closing-brace line
+        // stays put and the new lanzaboote lines sit at the same
+        // indent as their siblings inside the block. Inserting at
+        // `end - 1` (the `}` byte itself) would pull the
+        // closing-brace line's leading whitespace into our
+        // injection and leave `};` un-indented.
+        let range = value.syntax().text_range();
+        let end = u32::from(range.end()) as usize;
+        if content.as_bytes().get(end.wrapping_sub(1)) != Some(&b'}') {
+            return Err(UpdateError::CommandFailed(
+                "wrapper inputs block doesn't end in '}' as expected".into(),
+            ));
+        }
+        // Walk backward from the `}` to find the newline that
+        // starts the closing-brace line. If there's no newline
+        // (single-line `inputs = { ... };`) we fall back to
+        // inserting just before the `}` — produces ugly formatting
+        // but stays correct.
+        let insert_at = content[..end - 1].rfind('\n').map(|n| n + 1).unwrap_or(end - 1);
+        let mut out = String::with_capacity(content.len() + LANZABOOTE_INPUT_BLOCK.len());
+        out.push_str(&content[..insert_at]);
+        out.push_str(LANZABOOTE_INPUT_BLOCK);
+        out.push_str(&content[insert_at..]);
+        return Ok(out);
+    }
+    Err(UpdateError::CommandFailed(
+        "wrapper has no top-level `inputs = { ... }` attrset to inject into".into(),
+    ))
+}
+
+/// Strip every line that declares a lanzaboote input attribute
+/// (`lanzaboote.url`, `lanzaboote.inputs.<…>`). Pure text op — keeps
+/// surrounding whitespace and comments untouched.
+fn strip_lanzaboote_input(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("lanzaboote.url")
+            || trimmed.starts_with("lanzaboote.inputs.")
+        {
+            continue;
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 /// Check whether the upstream wrapper-flake template at the given
@@ -3330,7 +3509,7 @@ outputs = { nixpkgs, nasty, ... }: {
     fn wrapper_is_canonical_shape_accepts_canonical() {
         // The 0.0.9 canonical shape: nasty.url, nixpkgs.follows,
         // bcachefs-tools.url. nixpkgs must NOT have a .url; bcachefs
-        // MUST have one.
+        // MUST have one. No SB overlay on disk → no lanzaboote.
         let canonical = r#"{
   inputs = {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
@@ -3338,7 +3517,53 @@ outputs = { nixpkgs, nasty, ... }: {
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
   };
 }"#;
-        assert!(super::wrapper_is_canonical_shape(canonical));
+        assert!(super::wrapper_is_canonical_shape(canonical, false));
+    }
+
+    #[test]
+    fn wrapper_is_canonical_shape_accepts_canonical_with_lanzaboote_when_overlay_present() {
+        // Enrolled box: SB overlay on disk AND lanzaboote injected
+        // into the wrapper inputs. Both halves match → canonical.
+        let enrolled = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+    lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
+  };
+}"#;
+        assert!(super::wrapper_is_canonical_shape(enrolled, true));
+    }
+
+    #[test]
+    fn wrapper_is_canonical_shape_rejects_lanzaboote_without_overlay() {
+        // Lanzaboote in the wrapper but no SB overlay → drift.
+        // Migration should strip lanzaboote (the re-render won't
+        // carry it forward).
+        let drift = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+  };
+}"#;
+        assert!(!super::wrapper_is_canonical_shape(drift, false));
+    }
+
+    #[test]
+    fn wrapper_is_canonical_shape_rejects_overlay_without_lanzaboote() {
+        // SB overlay on disk but no lanzaboote input → drift.
+        // Migration should re-inject lanzaboote.
+        let drift = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        assert!(!super::wrapper_is_canonical_shape(drift, true));
     }
 
     #[test]
@@ -3352,7 +3577,7 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/main";
   };
 }"#;
-        assert!(!super::wrapper_is_canonical_shape(legacy));
+        assert!(!super::wrapper_is_canonical_shape(legacy, false));
     }
 
     #[test]
@@ -3367,14 +3592,97 @@ outputs = { nixpkgs, nasty, ... }: {
     bcachefs-tools.follows = "nasty/bcachefs-tools";
   };
 }"#;
-        assert!(!super::wrapper_is_canonical_shape(follows_both));
+        assert!(!super::wrapper_is_canonical_shape(follows_both, false));
     }
 
     #[test]
     fn wrapper_is_canonical_shape_returns_true_for_unparseable_content() {
         // Garbage in → don't claim "needs migration" and accidentally
         // rewrite whatever the operator has there. Safer default.
-        assert!(super::wrapper_is_canonical_shape("not a flake at all"));
+        assert!(super::wrapper_is_canonical_shape(
+            "not a flake at all",
+            false
+        ));
+    }
+
+    // ── lanzaboote injection / stripping (per-box opt-in SB) ────────
+
+    #[test]
+    fn inject_lanzaboote_input_adds_both_lines_before_closing_brace() {
+        let wrapper = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        let out = super::inject_lanzaboote_input(wrapper).expect("inject");
+        assert!(out.contains("lanzaboote.url = \"github:nix-community/lanzaboote/v1.0.0\""));
+        assert!(out.contains("lanzaboote.inputs.nixpkgs.follows = \"nasty/nixpkgs\""));
+        // Pre-existing inputs must still be there.
+        assert!(out.contains("nasty.url = \"github:nasty-project/nasty/v0.0.9\""));
+        assert!(out.contains("bcachefs-tools.url ="));
+    }
+
+    #[test]
+    fn strip_lanzaboote_input_removes_url_and_follows_lines() {
+        let wrapper = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+    lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
+  };
+}"#;
+        let out = super::strip_lanzaboote_input(wrapper);
+        assert!(!out.contains("lanzaboote.url"));
+        assert!(!out.contains("lanzaboote.inputs"));
+        assert!(out.contains("nasty.url"));
+        assert!(out.contains("bcachefs-tools.url"));
+    }
+
+    #[test]
+    fn strip_lanzaboote_input_is_idempotent_on_clean_wrapper() {
+        let wrapper = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        assert_eq!(super::strip_lanzaboote_input(wrapper), wrapper);
+    }
+
+    #[test]
+    fn inject_then_strip_lanzaboote_returns_original_content() {
+        let wrapper = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        let injected = super::inject_lanzaboote_input(wrapper).expect("inject");
+        let round_tripped = super::strip_lanzaboote_input(&injected);
+        assert_eq!(round_tripped, wrapper);
+    }
+
+    #[test]
+    fn inject_lanzaboote_input_preserves_canonical_shape_when_overlay_present() {
+        // After injection the wrapper plus an overlay-present claim
+        // should reach canonical. The previous canonical shape (no
+        // lanzaboote) is non-canonical under overlay-present.
+        let pre = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        assert!(!super::wrapper_is_canonical_shape(pre, true));
+        let injected = super::inject_lanzaboote_input(pre).expect("inject");
+        assert!(super::wrapper_is_canonical_shape(&injected, true));
     }
 
     #[tokio::test]
@@ -3394,7 +3702,7 @@ outputs = { nixpkgs, nasty, ... }: {
   };
   outputs = { ... }: {};
 }"#;
-        let migrated = super::migrate_wrapper_to_canonical_shape(legacy, "x86_64-linux")
+        let migrated = super::migrate_wrapper_to_canonical_shape(legacy, "x86_64-linux", false)
             .await
             .expect("migration succeeds");
         // The operator's chosen nasty ref survives:
@@ -3426,10 +3734,58 @@ outputs = { nixpkgs, nasty, ... }: {
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
   };
 }"#;
-        let out = super::migrate_wrapper_to_canonical_shape(canonical, "x86_64-linux")
+        let out = super::migrate_wrapper_to_canonical_shape(canonical, "x86_64-linux", false)
             .await
             .expect("noop succeeds");
         assert_eq!(out, canonical, "canonical wrapper passes through unchanged");
+    }
+
+    #[tokio::test]
+    async fn migrate_wrapper_reinjects_lanzaboote_when_overlay_present() {
+        // Re-render path with the SB overlay on disk: the freshly-
+        // rendered template (no lanzaboote) gets the lanzaboote
+        // input re-injected so an enrolled box doesn't lose its SB
+        // stack on a wrapper-shape migration.
+        let bare = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+  };
+}"#;
+        let out = super::migrate_wrapper_to_canonical_shape(bare, "x86_64-linux", true)
+            .await
+            .expect("migration with overlay present succeeds");
+        let parsed = super::parse_flake_input_urls(&out).expect("output parses");
+        assert!(
+            parsed.contains_key("lanzaboote"),
+            "overlay-present box must end up with lanzaboote declared after migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_wrapper_strips_lanzaboote_when_overlay_absent() {
+        // Drift case: wrapper has lanzaboote but no SB overlay on
+        // disk. Re-render drops lanzaboote (the template doesn't
+        // carry it forward), and with overlay_present=false the
+        // migrator doesn't re-inject. Net effect: dead lanzaboote
+        // gets cleaned up.
+        let drift = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.9";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+  };
+}"#;
+        let out = super::migrate_wrapper_to_canonical_shape(drift, "x86_64-linux", false)
+            .await
+            .expect("migration without overlay succeeds");
+        let parsed = super::parse_flake_input_urls(&out).expect("output parses");
+        assert!(
+            !parsed.contains_key("lanzaboote"),
+            "no-overlay box must end up without a lanzaboote declaration after migration"
+        );
     }
 
     #[tokio::test]
@@ -3445,7 +3801,7 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:my-fork/nasty/main";
   };
 }"#;
-        let err = super::migrate_wrapper_to_canonical_shape(fork, "x86_64-linux")
+        let err = super::migrate_wrapper_to_canonical_shape(fork, "x86_64-linux", false)
             .await
             .expect_err("fork URL should refuse migration");
         let msg = format!("{err:?}");

--- a/flake.lock
+++ b/flake.lock
@@ -42,7 +42,38 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1765145449,
+        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1761588595,
@@ -73,6 +104,52 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit": "pre-commit",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1765382359,
+        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.0.0",
+        "repo": "lanzaboote",
         "type": "github"
       }
     },
@@ -128,9 +205,33 @@
         "type": "github"
       }
     },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765016596,
+        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "bcachefs-tools": "bcachefs-tools",
+        "lanzaboote": "lanzaboote",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -147,6 +248,27 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "6604534e44090c917db714faa58d47861657690c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765075567,
+        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -206,6 +206,14 @@
       installerSystemFlakeLock = builtins.toJSON {
         version = rootLock.version;
         root = "root";
+        # Inherit nasty's own lock nodes verbatim (nasty's `nixpkgs`,
+        # `bcachefs-tools`, `lanzaboote`, and all their transitive
+        # deps), then layer in a `nasty` node pointing at nasty's
+        # bundled source path, plus a wrapper `root` that declares
+        # the three inputs the rendered wrapper template will read.
+        # lanzaboote is NOT declared at the wrapper root — Secure
+        # Boot is per-box opt-in and the engine injects the
+        # lanzaboote input + locks it at enrollment time.
         nodes = (builtins.removeAttrs rootLock.nodes [ "root" ]) // {
           nasty = {
             locked = {
@@ -220,18 +228,27 @@
               repo = installerNastyRepo;
               ref = installerNastyRef;
             };
+            # Direct refs to the inherited top-level nodes — matches
+            # what nasty's OWN flake.lock declares for its root.inputs,
+            # so the inherited subgraph stays internally consistent.
             inputs = {
-              bcachefs-tools = [ "bcachefs-tools" ];
-              lanzaboote = [ "lanzaboote" ];
-              nixpkgs = [ "nixpkgs" ];
+              bcachefs-tools = "bcachefs-tools";
+              lanzaboote = "lanzaboote";
+              nixpkgs = "nixpkgs";
             };
           };
           root = {
             inputs = {
-              bcachefs-tools = "bcachefs-tools";
-              lanzaboote = "lanzaboote";
               nasty = "nasty";
-              nixpkgs = "nixpkgs";
+              # Follows path matches the template's
+              # `nixpkgs.follows = "nasty/nixpkgs"` declaration.
+              # Without this representation, nix at install time
+              # detects a shape mismatch and triggers a relock,
+              # which rewrites flake.lock mid-evaluation and
+              # invalidates a `path:/mnt/etc/nixos` narHash that
+              # nix had already cached for the wrapper snapshot.
+              nixpkgs = [ "nasty" "nixpkgs" ];
+              bcachefs-tools = "bcachefs-tools";
             };
           };
         };

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -61,18 +61,27 @@
     # removed safely.
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
 
-    # Secure Boot integration. Pinned by NASty (operators shouldn't
-    # pick a lanzaboote rev — its protocol with sd-stub, the firmware
-    # key formats, and the install-hook contract are all things NASty
-    # tests against). Inert until the operator sets
-    # `nasty.secureBoot.enable = true` per box; on boxes that never
-    # opt in this is just a flake.lock entry, no boot path changes.
-    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
-    lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
+    # NOTE: lanzaboote is intentionally NOT declared as a top-level
+    # input here. Secure Boot is per-box opt-in: when the operator
+    # begins the enrollment ceremony from the Hardware page, the
+    # engine writes `secure-boot.nix` (consumed via the optional
+    # import below) AND injects the lanzaboote input into this
+    # flake.nix in the inputs block above. On unenroll, the engine
+    # strips it back out. Boxes that never opt in carry zero
+    # lanzaboote-related lock entries.
   };
 
-  outputs = { self, nixpkgs, nasty, lanzaboote, ... }:
+  outputs = inputs @ { self, nixpkgs, nasty, ... }:
     let
+      # lanzaboote is engine-injected when the operator enrolls in
+      # Secure Boot (see comment in `inputs` above). Absent on every
+      # non-SB box. nasty.nix:16 accepts the null and the conditional
+      # imports there keep boot.lanzaboote.* out of the option space
+      # until the input lands. nasty-secure-boot.nix is gated on the
+      # presence of `secure-boot.nix` and assertion-checks that
+      # lanzaboote is non-null before flipping the SB knobs.
+      lanzaboote = inputs.lanzaboote or null;
+
       nasty-version =
         (builtins.fromTOML (builtins.readFile "${nasty}/engine/Cargo.toml")).workspace.package.version;
 


### PR DESCRIPTION
## Summary

v0.0.9's fresh-install ISO died with a `path:/mnt/etc/nixos` NAR hash mismatch on first boot. Two stacked bugs:

1. **`lanzaboote` missing from `nasty/flake.lock`.** PR #325 added lanzaboote to `nasty/flake.nix` as a top-level input but the committed lock was never refreshed. CI passes because nix auto-resolves missing nodes at eval time; the install path can't.
2. **`installerSystemFlakeLock` shape mismatch with the template.** PR #312 changed the wrapper template to `nixpkgs.follows = "nasty/nixpkgs"`, but the bundled-lock construction in `flake.nix` still emitted `root.inputs.nixpkgs = "nixpkgs"` (the v0.0.8 direct-ref shape). At install time, nix detected the lock-vs-flake-nix shape mismatch and triggered a relock that rewrote `/mnt/etc/nixos/flake.lock` mid-evaluation. That invalidated the `path:/mnt/etc/nixos` narHash a `nastySystemFlakeSnapshot` evaluation had already cached, and verification fired.

Rather than just patching both bugs (Option 1: keep lanzaboote unconditionally in the wrapper, refresh the lock, fix the follows shape — every non-SB box pays 122 lines of lanzaboote-transitive lock entries forever), this is **Option 2**: make lanzaboote a truly per-box opt-in flake input, declared in the wrapper only when the operator enrolls in Secure Boot.

## Architecture

**Wrapper template** (`nixos/system-flake/flake.nix.template`): drops `lanzaboote.url` and `lanzaboote.inputs.nixpkgs.follows`. The `outputs` function reads `lanzaboote = inputs.lanzaboote or null`. `nasty.nix:16` already handled the null case (`lanzaboote = args.lanzaboote or null;`) — the comment there even predicted this exact use, so no NixOS-module-side changes were needed.

**Engine** (`engine/nasty-system/src/update.rs`):
  - New `add_lanzaboote_input_to_wrapper(path)` and `remove_lanzaboote_input_from_wrapper(path)`. Idempotent rnix-anchored text mutations of the wrapper's `inputs` block.
  - `wrapper_is_canonical_shape` now takes `overlay_present: bool` and treats *lanzaboote declared iff SB overlay on disk* as part of canonical. Drift in either direction triggers `migrate_wrapper_to_canonical_shape`, which re-injects when overlay is present and lets the re-render strip when it isn't.

**SB enrollment** (`engine/nasty-system/src/secure_boot_enrollment.rs`):
  - `begin()` calls `add_lanzaboote_input_to_wrapper` and `nix flake lock /etc/nixos` immediately after writing `secure-boot.nix`. If either fails (e.g. box offline), the overlay is rolled back so the operator doesn't end up half-configured.
  - `abort()` calls `remove_lanzaboote_input_from_wrapper` after removing the overlay. Best-effort; failure logs a warning but doesn't block the abort.

**`nasty/flake.lock`** refreshed to include `lanzaboote` and its transitive deps (lanzaboote, crane_2, flake-compat_2, gitignore, pre-commit, rust-overlay_2). +122 lines. **No other inputs bumped.** nasty's own outputs still consume lanzaboote (for the engine's SB-aware build paths), so it stays declared in `nasty/flake.nix`.

**`installerSystemFlakeLock`** construction: drop lanzaboote from `wrapper.root.inputs` and `nasty.inputs`; fix `nasty.inputs.*` to direct node refs (matching nasty's own lock for its root.inputs); change `root.inputs.nixpkgs` from `"nixpkgs"` to `[ "nasty" "nixpkgs" ]` to match the template's `nixpkgs.follows = "nasty/nixpkgs"`.

## Upgrade-path matrix

The fresh-install paths are covered by the broken-ISO note above (no v0.0.9 box exists in the wild). The upgrade-from-v0.0.8 paths split by what's on the box when the post-merge update reaches them:

| Path | Wrapper state pre-update | Migration behavior | Result |
|---|---|---|---|
| Fresh v0.0.9 install, non-SB | n/a | n/a | no lanzaboote |
| Fresh v0.0.9 + SB later | no lanzaboote | n/a (enrollment-time inject) | `begin()` injects + locks |
| v0.0.8 → v0.0.9 via WebUI, never enrolled in SB | `lanzaboote.url` present (v0.0.9 pre-PR template carried it unconditionally), no `secure-boot.nix` | drift detected → strip lanzaboote during re-render | dead lanzaboote lock entries pruned on next `nix flake lock`; no operational change (operator wasn't using SB) |
| v0.0.8 → v0.0.9 via WebUI, enrolled via the wizard | `lanzaboote.url` present, `secure-boot.nix` present | canonical (lanzaboote+overlay match) → no migration | unchanged; SB stays working |
| v0.0.8 → v0.0.9 via WebUI, then enrolls later | no lanzaboote (post-PR migration cleaned it) | enrollment-time inject | `begin()` injects + locks |

**Edge case worth flagging**: an operator who manually wired `boot.lanzaboote.*` outside the wizard (no engine-managed `secure-boot.nix` on disk) would see migration strip their lanzaboote.url at next update, breaking their setup at the next rebuild. The realistic population here is essentially zero — the intersection of "NASty user" + "manually wires lanzaboote" + "didn't use the SB wizard that exists for exactly this purpose" — but it's worth knowing this is a behavior of `migrate_wrapper_to_canonical_shape`'s pre-existing "we own the wrapper shape" stance, not a new risk introduced here.

## Risks called out

`nix flake lock` at enrollment time requires network. If the box is offline when the operator clicks Begin enrollment, the error surfaces with a clear "network required to fetch lanzaboote" message and the overlay is rolled back atomically. That's UX-acceptable for a feature gated on bootloader signing keys.

## Test plan

- [x] `cargo test --workspace` clean (8 new tests in `update.rs` covering inject/strip round-trip, idempotency, the four presence/absence combinations of (lanzaboote-in-wrapper, overlay-on-disk), and the migrate-with-overlay-present / migrate-without-overlay paths).
- [x] `cargo clippy --workspace --all-targets --no-deps` clean.
- [x] `nix flake check --no-build` — all outputs evaluate cleanly.
- [ ] CI green (Engine, Nix engine build, Integration).
- [ ] Post-merge: re-tag v0.0.9, re-dispatch build-iso, fresh install on Proxmox completes and lands at the WebUI.