### PR TITLE
nasty-top: bump to v0.0.7

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -684,12 +684,12 @@ in {
         nastyTopSrc = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
-          rev = "v0.0.6";
-          hash = "sha256-l7pVE7VQinMDr/hp2Nz+VVBrL5euZkcMu2b0fb5dLmc=";
+          rev = "v0.0.7";
+          hash = "sha256-1jIV4am9yv2L1qT6zA3AejW7hKjn29dpPMM6gmRvQp4=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.6";
+        version = "0.0.7";
         src = nastyTopSrc;
         # Vendor via Cargo.lock instead of a separate cargoHash so a
         # `cargo update` in nasty-top doesn't silently break this build.


### PR DESCRIPTION
## Summary

Bumps the bundled nasty-top to **v0.0.7**, which ships the fix for [nasty-top#11](https://github.com/nasty-project/nasty-top/issues/11) — sparse bcachefs dev-N numbering. Bcachefs assigns device indices at format / add time, so a pool that's had devices added or removed can have arbitrary gaps in \`dev-N\`. The pre-0.0.7 discovery code probed sequentially from \`dev-0\` and bailed on the first missing entry; on layouts like \`dev-2..dev-6\` it failed immediately and the top bar displayed \`0.0/0.0 GiB\`.

The reporter on #11 confirmed the predicted sparse-numbering pattern (\`dev-2 dev-3 dev-4 dev-5 dev-6\` with no \`dev-0\` or \`dev-1\`), so this is a verified-root-cause fix shipping to affected users.

## Diff

Three lines: \`rev\`, \`hash\`, \`version\`. \`cargoLock.lockFile\` (added in #362) takes care of vendoring, so no \`cargoHash\` recompute and no risk of nasty-top's own \`cargo update\` silently breaking this build.

## Test plan

- [x] \`nix-prefetch-github\` to confirm the new hash
- [ ] CI (Engine, Nix sandbox-visibility gate) — same matrix the previous bump went through