### PR TITLE
engine: REST gateway at /api/v1/{...} + OpenAPI 3.1 at /api/openapi.json

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -25,6 +25,7 @@ mod fs_lock;
 mod ingress_conflict;
 mod log_stream;
 mod registry;
+mod rest_gateway;
 mod router;
 mod subvolume_dependents;
 mod telemetry;
@@ -121,11 +122,22 @@ async fn main() -> anyhow::Result<()> {
             .get(2)
             .ok_or_else(|| anyhow::anyhow!("--dump-docs requires an output directory argument"))?;
         let (_g, groups) = registry::build_full_registry();
+        std::fs::create_dir_all(out_dir)?;
+
         let md = registry::render_markdown(&groups);
-        let out_path = std::path::Path::new(out_dir).join("api.md");
-        std::fs::create_dir_all(out_path.parent().unwrap())?;
-        std::fs::write(&out_path, &md)?;
-        println!("Written {} ({} bytes)", out_path.display(), md.len());
+        let md_path = std::path::Path::new(out_dir).join("api.md");
+        std::fs::write(&md_path, &md)?;
+        println!("Written {} ({} bytes)", md_path.display(), md.len());
+
+        let openapi = registry::render_openapi(version, &groups);
+        let openapi_text = serde_json::to_string_pretty(&openapi)?;
+        let openapi_path = std::path::Path::new(out_dir).join("openapi.json");
+        std::fs::write(&openapi_path, &openapi_text)?;
+        println!(
+            "Written {} ({} bytes)",
+            openapi_path.display(),
+            openapi_text.len()
+        );
         return Ok(());
     }
 
@@ -526,6 +538,8 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .merge(ws_routes)
+        .merge(rest_gateway::routes())
+        .route("/api/openapi.json", get(openapi_handler))
         .route("/api/login", post(login_handler))
         .route("/api/logout", post(logout_handler))
         .route(
@@ -2440,6 +2454,19 @@ async fn ws_origin_check(
         }
     }
     Ok(next.run(req).await)
