### PR TITLE
auth: hide login-page security-key button when no credentials registered

### DIFF
--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -884,6 +884,26 @@ impl AuthService {
     // other user-record write. The webauthn module owns the
     // crypto + challenge state; this module owns the on-disk shape.
 
+    /// Whether ANY user has at least one registered WebAuthn
+    /// credential. Used by the unauthenticated
+    /// `/api/auth/webauthn/available` endpoint to gate the login
+    /// page's "Sign in with security key" button — on a fresh
+    /// install with no keys registered yet the button is just
+    /// visual noise that fails at click time.
+    ///
+    /// One-bit leak (an unauthenticated caller learns whether any
+    /// keys exist) is intentional and matches the parallel
+    /// `/api/auth/oidc/available` — both endpoints exist to let
+    /// the login page render the right buttons without first
+    /// requiring auth.
+    pub async fn any_webauthn_credentials_registered(&self) -> bool {
+        let state = self.state.read().await;
+        state
+            .users
+            .iter()
+            .any(|u| !u.webauthn_credentials.is_empty())
+    }
+
     /// Snapshot of a user's registered WebAuthn credentials. Returns
     /// an empty vec when the user doesn't exist (caller is the
     /// session-bound user, so a missing entry is degenerate and

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -520,6 +520,10 @@ async fn main() -> anyhow::Result<()> {
             post(webauthn_login_finish_handler),
         )
         .route("/api/auth/oidc/available", get(oidc_available_handler))
+        .route(
+            "/api/auth/webauthn/available",
+            get(webauthn_available_handler),
+        )
         .route("/api/boot_status", get(boot_status_handler))
         .route("/api/auth/oidc/start", get(oidc_start_handler))
         .route("/api/auth/oidc/callback", get(oidc_callback_handler))
@@ -2254,6 +2258,26 @@ async fn oidc_available_handler(State(state): State<Arc<AppState>>) -> impl Into
     let configured = state.oidc.current().await.is_some();
     Json(serde_json::json!({
         "enabled": oidc.enabled && configured,
+    }))
+}
+
+/// Unauthenticated probe for the login page's "Sign in with security
+/// key" button visibility. Returns `{ "has_credentials": bool }` —
+/// true iff at least one user has at least one registered WebAuthn
+/// credential. On a fresh install the button is just visual noise
+/// (clicking it fails at the engine's "no credentials for user"
+/// check), so the WebUI gates the button on this AND the browser's
+/// own WebAuthn API support.
+///
+/// Parallels `/api/auth/oidc/available`. The one-bit leak (an
+/// unauthenticated caller learns whether any keys are registered)
+/// is acceptable for the same reason it is there: rendering the
+/// login page right requires answering this question before auth
+/// has happened.
+async fn webauthn_available_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let has_credentials = state.auth.any_webauthn_credentials_registered().await;
+    Json(serde_json::json!({
+        "has_credentials": has_credentials,
     }))
 }
 

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -82,6 +82,14 @@
 	let loginPass = $state('');
 	let loginError = $state('');
 	let ssoEnabled = $state(false);
+	// Whether the engine reports at least one user has registered a
+	// WebAuthn credential. Gates the "Sign in with security key"
+	// button on top of the browser-capability check — on a fresh
+	// install with no keys yet, clicking the button just fails at
+	// "no credentials for user", so hide it until there's something
+	// to sign in with. Populated by /api/auth/webauthn/available
+	// (unauthenticated, parallel to /api/auth/oidc/available).
+	let webauthnHasCredentials = $state(false);
 
 	// Boot status — populated by polling /api/boot_status. While
 	// `overall === 'booting'` we show a TrueNAS-style overlay
@@ -184,6 +192,18 @@
 				ssoEnabled = false;
 			}
 		} catch { ssoEnabled = false; }
+	}
+
+	async function refreshWebauthnAvailability() {
+		try {
+			const res = await fetch('/api/auth/webauthn/available');
+			if (res.ok) {
+				const body = await res.json();
+				webauthnHasCredentials = !!body.has_credentials;
+			} else {
+				webauthnHasCredentials = false;
+			}
+		} catch { webauthnHasCredentials = false; }
 	}
 
 	function startSso() {
@@ -434,6 +454,7 @@
 			const probe = await fetch('/api/auth/check');
 			if (probe.status !== 200) {
 				refreshSsoAvailability();
+				refreshWebauthnAvailability();
 				showLogin = true;
 				return;
 			}
@@ -462,6 +483,7 @@
 		} catch (e) {
 			resetClient();
 			refreshSsoAvailability();
+			refreshWebauthnAvailability();
 			showLogin = true;
 			if (e instanceof Error && e.message !== 'WebSocket connection failed') {
 				showError('Session expired, please sign in again');
@@ -761,14 +783,14 @@
 				</div>
 				<Button type="submit" class="w-full" disabled={webauthnPending}>Sign In</Button>
 			</form>
-			{#if webauthnLoginSupported || ssoEnabled}
+			{#if (webauthnLoginSupported && webauthnHasCredentials) || ssoEnabled}
 				<div class="my-4 flex items-center gap-3 text-xs text-muted-foreground">
 					<div class="h-px flex-1 bg-border"></div>
 					<span>or</span>
 					<div class="h-px flex-1 bg-border"></div>
 				</div>
 			{/if}
-			{#if webauthnLoginSupported}
+			{#if webauthnLoginSupported && webauthnHasCredentials}
 				<Button
 					type="button"
 					variant="outline"


### PR DESCRIPTION
## Summary

On a fresh install the "Sign in with security key" button appears as soon as the browser supports the WebAuthn API — but nobody has registered a credential yet, so clicking it just fails at the engine's "no credentials for user" check. Pure visual noise on the first-login case.

Adds a new unauthenticated REST endpoint at `/api/auth/webauthn/available` returning `{ "has_credentials": bool }` (true iff any user has any registered WebAuthn credential). WebUI gates the button on `(webauthnLoginSupported && webauthnHasCredentials)`. After someone registers a key from Access Control, the button appears on subsequent visits.

## Design

Mirrors the existing `/api/auth/oidc/available` pattern exactly:

- Unauthenticated REST endpoint (rendering the login page right requires answering this question *before* anyone is logged in)
- One-bit info leak (an unauthenticated caller learns whether any keys exist) — same trade-off as the OIDC endpoint already accepts for the SSO button
- `refreshWebauthnAvailability()` is called from the same three code paths that already call `refreshSsoAvailability()` (the three sites that drop the user to the login form)

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets --no-deps` clean
- [x] `svelte-check` 0 errors / 0 warnings
- [ ] Manual on a fresh install: login screen shows only Username/Password/Sign In — no security-key button
- [ ] After registering a key from Access Control + logging out: login screen now shows the button