### PR TITLE
nixos: cap restart attempts on engine + auxiliary services

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1439,6 +1439,16 @@ in {
         RUST_LOG = "nasty_metrics=info";
       };
 
+      # Cap restart attempts so a deterministic panic (corrupt sysfs
+      # parse, missing tool, divide-by-zero on a metric edge case)
+      # surfaces as a `failed` state in `systemctl status` instead of
+      # tight-looping every RestartSec, burning CPU and filling the
+      # journal. Operator escapes with `systemctl reset-failed`.
+      unitConfig = {
+        StartLimitIntervalSec = 60;
+        StartLimitBurst = 5;
+      };
+
       serviceConfig = {
         Type = "notify";
         ExecStart = "${cfg.engine.package}/bin/nasty-metrics";
@@ -1561,6 +1571,24 @@ in {
         # in-kernel RM. Setting TPM2TOOLS_TCTI cuts straight to /dev/tpmrm0
         # and keeps the journal readable.
         TPM2TOOLS_TCTI = "device:/dev/tpmrm0";
+      };
+
+      # Cap restart attempts so a deterministic panic (corrupt state
+      # file, schema-mismatch on a stored JSON blob, divide-by-zero on
+      # a metric edge case) surfaces as a `failed` state instead of
+      # tight-looping every 5s. Without this, an engine that panics on
+      # boot reload would burn a CPU core and spam the journal until
+      # the operator notices. The boot overlay (boot_status.rs) and
+      # `systemctl status nasty-engine` both surface the failed state
+      # clearly; operator escape is `systemctl reset-failed nasty-engine`
+      # after fixing the underlying cause.
+      #
+      # Headroom: 5 starts in 60s comfortably covers a normal
+      # self-update (1 restart) and an operator debugging session
+      # (manual restart 2-3 times in quick succession).
+      unitConfig = {
+        StartLimitIntervalSec = 60;
+        StartLimitBurst = 5;
       };
 
       serviceConfig = {
@@ -1794,6 +1822,13 @@ in {
       description = "restic REST server for NASty backups";
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
+      # Same restart-cap rationale as nasty-engine — a misconfigured
+      # repo path or a port-in-use error would otherwise tight-loop
+      # every 5s once the engine started this on demand.
+      unitConfig = {
+        StartLimitIntervalSec = 60;
+        StartLimitBurst = 5;
+      };
       serviceConfig = {
         Type = "simple";
         ExecStart = pkgs.writeShellScript "nasty-rest-server-start" ''
@@ -2150,6 +2185,13 @@ in {
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       wantedBy = []; # Engine manages lifecycle via systemctl start/stop
+      # Same restart-cap rationale as nasty-engine — a corrupt
+      # tailscaled.state file or an upstream API contract change
+      # would otherwise tight-loop and burn CPU.
+      unitConfig = {
+        StartLimitIntervalSec = 60;
+        StartLimitBurst = 5;
+      };
       serviceConfig = {
         ExecStart = "${pkgs.tailscale}/bin/tailscaled --state=/var/lib/nasty/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock";
         RuntimeDirectory = "tailscale";


### PR DESCRIPTION
A deterministic panic in any of our long-running services would previously tight-loop forever — \`Restart = \"always\"\` (engine, metrics) or \`Restart = \"on-failure\"\` (rest-server, tailscale) with \`RestartSec = 5\` means systemd respawns every 5s with no upper bound.

The failure shape that triggers this is depressingly mundane: a corrupted JSON state file, a schema-mismatch on a stored blob after a rollback, an unexpected \`/sys\` layout, a divide-by-zero on a metric edge case. The binary panics, systemd dutifully restarts it, the same input triggers the same panic, repeat.

Symptom in practice: a CPU core pegged to 100%, journald filling with identical panic frames, the operator notices hours later when disk fills with rotated logs or the WebUI starts timing out under load.

## What changes

Adds \`unitConfig.StartLimitIntervalSec = 60; StartLimitBurst = 5;\` to four services:

| Service              | Restart      | Why it's in scope                                |
| -------------------- | ------------ | ------------------------------------------------ |
| \`nasty-engine\`     | always       | Privileged manager; loop wedges the whole box    |
| \`nasty-metrics\`    | always       | Smartctl/sysfs parse errors are panic-prone     |
| \`nasty-rest-server\`| on-failure   | Misconfigured repo path or port-in-use loops    |
| \`nasty-tailscale\`  | on-failure   | Corrupt tailscaled.state / API contract changes |

After 5 starts inside a 60s window, systemd stops restarting and the unit lands in \`failed\` state. Two ways the operator sees this:

- \`systemctl status <unit>\` shows the failure with the last few journal lines — the panic message is usually right there.
- \`boot_status.rs\` marks the phase failed; the WebUI boot overlay refuses to dismiss until the operator acknowledges.

Escape hatch is \`systemctl reset-failed <unit>\` after fixing the underlying cause.

## Headroom rationale

5 restarts in 60s comfortably accommodates a normal self-update sequence (1 restart) and an operator debugging session (2-3 manual restarts in quick succession). A panic loop blows through it in 25s, well before journald starts truncating.

The engine self-update path triggers exactly one restart per \`nixos-rebuild\` — within budget. No effect on the happy path.

## Out of scope

An \`OnFailure=\` notifier service that emails / webhooks the operator when the StartLimit is hit. The existing boot overlay + \`systemctl status\` cover the common case; a notifier is a polish item once the dispatch infra (already exists for alerts) gets a \`system.unit_failed\` event hook.

## Test plan
- [ ] Engine self-update path still works (1 restart, well within 5/60s budget)
- [ ] Inject a deterministic panic in the engine, confirm it lands in \`failed\` state after 5 restarts instead of looping
- [ ] \`systemctl reset-failed nasty-engine\` followed by \`systemctl start\` recovers the unit
- [ ] Boot overlay surfaces the failed state
- [ ] No regression in appliance-smoke.nix