+}
+
+/// Serve the OpenAPI 3.1 document describing the REST gateway. Built once on
+/// first request (schemars walk is expensive) and cached for the process lifetime.
+async fn openapi_handler() -> impl IntoResponse {
+    static CACHED: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    let body = CACHED.get_or_init(|| {
+        let version = env!("CARGO_PKG_VERSION");
+        let (_g, groups) = registry::build_full_registry();
+        let doc = registry::render_openapi(version, &groups);
+        serde_json::to_string(&doc).expect("OpenAPI doc must serialize")
+    });
+    ([("content-type", "application/json")], body.clone())
 }
 
 async fn ws_handler(

--- a/engine/nasty-engine/src/registry/mod.rs
+++ b/engine/nasty-engine/src/registry/mod.rs
@@ -17,6 +17,11 @@ use serde_json::Value;
 
 mod markdown;
 mod methods;
+mod openapi;
+mod paths;
+
+pub use openapi::render_openapi;
+pub use paths::{HttpVerb, method_from_segments, translate};
 
 #[cfg(test)]
 mod tests;

--- a/engine/nasty-engine/src/registry/openapi.rs
+++ b/engine/nasty-engine/src/registry/openapi.rs
@@ -1,0 +1,334 @@
+//! Render the method registry as an OpenAPI 3.1 document.
+//!
+//! Consumed by Swagger UI at `/api/docs` (PR3) and emitted to disk by
+//! `nasty-engine --dump-docs`.
+//!
+//! OpenAPI 3.1 uses JSON Schema 2020-12 natively, which matches what schemars
+//! emits — so the params/result schemas drop in with only minor rewrites:
+//!   - `$ref: "#/$defs/X"` is rewritten to `$ref: "#/components/schemas/X"`
+//!   - all per-type `$defs` collections are merged into `components.schemas`
+//!
+//! Paths and verbs come from [`super::paths::translate`] so the REST gateway
+//! and the docs site agree on every URL.
+
+use super::paths::{HttpVerb, translate};
+use super::{Method, MethodParams, MethodRole};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+
+/// Build the full OpenAPI 3.1 document as a `serde_json::Value`.
+pub fn render_openapi(version: &'static str, groups: &[(&str, Vec<Method>)]) -> Value {
+    let mut paths: Map<String, Value> = Map::new();
+    let mut schemas: BTreeMap<String, Value> = BTreeMap::new();
+
+    for (group, methods) in groups {
+        for m in methods {
+            let (verb, path) = translate(m.name);
+            let op = build_operation(group, m, &mut schemas);
+
+            let entry = paths
+                .entry(path)
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let Value::Object(map) = entry {
+                map.insert(verb.as_str().to_string(), op);
+            }
+        }
+    }
+
+    let components_schemas: Map<String, Value> = schemas.into_iter().collect();
+
+    serde_json::json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": "NASty JSON-RPC API (REST gateway)",
+            "version": version,
+            "description": "NASty's JSON-RPC API surface, exposed over a thin REST gateway.\n\nEach JSON-RPC method `foo.bar.baz` is mounted at `/api/v1/foo/bar/baz` with an HTTP verb inferred from the method's last segment (`.get`/`.list`/`.status` → GET, `.delete`/`.remove` → DELETE, `.set`/`.update` → PUT, everything else → POST).\n\nGET methods take their params as query string; everything else takes a JSON body. Authentication mirrors the WebSocket transport: send the `nasty_session` cookie or an `Authorization: Bearer <token>` header.\n\nStreaming endpoints (log_stream, terminal, vm_console, telemetry pushes, event broadcasts) stay on the WebSocket at `/ws` and are intentionally not modeled here.",
+        },
+        "servers": [{"url": "/", "description": "This engine"}],
+        "paths": Value::Object(paths),
+        "components": {
+            "schemas": Value::Object(components_schemas),
+            "securitySchemes": {
+                "cookieAuth": {
+                    "type": "apiKey",
+                    "in": "cookie",
+                    "name": "nasty_session",
+                    "description": "Session cookie set by `POST /api/login`."
+                },
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "Long-lived API token created via `auth.token.create`."
+                }
+            }
+        },
+        "security": [{"cookieAuth": []}, {"bearerAuth": []}]
+    })
+}
+
+fn build_operation(group: &str, m: &Method, schemas: &mut BTreeMap<String, Value>) -> Value {
+    let (verb, _) = translate(m.name);
+    let mut op = Map::new();
+    op.insert("operationId".into(), Value::String(m.name.to_string()));
+    op.insert(
+        "tags".into(),
+        Value::Array(vec![Value::String(group.to_string())]),
+    );
+    op.insert("summary".into(), Value::String(m.desc.to_string()));
+    op.insert(
+        "x-nasty-role".into(),
+        Value::String(m.role.as_str().to_string()),
+    );
+    // Cheap, human-readable role tag in the description so Swagger UI renders it
+    // visibly under the summary even when the viewer ignores `x-*` extensions.
+    op.insert(
+        "description".into(),
+        Value::String(format!(
+            "{}\n\n**Required role:** `{}`",
+            m.desc,
+            m.role.as_str()
+        )),
+    );
+
+    // Params → query (GET) or requestBody (everything else).
+    match &m.params {
+        MethodParams::None => {}
+        MethodParams::Schema(v) | MethodParams::AdHoc(v) => {
+            let schema = process_schema(v, schemas);
+            if verb == HttpVerb::Get {
+                op.insert("parameters".into(), schema_to_query_params(&schema));
+            } else {
+                op.insert(
+                    "requestBody".into(),
+                    serde_json::json!({
+                        "required": true,
+                        "content": {
+                            "application/json": {"schema": schema}
+                        }
+                    }),
+                );
+            }
+        }
+    }
+
+    // Response.
+    let response = match &m.result {
+        None => serde_json::json!({"description": "Success — no content."}),
+        Some(v) => {
+            let schema = process_schema(v, schemas);
+            serde_json::json!({
+                "description": "OK",
+                "content": {
+                    "application/json": {"schema": schema}
+                }
+            })
+        }
+    };
+    let status_code = if m.result.is_none() { "204" } else { "200" };
+    op.insert(
+        "responses".into(),
+        serde_json::json!({
+            status_code: response,
+            "401": {"description": "Authentication required."},
+            "403": {"description": "Caller's role lacks permission for this method."},
+            "500": {"description": "Engine-side error (see `error.message` for detail).", "content": {"application/json": {"schema": json_rpc_error_schema()}}}
+        }),
+    );
+
+    // Role-aware security: methods marked `any` are still authenticated (no
+    // unauthenticated callers), but we keep them at the default security.
+    // Stricter security objects could narrow per-role in future.
+    let _ = MethodRole::Any; // marker only
+
+    Value::Object(op)
+}
+
+/// Transform a schemars-emitted JSON Schema for use inside an OpenAPI document:
+///   - lift any inline `$defs` into the shared `schemas` map
+///   - rewrite local `$ref` paths from `#/$defs/X` to `#/components/schemas/X`
+fn process_schema(schema: &Value, schemas: &mut BTreeMap<String, Value>) -> Value {
+    let mut s = schema.clone();
+    if let Some(obj) = s.as_object_mut()
+        && let Some(defs) = obj.remove("$defs")
+        && let Value::Object(defs_map) = defs
+    {
+        for (name, mut def_schema) in defs_map {
+            rewrite_refs(&mut def_schema);
+            schemas.entry(name).or_insert(def_schema);
+        }
+    }
+    rewrite_refs(&mut s);
+    s
+}
+
+/// Recursively rewrite `#/$defs/X` references to `#/components/schemas/X`.
+fn rewrite_refs(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            if let Some(r) = map.get_mut("$ref")
+                && let Some(s) = r.as_str()
+                && let Some(rest) = s.strip_prefix("#/$defs/")
+            {
+                *r = Value::String(format!("#/components/schemas/{rest}"));
+            }
+            for (_, child) in map.iter_mut() {
+                rewrite_refs(child);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr.iter_mut() {
+                rewrite_refs(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Convert an object schema into a list of OpenAPI `parameters` entries
+/// suitable for a GET request's query string.
+///
+/// Schemars-emitted object schemas use `properties` + `required`; each
+/// property becomes one `in: query` parameter. Schemas that aren't object-
+/// shaped (or don't have properties) produce an empty parameter list, which
+/// Swagger UI renders as "no parameters" — acceptable for the edge case.
+fn schema_to_query_params(schema: &Value) -> Value {
+    let Some(props) = schema.get("properties").and_then(|v| v.as_object()) else {
+        return Value::Array(vec![]);
+    };
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let params: Vec<Value> = props
+        .iter()
+        .map(|(name, prop)| {
+            let desc = prop
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            serde_json::json!({
+                "name": name,
+                "in": "query",
+                "required": required.contains(&name.as_str()),
+                "description": desc,
+                "schema": prop,
+            })
+        })
+        .collect();
+    Value::Array(params)
+}
+
+fn json_rpc_error_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "error": {
+                "type": "object",
+                "properties": {
+                    "code": {"type": "integer"},
+                    "message": {"type": "string"}
+                },
+                "required": ["code", "message"]
+            }
+        },
+        "required": ["error"]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rewrites_refs_to_components_schemas() {
+        let mut v = json!({"$ref": "#/$defs/Foo"});
+        rewrite_refs(&mut v);
+        assert_eq!(v, json!({"$ref": "#/components/schemas/Foo"}));
+    }
+
+    #[test]
+    fn rewrites_refs_in_nested_arrays_and_maps() {
+        let mut v = json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Item"}
+                },
+                "single": {"$ref": "#/$defs/Other"}
+            }
+        });
+        rewrite_refs(&mut v);
+        assert_eq!(
+            v.pointer("/properties/items/items/$ref").unwrap(),
+            "#/components/schemas/Item"
+        );
+        assert_eq!(
+            v.pointer("/properties/single/$ref").unwrap(),
+            "#/components/schemas/Other"
+        );
+    }
+
+    #[test]
+    fn process_schema_lifts_defs() {
+        let mut shared = BTreeMap::new();
+        let s = json!({
+            "$ref": "#/$defs/Outer",
+            "$defs": {
+                "Outer": {"type": "object", "properties": {"inner": {"$ref": "#/$defs/Inner"}}},
+                "Inner": {"type": "string"}
+            }
+        });
+        let cleaned = process_schema(&s, &mut shared);
+        assert!(shared.contains_key("Outer"));
+        assert!(shared.contains_key("Inner"));
+        assert_eq!(cleaned.get("$ref").unwrap(), "#/components/schemas/Outer");
+        // Outer's inner ref must also have been rewritten when it landed in shared.
+        let outer_inner_ref = shared
+            .get("Outer")
+            .unwrap()
+            .pointer("/properties/inner/$ref")
+            .unwrap();
+        assert_eq!(outer_inner_ref, "#/components/schemas/Inner");
+        // `$defs` is gone from the returned schema.
+        assert!(cleaned.get("$defs").is_none());
+    }
+
+    #[test]
+    fn schema_to_query_params_marks_required_fields() {
+        let s = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Name."},
+                "limit": {"type": "integer"}
+            },
+            "required": ["name"]
+        });
+        let params = schema_to_query_params(&s);
+        let arr = params.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let by_name: BTreeMap<&str, &Value> = arr
+            .iter()
+            .map(|p| (p.get("name").unwrap().as_str().unwrap(), p))
+            .collect();
+        assert_eq!(by_name["name"].get("required").unwrap(), true);
+        assert_eq!(by_name["limit"].get("required").unwrap(), false);
+        assert_eq!(by_name["name"].get("in").unwrap(), "query");
+    }
+
+    #[test]
+    fn full_registry_renders_valid_openapi() {
+        // Smoke test — produce the full doc against the live registry and
+        // assert top-level invariants hold. Catches any future method whose
+        // schemas crash the lift step.
+        let (_g, groups) = super::super::build_full_registry();
+        let doc = render_openapi("test", &groups);
+        assert_eq!(doc.get("openapi").unwrap(), "3.1.0");
+        assert!(doc.get("paths").unwrap().as_object().unwrap().len() > 250);
+        // Every registered method maps to an existing path; sample one.
+        assert!(doc.pointer("/paths/~1api~1v1~1system~1info/get").is_some());
+    }
+}

