### PR TITLE
SMART: surface PCIe link bandwidth per controller in Topology view

### DIFF
--- a/engine/nasty-common/src/metrics_types.rs
+++ b/engine/nasty-common/src/metrics_types.rs
@@ -112,6 +112,13 @@ pub struct DiskHealth {
     /// Human-readable controller name (e.g. `ASMedia ASM1166`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller_name: Option<String>,
+    /// PCIe link state for the controller. Carried per-disk for
+    /// schema simplicity (every drive on the same controller carries
+    /// the same value); the WebUI dedupes via its existing
+    /// controller-grouping logic in the Topology view. `None` for
+    /// non-PCIe-attached drives (USB bridges, virtio in VMs).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pcie_link: Option<PcieLink>,
     /// Drive model name reported by SMART.
     pub model: String,
     /// Drive serial number.
@@ -172,6 +179,31 @@ pub struct AtaHealth {
     /// through a smartctl earlier than 7.5.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endurance_used_percent: Option<u32>,
+}
+
+/// PCIe link state for a storage controller, sourced from
+/// `/sys/bus/pci/devices/<bdf>/{current,max}_link_{speed,width}`.
+/// When `current_*` is below `max_*` the link has trained down — common
+/// causes include PCIe ASPM power saving keeping the link in a low
+/// state during idle (transient — not always a real issue), broken
+/// bifurcation in a U.2 backplane, a flaky PCIe riser cable, or a
+/// physical x4 slot wired internally as x1.
+///
+/// The speed strings are passed through verbatim from sysfs
+/// (e.g. `"8.0 GT/s PCIe"`) so the WebUI displays the same text
+/// `lspci -vv` would. Conversion to per-lane MB/s and total bandwidth
+/// happens client-side from a small lookup table; that keeps API
+/// surface minimal and lets the UI choose precision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PcieLink {
+    /// Negotiated link speed (e.g. `"8.0 GT/s PCIe"` for PCIe 3.0).
+    pub current_speed: String,
+    /// Maximum link speed the device + slot can negotiate.
+    pub max_speed: String,
+    /// Currently active lane count (1, 2, 4, 8, 16, …).
+    pub current_width: u8,
+    /// Maximum lane count the device + slot supports.
+    pub max_width: u8,
 }
 
 /// NVMe SMART health information, parsed from smartctl's

--- a/engine/nasty-metrics/src/collect_system.rs
+++ b/engine/nasty-metrics/src/collect_system.rs
@@ -812,6 +812,7 @@ async fn build_disk_health(
         (None, None)
     };
     let controller_name = controller_pci.as_deref().and_then(resolve_pci_name);
