### PR TITLE
backup: long-running RPCs return a job handle; clients poll for state

### DIFF
--- a/engine/nasty-backup/src/jobs.rs
+++ b/engine/nasty-backup/src/jobs.rs
@@ -1,0 +1,469 @@
+//! Background job registry for long-running backup operations.
+//!
+//! Some backup RPCs — `backup.repo.init`, `backup.repo.check`, and
+//! `backup.run` — take long enough on real-world targets (remote
+//! restic-rest, large repos, cold S3) that the synchronous RPC
+//! pattern doesn't work for them: the WebUI's default 10 s WebSocket
+//! timeout fires before the call returns, even when the operation
+//! itself succeeds.  Observed: `backup.repo.init` against a remote
+//! REST target took 32 s, the WebUI gave up at 10 s and showed
+//! "Request timed out" while the engine kept going and successfully
+//! initialized the repo.
+//!
+//! This module provides the alternative: the RPC accepts the request,
+//! creates a [`BackupJob`] in [`Pending`], spawns the actual work in a
+//! detached `tokio::spawn`, and returns the job handle immediately.
+//! The client polls [`JobRegistry::get`] / [`JobRegistry::list`] to
+//! watch the state transition `Pending → Running → Succeeded|Failed`.
+//!
+//! State lives in-memory only.  An engine restart during a job loses
+//! the registry entry — but `BackupProfile.last_run` is persisted by
+//! the backup path itself, so an operator can still tell whether the
+//! actual backup completed by looking at the profile.  Persisting
+//! mid-flight job state would invite "job claims Running but the
+//! engine process that owned it is gone" inconsistencies that the
+//! restart-clears policy sidesteps.
+//!
+//! [`Pending`]: BackupJobState::Pending
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
+/// What the engine is doing on behalf of the job. The shape of the
+/// success [`BackupJob::result`] payload depends on this kind: an
+/// `InitRepo` job's success result is a plain message string,
+/// a `RunBackup` job's is a `BackupRunResult` JSON object, and
+/// `CheckRepo` is the rustic check message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BackupJobKind {
+    InitRepo,
+    RunBackup,
+    CheckRepo,
+}
+
+impl BackupJobKind {
+    fn label(self) -> &'static str {
+        match self {
+            BackupJobKind::InitRepo => "init",
+            BackupJobKind::RunBackup => "run",
+            BackupJobKind::CheckRepo => "check",
+        }
+    }
+}
+
+/// Lifecycle state of a [`BackupJob`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackupJobState {
+    /// Job created, task not yet spawned (essentially transient — the
+    /// caller sees this only on the very first response).
+    Pending,
+    /// Spawned task is running. `started_at` is populated.
+    Running,
+    /// Task finished without error. `finished_at` is populated and
+    /// `result` carries the engine's success payload.
+    Succeeded,
+    /// Task finished with an error. `finished_at` is populated and
+    /// `error` carries the operator-facing message.
+    Failed,
+}
+
+impl BackupJobState {
+    /// Has this job stopped progressing? Used by the GC sweep and by
+    /// the "is a job currently active for this profile" check.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, BackupJobState::Succeeded | BackupJobState::Failed)
+    }
+}
+
+/// One unit of long-running backup work tracked by the registry.
+/// Safe to surface to the WebUI as-is; carries no secrets (the
+/// `result` field for `InitRepo` / `CheckRepo` is a status message,
+/// for `RunBackup` it's a `BackupRunResult` which itself is already
+/// safe to expose).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BackupJob {
+    pub id: String,
+    pub profile_id: String,
+    pub kind: BackupJobKind,
+    pub state: BackupJobState,
+    /// RFC3339 timestamp string. Matches the convention used by
+    /// `BackupRunResult.timestamp` — schemars doesn't derive
+    /// `JsonSchema` for `chrono::DateTime` without an extra feature,
+    /// and we'd rather not pull that in just for log-style timestamps.
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+    /// Free-form operator-facing message surfaced while the job runs.
+    /// Reserved for a future progress-reporting hook (rustic exposes a
+    /// callback we don't yet wire); empty in this Phase 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<String>,
+    /// Engine result payload on success. Shape depends on `kind`:
+    /// JSON string for `InitRepo` / `CheckRepo`, `BackupRunResult`
+    /// JSON object for `RunBackup`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Operator-facing error message on failure. Display-formatted
+    /// from the underlying `BackupError`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl BackupJob {
+    fn new(profile_id: String, kind: BackupJobKind) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            profile_id,
+            kind,
+            state: BackupJobState::Pending,
+            created_at: now_rfc3339(),
+            started_at: None,
+            finished_at: None,
+            progress: None,
+            result: None,
+            error: None,
+        }
+    }
+}
+
+/// Errors surfaced from the registry's start path. Distinct from
+/// `BackupError` because the *job* lifecycle has failure modes the
+/// underlying backup code doesn't (collision with a running job).
+#[derive(Debug, Error)]
+pub enum JobError {
+    #[error("backup job already running for profile '{0}' (job id: {1})")]
+    AlreadyRunning(String, String),
+}
+
+/// How long a finished job's entry sticks around in the registry
+/// before being garbage-collected. Long enough that the WebUI's
+/// polling loop comfortably sees the terminal state and can render
+/// the success / failure UI before the entry disappears; short
+/// enough that an operator clicking Run repeatedly throughout the
+/// day doesn't accumulate thousands of entries.
+const JOB_RETENTION: Duration = Duration::hours(1);
+
+/// In-memory store of currently-active and recently-finished backup
+/// jobs. Cheap-to-clone Arc so the spawned task can update its own
+/// entry without going through the BackupService.
+#[derive(Clone, Default)]
+pub struct JobRegistry {
+    inner: Arc<RwLock<HashMap<String, BackupJob>>>,
+}
+
+impl JobRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a new Pending job for `profile_id` with `kind`, fail if
+    /// another non-terminal job already exists for the same profile.
+    /// Returns the freshly-inserted job by value so the caller can
+    /// hand it straight back to the RPC client without re-reading
+    /// the registry.
+    pub async fn start(
+        &self,
+        profile_id: &str,
+        kind: BackupJobKind,
+    ) -> Result<BackupJob, JobError> {
+        let mut map = self.inner.write().await;
+        self.gc_locked(&mut map);
+
+        if let Some(existing) = map
+            .values()
+            .find(|j| j.profile_id == profile_id && !j.state.is_terminal())
+        {
+            return Err(JobError::AlreadyRunning(
+                profile_id.to_string(),
+                existing.id.clone(),
+            ));
+        }
+
+        let job = BackupJob::new(profile_id.to_string(), kind);
+        map.insert(job.id.clone(), job.clone());
+        Ok(job)
+    }
+
+    /// Transition a job to `Running` and stamp `started_at`. Called
+    /// by the spawned task once it's actually picked up. No-op if the
+    /// job no longer exists (operator GC'd it manually somehow, or
+    /// the entry's been swept).
+    pub async fn mark_running(&self, job_id: &str) {
+        let mut map = self.inner.write().await;
+        if let Some(job) = map.get_mut(job_id) {
+            job.state = BackupJobState::Running;
+            job.started_at = Some(now_rfc3339());
+        }
+    }
+
+    /// Transition a job to Succeeded with the given result payload.
+    pub async fn mark_succeeded(&self, job_id: &str, result: serde_json::Value) {
+        let mut map = self.inner.write().await;
+        if let Some(job) = map.get_mut(job_id) {
+            job.state = BackupJobState::Succeeded;
+            job.finished_at = Some(now_rfc3339());
+            job.result = Some(result);
+        }
+    }
+
+    /// Transition a job to Failed with the given operator-facing
+    /// error message. Pre-formatted; the registry doesn't reach into
+    /// BackupError so this module stays decoupled from the backup
+    /// surface above it.
+    pub async fn mark_failed(&self, job_id: &str, error: String) {
+        let mut map = self.inner.write().await;
+        if let Some(job) = map.get_mut(job_id) {
+            job.state = BackupJobState::Failed;
+            job.finished_at = Some(now_rfc3339());
+            job.error = Some(error);
+        }
+    }
+
+    pub async fn get(&self, job_id: &str) -> Option<BackupJob> {
+        let mut map = self.inner.write().await;
+        self.gc_locked(&mut map);
+        map.get(job_id).cloned()
+    }
+
+    /// List jobs, optionally filtering to a single profile. Newer
+    /// jobs first (sorted by `created_at` descending) — matches how
+    /// the WebUI wants to render them.
+    pub async fn list(&self, profile_id: Option<&str>) -> Vec<BackupJob> {
+        let mut map = self.inner.write().await;
+        self.gc_locked(&mut map);
+        let mut jobs: Vec<BackupJob> = map
+            .values()
+            .filter(|j| profile_id.is_none_or(|p| j.profile_id == p))
+            .cloned()
+            .collect();
+        // RFC3339 strings sort lexically the same way they sort
+        // chronologically — so cmp on the strings gives us
+        // newest-first without parsing.
+        jobs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        jobs
+    }
+
+    /// Drop terminal jobs whose `finished_at` is older than
+    /// [`JOB_RETENTION`]. Cheap (called under the write lock we
+    /// already hold). Called opportunistically from every public
+    /// method that touches the map.
+    fn gc_locked(&self, map: &mut HashMap<String, BackupJob>) {
+        let cutoff = Utc::now() - JOB_RETENTION;
+        map.retain(|_, job| {
+            if !job.state.is_terminal() {
+                return true;
+            }
+            match job.finished_at.as_deref().and_then(parse_rfc3339) {
+                Some(ts) => ts > cutoff,
+                // Unparseable finished_at — bug-bait, but the
+                // conservative answer is to keep the entry rather
+                // than silently dropping it.
+                None => true,
+            }
+        });
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.with_timezone(&Utc))
+}
+
+impl BackupJob {
+    /// Helper for the kind-tagged log line each lifecycle stage emits.
+    pub fn log_target(&self) -> String {
+        format!(
+            "backup job {} (profile {}, kind {})",
+            self.id,
+            self.profile_id,
+            self.kind.label()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn delta_ago_rfc3339(seconds: i64) -> String {
+        (Utc::now() - Duration::seconds(seconds)).to_rfc3339()
+    }
+
+    #[tokio::test]
+    async fn start_returns_pending_job_with_uuid_id() {
+        let reg = JobRegistry::new();
+        let job = reg
+            .start("profile-a", BackupJobKind::InitRepo)
+            .await
+            .unwrap();
+        assert_eq!(job.profile_id, "profile-a");
+        assert_eq!(job.kind, BackupJobKind::InitRepo);
+        assert_eq!(job.state, BackupJobState::Pending);
+        assert!(job.started_at.is_none());
+        assert!(job.finished_at.is_none());
+        // UUIDs are 36 chars with hyphens — pin the rough shape so a
+        // future refactor doesn't silently switch to a shorter id
+        // format the WebUI's id-comparison logic can't see.
+        assert_eq!(job.id.len(), 36, "id was: {}", job.id);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_concurrent_jobs_for_same_profile() {
+        // rustic locks the repo during init/run/check, so two
+        // concurrent jobs against the same profile would either
+        // serialize behind that lock (slow, confusing UI) or
+        // deadlock outright. Better to refuse at the API boundary
+        // and tell the operator a job is already in flight.
+        let reg = JobRegistry::new();
+        let first = reg.start("p", BackupJobKind::RunBackup).await.unwrap();
+        let err = reg.start("p", BackupJobKind::RunBackup).await.unwrap_err();
+        match err {
+            JobError::AlreadyRunning(profile, job_id) => {
+                assert_eq!(profile, "p");
+                assert_eq!(job_id, first.id);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn start_allows_concurrent_jobs_for_different_profiles() {
+        let reg = JobRegistry::new();
+        let a = reg.start("a", BackupJobKind::InitRepo).await.unwrap();
+        let b = reg.start("b", BackupJobKind::RunBackup).await.unwrap();
+        assert_ne!(a.id, b.id);
+    }
+
+    #[tokio::test]
+    async fn start_allows_new_job_after_previous_finished() {
+        // Operator clicks Run, it completes, operator clicks Run
+        // again — must work. The "one per profile" rule applies to
+        // *active* jobs, not terminal ones.
+        let reg = JobRegistry::new();
+        let first = reg.start("p", BackupJobKind::RunBackup).await.unwrap();
+        reg.mark_succeeded(&first.id, serde_json::json!("ok")).await;
+        let second = reg.start("p", BackupJobKind::RunBackup).await.unwrap();
+        assert_ne!(second.id, first.id);
+    }
+
+    #[tokio::test]
+    async fn mark_running_then_succeeded_carries_result() {
+        let reg = JobRegistry::new();
+        let job = reg.start("p", BackupJobKind::RunBackup).await.unwrap();
+        reg.mark_running(&job.id).await;
+        let mid = reg.get(&job.id).await.unwrap();
+        assert_eq!(mid.state, BackupJobState::Running);
+        assert!(mid.started_at.is_some());
+        assert!(mid.finished_at.is_none());
+
+        reg.mark_succeeded(&job.id, serde_json::json!({"bytes_added": 1024}))
+            .await;
+        let end = reg.get(&job.id).await.unwrap();
+        assert_eq!(end.state, BackupJobState::Succeeded);
+        assert!(end.finished_at.is_some());
+        assert_eq!(end.result, Some(serde_json::json!({"bytes_added": 1024})));
+    }
+
+    #[tokio::test]
+    async fn mark_failed_carries_error_message() {
+        let reg = JobRegistry::new();
+        let job = reg.start("p", BackupJobKind::InitRepo).await.unwrap();
+        reg.mark_failed(&job.id, "no such backend".to_string())
+            .await;
+        let end = reg.get(&job.id).await.unwrap();
+        assert_eq!(end.state, BackupJobState::Failed);
+        assert_eq!(end.error.as_deref(), Some("no such backend"));
+        assert!(end.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_profile_and_sorts_newest_first() {
+        let reg = JobRegistry::new();
+        // Insert in interleaved profile order, time-shift created_at
+        // backward on the older ones so sort order is verifiable.
+        let a1 = reg.start("a", BackupJobKind::InitRepo).await.unwrap();
+        let _b1 = reg.start("b", BackupJobKind::InitRepo).await.unwrap();
+        reg.mark_succeeded(&a1.id, serde_json::json!("ok")).await;
+        let a2 = reg.start("a", BackupJobKind::RunBackup).await.unwrap();
+
+        let only_a = reg.list(Some("a")).await;
+        assert_eq!(only_a.len(), 2);
+        assert_eq!(only_a[0].id, a2.id, "newest-first by created_at");
+        assert_eq!(only_a[1].id, a1.id);
+
+        let all = reg.list(None).await;
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn gc_drops_terminal_jobs_older_than_retention_window() {
+        // Inject an artificially-old finished_at on a terminal job
+        // and confirm the next get / list call sweeps it.
+        let reg = JobRegistry::new();
+        let stale = reg.start("p", BackupJobKind::InitRepo).await.unwrap();
+        reg.mark_succeeded(&stale.id, serde_json::json!("ok")).await;
+        {
+            let mut map = reg.inner.write().await;
+            // Two hours ago — well outside JOB_RETENTION.
+            if let Some(j) = map.get_mut(&stale.id) {
+                j.finished_at = Some(delta_ago_rfc3339(7200));
+            }
+        }
+        // A fresh job for the same profile would collide with the
+        // stale one if GC didn't run. start() invokes gc_locked so
+        // the stale entry should be gone.
+        let fresh = reg.start("p", BackupJobKind::InitRepo).await.unwrap();
+        assert_ne!(fresh.id, stale.id);
+        assert!(
+            reg.get(&stale.id).await.is_none(),
+            "stale terminal job should have been GC'd"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_keeps_non_terminal_jobs_regardless_of_age() {
+        // A Pending or Running job is never swept, however long it's
+        // been hanging there. The operator may want to see "hey, this
+        // has been Running for 6 hours, something's wrong" rather
+        // than the entry silently vanishing.
+        let reg = JobRegistry::new();
+        let job = reg.start("p", BackupJobKind::RunBackup).await.unwrap();
+        reg.mark_running(&job.id).await;
+        {
+            let mut map = reg.inner.write().await;
+            // Pretend the job started 6 hours ago.
+            if let Some(j) = map.get_mut(&job.id) {
+                j.started_at = Some(delta_ago_rfc3339(6 * 3600));
+            }
+        }
+        let _ = reg.list(None).await; // triggers gc
+        assert!(reg.get(&job.id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn mark_methods_are_noop_on_missing_id() {
+        // Racing GC vs. caller — a spawned task might try to update
+        // a job that's already been swept. Must not panic.
+        let reg = JobRegistry::new();
+        reg.mark_running("does-not-exist").await;
+        reg.mark_succeeded("does-not-exist", serde_json::json!(null))
+            .await;
+        reg.mark_failed("does-not-exist", "irrelevant".into()).await;
+        assert!(reg.list(None).await.is_empty());
+    }
+}

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -3,8 +3,10 @@
 //! Manages backup profiles, scheduling, and execution. Uses rustic_core
 //! library directly for backup operations (restic-compatible repo format).
 
+pub mod jobs;
 pub mod scheduler;
 
+use jobs::{BackupJob, BackupJobKind, JobError, JobRegistry};
 use nasty_common::secrets::{self, EncryptedBlob, SecretsStatus};
 use rustic_backend::BackendOptions;
 use rustic_core::{
@@ -535,6 +537,10 @@ fn creds(password: &str) -> Credentials {
 pub struct BackupService {
     profiles: std::sync::Arc<tokio::sync::Mutex<Vec<BackupProfile>>>,
     running: std::sync::Arc<tokio::sync::Mutex<Option<String>>>,
+    /// In-memory registry of long-running backup jobs
+    /// (init / run / check). The async start_* methods spawn into
+    /// this. See `jobs.rs` for the lifecycle + GC story.
+    jobs: JobRegistry,
 }
 
 impl Default for BackupService {
@@ -548,6 +554,7 @@ impl BackupService {
         Self {
             profiles: std::sync::Arc::new(tokio::sync::Mutex::new(load_profiles())),
             running: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            jobs: JobRegistry::new(),
         }
     }
 
@@ -555,7 +562,14 @@ impl BackupService {
         Self {
             profiles: self.profiles.clone(),
             running: self.running.clone(),
+            jobs: self.jobs.clone(),
         }
+    }
+
+    /// Read-only access to the job registry — the router uses this
+    /// to expose backup.jobs.list / backup.jobs.get.
+    pub fn jobs(&self) -> &JobRegistry {
+        &self.jobs
     }
 
     pub async fn list_profiles(&self) -> Vec<BackupProfile> {
@@ -702,6 +716,89 @@ impl BackupService {
             profile_id: running_id,
             progress: None,
         }
+    }
+
+    /// Async wrapper around [`init_repo`]: creates a [`BackupJob`],
+    /// spawns the actual work, returns the job handle immediately so
+    /// the caller can poll. Returns `JobError::AlreadyRunning` if a
+    /// non-terminal job for the same profile already exists.
+    pub async fn start_init_repo(&self, id: &str) -> Result<BackupJob, JobError> {
+        let job = self.jobs.start(id, BackupJobKind::InitRepo).await?;
+        let job_id = job.id.clone();
+        let profile_id = id.to_string();
+        let registry = self.jobs.clone();
+        let service = self.clone_for_task();
+        tokio::spawn(async move {
+            registry.mark_running(&job_id).await;
+            match service.init_repo(&profile_id).await {
+                Ok(msg) => {
+                    registry
+                        .mark_succeeded(&job_id, serde_json::Value::String(msg))
+                        .await;
+                }
+                Err(e) => {
+                    registry.mark_failed(&job_id, e.to_string()).await;
+                }
+            }
+        });
+        Ok(job)
+    }
+
+    /// Async wrapper around [`run_backup`]: same shape as
+    /// [`start_init_repo`]. The job's `result` payload on success is
+    /// the serialized [`BackupRunResult`] (bytes_added, files_new,
+    /// etc.) so the WebUI can show what the run actually did.
+    pub async fn start_run_backup(&self, id: &str) -> Result<BackupJob, JobError> {
+        let job = self.jobs.start(id, BackupJobKind::RunBackup).await?;
+        let job_id = job.id.clone();
+        let profile_id = id.to_string();
+        let registry = self.jobs.clone();
+        let service = self.clone_for_task();
+        tokio::spawn(async move {
+            registry.mark_running(&job_id).await;
+            match service.run_backup(&profile_id).await {
+                Ok(result) => {
+                    let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+                    if result.success {
+                        registry.mark_succeeded(&job_id, value).await;
+                    } else {
+                        // run_backup() returns Ok with success=false
+                        // when rustic reported a failure. Map that to
+                        // a Failed job state so the WebUI's polling
+                        // loop renders it consistently with the
+                        // "engine returned an error" case.
+                        registry.mark_failed(&job_id, result.message.clone()).await;
+                    }
+                }
+                Err(e) => {
+                    registry.mark_failed(&job_id, e.to_string()).await;
+                }
+            }
+        });
+        Ok(job)
+    }
+
+    /// Async wrapper around [`check_repo`].
+    pub async fn start_check_repo(&self, id: &str) -> Result<BackupJob, JobError> {
+        let job = self.jobs.start(id, BackupJobKind::CheckRepo).await?;
+        let job_id = job.id.clone();
+        let profile_id = id.to_string();
+        let registry = self.jobs.clone();
+        let service = self.clone_for_task();
+        tokio::spawn(async move {
+            registry.mark_running(&job_id).await;
+            match service.check_repo(&profile_id).await {
+                Ok(msg) => {
+                    registry
+                        .mark_succeeded(&job_id, serde_json::Value::String(msg))
+                        .await;
+                }
+                Err(e) => {
+                    registry.mark_failed(&job_id, e.to_string()).await;
+                }
+            }
+        });
+        Ok(job)
     }
 
     pub async fn init_repo(&self, id: &str) -> Result<String, BackupError> {

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2091,12 +2091,10 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "backup.run",
-                    desc: "Spawn a background task that runs the profile's backup (auto-initializing the repo if needed, then pruning per the retention policy); the RPC returns immediately after accepting the request.",
+                    desc: "Spawn a background task that runs the profile's backup (auto-initializing the repo if needed, then pruning per the retention policy). Returns a BackupJob handle immediately; poll backup.jobs.get / backup.jobs.list to watch the Pending → Running → Succeeded|Failed transition. Returns an `AlreadyRunning` error if another job for the same profile is in flight.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Backup profile identifier.")),
-                    result: Some(
-                        serde_json::json!({"type": "string", "description": "Status message — typically \"Backup started\"."}),
-                    ),
+                    result: Some(gen_schema::<nasty_backup::jobs::BackupJob>(generator)),
                 },
                 Method {
                     name: "backup.snapshots",
@@ -2107,21 +2105,42 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "backup.repo.init",
-                    desc: "Initialize a fresh rustic repository at the profile's target using its password, then mark the profile as `repo_initialized`.",
+                    desc: "Initialize a fresh rustic repository at the profile's target using its password, then mark the profile as `repo_initialized`. Returns a BackupJob handle immediately; init can take 30+ seconds on remote REST / S3 targets so the actual work runs in the background and the caller polls backup.jobs.get for completion.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Backup profile identifier.")),
-                    result: Some(
-                        serde_json::json!({"type": "string", "description": "Status message — typically \"Repository initialized\"."}),
-                    ),
+                    result: Some(gen_schema::<nasty_backup::jobs::BackupJob>(generator)),
                 },
                 Method {
                     name: "backup.repo.check",
-                    desc: "Run a rustic repository integrity check (`repo.check`) on the profile's target repo and return a status message.",
+                    desc: "Run a rustic repository integrity check (`repo.check`) on the profile's target repo. Returns a BackupJob handle immediately; check can take minutes on large repos and the caller polls backup.jobs.get for the result.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Backup profile identifier.")),
-                    result: Some(
-                        serde_json::json!({"type": "string", "description": "Status message — typically \"Repository check passed\"."}),
-                    ),
+                    result: Some(gen_schema::<nasty_backup::jobs::BackupJob>(generator)),
+                },
+                Method {
+                    name: "backup.jobs.list",
+                    desc: "List active and recently-finished backup jobs (init / run / check), newest first. Optional `profile_id` filter narrows the list to one profile. Terminal jobs are GC'd one hour after they finish, so this returns a bounded window rather than full history.",
+                    role: MethodRole::Any,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "profile_id": {
+                                "type": "string",
+                                "description": "Optional profile id filter; omit to list jobs across all profiles."
+                            }
+                        }
+                    })),
+                    result: Some(gen_schema::<Vec<nasty_backup::jobs::BackupJob>>(generator)),
+                },
+                Method {
+                    name: "backup.jobs.get",
+                    desc: "Return one backup job by id. 404-equivalent error when the id is unknown (job never existed or was GC'd after its retention window).",
+                    role: MethodRole::Any,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "id",
+                        "Backup job identifier (UUID returned by backup.repo.init / backup.run / backup.repo.check).",
+                    )),
+                    result: Some(gen_schema::<nasty_backup::jobs::BackupJob>(generator)),
                 },
                 Method {
                     name: "backup.secrets_status",

--- a/engine/nasty-engine/src/router/backup.rs
+++ b/engine/nasty-engine/src/router/backup.rs
@@ -53,31 +53,26 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "backup.status" => ok(req, state.backups.status().await),
+        // The init / run / check RPCs return a BackupJob handle now.
+        // Long-running ops would otherwise blow through the 10 s
+        // WebSocket request timeout in the WebUI client — observed
+        // with `backup.repo.init` against a remote REST target
+        // taking 32 s. Clients poll backup.jobs.get / backup.jobs.list
+        // to watch the Pending → Running → Succeeded|Failed transition.
         "backup.repo.init" => match require_str(req, "id") {
-            Ok(id) => match state.backups.init_repo(id).await {
-                Ok(msg) => ok(req, msg),
-                Err(e) => err(req, e.to_rpc_error()),
+            Ok(id) => match state.backups.start_init_repo(id).await {
+                Ok(job) => ok(req, job),
+                Err(e) => err(req, e.to_string()),
             },
             Err(r) => r,
         },
-        "backup.run" => {
-            let id = match require_str(req, "id") {
-                Ok(s) => s.to_string(),
-                Err(r) => return Some(r),
-            };
-            // Run in background, return immediately. The RPC ack is just
-            // "we accepted the request" — the actual backup status lands
-            // in the journal, with a per-backup-id error so the user can
-            // grep for *which* backup failed.
-            let backups = state.backups.clone_for_task();
-            let id_for_log = id.clone();
-            tokio::spawn(async move {
-                if let Err(e) = backups.run_backup(&id).await {
-                    tracing::warn!("backup '{id_for_log}' failed: {e}");
-                }
-            });
-            ok(req, "Backup started")
-        }
+        "backup.run" => match require_str(req, "id") {
+            Ok(id) => match state.backups.start_run_backup(id).await {
+                Ok(job) => ok(req, job),
+                Err(e) => err(req, e.to_string()),
+            },
+            Err(r) => r,
+        },
         "backup.snapshots" => match require_str(req, "id") {
             Ok(id) => match state.backups.list_snapshots(id).await {
                 Ok(v) => ok(req, v),
@@ -86,9 +81,26 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "backup.repo.check" => match require_str(req, "id") {
-            Ok(id) => match state.backups.check_repo(id).await {
-                Ok(msg) => ok(req, msg),
-                Err(e) => err(req, e.to_rpc_error()),
+            Ok(id) => match state.backups.start_check_repo(id).await {
+                Ok(job) => ok(req, job),
+                Err(e) => err(req, e.to_string()),
+            },
+            Err(r) => r,
+        },
+        "backup.jobs.list" => {
+            // Optional `profile_id` filter — empty / missing returns all.
+            let profile_id = req
+                .params
+                .as_ref()
+                .and_then(|p| p.get("profile_id"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty());
+            ok(req, state.backups.jobs().list(profile_id).await)
+        }
+        "backup.jobs.get" => match require_str(req, "id") {
+            Ok(job_id) => match state.backups.jobs().get(job_id).await {
+                Some(job) => ok(req, job),
+                None => err(req, format!("backup job not found: {job_id}")),
             },
             Err(r) => r,
         },

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -276,6 +276,8 @@ fn is_read_only(method: &str) -> bool {
                 | "backup.profile.get"
                 | "backup.status"
                 | "backup.snapshots"
+                | "backup.jobs.list"
+                | "backup.jobs.get"
                 | "auth.oidc.config_status"
                 | "auth.webauthn.config"
                 | "auth.webauthn.list"

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1196,6 +1196,30 @@ export interface BackupStatus {
 	progress: string | null;
 }
 
+/** A long-running backup operation (init / run / check). Returned by
+ * `backup.repo.init`, `backup.run`, `backup.repo.check`; polled via
+ * `backup.jobs.get`/`backup.jobs.list`. The engine starts the work in
+ * a background tokio task and the client watches the state transition
+ * Pending → Running → Succeeded|Failed. Read-only on the client side. */
+export type BackupJobKind = 'init_repo' | 'run_backup' | 'check_repo';
+export type BackupJobState = 'pending' | 'running' | 'succeeded' | 'failed';
+
+export interface BackupJob {
+	id: string;
+	profile_id: string;
+	kind: BackupJobKind;
+	state: BackupJobState;
+	created_at: string;
+	started_at?: string | null;
+	finished_at?: string | null;
+	progress?: string | null;
+	/** Engine result payload on success. For `init_repo`/`check_repo`
+	 * this is a status message string; for `run_backup` it's a
+	 * `BackupRunResult` JSON object (bytes_added, files_new, …). */
+	result?: unknown;
+	error?: string | null;
+}
+
 // ── Notifications ──────────────────────────────────────────
 
 export interface NotificationConfig {

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -6,7 +6,7 @@
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 	import { formatBytes } from '$lib/format';
-	import type { BackupProfile, BackupSnapshot, BackupStatus, Subvolume, Filesystem } from '$lib/types';
+	import type { BackupProfile, BackupSnapshot, BackupStatus, BackupJob, Subvolume, Filesystem } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
@@ -200,6 +200,68 @@
 		if (runBackupPoll !== null) { clearInterval(runBackupPoll); runBackupPoll = null; }
 	}
 
+	/** Active backup jobs by profile id — populated by every call to
+	 * startBackupJob, used to render a "Init in progress…", "Backing
+	 * up…", "Checking…" badge inline with each profile. Cleared when
+	 * the job terminates. */
+	let activeJobs: Record<string, BackupJob> = $state({});
+	let jobPollers: Record<string, ReturnType<typeof setInterval>> = {};
+
+	function stopJobPoll(profileId: string) {
+		const t = jobPollers[profileId];
+		if (t !== undefined) {
+			clearInterval(t);
+			delete jobPollers[profileId];
+		}
+	}
+
+	function stopAllJobPolls() {
+		for (const id of Object.keys(jobPollers)) stopJobPoll(id);
+	}
+
+	/** Common path for backup.repo.init / backup.run / backup.repo.check:
+	 * fire the RPC, store the returned BackupJob keyed by profile id,
+	 * then poll backup.jobs.get every 2 s until it lands in a terminal
+	 * state. On success calls onSuccess (typically a list refresh) so
+	 * the operator sees the new repo_initialized / last_run state
+	 * immediately. */
+	async function startBackupJob(
+		profileId: string,
+		method: 'backup.repo.init' | 'backup.run' | 'backup.repo.check',
+		startMessage: string,
+		onSuccess?: () => Promise<void> | void,
+	) {
+		const job = await withToast(
+			() => client.call<BackupJob>(method, { id: profileId }),
+			startMessage,
+		);
+		if (!job) return;
+		activeJobs[profileId] = job;
+		stopJobPoll(profileId);
+		jobPollers[profileId] = setInterval(async () => {
+			try {
+				const updated = await client.call<BackupJob>('backup.jobs.get', { id: job.id });
+				activeJobs[profileId] = updated;
+				if (updated.state === 'succeeded' || updated.state === 'failed') {
+					stopJobPoll(profileId);
+					if (updated.state === 'failed') {
+						await withToast(
+							() => Promise.reject({ message: updated.error ?? 'backup job failed' }),
+							'',
+						);
+					}
+					delete activeJobs[profileId];
+					if (onSuccess) await onSuccess();
+				}
+			} catch {
+				// Job entry was GC'd or engine disconnected — stop
+				// polling rather than hammering a dead endpoint.
+				stopJobPoll(profileId);
+				delete activeJobs[profileId];
+			}
+		}, 2000);
+	}
+
 	onMount(async () => {
 		await refresh();
 		loading = false;
@@ -216,6 +278,7 @@
 
 	onDestroy(() => {
 		stopRunBackupPoll();
+		stopAllJobPolls();
 	});
 
 	let snapshotCounts: Record<string, number> = $state({});
@@ -278,26 +341,15 @@
 	}
 
 	async function initRepo(id: string) {
-		await withToast(() => client.call('backup.repo.init', { id }), 'Repository initialized');
-		await refresh();
+		await startBackupJob(id, 'backup.repo.init', 'Initializing repository…', refresh);
 	}
 
 	async function runBackup(id: string) {
-		await withToast(() => client.call('backup.run', { id }), 'Backup started');
-		// Poll status until the backup finishes — onDestroy cancels this on
-		// SPA navigation so we don't keep polling after the user leaves.
-		stopRunBackupPoll();
-		runBackupPoll = setInterval(async () => {
-			backupStatus = await client.call<BackupStatus>('backup.status');
-			if (!backupStatus?.running) {
-				stopRunBackupPoll();
-				await refresh();
-			}
-		}, 3000);
+		await startBackupJob(id, 'backup.run', 'Backup started', refresh);
 	}
 
 	async function checkRepo(id: string) {
-		await withToast(() => client.call('backup.repo.check', { id }), 'Repository check passed');
+		await startBackupJob(id, 'backup.repo.check', 'Repository check started');
 	}
 
 	async function loadSnapshots(id: string) {
@@ -566,6 +618,12 @@
 									<Badge variant={profile.repo_initialized ? 'default' : 'secondary'} class="text-[0.6rem]">
 										{profile.repo_initialized ? 'Ready' : 'Not initialized'}
 									</Badge>
+									{#if activeJobs[profile.id]}
+										{@const job = activeJobs[profile.id]}
+										<Badge variant="outline" class="text-[0.6rem] animate-pulse">
+											{job.kind === 'init_repo' ? 'Initializing…' : job.kind === 'run_backup' ? 'Backing up…' : 'Checking…'}
+										</Badge>
+									{/if}
 									{#if profile.schedule}
 										<Badge variant="outline" class="text-[0.6rem]">{describeSchedule(profile.schedule)}</Badge>
 										{@const nr = nextRun(profile.schedule)}
@@ -597,14 +655,18 @@
 							</div>
 							<div class="flex gap-2">
 								{#if !profile.repo_initialized}
-									<Button size="xs" onclick={() => initRepo(profile.id)}>Init Repo</Button>
+									<Button size="xs" onclick={() => initRepo(profile.id)} disabled={activeJobs[profile.id] !== undefined}>
+										{activeJobs[profile.id] ? 'Init Repo…' : 'Init Repo'}
+									</Button>
 								{:else}
 									<Button size="xs" variant="secondary" onclick={() => runBackup(profile.id)}
-										disabled={backupStatus?.running === true}>
-										{backupStatus?.running && backupStatus?.profile_id === profile.id ? 'Running...' : 'Run Now'}
+										disabled={activeJobs[profile.id] !== undefined}>
+										{activeJobs[profile.id]?.kind === 'run_backup' ? 'Running…' : 'Run Now'}
 									</Button>
 									<Button size="xs" variant="secondary" onclick={() => loadSnapshots(profile.id)}>Snapshots</Button>
-									<Button size="xs" variant="secondary" onclick={() => checkRepo(profile.id)}>Check</Button>
+									<Button size="xs" variant="secondary" onclick={() => checkRepo(profile.id)} disabled={activeJobs[profile.id] !== undefined}>
+										{activeJobs[profile.id]?.kind === 'check_repo' ? 'Checking…' : 'Check'}
+									</Button>
 								{/if}
 								<Button size="xs" variant="secondary" onclick={() => startEdit(profile)}>Edit</Button>
 								<Button size="xs" variant="destructive" onclick={() => deleteProfile(profile.id)}>Delete</Button>


### PR DESCRIPTION
Replaces the synchronous \`backup.repo.init\` / \`backup.run\` / \`backup.repo.check\` RPCs with a job-handle pattern so long operations no longer crash the WebUI's 10-second WebSocket timeout. **Observed problem**: \`backup.repo.init\` against a remote REST target took 32 s, the engine completed the op, but the WebUI timed out at 10 s and showed *\"Request timed out\"* — leaving the operator unsure whether the init had actually happened. Logged as \`RPC very slow: backup.repo.init took 32531ms\`.

## New module \`nasty_backup::jobs\`

| Item | Purpose |
| --- | --- |
| \`BackupJob\` | id / profile_id / kind / state (\`pending\` \\| \`running\` \\| \`succeeded\` \\| \`failed\`) / timestamps / optional progress / result / error. Serializes verbatim across JSON-RPC; carries no secrets. |
| \`JobRegistry\` | \`Arc<RwLock<HashMap<id, BackupJob>>>\`. Cheap to clone. Public: \`start\` (with per-profile *already-running* guard), \`mark_running\` / \`mark_succeeded\` / \`mark_failed\`, \`get\`, \`list\` (optional profile filter, newest-first). Opportunistic GC drops terminal jobs older than 1 hour. |

**Per-profile concurrency:** \`start\` refuses a new job if a non-terminal one already exists. rustic locks the repo during init/run/check anyway, so two concurrent jobs would serialize behind that lock and confuse the UI worse than a clear refusal.

**In-memory only.** Engine restart loses the registry entry, but \`BackupProfile.last_run\` is persisted by the backup path itself, so an operator can still tell whether the actual backup completed. Persisting mid-flight would invite *\"claims Running but the engine that owned it is gone\"* inconsistencies.

## BackupService gains three \`start_*\` wrappers

- \`start_init_repo\` / \`start_run_backup\` / \`start_check_repo\` each create a Pending \`BackupJob\`, spawn the existing sync method as a detached tokio task that transitions \`Pending → Running → Succeeded|Failed\`, and return the job handle to the caller. The original methods are unchanged — they're now internal callees of \`start_*\` (and of the scheduler loop from #402).
- \`run_backup\`'s \`Ok(result)\` with \`success=false\` is mapped to a Failed job state so the WebUI renders rustic errors the same way as engine-side errors.

## RPC surface

- \`backup.repo.init\` / \`backup.run\` / \`backup.repo.check\` now return a \`BackupJob\` handle instead of a status string. **No external callers** (kubectl-nasty, nasty-go, nasty-csi don't expose backup management), so the breaking shape change has zero out-of-tree blast radius.
- New \`backup.jobs.list\` (optional \`profile_id\` filter) and \`backup.jobs.get\` RPCs. Both Any-role.

## WebUI

- \`BackupJob\` / \`BackupJobKind\` / \`BackupJobState\` types added.
- \`startBackupJob\` helper: calls the start RPC, stores the returned job keyed by profile, polls \`backup.jobs.get\` every 2 s until terminal, refreshes on success, toasts the error message on failure, cleans up on SPA navigation. Init / Run / Check handlers all route through it.
- Inline status badges: pulsing *\"Initializing…\"* / *\"Backing up…\"* / *\"Checking…\"* badge appears next to the profile name while a job is active. The Init / Run / Check buttons disable while a job is in flight; the disabled-state label echoes the kind so the operator can tell what's happening.

## Tests

- 10 new \`nasty-backup::jobs\` tests covering: start returns pending job with UUID id; concurrent-job-for-same-profile rejection; concurrent jobs for different profiles allowed; new job allowed after previous finished; \`mark_running → mark_succeeded\` carries result; \`mark_failed\` carries error; list filters + sorts; GC drops terminal jobs past retention; GC keeps non-terminal jobs regardless of age; mark methods are no-ops on missing ids (handles registry-vs-spawned-task races).
- Existing 31 \`nasty-backup\` tests pass unchanged.
- \`cargo clippy --workspace --no-deps --all-targets\` clean, \`cargo fmt --check\` clean, \`svelte-check\` clean, 144 vitest cases pass.

## Out of scope (Phase 2)

- Progress reporting via rustic's callback API (\`BackupJob.progress\` is in the shape; just not populated).
- Job cancellation (rustic doesn't have a graceful abort; aborting a tokio task mid-rustic could leave the repo lock held until process restart).
- Persisting job state across engine restarts.

## Test plan

- [ ] Deploy to nas.0f.ee → click *Init Repo* on the offsite profile (the 32s one) → no more *\"Request timed out\"* toast; *\"Initializing…\"* badge shows; Init button disabled while it runs; success refresh on completion
- [ ] Click *Run Now* → similar progression; \`last_run\` populates as expected
- [ ] Click *Check* on an existing repo → same pattern
- [ ] Try clicking *Run Now* twice in quick succession → second click rejected with the already-running message
- [ ] Reload the Backups page mid-init → polling resumes against the still-Running job (works because \`backup.jobs.list\` enumerates active jobs and the badge re-attaches)