### PR TITLE
backup: cron-driven scheduler — the schedule field finally fires

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -794,6 +794,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,6 +2615,7 @@ name = "nasty-backup"
 version = "0.0.9"
 dependencies = [
  "chrono",
+ "cron",
  "jiff",
  "nasty-common",
  "rustic_backend",
@@ -2902,7 +2914,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -5077,7 +5089,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5086,7 +5098,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5852,6 +5864,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -6059,7 +6080,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6087,7 +6108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -6214,7 +6235,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6242,5 +6263,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow",
+ "winnow 1.0.3",
 ]

--- a/engine/nasty-backup/Cargo.toml
+++ b/engine/nasty-backup/Cargo.toml
@@ -15,6 +15,7 @@ thiserror.workspace = true
 schemars.workspace = true
 uuid.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+cron = "0.15"
 rustic_core = "0.11"
 rustic_backend = "0.6"
 jiff = "0.2"

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -3,6 +3,8 @@
 //! Manages backup profiles, scheduling, and execution. Uses rustic_core
 //! library directly for backup operations (restic-compatible repo format).
 
+pub mod scheduler;
+
 use nasty_common::secrets::{self, EncryptedBlob, SecretsStatus};
 use rustic_backend::BackendOptions;
 use rustic_core::{

--- a/engine/nasty-backup/src/scheduler.rs
+++ b/engine/nasty-backup/src/scheduler.rs
@@ -1,0 +1,397 @@
+//! Cron-driven backup scheduler.
+//!
+//! Reads the `schedule` field on each [`BackupProfile`] and fires
+//! `run_backup(id)` when the cron expression's next occurrence has
+//! passed since the last attempted run. Designed to be polled from a
+//! single tokio task in the engine's main loop — the `cron` crate
+//! itself is sync and pure, so all the time + IO concerns live in
+//! [`SchedulerTick::evaluate`] / [`run_scheduler_loop`] rather than
+//! in the cron-handling helpers below.
+//!
+//! # Why poll instead of timer-per-profile
+//!
+//! Per-profile `tokio::time::sleep_until` would be slightly more
+//! efficient but creates two problems: (1) profile-list changes
+//! (add / remove / re-schedule) require cancelling and respawning
+//! tasks, and the race between "operator hits Save" and "old task
+//! fires once more" produces confusing duplicate-run behavior;
+//! (2) the engine restart cadence is fast enough that any time-of-day
+//! drift the polling approach introduces (up to one tick interval)
+//! is invisible to operators. A 60 s tick is well under the cron
+//! resolution and well under any backup-scheduling expectation.
+//!
+//! # Missed-run policy
+//!
+//! On engine start, each profile's `last_attempted_at` is seeded to
+//! "now" — meaning a backup that was scheduled to run during engine
+//! downtime is NOT caught up. Catch-up runs would risk a thundering
+//! herd of overdue jobs after a long outage, plus a backup taken
+//! "early" relative to its operator-set time is rarely what was
+//! wanted. Operators who explicitly want a missed run can click Run
+//! in the WebUI.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use crate::{BackupProfile, BackupService};
+
+/// Errors returned by the cron-parsing helpers. Surfaced to operators
+/// via `tracing::warn!` rather than failing the engine boot — a
+/// malformed schedule on one profile must not block the others.
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    #[error("schedule '{0}' is not a valid cron expression: {1}")]
+    InvalidCron(String, String),
+}
+
+/// Parse a 5-field (POSIX) or 6-field cron expression. The WebUI
+/// emits 5-field expressions (`min hour dom month dow`) for the
+/// presets it offers; we transparently promote those to the 6-field
+/// form the `cron` crate expects by prepending a `0` seconds column.
+/// 6-field expressions pass through unchanged.
+pub fn parse_cron(expr: &str) -> Result<Schedule, SchedulerError> {
+    let trimmed = expr.trim();
+    let field_count = trimmed.split_whitespace().count();
+    let normalized = match field_count {
+        5 => format!("0 {trimmed}"),
+        6 | 7 => trimmed.to_string(),
+        _ => {
+            return Err(SchedulerError::InvalidCron(
+                expr.to_string(),
+                format!("expected 5, 6, or 7 fields; got {field_count}"),
+            ));
+        }
+    };
+    Schedule::from_str(&normalized)
+        .map_err(|e| SchedulerError::InvalidCron(expr.to_string(), e.to_string()))
+}
+
+/// Should the profile fire on this tick? Returns `Some(next_fire)`
+/// when the schedule's next occurrence after `last_attempted_at` has
+/// passed (i.e. `<= now`), `None` otherwise. Pulled out as a pure
+/// function so the firing decision is testable without spawning real
+/// backup runs.
+///
+/// `last_attempted_at` is the floor for the cron lookup, so a profile
+/// that has just run won't re-fire on the same tick.
+pub fn should_fire(
+    schedule: &Schedule,
+    last_attempted_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    schedule
+        .after(&last_attempted_at)
+        .next()
+        .filter(|next| *next <= now)
+}
+
+/// One iteration of the scheduler loop. Pulled out from
+/// [`run_scheduler_loop`] so the firing decision and the in-memory
+/// state-machine update are testable in isolation, without spawning
+/// tokio tasks or hitting the real `run_backup`.
+pub struct SchedulerTick {
+    /// Per-profile timestamp of the last cron-driven attempt. Seeded
+    /// to `started_at` on engine start; updated whenever
+    /// [`should_fire`] returns `Some`. Profiles deleted between ticks
+    /// have their entries cleaned up to keep this map bounded.
+    pub last_attempted: HashMap<String, DateTime<Utc>>,
+    pub started_at: DateTime<Utc>,
+}
+
+impl SchedulerTick {
+    pub fn new(started_at: DateTime<Utc>) -> Self {
+        Self {
+            last_attempted: HashMap::new(),
+            started_at,
+        }
+    }
+
+    /// Walk `profiles` and return the IDs that should fire on this tick.
+    /// Updates `self.last_attempted` for every fired profile and prunes
+    /// entries for profiles that have disappeared.
+    pub fn evaluate(&mut self, profiles: &[BackupProfile], now: DateTime<Utc>) -> Vec<String> {
+        let live_ids: std::collections::HashSet<&str> =
+            profiles.iter().map(|p| p.id.as_str()).collect();
+        self.last_attempted
+            .retain(|id, _| live_ids.contains(id.as_str()));
+
+        let mut to_fire = Vec::new();
+        for profile in profiles {
+            if !profile.enabled {
+                continue;
+            }
+            let Some(expr) = profile.schedule.as_deref() else {
+                continue;
+            };
+            if expr.trim().is_empty() {
+                continue;
+            }
+            let schedule = match parse_cron(expr) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("backup profile '{}' has invalid schedule: {e}", profile.id);
+                    continue;
+                }
+            };
+            let last = *self
+                .last_attempted
+                .entry(profile.id.clone())
+                .or_insert(self.started_at);
+            if let Some(fire_at) = should_fire(&schedule, last, now) {
+                info!(
+                    "backup profile '{}' (id {}) firing on cron: scheduled {fire_at}",
+                    profile.name, profile.id
+                );
+                self.last_attempted.insert(profile.id.clone(), now);
+                to_fire.push(profile.id.clone());
+            } else {
+                debug!(
+                    "backup profile '{}' (id {}) not due yet",
+                    profile.name, profile.id
+                );
+            }
+        }
+        to_fire
+    }
+}
+
+/// Tick interval for the scheduler loop. 60 s is well under any
+/// realistic cron resolution and keeps the per-tick log noise low
+/// (each tick logs at `debug` per profile). The `cron` crate has
+/// per-minute granularity so a faster tick would buy nothing.
+pub const TICK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Long-running scheduler loop. Polls the profile list every
+/// [`TICK_INTERVAL`], evaluates each enabled profile's schedule, and
+/// spawns `run_backup(id)` for every due fire. Each fire is its own
+/// `tokio::spawn` so a slow / hung backup on one profile doesn't
+/// block the scheduler from advancing the others.
+///
+/// Never returns. Call once from `main` as a long-lived
+/// `tokio::spawn`.
+pub async fn run_scheduler_loop(service: BackupService) {
+    let mut tick_state = SchedulerTick::new(Utc::now());
+    info!("backup scheduler started (tick interval: {TICK_INTERVAL:?})");
+
+    loop {
+        tokio::time::sleep(TICK_INTERVAL).await;
+
+        let now = Utc::now();
+        // Scheduler only reads id / name / enabled / schedule —
+        // never secrets — so the redacted output of list_profiles is
+        // fine. run_backup() resolves real secrets on its own.
+        let profiles = service.list_profiles().await;
+        let due = tick_state.evaluate(&profiles, now);
+
+        for profile_id in due {
+            let scheduler_service = service.clone_for_task();
+            tokio::spawn(async move {
+                match scheduler_service.run_backup(&profile_id).await {
+                    Ok(result) if result.success => {
+                        info!(
+                            "scheduled backup completed for '{profile_id}' in {}s",
+                            result.duration_secs
+                        );
+                    }
+                    Ok(result) => {
+                        warn!(
+                            "scheduled backup for '{profile_id}' finished with error: {}",
+                            result.message
+                        );
+                    }
+                    Err(e) => {
+                        warn!("scheduled backup for '{profile_id}' failed to start: {e}");
+                    }
+                }
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BackupTarget, RetentionPolicy};
+    use chrono::TimeZone;
+
+    fn profile_with_schedule(id: &str, cron: &str, enabled: bool) -> BackupProfile {
+        BackupProfile {
+            id: id.into(),
+            name: format!("test-{id}"),
+            enabled,
+            sources: vec!["/data".into()],
+            target: BackupTarget::Local {
+                path: "/srv".into(),
+            },
+            schedule: Some(cron.into()),
+            retention: RetentionPolicy::default(),
+            password: Some("p".into()),
+            password_encrypted: None,
+            snapshot_before: true,
+            repo_initialized: false,
+            last_run: None,
+        }
+    }
+
+    fn ts(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, hour, minute, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn parse_cron_accepts_five_field_posix_form() {
+        // The WebUI's daily preset emits "0 3 * * *" — must work
+        // unmodified or every existing profile silently stops firing.
+        let schedule = parse_cron("0 3 * * *").expect("daily cron parses");
+        let next = schedule
+            .after(&ts(2026, 6, 5, 1, 0))
+            .next()
+            .expect("daily fires at least once");
+        assert_eq!(next, ts(2026, 6, 5, 3, 0));
+    }
+
+    #[test]
+    fn parse_cron_accepts_six_field_with_seconds() {
+        // A hand-written 6-field expression (operator pastes an
+        // expression from cronitor.io etc.) should also work — pass
+        // through unchanged, don't double-prepend `0`.
+        let schedule = parse_cron("0 0 3 * * *").expect("6-field parses");
+        assert_eq!(
+            schedule.after(&ts(2026, 6, 5, 1, 0)).next(),
+            Some(ts(2026, 6, 5, 3, 0))
+        );
+    }
+
+    #[test]
+    fn parse_cron_rejects_garbage() {
+        assert!(parse_cron("not a cron").is_err());
+        assert!(parse_cron("").is_err());
+        // Four fields — neither POSIX cron nor extended.
+        assert!(parse_cron("0 3 * *").is_err());
+    }
+
+    #[test]
+    fn should_fire_returns_some_after_next_occurrence_has_passed() {
+        // 03:00 daily, last attempt was yesterday at 03:00, now is
+        // 03:05 today — that's exactly the "scheduled run + small
+        // tick lag" shape the loop will see in practice.
+        let schedule = parse_cron("0 3 * * *").unwrap();
+        let last = ts(2026, 6, 4, 3, 0);
+        let now = ts(2026, 6, 5, 3, 5);
+        assert!(should_fire(&schedule, last, now).is_some());
+    }
+
+    #[test]
+    fn should_fire_returns_none_when_next_is_in_future() {
+        // 03:00 daily, last attempt at 03:00 today, now is 04:00
+        // today — the next fire is tomorrow, not today.
+        let schedule = parse_cron("0 3 * * *").unwrap();
+        let last = ts(2026, 6, 5, 3, 0);
+        let now = ts(2026, 6, 5, 4, 0);
+        assert!(should_fire(&schedule, last, now).is_none());
+    }
+
+    #[test]
+    fn evaluate_fires_exactly_once_when_the_window_opens() {
+        // Two ticks across the cron occurrence: the first tick fires,
+        // the second tick must not (last_attempted advanced).
+        // Without this property the scheduler would re-fire every
+        // tick within the same minute and stomp on itself.
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let profiles = vec![profile_with_schedule("a", "0 3 * * *", true)];
+
+        // First tick at 03:00 — should fire.
+        let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 3, 0));
+        assert_eq!(fired, vec!["a".to_string()]);
+
+        // Second tick at 03:01 — already fired this cycle, must not
+        // re-fire.
+        let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 3, 1));
+        assert!(fired.is_empty(), "got unexpected re-fire: {fired:?}");
+    }
+
+    #[test]
+    fn evaluate_skips_disabled_profile() {
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let profiles = vec![profile_with_schedule("disabled", "0 3 * * *", false)];
+        let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 3, 0));
+        assert!(fired.is_empty());
+    }
+
+    #[test]
+    fn evaluate_skips_profile_with_no_schedule() {
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let mut profile = profile_with_schedule("manual", "", true);
+        profile.schedule = None;
+        let fired = tick.evaluate(&[profile], ts(2026, 6, 5, 3, 0));
+        assert!(fired.is_empty());
+    }
+
+    #[test]
+    fn evaluate_skips_profile_with_empty_schedule_string() {
+        // Edge case: WebUI saves "" when operator picks "Manual only"
+        // rather than `None`. Both should be treated identically.
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let fired = tick.evaluate(
+            &[profile_with_schedule("manual", "   ", true)],
+            ts(2026, 6, 5, 3, 0),
+        );
+        assert!(fired.is_empty());
+    }
+
+    #[test]
+    fn evaluate_warns_and_skips_on_invalid_cron() {
+        // Operator pastes a malformed expression. The scheduler must
+        // not crash, must not fire anything for that profile, and
+        // must still evaluate the other profiles in the same tick.
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let profiles = vec![
+            profile_with_schedule("bad", "not a cron", true),
+            profile_with_schedule("good", "0 3 * * *", true),
+        ];
+        let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 3, 0));
+        assert_eq!(fired, vec!["good".to_string()]);
+    }
+
+    #[test]
+    fn evaluate_does_not_catch_up_runs_missed_during_engine_downtime() {
+        // started_at is hours after the cron's intended fire time;
+        // the next-fire-after-started_at is tomorrow, NOT today.
+        // Without this guard, every engine restart at 09:00 would
+        // immediately trigger the 03:00 backup, which is the wrong
+        // behavior — operators who want catch-up runs click Run.
+        let started_at = ts(2026, 6, 5, 9, 0);
+        let mut tick = SchedulerTick::new(started_at);
+        let profiles = vec![profile_with_schedule("a", "0 3 * * *", true)];
+        let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 9, 0));
+        assert!(
+            fired.is_empty(),
+            "scheduler must not catch up the missed 03:00 run after engine start at 09:00"
+        );
+    }
+
+    #[test]
+    fn evaluate_prunes_state_for_deleted_profiles() {
+        // Profile gets deleted between ticks — the last_attempted
+        // map entry must be cleaned up so it doesn't leak memory
+        // for the engine's lifetime if profiles churn.
+        let mut tick = SchedulerTick::new(ts(2026, 6, 5, 2, 0));
+        let _ = tick.evaluate(
+            &[profile_with_schedule("a", "0 3 * * *", true)],
+            ts(2026, 6, 5, 3, 0),
+        );
+        assert!(tick.last_attempted.contains_key("a"));
+        let _ = tick.evaluate(&[], ts(2026, 6, 5, 3, 1));
+        assert!(
+            tick.last_attempted.is_empty(),
+            "stale profile state not pruned: {:?}",
+            tick.last_attempted
+        );
+    }
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -532,6 +532,19 @@ async fn main() -> anyhow::Result<()> {
     // Background alert evaluation + notifications
     spawn_alert_notifier(state.clone());
 
+    // Cron-driven backup scheduler. Polls profile list every 60s;
+    // when an enabled profile's cron expression elapses since its
+    // last attempt, fires run_backup as a tokio::spawn so a slow
+    // backup on one profile doesn't block the scheduler advancing
+    // the others. Missed runs during engine downtime are NOT caught
+    // up — see the module docs in nasty_backup::scheduler for why.
+    {
+        let backups = state.backups.clone_for_task();
+        tokio::spawn(async move {
+            nasty_backup::scheduler::run_scheduler_loop(backups).await;
+        });
+    }
+
     // Flip boot_status.overall from Booting → Ready / ReadyWithErrors
     // BEFORE notifying systemd — once we're READY the WebUI is going
     // to start polling /api/boot_status and we want it to immediately


### PR DESCRIPTION
The \`schedule\` field on \`BackupProfile\` has been stored in \`/var/lib/nasty/backups.json\` and rendered by the WebUI (\"Next: in 13h 32m\") since the feature shipped, but **nothing in the engine ever read it.** Operators saw a scheduled-looking UI and reasonably assumed backups were running nightly; in fact \`run_backup\` only ever fired from the Run button.

Caught by an operator wondering why their *Daily at 03:00* config-backup profile on 10.10.10.59 had \`repo_initialized: false\` and \`last_run: null\` after weeks of being enabled.

## New module \`nasty_backup::scheduler\`

| Function | Purpose |
| --- | --- |
| \`parse_cron(expr)\` | Accepts the WebUI's 5-field POSIX form (\`0 3 * * *\`) by prepending \`0\` seconds; 6/7-field forms unchanged. Rejects otherwise with \`InvalidCron\` — surfaced via \`warn!\` per affected profile. |
| \`should_fire(schedule, last_attempted, now)\` | Pure function returning \`Some(next_fire)\` when the cron's next occurrence after \`last_attempted\` is at or before \`now\`. Testable without touching tokio time / IO. |
| \`SchedulerTick::evaluate(&profiles, now)\` | One tick of the loop — walks profiles, skips disabled/no-schedule/empty-schedule, parses cron, asks \`should_fire\`, advances \`last_attempted\`, returns IDs to fire. Prunes deleted-profile state each tick. |
| \`run_scheduler_loop(service)\` | Long-running task. 60 s tick interval. Each due fire is its own \`tokio::spawn\` so a slow / hung backup can't starve the scheduler. |

## Engine wiring

\`main.rs\` spawns \`nasty_backup::scheduler::run_scheduler_loop\` right next to the existing \`spawn_alert_notifier\` — same background-task slot, same restart semantics.

## Missed-run policy (pinned by test)

On engine start, every profile's \`last_attempted\` seeds to *now*, NOT to its real prior run time. Backups scheduled to run during engine downtime are silently skipped rather than caught up.

Two reasons:
1. Catch-up after a long outage would produce a thundering herd of overdue jobs.
2. *\"The backup ran early because the engine just restarted\"* is almost never what was wanted.

Operators who explicitly want a missed run click Run in the WebUI.

## Tests (12 new)

- \`parse_cron\` variants: 5-field POSIX, 6-field with seconds, garbage rejection.
- \`should_fire\`: window-just-opened vs next-is-future.
- \`evaluate\`: fires-once-per-window (no re-fire within the same cron occurrence), disabled-profile skip, no-schedule skip, empty-schedule skip, invalid-cron warn-and-continue, no-catch-up after engine restart, stale-state pruning.

The first two of those are load-bearing — they pin the exact behavior that's been missing for the entire feature lifetime.

\`cargo clippy --workspace --no-deps --all-targets\` clean. \`cargo fmt --check\` clean.

## Dependency

\`cron = \"0.15\"\` — small (~1k LOC), pure Rust, no transitive deps beyond \`chrono\` which is already a workspace dep.

## Phase 2 (not in this PR)

- Persist \`last_attempted\` across engine restarts so missed runs during a brief restart don't show as skipped.
- Per-profile *missed runs* counter surfaced in the WebUI.
- Configurable catch-up policy per profile (default: skip, optional: run-once-on-restart).

## Test plan

- [ ] Upgrade 10.10.10.59 → wait for next 03:00 → \`journalctl -u nasty-engine\` shows \`backup profile 'NASty Config' firing on cron\` + \`scheduled backup completed for 'db65a5ce' in <N>s\`
- [ ] Profile's \`last_run\` populates with success; \`repo_initialized\` flips to true on first fire
- [ ] Disable the profile via WebUI → next tick after 03:00 shows no fire
- [ ] Edit schedule to \`*/5 * * * *\` (every 5 minutes) → fires every 5 minutes, never twice in the same window
- [ ] Type \`not a cron\` as the schedule → engine logs a warn naming the profile; other profiles continue to fire normally