### PR TITLE
ci: gate wrapper-lock shape with a `nix flake lock` idempotency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,86 @@ jobs:
             exit 1
           fi
           echo "Installer template correctly pins bcachefs-tools.url with a hardcoded semver tag."
+
+  installer-lock-shape:
+    # The dynamic counterpart to `installer-flake-template` above.
+    # The static checks there assert what the rendered template
+    # textually declares; this job actually runs `nix flake lock`
+    # against the rendered template and asserts the resulting lock
+    # is stable across a second pass.
+    #
+    # Why this exists: install-time `nixos-install` builds the
+    # wrapper-flake lock from the rendered template. If the lock
+    # construction and the template's input declarations disagree
+    # on shape, nix silently rewrites the lock mid-evaluation —
+    # which invalidates the `path:/mnt/etc/nixos` narHash that
+    # `nastySystemFlakeSnapshot` captures during the same eval pass
+    # and surfaces as the cryptic "NAR hash mismatch in input
+    # 'path:...'" errors. v0.0.9 cycle burned five PRs (#340-#344)
+    # chasing successive sub-cases of this class before #344 landed
+    # the "no bundled lock, regenerate at install time" fix that
+    # this check protects.
+    #
+    # Mechanism: render the template with sed substitutions matching
+    # what `render_system_flake_template_with_ref` does, point
+    # `nasty.url` at this checkout (so we test THIS commit, not a
+    # tagged release), then run `nix flake lock` twice. If pass 2
+    # reports `Added input` or `Updated input` lines, the lock that
+    # pass 1 produced doesn't match what nix's own resolver would
+    # produce — i.e. the template + lock-construction code have
+    # drifted out of shape with each other.
+    name: Installer wrapper-lock shape stable (nix flake lock idempotent)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Render wrapper template + run two nix-flake-lock passes
+        run: |
+          set -euo pipefail
+          TMP=$(mktemp -d)
+          # Match `render_system_flake_template_with_ref`'s substitutions.
+          # Rewrite `nasty.url` to a path: pointing at this checkout so we
+          # test the current commit's flake shape (and avoid hammering
+          # github on every CI run for what is essentially a self-test).
+          sed -e 's|"github:nasty-project/nasty/@NASTY_VERSION@"|"path:'"$GITHUB_WORKSPACE"'"|' \
+              -e 's|@LOCAL_SYSTEM@|x86_64-linux|g' \
+              -e 's|@WRAPPER_FLAKE_VERSION@|ci-render|g' \
+              nixos/system-flake/flake.nix.template > "$TMP/flake.nix"
+
+          # The template imports these optionally; nix needs them to
+          # exist when evaluating, even though we won't actually use
+          # the configurations they'd contribute.
+          cat > "$TMP/hardware-configuration.nix" <<'STUB'
+          { ... }: { }
+          STUB
+          cat > "$TMP/networking.nix" <<'STUB'
+          { ... }: { }
+          STUB
+
+          cd "$TMP"
+
+          echo "::group::Pass 1: nix flake lock (build the lock from the rendered template)"
+          nix flake lock 2>&1 | tee pass-1.log
+          echo "::endgroup::"
+
+          echo "::group::Pass 2: nix flake lock (must be a no-op)"
+          nix flake lock 2>&1 | tee pass-2.log
+          echo "::endgroup::"
+
+          if grep -qE 'Added input|Updated input' pass-2.log; then
+            echo "::error::Wrapper-lock shape is not stable — pass 2 of nix flake lock made changes."
+            echo "Without this stability, install-time nixos-install would do the same lock work mid-evaluation"
+            echo "and invalidate the path:/mnt/etc/nixos narHash that nastySystemFlakeSnapshot captures,"
+            echo "producing the NAR hash mismatch errors that bit the v0.0.9 cycle (PRs #340-#344)."
+            echo ""
+            echo "Pass 2 made these changes:"
+            grep -E 'Added input|Updated input' pass-2.log
+            exit 1
+          fi
+
+          echo "Wrapper-lock shape is stable across two consecutive nix flake lock passes."


### PR DESCRIPTION
## Summary

Closes the iteration-speed gap that burned the v0.0.9 cycle. PRs #340-#344 chased successive sub-cases of one bug class: the bundled wrapper-flake-lock shape disagreeing with the rendered template's input declarations. Each fix passed the existing CI gates (which are static \`grep\`s against the template) and then died at install time, where \`nixos-install\` rewrites the lock mid-evaluation and invalidates the \`path:/mnt/etc/nixos\` narHash. Iteration loop was ~30 min per attempt (ISO build + manual Proxmox install).

New \`installer-lock-shape\` CI job sits next to \`installer-flake-template\` and does the dynamic counterpart:

1. Renders the template into a tmpdir with the same sed substitutions \`render_system_flake_template_with_ref\` does
2. Points \`nasty.url\` at the checkout so we test **this commit** (not a tagged release)
3. Runs \`nix flake lock\` once (builds the lock from the rendered template)
4. Runs \`nix flake lock\` again — must be a no-op

If pass 2 reports any \`Added input\` / \`Updated input\` lines, the lock pass 1 produced doesn't match what nix's resolver would produce when run against the template alone — exactly the shape inconsistency that bit at install time.

## Why this gate works

Same logic as the manual repro I built in \`/tmp\` during the cycle. **Tested against PR #343's old shape** (minimal seed lock with just nasty pre-resolved) and the check correctly fails with the \`input 'nixpkgs' follows a non-existent input 'nasty/nixpkgs'\` error that bit the install. **Tested against current main** (post-#344, no bundled seed lock) and the check passes cleanly.

So the gate isn't a happy-path smoke test — it genuinely catches the class of bug.

## Cost

Adds one CI job, ~30s wall time on Ubuntu runners (the two \`nix flake lock\` passes are network-bound but small). No effect on existing jobs.

## Test plan

- [x] Local equivalent of the script passes on current main.
- [x] Local equivalent fails (correctly) when run against PR #343's seed lock.
- [ ] CI on this PR shows the new \`Installer wrapper-lock shape stable\` job green.