### PR TITLE
iscsi: redact CHAP password in configfs_write error logs

### DIFF
--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -592,7 +592,7 @@ impl IscsiService {
 
         if let (Some(userid), Some(password)) = (&req.userid, &req.password) {
             configfs_write(&format!("{acl_path}/auth/userid"), userid).await?;
-            configfs_write(&format!("{acl_path}/auth/password"), password).await?;
+            configfs_write_secret(&format!("{acl_path}/auth/password"), password).await?;
         }
 
         // Disable generate_node_acls when explicit ACLs are added
@@ -731,6 +731,17 @@ async fn configfs_write(path: &str, value: &str) -> Result<(), IscsiError> {
     tokio::fs::write(path, value)
         .await
         .map_err(|e| IscsiError::ConfigFs(format!("write {path}={value}: {e}")))
+}
+
+/// Like `configfs_write` but redacts `value` in the error message so
+/// secret payloads (CHAP passwords, future DH-CHAP keys) don't end up
+/// in tracing output / journald. Use for any write where the value is
+/// confidential — the path stays in the error so the operator can
+/// still tell which target/ACL the failure was on.
+async fn configfs_write_secret(path: &str, value: &str) -> Result<(), IscsiError> {
+    tokio::fs::write(path, value)
+        .await
+        .map_err(|e| IscsiError::ConfigFs(format!("write {path}=<redacted>: {e}")))
 }
 
 async fn configfs_symlink(target: &str, link: &str) -> Result<(), IscsiError> {
@@ -1063,5 +1074,55 @@ mod tests {
         assert!(validate_target_name("").is_err());
         assert!(validate_target_name(&"x".repeat(201)).is_err());
         assert!(validate_target_name(&"x".repeat(200)).is_ok());
+    }
+
+    #[tokio::test]
+    async fn configfs_write_secret_redacts_value_in_error() {
+        // Target a path that's guaranteed to fail (no /sys outside Linux,
+        // and on Linux the test process won't have configfs mounted at a
+        // bogus path). The failure path is what we care about — we want
+        // to confirm the resulting error message names the path but does
+        // NOT contain the secret value.
+        let bogus_path = "/sys/this/does/not/exist/auth/password";
+        let secret = "super-secret-chap-password-do-not-leak";
+
+        let err = configfs_write_secret(bogus_path, secret)
+            .await
+            .expect_err("write to nonexistent path must fail");
+        let msg = format!("{err}");
+
+        assert!(
+            msg.contains(bogus_path),
+            "error must surface the path so operator can identify the target: {msg}"
+        );
+        assert!(
+            msg.contains("<redacted>"),
+            "error must mark the value as redacted: {msg}"
+        );
+        assert!(
+            !msg.contains(secret),
+            "SECURITY: error message leaked the secret value: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn configfs_write_keeps_value_in_error_for_diagnostics() {
+        // The non-secret variant intentionally includes the value in
+        // the error — it's how operators debug "why did the write of
+        // '0' to /sys/.../enable fail?". Pin that behavior so a future
+        // over-eager redaction pass doesn't lose the diagnostic.
+        let bogus_path = "/sys/this/does/not/exist/enable";
+        let non_secret_value = "1";
+
+        let err = configfs_write(bogus_path, non_secret_value)
+            .await
+            .expect_err("write to nonexistent path must fail");
+        let msg = format!("{err}");
+
+        assert!(msg.contains(bogus_path));
+        assert!(
+            msg.contains(non_secret_value),
+            "non-secret values must surface in errors for diagnostics: {msg}"
+        );
     }
 }


### PR DESCRIPTION
A failed write to \`/sys/.../tpgt_1/acls/<iqn>/auth/password\` used to surface the plaintext CHAP password in the resulting error — both in the caller's \`IscsiError::ConfigFs\` string and in any \`tracing::error!\` / journald entry that wrapped it. The generic \`configfs_write\` helper formats \`\"write {path}={value}: {e}\"\` which is the right tradeoff for diagnostic values like \"0\" or \"1\" or an IP, but the wrong tradeoff for secrets.

## Fix

New parallel \`configfs_write_secret(path, value)\` that does the same \`tokio::fs::write\` but redacts the value in the error message:

\`\`\`
write /sys/.../auth/password=<redacted>: <io error>
\`\`\`

Only one call site needs to switch — the CHAP password write at \`add_acl\` line 595. The companion \`auth/userid\` write stays on the non-secret variant: usernames aren't secret, and seeing the failing username in logs is useful when debugging \"why isn't initiator X connecting?\".

## Scope

- NVMe-oF has no equivalent secret writes today (we don't implement DH-CHAP yet).
- SMB's \`set_smb_password\` formats the password into stdin but doesn't echo it in any error string — no log-path leak. Out of scope for this PR.

## Tests

- **\`configfs_write_secret_redacts_value_in_error\`** — the most important test in this PR. Targets a guaranteed-fail path, asserts the error includes the path + \`<redacted>\` but NOT the secret. If a future refactor accidentally re-introduces value formatting into the error, this fails loudly.
- **\`configfs_write_keeps_value_in_error_for_diagnostics\`** — pins the non-secret variant's behavior so a future over-eager redaction pass doesn't lose diagnostics on normal writes.

## Test plan
- [ ] Create an iSCSI target, add an ACL with a CHAP password to a *bad* IQN (forces the configfs write to fail), confirm journald shows \`<redacted>\` rather than the password
- [ ] Normal happy-path add_acl still works
- [ ] Removing the ACL still cleans up correctly