### PR TITLE
flake: pin nixpkgs to nixos-26.05

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-26.05
           extra_nix_config: |
             experimental-features = nix-command flakes
 

--- a/flake.lock
+++ b/flake.lock
@@ -176,16 +176,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779971959,
+        "narHash": "sha256-R5nauXyqyfRUFiZycFFZdkF7wl6eaUpPLst35+2nJQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "NASty - NAS System built on NixOS and bcachefs";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # ── bcachefs override (optional) ──────────────────────────────
     # Pinned to v1.38.3 release tag.

--- a/nixos/TESTING.md
+++ b/nixos/TESTING.md
@@ -82,7 +82,7 @@ Add NASty as a flake input in your system configuration:
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nasty.url = "path:/path/to/NAS"; # or github:your-org/nasty
   };
 


### PR DESCRIPTION
## Summary

Switches the project from rolling `nixos-unstable` to the just-released `nixos-26.05` stable line.

Since we've been running unstable, this is **strictly less surface area**: same code at the branch cut (we were already running it), then bugfix / security backports only — no new feature versions landing. NixOS 26.05 EOL: **2026-12-31** (seven months of backports).

## Diff

| File | Change |
|---|---|
| `flake.nix` | `nixos-unstable` → `nixos-26.05` |
| `flake.lock` | `nix flake update nixpkgs` — now at rev `ec942ba0` (2026-05-28) |
| `.github/workflows/build-iso.yml` | `channel:nixos-unstable` → `channel:nixos-26.05` |
| `nixos/TESTING.md` | docs sample |

That's everything. 4 files, +7 / -7.

## Why so small

- **Wrapper template (`nixos/system-flake/flake.nix.template:31`)** uses `nixpkgs.follows = "nasty/nixpkgs"`, so every existing operator box inherits the new pin on its next `system.update.apply` — no wrapper re-render, no per-box manual step.
- **`engine/nasty-system/src/update.rs`** has several `nixos-unstable` strings, but they're all parser test fixtures (sample wrapper-flake content). Intentionally left alone — they exist to exercise the parser against any plausible nixpkgs URL.

## Stage-1 systemd initrd (NixOS 26.05's biggest behavior change)

No-op for NASty: `boot.initrd.systemd.enable = true` is already set explicitly at `nixos/modules/nasty.nix:274` (originally for Plymouth-early boot). The explicit `= true;` becomes redundant after this PR but isn't worth removing in the same commit.

## Test plan

- [x] `cargo build -p nasty-engine` clean (Rust source doesn't depend on the channel)
- [x] `nix flake update nixpkgs` succeeded
- [ ] CI: nix engine build (the sandbox-visibility gate that caught the swagger-ui mistake in #353) — this is the main thing to watch on this PR
- [ ] Deploy to `10.10.10.71` and verify a basic `nixos-rebuild switch` works end-to-end
- [ ] After deploy, exercise `system.version.upgrade_tagged_release` from a second box still on the unstable wrapper, to confirm the migration RPC carries existing operators forward cleanly