### PR TITLE
iso: drop the seed flake.lock entirely (continuation of #343)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -222,58 +222,22 @@
         [ "@NASTY_VERSION@" "@LOCAL_SYSTEM@" ]
         [ installerNastyRef system ]
         (builtins.readFile ./nixos/system-flake/flake.nix.template);
-      # Minimal seed lock for the freshly-installed wrapper at
-      # /mnt/etc/nixos. Declares ONLY the nasty input, pre-resolved
-      # to nasty's bundled source path in the ISO's nix store — so
-      # the install-time `nix flake lock` step in iso.nix doesn't
-      # need to fetch nasty from GitHub (it already has it locally
-      # via `installerNastySource`).
+      # No seed flake.lock is bundled. PR #343 tried a minimal seed
+      # (just nasty pre-resolved); install-time `nix flake lock` then
+      # tripped on `nixpkgs follows non-existent input nasty/nixpkgs`
+      # because nasty's own input subgraph wasn't in the wrapper's
+      # lock either. Iterating the bundle further reintroduces the
+      # follows-shape gymnastics PRs #340/#341 went through and the
+      # class of bug they kept missing.
       #
-      # The other inputs the wrapper template declares (`nixpkgs`
-      # follows, `bcachefs-tools.url`) are deliberately NOT
-      # pre-populated here. iso.nix runs `nix flake lock` as an
-      # explicit pass AFTER bootstrap-system-flake writes flake.nix
-      # and BEFORE nixos-install starts evaluating. That pass adds
-      # the missing inputs cleanly based on what flake.nix declares,
-      # producing a lock that exactly matches the rendered template's
-      # shape. nixos-install then evaluates against a stable lock —
-      # the path:/mnt/etc/nixos narHash captured by
-      # `nastySystemFlakeSnapshot` stays valid throughout evaluation
-      # (no mid-eval lock rewrite invalidating it).
-      #
-      # Previous iterations tried to bundle the full transitive graph
-      # by hand (inheriting nasty's own lock nodes, rewriting follows
-      # paths for transplantation, etc). Each fix uncovered another
-      # sub-case of nix's lock-shape invariants: PR #340 (missing
-      # lanzaboote node), PR #341 (dangling lanzaboote follows in
-      # inherited subgraph), then the bcachefs-tools transitive-
-      # subtree sub-case. Letting `nix flake lock` build the rest
-      # at install time eliminates the entire class of bug.
-      installerSystemFlakeLock = builtins.toJSON {
-        version = rootLock.version;
-        root = "root";
-        nodes = {
-          root = {
-            inputs = {
-              nasty = "nasty";
-            };
-          };
-          nasty = {
-            locked = {
-              type = "path";
-              path = self.outPath;
-              narHash = self.narHash;
-              lastModified = self.lastModified;
-            };
-            original = {
-              type = "github";
-              owner = installerNastyOwner;
-              repo = installerNastyRepo;
-              ref = installerNastyRef;
-            };
-          };
-        };
-      };
+      # iso.nix runs `nix flake lock` after bootstrap-system-flake
+      # writes flake.nix and before nixos-install starts. Without a
+      # seed lock to disagree with, nix builds the entire transitive
+      # graph from the rendered template's input declarations
+      # — fetching nasty + nixpkgs + bcachefs-tools from upstream.
+      # That's ~20s of install-time network the operator's box can
+      # afford (the install already needs network for binary cache
+      # substitution).
       nastySystemFlakeSnapshot = pkgs.runCommand "nasty-system-flake-snapshot" {} ''
         mkdir -p "$out"
         cp ${self}/flake.nix "$out/flake.nix"
@@ -284,7 +248,6 @@
         cp ${./nixos/system-flake/hardware-configuration.nix} "$out/hardware-configuration.nix"
         cp ${./nixos/system-flake/networking.nix} "$out/networking.nix"
         cp ${pkgs.writeText "nasty-system-flake.nix" installerSystemFlakeNix} "$out/flake.nix"
-        cp ${pkgs.writeText "nasty-system-flake.lock" installerSystemFlakeLock} "$out/flake.lock"
       '';
     in rec {
       # Full NASty appliance configuration

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -270,7 +270,10 @@ in
 
       echo "==> Bootstrapping local system flake..."
       mkdir -p /mnt/etc/nixos
-      cp /etc/nasty-system-flake/flake.lock /mnt/etc/nixos/flake.lock
+      # No seed flake.lock — the explicit `nix flake lock` step at
+      # the bottom of this script builds the entire transitive lock
+      # graph from the rendered template's input declarations. See
+      # flake.nix's installerSystemFlake comment for why.
 
       echo "==> Detecting local system identifier..."
       LOCAL_SYSTEM=$(nix --extra-experimental-features 'nix-command flakes' eval --impure --raw --expr builtins.currentSystem)
@@ -359,6 +362,27 @@ in
           > /mnt/var/lib/nasty/networking.json
       fi
 
+      # Settle the wrapper's flake.lock against the rendered
+      # flake.nix BEFORE nixos-install starts evaluating. There's no
+      # seed lock to start from (flake.nix bundles only flake.nix
+      # itself, no flake.lock — see installerSystemFlake), so this
+      # pass builds the whole transitive lock graph from upstream:
+      # nasty + nixpkgs + bcachefs-tools. Network-bound; the install
+      # already needs network for binary cache substitution.
+      #
+      # Without this explicit pass, nixos-install would do the same
+      # lock work mid-evaluation, which invalidates the
+      # `path:/mnt/etc/nixos` narHash that nastySystemFlakeSnapshot
+      # captures during eval and produces the cryptic NAR hash
+      # mismatch errors that bit v0.0.9. PR #340 history walks
+      # through three earlier attempts that tried to hand-construct
+      # a complete bundled lock; each missed a different sub-case of
+      # nix's lock-shape invariants. Letting nix build the lock at
+      # install time eliminates the whole class.
+      echo "==> Locking wrapper flake inputs..."
+      nix --extra-experimental-features 'nix-command flakes' \
+        flake lock /mnt/etc/nixos
+
       echo "==> Recording installed NASty version..."
       NASTY_REF=$(jq -r '.nodes["nasty"].original.ref // empty' /mnt/etc/nixos/flake.lock 2>/dev/null || true)
       NASTY_REV=$(jq -r '.nodes["nasty"].locked.rev // empty' /mnt/etc/nixos/flake.lock 2>/dev/null || true)
@@ -366,21 +390,6 @@ in
         v*|s*) echo "$NASTY_REF" > /mnt/var/lib/nasty/version ;;
         *) [ -n "$NASTY_REV" ] && echo "''${NASTY_REV:0:7}" > /mnt/var/lib/nasty/version || true ;;
       esac
