### PR TITLE
webui: confirm before removing SSH key or SMB group membership

### DIFF
--- a/webui/src/routes/services/+page.svelte
+++ b/webui/src/routes/services/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import { getClient } from '$lib/client';
 	import { withToast } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
 	import type { ProtocolStatus, AppsStatus, Filesystem, TuningConfig, NutConfig, UpsStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -123,6 +124,14 @@
 	}
 
 	async function removeSshKey(key: string) {
+		// Removing an SSH key is destructive AND potentially self-locking
+		// (operator's current SSH session may be holding the only other
+		// path back into the box). Confirm before yanking it.
+		const fingerprint = key.split(/\s+/).slice(0, 2).join(' ');
+		if (!await confirm(
+			'Remove this SSH key?',
+			`The key (${fingerprint}…) will no longer be able to log in. If this is the key you used to SSH into this box, you'll lose your shell access.`,
+		)) return;
 		await withToast(() => client.call('system.ssh.remove_key', { key }), 'SSH key removed');
 		sshLoaded = false;
 		await loadSsh();

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -744,8 +744,22 @@
 										<label class="flex items-center gap-1.5 text-sm cursor-pointer rounded border px-2 py-1 transition-colors {isMember ? 'border-blue-500/40 bg-blue-500/10' : 'border-border hover:bg-muted/30'}">
 											<input type="checkbox" class="rounded border-input"
 												checked={isMember}
-												onchange={async () => {
+												onchange={async (e) => {
 													if (isMember) {
+														// Removing membership via a checkbox toggle is
+														// easy to misclick. Confirm before yanking the
+														// user out of an SMB group — depending on the
+														// share's valid_users list, this can sever
+														// their access entirely.
+														if (!await confirm(
+															`Remove ${user.username} from ${group.name}?`,
+															`Any SMB shares that restrict access to the ${group.name} group will become unreachable for this user until they're re-added.`,
+														)) {
+															// Operator canceled — revert the checkbox
+															// (Svelte's onchange already flipped it).
+															(e.currentTarget as HTMLInputElement).checked = true;
+															return;
+														}
 														await withToast(() => client.call('smb.group.remove_member', { group: group.name, user: user.username }), `Removed from ${group.name}`);
 													} else {
 														await withToast(() => client.call('smb.group.add_member', { group: group.name, user: user.username }), `Added to ${group.name}`);


### PR DESCRIPTION
Two missing confirmation dialogs from the recent security review. Both are destructive ops that fire on a single click with no undo path — easy misclick territory.

## SSH key remove (\`/services\`)

Click → keys gone immediately. Worst case: the removed key is the same one the operator is currently SSH'd in with, severing their last shell path back into the box if the WebUI also crashes.

Confirm dialog names the key (first two whitespace-separated tokens, which covers the type + base64 prefix without dumping a full pubkey into a small modal) and explicitly calls out the self-lockout risk.

## SMB group membership remove (\`/users\`)

Group memberships render as checkboxes next to each user. The \`onchange\` handler called \`smb.group.remove_member\` immediately on uncheck — a misclick on the wrong row silently broke a user's access to every share restricted to that group.

- Confirm dialog names the user + group; explains shares restricting to this group will go unreachable until re-added.
- On cancel, revert the checkbox via \`e.currentTarget.checked = true\` — Svelte's \`onchange\` already flipped it visually, so without the revert the operator would see the checkbox in the \"removed\" state even though the RPC didn't fire.

Add operations stay one-click — only the destructive direction needs the friction. Both pages already had the \`confirm()\` infrastructure in scope.

No new tests — the confirm component is well-covered, the wrapping logic is a single guard clause.

## Test plan
- [ ] SSH page: click Remove on a key → dialog appears with truncated fingerprint, naming the self-lockout risk
- [ ] Confirm → key removed; cancel → key stays
- [ ] Users page: uncheck a group membership checkbox → dialog appears
- [ ] Cancel → checkbox snaps back to checked, RPC never fires
- [ ] Confirm → membership removed
- [ ] Check (add) operation still one-click, no dialog