### PR TITLE
iscsi: make dual-stack default v6 portal best-effort

### DIFF
--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -272,25 +272,26 @@ impl IscsiService {
             return Ok(existing);
         }
 
-        let portals = match req.portals {
-            Some(p) => p,
+        // Split portals into "must succeed" and "best effort" buckets.
+        // Operator-supplied portals are always mandatory — if they
+        // typed `[::]:3260` and it can't bind, they need a loud error,
+        // not silent v4-only. The default v6 portal is best-effort:
+        // host_has_global_ipv6() catches the obvious "v4-only host"
+        // case, but it can't catch the harder ones (LIO compiled
+        // without v6, kernel iSCSI module loaded with ipv6 disabled,
+        // sysctl `net.ipv6.bindv6only=0`, container runtime that
+        // exposes v6 addresses but not v6 sockets). Those all surface
+        // as EINVAL from configfs mkdir of `[::]:3260` and used to
+        // wedge target creation entirely — observed in nasty-csi CI.
+        let (mandatory_portals, opportunistic_v6) = match req.portals {
+            Some(p) => (p, false),
             None => {
-                // Dual-stack default: always listen on v4 INADDR_ANY,
-                // additionally listen on v6 IN6ADDR_ANY when the host
-                // actually has a global v6 address. v4-only hosts stay
-                // v4-only — `[::]:3260` would bind successfully but
-                // accept zero connections and confuse `ss -tlnp` output.
-                let mut defaults = vec![Portal {
+                let defaults = vec![Portal {
                     ip: "0.0.0.0".to_string(),
                     port: 3260,
                 }];
-                if crate::v6::host_has_global_ipv6().await {
-                    defaults.push(Portal {
-                        ip: "::".to_string(),
-                        port: 3260,
-                    });
-                }
-                defaults
+                let try_v6 = crate::v6::host_has_global_ipv6().await;
+                (defaults, try_v6)
             }
         };
 
@@ -298,10 +299,41 @@ impl IscsiService {
         let tpg_path = format!("{ISCSI_BASE}/{iqn}/tpgt_1");
         configfs_mkdir(&tpg_path).await?;
 
-        // Create portals
-        for portal in &portals {
+        // Create mandatory portals first — any failure aborts the
+        // whole create, but we've only created the TPG dir so far,
+        // so cleanup is just rmdir'ing the TPG and the target dir.
+        let mut created_portals = Vec::with_capacity(mandatory_portals.len() + 1);
+        for portal in &mandatory_portals {
             let np_path = np_path_for(&tpg_path, &portal.ip, portal.port);
-            configfs_mkdir(&np_path).await?;
+            if let Err(e) = configfs_mkdir(&np_path).await {
+                // Best-effort cleanup of what we created so far so the
+                // next attempt doesn't trip the idempotency check with
+                // a stale half-target.
+                let _ = configfs_rmdir(&tpg_path).await;
+                let _ = configfs_rmdir(&format!("{ISCSI_BASE}/{iqn}")).await;
+                return Err(e);
+            }
+            created_portals.push(portal.clone());
+        }
+
+        // Best-effort v6 portal — skipped on EINVAL/etc. so v4 stays
+        // up on hosts where LIO can't bind v6. Operator can still add
+        // a specific v6 portal manually via share.iscsi.add_portal,
+        // which surfaces the real error (because that call is opted
+        // into and must not silently no-op).
+        if opportunistic_v6 {
+            let v6_portal = Portal {
+                ip: "::".to_string(),
+                port: 3260,
+            };
+            let np_path = np_path_for(&tpg_path, &v6_portal.ip, v6_portal.port);
+            match configfs_mkdir(&np_path).await {
+                Ok(()) => created_portals.push(v6_portal),
+                Err(e) => warn!(
+                    "iSCSI dual-stack default [::]:3260 portal for {iqn} skipped: {e}; \
+                     v4 portal is up, add a v6 portal manually if needed"
+                ),
+            }
         }
 
         // Disable authentication, allow any initiator, allow writes
@@ -316,7 +348,10 @@ impl IscsiService {
             id: Uuid::new_v4().to_string(),
             iqn: iqn.clone(),
             alias: req.alias,
-            portals,
+            // Stored list is what actually exists in configfs, not what
+            // the operator asked for — keeps state and reality in sync
+            // when the opportunistic v6 portal got skipped.
+            portals: created_portals,
             luns: vec![],
             acls: vec![],
             enabled: true,


### PR DESCRIPTION
Fixes the nasty-csi integration regression introduced by #391 (dual-stack auto-portal). Observed in [actions run 26914500373](https://github.com/nasty-project/nasty-csi/actions/runs/26914500373) — both \`E2E: iSCSI\` and \`E2E: Shared\` jobs failing with:

\`\`\`
rpc error: ... Failed to create iSCSI target '...': configfs
error: mkdir /sys/kernel/config/target/iscsi/.../tpgt_1/np/[::]:3260:
Invalid argument (os error 22)
\`\`\`

## What broke

PR #391 added a \`[::]:3260\` portal to the default list when \`host_has_global_ipv6()\` returns true. The detector catches the obvious \"v4-only host\" case but not the harder ones:

- LIO kernel module compiled without IPv6 support
- iSCSI target module loaded with IPv6 disabled  
- \`sysctl net.ipv6.bindv6only=0\` interacting badly with \`[::]\`
- Container / VM runtimes that expose v6 addresses on the interface but don't allow v6 listening sockets

All of those surface as EINVAL from \`configfs_mkdir\` on \`np/[::]:3260\`. The fail-fast loop bubbled that up, aborting target creation entirely and leaving a half-created TPG dir in configfs.

## Fix

Split portal handling into two buckets in \`IscsiService::create()\`:

| Bucket | What | Failure behavior |
| --- | --- | --- |
| Mandatory | Operator-supplied portals + default \`0.0.0.0:3260\` | Fail-fast; cleanup TPG + target dir before returning |
| Opportunistic | The dual-stack default \`[::]:3260\` only | Log \`warn!\`, skip the portal, continue |

The stored \`IscsiTarget.portals\` field now reflects what's actually in configfs (not what was attempted). Keeps state and reality in sync when v6 got skipped — the UI's Remove-portal button stays accurate, and restore-from-state on reboot doesn't try to re-create a portal LIO already rejected.

## Why not just disable the dual-stack default

Operator-supplied portals stay strictly required. If you type \`[::]:3260\` into the Add Portal form (PR #390) and it can't bind, you get a loud error — that's the correct behavior for an explicit ask. The opportunistic skip is only for the *automatic* dual-stack default that #391 added.

This brings iSCSI in line with the NVMe-oF dual-stack auto-port code in #391, which already used best-effort.

## Tests

No new unit tests — the failure mode requires real configfs and is exactly what the nasty-csi integration suite exercises. After this lands, the \`E2E: iSCSI\` and \`E2E: Shared\` jobs should go green on hosts where LIO rejects \`[::]\`.

## Test plan
- [ ] Merge → re-run nasty-csi Integration Tests → iSCSI + Shared E2E now pass
- [ ] On a dual-stack host with working LIO v6 (e.g. nasty.0f.ee with proper config), create iSCSI target without explicit portals → both v4 and v6 portals listed
- [ ] On a v6-broken host, create iSCSI target → v4 portal only, journal shows the \`warn!\` line naming the configfs error