### PR TITLE
flake: skip nix derivation checkPhase (engine tests already covered)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,25 @@
       # CFLAGS / LD path the build script reads.
       nativeBuildInputs = [ pkgs.pkg-config ];
       buildInputs = [ pkgs.openssl ];
+      # `rustPlatform.buildRustPackage` defaults to `doCheck = true`,
+      # which runs `cargo test` in the test profile after the build
+      # phase has already compiled everything in the release profile.
+      # Different cargo profile → different cfg → different artifact
+      # hashes → no sharing between phases → every crate gets compiled
+      # twice (test-profile then release-profile). ~9 minutes per arch
+      # on the CI runners.
+      #
+      # The test pass/fail signal is already covered by the standalone
+      # `Engine (fmt, clippy, test)` CI job, which runs
+      # `cargo test --workspace --all-targets` on a vanilla Ubuntu
+      # runner. The Nix sandbox build phase still runs (this only
+      # gates the check phase), so the sandbox-visibility gate — the
+      # point of `nix-engine-build.yml`, catching `-sys` crates with
+      # missing nix-side deps like openssl-sys → pkg-config + openssl
+      # above — is unaffected. What's lost is narrowly "tests pass
+      # even inside the hermetic sandbox", and the engine's test suite
+      # isn't sandbox-fragile.
+      doCheck = false;
       # Bake the flake's source rev into the engine binary as
       # NASTY_GIT_SHA, picked up by engine/nasty-system/build.rs and
       # exposed at runtime via option_env!. The engine uses this as


### PR DESCRIPTION
## Summary

`rustPlatform.buildRustPackage` defaults to `doCheck = true`, which runs `cargo test` in the test profile after the build phase has already compiled everything in the release profile. Different cargo profile + cfg → different artifact hashes → no sharing between phases → every workspace crate gets compiled twice.

Per the build log of [the most recent Nix engine build job](https://github.com/nasty-project/nasty/actions/runs/26657493521/job/78571337790), the test-phase compile of `nasty-system` starts at `19:28:59` and the build-phase compile starts again at `19:37:52` — ~9 minutes of duplicate compilation per arch.

## What we keep

- **Build phase still runs in the Nix sandbox.** The sandbox-visibility gate — the actual point of `nix-engine-build.yml`, catching `-sys` crates with missing nix-side deps like `openssl-sys` → `pkg-config` + `openssl` already in `mkEngine`'s `nativeBuildInputs` / `buildInputs` — is unaffected.
- **Test pass/fail signal.** Covered by the standalone `Engine (fmt, clippy, test)` CI job, which runs `cargo test --workspace --all-targets` on a vanilla Ubuntu runner.
- **Clippy + fmt + npmDepsHash + integration smoke tests.** All independent.

## What we lose

Narrowly: "tests pass even inside the hermetic Nix sandbox" — a test that passes on vanilla Ubuntu but fails inside Nix's restricted sandbox (no network, no `/etc`, no `/tmp` visibility, restricted syscalls) would silently stop being checked. In practice this catches almost nothing for engine-style code; if a test ever needs network or environmental side effects it'd need explicit reasoning anyway.

Standard tradeoff in nixpkgs — many slow-test-suite Rust packages set `doCheck = false` for the same reason.

## Expected savings

~9 min × 2 arches per Rust-touching PR, distributed across `nix-engine-build.yml`, `integration.yml`, and any other workflow that pulls in `.#packages.<arch>.engine`.

## Test plan

- [x] `nix flake check --no-build` clean.
- [ ] CI green.
- [ ] Compare nix-engine-build job timing before/after on a sample PR — expect drop from ~13 min to ~4 min on x86_64.