### PR TITLE
ci: bump magic-nix-cache-action to v14, opt out of FlakeHub

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,10 @@ jobs:
       # crate + downstream rebuild — the rest substitutes from Actions
       # cache. Realistic win on this job: ~36 min cold → ~15 min warm
       # (VM-boot overhead is still ~10 min and uncacheable).
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          # See sibling workflow nix-engine-build.yml for the rationale.
+          use-flakehub: false
 
       # Read-only on PRs and workflow_dispatch; the conditional push step
       # below populates the cache when this run is a push to main. Folding

--- a/.github/workflows/nix-engine-build.yml
+++ b/.github/workflows/nix-engine-build.yml
@@ -52,7 +52,16 @@ jobs:
       # runs: when only one Rust crate changes, only that crate +
       # downstream rebuild, the rest substitutes from Actions cache.
       # Realistic win on this job: ~17 min cold → ~5-8 min warm.
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          # FlakeHub cache requires a registration we don't have; the
+          # GHA store-path cache (the actual point of this action) works
+          # without it. Without `use-flakehub: false` v14 logs a
+          # "FlakeHub registration required" error annotation on every
+          # run even though the GHA cache is succeeding. v14 also
+          # upgrades the action's runtime from Node 20 (deprecated in
+          # the runner, removed September 2026) to Node 24.
+          use-flakehub: false
 
       # Read-only Cachix substituter: pull cached deps to speed cold
       # builds (rustc, openssl, etc. all come from cachix), but don't


### PR DESCRIPTION
## Summary

Two things at once, both visible in the post-#356 integration run [linked from screenshot]:

1. **Node.js 20 deprecation** on \`magic-nix-cache-action@v13\` — runner forces Node 24 on 2026-06-16, removes Node 20 on 2026-09-16. v14 ships on Node 24, so the deprecation warning goes away.
2. **\"FlakeHub registration required\"** error annotation — v14 enables FlakeHub cache by default; we don't have a FlakeHub registration. \`use-flakehub: false\` keeps the GHA store-path cache (the actual point of the action for us) and silences the error.

## Diff

Two workflows touched:

\`\`\`yaml
- uses: DeterminateSystems/magic-nix-cache-action@v14
  with:
    use-flakehub: false
\`\`\`

Applied to:
- \`.github/workflows/nix-engine-build.yml\` (sandbox-visibility gate)
- \`.github/workflows/integration.yml\` (bcachefs smoke + cachix push)

The behavior of the GHA store-path cache is unchanged. The FlakeHub-only behavior never worked for us anyway.

## Test plan

- [ ] CI runs on this PR — both jobs should complete with no deprecation warning and no FlakeHub error annotation
- [ ] Cache hit rate stays roughly the same as before (no functional change to what gets cached)