### PR TITLE
webui: IPv6-aware client-side validation for NVMe-oF + NFS forms

### DIFF
--- a/webui/src/lib/network.test.ts
+++ b/webui/src/lib/network.test.ts
@@ -3,11 +3,13 @@ import {
 	findOrphanInterfaces,
 	promoteOrphanedMembers,
 	stripInterfaces,
+	validateAddressForFamily,
 	validateDnsServer,
 	validateIpv4Address,
 	validateIpv4Cidr,
 	validateIpv6Address,
 	validateIpv6Cidr,
+	validateNfsHost,
 } from './network';
 import type {
 	BondConfig,
@@ -374,5 +376,76 @@ describe('validateDnsServer', () => {
 		// error message matches what the user wrote.
 		expect(validateDnsServer('not:a:v6')).toMatch(/IPv6/);
 		expect(validateDnsServer('not.a.v4')).toMatch(/IPv4/);
+	});
+});
+
+describe('validateNfsHost', () => {
+	it('accepts the host forms the engine accepts', () => {
+		// Same set the Rust validate_nfs_host unit test covers, ported
+		// here so a future divergence between client and server
+		// surfaces in CI rather than as a confusing runtime error.
+		expect(validateNfsHost('192.168.1.5')).toBeNull();
+		expect(validateNfsHost('192.168.1.0/24')).toBeNull();
+		expect(validateNfsHost('fd00::1/64')).toBeNull();
+		expect(validateNfsHost('client.example.com')).toBeNull();
+		expect(validateNfsHost('*')).toBeNull();
+		expect(validateNfsHost('@netgroup')).toBeNull();
+	});
+
+	it('passes empty input as null (let the required-field check handle it)', () => {
+		expect(validateNfsHost('')).toBeNull();
+		expect(validateNfsHost('   ')).toBeNull();
+	});
+
+	it('rejects shell-injection-relevant punctuation', () => {
+		// Match the engine: whitespace, control chars, parens, quotes,
+		// semicolons, commas, backslashes all forbidden. The exports
+		// file grammar is positional and these characters would let a
+		// value escape into a fresh export entry.
+		expect(validateNfsHost('host with space')).toBeTruthy();
+		expect(validateNfsHost('host\nnewline')).toBeTruthy();
+		expect(validateNfsHost('host(opts)')).toBeTruthy();
+		expect(validateNfsHost('host;evil')).toBeTruthy();
+		expect(validateNfsHost('host"quoted')).toBeTruthy();
+		expect(validateNfsHost('host,other')).toBeTruthy();
+	});
+});
+
+describe('validateAddressForFamily', () => {
+	it('accepts v4 strings under ipv4 family', () => {
+		expect(validateAddressForFamily('ipv4', '192.168.1.10')).toBeNull();
+		expect(validateAddressForFamily('ipv4', '10.0.0.1')).toBeNull();
+	});
+
+	it('accepts v6 strings under ipv6 family', () => {
+		expect(validateAddressForFamily('ipv6', 'fd00::1')).toBeNull();
+		expect(validateAddressForFamily('ipv6', '2001:db8::1')).toBeNull();
+		expect(validateAddressForFamily('ipv6', '::1')).toBeNull();
+	});
+
+	it('catches v6 string typed under ipv4 family', () => {
+		// Operator picked IPv4 in the dropdown but typed an IPv6
+		// address. Before this preflight, the engine would reject
+		// it late with a configfs EINVAL after submission.
+		expect(validateAddressForFamily('ipv4', 'fd00::1')).toBeTruthy();
+	});
+
+	it('catches v4 string typed under ipv6 family', () => {
+		expect(validateAddressForFamily('ipv6', '192.168.1.10')).toBeTruthy();
+	});
+
+	it('rejects a CIDR suffix on a listen address', () => {
+		// portal listen address is a single host — CIDR doesn't make
+		// sense here even though it does for client ACLs.
+		expect(validateAddressForFamily('ipv6', 'fd00::/64')).toMatch(/CIDR/);
+	});
+
+	it('accepts a v6 zone id (link-local interface scope)', () => {
+		expect(validateAddressForFamily('ipv6', 'fe80::1%eth0')).toBeNull();
+	});
+
+	it('passes empty input as null', () => {
+		expect(validateAddressForFamily('ipv4', '')).toBeNull();
+		expect(validateAddressForFamily('ipv6', '')).toBeNull();
 	});
 });

--- a/webui/src/lib/network.ts
+++ b/webui/src/lib/network.ts
@@ -241,3 +241,49 @@ export function validateDnsServer(s: string): string | null {
 	}
 	return validateIpv4Address(value);
 }
