### PR TITLE
sharing: dual-stack auto-portal defaults for iSCSI + NVMe-oF

### DIFF
--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -271,12 +271,27 @@ impl IscsiService {
             return Ok(existing);
         }
 
-        let portals = req.portals.unwrap_or_else(|| {
-            vec![Portal {
-                ip: "0.0.0.0".to_string(),
-                port: 3260,
-            }]
-        });
+        let portals = match req.portals {
+            Some(p) => p,
+            None => {
+                // Dual-stack default: always listen on v4 INADDR_ANY,
+                // additionally listen on v6 IN6ADDR_ANY when the host
+                // actually has a global v6 address. v4-only hosts stay
+                // v4-only — `[::]:3260` would bind successfully but
+                // accept zero connections and confuse `ss -tlnp` output.
+                let mut defaults = vec![Portal {
+                    ip: "0.0.0.0".to_string(),
+                    port: 3260,
+                }];
+                if crate::v6::host_has_global_ipv6().await {
+                    defaults.push(Portal {
+                        ip: "::".to_string(),
+                        port: 3260,
+                    });
+                }
+                defaults
+            }
+        };
 
         // Create target and TPG in configfs
         let tpg_path = format!("{ISCSI_BASE}/{iqn}/tpgt_1");

--- a/engine/nasty-sharing/src/lib.rs
+++ b/engine/nasty-sharing/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod iscsi;
 pub mod nfs;
 pub mod nvmeof;
-pub(crate) mod v6;
 pub mod smb;
+pub(crate) mod v6;
 
 pub use iscsi::IscsiService;
 pub use nfs::NfsService;

--- a/engine/nasty-sharing/src/lib.rs
+++ b/engine/nasty-sharing/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod iscsi;
 pub mod nfs;
 pub mod nvmeof;
