### PR TITLE
iscsi: portal management UI + add/remove RPCs with IPv6 support

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -17,8 +17,8 @@ use nasty_apps::{
 };
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
-    AddAclRequest, AddLunRequest, CreateTargetRequest, DeleteTargetRequest, IscsiTarget,
-    RemoveAclRequest, RemoveLunRequest,
+    AddAclRequest, AddLunRequest, AddPortalRequest, CreateTargetRequest, DeleteTargetRequest,
+    IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest,
 };
 use nasty_sharing::nfs::{
     CreateNfsShareRequest, DeleteNfsShareRequest, NfsShare, UpdateNfsShareRequest,
@@ -906,6 +906,20 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     desc: "Remove an iSCSI initiator ACL.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<RemoveAclRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.add_portal",
+                    desc: "Add a listening portal (IP:port) to an iSCSI target. Use 0.0.0.0 for all IPv4 interfaces, :: for all IPv6 interfaces, or a specific host address.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<AddPortalRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.remove_portal",
+                    desc: "Remove a listening portal from an iSCSI target. The last portal cannot be removed; add a replacement first.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<RemovePortalRequest>(generator)),
                     result: Some(gen_schema::<IscsiTarget>(generator)),
                 },
             ],

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -86,6 +86,8 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "share.iscsi.remove_lun"
                 | "share.iscsi.add_acl"
                 | "share.iscsi.remove_acl"
+                | "share.iscsi.add_portal"
+                | "share.iscsi.remove_portal"
                 | "share.nvmeof.create"
                 | "share.nvmeof.delete"
                 | "share.nvmeof.add_namespace"

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -234,6 +234,34 @@ pub(super) async fn try_route(
                 Err(e) => invalid(req, e),
             }
         }
