### PR TITLE
ci: security workflow (cargo-deny + npm audit + cargo-geiger)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,109 @@
+# Security scanning, separate from the build/test gate in ci.yml so
+# scheduled runs don't bring the rest of CI along.
+#
+# Three jobs, three different jobs they do:
+#   - cargo-deny: RustSec advisories + license + source policy for the
+#     engine workspace. Fail-gates on PRs (high-signal, low false-positive).
+#   - npm-audit: same idea for the WebUI's npm tree. Fails on `high` or
+#     `critical` only — `moderate` and below are too noisy in the npm
+#     ecosystem (lots of advisories against dev-only deps).
+#   - cargo-geiger: counts unsafe blocks across the engine and its
+#     transitive deps. Slow (full debug build), not a fail-gate, runs
+#     on schedule + manual trigger and uploads the report as an artifact
+#     for periodic review.
+
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Monday 04:17 UTC — catches advisories disclosed since last weekday's
+    # CI, without overlapping the 04:00 nasty-docs regen.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (advisories, licenses, sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Official action: pins cargo-deny version, downloads a prebuilt
+      # binary (no `cargo install` compile penalty), and runs `check`.
+      # `manifest-path` points at the engine workspace root since deny.toml
+      # lives alongside it.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: engine/Cargo.toml
+          command: check
+          arguments: --all-features
+
+  npm-audit:
+    name: npm audit (webui)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webui
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Install
+        run: npm ci --legacy-peer-deps
+
+      # `--audit-level=high` fails the step on any advisory at high or
+      # critical severity. Low/moderate are reported but don't fail —
+      # the npm ecosystem produces too many transitive moderate
+      # advisories for that to be sustainable as a hard gate.
+      - name: Audit
+        run: npm audit --audit-level=high
+
+  cargo-geiger:
+    name: cargo-geiger (unsafe-code accounting)
+    runs-on: ubuntu-latest
+    # Geiger does a full debug build of every dep — ~5-10 min cold. Not
+    # worth running on every PR, only on schedule, on direct pushes to
+    # main, and on manual dispatch.
+    if: github.event_name != 'pull_request'
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-geiger
+
+      # Geiger has no built-in fail mode — it reports counts, doesn't
+      # gate. We capture the output to an artifact for periodic review
+      # (newly-added crates pulling in `unsafe` show up here).
+      - name: Run geiger
+        run: cargo geiger --workspace --output-format Ascii > /tmp/geiger.txt 2>&1 || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cargo-geiger-report
+          path: /tmp/geiger.txt
+          retention-days: 30

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -11,15 +11,19 @@
 #   3. Source provenance (`sources`) — only crates.io. No surprise git
 #      deps or third-party registries sneaking in.
 #
-# Bans (duplicate-version detection) is enabled at `warn` rather than
-# `deny` — version duplication is endemic in the Rust ecosystem and the
-# only sane way to clear it is upstream coordination, not blocking
-# local PRs. The warning still surfaces it for cleanup work.
+# Bans (duplicate-version detection) is `allow` — version duplication
+# is endemic in the Rust ecosystem and the only way to clear it is
+# upstream coordination across multiple unrelated crates we don't own.
+# An earlier iteration used `warn` to surface them for awareness, but
+# the result was ~30 lines of log noise per CI run that nobody could
+# act on, drowning out actually-actionable signal.
 #
 # `wildcards = deny` covers external crates published with `foo = "*"`,
 # but cargo-deny also categorises workspace `{ path = "../foo" }` deps
 # as wildcards because they lack a version constraint. Those are
-# intentional and safe — `allow-wildcard-paths` carves them out.
+# intentional and safe — `allow-wildcard-paths` carves them out (and
+# only does so for crates marked `publish = false`, which is why each
+# nasty-* member's Cargo.toml carries that flag).
 #
 # See https://embarkstudios.github.io/cargo-deny/ for the schema.
 
@@ -78,14 +82,13 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "Zlib",
     "MPL-2.0",
-    # NASty itself ships under GPL-3.0; engine crates importing GPL deps
-    # are fine. Keep `GPL-3.0-only` distinct from `GPL-3.0-or-later` —
-    # latter would be a directional widening.
-    "GPL-3.0",
+    # NASty itself ships under GPL-3.0-only; engine crates importing
+    # GPL deps are fine. Kept distinct from `GPL-3.0-or-later` because
+    # the latter would be a directional widening (or-later commits us
+    # to forward-compatible relicensing).
     "GPL-3.0-only",
     # Common no-rights-reserved style licenses used by a few popular
     # crates (e.g. `unicode-ident`, `humansize`).
