### PR TITLE
nasty-rest-server: serve HTTPS using Caddy's already-issued cert

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1818,9 +1818,28 @@ in {
     };
 
     # ── Backup REST server (receives backups from other NASties) ─
+    #
+    # TLS handling: the rest-server serves HTTPS using Caddy's
+    # already-issued cert for the box's main TLS domain (the same
+    # one the WebUI uses). Cert + key files are looked up under
+    # /var/lib/caddy/.local/share/caddy/certificates/<issuer>/<domain>/
+    # at service-start time. When Caddy hasn't issued anything yet
+    # (fresh box, no tls_domain configured), the service falls back
+    # to plain HTTP rather than refusing to start — better degraded
+    # than offline.
+    #
+    # Cert renewal: Caddy renews ~30 days before expiry. The rest-
+    # server reads its cert files at startup and doesn't hot-reload.
+    # The old cert stays valid for the 30-day window between renewal
+    # and old-cert-expiry, so backups in flight during a renewal
+    # don't break; the rest-server picks up the new cert on the next
+    # restart (engine restart, NixOS update, or any unrelated
+    # systemctl restart). For the edge case of a long-uninterrupted
+    # run that spans the full 30-day overlap window, operators can
+    # `systemctl restart nasty-rest-server` manually.
     systemd.services.nasty-rest-server = {
       description = "restic REST server for NASty backups";
-      after = [ "network-online.target" ];
+      after = [ "network-online.target" "caddy.service" ];
       wants = [ "network-online.target" ];
       # Same restart-cap rationale as nasty-engine — a misconfigured
       # repo path or a port-in-use error would otherwise tight-loop
@@ -1832,6 +1851,7 @@ in {
       serviceConfig = {
         Type = "simple";
         ExecStart = pkgs.writeShellScript "nasty-rest-server-start" ''
+          set -u
           PATH_FILE="/var/lib/nasty/rest-server-path"
           if [ -f "$PATH_FILE" ]; then
             REPO_PATH=$(cat "$PATH_FILE")
@@ -1839,11 +1859,44 @@ in {
             REPO_PATH="/var/lib/nasty/rest-server"
           fi
           mkdir -p "$REPO_PATH"
-          exec ${pkgs.restic-rest-server}/bin/rest-server --listen :8000 --path "$REPO_PATH" --no-auth
+
+          # Look up Caddy's cert + key for the operator's configured
+          # TLS domain (settings.json's tls_domain field, set via the
+          # TLS page in the WebUI). Glob across the issuer subdirs —
+          # the path includes "local" for Caddy's internal CA and
+          # "acme-v02.api.letsencrypt.org-directory" for ACME, and we
+          # don't know which the operator picked until runtime.
+          TLS_DOMAIN=""
+          if [ -f /var/lib/nasty/settings.json ]; then
+            TLS_DOMAIN=$(${pkgs.jq}/bin/jq -r '.tls_domain // ""' /var/lib/nasty/settings.json 2>/dev/null || echo "")
+          fi
+          TLS_ARGS=""
+          if [ -n "$TLS_DOMAIN" ]; then
+            CERT=$(${pkgs.findutils}/bin/find /var/lib/caddy/.local/share/caddy/certificates \
+              -path "*/$TLS_DOMAIN/$TLS_DOMAIN.crt" 2>/dev/null | head -n1)
+            KEY=$(${pkgs.findutils}/bin/find /var/lib/caddy/.local/share/caddy/certificates \
+              -path "*/$TLS_DOMAIN/$TLS_DOMAIN.key" 2>/dev/null | head -n1)
+            if [ -n "$CERT" ] && [ -n "$KEY" ]; then
+              echo "nasty-rest-server: serving HTTPS with Caddy cert for $TLS_DOMAIN ($CERT)"
+              TLS_ARGS="--tls --tls-cert $CERT --tls-key $KEY"
+            else
+              echo "nasty-rest-server: WARNING tls_domain=$TLS_DOMAIN but Caddy has no matching cert yet — serving HTTP. Backup clients must use http:// URLs, or wait for Caddy to issue the cert and then restart this service." >&2
+            fi
+          else
+            echo "nasty-rest-server: no tls_domain in settings.json — serving HTTP. Configure a TLS domain in the WebUI's TLS page to enable HTTPS." >&2
+          fi
+
+          exec ${pkgs.restic-rest-server}/bin/rest-server \
+            --listen :8000 --path "$REPO_PATH" --no-auth $TLS_ARGS
         '';
         StateDirectory = "nasty/rest-server";
         Restart = "on-failure";
         RestartSec = "5s";
+        # The rest-server needs to read Caddy's cert files. Caddy's
+        # data dir is owned by the caddy user (0700) by default;
+        # rest-server runs as root, so it can read regardless.
+        # If a future refactor drops rest-server to a non-root user,
+        # the cert read path needs a group-read ACL on Caddy's dir.
       };
       wantedBy = lib.mkForce [];  # engine starts on demand
     };


### PR DESCRIPTION
The rest-server was running with \`--no-auth\` on plain HTTP, so a backup profile with an \`https://\` URL would TLS-handshake against a plaintext server and fail with the cryptic OpenSSL \"wrong version number\" error. Observed when an operator pointed \`nas.0f.ee\` at \`https://nasty.0f.ee:8000\` and watched rustic_core return *\"Backoff failed, please check the logs\"* — the actual cause was TLS-on-non-TLS, two layers down.

**The fix:** read Caddy's existing TLS cert for the box's configured \`tls_domain\` (the same one the WebUI uses) and pass it to \`restic-rest-server\`'s \`--tls\` / \`--tls-cert\` / \`--tls-key\` flags. Operators who've already enabled TLS for the WebUI get HTTPS rest-server for free.

## Service-script changes

- Reads \`tls_domain\` from \`/var/lib/nasty/settings.json\` via \`jq\`. Falls back to \`\"\"\` when missing — boxes without TLS configured stay on plain HTTP.
- Globs Caddy's cert directory for \`<tls_domain>/<tls_domain>.{crt,key}\`. The issuer subdir varies (\`local\` for internal CA vs \`acme-v02.api.letsencrypt.org-directory\` for ACME) so we glob across both rather than hardcoding the path.
- If both cert files exist, serves HTTPS. If \`TLS_DOMAIN\` is set but Caddy hasn't issued the cert yet (fresh box, mid-issuance), logs a WARNING and serves HTTP so backups don't refuse to work entirely.
- **Better degraded than offline:** rest-server never fails to start because of TLS state.

## Cert renewal handling (deliberately minimal)

rest-server reads cert files at startup and doesn't hot-reload. Caddy renews ~30 days before expiry; the old cert stays valid for that 30-day overlap window, so backups in flight during a renewal don't break — rest-server just keeps serving the old cert until the next restart picks up the new one.

\"Next restart\" is frequent enough in practice (engine restarts on every NixOS update / config tweak) that the rest-server rarely runs more than a few days without a restart. For the edge case of \"long uninterrupted run that spans the full 30-day overlap window\", operators can \`systemctl restart nasty-rest-server\`.

Skipped wiring a path-unit-driven auto-restart on cert change because systemd path units don't natively support recursive glob watching across the issuer-tagged subdirs — would need a per-domain unit generated at runtime, more complexity than the rare edge case warrants.

## Service unit ordering

- Added \`caddy.service\` to \`after\` so the rest-server doesn't race Caddy on first boot. Caddy issues asynchronously, so the \"no cert yet\" branch still fires sometimes — but at least we're not trying to read the cert before Caddy has had a chance to create the directory.
- **Did NOT** add \`requires\` — a Caddy outage shouldn't kill backup receiving; the degraded-HTTP fallback handles it.

## Out of scope (Phase 2)

- **Auth on the rest-server:** still \`--no-auth\`. Anyone who can reach port 8000 can write to (or delete) any repo. Adding TLS encrypts the wire but doesn't authenticate callers — rustic itself encrypts contents end-to-end so confidentiality is intact, but integrity against an active attacker who reaches the port is not. Follow-up should add \`--htpasswd\` with engine-generated credentials.
- **Cert-renewal auto-restart** via the engine's \`set_tls_automation\` success hook. Currently relies on natural restart cadence.

## Verification

- \`nix-instantiate --parse\`: clean.
- Manual smoke: on a box where Caddy has issued a cert for \`settings.tls_domain\`, \`systemctl restart nasty-rest-server\` followed by \`curl -v https://<tls_domain>:8000/\` should connect cleanly over TLS. With \`tls_domain\` unset, the service starts in HTTP mode and logs the WARNING line directing the operator to the TLS page.

## Test plan
- [ ] Deploy to nasty.0f.ee → restart rest-server → \`curl -v https://nasty.0f.ee:8000/\` returns HTTP 405 (rest-server's normal \"GET / not allowed\" response) without a TLS error
- [ ] From nas.0f.ee, click Init Repo on the offsite profile with the existing \`https://nasty.0f.ee:8000\` URL → succeeds without the OpenSSL \"wrong version number\" failure
- [ ] On a box with \`tls_domain\` empty, restart rest-server → journal shows the \"no tls_domain ... serving HTTP\" warning; \`curl http://...:8000/\` works, \`curl https://...:8000/\` fails (expected)
- [ ] Existing operators with \`http://\` URLs in their profiles continue to work unchanged on boxes with TLS configured (rest-server still listens on the same port; clients can still speak HTTP — wait actually no, rest-server with --tls only does HTTPS. Operators with http:// URLs on a box that just gained tls_domain will need to update their URL to https://)