### PR TITLE
metrics: show all disks, surface UNAVAILABLE smart_status (#349)

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1040,6 +1040,7 @@ pub(crate) async fn evaluate_active_alerts(
             device: d.device,
             temperature_c: d.temperature_c,
             health_passed: d.health_passed,
+            smart_status: d.smart_status,
         })
         .collect();
 

--- a/engine/nasty-metrics/src/collect_system.rs
+++ b/engine/nasty-metrics/src/collect_system.rs
@@ -348,45 +348,162 @@ struct SmartctlRaw {
     value: i64,
 }
 
-pub async fn disk_health() -> Vec<DiskHealth> {
-    let devices = match tokio::process::Command::new("lsblk")
-        .args(["-dn", "-o", "NAME,TYPE"])
-        .output()
-        .await
-    {
-        Ok(out) => {
-            let text = String::from_utf8_lossy(&out.stdout);
-            text.lines()
-                .filter_map(|line| {
-                    let mut parts = line.split_whitespace();
-                    let name = parts.next()?;
-                    let dtype = parts.next()?;
-                    if dtype == "disk"
-                        && !name.starts_with("mmcblk")
-                        && !name.starts_with("loop")
-                        && !name.starts_with("ram")
-                        && !name.starts_with("zram")
-                    {
-                        Some(format!("/dev/{name}"))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>()
-        }
-        Err(_) => return Vec::new(),
-    };
+/// What lsblk knows about a disk before we ask smartctl anything.
+///
+/// Keeping this around as a separate row means a disk shows up in the
+/// `system.disks` answer even when smartctl can't talk to it — useful for
+/// fresh / unformatted / wonky-USB-bridge drives (#349). Without this the
+/// older code path silently dropped the device, so the operator only saw
+/// disks that had already been formatted.
+struct LsblkDisk {
+    device: String,
+    size_bytes: u64,
+    model: String,
+    serial: String,
+}
 
-    let mut results = Vec::new();
-    for dev in devices {
-        if let Some(health) = query_smartctl(&dev).await {
-            results.push(health);
-        }
+/// Smart status sentinel used when smartctl produced no usable data for
+/// the device. WebUI styles this distinctly from PASSED/FAILED, and the
+/// alert rules (see `nasty_system::alerts::AlertMetric::SmartHealth`)
+/// intentionally don't fire on it — UNAVAILABLE is "unknown", not "bad".
+pub const SMART_STATUS_UNAVAILABLE: &str = "UNAVAILABLE";
+
+pub async fn disk_health() -> Vec<DiskHealth> {
+    let disks = enumerate_disks().await;
+    let mut results = Vec::with_capacity(disks.len());
+    for disk in disks {
+        results.push(build_disk_health(disk).await);
     }
     results
 }
 
-async fn query_smartctl(device: &str) -> Option<DiskHealth> {
+async fn enumerate_disks() -> Vec<LsblkDisk> {
+    // -J = JSON output (parses cleanly even when MODEL has spaces / lsblk
+    // version differs across NixOS releases). -d = top-level only.
+    // -b = bytes. -n = no header. -o = explicit column list.
+    let output = match tokio::process::Command::new("lsblk")
+        .args(["-Jdbno", "NAME,TYPE,SIZE,MODEL,SERIAL"])
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+    let parsed: serde_json::Value = match serde_json::from_slice(&output.stdout) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let Some(arr) = parsed.get("blockdevices").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+
+    arr.iter()
+        .filter_map(|d| {
+            let name = d.get("name").and_then(|v| v.as_str())?;
+            let dtype = d.get("type").and_then(|v| v.as_str())?;
+            if dtype != "disk"
+                || name.starts_with("mmcblk")
+                || name.starts_with("loop")
+                || name.starts_with("ram")
+                || name.starts_with("zram")
+            {
+                return None;
+            }
+            Some(LsblkDisk {
+                device: format!("/dev/{name}"),
+                size_bytes: d
+                    .get("size")
+                    .and_then(|v| {
+                        v.as_u64()
+                            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                    })
+                    .unwrap_or(0),
+                model: d
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("Unknown")
+                    .to_string(),
+                serial: d
+                    .get("serial")
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("Unknown")
+                    .to_string(),
+            })
+        })
+        .collect()
+}
+
+async fn build_disk_health(disk: LsblkDisk) -> DiskHealth {
+    let dev_name = disk.device.strip_prefix("/dev/").unwrap_or(&disk.device);
+    let (ata_port, controller_pci) = resolve_device_path(dev_name);
+    let controller_name = controller_pci.as_deref().and_then(resolve_pci_name);
+
+    match query_smartctl(&disk.device).await {
+        Some(s) => DiskHealth {
+            device: disk.device,
+            ata_port,
+            controller_pci,
+            controller_name,
+            // smartctl's strings are usually more accurate than lsblk's
+            // (lsblk reads sysfs's `model`, which truncates / pads), but
+            // for unfamiliar transports lsblk sometimes wins — prefer
+            // smartctl, fall back to lsblk, then to "Unknown".
+            model: s.model.filter(|s| !s.is_empty()).unwrap_or(disk.model),
+            serial: s.serial.filter(|s| !s.is_empty()).unwrap_or(disk.serial),
+            firmware: s.firmware.unwrap_or_else(|| "Unknown".into()),
+            capacity_bytes: if s.capacity_bytes > 0 {
+                s.capacity_bytes
+            } else {
+                disk.size_bytes
+            },
+            temperature_c: s.temperature_c,
+            power_on_hours: s.power_on_hours,
+            health_passed: s.health_passed,
+            smart_status: if s.health_passed {
+                "PASSED".to_string()
+            } else {
+                "FAILED".to_string()
+            },
+            attributes: s.attributes,
+        },
+        None => DiskHealth {
+            device: disk.device,
+            ata_port,
+            controller_pci,
+            controller_name,
+            model: disk.model,
+            serial: disk.serial,
+            firmware: "Unknown".into(),
+            capacity_bytes: disk.size_bytes,
+            temperature_c: None,
+            power_on_hours: None,
+            // Distinct from FAILED so the WebUI can style + the alert
+            // rules can skip. See SMART_STATUS_UNAVAILABLE.
+            health_passed: false,
+            smart_status: SMART_STATUS_UNAVAILABLE.to_string(),
+            attributes: Vec::new(),
+        },
+    }
+}
+
+/// SMART-derived fields, lifted out of `DiskHealth` so the no-data path
+/// is a clean `None` rather than a half-filled struct.
+struct SmartReport {
+    model: Option<String>,
+    serial: Option<String>,
+    firmware: Option<String>,
+    capacity_bytes: u64,
+    temperature_c: Option<i32>,
+    power_on_hours: Option<u64>,
+    health_passed: bool,
+    attributes: Vec<SmartAttribute>,
+}
+
+async fn query_smartctl(device: &str) -> Option<SmartReport> {
     let output = tokio::process::Command::new("smartctl")
         .args(["-a", "--json=c", device])
         .output()
@@ -395,11 +512,15 @@ async fn query_smartctl(device: &str) -> Option<DiskHealth> {
 
     let json: SmartctlJson = serde_json::from_slice(&output.stdout).ok()?;
 
-    let health_passed = json
-        .smart_status
-        .as_ref()
-        .map(|s| s.passed)
-        .unwrap_or(false);
+    // Treat "no smart_status object at all" as "unavailable" rather than
+    // "FAILED". smartctl returns the object on every supported transport;
+    // its absence means we got JSON back but it carried no SMART payload
+    // (USB-SATA bridge that needs `-d sat`, controller that doesn't
+    // proxy SMART, etc.). Returning None here flows through to the
+    // UNAVAILABLE branch in `build_disk_health` so the disk still
+    // shows up in the WebUI with whatever lsblk could tell us.
+    let smart_status = json.smart_status.as_ref()?;
+    let health_passed = smart_status.passed;
 
     let attributes: Vec<SmartAttribute> = json
         .ata_smart_attributes
@@ -420,29 +541,14 @@ async fn query_smartctl(device: &str) -> Option<DiskHealth> {
         })
         .unwrap_or_default();
 
-    let smart_status = if health_passed {
-        "PASSED".to_string()
-    } else {
-        "FAILED".to_string()
-    };
-
-    let dev_name = device.strip_prefix("/dev/").unwrap_or(device);
-    let (ata_port, controller_pci) = resolve_device_path(dev_name);
-    let controller_name = controller_pci.as_deref().and_then(resolve_pci_name);
-
-    Some(DiskHealth {
-        device: device.to_string(),
-        ata_port,
-        controller_pci,
-        controller_name,
-        model: json.model_name.unwrap_or_else(|| "Unknown".into()),
-        serial: json.serial_number.unwrap_or_else(|| "Unknown".into()),
-        firmware: json.firmware_version.unwrap_or_else(|| "Unknown".into()),
+    Some(SmartReport {
+        model: json.model_name,
+        serial: json.serial_number,
+        firmware: json.firmware_version,
         capacity_bytes: json.user_capacity.map(|c| c.bytes).unwrap_or(0),
         temperature_c: json.temperature.and_then(|t| t.current),
         power_on_hours: json.power_on_time.and_then(|p| p.hours),
         health_passed,
-        smart_status,
         attributes,
     })
 }

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -351,8 +351,19 @@ fn evaluate_rules(
                 }
             }
             AlertMetric::SmartHealth => {
-                // threshold=1 means "alert when health_passed == false"
+                // threshold=1 means "alert when health_passed == false".
+                // Skip disks where SMART itself is UNAVAILABLE (USB-SATA
+                // bridge without `-d sat`, controller that doesn't proxy
+                // SMART, unsupported transport, …) — "no data" isn't
+                // "FAILED", and firing a critical alert on every disk
+                // the metrics service can't read SMART for would be a
+                // false-positive storm. The disk still appears in the
+                // WebUI Disks page with status UNAVAILABLE, so the
+                // operator sees the gap.
                 for disk in disk_health {
+                    if disk.smart_status == "UNAVAILABLE" {
+                        continue;
+                    }
                     if !disk.health_passed {
                         alerts.push(ActiveAlert {
                             rule_id: rule.id.clone(),
@@ -573,6 +584,11 @@ pub struct DiskHealthSummary {
     pub device: String,
     pub temperature_c: Option<i32>,
     pub health_passed: bool,
+    /// Mirror of `DiskHealth::smart_status`. Carried into the summary so
+    /// the `SmartHealth` alert rule can distinguish "FAILED" (alert) from
+    /// "UNAVAILABLE" (don't alert — smartctl couldn't read SMART, that's
+    /// not the same as a confirmed health failure).
+    pub smart_status: String,
 }
 
 /// Kernel error data for alert evaluation.
@@ -1050,16 +1066,19 @@ mod tests {
                 device: "sda".into(),
                 temperature_c: Some(60),
                 health_passed: true,
+                smart_status: "PASSED".into(),
             },
             DiskHealthSummary {
                 device: "sdb".into(),
                 temperature_c: None, // skipped
                 health_passed: true,
+                smart_status: "PASSED".into(),
             },
             DiskHealthSummary {
                 device: "sdc".into(),
                 temperature_c: Some(45), // below threshold
                 health_passed: true,
+                smart_status: "PASSED".into(),
             },
         ];
         let alerts = evaluate_rules(
@@ -1083,11 +1102,13 @@ mod tests {
                 device: "sda".into(),
                 temperature_c: None,
                 health_passed: true,
+                smart_status: "PASSED".into(),
             },
             DiskHealthSummary {
                 device: "sdb".into(),
                 temperature_c: None,
                 health_passed: false,
+                smart_status: "FAILED".into(),
             },
         ];
         let alerts = evaluate_rules(
@@ -1101,6 +1122,36 @@ mod tests {
         );
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0].source, "sdb");
+    }
+
+    #[test]
+    fn evaluate_rules_smart_health_skips_unavailable_disks() {
+        // Regression for #349: disks with smart_status="UNAVAILABLE"
+        // (smartctl couldn't read SMART — USB-SATA bridge that needs
+        // -d sat, controller that doesn't proxy SMART, fresh disk
+        // before kernel finished initializing) carry health_passed=false
+        // by construction, but that's "unknown" not "FAILED". The
+        // SmartHealth rule must not fire on them.
+        let r = rule(AlertMetric::SmartHealth, AlertCondition::Equals, 1.0);
+        let disks = vec![DiskHealthSummary {
+            device: "sdb".into(),
+            temperature_c: None,
+            health_passed: false,
+            smart_status: "UNAVAILABLE".into(),
+        }];
+        let alerts = evaluate_rules(
+            &[r],
+            &zero_stats(),
+            &[],
+            &disks,
+            &[],
+            &KernelErrorAlert::default(),
+            DiskFreeSpace::default(),
+        );
+        assert!(
+            alerts.is_empty(),
+            "UNAVAILABLE smart_status must not trigger SmartHealth alerts"
+        );
     }
 
     fn bcachefs_health(devices: Vec<BcachefsDeviceHealth>) -> BcachefsHealth {

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -221,10 +221,16 @@
 			<p class="text-sm text-muted-foreground">No disks detected or smartctl not available.</p>
 		{:else}
 			{#each disks as disk}
-				<Card class="mb-4 {!disk.health_passed ? 'border-red-900' : ''}">
+				{@const unavailable = disk.smart_status === 'UNAVAILABLE'}
+				<Card class="mb-4 {!disk.health_passed && !unavailable ? 'border-red-900' : ''}">
 					<CardContent class="pt-5">
 						<div class="mb-4 flex items-center gap-4">
-							<span class="rounded px-2.5 py-1 text-xs font-bold {disk.health_passed ? 'bg-green-950 text-green-400' : 'bg-red-950 text-red-400'}">
+							<span class="rounded px-2.5 py-1 text-xs font-bold
+								{unavailable
+									? 'bg-muted text-muted-foreground'
+									: disk.health_passed
+										? 'bg-green-950 text-green-400'
+										: 'bg-red-950 text-red-400'}">
 								{disk.smart_status}
 							</span>
 							<div class="flex flex-1 items-baseline gap-3">
@@ -348,7 +354,12 @@
 										{formatTemp(disk.temperature_c) ?? '—'}
 									</td>
 									<td class="p-3">
-										<span class="rounded px-2 py-0.5 text-xs font-bold {disk.health_passed ? 'bg-green-950 text-green-400' : 'bg-red-950 text-red-400'}">
+										<span class="rounded px-2 py-0.5 text-xs font-bold
+											{disk.smart_status === 'UNAVAILABLE'
+												? 'bg-muted text-muted-foreground'
+												: disk.health_passed
+													? 'bg-green-950 text-green-400'
+													: 'bg-red-950 text-red-400'}">
 											{disk.smart_status}
 										</span>
 									</td>


### PR DESCRIPTION
## Summary

Closes #349 — *SMART Health: disk does not show unless you create a filesystem on it.*

## Root cause

\`disk_health\` in the metrics service silently dropped any disk whose smartctl call didn't produce a usable JSON envelope:

\`\`\`rust
let json: SmartctlJson = serde_json::from_slice(&output.stdout).ok()?;
\`\`\`

Common cases this hits:
- USB-SATA bridge that needs \`-d sat\` (not auto-detected)
- Controller that doesn't proxy SMART (some HBAs, some virtualization layers)
- Fresh disk before the kernel finished SMART initialization
- Any unsupported transport

The "filesystem creation makes it appear" symptom is a red herring — anything that nudges the kernel / smartctl into producing a valid SMART envelope (FS creation, partition table write, even just waiting long enough on some hardware) makes the disk appear. The real bug is the silent drop.

The WebUI's SMART Health and Topology tabs both iterate \`disks\` directly:

\`\`\`svelte
{#if smartProtocol?.enabled && disks.length > 0}
  ...iterate disks...
{:else}
  ...fallback to blockDevices...
\`\`\`

So when *any* disk produced valid SMART data, the SMART path activated and disks with no SMART were invisible.

## Fix

Restructured the collector so disks are surfaced from \`lsblk\` first and SMART is pure enrichment:

1. **\`enumerate_disks\`** — single \`lsblk -Jbno NAME,TYPE,SIZE,MODEL,SERIAL\` call, authoritative "what disks exist on this host."
2. **\`query_smartctl\`** — returns \`Option<SmartReport>\`; \`None\` means "no usable SMART data."
3. **\`build_disk_health\`** — always emits a \`DiskHealth\` per lsblk disk; uses smartctl fields when available, lsblk fields + \`smart_status = "UNAVAILABLE"\` otherwise.

### Downstream wiring

- **Alerts** (\`AlertMetric::SmartHealth\`): skips disks where \`smart_status == "UNAVAILABLE"\` so the new rows don't fire a flood of false-positive critical alerts. UNAVAILABLE is "unknown," not "FAILED." New regression test pins this.
- **\`DiskHealthSummary\`** (the slim shape the alert evaluator consumes) carries the status string through.
- **WebUI** (SMART tab + Topology tab) styles UNAVAILABLE with a neutral muted badge (not red) and omits the red border around the card.

## Test plan

- [x] \`cargo build -p nasty-metrics -p nasty-system -p nasty-engine\` clean
- [x] \`cargo clippy --all-targets --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p nasty-system --all-targets alerts\` → 20/20 pass, incl. new \`evaluate_rules_smart_health_skips_unavailable_disks\`
- [ ] On \`10.10.10.71\` with at least one unformatted disk: SMART tab + Topology tab both list it with status UNAVAILABLE
- [ ] After format: status flips to PASSED/FAILED based on actual smartctl read
- [ ] SMART alerts don't fire for UNAVAILABLE disks (no critical-alert storm)

Closes #349.