+pub(crate) mod v6;
 pub mod smb;
 
 pub use iscsi::IscsiService;

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -393,15 +393,53 @@ impl NvmeofService {
 
             // Add a port when a namespace was created
             if subsystem.ports.is_empty() {
+                let svc_port = req.port.unwrap_or(4420);
+                let explicit_addr = req.addr.clone();
                 subsystem = self
                     .add_port(AddPortRequest {
                         subsystem_id: subsystem.id.clone(),
                         transport: Some("tcp".to_string()),
                         addr: Some(req.addr.unwrap_or_else(|| "0.0.0.0".to_string())),
-                        service_id: Some(req.port.unwrap_or(4420)),
+                        service_id: Some(svc_port),
                         addr_family: Some("ipv4".to_string()),
                     })
                     .await?;
+
+                // Dual-stack auto-port: when the operator didn't pin a
+                // specific address and the host has a routable v6
+                // source, add a sibling port on the v6 address. Skips
+                // silently on v4-only hosts and on the explicit-addr
+                // path (operator chose v4 deliberately — don't surprise
+                // them by adding a v6 port too).
+                if explicit_addr.is_none()
+                    && let Some(v6) = crate::v6::detect_primary_ipv6().await
+                {
+                    match self
+                        .add_port(AddPortRequest {
+                            subsystem_id: subsystem.id.clone(),
+                            transport: Some("tcp".to_string()),
+                            addr: Some(v6.clone()),
+                            service_id: Some(svc_port),
+                            addr_family: Some("ipv6".to_string()),
+                        })
+                        .await
+                    {
+                        Ok(s) => {
+                            subsystem = s;
+                            info!("Auto-added IPv6 sibling port {v6} for '{}'", subsystem.nqn);
+                        }
+                        Err(e) => {
+                            // Don't fail the whole create — the v4 port
+                            // is up and the subsystem is usable. Log
+                            // and continue so the user gets a working
+                            // (if v4-only) target.
+                            warn!(
+                                "auto-add IPv6 port for '{}' on {v6} failed: {e}",
+                                subsystem.nqn
+                            );
+                        }
+                    }
+                }
             } else {
                 info!(
                     "Subsystem {} already has {} port(s), skipping",

--- a/engine/nasty-sharing/src/v6.rs
+++ b/engine/nasty-sharing/src/v6.rs
@@ -1,0 +1,60 @@
+//! IPv6 host-detection helpers shared by the share-protocol services.
+//!
+//! Used to drive dual-stack auto-portal defaults: on a host with a
+//! global v6 address, target/subsystem creation can add a second
+//! listen socket for free; on a v4-only host the same calls stay v4.
+//!
+//! Both helpers shell out to `ip` rather than reading `/proc/net/if_inet6`
+//! directly — `ip` already filters out tentative addresses, masks scope
+//! correctly, and matches what every other "is v6 working here?" check
+//! in NASty uses (see `network::get_addresses`).
+
+/// True if the host has at least one configured IPv6 address with
+/// global scope (excluding link-local `fe80::/10` and loopback `::1`).
+///
+/// Used to decide whether to add a `[::]:port` companion to a fresh
+/// `0.0.0.0:port` portal. Returns `false` on v4-only hosts, and also
+/// on errors invoking `ip` — better to silently stay v4 than to fail
+/// the user's create call because `ip` was missing.
+pub(crate) async fn host_has_global_ipv6() -> bool {
+    let Ok(output) = tokio::process::Command::new("ip")
+        .args(["-6", "addr", "show", "scope", "global"])
+        .output()
+        .await
+    else {
+        return false;
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines().any(|line| line.trim_start().starts_with("inet6 "))
+}
+
+/// Best-effort detect a routable IPv6 source address. Used by NVMe-oF
+/// where configfs requires a concrete address per port (the `::`
+/// wildcard rejects with EINVAL during subsystem linking). Mirrors
+/// `detect_primary_ip()` in `nvmeof.rs` but for v6 — picks the
+/// address the kernel would use to reach a global v6 target.
+///
+/// Returns `None` on v4-only hosts, on missing `ip` binary, or when
+/// no v6 default route is configured.
+pub(crate) async fn detect_primary_ipv6() -> Option<String> {
+    // 2001:4860:4860::8888 is Google Public DNS over v6 — same role as
+    // 1.1.1.1 in the v4 path: a stable globally-routable address used
+    // only as a routing-table probe target. No packet is actually sent.
+    let output = tokio::process::Command::new("ip")
+        .args(["-6", "route", "get", "2001:4860:4860::8888"])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    // Output: "2001:4860:4860::8888 from :: via fe80::1 dev eth0 src 2001:db8::5 metric 100 pref medium"
+    let mut iter = text.split_whitespace();
+    while let Some(token) = iter.next() {
+        if token == "src" {
+            return iter.next().map(|s| s.to_string());
+        }
+    }
+    None
+}

--- a/engine/nasty-sharing/src/v6.rs
+++ b/engine/nasty-sharing/src/v6.rs
@@ -25,7 +25,8 @@ pub(crate) async fn host_has_global_ipv6() -> bool {
         return false;
     };
     let text = String::from_utf8_lossy(&output.stdout);
-    text.lines().any(|line| line.trim_start().starts_with("inet6 "))
+    text.lines()
+        .any(|line| line.trim_start().starts_with("inet6 "))
 }
 
 /// Best-effort detect a routable IPv6 source address. Used by NVMe-oF


### PR DESCRIPTION
Tier 2 second half of #388. Creating an iSCSI target or NVMe-oF subsystem on a v6-capable host now gets a v6 listen socket for free — operators no longer have to add it manually after the fact. Pairs with the per-target portal management UI from #390.

> Depends on #390 (manual portal UI) in spirit — review separately, but the operator escape-hatch UI for non-default portal configs lives there.

## iSCSI default portals

\`IscsiService::create()\` with \`req.portals = None\`:

| Host has global v6? | Old default                | New default                                  |
| ------------------- | -------------------------- | -------------------------------------------- |
| Yes                 | \`[0.0.0.0:3260]\`         | \`[0.0.0.0:3260, [::]:3260]\`               |
| No                  | \`[0.0.0.0:3260]\`         | \`[0.0.0.0:3260]\` (unchanged)              |

v4-only hosts stay v4 — \`[::]:3260\` would bind on v4-only hosts but accept zero connections and pollute \`ss -tlnp\` with a permanently-idle socket. Explicit \`portals: [<specific>]\` passes through unchanged.

## NVMe-oF auto-port

\`NvmeofService::create()\` when called without an explicit \`addr\` and with a namespace-creating \`device_path\` now adds a sibling v6 port after the v4 auto-port, using a probed primary v6 address.

- NVMe-oF can't bind \`::\` (configfs rejects with EINVAL on subsystem-to-port linking), so detection has to pick a real address — same approach as the existing v4 path that probes via \`ip route get 1.1.1.1\`.
- The sibling port is **best-effort**: failure logs a warning, doesn't fail the create. v4 port is already up, subsystem is usable, \`share.nvmeof.add_port\` is available as a manual fallback.
- Skipped entirely when the operator passed an explicit \`addr\` — a deliberate v4-only choice shouldn't surprise them with a v6 sibling.

## New helpers (\`v6.rs\`, crate-private)

- \`host_has_global_ipv6()\` — yes/no gate for iSCSI's \`::\` default. Shells out to \`ip -6 addr show scope global\` and checks for any \`inet6 \` line. Errors degrade to \`false\` (stay v4 on a misconfigured host rather than fail the create).
- \`detect_primary_ipv6()\` — mirror of the existing v4 detector for NVMe-oF. Uses \`ip -6 route get 2001:4860:4860::8888\` (Google DNS over v6) as the routing-table probe target; no packet is sent. \`None\` on v4-only / missing-ip / no-v6-default-route.

Both helpers shell out to \`ip\` to match the existing pattern in \`network::get_addresses\` (handles tentative/duplicate/scope filtering correctly without reinventing the per-line parsing).

## Out of scope (Tier 3 in #388)

Listen-address picker — drop-down of host interfaces / addresses instead of free-form text input. The dual-stack default + the UI from #390 cover most use cases; a picker is a polish item for later.

## Test plan
- [ ] Create iSCSI target on dual-stack host → portals list shows both \`0.0.0.0:3260\` and \`[::]:3260\`; \`ss -tlnp\` confirms both sockets
- [ ] Create iSCSI target on v4-only host → portals list shows only \`0.0.0.0:3260\`
- [ ] Create iSCSI target with explicit \`portals\` arg → exactly what was asked for, no v6 sibling injected
- [ ] Create NVMe-oF subsystem with \`device_path\` on dual-stack host → two ports listed (v4 + v6)
- [ ] Create NVMe-oF subsystem on v4-only host → one port listed (v4 only)
- [ ] Create NVMe-oF subsystem with explicit \`addr=192.168.1.10\` → one port at that address, no v6 sibling
- [ ] On a v6-capable host without v6 default route → NVMe-oF v6 sibling silently skipped (\`detect_primary_ipv6\` returns None)