### PR TITLE
webui: spinner safety net + reconnect state-machine debug logging

### DIFF
--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -143,6 +143,11 @@ export class NastyClient {
 						this.consecutiveFailedReconnects = 0;
 						this._readyResolve?.();
 						this._readyResolve = null;
+						if (NastyClient.debug) {
+							console.debug(
+								`[rpc] auth ok (wasReconnect=${wasReconnect}, firing ${this.reconnectHandlers.length} reconnect handlers)`
+							);
+						}
 						if (wasReconnect) {
 							for (const h of this.reconnectHandlers) h();
 						}
@@ -170,13 +175,18 @@ export class NastyClient {
 				}
 			};
 
-			this.ws.onclose = () => {
+			this.ws.onclose = (ev) => {
 				this._authenticated = false;
 				// Reject all pending calls so awaiting code doesn't hang forever
 				for (const pending of this.pending.values()) {
 					pending.reject({ code: -32000, message: 'WebSocket disconnected' });
 				}
 				this.pending.clear();
+				if (NastyClient.debug) {
+					console.debug(
+						`[rpc] ws closed (code=${ev.code}, reason="${ev.reason}", clean=${ev.wasClean}, _shouldReconnect=${this._shouldReconnect}, firing ${this._shouldReconnect ? this.disconnectHandlers.length : 0} disconnect handlers)`
+					);
+				}
 				// Keep retrying as long as we haven't been explicitly disconnected.
 				if (this._shouldReconnect) {
 					for (const h of this.disconnectHandlers) h();
@@ -248,6 +258,11 @@ export class NastyClient {
 			this.reconnectDelayMs * 2,
 			this.reconnectCeilMs,
 		);
+		if (NastyClient.debug) {
+			console.debug(
+				`[rpc] scheduling reconnect in ${delay}ms (next ceiling: ${this.reconnectDelayMs}ms, consecutive failures: ${this.consecutiveFailedReconnects}, aggressive=${this._aggressive})`
+			);
+		}
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
 			this.connect().catch((err) => {
@@ -326,6 +341,11 @@ export class NastyClient {
 	setAggressiveReconnect(active: boolean) {
 		if (this._aggressive === active) return;
 		this._aggressive = active;
+		if (NastyClient.debug) {
+			console.debug(
+				`[rpc] setAggressiveReconnect(${active}) — floor=${this.reconnectFloorMs}ms, ceiling=${this.reconnectCeilMs}ms`
+			);
+		}
 		// If we just entered aggressive mode mid-outage, the current
 		// reconnectDelayMs may already be at the old (5 s / 30 s) ceiling.
 		// Snap it down so the very next scheduled retry fires fast.

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -76,6 +76,20 @@
 	let connected = $state(false);
 	let authInfo: AuthResult | null = $state(null);
 
+	// Debug helper for the reconnect / power-cycle state machine.
+	// Mirrors `NastyClient.debug` in `rpc.ts` — both are gated on the
+	// same localStorage flag (`localStorage.setItem('nasty-debug', '1')`
+	// then reload). Used to trace the path through `onDisconnect` →
+	// 800ms timer → `reconnecting = true` → `onReconnect`, which is
+	// load-bearing for the "Reconnecting…" spinner appearing during
+	// reboots. Cached at module load — set the flag then reload.
+	const _uiDebug =
+		typeof localStorage !== 'undefined'
+		&& localStorage.getItem('nasty-debug') === '1';
+	function dbg(...args: unknown[]) {
+		if (_uiDebug) console.debug('[ui]', ...args);
+	}
+
 	// Login form
 	let showLogin = $state(false);
 	let loginUser = $state('admin');
@@ -359,6 +373,7 @@
 	onMount(() => {
 		tryConnect();
 		const onReconnect = async () => {
+			dbg(`reconnect cb fired — clearing powering=${powering}, reconnecting=${reconnecting}, timer=${reconnectingTimer ? 'armed' : 'none'}`);
 			powering = false;
 			if (reconnectingTimer) {
 				clearTimeout(reconnectingTimer);
@@ -385,8 +400,10 @@
 			sysInfoRefresh.trigger();
 		};
 		const onDisconnect = () => {
+			dbg(`disconnect cb fired — arming ${RECONNECT_OVERLAY_DELAY_MS}ms reconnect-overlay timer (powering=${powering}, prior timer=${reconnectingTimer ? 'rearming' : 'fresh'})`);
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
 			reconnectingTimer = setTimeout(() => {
+				dbg(`reconnect-overlay timer fired — reconnecting=true (powering=${powering})`);
 				reconnecting = true;
 				reconnectingTimer = null;
 			}, RECONNECT_OVERLAY_DELAY_MS);
@@ -552,9 +569,32 @@
 	async function handleRestart() {
 		powerOpen = false;
 		if (!await confirm('Restart NASty?', 'All active connections will be dropped.')) return;
+		dbg('handleRestart — powering=true, calling system.reboot');
 		powering = true;
 		rebootState.clear();
+		// Safety net: the spinner relies on `onDisconnect` firing and
+		// arming the 800ms overlay timer. If anything in that path
+		// silently breaks (we hit this once on a first-reboot post-
+		// upgrade — couldn't repro deterministically), the operator
+		// stares at "Shutting down…" forever with no motion.
+		// Promote `reconnecting` to true after 5s regardless if
+		// `powering` is still set; cleared cleanly by `onReconnect`
+		// when the engine comes back. Costs nothing on the normal
+		// path because `onReconnect` clears both flags long before 5s.
+		const safetyTimer = setTimeout(() => {
+			if (powering && !reconnecting) {
+				console.warn(
+					'[nasty] reboot: spinner safety net fired at 5s — onDisconnect path did not arm the reconnect overlay. Enable nasty-debug for a state-machine trace.'
+				);
+				reconnecting = true;
+			}
+		}, 5000);
 		try { await getClient().call('system.reboot'); } catch { /* expected — engine dies */ }
+		// Don't clear the safety timer on RPC completion — the engine
+		// returning success here doesn't mean the reboot finished, just
+		// that the request was accepted. The timer self-cancels via the
+		// `powering` check if `onReconnect` has already cleared things.
+		void safetyTimer;
 	}
 
 	async function handleShutdown() {


### PR DESCRIPTION
## Summary

Two pieces, both defensive after the intermittent post-upgrade "Restart click shows only 'Shutting down…', spinner never appears" bug from the v0.0.9 cycle. No deterministic repro — this is diagnostics + belt-and-braces.

## Debug logging

Gated on the existing \`nasty-debug\` localStorage flag (set with \`localStorage.setItem('nasty-debug', '1')\` then reload). Adds \`console.debug\` lines at every transition in the reconnect state machine that today is silent even with debug on:

**\`rpc.ts\`:**
- \`ws closed (code, reason, clean, _shouldReconnect, ...)\`
- \`auth ok (wasReconnect=…, firing N reconnect handlers)\`
- \`scheduling reconnect in Xms (ceiling, attempt N, aggressive=…)\`
- \`setAggressiveReconnect(value) — floor=Xms, ceiling=Yms\`

**\`+layout.svelte\`:**
- \`disconnect cb fired — arming 800ms reconnect-overlay timer\`
- \`reconnect-overlay timer fired — reconnecting=true\`
- \`reconnect cb fired — clearing powering=…, reconnecting=…\`
- \`handleRestart — powering=true, calling system.reboot\`

**Goal**: next time someone hits the spinner-missing bug, the console shows exactly which transition didn't fire. Today there'd be nothing in the console even with debug on because none of these moments emit anything.

## Safety net (\`handleRestart\`)

The spinner is currently gated entirely on \`onDisconnect\` firing and arming the 800ms overlay timer. If anything in that path silently breaks (which it did at least once), the operator stares at "Shutting down…" with no further motion.

After clicking Restart, schedule a 5s timer that promotes \`reconnecting = true\` if \`powering\` is still set and \`reconnecting\` is still false. Logs an always-on \`console.warn\` if the safety net actually triggers, so the bug leaves a fingerprint even without nasty-debug enabled.

5s is well past where a real reboot's WS death would have already triggered the normal 800ms path. Net effect: normal reboot path is unchanged, broken-state path degrades to "~4s late spinner" instead of "no spinner forever".

Only applied to \`handleRestart\`; \`handleShutdown\` deliberately omitted because a shutdown doesn't expect a reconnect.

## What this is NOT

Not a fix for the bug itself — no repro, no fix. Defensive code for the next occurrence + diagnostics for the one after that.

## Test plan

- [x] \`svelte-check\` 0 errors / 0 warnings.
- [ ] CI green.
- [ ] Manual: enable \`nasty-debug\` and observe console traces on a normal reboot (should see the full transition sequence).
- [ ] Manual: enable \`nasty-debug\` and watch console on next post-upgrade kernel/driver reboot. If the bug repros, the trace will show which transition didn't fire and the safety-net warn will fire.