### PR TITLE
flake: rewrite lanzaboote follows in inherited wrapper-lock subgraph

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -203,18 +203,46 @@
         [ "@NASTY_VERSION@" "@LOCAL_SYSTEM@" ]
         [ installerNastyRef system ]
         (builtins.readFile ./nixos/system-flake/flake.nix.template);
+      # Rewrite a follows path so it resolves correctly when nasty's
+      # lock subgraph is transplanted into the wrapper's lock. In
+      # nasty's own lock context, `["lanzaboote", …]` means "from
+      # nasty's root, take lanzaboote, then …". In the wrapper's
+      # lock context, lanzaboote isn't at wrapper-root (it's per-
+      # box opt-in: the engine injects the input + lock entries
+      # only at SB enrollment). It's still reachable via
+      # `nasty/lanzaboote`, so the rewrite prefixes the path with
+      # `nasty`. The other top-level names in nasty's own lock
+      # (nixpkgs, bcachefs-tools) ARE present at wrapper-root (the
+      # wrapper has its own nixpkgs.follows + bcachefs-tools.url),
+      # so paths starting with those are left alone — they resolve
+      # in the wrapper to the same content nasty's lock pointed at.
+      rewriteFollowForWrapper = path:
+        if path != [] && (builtins.head path) == "lanzaboote"
+        then [ "nasty" ] ++ path
+        else path;
+      rewriteInputRef = v:
+        if builtins.isList v then rewriteFollowForWrapper v else v;
+      rewriteNodeInputs = node:
+        if node ? inputs
+        then node // { inputs = builtins.mapAttrs (_: rewriteInputRef) node.inputs; }
+        else node;
+      inheritedNastyNodes = builtins.mapAttrs
+        (_: rewriteNodeInputs)
+        (builtins.removeAttrs rootLock.nodes [ "root" ]);
       installerSystemFlakeLock = builtins.toJSON {
         version = rootLock.version;
         root = "root";
-        # Inherit nasty's own lock nodes verbatim (nasty's `nixpkgs`,
+        # Inherit nasty's own lock nodes (nasty's `nixpkgs`,
         # `bcachefs-tools`, `lanzaboote`, and all their transitive
         # deps), then layer in a `nasty` node pointing at nasty's
-        # bundled source path, plus a wrapper `root` that declares
-        # the three inputs the rendered wrapper template will read.
-        # lanzaboote is NOT declared at the wrapper root — Secure
-        # Boot is per-box opt-in and the engine injects the
-        # lanzaboote input + locks it at enrollment time.
-        nodes = (builtins.removeAttrs rootLock.nodes [ "root" ]) // {
+        # bundled source path, plus a wrapper `root`. Follows paths
+        # inside the inherited subgraph that pointed through nasty's
+        # root-level `lanzaboote` are rewritten to go through
+        # `nasty/lanzaboote` (see `rewriteFollowForWrapper` above)
+        # because the wrapper doesn't declare lanzaboote at its own
+        # root — Secure Boot is per-box opt-in and the engine
+        # injects the input + lock entries at enrollment time.
+        nodes = inheritedNastyNodes // {
           nasty = {
             locked = {
               type = "path";


### PR DESCRIPTION
## Summary

Continuation of PR #340. That PR removed lanzaboote from the wrapper template and from `wrapper.root.inputs` in `installerSystemFlakeLock`, but left the inherited subgraph from nasty's lock (`builtins.removeAttrs rootLock.nodes [ "root" ]`) **untouched**. Nodes in that subgraph (e.g. `pre-commit`, `gitignore`) have follows paths like `["lanzaboote", "pre-commit", "nixpkgs"]` that resolve in nasty's own lock (nasty has lanzaboote at root) but dangle in the wrapper's lock (wrapper has no top-level lanzaboote per the opt-in design).

At install time the operator hit:

\`\`\`
error: input 'nasty/lanzaboote/pre-commit/gitignore/nixpkgs' follows a non-existent input 'lanzaboote/pre-commit/nixpkgs'
\`\`\`

## Fix

Walk the inherited subgraph and rewrite every follows path so that paths starting with `lanzaboote` are prefixed with `nasty`. In the wrapper's lock context, lanzaboote is still reachable via `nasty/lanzaboote` (nasty's flake declares lanzaboote; nasty.inputs.lanzaboote points at the inherited `lanzaboote` node), so the rewritten paths resolve to the same nodes they did under nasty's root context.

Other top-level names from nasty's lock (`nixpkgs`, `bcachefs-tools`) are intentionally NOT rewritten — both are also wrapper-root-level inputs in the rendered template, so follows starting with them already resolve in the wrapper to the same content.

## Test plan

- [x] `nix flake check --no-build` clean.
- [ ] CI green.
- [ ] Post-merge: re-tag v0.0.9, re-dispatch build-iso, fresh install on Proxmox completes through to the WebUI.

The flake-check check is the only verification I can do without a Linux build host; this fix may still miss a sub-case that only surfaces at install time. If it does, the next step is to drop the bundled-lock approach entirely and have `iso.nix` run `nix flake lock /mnt/etc/nixos` explicitly after `bootstrap-system-flake` — robust but a bigger conceptual shift.