### PR TITLE
notifications: structured webhook payload + HMAC signing + retry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -668,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1134,6 +1149,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1810,7 +1826,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1820,6 +1836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2705,6 +2730,7 @@ version = "0.0.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "hmac 0.13.0",
  "lettre",
  "libc",
  "nasty-apps",
@@ -2965,7 +2991,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "itertools 0.10.5",
  "log",
@@ -3257,7 +3283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3791,7 +3817,7 @@ dependencies = [
  "form_urlencoded",
  "getrandom 0.2.17",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "http",
  "jsonwebtoken",
@@ -3896,7 +3922,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -2777,7 +2777,23 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
                             "{}\n\nSource: {}\nValue: {:.1}\nThreshold: {:.1}",
                             alert.message, alert.source, alert.current_value, alert.threshold
                         );
-                        notifications::send(&config, &subject, &body).await;
+                        // Stable event id derived from rule + source +
+                        // current value so the webhook receiver can
+                        // dedupe a retry against the original delivery
+                        // even though we don't persist outbox state.
+                        let event_id = format!(
+                            "alert-{}-{}-{}",
+                            alert.rule_id, alert.source, alert.current_value as i64
+                        );
+                        let data = serde_json::to_value(alert).unwrap_or(serde_json::Value::Null);
+                        let event = notifications::Event {
+                            event_type: "alert.fired",
+                            event_id: &event_id,
+                            subject: &subject,
+                            body: &body,
+                            data,
+                        };
+                        notifications::send_event(&config, &event).await;
                     }
                 }
             }

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -18,6 +18,7 @@ schemars.workspace = true
 libc.workspace = true
 base64.workspace = true
 sha2 = "0.11"
+hmac = "0.13"
 rnix = "0.14"
 x509-parser = "0.18"
 rowan = "0.16"

