### PR TITLE
engine: tighten input validation for share names, NQNs, subvolume names, and volsize

### DIFF
--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -263,6 +263,7 @@ impl IscsiService {
     }
 
     pub async fn create(&self, req: CreateTargetRequest) -> Result<IscsiTarget, IscsiError> {
+        validate_target_name(&req.name)?;
         let targets: Vec<IscsiTarget> = state_dir().load_all().await;
         let iqn = format!("{DEFAULT_IQN_PREFIX}:{}", req.name);
 
@@ -910,6 +911,38 @@ fn np_path_for(tpg_path: &str, ip: &str, port: u16) -> String {
     }
 }
 
+/// Validate the user-supplied portion of an iSCSI target name. The
+/// engine builds the full IQN as `iqn.2137-04.storage.nasty:<name>` and
+/// then uses that string as a configfs directory name and a key in
+/// state files. RFC 3720 allows lowercase ASCII letters, digits, and
+/// `-`, `.`, `:` in the user-suffix — we accept the same set plus
+/// uppercase (LIO is case-insensitive in practice) and `_` (common in
+/// existing operator naming conventions). Reject everything else,
+/// notably `/` (would escape the configfs subsystem dir) and control
+/// characters (would smuggle newlines into saveconfig.json).
+fn validate_target_name(name: &str) -> Result<(), IscsiError> {
+    if name.is_empty() {
+        return Err(IscsiError::CommandFailed(
+            "iSCSI target name is empty".to_string(),
+        ));
+    }
+    if name.len() > 200 {
+        return Err(IscsiError::CommandFailed(
+            "iSCSI target name exceeds 200 chars".to_string(),
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | ':'))
+    {
+        return Err(IscsiError::CommandFailed(format!(
+            "iSCSI target name '{name}' contains invalid characters \
+             (allowed: A-Z, a-z, 0-9, '-', '.', '_', ':')"
+        )));
+    }
+    Ok(())
+}
+
 /// Validate a portal IP and return it normalized (whitespace-trimmed,
 /// brackets stripped if the operator typed `[fd00::1]`). Both forms
 /// reach the engine in practice — the WebUI sends bare addresses, but
@@ -993,5 +1026,42 @@ mod tests {
         // initiators do their own DNS but the engine writes a numeric
         // address into configfs.
         assert!(validate_portal_ip("example.com").is_err());
+    }
+
+    #[test]
+    fn validate_target_name_accepts_typical_names() {
+        assert!(validate_target_name("tank").is_ok());
+        assert!(validate_target_name("DB-Server-01").is_ok());
+        assert!(validate_target_name("vmware.cluster.prod").is_ok());
+        assert!(validate_target_name("backup_2024").is_ok());
+        // Colon is allowed in the user-suffix per RFC 3720; some shops
+        // use it to mirror their hostname:purpose convention.
+        assert!(validate_target_name("host:purpose").is_ok());
+    }
+
+    #[test]
+    fn validate_target_name_rejects_configfs_escape() {
+        // Slash would escape the configfs subsystem directory,
+        // potentially creating /sys/.../tpgt_1/etc/...
+        assert!(validate_target_name("../escape").is_err());
+        assert!(validate_target_name("with/slash").is_err());
+        assert!(validate_target_name("with\\backslash").is_err());
+    }
+
+    #[test]
+    fn validate_target_name_rejects_control_chars_and_whitespace() {
+        // Newlines would smuggle JSON entries into saveconfig.json;
+        // spaces break shell quoting in legacy targetcli operations.
+        assert!(validate_target_name("with newline\n").is_err());
+        assert!(validate_target_name("with tab\t").is_err());
+        assert!(validate_target_name("with space").is_err());
+        assert!(validate_target_name("with\x00null").is_err());
+    }
+
+    #[test]
+    fn validate_target_name_rejects_empty_and_oversize() {
+        assert!(validate_target_name("").is_err());
+        assert!(validate_target_name(&"x".repeat(201)).is_err());
+        assert!(validate_target_name(&"x".repeat(200)).is_ok());
     }
 }

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -340,6 +340,12 @@ impl NvmeofService {
         &self,
         req: CreateSubsystemRequest,
     ) -> Result<NvmeofSubsystem, NvmeofError> {
+        validate_subsystem_name(&req.name)?;
+        if let Some(ref hosts) = req.allowed_hosts {
+            for host_nqn in hosts {
+                validate_host_nqn(host_nqn)?;
+            }
+        }
         let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
         let nqn = format!("{DEFAULT_NQN_PREFIX}:{}", req.name);
 
@@ -795,6 +801,7 @@ impl NvmeofService {
     }
 
     pub async fn add_host(&self, req: AddHostRequest) -> Result<NvmeofSubsystem, NvmeofError> {
+        validate_host_nqn(&req.host_nqn)?;
         let mut subsys: NvmeofSubsystem = state_dir()
             .load(&req.subsystem_id)
             .await
@@ -978,4 +985,148 @@ async fn detect_primary_ip() -> Option<String> {
         }
     }
     None
+}
+
+/// Validate the user-supplied portion of an NVMe-oF subsystem name.
+/// The engine builds the full NQN as `nqn.2137-04.storage.nasty:<name>`
+/// and uses that string as a configfs directory name. NVMe-oF (NVMe
+/// base spec 1.4 §7.9) requires NQNs to be UTF-8 within 223 bytes —
+/// but configfs is far less forgiving. Restrict to the same conservative
+/// set as iSCSI target names (A-Z, a-z, 0-9, '-', '.', '_', ':') so a
+/// name can't escape the subsystem directory via '/' or smuggle
+/// newlines into state files.
+fn validate_subsystem_name(name: &str) -> Result<(), NvmeofError> {
+    if name.is_empty() {
+        return Err(NvmeofError::ConfigFs(
+            "NVMe-oF subsystem name is empty".to_string(),
+        ));
+    }
+    if name.len() > 200 {
+        return Err(NvmeofError::ConfigFs(
+            "NVMe-oF subsystem name exceeds 200 chars".to_string(),
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | ':'))
+    {
+        return Err(NvmeofError::ConfigFs(format!(
+            "NVMe-oF subsystem name '{name}' contains invalid characters \
+             (allowed: A-Z, a-z, 0-9, '-', '.', '_', ':')"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an allowed-host NQN string. Unlike the subsystem name, the
+/// host NQN is a full NQN supplied by the caller (initiators identify
+/// themselves with strings like `nqn.2014-08.org.nvmexpress:uuid:...`).
+/// We can't enforce the full NQN grammar here without breaking valid
+/// initiator names, but we *can* reject the characters that would
+/// escape the configfs hosts directory or break the `allowed_hosts`
+/// symlink path.
+fn validate_host_nqn(nqn: &str) -> Result<(), NvmeofError> {
+    if nqn.is_empty() {
+        return Err(NvmeofError::ConfigFs("host NQN is empty".to_string()));
+    }
+    if nqn.len() > 223 {
+        // NVMe base spec 1.4 §7.9: NQN is at most 223 bytes.
+        return Err(NvmeofError::ConfigFs(
+            "host NQN exceeds 223 chars (NVMe spec limit)".to_string(),
+        ));
+    }
+    if !nqn.starts_with("nqn.") {
+        return Err(NvmeofError::ConfigFs(format!(
+            "host NQN '{nqn}' must start with 'nqn.' (per NVMe spec)"
+        )));
+    }
+    if nqn.contains('/') || nqn.contains('\\') || nqn.chars().any(|c| c.is_control() || c == ' ') {
+        return Err(NvmeofError::ConfigFs(format!(
+            "host NQN '{nqn}' contains invalid characters \
+             (must not contain '/', '\\', whitespace, or control characters)"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_subsystem_name_accepts_typical_names() {
+        assert!(validate_subsystem_name("faststore").is_ok());
+        assert!(validate_subsystem_name("DB-01").is_ok());
+        assert!(validate_subsystem_name("vmware.cluster.prod").is_ok());
+        assert!(validate_subsystem_name("ns_2024").is_ok());
+        assert!(validate_subsystem_name("host:purpose").is_ok());
+    }
+
+    #[test]
+    fn validate_subsystem_name_rejects_configfs_escape() {
+        assert!(validate_subsystem_name("../escape").is_err());
+        assert!(validate_subsystem_name("with/slash").is_err());
+        assert!(validate_subsystem_name("with\\backslash").is_err());
+    }
+
+    #[test]
+    fn validate_subsystem_name_rejects_control_and_whitespace() {
+        assert!(validate_subsystem_name("with newline\n").is_err());
+        assert!(validate_subsystem_name("with space").is_err());
+        assert!(validate_subsystem_name("with\x00null").is_err());
+    }
+
+    #[test]
+    fn validate_subsystem_name_rejects_empty_and_oversize() {
+        assert!(validate_subsystem_name("").is_err());
+        assert!(validate_subsystem_name(&"x".repeat(201)).is_err());
+        assert!(validate_subsystem_name(&"x".repeat(200)).is_ok());
+    }
+
+    #[test]
+    fn validate_host_nqn_accepts_standard_initiator_forms() {
+        // The two common forms an initiator's host NQN takes in the wild.
+        assert!(
+            validate_host_nqn(
+                "nqn.2014-08.org.nvmexpress:uuid:8e69b1d0-1234-5678-9abc-def012345678"
+            )
+            .is_ok()
+        );
+        assert!(validate_host_nqn("nqn.2024-01.com.example:client01").is_ok());
+    }
+
+    #[test]
+    fn validate_host_nqn_requires_nqn_prefix() {
+        // Per NVMe base spec §7.9, every NQN starts with "nqn.YYYY-MM"
+        // — anything else is either an initiator typo or a hostname
+        // being passed where an NQN should go.
+        assert!(validate_host_nqn("example.com:client").is_err());
+        assert!(validate_host_nqn("client01").is_err());
+    }
+
+    #[test]
+    fn validate_host_nqn_rejects_path_escape() {
+        // Slash would escape the configfs hosts directory.
+        assert!(validate_host_nqn("nqn.../etc/passwd").is_err());
+        assert!(validate_host_nqn("nqn.2024-01.com.example:a\\b").is_err());
+    }
+
+    #[test]
+    fn validate_host_nqn_rejects_whitespace_and_control() {
+        // Whitespace would break the configfs symlink path; control
+        // characters would smuggle into state files.
+        assert!(validate_host_nqn("nqn.2024-01.example com").is_err());
+        assert!(validate_host_nqn("nqn.2024-01.example\nnewline").is_err());
+        assert!(validate_host_nqn("nqn.2024-01.example\x00null").is_err());
+    }
+
+    #[test]
+    fn validate_host_nqn_rejects_oversize() {
+        // 224 chars exceeds the NVMe spec's 223-byte ceiling.
+        let oversize = format!("nqn.2024-01.{}", "x".repeat(212));
+        assert!(validate_host_nqn(&oversize).is_err());
+        let at_limit = format!("nqn.2024-01.{}", "x".repeat(211));
+        assert_eq!(at_limit.len(), 223);
+        assert!(validate_host_nqn(&at_limit).is_ok());
+    }
 }

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -139,6 +139,7 @@ impl SmbService {
 
     pub async fn create(&self, req: CreateSmbShareRequest) -> Result<SmbShare, SmbError> {
         validate_share_name(&req.name)?;
+        validate_share_path(&req.path)?;
 
         if !Path::new(&req.path).exists() {
             return Err(SmbError::PathNotFound(req.path));
@@ -267,6 +268,32 @@ fn validate_share_name(name: &str) -> Result<(), SmbError> {
     {
         return Err(SmbError::InvalidName(
             "Share name must be 1-80 chars without special characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a share path before it's written into smb.conf as
+/// `path = <path>`. The create/update flow also canonicalizes and
+/// requires the path live under `/fs/`, so this is defense-in-depth:
+/// reject characters that, if present in a real filesystem entry name,
+/// would smuggle a new `include = /etc/passwd` directive into the
+/// rendered share section. Newlines and carriage returns are the
+/// primary concern; the rest are belt-and-braces against weird
+/// filesystem entries (most are syntactically invalid in smb.conf
+/// values anyway but we'd rather fail loudly than render garbage).
+fn validate_share_path(path: &str) -> Result<(), SmbError> {
+    if path.is_empty() {
+        return Err(SmbError::InvalidName("share path is empty".to_string()));
+    }
+    if path
+        .chars()
+        .any(|c| c == '\n' || c == '\r' || c == '\0' || c == '"' || c == '#')
+    {
+        return Err(SmbError::InvalidName(
+            "share path contains characters that would inject smb.conf directives \
+             (newline, CR, NUL, double-quote, '#')"
+                .to_string(),
         ));
     }
     Ok(())
@@ -830,6 +857,33 @@ mod tests {
         for bad in ["a/b", "a\\b", "a[b", "a]b", "a:b", "a|b", "a;b"] {
             assert!(validate_share_name(bad).is_err(), "should reject '{bad}'");
         }
+    }
+
+    #[test]
+    fn validate_share_path_accepts_real_paths() {
+        assert!(validate_share_path("/fs/tank/docs").is_ok());
+        assert!(validate_share_path("/fs/pool/My Files").is_ok());
+        assert!(validate_share_path("/fs/a/b/c-d_e.f").is_ok());
+    }
+
+    #[test]
+    fn validate_share_path_rejects_smb_conf_injection() {
+        // Newline + new key=value smuggles a fresh smb.conf directive
+        // into the rendered share section, e.g. an extra `include = `.
+        assert!(validate_share_path("/fs/tank\ninclude = /etc/passwd").is_err());
+        assert!(validate_share_path("/fs/tank\rinclude").is_err());
+        assert!(validate_share_path("/fs/tank\0bad").is_err());
+        // `#` starts a comment in smb.conf — a path containing it
+        // would silently truncate the path line on parse.
+        assert!(validate_share_path("/fs/tank#comment").is_err());
+        // Double-quote could break a quoted value if the renderer
+        // later switches to quoted style.
+        assert!(validate_share_path("/fs/tank\"quoted").is_err());
+    }
+
+    #[test]
+    fn validate_share_path_rejects_empty() {
+        assert!(validate_share_path("").is_err());
     }
 
     // ── render_share_conf ──────────────────────────────────────────

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -50,10 +50,90 @@ pub enum SubvolumeError {
     AccessDenied,
     #[error("volsize is required for block subvolumes")]
     VolsizeRequired,
+    #[error("invalid name: {0}")]
+    InvalidName(String),
+    #[error("invalid volsize: {0}")]
+    InvalidVolsize(String),
     #[error("command failed: {0}")]
     CommandFailed(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Hard ceiling on block-subvolume size requests. A NAS volume has no
+/// legitimate reason to need >256 TiB — bcachefs would happily accept
+/// the truncate but the resulting sparse file confuses every downstream
+/// (df, NFS clients, du, backup tools that try to estimate transfer
+/// size). The cap rejects obvious typos (extra zero) and protects
+/// against an Operator-role caller trying to ENOSPC the filesystem by
+/// requesting `u64::MAX`.
+const MAX_VOLSIZE_BYTES: u64 = 256 * 1024 * 1024 * 1024 * 1024; // 256 TiB
+
+/// Validate a subvolume name. Names may contain `/` (intentional —
+/// nested subvolumes like `projects/web` are a supported pattern), but
+/// must not escape the filesystem mount via `..`, must not start with
+/// `/` (we always prefix the mount point), and must not contain `@`
+/// (bcachefs uses `@` as the snapshot separator — colliding here
+/// corrupts snapshot lookups) or control characters (would smuggle
+/// newlines into log lines and config files downstream).
+fn validate_subvolume_name(name: &str) -> Result<(), SubvolumeError> {
+    if name.is_empty() {
+        return Err(SubvolumeError::InvalidName("name is empty".to_string()));
+    }
+    if name.len() > 200 {
+        return Err(SubvolumeError::InvalidName(
+            "name exceeds 200 chars".to_string(),
+        ));
+    }
+    if name.starts_with('/') {
+        return Err(SubvolumeError::InvalidName(
+            "name must not start with '/'".to_string(),
+        ));
+    }
+    if name.starts_with('.') {
+        // Leading dot would create a hidden directory that the WebUI
+        // doesn't surface and that's hard to clean up via shell.
+        return Err(SubvolumeError::InvalidName(
+            "name must not start with '.'".to_string(),
+        ));
+    }
+    for component in name.split('/') {
+        if component.is_empty() {
+            return Err(SubvolumeError::InvalidName(
+                "name must not contain empty path components ('//')".to_string(),
+            ));
+        }
+        if component == ".." || component == "." {
+            return Err(SubvolumeError::InvalidName(
+                "name must not contain '.' or '..' components".to_string(),
+            ));
+        }
+        if component.contains('@') {
+            return Err(SubvolumeError::InvalidName(
+                "name must not contain '@' (reserved for snapshot syntax)".to_string(),
+            ));
+        }
+        if component.chars().any(|c| c.is_control()) {
+            return Err(SubvolumeError::InvalidName(
+                "name must not contain control characters".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_volsize_bytes(bytes: u64) -> Result<(), SubvolumeError> {
+    if bytes == 0 {
+        return Err(SubvolumeError::InvalidVolsize(
+            "volsize must be greater than zero".to_string(),
+        ));
+    }
+    if bytes > MAX_VOLSIZE_BYTES {
+        return Err(SubvolumeError::InvalidVolsize(format!(
+            "volsize {bytes} exceeds maximum {MAX_VOLSIZE_BYTES} (256 TiB)"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
@@ -776,11 +856,7 @@ impl SubvolumeService {
         req: CreateSubvolumeRequest,
         owner: Option<String>,
     ) -> Result<Subvolume, SubvolumeError> {
-        if req.name.contains('@') {
-            return Err(SubvolumeError::CommandFailed(
-                "subvolume name may not contain '@'".to_string(),
-            ));
-        }
+        validate_subvolume_name(&req.name)?;
 
         let mount_point = self.fs_mount_point(&req.filesystem).await?;
         let subvol_path = subvol_path(&mount_point, &req.name);
@@ -795,6 +871,9 @@ impl SubvolumeService {
 
         if req.subvolume_type == SubvolumeType::Block && req.volsize_bytes.is_none() {
             return Err(SubvolumeError::VolsizeRequired);
+        }
+        if let Some(bytes) = req.volsize_bytes {
+            validate_volsize_bytes(bytes)?;
         }
 
         // Ensure parent directories exist for nested subvolumes (e.g. "projects/web")
@@ -1063,6 +1142,7 @@ impl SubvolumeService {
         req: ResizeSubvolumeRequest,
         owner_filter: Option<&str>,
     ) -> Result<Subvolume, SubvolumeError> {
+        validate_volsize_bytes(req.volsize_bytes)?;
         let subvol = self.get(&req.filesystem, &req.name, owner_filter).await?;
 
         match subvol.subvolume_type {
@@ -1939,4 +2019,90 @@ async fn find_child_subvolumes(mount_point: &str, parent_name: &str) -> Vec<Stri
     // Sort so deeper paths come later — reverse for depth-first deletion
     children.sort();
     children
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_subvolume_name_accepts_typical_names() {
+        assert!(validate_subvolume_name("tank").is_ok());
+        assert!(validate_subvolume_name("My-Docs_2024").is_ok());
+        assert!(validate_subvolume_name("projects/web").is_ok());
+        assert!(validate_subvolume_name("a/b/c/d").is_ok());
+        assert!(validate_subvolume_name("name.with.dots").is_ok());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_traversal() {
+        assert!(validate_subvolume_name("..").is_err());
+        assert!(validate_subvolume_name("../etc").is_err());
+        assert!(validate_subvolume_name("ok/../bad").is_err());
+        assert!(validate_subvolume_name("ok/.").is_err());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_leading_separators() {
+        assert!(validate_subvolume_name("/etc/passwd").is_err());
+        assert!(validate_subvolume_name("//doubled").is_err());
+        // Empty path components from a trailing or doubled `/` are flagged
+        // because the resulting `format!("{mount}/{name}")` would silently
+        // collapse them and confuse later listing/parse code.
+        assert!(validate_subvolume_name("a//b").is_err());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_hidden_prefix() {
+        // Leading dot creates a directory that the WebUI doesn't surface;
+        // the operator has no UI path to clean it up afterwards.
+        assert!(validate_subvolume_name(".hidden").is_err());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_snapshot_collision() {
+        // `@` is bcachefs's snapshot separator (`subvol@snapname`).
+        // Allowing it in the subvolume name would corrupt snapshot
+        // lookups in find_child_subvolumes() and snap_path().
+        assert!(validate_subvolume_name("subvol@snap").is_err());
+        assert!(validate_subvolume_name("nested/@evil").is_err());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_control_chars() {
+        assert!(validate_subvolume_name("name\nwith\nnewline").is_err());
+        assert!(validate_subvolume_name("name\twith\ttab").is_err());
+        assert!(validate_subvolume_name("name\x00with\x00null").is_err());
+    }
+
+    #[test]
+    fn validate_subvolume_name_rejects_empty_and_oversize() {
+        assert!(validate_subvolume_name("").is_err());
+        assert!(validate_subvolume_name(&"x".repeat(201)).is_err());
+        // Boundary is inclusive: 200 chars is accepted.
+        assert!(validate_subvolume_name(&"x".repeat(200)).is_ok());
+    }
+
+    #[test]
+    fn validate_volsize_bytes_accepts_sensible_sizes() {
+        assert!(validate_volsize_bytes(1024).is_ok());
+        assert!(validate_volsize_bytes(1024 * 1024 * 1024).is_ok()); // 1 GiB
+        assert!(validate_volsize_bytes(1024_u64.pow(4)).is_ok()); // 1 TiB
+        assert!(validate_volsize_bytes(MAX_VOLSIZE_BYTES).is_ok()); // boundary
+    }
+
+    #[test]
+    fn validate_volsize_bytes_rejects_zero() {
+        // A zero-byte block subvolume would create a useless backing file
+        // and is almost always a typo or a UI-bind glitch.
+        assert!(validate_volsize_bytes(0).is_err());
+    }
+
+    #[test]
+    fn validate_volsize_bytes_rejects_above_cap() {
+        // 257 TiB > 256 TiB cap. A request of u64::MAX is the canonical
+        // worst case (Operator-role caller trying to ENOSPC the filesystem).
+        assert!(validate_volsize_bytes(MAX_VOLSIZE_BYTES + 1).is_err());
+        assert!(validate_volsize_bytes(u64::MAX).is_err());
+    }
 }


### PR DESCRIPTION
Closes the input-validation gaps surfaced by the recent security review. Operator-role callers could previously supply names containing path separators, control characters, or whitespace that flowed into configfs directory paths, smb.conf directives, and bcachefs subvolume paths. The engine accepted them; the failure modes ranged from confusing error messages to corrupted state files (snapshot lookups collide on \`@\`, nested subvolume cleanup walks the wrong dirs on \`..\`).

## Subvolume name + volsize (\`nasty-storage/src/subvolume.rs\`)

- **\`validate_subvolume_name()\`** rejects: empty, >200 chars, leading \`/\`, leading \`.\`, \`..\`/\`.\` path components, \`@\` (collides with bcachefs snapshot syntax), and control characters. \`/\` itself stays allowed — nested subvolumes like \`projects/web\` are an intentional pattern (\`create_dir_all\` for parents) and existing call sites depend on it.
- Replaces the prior single-line \`@\` check in \`create()\` with the full validator.
- **\`validate_volsize_bytes()\`** caps requests at 256 TiB and rejects zero. The cap rejects the obvious DoS shape (\`u64::MAX\` truncate drives the filesystem into a confusing state) and the common typo shape (extra zero on a manual size). Applied at both \`create()\` and \`resize()\` so the cap can't be bypassed by creating small then resizing large.
- New \`SubvolumeError::InvalidName\` and \`InvalidVolsize\` variants for cleaner error surfacing (previously masqueraded as \`CommandFailed\`).

## iSCSI target name (\`nasty-sharing/src/iscsi.rs\`)

- **\`validate_target_name()\`** restricts the user-supplied portion of the IQN (after \`:\`) to ASCII alphanumerics plus \`-._:\`. The full IQN flows directly into a configfs directory name; \`/\` would escape the subsystem directory and newlines would smuggle entries into \`saveconfig.json\` on the next persist.
- Length cap 200 chars. Empty rejected.

## NVMe-oF subsystem name + host NQN (\`nasty-sharing/src/nvmeof.rs\`)

- **\`validate_subsystem_name()\`** applies the same conservative charset as iSCSI to the user-suffix of the NQN, for the same configfs-directory reason.
- **\`validate_host_nqn()\`** is stricter: requires \`nqn.\` prefix (per NVMe base spec 1.4 §7.9), enforces the 223-byte spec limit, and rejects \`/\`, \`\\\`, whitespace, and control characters. Initiator NQNs vary widely in the wild (uuid forms, hostname forms) so the charset stays permissive — the goal is to block path escape, not enforce the full grammar.
- Wired into \`create()\` (subsystem name + the optional \`allowed_hosts\` list) and \`add_host()\` (single host NQN).

## SMB share path (\`nasty-sharing/src/smb.rs\`)

- Defense in depth — \`create()\` already canonicalizes the path and requires it to live under \`/fs/\`, but the stored field is \`req.path\` (the operator string), not the canonical path. A real filesystem entry whose name contains a newline would land in \`smb.conf\` as \`path = /fs/share\\ninclude = /etc/passwd\`.
- **\`validate_share_path()\`** rejects newline, CR, NUL, \`\"\`, and \`#\` (smb.conf comment marker).

## Tests

- 11 new \`subvolume.rs\` tests covering accept set, traversal, leading separators, hidden-prefix, snapshot collision, control chars, oversize, plus volsize boundary cases.
- 4 new \`iscsi.rs\` tests (accept set, configfs-escape rejection, whitespace/control rejection, length boundary).
- 7 new \`nvmeof.rs\` tests covering both validators including the spec-boundary 223-byte case.
- 3 new \`smb.rs\` tests for the share-path validator.
- Total: 25 new unit tests. \`cargo test --workspace --lib\` green; \`cargo clippy --workspace --no-deps --all-targets\` clean; \`cargo fmt --check\` clean.

All four validators follow the same shape (\`fn ... -> Result<(), Err>\`) and charset philosophy: whitelist what's known-safe, reject everything else, fail loudly with a message that names the offending class of character.

## Out of scope (other findings from the security review)

- Secret hygiene: CHAP password leak in \`configfs_write\` logging, backup creds in plaintext JSON
- Systemd \`StartLimitBurst\` hardening
- Telemetry rate limit (different repo)
- WebUI confirmation gaps (different PR)

## Test plan
- [ ] Create subvolume with name \`../../etc\` → rejected with InvalidName
- [ ] Create subvolume with name \`projects/web\` → succeeds (nested path still allowed)
- [ ] Create subvolume with name \`backup@daily\` → rejected
- [ ] Create block subvolume with \`volsize_bytes: u64::MAX\` → rejected with InvalidVolsize
- [ ] Resize block subvolume to 300 TiB → rejected
- [ ] Create iSCSI target with name \`db/server\` → rejected
- [ ] Create NVMe-oF subsystem with name \`db/server\` → rejected
- [ ] \`share.nvmeof.add_host\` with \`host_nqn: \"example.com\"\` (missing nqn. prefix) → rejected with clear error
- [ ] Existing valid names (alphanumerics, dots, dashes, nested paths) continue to work