### PR TITLE
nasty.nix: bump nasty-top to 0.0.6

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -682,14 +682,14 @@ in {
       restic-rest-server # REST API server for receiving backups from other machines
       (pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.5";
+        version = "0.0.6";
         src = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
-          rev = "v0.0.5";
-          hash = "sha256-8oefkH5hRIYYuECdmVUsbCtqnTJxC3IgwGoPQppmTYc=";
+          rev = "v0.0.6";
+          hash = "sha256-l7pVE7VQinMDr/hp2Nz+VVBrL5euZkcMu2b0fb5dLmc=";
         };
-        cargoHash = "sha256-d1gVWeQMLx03/qE62qY4Yk+Xqa/bWfdpIg8sjV4XX50=";
+        cargoHash = "sha256-3HzzaLC6Cvr/n+v9VSmpVDsS1X6WwvOAXiFxuwibKlg=";
         meta.mainProgram = "nasty-top";
       })
 


### PR DESCRIPTION
## Summary

Picks up the two reporter-filed fixes from nasty-top v0.0.6:

- **#11**: brighten DIM and ROW_ALT for WCAG AA contrast — the Devices panel's label column was nearly invisible on alternating rows, especially after 256-color quantization on \`screen\` / \`vt100\`.
- **#12**: heavy-load / multi-device handling — top-bar capacity now falls back to \`bcachefs fs usage\` parsing when \`statvfs\` reports 0 blocks (multi-device kernels), load avg drops decimals when any value is ≥ 10 so the System panel doesn't clip, and both bcachefs CLI parsers defensively filter the \`CONFIG_RUST\` kernel warning.

Plus a routine \`cargo update\` (transitive patch-level bumps only — \`serde_json\`, \`uuid\`, \`typenum\`, etc.).

## Diff

| Line | Before | After |
|---|---|---|
| version | \`0.0.5\` | \`0.0.6\` |
| rev | \`v0.0.5\` | \`v0.0.6\` |
| hash (src) | \`sha256-8oefkH5hRIYYuECdmVUsbCtqnTJxC3IgwGoPQppmTYc=\` | \`sha256-l7pVE7VQinMDr/hp2Nz+VVBrL5euZkcMu2b0fb5dLmc=\` |
| cargoHash | \`sha256-d1gVWeQMLx03/qE62qY4Yk+Xqa/bWfdpIg8sjV4XX50=\` | \`sha256-3HzzaLC6Cvr/n+v9VSmpVDsS1X6WwvOAXiFxuwibKlg=\` |

## Test plan

- [x] Standalone \`nix-build\` of the pinned definition completes cleanly with the new hashes — produces \`/nix/store/.../nasty-top-0.0.6/bin/nasty-top\`
- [ ] CI: \`Nix engine build\` job (sandbox-visibility gate) picks up nasty-top via the same path
- [ ] On \`10.10.10.71\`: \`nasty-top\` shows the new contrast + load-avg behaviour