+    let pcie_link = controller_pci.as_deref().and_then(resolve_pcie_link);
 
     match query_smartctl(&endpoint.device, endpoint.transport.as_deref()).await {
         Some(s) => DiskHealth {
@@ -820,6 +821,7 @@ async fn build_disk_health(
             ata_port,
             controller_pci,
             controller_name,
+            pcie_link,
             // smartctl's strings are usually more accurate than lsblk's
             // (lsblk reads sysfs's `model`, which truncates / pads), but
             // for unfamiliar transports lsblk sometimes wins — prefer
@@ -874,12 +876,14 @@ fn build_disk_health_unreachable_for_endpoint(
         (None, None)
     };
     let controller_name = controller_pci.as_deref().and_then(resolve_pci_name);
+    let pcie_link = controller_pci.as_deref().and_then(resolve_pcie_link);
     DiskHealth {
         device: endpoint.device.clone(),
         transport: endpoint.transport.clone(),
         ata_port,
         controller_pci,
         controller_name,
+        pcie_link,
         model: lsblk_hint
             .map(|d| d.model.clone())
             .unwrap_or_else(|| "Unknown".into()),
@@ -1304,6 +1308,65 @@ fn resolve_pci_name(pci_addr: &str) -> Option<String> {
     }
 }
 
+/// Read PCIe link state for a storage controller from sysfs. Returns
+/// `None` when the controller isn't found, lacks the link files (some
+/// virtual PCIe devices, very old kernels), or returns malformed data.
+///
+/// `pci_addr` is the short BDF form (e.g. `"03:00.0"`) — we prepend the
+/// canonical `0000:` domain when looking up the sysfs path because
+/// that's what `resolve_device_path()` returns elsewhere in this file
+/// and we want consistency.
+fn resolve_pcie_link(pci_addr: &str) -> Option<PcieLink> {
+    let base = format!("/sys/bus/pci/devices/0000:{pci_addr}");
+    parse_pcie_link(
+        &std::fs::read_to_string(format!("{base}/current_link_speed")).ok()?,
+        &std::fs::read_to_string(format!("{base}/max_link_speed")).ok()?,
+        &std::fs::read_to_string(format!("{base}/current_link_width")).ok()?,
+        &std::fs::read_to_string(format!("{base}/max_link_width")).ok()?,
+    )
+}
+
+/// Pure-data parser for PCIe link sysfs strings. Split out from
+/// `resolve_pcie_link` so the parser can be unit-tested without a real
+/// `/sys` tree to point at.
+///
+/// Kernels normalize speed strings to forms like `"8.0 GT/s PCIe"`
+/// (recent) or `"8.0 GT/s"` (older); both pass through verbatim after
+/// whitespace-trimming. Width files contain a bare decimal. Any value
+/// that fails to parse (or returns the literal `"Unknown"` some
+/// kernels emit for downed links) makes the whole block return `None`
+/// — we don't surface a half-populated link record.
+fn parse_pcie_link(
+    cur_speed: &str,
+    max_speed: &str,
+    cur_width: &str,
+    max_width: &str,
+) -> Option<PcieLink> {
+    let cur_speed = cur_speed.trim();
+    let max_speed = max_speed.trim();
+    if cur_speed.is_empty()
+        || max_speed.is_empty()
+        || cur_speed.eq_ignore_ascii_case("Unknown")
+        || max_speed.eq_ignore_ascii_case("Unknown")
+    {
+        return None;
+    }
+    let cur_width: u8 = cur_width.trim().parse().ok()?;
+    let max_width: u8 = max_width.trim().parse().ok()?;
+    // A zero width means the link is in some degenerate state (e.g.
+    // device powered off, hot-removed). Reporting "PCIe x0" would be
+    // misleading; drop the record entirely.
+    if cur_width == 0 || max_width == 0 {
+        return None;
+    }
+    Some(PcieLink {
+        current_speed: cur_speed.to_string(),
+        max_speed: max_speed.to_string(),
+        current_width: cur_width,
+        max_width,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1682,6 +1745,52 @@ mod tests {
         let ata = build_ata_health(&j).expect("ATA block present");
         assert_eq!(ata.endurance_used_percent, None);
         assert!(ata.interface_speed_current.is_some());
+    }
+
+    // ── PCIe link state ───────────────────────────────────────────
+
+    #[test]
+    fn parse_pcie_link_typical_modern_kernel_output() {
+        // What `cat /sys/bus/pci/devices/0000:03:00.0/current_link_speed`
+        // emits on a recent kernel — single newline, "PCIe" suffix.
+        let link = parse_pcie_link("8.0 GT/s PCIe\n", "8.0 GT/s PCIe\n", "2\n", "2\n")
+            .expect("link present");
+        assert_eq!(link.current_speed, "8.0 GT/s PCIe");
+        assert_eq!(link.max_speed, "8.0 GT/s PCIe");
+        assert_eq!(link.current_width, 2);
+        assert_eq!(link.max_width, 2);
+    }
+
+    #[test]
+    fn parse_pcie_link_handles_older_kernel_format_without_pcie_suffix() {
+        // Older kernels emit "8 GT/s" without the "PCIe" suffix —
+        // accept verbatim, don't try to normalize.
+        let link = parse_pcie_link("8 GT/s\n", "8 GT/s\n", "4\n", "4\n").expect("link present");
+        assert_eq!(link.current_speed, "8 GT/s");
+        assert_eq!(link.max_width, 4);
+    }
+
+    #[test]
+    fn parse_pcie_link_detects_downgrade() {
+        // Trained-down case — controller could do 16 GT/s x4 but the
+        // slot or cable only negotiated 8 GT/s x2. WebUI flags this
+        // amber.
+        let link = parse_pcie_link("8.0 GT/s\n", "16.0 GT/s\n", "2\n", "4\n").expect("link");
+        assert_ne!(link.current_speed, link.max_speed);
+        assert_ne!(link.current_width, link.max_width);
+    }
+
+    #[test]
+    fn parse_pcie_link_rejects_degenerate_states() {
+        // Kernel sometimes reports "Unknown" speed during a power-state
+        // transition. Reporting "PCIe Unknown x0" would be worse than
+        // hiding the chip entirely.
+        assert!(parse_pcie_link("Unknown\n", "8.0 GT/s\n", "2\n", "2\n").is_none());
+        assert!(parse_pcie_link("8.0 GT/s\n", "8.0 GT/s\n", "0\n", "2\n").is_none());
+        // Empty / missing files — caller passes empty strings.
+        assert!(parse_pcie_link("\n", "\n", "0\n", "0\n").is_none());
+        // Garbage in width files (non-numeric).
+        assert!(parse_pcie_link("8.0 GT/s\n", "8.0 GT/s\n", "x4\n", "4\n").is_none());
     }
 
     #[test]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -618,6 +618,7 @@ export interface DiskHealth {
 	ata_port?: string;
 	controller_pci?: string;
 	controller_name?: string;
+	pcie_link?: PcieLink;
 	model: string;
 	serial: string;
 	firmware: string;
@@ -630,6 +631,20 @@ export interface DiskHealth {
 	nvme?: NvmeHealth;
 	scsi?: ScsiHealth;
 	ata?: AtaHealth;
+}
+
+/** PCIe link state for a storage controller, sourced from
+ * `/sys/bus/pci/devices/<bdf>/{current,max}_link_{speed,width}`.
+ * When `current_*` is below `max_*` the link has trained down — common
+ * causes include PCIe ASPM power saving, broken bifurcation in a U.2
+ * backplane, a flaky riser cable, or a slot wired narrower than
+ * physically advertised. Speed strings are passed through verbatim
+ * from sysfs (e.g. `"8.0 GT/s PCIe"`). */
+export interface PcieLink {
+	current_speed: string;
+	max_speed: string;
+	current_width: number;
+	max_width: number;
 }
 
 /** ATA / SATA summary fields complementing the generic SMART attribute

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -173,6 +173,7 @@
 	interface ControllerGroup {
 		pci: string;
 		name: string;
+		pcieLink?: import('$lib/types').PcieLink;
 		disks: DiskHealth[];
 	}
 
@@ -182,12 +183,56 @@
 			const pci = disk.controller_pci ?? 'unknown';
 			const name = disk.controller_name ?? 'Unknown Controller';
 			if (!groups.has(pci)) {
-				groups.set(pci, { pci, name, disks: [] });
+				// PCIe link state is per-controller; every disk on the
+				// same controller carries the same value, so the first
+				// non-null wins.
+				groups.set(pci, { pci, name, pcieLink: disk.pcie_link, disks: [] });
 			}
 			groups.get(pci)!.disks.push(disk);
 		}
 		// Sort groups: known controllers first, then by PCI address
 		return [...groups.values()].sort((a, b) => a.pci.localeCompare(b.pci));
+	}
+
+	// PCIe per-lane bandwidth lookup. Values are the spec's effective
+	// data rates (after 128b/130b for gen3+ and 8b/10b for gen1/2),
+	// rounded to whole MB/s. Matches what `lspci -vv` reports as
+	// "LnkSta:" bandwidth and what operators see on every PCIe-spec
+	// reference page.
+	function pcieLaneMbps(speedStr: string): number | null {
+		// Kernel emits forms like "8.0 GT/s PCIe" or "8 GT/s" — take
+		// the leading number, ignore the unit + suffix.
+		const m = speedStr.match(/^([\d.]+)/);
+		if (!m) return null;
+		const gtps = parseFloat(m[1]);
+		// Gen 1: 2.5 GT/s, 2: 5.0, 3: 8.0, 4: 16.0, 5: 32.0, 6: 64.0
+		// Effective MB/s per lane (rounded): 250, 500, 985, 1969, 3938, 7877
+		const table: Record<number, number> = {
+			2.5: 250, 5: 500, 8: 985, 16: 1969, 32: 3938, 64: 7877,
+		};
+		return table[gtps] ?? null;
+	}
+
+	function formatPcieLink(link: import('$lib/types').PcieLink): string {
+		// Show generation if we can derive it ("PCIe 3.0 x2"), else
+		// fall back to the raw kernel string. PCIe 3.0 = 8 GT/s, etc.
+		const m = link.current_speed.match(/^([\d.]+)/);
+		const gtps = m ? parseFloat(m[1]) : null;
+		const genTable: Record<number, string> = {
+			2.5: '1.0', 5: '2.0', 8: '3.0', 16: '4.0', 32: '5.0', 64: '6.0',
+		};
+		const gen = gtps != null ? genTable[gtps] : null;
+		const speed = gen ? `PCIe ${gen}` : link.current_speed;
+		return `${speed} x${link.current_width}`;
+	}
+
+	function pcieTotalMbps(link: import('$lib/types').PcieLink): number | null {
+		const perLane = pcieLaneMbps(link.current_speed);
+		return perLane != null ? perLane * link.current_width : null;
+	}
+
+	function pcieLinkDowngraded(link: import('$lib/types').PcieLink): boolean {
+		return link.current_speed !== link.max_speed || link.current_width !== link.max_width;
 	}
 </script>
 
@@ -648,10 +693,23 @@
 	{:else if activeTab === 'topology'}
 		{#if smartProtocol?.enabled && disks.length > 0}
 			{#each groupByController(disks) as group}
+				{@const link = group.pcieLink}
+				{@const linkMbps = link ? pcieTotalMbps(link) : null}
+				{@const linkDowngraded = link ? pcieLinkDowngraded(link) : false}
 				<div class="mb-6">
 					<div class="mb-3 flex items-baseline gap-3">
 						<h3 class="text-sm font-semibold text-foreground">{group.name}</h3>
 						<span class="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">PCI {group.pci}</span>
+						{#if link}
+							<span
+								class="rounded px-2 py-0.5 font-mono text-xs {linkDowngraded ? 'bg-amber-950 text-amber-400' : 'bg-muted text-muted-foreground'}"
+								title={linkDowngraded
+									? `Link trained down — max ${link.max_speed} x${link.max_width}. Common causes: PCIe ASPM power saving, broken backplane bifurcation, riser cable issue, or slot wired narrower than physically advertised.`
+									: 'Upstream PCIe link to the host CPU. Total bandwidth = per-lane MB/s × width.'}
+							>
+								{formatPcieLink(link)}{#if linkMbps != null} ({linkMbps.toLocaleString()} MB/s){/if}
+							</span>
+						{/if}
 					</div>
 					<table class="w-full text-sm">
 						<thead>


### PR DESCRIPTION
## Why

The Topology tab groups disks by PCI controller but says nothing about the controller's upstream link bandwidth. That matters for sustained multi-drive workloads: a 6-disk SATA SSD array on an ASMedia ASM1166 PCIe 3.0 x2 controller has ~2 GB/s of upstream bandwidth shared among 6 drives that can each push ~550 MB/s sequential. The aggregate of 6 × 550 = 3.3 GB/s **doesn't fit** through 2 GB/s of PCIe — sustained reads are PCIe-capped, not drive-capped, and operators have no way to see that today.

Data already lives in sysfs (every PCIe device exposes \`current_link_speed\` / \`max_link_speed\` / \`current_link_width\` / \`max_link_width\` under \`/sys/bus/pci/devices/<bdf>/\`). No new dependency, just one extra read per controller per metrics poll.

## What an operator will see

Topology tab today:
```
ASMedia Technology Inc. ASM1166 Serial ATA Controller   PCI 03:00.0
```

After this PR:
```
ASMedia Technology Inc. ASM1166 Serial ATA Controller   PCI 03:00.0   PCIe 3.0 x2 (1970 MB/s)
```

When the link has trained down (e.g. PCIe ASPM holding it in a low-power state, broken bifurcation, riser cable issue), the chip goes amber and the tooltip enumerates the common causes.

## Backend

- New \`PcieLink\` struct in nasty-common with \`current_speed\` / \`max_speed\` / \`current_width\` / \`max_width\`.
- Optional \`pcie_link: Option<PcieLink>\` on \`DiskHealth\`. Per-disk for schema simplicity — every disk on the same controller carries the same value, and the WebUI's \`groupByController()\` already dedupes.
- \`resolve_pcie_link()\` reads the four sysfs files. Speed strings pass through verbatim (kernels emit \`\"8.0 GT/s PCIe\"\` or \`\"8 GT/s\"\` depending on age; both accepted, neither normalized — operator sees the same text as \`lspci -vv\`).
- Edge cases that return \`None\` (hide the chip): sysfs reports \`\"Unknown\"\` speed during power-state transitions, width of 0 means link is in a degenerate state, non-numeric width is garbage. No half-populated records.
- Pure-data \`parse_pcie_link()\` extracted so the parser is unit-testable without a real \`/sys\` tree.

## WebUI

- Topology tab header chip after each controller's PCI address.
- Shows \`PCIe N.M xK (X MB/s)\` when the generation can be derived from the GT/s rate; falls back to the raw kernel string for exotic speeds we don't know about.
- Per-lane bandwidth lookup table lives in the WebUI: 250/500/985/1969/3938/7877 MB/s for PCIe 1.0/2.0/3.0/4.0/5.0/6.0. Spec effective rates after encoding overhead — matches what \`lspci -vv\` reports as LnkSta bandwidth.

## Why not a separate Controller endpoint?

Considered, decided against. Existing \`DiskHealth.controller_name\` is also per-disk duplicated; staying consistent. Total JSON overhead: ~80 bytes per disk × N disks. For a 24-disk array that's ~2 KB extra; not worth a schema refactor.

## Test plan

- [x] \`cargo test --workspace\` (31 metrics tests, 4 new — covering typical / older-kernel formats / downgrade detection / degenerate-state rejection)
- [x] \`cargo clippy --workspace --no-deps --all-targets\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`npm run check\` in webui
- [ ] Visual check on a real box — the ASM1166 in your test box should display \`PCIe 3.0 x2 (1970 MB/s)\` next to the Topology controller header