-
-      # Settle the wrapper's flake.lock against the rendered
-      # flake.nix BEFORE nixos-install starts evaluating. The seed
-      # lock shipped on the ISO declares only nasty (pre-resolved
-      # to its bundled source path); this pass adds the wrapper's
-      # other declared inputs (nixpkgs follows + bcachefs-tools)
-      # cleanly. Without this explicit pass, nixos-install would
-      # detect the lock-vs-flake.nix shape mismatch and rewrite the
-      # lock mid-evaluation, which invalidates the
-      # `path:/mnt/etc/nixos` narHash that nastySystemFlakeSnapshot
-      # captures during eval and produces the cryptic NAR hash
-      # mismatch errors that bit v0.0.9 (see PR #340 history).
-      echo "==> Locking wrapper flake inputs..."
-      nix --extra-experimental-features 'nix-command flakes' \
-        flake lock /mnt/etc/nixos
 
       echo "==> Installing NASty..."
       echo "    (this may take a while on first install)"


### PR DESCRIPTION
## Summary

PR #343 shipped a minimal seed lock containing just `nasty` (pre-resolved to its bundled source path), expecting `nix flake lock` to fill in the rest at install time. Install on Proxmox tripped on:

```
error: input 'nixpkgs' follows a non-existent input 'nasty/nixpkgs'
```

nix can resolve `nasty/nixpkgs` only if nasty's own input subgraph is present in the wrapper's lock — and the seed lock had only nasty's `locked`/`original` metadata, no `nasty.inputs`. Iterating the seed lock further brings back the follows-shape gymnastics that PRs #340 and #341 went through and kept missing sub-cases of.

## Fix

Don't bundle a seed lock at all. `flake.nix`'s `installerSystemFlake` no longer copies a `flake.lock` into the ISO bundle. `iso.nix`'s install script reorders so:

1. `bootstrap-system-flake` writes `flake.nix` (no `flake.lock` alongside).
2. **Explicit `nix flake lock` pass** — builds the entire transitive graph fresh from the rendered template's input declarations.
3. NASty-version recording — reads `original.ref` from the freshly-written lock.
4. `nixos-install`.

With nothing for nix to disagree with up front, the lock matches the template by definition. No more shape-mismatch sub-cases.

## Cost

~10-20s of install-time network as nix fetches `nasty` + `nixpkgs` + `bcachefs-tools` from upstream. The install already needs network for binary cache substitution.

## Validation

Updated the local reproducer (kept in `/tmp` for now; in-tree CI gate is a follow-up PR) to mirror the production flow more faithfully. The variant **with PR #343's seed lock now reliably reproduces** the `nasty/nixpkgs` failure, confirming the test catches this class. The variant matching this PR's code (no seed) succeeds both lock passes and stays idempotent.

## Why so many iterations on this

Hand-constructed locks keep missing edge cases because nix's lock graph has subtle follows-resolution invariants that are hard to anticipate without running an actual lock pass. Each fix uncovered a new sub-case. The robust path is the one this PR lands: let nix build the lock fresh against the rendered template. Whatever the template declares, the lock matches.

## Test plan

- [x] `nix flake check --no-build` clean.
- [x] Local reproducer (no seed): both lock passes succeed, pass 2 stable.
- [x] Local reproducer (PR #343's seed): reproduces the production failure.
- [ ] CI green.
- [ ] Post-merge: re-tag v0.0.9, re-dispatch build-iso, **fresh install on Proxmox completes through to the WebUI**.

## Follow-up

Land the reproducer in-tree as `checks.x86_64-linux.installer-lock-shape` so this class is caught at PR time, not after a 30-min ISO build + manual install. Separate PR — this one stays focused on unblocking v0.0.9.