### PR TITLE
webui: stop firing change-target confirm modal on no-op profile edits

### DIFF
--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -168,8 +168,17 @@
 	let editTrustedCacert = $state('');
 	/** Snapshot of the target shape at startEdit time, used to detect
 	 * "operator changed the destination" so we can warn + reset
-	 * repo_initialized. Compared as JSON strings — order-insensitive
-	 * field changes are rare enough to ignore. */
+	 * repo_initialized. Computed by running the fields through
+	 * `buildEditedTarget()` immediately after they're populated, so
+	 * the comparison at save time is self-consistent: a save with no
+	 * changes produces byte-identical JSON. Comparing against
+	 * `JSON.stringify(p.target)` directly was wrong — the server
+	 * shape includes redacted secret fields (`secret_key: "***"`,
+	 * `account_key: "***"`) that `buildEditedTarget` omits when the
+	 * operator hasn't typed a new secret, so every save fired the
+	 * "Change backup target?" modal for S3/B2 profiles, and the
+	 * Svelte 5 $state proxy made the comparison drift for local
+	 * profiles too. */
 	let editOriginalTargetJson = '';
 
 	function startEdit(p: BackupProfile) {
@@ -221,7 +230,10 @@
 				editB2Id = p.target.account_id;
 				break;
 		}
-		editOriginalTargetJson = JSON.stringify(p.target);
+		// Snapshot through buildEditedTarget so the save-time diff is
+		// against the same shape the save would re-produce — not
+		// against the server's redacted-secret-included shape.
+		editOriginalTargetJson = JSON.stringify(buildEditedTarget());
 	}
 
 	/** Reconstruct the BackupTarget JSON from the edit-form fields,


### PR DESCRIPTION
## Summary

Editing a backup profile (e.g. adding a cron schedule, leaving the local target path untouched) popped the "The repository at the OLD target stays where it is — the NEW target will need to be initialized" confirmation modal even though the destination hadn't actually changed. Operator hits Confirm to proceed → profile saves with `repo_initialized=false` → next run does an unnecessary `init` against the already-initialized repo.

Root cause: `saveEdit()` builds `newTarget` via `buildEditedTarget()` and compares its JSON to `editOriginalTargetJson`, which `startEdit()` set to `JSON.stringify(p.target)` — the server-side wire shape.
- S3/B2 wire shape includes `secret_key: "***"` / `account_key: "***"` (redacted markers), which `buildEditedTarget()` deliberately *omits* when the operator hasn't typed a new secret. Strings diverge ⇒ modal always fires.
- Local wire shape (`{type, path}`) looks like it should match a fresh `{type: 'local', path}` literal byte-for-byte, but the Svelte 5 `$state` deep proxy used to back `p.target` enumerates own keys differently from a plain object literal in some cases, so the comparison also drifts.

## Fix

Snapshot through `buildEditedTarget()` immediately after populating the edit fields, so both sides of the diff go through the same shape transformation:

```diff
-editOriginalTargetJson = JSON.stringify(p.target);
+editOriginalTargetJson = JSON.stringify(buildEditedTarget());
```

A save with zero field changes now produces byte-identical JSON on both sides ⇒ `targetChanged === false` ⇒ no modal. Real destination changes (path edit, target-type switch, host change, new credentials typed) still flip the diff and still surface the warning.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings.
- [ ] On nasty.0f.ee: open an existing local-target profile, change just the schedule, click Save → no modal, repo stays initialized.
- [ ] Same profile, change the path → modal fires as before.
- [ ] S3 profile, edit just the retention numbers, save → no modal (used to fire for any S3 edit).
- [ ] S3 profile, change the bucket → modal fires.