### PR TITLE
webui: add Permissions-Policy and Cross-Origin-Opener-Policy headers

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1972,12 +1972,27 @@ in {
           # 'unsafe-inline' for now because SvelteKit emits inline
           # bootstrap + theme-detection scripts in index.html;
           # nonces / hashes are a follow-up.
+          #
+          # Permissions-Policy denies every powerful browser feature
+          # — a NAS dashboard has no business asking for camera,
+          # microphone, geolocation, etc., so if a future XSS slips
+          # through CSP, the browser still won't prompt the operator
+          # for those permissions. `interest-cohort=()` opts out of
+          # FLoC / Topics for the same defense-in-depth reason.
+          #
+          # COOP `same-origin` severs the `window.opener` channel for
+          # any popup we open. NASty doesn't deliberately open external
+          # popups today, but the cost of pre-committing to the
+          # tighter policy is zero and it eliminates a future-XSS
+          # pivot point.
           header {
             Strict-Transport-Security "max-age=31536000; includeSubDomains"
             X-Content-Type-Options "nosniff"
             X-Frame-Options "DENY"
             Referrer-Policy "same-origin"
             Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; connect-src 'self' ws: wss:; frame-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+            Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()"
+            Cross-Origin-Opener-Policy "same-origin"
           }
 
           # File-content preview: same engine endpoint, but a much


### PR DESCRIPTION
Closes two info-level findings from an external security scan against the Caddy-served WebUI. Both are real and both are defense-in-depth rather than active exploit fixes — the scanner correctly flagged them as INFO.

The existing \`header { }\` block in \`(nasty_webui_routes)\` already sets HSTS, CSP, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy. This adds the two remaining headers commonly checked by security scanners.

## Permissions-Policy

Browser default for camera / microphone / geolocation / payment / usb / accelerometer / gyroscope / magnetometer permits any same-origin page to prompt the operator. A NAS dashboard has no business asking for any of those, so if a future XSS slips through CSP, the browser still won't surface the prompt — one less primitive in the attacker's toolkit. \`interest-cohort=()\` opts out of FLoC / Topics for the same reason.

\`\`\`
Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
\`\`\`

## Cross-Origin-Opener-Policy

\`same-origin\` severs \`window.opener\` for any popup the WebUI opens. NASty doesn't deliberately open external popups today (downloads go through the engine), so live exploitability is essentially zero — but pre-committing to the tighter policy costs nothing and removes a future-XSS pivot point if someone later adds a \`<a target=_blank>\` to an external URL.

\`\`\`
Cross-Origin-Opener-Policy: same-origin
\`\`\`

## Why no COEP

\`Cross-Origin-Embedder-Policy\` is only needed for SharedArrayBuffer / WebAssembly threading, neither of which the WebUI uses. Adding COEP would actually break some embed scenarios (e.g. the file-content preview iframe) without buying anything.

## Test plan
- [ ] After deploy: \`curl -I https://nas.0f.ee\` shows both new headers in the response
- [ ] Re-run the original security scan — both findings now resolved
- [ ] WebUI loads and functions normally (no console errors, no broken iframes)
- [ ] File-content preview iframe still renders (verifies the \`/api/files/content\` block isn't accidentally over-restricted)
- [ ] Long-running websockets (terminal, VM console, log viewer) still connect