--- a/engine/nasty-engine/src/registry/paths.rs
+++ b/engine/nasty-engine/src/registry/paths.rs
@@ -1,0 +1,213 @@
+//! JSON-RPC method name → REST path + HTTP verb translation.
+//!
+//! Used by the OpenAPI emitter and the REST gateway in `rest_gateway.rs` so
+//! the two never disagree about what URL a method lives at.
+//!
+//! Translation is purely mechanical:
+//!   - dots → slashes, segments otherwise unchanged
+//!   - verb inferred from the underscore-separated words of the last segment:
+//!       * **first word** matches an action-verb table (`delete`, `set`, …)
+//!       * **last word** matches a noun-read table (`info`, `notice`, …)
+//!       * action verbs take priority; default is POST
+//!
+//! The split into first-word vs last-word matching is what handles compound
+//! names: `delete_user` matches `delete` as the first word (→ DELETE), and
+//! `tagged_release_notice` matches `notice` as the last word (→ GET).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HttpVerb {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+impl HttpVerb {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HttpVerb::Get => "get",
+            HttpVerb::Post => "post",
+            HttpVerb::Put => "put",
+            HttpVerb::Delete => "delete",
+        }
+    }
+}
+
+/// First-word table: action verbs at the start of the last segment.
+const ACTION_VERBS: &[(&str, HttpVerb)] = &[
+    ("get", HttpVerb::Get),
+    ("list", HttpVerb::Get),
+    ("status", HttpVerb::Get),
+    ("check", HttpVerb::Get),
+    ("find", HttpVerb::Get),
+    ("delete", HttpVerb::Delete),
+    ("destroy", HttpVerb::Delete),
+    ("remove", HttpVerb::Delete),
+    ("set", HttpVerb::Put),
+    ("update", HttpVerb::Put),
+];
+
+/// Last-word table: noun reads at the end of the last segment.
+///
+/// These cover methods that don't have an action-verb prefix but are still
+/// reads (`system.info`, `system.alerts`, `system.version.tagged_release_notice`).
+/// Without them, those methods would default to POST and Swagger UI would
+/// render a misleading empty-body editor.
+const READ_NOUNS: &[&str] = &[
+    "info",
+    "health",
+    "stats",
+    "version",
+    "alerts",
+    "disks",
+    "usage",
+    "timezones",
+    "notice",
+    "me",
+    "config",
+    "available",
+    "routes",
+    "logs",
+    "summary",
+    "iommu",
+    "level",
+    "history",
+    "prometheus",
+    "pending",
+    "devices",
+    "capabilities",
+    "constraints",
+    "readiness",
+    "snapshots",
+    "dependents",
+    "children",
+    "top",
+    "timestats",
+    "required",
+];
+
+/// Translate a JSON-RPC method name to (verb, REST path).
+pub fn translate(method: &str) -> (HttpVerb, String) {
+    let path = format!("/api/v1/{}", method.replace('.', "/"));
+    let verb = infer_verb(method);
+    (verb, path)
+}
+
+/// Reverse direction: REST path segments → JSON-RPC method name.
+/// Used by the gateway to recover the method name from the captured URL tail.
+pub fn method_from_segments(segments: &str) -> String {
+    segments.replace('/', ".")
+}
+
+fn infer_verb(method: &str) -> HttpVerb {
+    let last_segment = method.rsplit('.').next().unwrap_or(method);
+    let words: Vec<&str> = last_segment.split('_').collect();
+    let first = words[0];
+    let last_word = *words.last().unwrap();
+
+    if let Some((_, verb)) = ACTION_VERBS.iter().find(|(kw, _)| first == *kw) {
+        return *verb;
+    }
+    if READ_NOUNS.contains(&last_word) {
+        return HttpVerb::Get;
+    }
+    HttpVerb::Post
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dots_become_slashes() {
+        let (_, path) = translate("system.update.build_dir.set");
+        assert_eq!(path, "/api/v1/system/update/build_dir/set");
+    }
+
+    #[test]
+    fn method_from_segments_inverts_translate() {
+        let (_, path) = translate("share.iscsi.remove_acl");
+        let tail = path.strip_prefix("/api/v1/").unwrap();
+        assert_eq!(method_from_segments(tail), "share.iscsi.remove_acl");
+    }
+
+    #[test]
+    fn first_word_action_verbs_dominate() {
+        assert_eq!(translate("fs.get").0, HttpVerb::Get);
+        assert_eq!(translate("subvolume.list").0, HttpVerb::Get);
+        assert_eq!(translate("subvolume.list_all").0, HttpVerb::Get);
+        assert_eq!(translate("fs.scrub.status").0, HttpVerb::Get);
+        assert_eq!(translate("subvolume.find_by_property").0, HttpVerb::Get);
+        assert_eq!(translate("auth.delete_user").0, HttpVerb::Delete);
+        assert_eq!(translate("share.iscsi.remove_acl").0, HttpVerb::Delete);
+        assert_eq!(translate("fs.options.update").0, HttpVerb::Put);
+        assert_eq!(translate("fs.device.set_label").0, HttpVerb::Put);
+    }
+
+    #[test]
+    fn last_word_noun_reads_map_to_get() {
+        assert_eq!(translate("auth.me").0, HttpVerb::Get);
+        assert_eq!(translate("system.info").0, HttpVerb::Get);
+        assert_eq!(translate("system.health").0, HttpVerb::Get);
+        assert_eq!(translate("system.alerts").0, HttpVerb::Get);
+        assert_eq!(translate("bcachefs.usage").0, HttpVerb::Get);
+        assert_eq!(translate("system.update.version").0, HttpVerb::Get);
+        assert_eq!(
+            translate("system.version.tagged_release_notice").0,
+            HttpVerb::Get
+        );
+        // Methods covered by the expanded noun list:
+        assert_eq!(translate("apps.config").0, HttpVerb::Get);
+        assert_eq!(translate("apps.caddy.routes").0, HttpVerb::Get);
+        assert_eq!(translate("apps.logs").0, HttpVerb::Get);
+        assert_eq!(translate("system.hardware.summary").0, HttpVerb::Get);
+        assert_eq!(translate("system.hardware.iommu").0, HttpVerb::Get);
+        assert_eq!(translate("system.log.level").0, HttpVerb::Get);
+        assert_eq!(translate("system.metrics.history").0, HttpVerb::Get);
+        assert_eq!(translate("system.metrics.prometheus").0, HttpVerb::Get);
+        assert_eq!(translate("backup.snapshots").0, HttpVerb::Get);
+        assert_eq!(translate("vm.capabilities").0, HttpVerb::Get);
+        assert_eq!(translate("firmware.constraints").0, HttpVerb::Get);
+        assert_eq!(translate("firmware.devices").0, HttpVerb::Get);
+        assert_eq!(translate("firmware.available").0, HttpVerb::Get);
+        assert_eq!(translate("system.secure_boot.readiness").0, HttpVerb::Get);
+        assert_eq!(translate("subvolume.children").0, HttpVerb::Get);
+        assert_eq!(translate("fs.dependents").0, HttpVerb::Get);
+        assert_eq!(translate("fs.locked_dependents").0, HttpVerb::Get);
+        assert_eq!(translate("bcachefs.top").0, HttpVerb::Get);
+        assert_eq!(translate("bcachefs.timestats").0, HttpVerb::Get);
+        assert_eq!(translate("system.reboot_required").0, HttpVerb::Get);
+    }
+
+    #[test]
+    fn side_effect_methods_without_verb_or_noun_stay_post() {
+        assert_eq!(translate("system.reboot").0, HttpVerb::Post);
+        assert_eq!(translate("system.shutdown").0, HttpVerb::Post);
+        assert_eq!(translate("auth.logout").0, HttpVerb::Post);
+        assert_eq!(translate("system.update.apply").0, HttpVerb::Post);
+        assert_eq!(translate("system.update.rollback").0, HttpVerb::Post);
+        assert_eq!(
+            translate("system.version.upgrade_tagged_release").0,
+            HttpVerb::Post
+        );
+        // Service / app lifecycle actions
+        assert_eq!(translate("apps.enable").0, HttpVerb::Post);
+        assert_eq!(translate("apps.disable").0, HttpVerb::Post);
+        assert_eq!(translate("apps.start").0, HttpVerb::Post);
+        assert_eq!(translate("apps.stop").0, HttpVerb::Post);
+        assert_eq!(translate("apps.restart").0, HttpVerb::Post);
+        assert_eq!(translate("apps.install").0, HttpVerb::Post);
+        assert_eq!(translate("apps.pull").0, HttpVerb::Post);
+        assert_eq!(translate("apps.prune").0, HttpVerb::Post);
+        // VM lifecycle
+        assert_eq!(translate("vm.start").0, HttpVerb::Post);
+        assert_eq!(translate("vm.stop").0, HttpVerb::Post);
+        assert_eq!(translate("vm.kill").0, HttpVerb::Post);
+        assert_eq!(translate("vm.snapshot").0, HttpVerb::Post);
+        // Tailscale / SSH side-effects
+        assert_eq!(translate("system.tailscale.connect").0, HttpVerb::Post);
+        assert_eq!(translate("system.tailscale.disconnect").0, HttpVerb::Post);
+        // Backup runs
+        assert_eq!(translate("backup.run").0, HttpVerb::Post);
+    }
+}

