### PR TITLE
readme: add Community section with the Proxmox plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ NASty can serve as a storage backend for Kubernetes — provisioning persistent 
 - **[nasty-chart](https://github.com/nasty-project/nasty-chart)** — Helm chart for one-command install
 - **[nasty-plugin](https://github.com/nasty-project/nasty-plugin)** — `kubectl-nasty` for inspecting volumes, snapshots, clones, and health from the CLI
 
+## Community
+
+Integrations built by the community on top of NASty's JSON-RPC API:
+
+- **[nastyplugin](https://github.com/WarlockSyno/nastyplugin)** by [@WarlockSyno](https://github.com/WarlockSyno) — Proxmox storage plugin for using NASty as a backing store for VM and container disks
+
+Building something with NASty? Open an issue or PR and we'll add it here.
+
 ## Screenshots
 
 <p align="center">


### PR DESCRIPTION
@WarlockSyno built a [Proxmox storage plugin](https://github.com/WarlockSyno/nastyplugin) on top of NASty's JSON-RPC API — surfacing it in the README so other Proxmox operators can find it.

Adds a new **Community** section right after Kubernetes (which lists the first-party CSI / chart / kubectl plugin) with a short invitation for others to add their own integrations.

The framing is intentionally light — *\"built by the community\"* rather than *\"third-party / not officially supported\"* — to acknowledge the work without taking on a maintenance promise for someone else's repo.

## Test plan
- [ ] Rendered Markdown looks right on GitHub (correct heading hierarchy, link works, sits between Kubernetes and Screenshots)