### PR TITLE
WebUI: annotate chipset-integrated controllers in Topology view

### DIFF
--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -696,6 +696,7 @@
 				{@const link = group.pcieLink}
 				{@const linkMbps = link ? pcieTotalMbps(link) : null}
 				{@const linkDowngraded = link ? pcieLinkDowngraded(link) : false}
+				{@const chipsetIntegrated = !link && group.pci !== 'unknown'}
 				<div class="mb-6">
 					<div class="mb-3 flex items-baseline gap-3">
 						<h3 class="text-sm font-semibold text-foreground">{group.name}</h3>
@@ -708,6 +709,13 @@
 									: 'Upstream PCIe link to the host CPU. Total bandwidth = per-lane MB/s × width.'}
 							>
 								{formatPcieLink(link)}{#if linkMbps != null} ({linkMbps.toLocaleString()} MB/s){/if}
+							</span>
+						{:else if chipsetIntegrated}
+							<span
+								class="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground italic"
+								title={'The kernel exposes no individual PCIe link for this controller — it\'s a chipset-integrated function (Intel PCH / AMD FCH), wired into the chipset\'s internal fabric rather than a discrete PCIe link. Aggregate bandwidth is the chipset\'s upstream DMI link, shared with every other chipset function (USB, integrated NICs, audio). Look up the chipset spec for the actual number.'}
+							>
+								chipset-integrated
 							</span>
 						{/if}
 					</div>


### PR DESCRIPTION
Tiny follow-up to #380/#381. Adds a small italic \`chipset-integrated\` chip next to controllers that have a known PCI BDF but no queryable PCIe link state — Intel PCH SATA AHCI, AMD FCH SATA, integrated NVMe, etc. These functions live on the chipset's internal fabric, not a discrete PCIe link, so there's no \`current_link_speed\` file in sysfs and the existing bandwidth chip silently doesn't render.

That silence is misleading — operators see a controller with name + BDF but no bandwidth info and reasonably wonder if NASty is broken. Now the row reads:

```
Intel Corporation Jasper Lake SATA AHCI Controller   PCI 00:17.0   chipset-integrated
```

Hovering the chip explains:

> The kernel exposes no individual PCIe link for this controller — it's a chipset-integrated function (Intel PCH / AMD FCH), wired into the chipset's internal fabric rather than a discrete PCIe link. Aggregate bandwidth is the chipset's upstream DMI link, shared with every other chipset function (USB, integrated NICs, audio). Look up the chipset spec for the actual number.

## Logic

```svelte
{@const chipsetIntegrated = !link && group.pci !== 'unknown'}
{#if link}
  <PCIe-bandwidth chip>
{:else if chipsetIntegrated}
  <chipset-integrated chip>
{/if}
```

Skipped when \`pci === 'unknown'\` — that's the case where we don't have a PCI BDF at all (USB bridges, virtio with weird path resolution, etc.), so the chip would be both technically and semantically wrong.

## Styling

Italic + muted (\`text-muted-foreground italic\`) — distinct from the amber \"DOWNGRADED\" treatment we use for trained-down links. Conveys \"informational, not a warning\".

## Test plan

- [x] \`npm run check\` (svelte-check clean)
- [ ] Visual on a real box with a chipset-integrated SATA controller — chip should render with the explanation in the tooltip