### PR TITLE
iso: explicit `nix flake lock` pre-install + minimal seed lock

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -222,46 +222,42 @@
         [ "@NASTY_VERSION@" "@LOCAL_SYSTEM@" ]
         [ installerNastyRef system ]
         (builtins.readFile ./nixos/system-flake/flake.nix.template);
-      # Rewrite a follows path so it resolves correctly when nasty's
-      # lock subgraph is transplanted into the wrapper's lock. In
-      # nasty's own lock context, `["lanzaboote", …]` means "from
-      # nasty's root, take lanzaboote, then …". In the wrapper's
-      # lock context, lanzaboote isn't at wrapper-root (it's per-
-      # box opt-in: the engine injects the input + lock entries
-      # only at SB enrollment). It's still reachable via
-      # `nasty/lanzaboote`, so the rewrite prefixes the path with
-      # `nasty`. The other top-level names in nasty's own lock
-      # (nixpkgs, bcachefs-tools) ARE present at wrapper-root (the
-      # wrapper has its own nixpkgs.follows + bcachefs-tools.url),
-      # so paths starting with those are left alone — they resolve
-      # in the wrapper to the same content nasty's lock pointed at.
-      rewriteFollowForWrapper = path:
-        if path != [] && (builtins.head path) == "lanzaboote"
-        then [ "nasty" ] ++ path
-        else path;
-      rewriteInputRef = v:
-        if builtins.isList v then rewriteFollowForWrapper v else v;
-      rewriteNodeInputs = node:
-        if node ? inputs
-        then node // { inputs = builtins.mapAttrs (_: rewriteInputRef) node.inputs; }
-        else node;
-      inheritedNastyNodes = builtins.mapAttrs
-        (_: rewriteNodeInputs)
-        (builtins.removeAttrs rootLock.nodes [ "root" ]);
+      # Minimal seed lock for the freshly-installed wrapper at
+      # /mnt/etc/nixos. Declares ONLY the nasty input, pre-resolved
+      # to nasty's bundled source path in the ISO's nix store — so
+      # the install-time `nix flake lock` step in iso.nix doesn't
+      # need to fetch nasty from GitHub (it already has it locally
+      # via `installerNastySource`).
+      #
+      # The other inputs the wrapper template declares (`nixpkgs`
+      # follows, `bcachefs-tools.url`) are deliberately NOT
+      # pre-populated here. iso.nix runs `nix flake lock` as an
+      # explicit pass AFTER bootstrap-system-flake writes flake.nix
+      # and BEFORE nixos-install starts evaluating. That pass adds
+      # the missing inputs cleanly based on what flake.nix declares,
+      # producing a lock that exactly matches the rendered template's
+      # shape. nixos-install then evaluates against a stable lock —
+      # the path:/mnt/etc/nixos narHash captured by
+      # `nastySystemFlakeSnapshot` stays valid throughout evaluation
+      # (no mid-eval lock rewrite invalidating it).
+      #
+      # Previous iterations tried to bundle the full transitive graph
+      # by hand (inheriting nasty's own lock nodes, rewriting follows
+      # paths for transplantation, etc). Each fix uncovered another
+      # sub-case of nix's lock-shape invariants: PR #340 (missing
+      # lanzaboote node), PR #341 (dangling lanzaboote follows in
+      # inherited subgraph), then the bcachefs-tools transitive-
+      # subtree sub-case. Letting `nix flake lock` build the rest
+      # at install time eliminates the entire class of bug.
       installerSystemFlakeLock = builtins.toJSON {
         version = rootLock.version;
         root = "root";
-        # Inherit nasty's own lock nodes (nasty's `nixpkgs`,
-        # `bcachefs-tools`, `lanzaboote`, and all their transitive
-        # deps), then layer in a `nasty` node pointing at nasty's
-        # bundled source path, plus a wrapper `root`. Follows paths
-        # inside the inherited subgraph that pointed through nasty's
-        # root-level `lanzaboote` are rewritten to go through
-        # `nasty/lanzaboote` (see `rewriteFollowForWrapper` above)
-        # because the wrapper doesn't declare lanzaboote at its own
-        # root — Secure Boot is per-box opt-in and the engine
-        # injects the input + lock entries at enrollment time.
-        nodes = inheritedNastyNodes // {
+        nodes = {
+          root = {
+            inputs = {
+              nasty = "nasty";
+            };
+          };
           nasty = {
             locked = {
               type = "path";
@@ -274,28 +270,6 @@
               owner = installerNastyOwner;
               repo = installerNastyRepo;
               ref = installerNastyRef;
-            };
-            # Direct refs to the inherited top-level nodes — matches
-            # what nasty's OWN flake.lock declares for its root.inputs,
-            # so the inherited subgraph stays internally consistent.
-            inputs = {
-              bcachefs-tools = "bcachefs-tools";
-              lanzaboote = "lanzaboote";
-              nixpkgs = "nixpkgs";
-            };
-          };
-          root = {
-            inputs = {
-              nasty = "nasty";
-              # Follows path matches the template's
-              # `nixpkgs.follows = "nasty/nixpkgs"` declaration.
-              # Without this representation, nix at install time
-              # detects a shape mismatch and triggers a relock,
-              # which rewrites flake.lock mid-evaluation and
-              # invalidates a `path:/mnt/etc/nixos` narHash that
-              # nix had already cached for the wrapper snapshot.
-              nixpkgs = [ "nasty" "nixpkgs" ];
-              bcachefs-tools = "bcachefs-tools";
             };
           };
         };

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -367,6 +367,21 @@ in
         *) [ -n "$NASTY_REV" ] && echo "''${NASTY_REV:0:7}" > /mnt/var/lib/nasty/version || true ;;
       esac
 
