### PR TITLE
webui services: show Backup Server CA cert inline

### DIFF
--- a/webui/src/routes/services/+page.svelte
+++ b/webui/src/routes/services/+page.svelte
@@ -192,12 +192,67 @@
 	let restCredentialsLoading = $state(false);
 	let restPasswordRevealed = $state(false);
 
+	/** PEM-encoded internal CA cert that signed this box's TLS leaf —
+	 * source boxes pointing backups at this Backup Server paste it
+	 * into the profile's "Trusted CA certificate" textarea so their
+	 * HTTPS connection to the rest-server validates. Loaded lazily
+	 * via `system.tls.local_ca_root` (same RPC the /tls page uses
+	 * for its file download). */
+	let caCertPem: string | null = $state(null);
+	let caCertLoading = $state(false);
+	let caCertExpanded = $state(true);
+	/** `null` until the section opens; drives whether the CA cert
+	 * block defaults to expanded. When ACME succeeded, source boxes
+	 * already trust the leaf via the system root store, so the
+	 * internal CA cert is irrelevant for backups — collapse the
+	 * block but still let the operator open it (some operators run
+	 * mixed trust setups, or want it for parallel non-backup use). */
+	let acmeIsPublic: boolean | null = $state(null);
+
+	async function loadCaCert() {
+		if (caCertPem !== null || caCertLoading) return;
+		caCertLoading = true;
+		try {
+			caCertPem = await client.call<string>('system.tls.local_ca_root');
+		} catch (e) {
+			error(`Load CA cert: ${e}`);
+		}
+		caCertLoading = false;
+	}
+
+	function downloadCaCert() {
+		if (!caCertPem) return;
+		const blob = new Blob([caCertPem], { type: 'application/x-pem-file' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'nasty-local-ca.crt';
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	}
+
 	async function loadRestConfig() {
 		try {
 			const cfg = await client.call<{ path: string }>('service.rest_server.config');
 			restServerPath = cfg.path;
 			restConfigLoaded = true;
 		} catch { /* ignore */ }
+		// Best-effort ACME state — only used to decide whether the CA
+		// cert block defaults expanded or collapsed. A failure here
+		// just means we default to expanded (the safer assumption
+		// since the internal-CA case is the only one that actually
+		// needs operator action source-side).
+		try {
+			const acme = await client.call<{ state: string }>('system.acme.status');
+			acmeIsPublic = acme.state === 'success';
+			caCertExpanded = !acmeIsPublic;
+		} catch {
+			acmeIsPublic = false;
+			caCertExpanded = true;
+		}
+		if (caCertExpanded) loadCaCert();
 	}
 
 	async function saveRestConfig() {
@@ -557,6 +612,42 @@
 														{copiedKey === 'rest-password' ? 'Copied!' : 'Copy'}
 													</Button>
 												</div>
+											</div>
+										{/if}
+									</div>
+
+									<div class="rounded-md border border-border p-3 max-w-md">
+										<button type="button"
+											onclick={() => { caCertExpanded = !caCertExpanded; if (caCertExpanded) loadCaCert(); }}
+											class="flex w-full items-start justify-between gap-3 text-left">
+											<div>
+												<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trusted CA certificate</p>
+												<p class="mt-1 text-xs text-muted-foreground">
+													{#if acmeIsPublic}
+														Not required — this box's TLS leaf is publicly trusted via ACME. Expand only if a source box explicitly needs to pin this CA.
+													{:else}
+														Paste into the source-side backup profile's "Trusted CA certificate" field so its HTTPS connection to this Backup Server validates.
+													{/if}
+												</p>
+											</div>
+											<span class="mt-0.5 shrink-0 text-xs text-muted-foreground">{caCertExpanded ? '▾' : '▸'}</span>
+										</button>
+										{#if caCertExpanded}
+											<div class="mt-3 space-y-2">
+												{#if caCertLoading}
+													<p class="text-xs text-muted-foreground">Loading…</p>
+												{:else if caCertPem}
+													<textarea readonly rows="6" value={caCertPem}
+														class="w-full rounded-md border border-input bg-muted/20 px-3 py-2 font-mono text-xs"></textarea>
+													<div class="flex gap-2">
+														<Button size="xs" variant="ghost" onclick={() => copyToClipboard(caCertPem!, 'ca-cert')}>
+															{copiedKey === 'ca-cert' ? 'Copied!' : 'Copy'}
+														</Button>
+														<Button size="xs" variant="ghost" onclick={downloadCaCert}>Download .crt</Button>
+													</div>
+												{:else}
+													<Button size="xs" variant="secondary" onclick={loadCaCert}>Load certificate</Button>
+												{/if}
 											</div>
 										{/if}
 									</div>


### PR DESCRIPTION
## Summary

Source-side backup profiles pointing at this box need to trust the TLS chain the rest-server serves (Caddy's internal CA leaf, per #407). Previously the only way to get that root cert into the source-side profile's "Trusted CA certificate" textarea (added in #409) was: navigate to /tls → click Download CA Root → open the file in a viewer → copy contents → paste. Three context switches for what's the obvious next step right after copying the receiver username + password.

Adds a third "Trusted CA certificate" block to the /services Backup Server panel, alongside the existing Receiver Credentials box. Same RPC the /tls page uses (`system.tls.local_ca_root`); renders the PEM in a readonly textarea with Copy + Download .crt buttons.

**ACME-aware default expansion** — when `system.acme.status.state === "success"` the rest-server's leaf is publicly trusted via the system root store and source boxes don't need to pin anything, so the block collapses with a "Not required" note. Operator can still expand it for mixed-trust deployments or parallel non-backup pinning. The typical internal-CA case (Caddy default) starts expanded and auto-fetches the PEM on first render so the operator sees it ready to copy.

## Sketch

```
Receiver credentials                    [Show] [Rotate]
  Username  nasty-backup            [Copy]
  Password  ••••••••••••••••       [Copy]

Trusted CA certificate                              ▾
  Paste into the source-side backup profile's "Trusted
  CA certificate" field so its HTTPS connection to this
  Backup Server validates.

  ┌──────────────────────────────────────────────────┐
  │ -----BEGIN CERTIFICATE-----                      │
  │ MIIDazCCAlOgAwIBAgIUJfNxJh...                    │
  │ -----END CERTIFICATE-----                        │
  └──────────────────────────────────────────────────┘
  [Copy] [Download .crt]
```

When ACME succeeded:
```
Trusted CA certificate                              ▸
  Not required — this box's TLS leaf is publicly trusted via
  ACME. Expand only if a source box explicitly needs to pin
  this CA.
```

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings.
- [ ] On nasty.0f.ee (internal CA): open /services → Backup Server → block starts expanded, textarea shows the PEM, Copy + Download work.
- [ ] On a hypothetical ACME-success box: block starts collapsed with the "Not required" note; clicking the header expands it and fetches the cert.
- [ ] End-to-end: copy the PEM from nasty.0f.ee, paste into a new backup profile on nas.0f.ee, init repo over HTTPS → no TLS error.