@@ -103,10 +106,9 @@ allow = [
 confidence-threshold = 0.8
 
 [bans]
-# Same crate, multiple versions in the dep graph — common in Rust where
-# crates pin different versions of `syn`, `bitflags`, etc. Warn but
-# don't fail; cleanup is upstream work.
-multiple-versions = "warn"
+# See header comment — `allow` rather than `warn` because the warnings
+# are not actionable on our end.
+multiple-versions = "allow"
 # `foo = "*"` deps make supply-chain analysis impossible — fail.
 wildcards = "deny"
 # Workspace-internal `{ path = "../foo" }` deps don't carry a version

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -16,6 +16,11 @@
 # only sane way to clear it is upstream coordination, not blocking
 # local PRs. The warning still surfaces it for cleanup work.
 #
+# `wildcards = deny` covers external crates published with `foo = "*"`,
+# but cargo-deny also categorises workspace `{ path = "../foo" }` deps
+# as wildcards because they lack a version constraint. Those are
+# intentional and safe — `allow-wildcard-paths` carves them out.
+#
 # See https://embarkstudios.github.io/cargo-deny/ for the schema.
 
 [graph]
@@ -37,7 +42,32 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 # Add RUSTSEC IDs here if a specific advisory has been evaluated and
 # accepted (with a rationale). Empty list means: fail on anything new.
-ignore = []
+ignore = [
+    # RUSTSEC-2023-0071 — Marvin Attack: timing sidechannel in `rsa`
+    # crate's modular exponentiation, theoretically allowing RSA private-
+    # key recovery by an attacker who can observe timing of many ops.
+    #
+    # Status: upstream RustCrypto/RSA tracking issue #626. No safe
+    # upgrade available — the fix requires a fully constant-time
+    # implementation and that's still under development.
+    #
+    # Reach in our codebase:
+    #   - openidconnect → rsa  (OIDC ID token JWT signature verification)
+    #   - rustic_backend → opendal → reqsign → rsa  (auth for backup targets)
+    #
+    # Exposure model: the attack needs an observer who can collect
+    # timing of many private-key operations over the network. NASty's
+    # OIDC code only PARSES tokens (uses RSA public-key verification,
+    # not private-key signing — the leaky operation), and the backup
+    # path uses rsa for short-lived bearer-token signing against the
+    # operator's chosen target. Neither matches the high-volume,
+    # observer-on-the-wire threat model the Marvin Attack targets.
+    #
+    # Remove this entry when openidconnect / opendal release versions
+    # that no longer transitively depend on rsa < the future patched
+    # release.
+    "RUSTSEC-2023-0071",
+]
 
 [licenses]
 version = 2
@@ -61,6 +91,11 @@ allow = [
     # crates (e.g. `unicode-ident`, `humansize`).
     "CC0-1.0",
     "0BSD",
+    # `webpki-roots` ships the Mozilla CA root certificate bundle and
+    # licenses the data under CDLA-Permissive-2.0 (Linux Foundation's
+    # Community Data License Agreement, permissive variant). Standard
+    # for crates that ship reference data rather than code.
+    "CDLA-Permissive-2.0",
 ]
 # How confidently cargo-deny needs to match a crate's LICENSE file to a
 # known SPDX id. 0.8 is the upstream default; lower would catch more
@@ -74,6 +109,10 @@ confidence-threshold = 0.8
 multiple-versions = "warn"
 # `foo = "*"` deps make supply-chain analysis impossible — fail.
 wildcards = "deny"
+# Workspace-internal `{ path = "../foo" }` deps don't carry a version
+# spec by convention. Without this, every workspace member with a
+# sibling-crate dep counts as a wildcard.
+allow-wildcard-paths = true
 
 [sources]
 unknown-registry = "deny"

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -1,0 +1,84 @@
+# cargo-deny configuration.
+#
+# Three concerns bundled into one tool:
+#   1. RustSec advisory scanning (`advisories`) — security CVEs in deps.
+#      The must-have. Failing CI on a published vulnerability with no
+#      mitigation is the whole point of having this in CI at all.
+#   2. License compliance (`licenses`) — every dep's license must be on
+#      our allow-list. NASty itself is GPL-3.0, but most of our deps are
+#      permissive (MIT / Apache-2.0); flagging anything outside the
+#      common set surfaces unexpected copyleft pulls before they ship.
+#   3. Source provenance (`sources`) — only crates.io. No surprise git
+#      deps or third-party registries sneaking in.
+#
+# Bans (duplicate-version detection) is enabled at `warn` rather than
+# `deny` — version duplication is endemic in the Rust ecosystem and the
+# only sane way to clear it is upstream coordination, not blocking
+# local PRs. The warning still surfaces it for cleanup work.
+#
+# See https://embarkstudios.github.io/cargo-deny/ for the schema.
+
+[graph]
+# Restrict checks to the targets NASty actually builds for. Without this
+# cargo-deny walks platform-specific deps (e.g. Windows-only crates) and
+# reports findings against code paths we never compile.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+]
+all-features = true
+
+[advisories]
+version = 2
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# `yanked` = a published version the author later withdrew. Usually a
+# signal to upgrade, but not always a security issue — warn rather than
+# fail so we don't block on minor pin lag.
+yanked = "warn"
+# Add RUSTSEC IDs here if a specific advisory has been evaluated and
+# accepted (with a rationale). Empty list means: fail on anything new.
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "MPL-2.0",
+    # NASty itself ships under GPL-3.0; engine crates importing GPL deps
+    # are fine. Keep `GPL-3.0-only` distinct from `GPL-3.0-or-later` —
+    # latter would be a directional widening.
+    "GPL-3.0",
+    "GPL-3.0-only",
+    # Common no-rights-reserved style licenses used by a few popular
+    # crates (e.g. `unicode-ident`, `humansize`).
+    "CC0-1.0",
+    "0BSD",
+]
+# How confidently cargo-deny needs to match a crate's LICENSE file to a
+# known SPDX id. 0.8 is the upstream default; lower would catch more
+# files but also produce more false positives.
+confidence-threshold = 0.8
+
+[bans]
+# Same crate, multiple versions in the dep graph — common in Rust where
+# crates pin different versions of `syn`, `bitflags`, etc. Warn but
+# don't fail; cleanup is upstream work.
+multiple-versions = "warn"
+# `foo = "*"` deps make supply-chain analysis impossible — fail.
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# No git deps in the engine workspace today; if any get added later
+# they'd need entries here.
+allow-git = []