+
+/** Validate an NFS client host entry. Mirrors the engine's
+ * `validate_nfs_host` (engine/nasty-sharing/src/nfs.rs): rejects
+ * whitespace, control chars, and the shell-injection-relevant
+ * punctuation (`(`, `)`, `"`, `'`, `;`, `,`, `\`) that could let a
+ * value escape its position in the exports file's
+ * `host(opts) host(opts) ...` grammar.
+ *
+ * Deliberately permissive on what *kind* of host it is — IPv4
+ * addresses, IPv6 addresses (with or without CIDR), hostnames,
+ * `*`, `@netgroup` and the like all pass. Anything that doesn't
+ * trip the injection filter is the engine's job to interpret. */
+export function validateNfsHost(s: string): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	if (/[\s\x00-\x1f()"';,\\]/.test(value)) {
+		return 'Contains invalid characters (whitespace, quotes, parentheses, semicolons, commas, backslashes)';
+	}
+	return null;
+}
+
+/** Validate a listen address picked alongside an explicit address
+ * family selector — used by the NVMe-oF port form, where the operator
+ * picks `ipv4` or `ipv6` from a `<select>` and then types the
+ * matching address. Today the form had no cross-check, so an
+ * `ipv6` family + a v4 string sent the engine a mismatched payload
+ * that errored late with a configfs EINVAL. */
+export function validateAddressForFamily(
+	family: 'ipv4' | 'ipv6',
+	s: string,
+): string | null {
+	const value = s.trim();
+	if (!value) return null;
+	if (family === 'ipv6') {
+		// Accept literal v6 with or without zone id (`fe80::1%eth0`),
+		// reject CIDR — the listen address is a single host.
+		if (value.includes('/')) {
+			return 'Listen address must be a bare address (no CIDR prefix)';
+		}
+		if (!validIpv6Body(value.split('%')[0])) {
+			return `'${value}' is not a valid IPv6 address`;
+		}
+		return null;
+	}
+	return validateIpv4Address(value);
+}