--- a/engine/nasty-engine/src/registry/tests.rs
+++ b/engine/nasty-engine/src/registry/tests.rs
@@ -154,6 +154,29 @@ fn render_properties_returns_none_for_empty_object() {
 }
 
 #[test]
+fn translation_produces_no_collisions_across_registry() {
+    // Every registered method must translate to a unique (verb, path) pair —
+    // otherwise the REST gateway can't route requests unambiguously.
+    use super::paths::translate;
+    use std::collections::HashMap;
+    let (_g, groups) = super::build_full_registry();
+    let mut seen: HashMap<(super::paths::HttpVerb, String), &'static str> = HashMap::new();
+    for (_, methods) in &groups {
+        for m in methods {
+            let key = translate(m.name);
+            if let Some(prior) = seen.insert(key.clone(), m.name) {
+                panic!(
+                    "translation collision: `{prior}` and `{}` both map to {} {}",
+                    m.name,
+                    key.0.as_str().to_uppercase(),
+                    key.1
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn registry_builds_without_panic() {
     // Smoke test: build the full registry. Catches schema-derivation
     // panics from any registered type — schemars sometimes throws on

--- a/engine/nasty-engine/src/rest_gateway.rs
+++ b/engine/nasty-engine/src/rest_gateway.rs
@@ -1,0 +1,394 @@
+//! REST gateway in front of the JSON-RPC dispatcher.
+//!
+//! Each registered method `foo.bar.baz` is reachable at `/api/v1/foo/bar/baz`
+//! with the HTTP verb [`super::registry::translate`] assigns. The handler is
+//! a thin envelope translator:
+//!
+//!   1. Extract the session token from `nasty_session` cookie or
+//!      `Authorization: Bearer` header (same path `/ws` uses).
+//!   2. Validate the token via `AuthService` → `Session`.
+//!   3. Convert the URL tail (`foo/bar/baz`) back to the method name.
+//!   4. Build a JSON-RPC `Request` with `params` taken from the query string
+//!      (GET) or the JSON body (everything else).
+//!   5. Call [`crate::router::handle_rpc_request`] — the *same* function the
+//!      WebSocket path uses, so role enforcement, audit logging, slow-call
+//!      tracing, and post-mutation event broadcasts all fire identically.
+//!   6. Unwrap the JSON-RPC envelope: `result` → 200 with the inner value,
+//!      `error` → HTTP status mapped from the error message + code.
+//!
+//! Streaming endpoints (log_stream, terminal, vm_console, telemetry pushes)
+//! stay on the WebSocket — they're not in the method registry and the
+//! gateway doesn't try to model them.
+
+use axum::{
+    Json, Router,
+    extract::{Path, RawQuery, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use serde_json::{Map, Value};
+use std::sync::{Arc, OnceLock};
+use tracing::debug;
+
+use crate::AppState;
+use crate::auth::AuthError;
+use crate::registry::{HttpVerb, method_from_segments, translate};
+use crate::router::handle_rpc_request;
+use crate::token_from_headers;
+
+/// Build the REST gateway sub-router. Mounted as a sibling of `/ws` and
+/// `/api/login`.
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new().route(
+        "/api/v1/{*path}",
+        get(gateway_get)
+            .post(gateway_post)
+            .put(gateway_put)
+            .delete(gateway_delete),
+    )
+}
+
+async fn gateway_get(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    RawQuery(query): RawQuery,
+) -> Response {
+    let params = query_to_json(query.as_deref().unwrap_or(""));
+    dispatch(state, headers, &path, HttpVerb::Get, params).await
+}
+
+async fn gateway_post(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Option<Json<Value>>,
+) -> Response {
+    dispatch(
+        state,
+        headers,
+        &path,
+        HttpVerb::Post,
+        body.map(|j| j.0).unwrap_or(Value::Null),
+    )
+    .await
+}
+
+async fn gateway_put(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Option<Json<Value>>,
+) -> Response {
+    dispatch(
+        state,
+        headers,
+        &path,
+        HttpVerb::Put,
+        body.map(|j| j.0).unwrap_or(Value::Null),
+    )
+    .await
+}
+
+async fn gateway_delete(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(path): Path<String>,
+    body: Option<Json<Value>>,
+) -> Response {
+    dispatch(
+        state,
+        headers,
+        &path,
+        HttpVerb::Delete,
+        body.map(|j| j.0).unwrap_or(Value::Null),
+    )
+    .await
+}
+
+async fn dispatch(
+    state: Arc<AppState>,
+    headers: HeaderMap,
+    path_tail: &str,
+    verb: HttpVerb,
+    params: Value,
+) -> Response {
+    // 1. Path → method name + verb sanity check.
+    let method = method_from_segments(path_tail);
+    let Some(canonical_verb) = canonical_verb_for(&method) else {
+        return (
+            StatusCode::NOT_FOUND,
+            json_error(format!("unknown RPC method: {method}")),
+        )
+            .into_response();
+    };
+    if canonical_verb != verb {
+        return (
+            StatusCode::METHOD_NOT_ALLOWED,
+            json_error(format!(
+                "method `{method}` is exposed as {}, not {}",
+                canonical_verb.as_str().to_uppercase(),
+                verb.as_str().to_uppercase()
+            )),
+        )
+            .into_response();
+    }
+
+    // 2. Auth: pull token, validate → Session.
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+    let Some(token) = token_from_headers(&headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            json_error("missing session token"),
+        )
+            .into_response();
+    };
+    let session = match state.auth.validate(&token, &client_ip).await {
+        Ok(s) => s,
+        Err(e) => return auth_error_to_response(e),
+    };
+
+    // 3. Build JSON-RPC envelope. `id` is a synthesized UUID so audit/slow-
+    //    call logs in `handle_rpc_request` have something to correlate on.
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let envelope = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": params,
+    });
+    let raw = serde_json::to_string(&envelope).expect("envelope must serialize");
+
+    debug!(
+        "REST→RPC: {} {} (user: {})",
+        verb.as_str().to_uppercase(),
+        method,
+        session.username
+    );
+    let response_str = handle_rpc_request(&raw, &state, &session).await;
+
+    // 4. Unwrap.
+    let response: Value = match serde_json::from_str(&response_str) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json_error(format!("malformed engine response: {e}")),
+            )
+                .into_response();
+        }
+    };
+    if let Some(err) = response.get("error") {
+        let message = err
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(-32603);
+        let status = map_error_to_status(code, message);
+        return (
+            status,
+            Json(serde_json::json!({
+                "error": {"code": code, "message": message}
+            })),
+        )
+            .into_response();
+    }
+    let result = response.get("result").cloned().unwrap_or(Value::Null);
+    // Endpoints with no result (e.g. delete arms returning literal "ok") get
+    // 204 No Content; otherwise 200 + body.
+    if matches!(&result, Value::String(s) if s == "ok") || matches!(&result, Value::Null) {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        (StatusCode::OK, Json(result)).into_response()
+    }
+}
+
+fn auth_error_to_response(err: AuthError) -> Response {
+    let (status, msg) = match err {
+        AuthError::InvalidToken => (StatusCode::UNAUTHORIZED, "invalid token"),
+        AuthError::TokenExpired => (StatusCode::UNAUTHORIZED, "token expired"),
+        _ => (StatusCode::UNAUTHORIZED, "authentication failed"),
+    };
+    (status, json_error(msg)).into_response()
+}
+
+/// Map JSON-RPC error code + message → HTTP status.
+///
+/// JSON-RPC's error model is one big -32603 bucket for everything outside the
+/// parse/invalid-request range, so the message itself is the only signal for
+/// most cases. We pattern-match on the well-known message prefixes the engine
+/// emits.
+fn map_error_to_status(code: i64, message: &str) -> StatusCode {
+    if code == -32700 || code == -32600 || code == -32602 {
+        return StatusCode::BAD_REQUEST;
+    }
+    if code == -32601 {
+        return StatusCode::NOT_FOUND;
+    }
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("permission denied") || lower.contains("access denied") {
+        return StatusCode::FORBIDDEN;
+    }
+    if lower.contains("not found") {
+        return StatusCode::NOT_FOUND;
+    }
+    if lower.contains("missing params")
+        || lower.contains("missing field")
+        || lower.contains("invalid")
+    {
+        return StatusCode::BAD_REQUEST;
+    }
+    StatusCode::INTERNAL_SERVER_ERROR
+}
+
+/// Parse a URL-encoded query string into a JSON object, treating each value
+/// as a JSON literal where it parses (so `?limit=200` becomes `{"limit": 200}`)
+/// and as a plain string otherwise (so `?name=foo` becomes `{"name": "foo"}`).
+fn query_to_json(query: &str) -> Value {
+    if query.is_empty() {
+        return Value::Null;
+    }
+    let mut obj = Map::new();
+    for pair in query.split('&') {
+        let (k, v) = match pair.split_once('=') {
+            Some(t) => t,
+            None => (pair, ""),
+        };
+        let k = url_decode(k);
+        let v = url_decode(v);
+        let parsed = serde_json::from_str::<Value>(&v).unwrap_or(Value::String(v));
+        obj.insert(k, parsed);
+    }
+    Value::Object(obj)
+}
+
+fn url_decode(s: &str) -> String {
+    url::form_urlencoded::parse(format!("k={s}").as_bytes())
+        .next()
+        .map(|(_, v)| v.into_owned())
+        .unwrap_or_else(|| s.to_string())
+}
+
+fn json_error(msg: impl Into<String>) -> Json<Value> {
+    Json(serde_json::json!({"error": msg.into()}))
+}
+
+/// Cheap lookup: method name → canonical HTTP verb from the registry.
+/// Built once at first call so REST requests don't pay the schemars cost.
+fn canonical_verb_for(method: &str) -> Option<HttpVerb> {
+    use std::collections::HashMap;
+    static TABLE: OnceLock<HashMap<String, HttpVerb>> = OnceLock::new();
+    let table = TABLE.get_or_init(|| {
+        let (_g, groups) = crate::registry::build_full_registry();
+        groups
+            .into_iter()
+            .flat_map(|(_, ms)| {
+                ms.into_iter()
+                    .map(|m| (m.name.to_string(), translate(m.name).0))
+            })
+            .collect()
+    });
+    table.get(method).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn query_to_json_parses_json_literals() {
+        let v = query_to_json("limit=200&name=foo");
+        assert_eq!(v, json!({"limit": 200, "name": "foo"}));
+    }
+
+    #[test]
+    fn query_to_json_handles_empty() {
+        assert_eq!(query_to_json(""), Value::Null);
+    }
+
+    #[test]
+    fn query_to_json_keeps_string_for_non_json_values() {
+        // `bar` is a bare identifier — not valid JSON. Treated as a string.
+        let v = query_to_json("foo=bar");
+        assert_eq!(v, json!({"foo": "bar"}));
+    }
+
+    #[test]
+    fn query_to_json_handles_booleans_and_null() {
+        let v = query_to_json("enabled=true&limit=null");
+        assert_eq!(v, json!({"enabled": true, "limit": null}));
+    }
+
+    #[test]
+    fn query_to_json_url_decodes_values() {
+        let v = query_to_json("name=hello%20world");
+        assert_eq!(v, json!({"name": "hello world"}));
+    }
+
+    #[test]
+    fn error_mapping_permission_denied() {
+        assert_eq!(
+            map_error_to_status(-32603, "Permission denied"),
+            StatusCode::FORBIDDEN
+        );
+        // Case-insensitive.
+        assert_eq!(
+            map_error_to_status(-32603, "ACCESS DENIED"),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn error_mapping_not_found() {
+        assert_eq!(
+            map_error_to_status(-32603, "filesystem not found: mypool"),
+            StatusCode::NOT_FOUND
+        );
+        // JSON-RPC code -32601 = MethodNotFound.
+        assert_eq!(
+            map_error_to_status(-32601, "whatever"),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn error_mapping_bad_request_for_parse_errors() {
+        assert_eq!(map_error_to_status(-32700, "x"), StatusCode::BAD_REQUEST);
+        assert_eq!(map_error_to_status(-32600, "x"), StatusCode::BAD_REQUEST);
+        assert_eq!(map_error_to_status(-32602, "x"), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            map_error_to_status(-32603, "missing params"),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn error_mapping_falls_through_to_500() {
+        assert_eq!(
+            map_error_to_status(-32603, "something exploded"),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn canonical_verb_lookup_covers_known_methods() {
+        // Cold lookup — also exercises the OnceLock init path.
+        assert_eq!(canonical_verb_for("system.info"), Some(HttpVerb::Get));
+        assert_eq!(
+            canonical_verb_for("auth.delete_user"),
+            Some(HttpVerb::Delete)
+        );
+        assert_eq!(
+            canonical_verb_for("system.update.build_dir.set"),
+            Some(HttpVerb::Put)
+        );
+        assert_eq!(canonical_verb_for("system.reboot"), Some(HttpVerb::Post));
+        assert_eq!(canonical_verb_for("nonexistent.method"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the existing JSON-RPC dispatcher in a thin HTTP envelope so every registered method is reachable from curl, kubectl-style clients, and (in PR3) Swagger UI without speaking WebSocket.

This is **PR2** of 3 toward in-engine OpenAPI docs and a vendored Swagger UI at `/api/docs`. PR3 will vendor `swagger-ui-dist` and serve the docs page.

## What's new

```
engine/nasty-engine/src/
  registry/paths.rs       — method name ↔ REST path / HTTP verb translation
  registry/openapi.rs     — registry → OpenAPI 3.1 document
  rest_gateway.rs         — Axum handlers wrapping handle_rpc_request
```

Plus `/api/openapi.json` route and a `--dump-docs` extension that emits `openapi.json` alongside `api.md`.

## URL scheme

Dots → slashes, verb inferred from the last segment:

| Last-segment match | Verb | Example |
|---|---|---|
| `.get`/`.list`/`.status`/`.check`/`.find` | GET | `GET /api/v1/system/info` |
| `.delete`/`.destroy`/`.remove` | DELETE | `DELETE /api/v1/share/nfs/delete` |
| `.set`/`.update` | PUT | `PUT /api/v1/system/network/update` |
| (everything else) | POST | `POST /api/v1/system/reboot` |

Plus a "noun-read" tail-word table for methods like `system.info`, `system.alerts`, `system.version.tagged_release_notice` that have no verb prefix but are still reads.

GET methods take params from the query string (values parsed as JSON literals where possible — `?limit=200` becomes `{"limit": 200}`). Everything else takes a JSON body.

## Auth and dispatch

Mirrors `/ws` exactly:

1. Pull token from `nasty_session` cookie or `Authorization: Bearer` header.
2. `state.auth.validate(token, client_ip)` → `Session`.
3. Repackage into a JSON-RPC envelope, dispatch through the existing `handle_rpc_request`.
4. Role enforcement, audit logging, slow-call tracing, and post-mutation event broadcasts all fire identically.
5. Unwrap: `result` → 200 + body (or 204 if the result is `null`/`"ok"`), `error` → mapped HTTP status.

## Error mapping

| JSON-RPC condition | HTTP |
|---|---|
| Code -32700 / -32600 / -32602 | 400 |
| Code -32601, or message contains "not found" | 404 |
| Message contains "permission denied" / "access denied" | 403 |
| Message contains "missing field" / "missing params" / "invalid" | 400 |
| Default | 500 |

## /api/openapi.json

Built once on first request (schemars walk is expensive — ~1.1 MB doc covering all 256 methods plus 104 component schemas), cached for the process lifetime via `OnceLock`.

`nasty-engine --dump-docs <dir>` now writes both `api.md` and `openapi.json` from the same registry build.

## What's NOT in this PR

- **Streaming endpoints** (`log_stream`, `terminal`, `vm_console`, telemetry pushes, event broadcasts) stay on `/ws` — not in the method registry, not modeled by OpenAPI.
- **Swagger UI** is PR3.
- **Role check rewiring** (consulting `registry::role_lookup` instead of the `is_universally_allowed` / `is_operator_allowed` string lists) — deferred to a separate PR to keep dispatch-behavior changes isolated.

## Test plan

- [x] `cargo build -p nasty-engine`
- [x] `cargo clippy -p nasty-engine --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p nasty-engine --all-targets` → 103 tests pass
  - 5 path-translation tests
  - 5 OpenAPI emitter tests (incl. a smoke test that builds the full spec)
  - 10 REST gateway tests (query parsing, error mapping, verb lookup)
  - 1 registry-wide invariant: no two methods translate to the same `(verb, path)`
- [x] `nasty-engine --dump-docs <dir>` writes `api.md` (265 KB) + `openapi.json` (1.1 MB, 256 paths, 104 schemas)
- [x] `python3 -m json.tool` parses the generated `openapi.json` without errors
- [ ] Live `curl` against a running engine (manual smoke test post-merge)
- [ ] Full workspace `cargo test --workspace --all-targets` (CI)
- [ ] Integration workflow (Nix sandbox build)