### PR TITLE
storage: propagate child-delete + loop-detach errors instead of warn-and-continue

### DIFF
--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -54,6 +54,10 @@ pub enum SubvolumeError {
     InvalidName(String),
     #[error("invalid volsize: {0}")]
     InvalidVolsize(String),
+    #[error("could not delete child subvolume(s): {0}")]
+    ChildrenStuck(String),
+    #[error("could not detach loop device {device}: {reason}")]
+    LoopDetachFailed { device: String, reason: String },
     #[error("command failed: {0}")]
     CommandFailed(String),
     #[error("io error: {0}")]
@@ -134,6 +138,17 @@ fn validate_volsize_bytes(bytes: u64) -> Result<(), SubvolumeError> {
         )));
     }
     Ok(())
+}
+
+/// `losetup -d` returns one of a small set of "device wasn't attached
+/// in the first place" errors depending on kernel + util-linux version.
+/// They all mean the same thing to us — there's nothing to detach, so
+/// the cleanup step is already satisfied. Returning `true` lets the
+/// caller treat the failure as success and proceed with the rest of
+/// the delete instead of erroring out on an idempotent retry.
+fn is_already_detached(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("no such device") || lower.contains("not in use")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
@@ -1033,13 +1048,30 @@ impl SubvolumeService {
     ) -> Result<(), SubvolumeError> {
         let subvol = self.get(&req.filesystem, &req.name, owner_filter).await?;
 
-        // For block subvolumes: detach loop device first
+        // For block subvolumes: detach loop device first. A failure here
+        // (typically EBUSY — something still has the device open) used
+        // to log a warn and continue; the subsequent bcachefs delete
+        // would then fail because the backing file is in use, leaving
+        // the loop device attached to a half-gone subvolume. Fail
+        // loudly with the real cause instead so the operator knows
+        // *which* device is stuck and why, before we touch the
+        // filesystem state.
+        //
+        // Exception: tolerate "No such device" / "not in use" — that's
+        // the shape losetup returns when the device is already detached
+        // (operator cleaned up manually, or a prior failed delete made
+        // it part-way). Treating that as success keeps retries idempotent.
         if subvol.subvolume_type == SubvolumeType::Block
             && let Some(ref loop_dev) = subvol.block_device
         {
             info!("Detaching loop device {} for '{}'", loop_dev, req.name);
-            if let Err(e) = cmd::run_ok("losetup", &["-d", loop_dev]).await {
-                warn!("Failed to detach loop device {loop_dev}: {e}");
+            if let Err(e) = cmd::run_ok("losetup", &["-d", loop_dev]).await
+                && !is_already_detached(&e)
+            {
+                return Err(SubvolumeError::LoopDetachFailed {
+                    device: loop_dev.clone(),
+                    reason: e,
+                });
             }
         }
 
@@ -1052,7 +1084,18 @@ impl SubvolumeService {
 
         // Delete child subvolumes first (depth-first) — bcachefs rejects
         // deleting a subvolume that contains nested subvolumes.
+        //
+        // Try every child even if one fails, so the operator gets the
+        // full list of stuck children in a single round trip instead
+        // of fix-one, retry, fix-next, retry. The partial-deletion
+        // window (some children gone, others not) is unavoidable —
+        // bcachefs has no transactional batch-delete and no "undo".
+        // Erroring out before the parent delete preserves the same
+        // partial state the old warn-and-continue path produced, but
+        // surfaces the real cause instead of a generic
+        // "directory not empty" from the parent attempt.
         let children = find_child_subvolumes(&mount_point, &req.name).await;
+        let mut stuck: Vec<String> = Vec::new();
         for child in children.iter().rev() {
             let child_path = format!("{mount_point}/{child}");
             info!(
@@ -1061,7 +1104,11 @@ impl SubvolumeService {
             );
             if let Err(e) = cmd::run_ok("bcachefs", &["subvolume", "delete", &child_path]).await {
                 warn!("Failed to delete child subvolume '{child}': {e}");
+                stuck.push(format!("{child} ({e})"));
             }
+        }
+        if !stuck.is_empty() {
+            return Err(SubvolumeError::ChildrenStuck(stuck.join("; ")));
         }
 
         info!(
@@ -2104,5 +2151,67 @@ mod tests {
         // worst case (Operator-role caller trying to ENOSPC the filesystem).
         assert!(validate_volsize_bytes(MAX_VOLSIZE_BYTES + 1).is_err());
         assert!(validate_volsize_bytes(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn is_already_detached_matches_real_losetup_errors() {
+        // Strings observed in the wild from util-linux losetup -d on a
+        // device that isn't currently associated with a backing file.
+        // Capitalization varies by version.
+        assert!(is_already_detached(
+            "losetup exited with exit code: 1: losetup: /dev/loop3: detach failed: No such device or address"
+        ));
+        assert!(is_already_detached(
+            "losetup: /dev/loop0: detach failed: no such device"
+        ));
+        assert!(is_already_detached(
+            "losetup: cannot find device /dev/loop9: loop device not in use"
+        ));
+    }
+
+    #[test]
+    fn is_already_detached_rejects_real_failures() {
+        // Device is still in use by something — operator needs to see
+        // this so they can find the process holding it open.
+        assert!(!is_already_detached(
+            "losetup exited with exit code: 1: losetup: /dev/loop3: detach failed: Device or resource busy"
+        ));
+        // Permission denied — a real configuration problem the
+        // operator needs to act on, not an idempotent no-op.
+        assert!(!is_already_detached(
+            "losetup: /dev/loop3: detach failed: Operation not permitted"
+        ));
+        // Unrelated tool failure — log unchanged.
+        assert!(!is_already_detached("failed to spawn losetup: ENOENT"));
+    }
+
+    #[test]
+    fn subvolume_error_display_lists_stuck_children() {
+        // The ChildrenStuck variant is operator-facing: the operator
+        // sees this message in a toast in the WebUI and uses it to
+        // figure out which subvolumes are blocking the parent delete.
+        // Format must surface the names; pin it here so a future
+        // accidental message change shows up as a test failure.
+        let err = SubvolumeError::ChildrenStuck(
+            "projects/web (busy); projects/api (mounted)".to_string(),
+        );
+        let msg = format!("{err}");
+        assert!(msg.contains("projects/web"));
+        assert!(msg.contains("projects/api"));
+        assert!(msg.contains("busy"));
+        assert!(msg.contains("mounted"));
+    }
+
+    #[test]
+    fn subvolume_error_display_names_loop_device() {
+        // Same operator-facing constraint as ChildrenStuck — they need
+        // to know *which* device is stuck to run lsof / fuser / debug.
+        let err = SubvolumeError::LoopDetachFailed {
+            device: "/dev/loop7".to_string(),
+            reason: "Device or resource busy".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("/dev/loop7"));
+        assert!(msg.contains("Device or resource busy"));
     }
 }


### PR DESCRIPTION
The subvolume delete path had two places where a real failure was masked as a \`warn()\` and the code continued, leaving the operator with a confusing downstream error instead of the actual cause. Both came up in the recent security review and share the same shape — fix together since the rationale is identical.

## Child subvolume delete

\`bcachefs subvolume delete\` rejects a parent that still contains children, so the engine walks the children first. The old loop used \`if let Err(e) = ... { warn!(...) }\` — any child whose delete failed (typically because a VM/app still has it open) was logged and skipped. The parent delete then failed with bcachefs's own *\"directory not empty\"* error; the operator saw a generic message with no hint about which child was the actual culprit, and the state was left half-deleted (other children removed, stuck child + parent still present).

**Fix**: collect the per-child failures into a Vec, attempt every child anyway so the operator gets the full list in a single round trip, then short-circuit before the parent delete with \`SubvolumeError::ChildrenStuck(String)\` whose message names every stuck child and its error.

The partial-deletion window (some children gone, others not) is unavoidable — bcachefs has no transactional batch-delete and no \"undo\". This change keeps the same partial state but surfaces the real cause instead of a generic parent-delete error.

## Loop device detach

Block subvolumes have a \`losetup\`-attached loop device that the delete must release before bcachefs can free the backing image. The old code logged and continued on \`losetup -d\` failure; the subsequent bcachefs delete would then fail with *\"Device or resource busy\"* or similar, leaving the device attached to a half-gone subvolume — a dangling loop device that survives reboot and shows up as a stale entry in \`losetup -l\` forever.

**Fix**: return \`SubvolumeError::LoopDetachFailed { device, reason }\` when the detach fails. The error names the specific \`/dev/loopN\` so the operator can \`fuser /dev/loopN\` or \`lsof\` to find what's holding it.

**Exception**: \`is_already_detached()\` helper recognizes the *\"No such device or address\"* / *\"not in use\"* error shapes that util-linux returns when the device is already cleaned up (operator did it manually, or a prior failed delete made it part-way). Treating that as success keeps retries idempotent.

## New error variants

Both \`thiserror\`-derived, \`Display\`-formatted, flow through the existing router \`err(req, e)\` mapping to a JSON-RPC error response — no changes needed in \`router/subvolume.rs\`.

- \`SubvolumeError::ChildrenStuck(String)\` — list of stuck children with their per-child error messages joined by \`;\`.
- \`SubvolumeError::LoopDetachFailed { device, reason }\` — names the device + the underlying losetup stderr.

## Tests

- **\`is_already_detached_matches_real_losetup_errors\`** — pins the three error shapes seen in the wild across util-linux versions.
- **\`is_already_detached_rejects_real_failures\`** — confirms EBUSY, EPERM, and spawn failures aren't mistaken for \"already cleaned up\".
- **\`subvolume_error_display_lists_stuck_children\`** — pins the operator-facing message format so a future accidental change surfaces as a test failure (the WebUI renders this string in a toast — getting it right matters).
- **\`subvolume_error_display_names_loop_device\`** — same constraint for the loop-device variant.
- 14 \`subvolume::\` tests pass, full workspace clippy clean.

## Out of scope

- Pre-flight check (test each child before starting) — bcachefs has no dry-run and any check would race with concurrent opens. The collect-and-report approach matches reality more honestly.
- Atomic rollback — not possible at the filesystem layer.
- Integration test exercising the live failure path — needs the fault-injection harness called out in the security audit (nasty-tests recovery flows, separate multi-week scope).

## Test plan
- [ ] Create subvolume \`parent\` with nested \`parent/child1\`, \`parent/child2\`
- [ ] Mount \`parent/child1\` from a VM (or open a long-lived fd)
- [ ] Delete \`parent\` via WebUI → error toast names \`parent/child1\` and the bcachefs reason, doesn't trip a generic \"directory not empty\"
- [ ] Release the lock, retry delete → succeeds
- [ ] Create block subvolume, manually \`losetup -d\` its device, delete via WebUI → succeeds (idempotent)
- [ ] Create block subvolume, hold the loop device open from another process, delete via WebUI → error toast names \`/dev/loopN\` and the busy reason