--- a/webui/src/routes/sharing/NfsPanel.svelte
+++ b/webui/src/routes/sharing/NfsPanel.svelte
@@ -5,6 +5,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { requiredFieldCls } from '$lib/utils';
+	import { validateNfsHost } from '$lib/network';
 	import {
 		nfs,
 		nfsToggleSort,
@@ -23,8 +24,9 @@
 	 * collapses (showAddClientShare is cleared elsewhere). */
 	let addClientTried = $state(false);
 
+	const addClientHostError = $derived(validateNfsHost(nfs.addClientHost));
 	async function nfsAddClickHost(share: Parameters<typeof nfsAddClient>[0]) {
-		if (!nfs.addClientHost) { addClientTried = true; return; }
+		if (!nfs.addClientHost || addClientHostError) { addClientTried = true; return; }
 		addClientTried = false;
 		await nfsAddClient(share);
 	}
@@ -121,7 +123,14 @@
 								<div class="flex items-end gap-2">
 									<div>
 										<Label class="text-xs">Host / Network {#if !nfs.addClientHost && addClientTried}<span class="text-amber-500">required</span>{/if}</Label>
-										<Input bind:value={nfs.addClientHost} placeholder="192.168.1.0/24" class="mt-1 h-8 w-44 text-xs {requiredFieldCls(!nfs.addClientHost, addClientTried)}" />
+										<Input
+											bind:value={nfs.addClientHost}
+											placeholder="192.168.1.0/24, fd00::/64, *, or host.example.com"
+											class="mt-1 h-8 w-72 text-xs {requiredFieldCls(!nfs.addClientHost, addClientTried)} {addClientHostError ? 'border-red-400' : ''}"
+										/>
+										{#if addClientHostError}
+											<p class="mt-1 text-[0.7rem] text-red-400">{addClientHostError}</p>
+										{/if}
 									</div>
 									<div>
 										<Label class="text-xs">Options</Label>

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -6,6 +6,7 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { requiredFieldCls } from '$lib/utils';
+	import { validateAddressForFamily } from '$lib/network';
 	import {
 		nvme,
 		nvmeToggleSort,
@@ -43,6 +44,24 @@
 		if (!nvme.addHostNqn) { addHostTried = true; return; }
 		addHostTried = false;
 		await nvmeAddHost();
+	}
+
+	// Per-port-add cross-validation: family selector + address text
+	// input were independent before — operator could pick `ipv6` and
+	// type a v4 address (or vice versa), the engine would reject with
+	// a generic configfs EINVAL. Now we preflight with the same
+	// per-family check as the rest of the network forms.
+	let addPortTried = $state(false);
+	const addPortAddrError = $derived(
+		validateAddressForFamily(
+			nvme.addPortFamily === 'ipv6' ? 'ipv6' : 'ipv4',
+			nvme.addPortAddr,
+		),
+	);
+	async function nvmeAddPortGuarded() {
+		if (!nvme.addPortAddr || addPortAddrError) { addPortTried = true; return; }
+		addPortTried = false;
+		await nvmeAddPort();
 	}
 
 	const nvmeFiltered = $derived(
@@ -211,8 +230,15 @@
 											</div>
 											<div class="grid grid-cols-2 gap-2 mb-2">
 												<div>
-													<Label class="text-xs">Listen Address</Label>
-													<Input bind:value={nvme.addPortAddr} class="mt-1 h-8 text-xs" />
+													<Label class="text-xs">Listen Address {#if !nvme.addPortAddr && addPortTried}<span class="text-amber-500">required</span>{/if}</Label>
+													<Input
+														bind:value={nvme.addPortAddr}
+														placeholder={nvme.addPortFamily === 'ipv6' ? 'fd00::1 or 2001:db8::1' : '192.168.1.10'}
+														class="mt-1 h-8 text-xs {requiredFieldCls(!nvme.addPortAddr, addPortTried)} {addPortAddrError ? 'border-red-400' : ''}"
+													/>
+													{#if addPortAddrError}
+														<p class="mt-1 text-[0.7rem] text-red-400">{addPortAddrError}</p>
+													{/if}
 												</div>
 												<div>
 													<Label class="text-xs">Port</Label>
@@ -220,8 +246,8 @@
 												</div>
 											</div>
 											<div class="flex gap-2">
-												<Button size="xs" onclick={nvmeAddPort}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { nvme.addPortSubsys = ''; }}>Cancel</Button>
+												<Button size="xs" onclick={nvmeAddPortGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { nvme.addPortSubsys = ''; addPortTried = false; }}>Cancel</Button>
 											</div>
 										</div>
 									{:else}


### PR DESCRIPTION
Tier 1 of #388 — closes the two highest-impact IPv6 papercuts in the share-creation flows. Engine already accepts v6 in both places; the WebUI was hiding that capability and validating only the v4 case, so operators trying v6 saw confusing post-submit errors.

## Changes

**NVMe-oF Add Port form**
- Cross-validate the typed Listen Address against the Family `<select>` (`ipv4` / `ipv6`). Previously they were independent: pick `ipv6`, type `192.168.1.10`, hit Add → engine rejected with a generic configfs EINVAL after the fact.
- Per-family placeholder updates as the dropdown changes (`192.168.1.10` vs `fd00::1 or 2001:db8::1`).
- Accepts v6 zone IDs (`fe80::1%eth0`) — a portal can legitimately target a specific link-local interface.
- Add button is now guarded; submit refuses until the address parses as the selected family, with inline red error.

**NFS Add Client form**
- New `validateNfsHost` mirrors the engine's `validate_nfs_host` (`engine/nasty-sharing/src/nfs.rs`): rejects whitespace, control chars, parens, quotes, semicolons, commas, backslashes — the shell-injection-relevant punctuation that could let a host string escape its position in the exports-file grammar. Deliberately permissive on what *kind* of host it is (v4, v6, hostname, `*`, `@netgroup` all pass).
- Placeholder expanded: `192.168.1.0/24, fd00::/64, *, or host.example.com` — every legitimate form shown at a glance instead of the v4-only example that suggested v6 wasn't supported.
- Input widened from `w-44` to `w-72` to fit the new placeholder + typical v6/CIDR hosts.
- Submit guarded the same way — operator sees the issue inline rather than via a server-side error toast.

## Tests
- `validateNfsHost`: accept set mirrors the engine's Rust unit test (`192.168.1.5`, `192.168.1.0/24`, `fd00::1/64`, `*`, hostnames, `@netgroups`); rejects the injection vectors.
- `validateAddressForFamily`: accept-on-match for both families, cross-family rejection (v4 string under ipv6 family and vice versa), CIDR rejection on listen address, zone ID accepted.
- 136 tests pass (15 new). `svelte-check` clean.

## Out of scope (Tier 2/3 in #388)
- iSCSI panel still has no portal-management UI at all — separate, larger UI piece
- Dual-stack auto-portal creation
- Listen-address picker (drop-down of configured interface addresses) instead of free-form text field

## Test plan
- [ ] NVMe-oF Add Port: pick ipv6, type a v4 → inline error, Add button refuses
- [ ] NVMe-oF Add Port: pick ipv6, type `fd00::1` → submits cleanly
- [ ] NVMe-oF Add Port: pick ipv4, type `fd00::1` → inline error
- [ ] NFS Add Client: type `fd00::/64` → submits cleanly; engine creates the export
- [ ] NFS Add Client: type `host;evil` → inline rejection, no submit
- [ ] Existing v4 flows unchanged