### PR TITLE
nasty.nix: disable multicast_snooping on engine-created bridges (#291)

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2192,6 +2192,30 @@ in {
       "interface-name:cni*"
       "interface-name:flannel*"
     ];
+
+    # mDNS / WS-Discovery fix for engine-created Linux bridges (#291).
+    #
+    # The kernel defaults a fresh bridge to multicast_snooping=1 with no
+    # multicast_querier — fine on a network with an IGMP querier (managed
+    # switch, dedicated router daemon), broken on the typical home LAN
+    # that has neither. Without a querier, IGMP memberships time out
+    # ~5 minutes after the last join and the bridge stops forwarding
+    # multicast (including mDNS / WS-Discovery), so avahi and samba-wsdd
+    # announce successfully right after a restart and then go invisible
+    # to file managers as soon as memberships expire. TrueNAS et al.
+    # don't hit this because they aren't behind a Linux bridge.
+    #
+    # Setting multicast_snooping=0 makes the bridge flood multicast to
+    # all ports unconditionally — which is what every home-LAN deployment
+    # actually wants, and what the operator was already expecting
+    # the moment they put NASty on a bridged interface.
+    #
+    # The KERNEL pattern matches our brN naming convention (br0, br1, …)
+    # and intentionally skips Docker's `br-<hash>` and any tap/veth
+    # interface that happens to expose a `bridge/` subdir.
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="net", KERNEL=="br[0-9]*", ATTR{bridge/multicast_snooping}="0"
+    '';
     })
   ];
 }


### PR DESCRIPTION
## Summary

Lands the permanent fix for #291 (NASty not showing up in file manager when configured behind a Linux bridge).

The kernel defaults a fresh bridge to `multicast_snooping=1` with no `multicast_querier` — fine on a network with a real IGMP querier (managed switch, dedicated daemon), broken on the typical home LAN that has neither. Without a querier, IGMP memberships time out ~5 minutes after the last join and the bridge stops forwarding multicast, including mDNS / WS-Discovery. So `avahi-daemon` and `samba-wsdd` announce successfully right after a restart and then go invisible to file managers a few minutes later — exactly what the reporter in #291 saw.

The two-line workaround (`echo 0 > /sys/class/net/br0/bridge/multicast_snooping`) was confirmed working by the reporter; this PR makes it permanent.

## Approach

One declarative udev rule in `nixos/modules/nasty.nix`:

```
ACTION=="add", SUBSYSTEM=="net", KERNEL=="br[0-9]*", ATTR{bridge/multicast_snooping}="0"
```

Fires whenever a bridge appears — whether NM creates it at boot, the engine reapplies network config at runtime, or the operator hand-creates one. No engine-side sysfs poke, no boot-only oneshot.

The `KERNEL=="br[0-9]*"` pattern matches the brN convention NASty's WebUI uses (`br0`, `br1`, …) and intentionally skips Docker's `br-<hash>` and any tap/veth that happens to expose a `bridge/` subdir.

## Test plan

- [x] `nixos/modules/nasty.nix` edits land cleanly (single block in the NM-config section)
- [ ] Deploy to `10.10.10.71` and verify a fresh `br0` lands with `cat /sys/class/net/br0/bridge/multicast_snooping == 0` (i.e., the udev rule fires)
- [ ] From a LAN client: `avahi-browse -art | grep -i smb` lists the NASty box and remains visible past the ~5-minute IGMP timeout window
- [ ] Windows Explorer → Network shows the box and keeps showing it

Closes #291.