### PR TITLE
nasty.nix: vendor nasty-top via Cargo.lock instead of cargoHash

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -680,16 +680,25 @@ in {
       croc              # peer-to-peer file transfer for sending debug reports
       rustic             # deduplicating encrypted backups (restic-compatible)
       restic-rest-server # REST API server for receiving backups from other machines
-      (pkgs.rustPlatform.buildRustPackage {
-        pname = "nasty-top";
-        version = "0.0.6";
-        src = pkgs.fetchFromGitHub {
+      (let
+        nastyTopSrc = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
           rev = "v0.0.6";
           hash = "sha256-l7pVE7VQinMDr/hp2Nz+VVBrL5euZkcMu2b0fb5dLmc=";
         };
-        cargoHash = "sha256-3HzzaLC6Cvr/n+v9VSmpVDsS1X6WwvOAXiFxuwibKlg=";
+      in pkgs.rustPlatform.buildRustPackage {
+        pname = "nasty-top";
+        version = "0.0.6";
+        src = nastyTopSrc;
+        # Vendor via Cargo.lock instead of a separate cargoHash so a
+        # `cargo update` in nasty-top doesn't silently break this build.
+        # The previous cargoHash had to be recomputed on every release
+        # (last bumped in #362). cargoLock.lockFile has Nix synthesize
+        # one fetchurl per crate keyed on the SHA Cargo wrote into the
+        # lockfile — zero hash to maintain, no drift possible. Mirrors
+        # what nasty-top's own flake does after nasty-top#17.
+        cargoLock.lockFile = "${nastyTopSrc}/Cargo.lock";
         meta.mainProgram = "nasty-top";
       })
 


### PR DESCRIPTION
## Summary

Companion to **[nasty-top#17](https://github.com/nasty-project/nasty-top/pull/17)**. Kills the recurring \"recompute cargoHash on every nasty-top release\" maintenance step for the consumer side too.

The previous \`cargoHash\` had to be recomputed on every nasty-top release — last bumped in #362, a few hours ago. \`cargoLock.lockFile\` reads the SHAs Cargo already wrote into \`Cargo.lock\`, so there's no separate vendor-tarball hash to maintain.

## Release flow after this lands

| | Old | New |
|---|---|---|
| Bump version | \`version = \"0.0.X\"\` | same |
| Bump src tag | \`rev = \"v0.0.X\"\` | same |
| Bump src hash | \`hash = \"sha256-...\"\` | same (one hash, computed by \`nix-prefetch-url\`) |
| Bump cargoHash | manually trigger build, parse error message, paste | **gone** |

The \`src.hash\` step stays — we still have to verify what we pulled from GitHub. But that's a single straightforward \`nix-prefetch-url\` invocation, not a fakeHash-then-rebuild-then-parse dance.

## Mechanical change

Bound the \`fetchFromGitHub\` call to a local \`let\` so \`cargoLock.lockFile\` can reference \`\${nastyTopSrc}/Cargo.lock\` — Nix realizes the (hash-known) source first, then reads the lockfile out of it.

## Test plan

- [x] Standalone \`nix-build\` of the new shape against \`v0.0.6\` produces a working \`bin/nasty-top\`
- [ ] CI: \`Nix engine build\` job picks it up

## Order with nasty-top#17

This PR doesn't depend on nasty-top#17 — it consumes \`v0.0.6\` whose \`Cargo.lock\` is already published. nasty-top#17 fixes the same pattern for nasty-top's own \`flake.nix\`. Both are standalone wins; merge order doesn't matter.