### PR TITLE
webui: store new VM disks under vms/<name> (#354)

### DIFF
--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -640,7 +640,13 @@
 
 		// Create a new block subvolume if requested
 		if (newDiskCreate && newDiskFs && newDiskSize > 0) {
-			const svName = `vm-${newName}`;
+			// Subvolume name uses a slash so the disk lands at
+			// /fs/<filesystem>/vms/<name> rather than as a top-level
+			// vm-<name> subvolume next to the operator's data subvolumes
+			// (#354). Matches the layout `vms/images` already uses for VM
+			// disk-image uploads and mirrors how apps land under apps/.
+			// subvolume.create auto-creates the `vms/` parent on demand.
+			const svName = `vms/${newName}`;
 			const sizeBytes = newDiskSize * 1024 * 1024 * 1024;
 			const svResult = await withToast(
 				() => client.call('subvolume.create', {
@@ -1157,7 +1163,7 @@
 							<Input type="number" bind:value={newDiskSize} min={1} class="mt-1" />
 						</div>
 					</div>
-					<span class="mt-1 block text-xs text-muted-foreground">A block subvolume named "vm-{newName || '...'}" will be created.</span>
+					<span class="mt-1 block text-xs text-muted-foreground">A block subvolume named "vms/{newName || '...'}" will be created.</span>
 				{:else}
 					<select bind:value={newDisk} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
 						<option value="">None (ISO boot only)</option>
@@ -1385,7 +1391,7 @@
 				<span>{newBootOrder}</span>
 				{#if newDisk || newDiskCreate}
 					<span class="text-muted-foreground">Disk</span>
-					<span class="font-mono text-xs">{newDiskCreate ? `vm-${newName} (${newDiskSize} GiB, new)` : newDisk}</span>
+					<span class="font-mono text-xs">{newDiskCreate ? `vms/${newName} (${newDiskSize} GiB, new)` : newDisk}</span>
 				{/if}
 				{#if newIsos.some(Boolean)}
 					{@const selectedIsos = newIsos.filter(Boolean)}


### PR DESCRIPTION
## Summary

Closes #354. New VMs created via the WebUI wizard now land at \`/fs/<filesystem>/vms/<name>\` instead of as a top-level \`vm-<name>\` subvolume.

Matches the established layout: apps live under \`apps/\`, VM disk images already live under \`vms/images/\`, so VM disks naturally belong under \`vms/<name>\` alongside.

## Diff

Three small touches in \`webui/src/routes/vms/+page.svelte\`:

| Line | Change |
|---|---|
| Subvolume create call | \`\`vm-${newName}\`\` → \`\`vms/${newName}\`\` |
| Wizard hint | "A block subvolume named **vm-{name}** will be created." → "**vms/{name}**" |
| Review summary | same prefix swap |

Engine code is untouched — \`subvolume.create\` already supports nested names (see comment at \`nasty-storage/src/subvolume.rs:800\` literally referencing \`"projects/web"\`), and the \`vms/\` parent directory is auto-created on demand alongside the existing \`vms/images/\`.

## What this doesn't do

**No migration.** Existing VMs keep working at their old \`vm-<name>\` paths — VmConfig stores absolute disk paths, not just subvolume names, so nothing breaks. Only new VMs created after this lands use the new layout. Moving an existing VM disk would require stopping the VM, renaming the subvolume, and editing the disk path in its VmConfig — that's a separate concern.

## Test plan

- [x] \`svelte-check\` clean
- [ ] On \`10.10.10.71\`: create a new VM with auto-create disk → the new block subvolume lands at \`/fs/<vol>/vms/<name>\`, not \`/fs/<vol>/vm-<name>\`
- [ ] Pre-existing \`vm-haos\`-style VMs still start and run normally after the upgrade

Closes #354.