### PR TITLE
backup: use internal getter on the run/init/check/prune paths

### DIFF
--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -703,7 +703,7 @@ impl BackupService {
     }
 
     pub async fn init_repo(&self, id: &str) -> Result<String, BackupError> {
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.target.resolve_secrets(&profile.id).await?;
         tokio::task::spawn_blocking(move || {
@@ -729,7 +729,7 @@ impl BackupService {
     }
 
     pub async fn run_backup(&self, id: &str) -> Result<BackupRunResult, BackupError> {
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
 
         // Auto-init repo if not yet initialized
         if !profile.repo_initialized {
@@ -740,7 +740,7 @@ impl BackupService {
             self.init_repo(id).await?;
         }
 
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.target.resolve_secrets(&profile.id).await?;
         let start = std::time::Instant::now();
@@ -818,7 +818,7 @@ impl BackupService {
     }
 
     pub async fn list_snapshots(&self, id: &str) -> Result<Vec<BackupSnapshot>, BackupError> {
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.target.resolve_secrets(&profile.id).await?;
         tokio::task::spawn_blocking(move || {
@@ -846,7 +846,7 @@ impl BackupService {
     }
 
     async fn prune(&self, id: &str) -> Result<(), BackupError> {
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.target.resolve_secrets(&profile.id).await?;
         let r = profile.retention.clone();
@@ -898,7 +898,7 @@ impl BackupService {
     }
 
     pub async fn check_repo(&self, id: &str) -> Result<String, BackupError> {
-        let profile = self.get_profile(id).await?;
+        let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.target.resolve_secrets(&profile.id).await?;
         tokio::task::spawn_blocking(move || {
@@ -1353,6 +1353,56 @@ mod tests {
         assert!(
             result.is_err(),
             "resolve_secret must try encrypted first; got plaintext fallback {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn redacted_post_migration_profile_is_unusable_for_internal_callers() {
+        // Regression pin for the post-migration "neither encrypted nor
+        // plaintext" failure observed on 10.10.10.84 after #401 landed:
+        // migrate_secrets converted a plaintext password into
+        // password_encrypted=Some(blob), leaving password=None. Routing
+        // such a profile through redacted() blanks the encrypted blob,
+        // so a downstream resolve_profile_password reports the profile
+        // as missing both fields.
+        //
+        // The fix is structural — internal callers (init_repo,
+        // run_backup, list_snapshots, prune, check_repo) must use
+        // get_profile_internal, not the redacted-for-API get_profile.
+        // This test pins the *symptom*: a post-migration profile,
+        // round-tripped through redacted(), MUST come out unusable for
+        // backup operations. If a future refactor makes redacted()
+        // keep secrets, this test fails and forces a conversation
+        // about why the JSON-RPC layer is now leaking blobs.
+        let mut profile = baseline_profile(BackupTarget::Local {
+            path: "/srv".into(),
+        });
+        profile.password = None;
+        profile.password_encrypted = Some(test_blob("ENC"));
+
+        let redacted = profile.redacted();
+        assert!(
+            redacted.password.is_none(),
+            "redacted password leaked: {:?}",
+            redacted.password
+        );
+        assert!(
+            redacted.password_encrypted.is_none(),
+            "redacted encrypted blob leaked: {:?}",
+            redacted.password_encrypted
+        );
+
+        // Confirm the symptom: resolve fails on the redacted profile.
+        // Callers that hit this error in production are using the
+        // wrong getter — fix the caller, don't loosen redacted().
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { resolve_profile_password(&redacted).await });
+        assert!(
+            result.is_err(),
+            "redacted post-migration profile must NOT resolve a password \
+             (otherwise internal callers can accidentally backup with '***'); got {:?}",
             result
         );
     }


### PR DESCRIPTION
Real regression from #401, observed on 10.10.10.84:

\`\`\`
backup failed: secret 'nasty.backup.d446c471.password' is neither
encrypted nor plaintext (profile is missing required field)
\`\`\`

## What broke

The internal callers that resolve secrets — \`init_repo\`, \`run_backup\`, \`list_snapshots\`, \`prune\`, \`check_repo\` — were all going through the **public** \`get_profile()\`, which #401 changed to return a redacted clone.

Post-migration profiles have \`password = None\` + \`password_encrypted = Some(blob)\`. Routing such a profile through \`redacted()\` blanks the encrypted blob AND leaves password as None, so the downstream \`resolve_profile_password\` correctly reports the profile as missing both fields.

Timeline on 10.10.10.84 from journalctl:

\`\`\`
12:35:39  boot phase 'backups.migrate_secrets' completed in 169 ms
12:36:11  backup 'd446c471' failed: ... is neither encrypted nor plaintext
\`\`\`

Migration converted the password correctly (\`password_encrypted\` blob in JSON is real systemd-creds output, intact). The next Run-Now click hit the redacted-profile path and errored before rustic was even called.

## Fix

Swap all six \`self.get_profile(id).await?\` sites in \`BackupService\` to \`self.get_profile_internal(id).await?\` — the internal getter already exists (added in #401 for exactly this use case). The public \`get_profile\` keeps redacting for JSON-RPC callers; we just had the wrong getter at the internal sites.

## Regression test

\`redacted_post_migration_profile_is_unusable_for_internal_callers\` constructs the exact post-migration profile shape, routes it through \`redacted()\`, then asserts both:

1. Redaction blanks the encrypted blob (the JSON-RPC layer must never echo it).
2. \`resolve_profile_password\` on the redacted clone fails.

Property (2) is **intentional** — it's why \`get_profile_internal\` exists. If a future refactor loosens \`redacted()\` so it keeps blobs, this test fails and forces the *\"why are we leaking blobs to the API layer?\"* conversation.

## Why the screenshot showed a prior success

That backup was the *first* run after the engine upgraded, before \`redacted()\` was on this path — it ran with the plaintext password still in place. The migration happened during the next engine restart, converting \`password\` → \`password_encrypted\`. The next Run-Now click after that restart was the first to exercise the broken path.

## Operator impact

- **No data loss.** No security regression — encrypted blob is intact on disk.
- **Affected boxes:** any host that ran the \`migrate_secrets\` boot phase successfully but hasn't taken this hotfix yet.
- **Workaround until deploy:** edit the profile via WebUI and re-enter the password — the \`carry_forward\` + encrypt-on-save path re-populates \`password_encrypted\` from operator input. (But really, just ship the hotfix.)

## Test plan
- [ ] Deploy to 10.10.10.84 → click Run Now → backup completes successfully without re-entering the password
- [ ] Confirm the \`last_run\` payload returned to the WebUI still has the password field absent (no regression in the API redaction)
- [ ] Same for a profile with an S3 cloud secret — operator never re-entered \`secret_key\` post-migration, scheduled backup still succeeds