--- a/engine/nasty-system/src/notifications.rs
+++ b/engine/nasty-system/src/notifications.rs
@@ -41,6 +41,14 @@ pub enum ChannelType {
         url: String,
         #[serde(default)]
         headers: std::collections::HashMap<String, String>,
+        /// HMAC-SHA256 signing key. When set, every webhook POST carries
+        /// an `X-NASty-Signature: sha256=<hex>` header that's the HMAC
+        /// of the raw body. Receivers verify the request really came
+        /// from NASty by recomputing the signature with the shared
+        /// secret. Optional — old webhook configs without a secret
+        /// still work, just unsigned.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        secret: Option<String>,
     },
     Ntfy {
         server_url: String,
@@ -80,13 +88,58 @@ impl NotificationConfig {
 
 // ── Dispatcher ─────────────────────────────────────────────────
 
-/// Send a notification to all enabled channels.
+/// Structured event payload carried by webhooks. Human-readable
+/// channels (SMTP, Telegram, Ntfy, Signal) ignore the typed `data`
+/// field and use `subject`/`body` like before — they're consumed by
+/// humans reading the message. The webhook channel uses the typed
+/// fields so integration tools (Home Assistant, n8n, monitoring
+/// receivers) can match on `event_type` and pull values out of
+/// `data` without parsing the human string.
+#[derive(Debug, Clone)]
+pub struct Event<'a> {
+    /// Stable identifier for the event class (`"alert.fired"`,
+    /// `"test"`, …). Receivers route on this.
+    pub event_type: &'a str,
+    /// Per-event identifier — operators correlate retries / dedupe
+    /// on this. The webhook re-uses the same id across all retry
+    /// attempts so a receiver that sees the same id twice can drop
+    /// the duplicate.
+    pub event_id: &'a str,
+    /// Human subject (used as-is by SMTP/Telegram/Ntfy/Signal).
+    pub subject: &'a str,
+    /// Human body (same).
+    pub body: &'a str,
+    /// Typed payload for the webhook receiver. Channels other than
+    /// webhook ignore this. `serde_json::Value` rather than a
+    /// generic so the caller doesn't have to bake event-type-specific
+    /// types into the notifications crate.
+    pub data: serde_json::Value,
+}
+
+/// Send a notification to all enabled channels. Backward-compatible
+/// thin wrapper that wraps the legacy subject/body call shape into
+/// an event with no typed `data` — old callers don't have to thread
+/// structured data through. New callers should prefer `send_event`
+/// directly so webhook consumers get the typed payload.
 pub async fn send(config: &NotificationConfig, subject: &str, body: &str) {
+    let event = Event {
+        event_type: "notification",
+        event_id: &generate_event_id(),
+        subject,
+        body,
+        data: serde_json::Value::Null,
+    };
+    send_event(config, &event).await;
+}
+
+/// Fan an event out to every enabled channel. Errors are logged per
+/// channel; one channel's failure doesn't block the others.
+pub async fn send_event(config: &NotificationConfig, event: &Event<'_>) {
     for ch in &config.channels {
         if !ch.enabled {
             continue;
         }
-        if let Err(e) = send_to_channel(&ch.channel, subject, body).await {
+        if let Err(e) = send_to_channel(&ch.channel, event).await {
             warn!("Notification to '{}' ({}) failed: {e}", ch.name, ch.id);
         } else {
             info!("Notification sent to '{}' ({})", ch.name, ch.id);
@@ -94,18 +147,20 @@ pub async fn send(config: &NotificationConfig, subject: &str, body: &str) {
     }
 }
 
-/// Test a specific channel by sending a test message.
+/// Test a specific channel by sending a synthetic test event.
 pub async fn test_channel(channel: &ChannelType) -> Result<String, String> {
-    send_to_channel(
-        channel,
-        "NASty Test",
-        "This is a test notification from NASty.",
-    )
-    .await?;
+    let event = Event {
+        event_type: "test",
+        event_id: &generate_event_id(),
+        subject: "NASty Test",
+        body: "This is a test notification from NASty.",
+        data: serde_json::json!({"test": true}),
+    };
+    send_to_channel(channel, &event).await?;
     Ok("Test notification sent successfully".to_string())
 }
 
-async fn send_to_channel(channel: &ChannelType, subject: &str, body: &str) -> Result<(), String> {
+async fn send_to_channel(channel: &ChannelType, event: &Event<'_>) -> Result<(), String> {
     match channel {
         ChannelType::Smtp {
             host,
@@ -114,22 +169,58 @@ async fn send_to_channel(channel: &ChannelType, subject: &str, body: &str) -> Re
             password,
             from,
             to,
-        } => send_smtp(host, *port, username, password, from, to, subject, body).await,
-        ChannelType::Telegram { bot_token, chat_id } => {
-            send_telegram(bot_token, chat_id, subject, body).await
+        } => {
+            send_smtp(
+                host,
+                *port,
+                username,
+                password,
+                from,
+                to,
+                event.subject,
+                event.body,
+            )
+            .await
         }
-        ChannelType::Webhook { url, headers } => send_webhook(url, headers, subject, body).await,
+        ChannelType::Telegram { bot_token, chat_id } => {
+            send_telegram(bot_token, chat_id, event.subject, event.body).await
+        }
+        ChannelType::Webhook {
+            url,
+            headers,
+            secret,
+        } => send_webhook(url, headers, secret.as_deref(), event).await,
         ChannelType::Ntfy {
             server_url,
             topic,
             token,
-        } => send_ntfy(server_url, topic, token.as_deref(), subject, body).await,
+        } => {
+            send_ntfy(
+                server_url,
+                topic,
+                token.as_deref(),
+                event.subject,
+                event.body,
+            )
+            .await
+        }
         ChannelType::Signal {
             api_url,
             from_number,
             to_number,
-        } => send_signal(api_url, from_number, to_number, subject, body).await,
+        } => send_signal(api_url, from_number, to_number, event.subject, event.body).await,
     }
+}
+
+/// Generate a short event id (`evt-<uuid7-style>`). Re-used across
+/// retry attempts so webhook receivers can dedupe on it.
+fn generate_event_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let micros = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros())
+        .unwrap_or(0);
+    format!("evt-{:016x}", micros)
 }
 
 // ── SMTP ───────────────────────────────────────────────────────
@@ -223,39 +314,126 @@ async fn send_telegram(
 
 // ── Webhook ────────────────────────────────────────────────────
 
+/// Build the JSON body the webhook POST carries. Backward-compatible
+/// with the pre-v0.0.10 shape — the original `subject`, `body`,
+/// `source`, `timestamp` fields are still here so existing consumers
+/// (Home Assistant automations, simple scripts that match on `subject`)
+/// keep working. The new `event_type`, `event_id`, `data`,
+/// `nasty_version`, `nasty_hostname` fields land alongside for
+/// consumers that want typed event data instead of regex-matching the
+/// human strings.
+fn webhook_payload(event: &Event<'_>) -> String {
+    let host = std::fs::read_to_string("/etc/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "nasty".to_string());
+    let payload = serde_json::json!({
+        "subject": event.subject,
+        "body": event.body,
+        "source": "nasty",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "event_type": event.event_type,
+        "event_id": event.event_id,
+        "nasty_version": env!("CARGO_PKG_VERSION"),
+        "nasty_hostname": host,
+        "data": event.data,
+    });
+    payload.to_string()
+}
+
+/// HMAC-SHA256 the body with the secret and return the hex digest.
+/// Receivers verify by recomputing and constant-time-comparing the
+/// header value's `sha256=…` substring.
+fn sign_webhook(secret: &str, body: &[u8]) -> String {
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+    let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(secret.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+    let mut hex = String::with_capacity(result.len() * 2);
+    for b in result {
+        use std::fmt::Write;
+        let _ = write!(&mut hex, "{:02x}", b);
+    }
+    hex
+}
+
 async fn send_webhook(
     url: &str,
     headers: &std::collections::HashMap<String, String>,
-    subject: &str,
-    body: &str,
+    secret: Option<&str>,
+    event: &Event<'_>,
 ) -> Result<(), String> {
-    let client = reqwest::Client::new();
-    let mut req = client.post(url).json(&serde_json::json!({
-        "subject": subject,
-        "body": body,
-        "source": "nasty",
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-    }));
+    let body = webhook_payload(event);
+    let signature = secret.map(|s| sign_webhook(s, body.as_bytes()));
 
+    // Retry transient failures (network errors + 5xx) with an
+    // exponential backoff. 4xx responses are NOT retried — they're
+    // configuration / endpoint errors that won't fix themselves on
+    // resend. Total wall-clock cap: ~35s.
+    let mut attempt = 0;
+    let mut last_err = String::new();
+    loop {
+        attempt += 1;
+        match send_webhook_once(url, headers, signature.as_deref(), &body).await {
+            Ok(()) => return Ok(()),
+            Err(WebhookError::Transient(e)) if attempt < 3 => {
+                last_err = e;
+                let wait_secs = if attempt == 1 { 5 } else { 30 };
+                tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
+            }
+            Err(WebhookError::Transient(e)) => {
+                return Err(format!("after {attempt} attempts: {e} (last: {last_err})"));
+            }
+            Err(WebhookError::Permanent(e)) => return Err(e),
+        }
+    }
+}
+
+enum WebhookError {
+    /// 5xx response or network failure — worth retrying.
+    Transient(String),
+    /// 4xx or other client-fault response — retry won't help.
+    Permanent(String),
+}
+
+async fn send_webhook_once(
+    url: &str,
+    headers: &std::collections::HashMap<String, String>,
+    signature: Option<&str>,
+    body: &str,
+) -> Result<(), WebhookError> {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body.to_string());
+    if let Some(sig) = signature {
+        req = req.header("X-NASty-Signature", format!("sha256={sig}"));
+    }
     for (k, v) in headers {
         req = req.header(k, v);
     }
-
     let resp = req
         .send()
         .await
-        .map_err(|e| format!("webhook request: {e}"))?;
+        .map_err(|e| WebhookError::Transient(format!("webhook request: {e}")))?;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .unwrap_or_else(|e| format!("(failed to read body: {e})"));
-        return Err(format!("webhook error {status}: {body}"));
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
     }
-
-    Ok(())
+    let body = resp
+        .text()
+        .await
+        .unwrap_or_else(|e| format!("(failed to read body: {e})"));
+    let msg = format!("webhook error {status}: {body}");
+    if status.is_server_error() {
+        Err(WebhookError::Transient(msg))
+    } else {
+        Err(WebhookError::Permanent(msg))
+    }
 }
 
 // ── ntfy ───────────────────────────────────────────────────────
@@ -328,4 +506,88 @@ async fn send_signal(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_signature_is_stable_for_same_input() {
+        // Receivers verify by recomputing — same key + body must
+        // always produce the same digest, byte-for-byte.
+        let sig_a = sign_webhook("hunter2", b"{\"event\":\"test\"}");
+        let sig_b = sign_webhook("hunter2", b"{\"event\":\"test\"}");
+        assert_eq!(sig_a, sig_b);
+        // Hex-encoded 32-byte SHA256 digest is 64 chars.
+        assert_eq!(sig_a.len(), 64);
+        assert!(sig_a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hmac_signature_changes_with_key() {
+        let body = b"{\"event\":\"test\"}";
+        let sig_a = sign_webhook("hunter2", body);
+        let sig_b = sign_webhook("different-key", body);
+        assert_ne!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn hmac_signature_changes_with_body() {
+        // The whole point of signing: tampering with the body
+        // invalidates the signature.
+        let sig_a = sign_webhook("hunter2", b"{\"event\":\"alert.fired\"}");
+        let sig_b = sign_webhook("hunter2", b"{\"event\":\"alert.resolved\"}");
+        assert_ne!(sig_a, sig_b);
+    }
+
+    #[test]
+    fn hmac_matches_python_reference() {
+        // Cross-checked against:
+        //   import hmac, hashlib
+        //   hmac.new(b"secret", b"hello", hashlib.sha256).hexdigest()
+        //   -> '88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b'
+        // Receivers in Python / Node / Go will use the same standard
+        // HMAC-SHA256 so a wire-compat test against a known fixture
+        // catches any future crate-bump surprises.
+        let sig = sign_webhook("secret", b"hello");
+        assert_eq!(
+            sig,
+            "88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b"
+        );
+    }
+
+    #[test]
+    fn webhook_payload_carries_both_legacy_and_structured_fields() {
+        // Backward compat — the pre-v0.0.10 webhook shape had
+        // {subject, body, source, timestamp}. Consumers that match
+        // on subject regex must keep working. New consumers want
+        // event_type / event_id / data for typed dispatch.
+        let event = Event {
+            event_type: "alert.fired",
+            event_id: "evt-deadbeef",
+            subject: "[NASty CRITICAL] disk failing",
+            body: "Disk /dev/sda SMART health check FAILED",
+            data: serde_json::json!({
+                "rule_id": "smart-health",
+                "severity": "critical",
+            }),
+        };
+        let body_str = webhook_payload(&event);
+        let parsed: serde_json::Value = serde_json::from_str(&body_str).expect("valid JSON");
+
+        // Legacy keys for existing consumers.
+        assert_eq!(parsed["subject"], "[NASty CRITICAL] disk failing");
+        assert_eq!(parsed["body"], "Disk /dev/sda SMART health check FAILED");
+        assert_eq!(parsed["source"], "nasty");
+        assert!(parsed["timestamp"].is_string());
+
+        // New structured keys.
+        assert_eq!(parsed["event_type"], "alert.fired");
+        assert_eq!(parsed["event_id"], "evt-deadbeef");
+        assert_eq!(parsed["data"]["rule_id"], "smart-health");
+        assert_eq!(parsed["data"]["severity"], "critical");
+        assert!(parsed["nasty_version"].is_string());
+        assert!(parsed["nasty_hostname"].is_string());
+    }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1221,6 +1221,11 @@ export interface NotificationChannel {
 	// Webhook
 	url?: string;
 	headers?: Record<string, string>;
+	/** Optional HMAC-SHA256 signing key. When set, every webhook POST
+	 * carries an `X-NASty-Signature: sha256=<hex>` header. Receivers
+	 * verify by recomputing HMAC-SHA256 of the raw body with the same
+	 * key — proves the request actually came from NASty. */
+	secret?: string;
 	// ntfy
 	server_url?: string;
 	topic?: string;

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -37,6 +37,7 @@
 	let nfFrom = $state(''); let nfTo = $state('');
 	let nfBotToken = $state(''); let nfChatId = $state('');
 	let nfUrl = $state('');
+	let nfSecret = $state('');
 	let nfNtfyServer = $state('https://ntfy.sh'); let nfNtfyTopic = $state(''); let nfNtfyToken = $state('');
 	let nfSignalUrl = $state('http://localhost:8080'); let nfSignalFrom = $state(''); let nfSignalTo = $state('');
 
@@ -553,7 +554,7 @@
 		const payload: Record<string, unknown> = { type: ch.type };
 		if (ch.type === 'smtp') Object.assign(payload, { host: ch.host, port: ch.port, username: ch.username, password: ch.password, from: ch.from, to: ch.to });
 		else if (ch.type === 'telegram') Object.assign(payload, { bot_token: ch.bot_token, chat_id: ch.chat_id });
-		else if (ch.type === 'webhook') Object.assign(payload, { url: ch.url, headers: ch.headers || {} });
+		else if (ch.type === 'webhook') Object.assign(payload, { url: ch.url, headers: ch.headers || {}, secret: ch.secret || undefined });
 		else if (ch.type === 'ntfy') Object.assign(payload, { server_url: ch.server_url, topic: ch.topic, token: ch.token });
 		else if (ch.type === 'signal') Object.assign(payload, { api_url: ch.api_url, from_number: ch.from_number, to_number: ch.to_number });
 		await withToast(
@@ -569,7 +570,7 @@
 		const payload: Record<string, unknown> = { type: notifAddType };
 		if (notifAddType === 'smtp') Object.assign(payload, { host: nfHost, port: nfPort, username: nfUser, password: nfPass, from: nfFrom, to: nfTo });
 		else if (notifAddType === 'telegram') Object.assign(payload, { bot_token: nfBotToken, chat_id: nfChatId });
-		else if (notifAddType === 'webhook') Object.assign(payload, { url: nfUrl, headers: {} });
+		else if (notifAddType === 'webhook') Object.assign(payload, { url: nfUrl, headers: {}, secret: nfSecret || undefined });
 		else if (notifAddType === 'ntfy') Object.assign(payload, { server_url: nfNtfyServer, topic: nfNtfyTopic, token: nfNtfyToken || undefined });
 		else if (notifAddType === 'signal') Object.assign(payload, { api_url: nfSignalUrl, from_number: nfSignalFrom, to_number: nfSignalTo });
 		await withToast(
@@ -585,7 +586,7 @@
 		const ch: NotificationChannel = { id, name: nfName, enabled: true, type: notifAddType };
 		if (notifAddType === 'smtp') Object.assign(ch, { host: nfHost, port: nfPort, username: nfUser, password: nfPass, from: nfFrom, to: nfTo });
 		else if (notifAddType === 'telegram') Object.assign(ch, { bot_token: nfBotToken, chat_id: nfChatId });
-		else if (notifAddType === 'webhook') Object.assign(ch, { url: nfUrl, headers: {} });
+		else if (notifAddType === 'webhook') Object.assign(ch, { url: nfUrl, headers: {}, secret: nfSecret || undefined });
 		else if (notifAddType === 'ntfy') Object.assign(ch, { server_url: nfNtfyServer, topic: nfNtfyTopic, token: nfNtfyToken || undefined });
 		else if (notifAddType === 'signal') Object.assign(ch, { api_url: nfSignalUrl, from_number: nfSignalFrom, to_number: nfSignalTo });
 		notifConfig.channels = [...notifConfig.channels, ch];
@@ -607,7 +608,7 @@
 		notifAddType = null; nfName = '';
 		nfHost = ''; nfPort = 587; nfUser = ''; nfPass = ''; nfFrom = ''; nfTo = '';
 		nfBotToken = ''; nfChatId = '';
-		nfUrl = '';
+		nfUrl = ''; nfSecret = '';
 		nfNtfyServer = 'https://ntfy.sh'; nfNtfyTopic = ''; nfNtfyToken = '';
 		nfSignalUrl = 'http://localhost:8080'; nfSignalFrom = ''; nfSignalTo = '';
 	}
@@ -1231,7 +1232,7 @@
 					{:else if notifAddType === 'telegram'}
 						<p class="text-xs text-muted-foreground">Send alerts to a Telegram chat. Create a bot via <a href="https://t.me/BotFather" target="_blank" rel="noopener" class="text-primary hover:underline">@BotFather</a>, copy the token. Then send a message to the bot and get your Chat ID from <code class="font-mono">https://api.telegram.org/bot&lt;TOKEN&gt;/getUpdates</code>.</p>
 					{:else if notifAddType === 'webhook'}
-						<p class="text-xs text-muted-foreground">Send a JSON POST to any URL when alerts fire. The payload includes <code class="font-mono">subject</code>, <code class="font-mono">body</code>, <code class="font-mono">source</code>, and <code class="font-mono">timestamp</code> fields. Works with Discord webhooks, Slack incoming webhooks, Home Assistant, or any custom endpoint.</p>
+						<p class="text-xs text-muted-foreground">Send a JSON POST to any URL when alerts fire. The payload carries both human fields (<code class="font-mono">subject</code>, <code class="font-mono">body</code>) and typed fields (<code class="font-mono">event_type</code>, <code class="font-mono">event_id</code>, <code class="font-mono">data</code>) so integrations can match either way. Set a Signing Secret below to have NASty add an <code class="font-mono">X-NASty-Signature: sha256=&lt;hex&gt;</code> header that the receiver can verify with HMAC-SHA256.</p>
 					{:else if notifAddType === 'ntfy'}
 						<p class="text-xs text-muted-foreground">Push notifications via <a href="https://ntfy.sh" target="_blank" rel="noopener" class="text-primary hover:underline">ntfy</a> — install the ntfy app on your phone, subscribe to your topic, and alerts arrive as push notifications. The free ntfy.sh server works without a token. Self-hosted servers may require one.</p>
 					{:else if notifAddType === 'signal'}
@@ -1283,6 +1284,11 @@
 							<label for="nf-url" class="text-xs text-muted-foreground">URL</label>
 							<input id="nf-url" bind:value={nfUrl} placeholder="https://discord.com/api/webhooks/..." class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono" />
 							<p class="mt-1 text-xs text-muted-foreground">Example: Discord webhook URL, Slack incoming webhook, or any endpoint that accepts JSON POST.</p>
+						</div>
+						<div>
+							<label for="nf-secret" class="text-xs text-muted-foreground">Signing Secret (optional)</label>
+							<input id="nf-secret" bind:value={nfSecret} type="password" placeholder="leave empty for unsigned" class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono" />
+							<p class="mt-1 text-xs text-muted-foreground">If set, NASty signs each POST body with HMAC-SHA256 and sends the hex digest in <code class="font-mono">X-NASty-Signature</code>. Receivers in Python: <code class="font-mono">hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()</code> and compare. Discord / Slack webhooks ignore this header — only matters for custom endpoints.</p>
 						</div>
 					{:else if notifAddType === 'ntfy'}
 						<div>


### PR DESCRIPTION
The Webhook notification channel today sends `{subject, body, source, timestamp}` strings to a configured URL and gives up on the first failed POST. That's enough for \"fire a Discord message when something breaks\" but it doesn't compose with Home Assistant / n8n / monitoring receivers that want typed dispatch, and one transient 503 silently loses the event.

Three additions, all backward-compatible.

## Structured payload

Today:
```json
{ \"subject\": \"[NASty CRITICAL] disk failing\", \"body\": \"…\", \"source\": \"nasty\", \"timestamp\": \"…\" }
```

After this PR:
```json
{
  \"subject\": \"[NASty CRITICAL] disk failing\",
  \"body\": \"Disk /dev/sda SMART health check FAILED\",
  \"source\": \"nasty\",
  \"timestamp\": \"2026-06-02T…\",
  \"event_type\": \"alert.fired\",
  \"event_id\": \"alert-smart-health-/dev/sda-0\",
  \"nasty_version\": \"0.0.10\",
  \"nasty_hostname\": \"nasty\",
  \"data\": {
    \"rule_id\": \"smart-health\",
    \"rule_name\": \"SMART health failure\",
    \"severity\": \"critical\",
    \"metric\": \"smart_health\",
    \"message\": \"Disk /dev/sda SMART health check FAILED\",
    \"source\": \"/dev/sda\",
    \"current_value\": 0.0,
    \"threshold\": 1.0
  }
}
```

The legacy fields stay so consumers that regex on `subject` keep working. New consumers route on `event_type` and pull typed values out of `data` (which is the full `ActiveAlert` serialized via serde — every field the WebUI shows).

## HMAC-SHA256 signing

Optional \`secret: Option<String>\` field on the Webhook channel. When set:

- Every POST carries `X-NASty-Signature: sha256=<hex>`, the HMAC-SHA256 of the raw body
- Receivers verify by recomputing — proves the request really came from NASty
- Cross-checked against Python's stdlib in a unit test so a future crate-bump can't silently break wire compat:
  ```python
  hmac.new(b\"secret\", b\"hello\", hashlib.sha256).hexdigest()
  == \"88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b\"
  ```
- Optional — old configs without a secret still work, just unsigned

## Retry on transient failure

- Three attempts with 5s + 30s backoff (total wall-clock cap ~35s)
- 5xx and network errors retried; 4xx not (won't fix itself)
- Event id is stable across attempts so receivers can dedupe on it

## Plumbing

- New `Event<'a>` struct carries the structured fields alongside the legacy subject/body
- New `send_event()` is the structured entry; existing `send(subject, body)` thin-wraps it for the SMTP/Telegram/etc. channels that have no use for typed data
- Alert dispatch site (`main.rs`) now passes the `ActiveAlert` as typed `data`

## WebUI

- Optional \"Signing Secret\" input next to the Webhook URL
- Form description updated to mention structured fields + HMAC verification recipe

## Tests (5 new in nasty-system)

- HMAC stable across runs, varies with key, varies with body
- HMAC matches Python reference for fixture vector
- Webhook payload carries both legacy + structured fields

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --no-deps --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check` in webui
- [ ] Manual: configure a webhook with a secret pointing at https://webhook.site, fire a test alert, verify both the payload shape and that the X-NASty-Signature header validates