+      # Settle the wrapper's flake.lock against the rendered
+      # flake.nix BEFORE nixos-install starts evaluating. The seed
+      # lock shipped on the ISO declares only nasty (pre-resolved
+      # to its bundled source path); this pass adds the wrapper's
+      # other declared inputs (nixpkgs follows + bcachefs-tools)
+      # cleanly. Without this explicit pass, nixos-install would
+      # detect the lock-vs-flake.nix shape mismatch and rewrite the
+      # lock mid-evaluation, which invalidates the
+      # `path:/mnt/etc/nixos` narHash that nastySystemFlakeSnapshot
+      # captures during eval and produces the cryptic NAR hash
+      # mismatch errors that bit v0.0.9 (see PR #340 history).
+      echo "==> Locking wrapper flake inputs..."
+      nix --extra-experimental-features 'nix-command flakes' \
+        flake lock /mnt/etc/nixos
+
       echo "==> Installing NASty..."
       echo "    (this may take a while on first install)"
       nixos-install --flake /mnt/etc/nixos#nasty --no-root-passwd


### PR DESCRIPTION
## Summary

PRs #340 and #341 tried to fix install-time NAR hash mismatches by hand-constructing a wrapper `flake.lock` that anticipates every nix shape invariant. Each fix uncovered another sub-case:

- **PR #340**: lanzaboote node missing from inherited subgraph
- **PR #341**: dangling lanzaboote follows in inherited subgraph
- **This iteration**: bcachefs-tools transitive subtree not separately rooted under `nasty/`

Root cause beneath all three: `nixos-install` runs a lock-update mid-evaluation when it detects ANY shape inconsistency between the bundled lock and the rendered `flake.nix`. That mid-eval rewrite invalidates the `path:/mnt/etc/nixos` narHash that `nastySystemFlakeSnapshot` captures during the same eval pass, producing the cryptic `NAR hash mismatch in input 'path:...'` errors.

## Fix

Stop trying to bundle a complete lock. Instead:

1. **`flake.nix`**: ship a MINIMAL seed lock that declares only `nasty`, pre-resolved to its bundled source path so install-time doesn't need to fetch from GitHub. `installerSystemFlakeLock` collapses from ~60 lines of construction (inherited subgraph + follows rewriting + lanzaboote-shape special-casing) to a flat 20-line JSON.
2. **`iso.nix`**: run `nix flake lock /mnt/etc/nixos` as an EXPLICIT pass after `bootstrap-system-flake` writes `flake.nix` and BEFORE `nixos-install` starts evaluating. That pass fills in the wrapper's other declared inputs (`nixpkgs` follows + `bcachefs-tools.url`) cleanly based on what `flake.nix` declares.

By the time `nixos-install` evaluates, the lock is stable. No mid-eval rewrite, no `path:` narHash invalidation, no class of bug.

## What this changes for installs

- One extra network-bound step at install time (`nix flake lock`) — ~10-30 seconds depending on connectivity. The install already needs network for binary cache fetches, so this isn't a new requirement.
- Nasty resolution stays local (the seed lock's `nasty.locked.path = self.outPath` keeps pointing at the bundled `/nix/store/<hash>-source` from `installerNastySource`).

## Validation

Built a local reproducer (bash script in `/tmp`) that:
1. Renders the wrapper template into a temp dir (substituting placeholders)
2. Runs `nix flake lock` twice
3. Runs `nix eval .#nixosConfigurations.nasty.config.system.build.toplevel.drvPath`

Result: second `nix flake lock` is stable (no `Added input` / `Updated input`), and the eval gets past the flake-resolution stage where the `path:/mnt/etc/nixos` narHash mismatch would fire. This validated the fix locally in ~30 seconds, instead of the ~30-minute ISO + Proxmox-install loop that each previous iteration required.

## Follow-up

Land the reproducer as an in-tree CI check (`checks.<arch>.installer-lock-stability`) so any future wrapper-lock shape regression is caught pre-merge, not at install time. Filing as a separate PR — this one stays focused on unblocking v0.0.9.

## Test plan

- [x] `nix flake check --no-build` clean.
- [x] Local reproducer: lock pass 2 stable, eval gets past flake-resolution stage.
- [ ] CI green.
- [ ] Post-merge: re-tag v0.0.9, re-dispatch build-iso, **install on Proxmox should complete cleanly through to the WebUI for the first time this v0.0.9 cycle.**