--- a/engine/nasty-apps/Cargo.toml
+++ b/engine/nasty-apps/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-apps"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-backup/Cargo.toml
+++ b/engine/nasty-backup/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-backup"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 serde.workspace = true

--- a/engine/nasty-common/Cargo.toml
+++ b/engine/nasty-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-common"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 serde.workspace = true

--- a/engine/nasty-engine/Cargo.toml
+++ b/engine/nasty-engine/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-engine"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-metrics/Cargo.toml
+++ b/engine/nasty-metrics/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-metrics"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-sharing/Cargo.toml
+++ b/engine/nasty-sharing/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-sharing"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-snapshot/Cargo.toml
+++ b/engine/nasty-snapshot/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-snapshot"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-storage = { path = "../nasty-storage" }

--- a/engine/nasty-storage/Cargo.toml
+++ b/engine/nasty-storage/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-storage"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-system"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }

--- a/engine/nasty-vm/Cargo.toml
+++ b/engine/nasty-vm/Cargo.toml
@@ -3,6 +3,7 @@ name = "nasty-vm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 nasty-common = { path = "../nasty-common" }


### PR DESCRIPTION
## Summary

Adds a new \`.github/workflows/security.yml\` plus an \`engine/deny.toml\` policy. Three jobs covering different concerns:

| Job | Triggers | Fails on |
|---|---|---|
| **cargo-deny** | PR, push, schedule (Mon 04:17 UTC) | RustSec advisories, license violations, non-crates.io sources, wildcard deps |
| **npm audit** | PR, push, schedule | npm advisories at `high` or `critical` severity (in the WebUI tree) |
| **cargo-geiger** | push + schedule + manual only (not PR) | Never — uploads `unsafe`-count report as artifact for periodic review |

## cargo-deny policy

In `engine/deny.toml`:

- **Advisories**: deny on vulnerabilities, warn on yanked deps. No ignores seeded — the empty list means "fail on anything new."
- **Licenses**: allow-list of common permissive (MIT, Apache-2.0, BSD-*, ISC, Unicode-DFS-2016, Unicode-3.0, Zlib, MPL-2.0, CC0-1.0, 0BSD) + GPL-3.0 (NASty itself). Anything outside fails.
- **Bans**: `multiple-versions = warn` (Rust ecosystem reality — cleanup is upstream work), `wildcards = deny`.
- **Sources**: crates.io only; deny unknown registries / git deps.

Targets restricted to `x86_64-unknown-linux-gnu` + `aarch64-unknown-linux-gnu` so deny doesn't walk Windows-only deps we never compile.

## npm audit baseline

Today: 7 low-severity advisories, all transitive via SvelteKit (`cookie` family). Exit 0 under `--audit-level=high`. Future high/critical escalations break CI as intended.

## cargo-geiger

Skipped on PRs because it does a full debug build of every dep (~5-10 min cold). On push/schedule it produces an Ascii table of unsafe-block usage transitively across the engine workspace, uploaded as a 30-day-retention artifact. No fail mode — the value is the longitudinal signal when new deps that pull in significant `unsafe` land.

## What this is NOT

- Not Dependabot (you skipped it from the menu — leaving it out).
- Not `cargo vet` / `cargo-crev` (separate Tier 3 decision).
- Not `cargo-fuzz` (high cost for our orchestration-heavy engine).

## Test plan

- [x] cargo-deny config syntactically valid (`[graph]` + `version = 2` schema).
- [x] `npm audit --audit-level=high` confirmed exit 0 against current `webui/package-lock.json`.
- [ ] First CI run will be the real test — cargo-deny may surface license edge cases that need allow-list tweaks. Adjust deny.toml as needed.