+        "share.iscsi.add_portal" => {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
+                return Some(r);
+            }
+            match parse_params(req) {
+                Ok(p) => match state.iscsi.add_portal(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
+        "share.iscsi.remove_portal" => {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
+                return Some(r);
+            }
+            match parse_params(req) {
+                Ok(p) => match state.iscsi.remove_portal(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         "share.nvmeof.list" => match state.nvmeof.list().await {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -179,6 +179,28 @@ pub struct RemoveAclRequest {
     pub initiator_iqn: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddPortalRequest {
+    /// ID of the target to add the portal to.
+    pub target_id: String,
+    /// Listening IP address. `0.0.0.0` for all v4 interfaces, `::` for
+    /// all v6 interfaces, or a specific host address.
+    pub ip: String,
+    /// TCP port to listen on. Standard iSCSI port is 3260.
+    pub port: u16,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemovePortalRequest {
+    /// ID of the target from which to remove the portal.
+    pub target_id: String,
+    /// Listen address of the portal to remove. Must match the stored
+    /// value exactly (no normalization).
+    pub ip: String,
+    /// TCP port of the portal to remove.
+    pub port: u16,
+}
+
 fn state_dir() -> StateDir {
     StateDir::new(STATE_DIR)
 }
@@ -262,7 +284,7 @@ impl IscsiService {
 
         // Create portals
         for portal in &portals {
-            let np_path = format!("{tpg_path}/np/{}:{}", portal.ip, portal.port);
+            let np_path = np_path_for(&tpg_path, &portal.ip, portal.port);
             configfs_mkdir(&np_path).await?;
         }
 
@@ -362,7 +384,7 @@ impl IscsiService {
 
         // Remove portals
         for portal in &target.portals {
-            let np_path = format!("{tpg_path}/np/{}:{}", portal.ip, portal.port);
+            let np_path = np_path_for(&tpg_path, &portal.ip, portal.port);
             let _ = configfs_rmdir(&np_path).await;
         }
 
@@ -597,6 +619,82 @@ impl IscsiService {
         info!("Removed ACL from target '{}'", target.iqn);
         Ok(target.redacted())
     }
+
+    pub async fn add_portal(&self, req: AddPortalRequest) -> Result<IscsiTarget, IscsiError> {
+        let mut target: IscsiTarget = state_dir()
+            .load(&req.target_id)
+            .await
+            .ok_or_else(|| IscsiError::NotFound(req.target_id.clone()))?;
+
+        let ip = validate_portal_ip(&req.ip)?;
+
+        if target
+            .portals
+            .iter()
+            .any(|p| p.ip == ip && p.port == req.port)
+        {
+            info!(
+                "Portal {ip}:{} already exists on target '{}', skipping",
+                req.port, target.iqn
+            );
+            return Ok(target.redacted());
+        }
+
+        let tpg_path = format!("{ISCSI_BASE}/{}/tpgt_1", target.iqn);
+        let np_path = np_path_for(&tpg_path, &ip, req.port);
+        configfs_mkdir(&np_path).await?;
+
+        target.portals.push(Portal {
+            ip: ip.clone(),
+            port: req.port,
+        });
+
+        state_dir().save(&target.id, &target).await?;
+        save_lio_config().await;
+
+        info!("Added portal {ip}:{} to target '{}'", req.port, target.iqn);
+        Ok(target.redacted())
+    }
+
+    pub async fn remove_portal(&self, req: RemovePortalRequest) -> Result<IscsiTarget, IscsiError> {
+        let mut target: IscsiTarget = state_dir()
+            .load(&req.target_id)
+            .await
+            .ok_or_else(|| IscsiError::NotFound(req.target_id.clone()))?;
+
+        let portal_idx = target
+            .portals
+            .iter()
+            .position(|p| p.ip == req.ip && p.port == req.port)
+            .ok_or_else(|| {
+                IscsiError::NotFound(format!("portal {}:{} not found", req.ip, req.port))
+            })?;
+
+        // Refuse to remove the last portal — a target with zero portals
+        // is unreachable, and the engine has no UI to recover from that
+        // state short of re-adding via API. Operators wanting to swap
+        // portals should add the replacement first, then remove the old.
+        if target.portals.len() == 1 {
+            return Err(IscsiError::CommandFailed(
+                "Cannot remove the last portal — target would become unreachable. Add a replacement portal first.".to_string(),
+            ));
+        }
+
+        let tpg_path = format!("{ISCSI_BASE}/{}/tpgt_1", target.iqn);
+        let np_path = np_path_for(&tpg_path, &req.ip, req.port);
+        let _ = configfs_rmdir(&np_path).await;
+
+        target.portals.remove(portal_idx);
+
+        state_dir().save(&target.id, &target).await?;
+        save_lio_config().await;
+
+        info!(
+            "Removed portal {}:{} from target '{}'",
+            req.ip, req.port, target.iqn
+        );
+        Ok(target.redacted())
+    }
 }
 
 // ── configfs helpers ────────────────────────────────────────────
@@ -783,5 +881,102 @@ async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
             }
             Err(e) => warn!("Failed to serialize patched saveconfig.json: {e}"),
         }
+    }
+}
+
+/// Build the configfs `np/<addr>` path for a portal. LIO's configfs
+/// expects IPv6 addresses bracketed (`[::]:3260`) so the `:` between
+/// address and port stays unambiguous; IPv4 stays bare.
+fn np_path_for(tpg_path: &str, ip: &str, port: u16) -> String {
+    if ip.contains(':') {
+        format!("{tpg_path}/np/[{ip}]:{port}")
+    } else {
+        format!("{tpg_path}/np/{ip}:{port}")
+    }
+}
+
+/// Validate a portal IP and return it normalized (whitespace-trimmed,
+/// brackets stripped if the operator typed `[fd00::1]`). Both forms
+/// reach the engine in practice — the WebUI sends bare addresses, but
+/// curl users often copy the bracketed form from documentation.
+fn validate_portal_ip(ip: &str) -> Result<String, IscsiError> {
+    let trimmed = ip.trim();
+    if trimmed.is_empty() {
+        return Err(IscsiError::CommandFailed("portal IP is empty".to_string()));
+    }
+    let unwrapped = trimmed
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(trimmed);
+    if unwrapped.parse::<std::net::IpAddr>().is_err() {
+        return Err(IscsiError::CommandFailed(format!(
+            "portal IP '{ip}' is not a valid IPv4 or IPv6 address"
+        )));
+    }
+    Ok(unwrapped.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn np_path_brackets_v6_addresses() {
+        assert_eq!(
+            np_path_for("/sys/.../tpgt_1", "0.0.0.0", 3260),
+            "/sys/.../tpgt_1/np/0.0.0.0:3260"
+        );
+        assert_eq!(
+            np_path_for("/sys/.../tpgt_1", "192.168.1.10", 3260),
+            "/sys/.../tpgt_1/np/192.168.1.10:3260"
+        );
+        assert_eq!(
+            np_path_for("/sys/.../tpgt_1", "::", 3260),
+            "/sys/.../tpgt_1/np/[::]:3260"
+        );
+        assert_eq!(
+            np_path_for("/sys/.../tpgt_1", "fd00::1", 3260),
+            "/sys/.../tpgt_1/np/[fd00::1]:3260"
+        );
+        assert_eq!(
+            np_path_for("/sys/.../tpgt_1", "2001:db8::1", 8260),
+            "/sys/.../tpgt_1/np/[2001:db8::1]:8260"
+        );
+    }
+
+    #[test]
+    fn validate_portal_ip_accepts_v4_and_v6() {
+        assert_eq!(validate_portal_ip("0.0.0.0").unwrap(), "0.0.0.0");
+        assert_eq!(validate_portal_ip("192.168.1.10").unwrap(), "192.168.1.10");
+        assert_eq!(validate_portal_ip("::").unwrap(), "::");
+        assert_eq!(validate_portal_ip("fd00::1").unwrap(), "fd00::1");
+        assert_eq!(validate_portal_ip("2001:db8::1").unwrap(), "2001:db8::1");
+    }
+
+    #[test]
+    fn validate_portal_ip_strips_brackets() {
+        // Operators copying `[fd00::1]` from RFC examples should still
+        // get accepted — strip the brackets and store the canonical form
+        // so list/remove lookups stay consistent.
+        assert_eq!(validate_portal_ip("[fd00::1]").unwrap(), "fd00::1");
+        assert_eq!(validate_portal_ip("[::]").unwrap(), "::");
+    }
+
+    #[test]
+    fn validate_portal_ip_trims_whitespace() {
+        assert_eq!(validate_portal_ip("  10.0.0.1  ").unwrap(), "10.0.0.1");
+    }
+
+    #[test]
+    fn validate_portal_ip_rejects_garbage() {
+        assert!(validate_portal_ip("").is_err());
+        assert!(validate_portal_ip("   ").is_err());
+        assert!(validate_portal_ip("not.an.ip").is_err());
+        assert!(validate_portal_ip("192.168.1").is_err());
+        assert!(validate_portal_ip("fd00::xyz").is_err());
+        // Hostname rejected — portal must be a numeric address; iSCSI
+        // initiators do their own DNS but the engine writes a numeric
+        // address into configfs.
+        assert!(validate_portal_ip("example.com").is_err());
     }
 }

--- a/webui/src/lib/sharing/iscsi.svelte.ts
+++ b/webui/src/lib/sharing/iscsi.svelte.ts
@@ -29,6 +29,10 @@ export const iscsi = $state({
 	addAclIqn: '',
 	addAclUser: '',
 	addAclPass: '',
+	addPortalTarget: '',
+	addPortalIp: '',
+	addPortalPort: 3260,
+	addPortalFamily: 'ipv4' as 'ipv4' | 'ipv6',
 	search: '',
 	sortDir: 'asc' as 'asc' | 'desc',
 });
@@ -117,6 +121,34 @@ export async function iscsiRemoveAcl(targetId: string, initiatorIqn: string) {
 	await withToast(
 		() => client.call('share.iscsi.remove_acl', { target_id: targetId, initiator_iqn: initiatorIqn }),
 		'ACL removed'
+	);
+	await iscsiRefresh();
+}
+
+export async function iscsiAddPortal() {
+	if (!iscsi.addPortalTarget || !iscsi.addPortalIp) return;
+	const ok = await withToast(
+		() => client.call('share.iscsi.add_portal', {
+			target_id: iscsi.addPortalTarget,
+			ip: iscsi.addPortalIp.trim(),
+			port: iscsi.addPortalPort,
+		}),
+		'Portal added',
+	);
+	if (ok !== undefined) {
+		iscsi.addPortalTarget = '';
+		iscsi.addPortalIp = '';
+		iscsi.addPortalPort = 3260;
+		iscsi.addPortalFamily = 'ipv4';
+		await iscsiRefresh();
+	}
+}
+
+export async function iscsiRemovePortal(targetId: string, ip: string, port: number) {
+	if (!await confirm(`Remove portal ${ip}:${port}?`)) return;
+	await withToast(
+		() => client.call('share.iscsi.remove_portal', { target_id: targetId, ip, port }),
+		'Portal removed',
 	);
 	await iscsiRefresh();
 }

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -5,6 +5,7 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { requiredFieldCls } from '$lib/utils';
+	import { validateAddressForFamily } from '$lib/network';
 	import {
 		iscsi,
 		iscsiToggleSort,
@@ -15,6 +16,8 @@
 		iscsiRemoveLun,
 		iscsiAddAcl,
 		iscsiRemoveAcl,
+		iscsiAddPortal,
+		iscsiRemovePortal,
 		iscsiLoadSubvolumes,
 	} from '$lib/sharing/iscsi.svelte';
 
@@ -25,6 +28,7 @@
 	let createTried = $state(false);
 	let addLunTried = $state(false);
 	let addAclTried = $state(false);
+	let addPortalTried = $state(false);
 
 	async function iscsiCreateGuarded() {
 		if (!iscsi.newName || !iscsi.newDevice) { createTried = true; return; }
@@ -40,6 +44,15 @@
 		if (!iscsi.addAclIqn) { addAclTried = true; return; }
 		addAclTried = false;
 		await iscsiAddAcl();
+	}
+
+	const addPortalIpError = $derived(
+		validateAddressForFamily(iscsi.addPortalFamily, iscsi.addPortalIp),
+	);
+	async function iscsiAddPortalGuarded() {
+		if (!iscsi.addPortalIp || addPortalIpError) { addPortalTried = true; return; }
+		addPortalTried = false;
+		await iscsiAddPortal();
 	}
 
 	const iscsiFiltered = $derived(
@@ -132,11 +145,51 @@
 									{#if target.portals.length === 0}
 										<p class="text-xs text-muted-foreground">None</p>
 									{:else}
-										<div class="flex flex-wrap gap-2">
+										<div class="space-y-1">
 											{#each target.portals as p}
-												<span class="rounded bg-secondary px-2 py-0.5 font-mono text-xs">{p.ip}:{p.port}</span>
+												<div class="flex items-center gap-3 rounded bg-secondary/50 px-2 py-1.5">
+													<span class="font-mono text-xs">{p.ip.includes(':') && p.ip !== '0.0.0.0' ? `[${p.ip}]` : p.ip}:{p.port}</span>
+													{#if target.portals.length > 1}
+														<Button variant="destructive" size="xs" onclick={() => iscsiRemovePortal(target.id, p.ip, p.port)}>Remove</Button>
+													{/if}
+												</div>
 											{/each}
 										</div>
+									{/if}
+									{#if iscsi.addPortalTarget === target.id}
+										<div class="mt-3 rounded border p-3">
+											<div class="flex flex-wrap items-end gap-2">
+												<div>
+													<Label class="text-xs">Family</Label>
+													<select bind:value={iscsi.addPortalFamily} class="mt-1 h-8 rounded-md border border-input bg-transparent px-2 text-xs">
+														<option value="ipv4">IPv4</option>
+														<option value="ipv6">IPv6</option>
+													</select>
+												</div>
+												<div>
+													<Label class="text-xs">Listen Address {#if !iscsi.addPortalIp && addPortalTried}<span class="text-amber-500">required</span>{/if}</Label>
+													<Input
+														bind:value={iscsi.addPortalIp}
+														placeholder={iscsi.addPortalFamily === 'ipv6' ? ':: or fd00::1' : '0.0.0.0 or 192.168.1.10'}
+														class="mt-1 h-8 w-56 text-xs {requiredFieldCls(!iscsi.addPortalIp, addPortalTried)} {addPortalIpError ? 'border-red-400' : ''}"
+													/>
+												</div>
+												<div>
+													<Label class="text-xs">Port</Label>
+													<Input type="number" bind:value={iscsi.addPortalPort} class="mt-1 h-8 w-24 text-xs" />
+												</div>
+												<Button size="xs" onclick={iscsiAddPortalGuarded}>Add</Button>
+												<Button size="xs" variant="ghost" onclick={() => { iscsi.addPortalTarget = ''; addPortalTried = false; }}>Cancel</Button>
+											</div>
+											{#if addPortalIpError}
+												<p class="mt-1 text-[0.7rem] text-red-400">{addPortalIpError}</p>
+											{/if}
+											<p class="mt-2 text-[0.7rem] text-muted-foreground">
+												Use <code>0.0.0.0</code> for all IPv4 interfaces, <code>::</code> for all IPv6 interfaces, or a specific host address for a single-NIC bind.
+											</p>
+										</div>
+									{:else}
+										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; }}>+ Add Portal</Button>
 									{/if}
 								</div>
 


### PR DESCRIPTION
Tier 2 of #388 — first half. Operators now have a WebUI path to add, edit, and remove iSCSI portals. Previously the engine auto-created one v4 portal at \`0.0.0.0:3260\` at target creation and that was it; managing multiple portals or adding a v6 listen required curl against the JSON-RPC endpoint.

## New engine RPCs

- \`share.iscsi.add_portal { target_id, ip, port }\` → updated target
- \`share.iscsi.remove_portal { target_id, ip, port }\` → updated target

Both are \`Admin\`-role, gated by the iscsi protocol-enabled check, and included in the operator-allowed methods list (same access controls as \`add_lun\` / \`add_acl\`).

## IPv6 in configfs

- \`np_path_for()\` wraps v6 addresses in brackets when building the configfs np entry — LIO expects \`np/[::]:3260\` form so the \`:\` between address and port stays unambiguous. v4 paths unchanged. Existing \`create()\` and \`delete()\` switched to the helper so a target created with a v6 portal can also be deleted cleanly.
- \`validate_portal_ip()\` accepts both bare and bracketed forms (curl users often paste \`[fd00::1]\` from RFC examples), strips the brackets, parses through \`std::net::IpAddr\`, and stores the canonical bare form for consistent list/remove lookups.

## Safety rails

- Refuse to remove the last portal — a target with zero portals is unreachable and there's no recovery short of re-adding via API. UI hides the Remove button when only one portal remains.
- Idempotent add: if the same \`ip:port\` already exists on the target, return the existing target instead of erroring (same pattern as \`create()\` / \`add_lun()\`).

## WebUI panel

- Per-portal row instead of inline badge — space for the Remove button next to each entry.
- IPv6 portals rendered bracketed in the listing (\`[::]:3260\`) so the address/port boundary is obvious at a glance.
- Add Portal form: Family selector (ipv4 / ipv6), Listen Address with per-family placeholder, Port input (default 3260).
- Cross-family validation reuses \`validateAddressForFamily\` from #389 — pick ipv6 + type \`192.168.1.10\` → inline red error, Add button refuses.
- Helper text explains \`0.0.0.0\` vs \`::\` vs specific-host bind.

## Tests

- 5 new Rust unit tests for \`np_path_for\` bracket placement and \`validate_portal_ip\` accept / strip-brackets / trim / reject paths.
- Existing 136 WebUI vitest run unchanged; svelte-check clean.

## Out of scope (next PR for #388)

- **Dual-stack auto-portal default**: target creation still defaults to a single \`0.0.0.0:3260\` portal. Operators can now add \`[::]:3260\` themselves via the UI; engine doesn't yet pick that up automatically on v6-capable hosts.
- **NVMe-oF auto-pick v6-awareness** (issue #388 §5).

## Test plan
- [ ] Create iSCSI target → portal listed; Remove button hidden (only one portal)
- [ ] Add Portal: pick IPv4, type \`192.168.1.10\` → added, both shown, Remove now visible on both
- [ ] Add Portal: pick IPv6, type \`fd00::1\` → added, displayed as \`[fd00::1]:3260\`
- [ ] Add Portal: pick IPv6, type a v4 string → inline error, Add refuses
- [ ] Try to remove the last remaining portal via API → engine returns error
- [ ] \`ss -tlnp | grep 3260\` on a target with both v4 and v6 portals shows both sockets