### PR TITLE
SAS: classify and badge as their own class (#365)

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1781,12 +1781,21 @@ impl FilesystemService {
 
         let mut devices = Vec::new();
         if let Some(blockdevices) = parsed.get("blockdevices").and_then(|v| v.as_array()) {
-            fn classify(name: &str, rota: bool) -> (bool, String) {
+            fn classify(name: &str, rota: bool, transport: Option<&str>) -> (bool, String) {
                 if name.starts_with("nvme") {
                     return (false, "nvme".to_string());
                 }
                 if name.starts_with("mmcblk") {
                     return (false, "mmc".to_string());
+                }
+                // SAS drives report `tran == "sas"` from lsblk. Both SAS HDDs
+                // and SAS SSDs get the `sas` class so the WebUI Devices tab
+                // can badge them as the enterprise drives they are rather
+                // than disguising them as SATA hdd/ssd (issue #365). The
+                // rotational bit is still set correctly so callers that care
+                // about spinning vs solid-state get the right answer.
+                if matches!(transport, Some("sas")) {
+                    return (rota, "sas".to_string());
                 }
                 if rota {
                     (true, "hdd".to_string())
@@ -1839,8 +1848,6 @@ impl FilesystemService {
                                 .or_else(|| v.as_u64().map(|n| n == 1))
                         })
                         .unwrap_or(false);
-                    let (rotational, device_class) = classify(name, rota);
-
                     // lsblk surfaces these only on whole disks; on partitions
                     // they're empty/null. Treat empty-after-trim as None so
                     // the WebUI can hide the field entirely instead of
@@ -1855,6 +1862,11 @@ impl FilesystemService {
                     let serial = pick("serial");
                     let vendor = pick("vendor");
                     let transport = pick("tran");
+
+                    // Transport needs to be resolved before classify so the
+                    // SAS path can use it.
+                    let (rotational, device_class) =
+                        classify(name, rota, transport.as_deref());
 
                     if dev_type == "disk" || dev_type == "part" {
                         let path = format!("/dev/{name}");

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1865,8 +1865,7 @@ impl FilesystemService {
 
                     // Transport needs to be resolved before classify so the
                     // SAS path can use it.
-                    let (rotational, device_class) =
-                        classify(name, rota, transport.as_deref());
+                    let (rotational, device_class) = classify(name, rota, transport.as_deref());
 
                     if dev_type == "disk" || dev_type == "part" {
                         let path = format!("/dev/{name}");

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -101,6 +101,9 @@
 			case 'ssd': return 'bg-blue-950 text-blue-400';
 			case 'mmc': return 'bg-amber-950 text-amber-400';
 			case 'hdd': return 'bg-emerald-950 text-emerald-400';
+			// SAS = enterprise transport, distinct colour so it doesn't get
+			// visually conflated with consumer SATA hdd/ssd (#365).
+			case 'sas': return 'bg-rose-950 text-rose-400';
 			default: return 'bg-secondary text-muted-foreground';
 		}
 	}
@@ -313,7 +316,7 @@
 								</table>
 							</div>
 						{:else if expandedDisk === disk.device}
-							<p class="mt-4 text-sm text-muted-foreground">No SMART attributes available (NVMe drives use a different format).</p>
+							<p class="mt-4 text-sm text-muted-foreground">No SMART attributes available (NVMe and SAS drives use a different format).</p>
 						{/if}
 					</CardContent>
 				</Card>


### PR DESCRIPTION
## Summary

Two small no-test-data changes from the menu in #365's comment thread. Full SAS smartctl-attribute parsing still pending the reporter's actual \`smartctl -a --json=c\` dump.

## Changes

1. **\`device_class = \"sas\"\`** for SAS drives, set in \`engine/nasty-storage/src/filesystem.rs::classify\`. Previously SAS drives fell through to \`hdd\` (rotational SAS) or \`ssd\` (solid-state SAS) — same class as their consumer SATA equivalents, transport entirely disguised. lsblk already reports \`tran == \"sas\"\` for the right devices; we just weren't using it. Rotational bit still flows correctly through callers that care about spinning vs solid-state.

2. **WebUI Devices tab badge** styles \`sas\` with a rose colour — visually distinct from \`emerald\` (hdd), \`blue\` (ssd), \`purple\` (nvme), \`amber\` (mmc). Default-case branch unchanged, so any future class still falls through to the muted style.

3. **SMART tab fallback message**: \"No SMART attributes available (NVMe drives use a different format)\" → \"... (NVMe and SAS drives use a different format)\". Same code path, the message just wasn't acknowledging SAS. The reporter on #365 hit it expecting their SAS drives but got an NVMe-specific tooltip.

## Test plan

- [x] \`cargo build -p nasty-storage -p nasty-engine\` clean
- [x] \`cargo clippy -p nasty-storage --all-targets --no-deps -- -D warnings\` clean
- [x] \`svelte-check --threshold error\` clean
- [ ] Verify on the reporter's box once the smartctl dump arrives — SAS drives should now show with a rose \`SAS\` badge and the message should mention SAS

## Doesn't close #365

The underlying SMART-attribute parser still drops SAS \`scsi_grown_defect_list\`, \`scsi_error_counter_log\`, \`scsi_revision\`, etc. on the floor. Firmware will still display as Unknown. Real fix waits on the reporter pasting their \`smartctl -a --json=c /dev/sdi\` so we can map field names without guessing.