### PR TITLE
webui: refresh lockfile to latest semver-compatible SvelteKit/svelte

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-Sf6Lvlz4rwSgZxxKgD0fn1s1iW+lDaqnnjXX+98vm3w=";
+      npmDepsHash = "sha256-Sa7qk897tXfIUR87E6/aD8bbUo/my8CAfOIkitULN9s=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -768,9 +768,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.61.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.1.tgz",
-			"integrity": "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==",
+			"version": "2.63.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.63.0.tgz",
+			"integrity": "sha512-1DrR7vQ9brXLrNE2sLtFXApwr7AUXPfpbIFYc+CQRf2+iURaZbXGU+7TG/RLr+9fdFkoRdyCAVUOHCChw11LFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -807,6 +807,16 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@sveltejs/load-config": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
+			"integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1877,9 +1887,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
-			"version": "2.2.10",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.10.tgz",
-			"integrity": "sha512-HUTyxhhAQBl1hhsyLlHD1sh9xF6o6vaejzLxK5sge+LzrdEflQPQaNhC+n98d+OVB8v3LCCF+y80x/4bACjjJw==",
+			"version": "2.2.11",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.11.tgz",
+			"integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2693,9 +2703,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.1.tgz",
-			"integrity": "sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g==",
+			"version": "5.56.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.2.tgz",
+			"integrity": "sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2710,7 +2720,7 @@
 				"clsx": "^2.1.1",
 				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.9",
+				"esrap": "^2.2.11",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -2721,13 +2731,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.5.0.tgz",
-			"integrity": "sha512-9lNwPxCLWniFvQIcEv1LFqjIxcFtO3smb5+5BKbRJ3ttL4o2lXCej5rLF4DAnfLPI66oaA81vAxw6ILdIWI7kA==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
+			"integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
+				"@sveltejs/load-config": "0.1.1",
 				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",


### PR DESCRIPTION
## Summary

Pure lockfile bump — `package.json`'s existing caret ranges already permit the newer versions; `npm update` brings them in:

| Package | Before | After |
|---|---|---|
| `@sveltejs/kit` | 2.61.1 | 2.63.0 |
| `svelte` | 5.56.1 | 5.56.2 |
| `svelte-check` | 4.5.0 | 4.6.0 |

No app code changes; `package.json` unchanged.

`layerchart` shows up in `npm outdated` as "behind" because we're tracking a `2.0.0-next.*` prerelease and npm compares against the `latest` tag (`1.0.13`). Intentional, leave as-is.

## Known leftover

A transitive `cookie <0.7.0` advisory still surfaces in `npm audit` via @sveltejs/kit. The offered `--force` fix downgrades kit to 0.0.30 (wrong direction). Stays until upstream cuts a kit release with the cookie bump.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings.
- [x] `npm run build` — clean, same static site output.