### PR TITLE
webui: listen-address picker for iSCSI + NVMe-oF port forms

### DIFF
--- a/webui/src/lib/components/ListenAddressPicker.svelte
+++ b/webui/src/lib/components/ListenAddressPicker.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { getClient } from '$lib/client';
+	import { listenAddressOptions } from '$lib/network';
+	import type { LiveInterface, NetworkState } from '$lib/types';
+
+	let {
+		address = $bindable(),
+		family = $bindable(),
+		allowWildcards = false,
+		error = null,
+		placeholderV4 = '192.168.1.10',
+		placeholderV6 = 'fd00::1',
+	}: {
+		address: string;
+		family: 'ipv4' | 'ipv6';
+		allowWildcards?: boolean;
+		error?: string | null;
+		placeholderV4?: string;
+		placeholderV6?: string;
+	} = $props();
+
+	let interfaces = $state<LiveInterface[]>([]);
+	let loaded = $state(false);
+	let selection = $state<string>('custom');
+
+	$effect(() => {
+		getClient()
+			.call<NetworkState>('system.network.get')
+			.then((s) => {
+				interfaces = s.interfaces ?? [];
+			})
+			.catch(() => {
+				// Picker degrades to Custom-only — operator can still
+				// type an address. Don't surface a toast: the form
+				// works without the suggestions, and the share-panel
+				// already shows its own errors prominently.
+			})
+			.finally(() => {
+				loaded = true;
+			});
+	});
+
+	const options = $derived(listenAddressOptions(interfaces, allowWildcards));
+
+	function onSelectionChange() {
+		if (selection === 'custom') return;
+		const opt = options.find((o) => o.key === selection);
+		if (opt) {
+			address = opt.addr;
+			family = opt.family;
+		}
+	}
+</script>
+
+<div>
+	<Label class="text-xs">Listen Address</Label>
+	<select
+		bind:value={selection}
+		onchange={onSelectionChange}
+		class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs"
+	>
+		<option value="custom">Custom address…</option>
+		{#each options as opt (opt.key)}
+			<option value={opt.key}>{opt.label}</option>
+		{/each}
+	</select>
+	{#if loaded && options.length === 0 && !allowWildcards}
+		<p class="mt-1 text-[0.7rem] text-muted-foreground">
+			No live interface addresses detected — fall back to a custom address below.
+		</p>
+	{/if}
+
+	{#if selection === 'custom'}
+		<div class="mt-2 flex items-end gap-2">
+			<div>
+				<Label class="text-[0.7rem] text-muted-foreground">Family</Label>
+				<select
+					bind:value={family}
+					class="mt-1 h-8 rounded-md border border-input bg-transparent px-2 text-xs"
+				>
+					<option value="ipv4">IPv4</option>
+					<option value="ipv6">IPv6</option>
+				</select>
+			</div>
+			<div class="flex-1">
+				<Label class="text-[0.7rem] text-muted-foreground">Address</Label>
+				<Input
+					bind:value={address}
+					placeholder={family === 'ipv6' ? placeholderV6 : placeholderV4}
+					class="mt-1 h-8 text-xs {error ? 'border-red-400' : ''}"
+				/>
+			</div>
+		</div>
+		{#if error}
+			<p class="mt-1 text-[0.7rem] text-red-400">{error}</p>
+		{/if}
+	{:else}
+		<p class="mt-1 text-[0.7rem] text-muted-foreground">
+			Listening on <code>{address}</code> ({family.toUpperCase()})
+		</p>
+	{/if}
+</div>

--- a/webui/src/lib/network.test.ts
+++ b/webui/src/lib/network.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	findOrphanInterfaces,
+	listenAddressOptions,
 	promoteOrphanedMembers,
 	stripInterfaces,
 	validateAddressForFamily,
@@ -447,5 +448,89 @@ describe('validateAddressForFamily', () => {
 	it('passes empty input as null', () => {
 		expect(validateAddressForFamily('ipv4', '')).toBeNull();
 		expect(validateAddressForFamily('ipv6', '')).toBeNull();
+	});
+});
+
+describe('listenAddressOptions', () => {
+	function iface(name: string, v4: string[] = [], v6: string[] = [], up = true): LiveInterface {
+		return {
+			name,
+			mac: '00:00:00:00:00:00',
+			up,
+			speed_mbps: null,
+			carrier: up,
+			ipv4_addresses: v4,
+			ipv6_addresses: v6,
+			mtu: 1500,
+			kind: 'ethernet',
+		};
+	}
+
+	it('prepends wildcards when allowed', () => {
+		const opts = listenAddressOptions([], true);
+		expect(opts.map((o) => o.addr)).toEqual(['0.0.0.0', '::']);
+		expect(opts[0].family).toBe('ipv4');
+		expect(opts[1].family).toBe('ipv6');
+	});
+
+	it('skips wildcards for NVMe-oF (configfs EINVAL on ::)', () => {
+		const opts = listenAddressOptions([iface('eth0', ['10.0.0.5/24'])], false);
+		expect(opts.map((o) => o.addr)).toEqual(['10.0.0.5']);
+	});
+
+	it('strips CIDR suffix from interface addresses', () => {
+		// LiveInterface carries CIDR ("10.0.0.5/24"), the engine wants
+		// a bare address — picker has to strip so the operator doesn't
+		// end up posting "10.0.0.5/24" to add_portal.
+		const opts = listenAddressOptions([iface('eth0', ['10.0.0.5/24'])], false);
+		expect(opts[0].addr).toBe('10.0.0.5');
+	});
+
+	it('filters loopback addresses', () => {
+		// Binding a network share to 127.0.0.1 / ::1 is almost always
+		// a mistake — hide them so the picker doesn't suggest them.
+		const opts = listenAddressOptions(
+			[iface('lo', ['127.0.0.1/8'], ['::1/128'])],
+			false,
+		);
+		expect(opts).toEqual([]);
+	});
+
+	it('filters link-local v6 (no zone id in picker payload)', () => {
+		const opts = listenAddressOptions(
+			[iface('eth0', [], ['fe80::1/64', 'fd00::1/64'])],
+			false,
+		);
+		expect(opts.map((o) => o.addr)).toEqual(['fd00::1']);
+	});
+
+	it('hides down interfaces', () => {
+		// An address on a down interface would bind successfully in
+		// configfs but accept no connections — don't tempt the operator.
+		const opts = listenAddressOptions(
+			[iface('eth0', ['10.0.0.5/24'], [], /* up */ false)],
+			false,
+		);
+		expect(opts).toEqual([]);
+	});
+
+	it('labels and tags family for each interface address', () => {
+		const opts = listenAddressOptions(
+			[iface('eth0', ['10.0.0.5/24'], ['fd00::1/64'])],
+			false,
+		);
+		expect(opts).toHaveLength(2);
+		expect(opts[0]).toMatchObject({ label: 'eth0 — 10.0.0.5', family: 'ipv4' });
+		expect(opts[1]).toMatchObject({ label: 'eth0 — fd00::1', family: 'ipv6' });
+		// keys are unique + stable across renders (used as <option value=...>)
+		expect(new Set(opts.map((o) => o.key)).size).toBe(opts.length);
+	});
+
+	it('combines wildcards + interface addresses in order', () => {
+		const opts = listenAddressOptions(
+			[iface('eth0', ['10.0.0.5/24'], ['fd00::1/64'])],
+			true,
+		);
+		expect(opts.map((o) => o.addr)).toEqual(['0.0.0.0', '::', '10.0.0.5', 'fd00::1']);
 	});
 });

--- a/webui/src/lib/network.ts
+++ b/webui/src/lib/network.ts
@@ -287,3 +287,76 @@ export function validateAddressForFamily(
 	}
 	return validateIpv4Address(value);
 }
+
+/** A single option in the listen-address picker dropdown. `key` is a
+ * stable string identifier used as the `<option value=...>`, `addr` is
+ * the bare address to push into the address field on selection, and
+ * `family` decides which v4/v6 selector value to mirror. */
+export interface ListenAddressOption {
+	key: string;
+	label: string;
+	addr: string;
+	family: 'ipv4' | 'ipv6';
+}
+
+/** Derive picker options from the live interface list. Used by the
+ * shared `<ListenAddressPicker>` to populate its dropdown.
+ *
+ * `allowWildcards` controls whether `0.0.0.0` / `::` are offered — iSCSI
+ * accepts both (configfs creates the np entries without complaint),
+ * NVMe-oF rejects them with EINVAL when the subsystem-to-port symlink
+ * is created, so the picker hides them on the NVMe-oF panel.
+ *
+ * Filters: skip link-local v6 (`fe80::/10`) since it requires a zone
+ * id the picker doesn't carry; skip loopback addresses since binding
+ * a network share to `127.0.0.1` or `::1` is almost always a mistake;
+ * skip interfaces with `up: false` — picking an address on a down
+ * interface would succeed in configfs but accept no connections. */
+export function listenAddressOptions(
+	interfaces: import('./types').LiveInterface[],
+	allowWildcards: boolean,
+): ListenAddressOption[] {
+	const opts: ListenAddressOption[] = [];
+
+	if (allowWildcards) {
+		opts.push({
+			key: 'wild:0.0.0.0',
+			label: 'All IPv4 interfaces (0.0.0.0)',
+			addr: '0.0.0.0',
+			family: 'ipv4',
+		});
+		opts.push({
+			key: 'wild:::',
+			label: 'All IPv6 interfaces (::)',
+			addr: '::',
+			family: 'ipv6',
+		});
+	}
+
+	for (const iface of interfaces) {
+		if (!iface.up) continue;
+		for (const cidr of iface.ipv4_addresses ?? []) {
+			const bare = cidr.split('/')[0];
+			if (bare === '127.0.0.1' || bare.startsWith('127.')) continue;
+			opts.push({
+				key: `if:${iface.name}:v4:${bare}`,
+				label: `${iface.name} — ${bare}`,
+				addr: bare,
+				family: 'ipv4',
+			});
+		}
+		for (const cidr of iface.ipv6_addresses ?? []) {
+			const bare = cidr.split('/')[0];
+			if (bare === '::1') continue;
+			if (bare.toLowerCase().startsWith('fe80')) continue;
+			opts.push({
+				key: `if:${iface.name}:v6:${bare}`,
+				label: `${iface.name} — ${bare}`,
+				addr: bare,
+				family: 'ipv6',
+			});
+		}
+	}
+
+	return opts;
+}

--- a/webui/src/lib/sharing/nvmeof.svelte.ts
+++ b/webui/src/lib/sharing/nvmeof.svelte.ts
@@ -29,7 +29,7 @@ export const nvme = $state({
 	addPortTransport: 'tcp',
 	addPortAddr: '0.0.0.0',
 	addPortSvcId: 4420,
-	addPortFamily: 'ipv4',
+	addPortFamily: 'ipv4' as 'ipv4' | 'ipv6',
 	addHostSubsys: '',
 	addHostNqn: '',
 	search: '',

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -6,6 +6,7 @@
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 	import { validateAddressForFamily } from '$lib/network';
+	import ListenAddressPicker from '$lib/components/ListenAddressPicker.svelte';
 	import {
 		iscsi,
 		iscsiToggleSort,
@@ -158,22 +159,15 @@
 									{/if}
 									{#if iscsi.addPortalTarget === target.id}
 										<div class="mt-3 rounded border p-3">
-											<div class="flex flex-wrap items-end gap-2">
-												<div>
-													<Label class="text-xs">Family</Label>
-													<select bind:value={iscsi.addPortalFamily} class="mt-1 h-8 rounded-md border border-input bg-transparent px-2 text-xs">
-														<option value="ipv4">IPv4</option>
-														<option value="ipv6">IPv6</option>
-													</select>
-												</div>
-												<div>
-													<Label class="text-xs">Listen Address {#if !iscsi.addPortalIp && addPortalTried}<span class="text-amber-500">required</span>{/if}</Label>
-													<Input
-														bind:value={iscsi.addPortalIp}
-														placeholder={iscsi.addPortalFamily === 'ipv6' ? ':: or fd00::1' : '0.0.0.0 or 192.168.1.10'}
-														class="mt-1 h-8 w-56 text-xs {requiredFieldCls(!iscsi.addPortalIp, addPortalTried)} {addPortalIpError ? 'border-red-400' : ''}"
-													/>
-												</div>
+											<ListenAddressPicker
+												bind:address={iscsi.addPortalIp}
+												bind:family={iscsi.addPortalFamily}
+												allowWildcards
+												error={addPortalTried ? addPortalIpError : null}
+												placeholderV4="0.0.0.0 or 192.168.1.10"
+												placeholderV6=":: or fd00::1"
+											/>
+											<div class="mt-3 flex items-end gap-2">
 												<div>
 													<Label class="text-xs">Port</Label>
 													<Input type="number" bind:value={iscsi.addPortalPort} class="mt-1 h-8 w-24 text-xs" />
@@ -181,12 +175,9 @@
 												<Button size="xs" onclick={iscsiAddPortalGuarded}>Add</Button>
 												<Button size="xs" variant="ghost" onclick={() => { iscsi.addPortalTarget = ''; addPortalTried = false; }}>Cancel</Button>
 											</div>
-											{#if addPortalIpError}
-												<p class="mt-1 text-[0.7rem] text-red-400">{addPortalIpError}</p>
+											{#if !iscsi.addPortalIp && addPortalTried}
+												<p class="mt-1 text-[0.7rem] text-amber-500">Listen address is required.</p>
 											{/if}
-											<p class="mt-2 text-[0.7rem] text-muted-foreground">
-												Use <code>0.0.0.0</code> for all IPv4 interfaces, <code>::</code> for all IPv6 interfaces, or a specific host address for a single-NIC bind.
-											</p>
 										</div>
 									{:else}
 										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; }}>+ Add Portal</Button>

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -7,6 +7,7 @@
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 	import { validateAddressForFamily } from '$lib/network';
+	import ListenAddressPicker from '$lib/components/ListenAddressPicker.svelte';
 	import {
 		nvme,
 		nvmeToggleSort,
@@ -212,43 +213,31 @@
 									{/if}
 									{#if nvme.addPortSubsys === subsys.id}
 										<div class="mt-3 rounded border p-3">
-											<div class="grid grid-cols-2 gap-2 mb-2">
-												<div>
-													<Label class="text-xs">Transport</Label>
-													<select bind:value={nvme.addPortTransport} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
-														<option value="tcp">TCP</option>
-														<option value="rdma">RDMA</option>
-													</select>
-												</div>
-												<div>
-													<Label class="text-xs">Address Family</Label>
-													<select bind:value={nvme.addPortFamily} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
-														<option value="ipv4">IPv4</option>
-														<option value="ipv6">IPv6</option>
-													</select>
-												</div>
+											<div class="mb-2">
+												<Label class="text-xs">Transport</Label>
+												<select bind:value={nvme.addPortTransport} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
+													<option value="tcp">TCP</option>
+													<option value="rdma">RDMA</option>
+												</select>
 											</div>
-											<div class="grid grid-cols-2 gap-2 mb-2">
-												<div>
-													<Label class="text-xs">Listen Address {#if !nvme.addPortAddr && addPortTried}<span class="text-amber-500">required</span>{/if}</Label>
-													<Input
-														bind:value={nvme.addPortAddr}
-														placeholder={nvme.addPortFamily === 'ipv6' ? 'fd00::1 or 2001:db8::1' : '192.168.1.10'}
-														class="mt-1 h-8 text-xs {requiredFieldCls(!nvme.addPortAddr, addPortTried)} {addPortAddrError ? 'border-red-400' : ''}"
-													/>
-													{#if addPortAddrError}
-														<p class="mt-1 text-[0.7rem] text-red-400">{addPortAddrError}</p>
-													{/if}
-												</div>
+											<ListenAddressPicker
+												bind:address={nvme.addPortAddr}
+												bind:family={nvme.addPortFamily}
+												error={addPortTried ? addPortAddrError : null}
+												placeholderV4="192.168.1.10"
+												placeholderV6="fd00::1 or 2001:db8::1"
+											/>
+											<div class="mt-2 flex items-end gap-2">
 												<div>
 													<Label class="text-xs">Port</Label>
-													<Input type="number" bind:value={nvme.addPortSvcId} class="mt-1 h-8 text-xs" />
+													<Input type="number" bind:value={nvme.addPortSvcId} class="mt-1 h-8 w-24 text-xs" />
 												</div>
-											</div>
-											<div class="flex gap-2">
 												<Button size="xs" onclick={nvmeAddPortGuarded}>Add</Button>
 												<Button size="xs" variant="ghost" onclick={() => { nvme.addPortSubsys = ''; addPortTried = false; }}>Cancel</Button>
 											</div>
+											{#if !nvme.addPortAddr && addPortTried}
+												<p class="mt-1 text-[0.7rem] text-amber-500">Listen address is required.</p>
+											{/if}
 										</div>
 									{:else}
 										<Button size="xs" variant="outline" class="mt-2" onclick={() => { nvme.addPortSubsys = subsys.id; }}>+ Add Port</Button>


### PR DESCRIPTION
Tier 3 of #388 — final polish on the share-creation flow. Operators no longer have to remember which IPs the host actually owns; the form lists them up front.

## New shared component \`<ListenAddressPicker>\`

Drop-in replacement for the two-control "Family selector + free-form Listen Address" pair used by both panels.

- Single dropdown with: **Custom address…** (default — reveals manual Family + Address inputs as before), the wildcards \`0.0.0.0\` / \`::\` when \`allowWildcards\`, plus one entry per detected interface address labelled \`<iface> — <addr>\`.
- Selecting a preset auto-populates \`bind:address\` + \`bind:family\` via Svelte 5 \`$bindable\` bindings; form state shape doesn't change, so Add handlers keep working unmodified.
- Loads live interfaces via \`system.network.get\` on mount; errors degrade silently to Custom-only (operator can still type — no point surfacing a toast for a feature whose absence is invisible).

## Picker options derive from a new pure helper

\`listenAddressOptions(interfaces: LiveInterface[], allowWildcards: boolean): ListenAddressOption[]\`

Filters baked into the helper:

| Filter | Why |
| --- | --- |
| \`up: false\` interfaces hidden | binding to an address on a down interface succeeds in configfs but accepts no connections |
| Loopback (\`127.0.0.0/8\`, \`::1\`) hidden | binding a network share to loopback is almost always a mistake |
| Link-local v6 (\`fe80::/10\`) hidden | needs a zone id and the picker doesn't carry one |
| CIDR suffix stripped | engine wants bare addresses; \`LiveInterface\` carries CIDRs |
| \`allowWildcards = false\` (NVMe-oF) hides \`0.0.0.0\` / \`::\` | both fail with configfs EINVAL during subsystem-to-port linking |

## Wired into both panels

- **IscsiPanel Add Portal**: replaces the inline Family + Address grid with the picker (allowWildcards on). Helper text moved into the picker's own labels — no behavior change to submit logic.
- **NvmeofPanel Add Port**: same drop-in but without wildcards. Type of \`nvme.addPortFamily\` was explicitly narrowed in the store from \`string\` to \`'ipv4' | 'ipv6'\` to match the picker's bind type — caught by svelte-check.

## Tests

- 8 new vitest cases for \`listenAddressOptions\` covering wildcard inclusion / suppression, CIDR stripping, loopback / link-local / down-iface filtering, label format, key uniqueness, and combined wildcard + iface ordering.
- 144 tests pass total; \`svelte-check\` + \`svelte build\` clean.

## Closes
Final piece of #388 (Tier 3). Issue can be closed after merge.

## Test plan
- [ ] iSCSI Add Portal on dual-stack host: dropdown lists \`All IPv4 (0.0.0.0)\`, \`All IPv6 (::)\`, plus each interface's v4 + v6 addresses. Picking one auto-fills address and family.
- [ ] Pick "Custom address…" → manual Family + Address inputs appear, behave like before.
- [ ] NVMe-oF Add Port: dropdown lists interface addresses but NOT \`0.0.0.0\` / \`::\` (NVMe-oF rejects them).
- [ ] Interface with only a link-local v6 address: not offered (would need a zone id the picker can't carry).
- [ ] Loopback interface: not offered.
- [ ] Down interface: not offered.
- [ ] \`system.network.get\` failure: dropdown stays on Custom; form remains usable.