### PR TITLE
webui: fix invisible <select> options in Chromium dark mode (#377)

### DIFF
--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -5,6 +5,14 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  /* Tells the browser to render native form controls (select dropdowns,
+   * date pickers, checkboxes, scrollbars) using its light theme. Without
+   * this, Chromium on Linux ignores our CSS for the *popup* of a <select>
+   * and renders it with a white background — so dark-mode page CSS that
+   * sets white-on-dark text inherits into the popup as white-on-white
+   * and the options become invisible. Firefox + Safari handle this
+   * automatically; only Chromium needs the explicit hint. See #377. */
+  color-scheme: light;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
@@ -40,6 +48,10 @@
 }
 
 .dark {
+  /* See note in :root — switches the native form-control theme to
+   * match our dark mode so Chromium renders <select> popups with
+   * a dark background instead of white. */
+  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);


### PR DESCRIPTION
Closes #377.

## Symptom

Reporter on EndeavourOS with Chrome / Vivaldi saw white-on-white text in the compression-type dropdowns on the filesystem-edit page — only the highlighted option (\`Gzip\` in their screenshot) was visible:

[![screenshot from issue](https://github.com/user-attachments/assets/7fde041d-53ca-4beb-aa50-be479b3a1b25)](https://github.com/nasty-project/nasty/issues/377)

Firefox, macOS Chrome, and Windows Chrome render fine — making this hard to repro without a Linux + Chromium setup.

## Root cause

Chromium on Linux uses the OS native renderer for \`<select>\` popups. Without an explicit \`color-scheme\` hint, the popup defaults to a white background but inherits the page's text color (white in our dark mode), so option labels render white-on-white. Highlighted rows look right because the highlight gives them their own background.

Firefox and Safari infer the color scheme from page background automatically, which is why the bug was invisible to most testers. Chromium on macOS / Windows uses platform-specific code paths that ignore the hint and theme correctly by default. Only Chromium-on-Linux needed the explicit signal.

## Fix

One \`color-scheme\` declaration per theme block in \`webui/src/app.css\`:

```css
:root {
  color-scheme: light;
  /* ...existing custom properties... */
}
.dark {
  color-scheme: dark;
  /* ...existing custom properties... */
}
```

That tells the browser to render native form controls (select popups, date pickers, scrollbars, checkboxes) using the matching theme. About 60 seconds of work.

## Why not explicit \`option {color, background}\` styling?

That would also fix this case, but \`color-scheme\` is the canonical answer — it covers every native control consistently and is the path browser vendors expect sites to use. Hard-coding option colors leaves date pickers, native scrollbars, and OS dialogs still mis-themed.

## Test plan

- [x] \`npm run check\` (svelte-check clean)
- [ ] Reporter (or anyone on Chromium Linux) confirms the dropdowns render correctly after merge