### PR TITLE
CI: bump workflow tracks whatever kernel nixpkgs defaults to

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -62,20 +62,37 @@ jobs:
           fi
 
       - name: Detect kernel bump
-        # Best-effort: pull the 6.18 LTS version string out of both
-        # nixpkgs commits and surface it in the PR title/body so the
-        # reviewer sees at a glance whether this round brought a
-        # kernel update.
+        # Resolve the kernel version each nixpkgs rev's `linuxPackages`
+        # alias points at, and surface a delta in the PR title/body.
+        #
+        # `linuxPackages` is what `boot.kernelPackages` defaults to when
+        # nothing in NASty overrides it (and we don't override). It's
+        # an alias maintained inside nixpkgs that tracks the channel's
+        # default LTS, so this auto-follows when the default rolls from
+        # one LTS line to the next — no need to come back and bump a
+        # hard-coded version key here.
+        #
+        # Was previously a hard-coded `"6.18"` lookup against
+        # `kernels-org.json` (#370 reviewer noticed it'd silently break
+        # once nixpkgs flips the default LTS away from 6.18).
         id: kernel
         if: steps.update.outputs.changed == 'true'
         run: |
           set -eu
-          BEFORE_VER=$(curl -fsSL "https://raw.githubusercontent.com/NixOS/nixpkgs/${{ steps.update.outputs.before }}/pkgs/os-specific/linux/kernel/kernels-org.json" 2>/dev/null | jq -r '."6.18".version // "unknown"' || echo "unknown")
-          AFTER_VER=$(curl -fsSL "https://raw.githubusercontent.com/NixOS/nixpkgs/${{ steps.update.outputs.after }}/pkgs/os-specific/linux/kernel/kernels-org.json" 2>/dev/null | jq -r '."6.18".version // "unknown"' || echo "unknown")
+          eval_kernel_version() {
+            nix eval --raw --impure --expr "
+              let
+                pkgs = (builtins.getFlake \"github:NixOS/nixpkgs/$1\").legacyPackages.x86_64-linux;
+                tried = builtins.tryEval pkgs.linuxPackages.kernel.version;
+              in if tried.success then tried.value else \"unknown\"
+            " 2>/dev/null || echo "unknown"
+          }
+          BEFORE_VER=$(eval_kernel_version "${{ steps.update.outputs.before }}")
+          AFTER_VER=$(eval_kernel_version "${{ steps.update.outputs.after }}")
           echo "before=$BEFORE_VER" >> "$GITHUB_OUTPUT"
           echo "after=$AFTER_VER" >> "$GITHUB_OUTPUT"
           if [ "$BEFORE_VER" != "$AFTER_VER" ] && [ "$BEFORE_VER" != "unknown" ] && [ "$AFTER_VER" != "unknown" ]; then
-            echo "summary=Linux 6.18: $BEFORE_VER → $AFTER_VER" >> "$GITHUB_OUTPUT"
+            echo "summary=Linux $BEFORE_VER → $AFTER_VER" >> "$GITHUB_OUTPUT"
           else
             echo "summary=" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Why

The weekly nixpkgs-bump workflow's kernel-detection step is hard-coded to look up `."6.18".version` in `kernels-org.json`. Currently correct because nixos-26.05 ships 6.18 LTS as the channel default, but it'll silently break the moment nixpkgs flips the default LTS line — the lookup returns `"unknown"`, the comparison short-circuits, and bump PRs lose the kernel-version callout in title + body until someone notices the omission.

Caught while inspecting [PR #370](https://github.com/nasty-project/nasty/pull/370) — the empty kernel summary there is genuine (no 6.18.x change this week), but it took a manual `curl + jq` against the locked rev to confirm the workflow wasn't silently broken.

## What changed

Replaced the curl-and-jq with a `nix eval` of `pkgs.linuxPackages.kernel.version` for each rev. `linuxPackages` is the standard nixpkgs alias that `boot.kernelPackages` defaults to when nothing overrides it — and NASty doesn't override. When nixpkgs rolls the channel default forward (or sideways to a different LTS line), this resolves to whatever the new default ships, with no workflow edit needed.

Also dropped the now-redundant `"6.18:"` prefix in the summary string — the full version (`Linux 6.18.26 → 6.18.29`) conveys the major.minor naturally and stays readable across LTS transitions.

## Cost

Two extra `nix eval` calls per bump (one per rev). Each downloads + evaluates the nixpkgs flake, ~30–60s on a GitHub runner. Workflow runs weekly so the extra ~1–2 min is a non-issue.

## Test plan

- [ ] Manual `workflow_dispatch` run after merge — should populate `**Kernel**: Linux 6.18.x → 6.18.x` (or empty if no kernel bump in this week's nixpkgs delta) in the next PR body
- [ ] Verify the resulting bump PR's title matches the same format