### PR TITLE
fs.scrub: stream bcachefs output for live progress percent

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -583,6 +583,13 @@ pub struct ScrubStatus {
     /// `running`; cleared on completion.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<i64>,
+    /// 0-100 progress of the in-flight scrub, parsed from the
+    /// most recent `XX%` token in bcachefs's streaming output. Only
+    /// populated while `running`; deliberately NOT persisted so an
+    /// engine restart while a scrub is in flight doesn't surface
+    /// a stale percent from a child that's no longer being read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_percent: Option<f32>,
     /// Unix seconds when the most recent completed scrub finished.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_run_at: Option<i64>,
@@ -2451,6 +2458,7 @@ impl FilesystemService {
             let entry = state.entry(fs_name.clone()).or_insert_with(|| ScrubStatus {
                 running: false,
                 started_at: None,
+                progress_percent: None,
                 last_run_at: None,
                 last_duration_secs: None,
                 last_outcome: None,
@@ -2467,44 +2475,14 @@ impl FilesystemService {
         info!("Starting scrub on filesystem '{}'", name);
         tokio::spawn(async move {
             let mount = mount_point;
-            let output = cmd::run("bcachefs", &["scrub", &mount]).await;
+            // Stream stdout+stderr line-by-line so we can pick the
+            // most recent `XX%` token out of bcachefs's progress
+            // updates as it runs. Falls back gracefully when the
+            // binary doesn't print percent at all — the chip just
+            // shows "scrubbing (Nh ago)" via the elapsed timestamp.
+            let (outcome, captured) = stream_scrub_and_collect(&mount, &fs_name, &store).await;
             let end = unix_now_secs();
             let duration = (end - now).max(0) as u64;
-
-            let (outcome, captured) = match output {
-                Ok(out) => {
-                    // Combined output for operator inspection. stderr
-                    // first, then stdout — bcachefs uses stderr for
-                    // progress + error counters and stdout for summary.
-                    let stderr = String::from_utf8_lossy(&out.stderr);
-                    let stdout = String::from_utf8_lossy(&out.stdout);
-                    let combined = if stderr.is_empty() {
-                        stdout.into_owned()
-                    } else if stdout.is_empty() {
-                        stderr.into_owned()
-                    } else {
-                        format!("{stderr}\n{stdout}")
-                    };
-                    let classified = if !out.status.success() {
-                        ScrubOutcome::Failed
-                    } else if combined_indicates_errors(&combined) {
-                        ScrubOutcome::Errors
-                    } else {
-                        ScrubOutcome::Ok
-                    };
-                    (classified, combined)
-                }
-                Err(e) => {
-                    // Spawn failure (binary missing, permission denied)
-                    // — treat as Failed and keep the error message
-                    // so the operator can see *why* in the WebUI rather
-                    // than only in the journal.
-                    (
-                        ScrubOutcome::Failed,
-                        format!("failed to spawn bcachefs scrub: {e}"),
-                    )
-                }
-            };
 
             match outcome {
                 ScrubOutcome::Ok => info!("Scrub on '{fs_name}' completed in {duration}s: ok",),
@@ -2527,6 +2505,7 @@ impl FilesystemService {
                 let entry = state.entry(fs_name.clone()).or_insert_with(|| ScrubStatus {
                     running: false,
                     started_at: None,
+                    progress_percent: None,
                     last_run_at: None,
                     last_duration_secs: None,
                     last_outcome: None,
@@ -2535,6 +2514,7 @@ impl FilesystemService {
                 });
                 entry.running = false;
                 entry.started_at = None;
+                entry.progress_percent = None;
                 entry.last_run_at = Some(end);
                 entry.last_duration_secs = Some(duration);
                 entry.last_outcome = Some(outcome);
@@ -2567,6 +2547,7 @@ impl FilesystemService {
             state.get(name).cloned().unwrap_or_else(|| ScrubStatus {
                 running: false,
                 started_at: None,
+                progress_percent: None,
                 last_run_at: None,
                 last_duration_secs: None,
                 last_outcome: None,
@@ -2603,6 +2584,7 @@ impl FilesystemService {
                     .or_insert_with(|| status.clone());
                 entry.running = false;
                 entry.started_at = None;
+                entry.progress_percent = None;
                 entry.last_run_at = Some(end);
                 entry.last_duration_secs = Some(duration);
                 entry.last_outcome = Some(ScrubOutcome::Failed);
@@ -3563,6 +3545,221 @@ fn truncate_tail(s: &str, max: usize) -> String {
     out
 }
 
+/// Extract the last `XX%` / `XX.X%` token in a string. Walks back
+/// from the rightmost `%`, skips optional whitespace, then collects
+/// digits + an optional dot. Returns `None` when no parseable
+/// percent is present, or when the parsed value is out of [0, 100].
+/// Used by the scrub output streamer — bcachefs emits "32.5%" or
+/// similar inside its progress lines.
+fn parse_percent(s: &str) -> Option<f32> {
+    let bytes = s.as_bytes();
+    let percent_pos = bytes.iter().rposition(|&b| b == b'%')?;
+    let mut end = percent_pos;
+    while end > 0 && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    let mut start = end;
+    while start > 0 && (bytes[start - 1].is_ascii_digit() || bytes[start - 1] == b'.') {
+        start -= 1;
+    }
+    if start == end {
+        return None;
+    }
+    std::str::from_utf8(&bytes[start..end])
+        .ok()?
+        .parse::<f32>()
+        .ok()
+        .filter(|p| (0.0..=100.0).contains(p))
+}
+
+/// Cap on how much output we hold in memory during a running scrub.
+/// `bcachefs scrub` on a multi-TB pool can run for hours and chatter
+/// across the entire window; without a cap a particularly noisy run
+/// could balloon the engine's RSS. 1 MiB is well above any expected
+/// real-world transcript and still cheap to hold.
+const SCRUB_CAPTURE_INFLIGHT_CAP: usize = 1024 * 1024;
+
+/// Spawn `bcachefs scrub <mount>` with piped stdout+stderr, stream
+/// every line (and every `\r`-separated progress update — bcachefs
+/// uses carriage returns for in-place percent updates), feed the
+/// most-recent `XX%` token back into the in-memory scrub state, and
+/// return the (outcome, full captured transcript) on process exit.
+async fn stream_scrub_and_collect(
+    mount: &str,
+    fs_name: &str,
+    store: &ScrubStateMap,
+) -> (ScrubOutcome, String) {
+    use tokio::io::AsyncReadExt;
+    use tokio::process::Command;
+
+    let mut child = match Command::new("bcachefs")
+        .args(["scrub", mount])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                ScrubOutcome::Failed,
+                format!("failed to spawn bcachefs scrub: {e}"),
+            );
+        }
+    };
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let store_for_progress = store.clone();
+    let fs_name_for_progress = fs_name.to_string();
+    let capture = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let capture_for_task = capture.clone();
+
+    // One reader task per stream. Each task accumulates into the
+    // shared capture buffer and updates the in-memory progress
+    // percent whenever it sees a parseable `XX%` token. Streams
+    // run concurrently because stdout (final summary) and stderr
+    // (progress) come on different file descriptors.
+    let drain = async move |handle: Option<tokio::process::ChildStdout>,
+                            err_handle: Option<tokio::process::ChildStderr>| {
+        let store = store_for_progress;
+        let fs_name = fs_name_for_progress;
+        let cap = capture_for_task;
+        let mut stdout_buf = [0u8; 1024];
+        let mut stderr_buf = [0u8; 1024];
+        let mut stdout_pending = String::new();
+        let mut stderr_pending = String::new();
+
+        let mut stdout = handle;
+        let mut stderr = err_handle;
+
+        loop {
+            tokio::select! {
+                read = async {
+                    match stdout.as_mut() {
+                        Some(s) => s.read(&mut stdout_buf).await,
+                        None => Ok(0),
+                    }
+                }, if stdout.is_some() => {
+                    match read {
+                        Ok(0) => { stdout = None; }
+                        Ok(n) => process_chunk(
+                            &stdout_buf[..n],
+                            &mut stdout_pending,
+                            &cap,
+                            &store,
+                            &fs_name,
+                        ).await,
+                        Err(_) => { stdout = None; }
+                    }
+                }
+                read = async {
+                    match stderr.as_mut() {
+                        Some(s) => s.read(&mut stderr_buf).await,
+                        None => Ok(0),
+                    }
+                }, if stderr.is_some() => {
+                    match read {
+                        Ok(0) => { stderr = None; }
+                        Ok(n) => process_chunk(
+                            &stderr_buf[..n],
+                            &mut stderr_pending,
+                            &cap,
+                            &store,
+                            &fs_name,
+                        ).await,
+                        Err(_) => { stderr = None; }
+                    }
+                }
+                else => break,
+            }
+        }
+        // Flush any trailing un-terminated lines.
+        if !stdout_pending.is_empty() {
+            push_line(&stdout_pending, &cap, &store, &fs_name).await;
+        }
+        if !stderr_pending.is_empty() {
+            push_line(&stderr_pending, &cap, &store, &fs_name).await;
+        }
+    };
+
+    let drain_handle = tokio::spawn(drain(stdout, stderr));
+
+    let status = match child.wait().await {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = drain_handle.await;
+            return (
+                ScrubOutcome::Failed,
+                format!("bcachefs scrub child wait failed: {e}"),
+            );
+        }
+    };
+    let _ = drain_handle.await;
+
+    let captured = capture.lock().map(|g| g.clone()).unwrap_or_default();
+    let outcome = if !status.success() {
+        ScrubOutcome::Failed
+    } else if combined_indicates_errors(&captured) {
+        ScrubOutcome::Errors
+    } else {
+        ScrubOutcome::Ok
+    };
+    (outcome, captured)
+}
+
+/// Append a freshly-read chunk to the per-stream pending buffer,
+/// then drain any complete lines (split on `\n` or `\r` — bcachefs
+/// uses both, carriage returns for in-place progress updates).
+async fn process_chunk(
+    chunk: &[u8],
+    pending: &mut String,
+    cap: &std::sync::Arc<std::sync::Mutex<String>>,
+    store: &ScrubStateMap,
+    fs_name: &str,
+) {
+    pending.push_str(&String::from_utf8_lossy(chunk));
+    while let Some(boundary) = pending.find(['\n', '\r']) {
+        let line: String = pending.drain(..=boundary).collect();
+        let line = line.trim_end_matches(['\n', '\r']);
+        if line.is_empty() {
+            continue;
+        }
+        push_line(line, cap, store, fs_name).await;
+    }
+}
+
+/// Append one captured line to the in-memory transcript (capped at
+/// `SCRUB_CAPTURE_INFLIGHT_CAP`) and update the in-memory progress
+/// percent when the line carries a `XX%` token.
+async fn push_line(
+    line: &str,
+    cap: &std::sync::Arc<std::sync::Mutex<String>>,
+    store: &ScrubStateMap,
+    fs_name: &str,
+) {
+    if let Ok(mut buf) = cap.lock() {
+        buf.push_str(line);
+        buf.push('\n');
+        if buf.len() > SCRUB_CAPTURE_INFLIGHT_CAP {
+            // Trim from the front, keep the trailing 75% so the
+            // final summary survives whatever bcachefs prints next.
+            let drop = buf.len() - (SCRUB_CAPTURE_INFLIGHT_CAP * 3 / 4);
+            let mut start = drop;
+            while start < buf.len() && !buf.is_char_boundary(start) {
+                start += 1;
+            }
+            *buf = buf[start..].to_string();
+        }
+    }
+    if let Some(pct) = parse_percent(line) {
+        let mut state = store.lock().await;
+        if let Some(entry) = state.get_mut(fs_name) {
+            entry.progress_percent = Some(pct);
+        }
+    }
+}
+
 fn get_fs_mount_options(state: &FsState, name: &str) -> FsMountOptions {
     state.get(name).cloned().unwrap_or_default()
 }
@@ -4111,6 +4308,41 @@ mod tests {
         assert!(trimmed.starts_with("[output truncated]"));
         assert!(trimmed.ends_with("errors: 0\n"));
         assert!(trimmed.len() < chatty.len());
+    }
+
+    #[test]
+    fn scrub_parse_percent_extracts_typical_progress_line() {
+        // bcachefs prints something like "data scrub: 32.5% complete"
+        // (and similar — exact format may vary across tools versions).
+        // The parser walks back from the rightmost `%` so trailing
+        // descriptive text doesn't trip us up.
+        assert_eq!(parse_percent("data scrub: 32.5% complete"), Some(32.5));
+        assert_eq!(parse_percent("47%"), Some(47.0));
+        assert_eq!(parse_percent("scrubbing 100%"), Some(100.0));
+        assert_eq!(parse_percent("0%"), Some(0.0));
+        // Space between number and `%` should still parse — some
+        // tools print "47 %".
+        assert_eq!(parse_percent("47 %"), Some(47.0));
+    }
+
+    #[test]
+    fn scrub_parse_percent_rejects_invalid_or_out_of_range() {
+        assert_eq!(parse_percent("no percent here"), None);
+        assert_eq!(parse_percent(""), None);
+        // 150% is nonsense — clamp by rejecting rather than
+        // displaying a > 100 progress bar that looks broken.
+        assert_eq!(parse_percent("150%"), None);
+        // Bare `%` with no number.
+        assert_eq!(parse_percent("xxx%"), None);
+    }
+
+    #[test]
+    fn scrub_parse_percent_picks_rightmost_when_multiple() {
+        // When a line contains multiple percent tokens, the most
+        // recent one is the operator-meaningful current progress.
+        // (rationale: bcachefs may print "errors: 0%, scrubbing: 47%"
+        // or similar composites in future versions.)
+        assert_eq!(parse_percent("errors: 0%, scrub: 47.5%"), Some(47.5));
     }
 
     #[test]

--- a/webui/src/lib/components/BcachefsDiagnostics.svelte
+++ b/webui/src/lib/components/BcachefsDiagnostics.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { getClient } from '$lib/client';
 	import { error as showError } from '$lib/toast.svelte';
-	import type { Filesystem } from '$lib/types';
+	import type { Filesystem, ScrubStatus } from '$lib/types';
 	import { RefreshCw, SquareArrowOutUpRight } from '@lucide/svelte';
 
 	type Tab = 'usage' | 'top' | 'timestats' | 'scrub' | 'reconcile';
@@ -56,6 +56,11 @@
 	let scrubOutput = $state('');
 	let scrubRunning = $state(false);
 	let scrubLoading = $state(false);
+	/** Full ScrubStatus from the engine — drives the progress bar,
+	 * last-run summary, and outcome chip. The legacy `scrubOutput` /
+	 * `scrubRunning` state above stays in sync for the existing
+	 * `<pre>` render so the diff is additive rather than a rewrite. */
+	let scrubFull: ScrubStatus | null = $state(null);
 	let reconcileOutput = $state('');
 	let reconcileLoading = $state(false);
 	let reconcileEnabled = $state(true);
@@ -80,13 +85,17 @@
 
 	function startScrubPolling() {
 		if (scrubPollId) return;
+		// 2s while a scrub is in flight so the streamed percent feels
+		// live in the progress bar. scrub_status is cheap (in-memory
+		// hashmap lookup + one pgrep), and a multi-TB scrub gives us
+		// plenty of run-time to see the bar move at this cadence.
 		scrubPollId = setInterval(async () => {
 			await refreshScrub();
 			if (!scrubRunning && scrubPollId) {
 				clearInterval(scrubPollId);
 				scrubPollId = null;
 			}
-		}, 5000);
+		}, 2000);
 	}
 
 	function stopScrubPolling() {
@@ -166,16 +175,39 @@
 		if (!selectedFs) return;
 		scrubLoading = true;
 		try {
-			const result = await getClient().call<{ raw: string; running: boolean }>('fs.scrub.status', { name: selectedFs });
-			scrubOutput = result.raw || 'No scrub data available.';
+			const result = await getClient().call<ScrubStatus>('fs.scrub.status', { name: selectedFs });
+			scrubFull = result;
+			// Prefer the rich last_output (engine-captured transcript)
+			// when present; fall back to the legacy `raw` one-liner for
+			// fresh / never-scrubbed FSes.
+			scrubOutput = result.last_output || result.raw || 'No scrub data available.';
 			scrubRunning = result.running ?? false;
 			if (scrubRunning) startScrubPolling();
 			else stopScrubPolling();
 		} catch (e) {
+			scrubFull = null;
 			scrubOutput = e instanceof Error ? e.message : String(e);
 		} finally {
 			scrubLoading = false;
 		}
+	}
+
+	function formatScrubAgo(unixSecs: number | null | undefined): string {
+		if (!unixSecs) return '';
+		const delta = Math.max(0, Math.floor(Date.now() / 1000) - unixSecs);
+		if (delta < 60) return `${delta}s ago`;
+		if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+		if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
+		return `${Math.floor(delta / 86400)}d ago`;
+	}
+
+	function formatScrubDuration(secs: number | null | undefined): string {
+		if (!secs) return '';
+		if (secs < 60) return `${secs}s`;
+		if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+		const h = Math.floor(secs / 3600);
+		const m = Math.floor((secs % 3600) / 60);
+		return m ? `${h}h${m}m` : `${h}h`;
 	}
 
 	async function startScrub() {
@@ -547,9 +579,37 @@
 			{:else}
 				<div class="p-4">
 					{#if scrubRunning}
-						<div class="mb-3 flex items-center gap-2">
-							<span class="inline-block h-2 w-2 rounded-full bg-yellow-500 animate-pulse"></span>
-							<span class="text-sm font-medium text-yellow-500">Scrub in progress</span>
+						<div class="mb-3 space-y-2">
+							<div class="flex items-center gap-2">
+								<span class="inline-block h-2 w-2 rounded-full bg-yellow-500 animate-pulse"></span>
+								<span class="text-sm font-medium text-yellow-500">
+									Scrub in progress{#if scrubFull?.started_at} · started {formatScrubAgo(scrubFull.started_at)}{/if}
+								</span>
+							</div>
+							{#if scrubFull?.progress_percent != null}
+								<div class="space-y-1">
+									<div class="h-2 w-full overflow-hidden rounded-full bg-secondary">
+										<div
+											class="h-full rounded-full bg-yellow-500 transition-[width] duration-500"
+											style="width: {Math.min(100, Math.max(0, scrubFull.progress_percent))}%"
+										></div>
+									</div>
+									<span class="text-xs text-muted-foreground font-mono">
+										{scrubFull.progress_percent.toFixed(scrubFull.progress_percent >= 10 ? 1 : 2)}%
+									</span>
+								</div>
+							{/if}
+						</div>
+					{:else if scrubFull?.last_run_at}
+						{@const outcome = scrubFull.last_outcome ?? 'ok'}
+						{@const cls = outcome === 'ok' ? 'text-green-500' : outcome === 'errors' ? 'text-amber-500' : 'text-red-500'}
+						{@const label = outcome === 'ok' ? 'completed successfully' : outcome === 'errors' ? 'completed with errors' : 'failed'}
+						<div class="mb-3 flex items-center gap-2 text-sm">
+							<span class="inline-block h-2 w-2 rounded-full {outcome === 'ok' ? 'bg-green-500' : outcome === 'errors' ? 'bg-amber-500' : 'bg-red-500'}"></span>
+							<span class="font-medium {cls}">Last scrub {label}</span>
+							<span class="text-muted-foreground">
+								· {formatScrubAgo(scrubFull.last_run_at)}{#if scrubFull.last_duration_secs} · took {formatScrubDuration(scrubFull.last_duration_secs)}{/if}
+							</span>
 						</div>
 					{/if}
 					<pre class="text-xs font-mono overflow-x-auto whitespace-pre leading-relaxed">{scrubOutput}</pre>

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -382,6 +382,10 @@ export interface ScrubStatus {
 	running: boolean;
 	/** Unix seconds when the current run started; set while running. */
 	started_at?: number | null;
+	/** 0-100 progress of the in-flight scrub, parsed from the most
+	 * recent `XX%` token in bcachefs's streaming output. Only set
+	 * while `running`. */
+	progress_percent?: number | null;
 	/** Unix seconds when the most recent completed scrub finished. */
 	last_run_at?: number | null;
 	/** Duration of the most recent completed scrub, in seconds. */

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -146,6 +146,11 @@
 	function updateScrubPolling() {
 		const anyRunning = Object.values(scrubStatuses).some((s) => s.running);
 		if (anyRunning && !scrubPoll) {
+			// 2s while a scrub is in flight so the streamed percent
+			// feels live without hammering the engine. The
+			// scrub_status RPC is cheap (in-memory hashmap lookup +
+			// one pgrep per call); the prior 5s cadence was too slow
+			// to make the new percent-chip feel responsive.
 			scrubPoll = setInterval(async () => {
 				const updates = await Promise.all(
 					filesystems
@@ -161,7 +166,7 @@
 				for (const r of updates) if (r) next[r[0]] = r[1];
 				scrubStatuses = next;
 				updateScrubPolling();
-			}, 5000);
+			}, 2000);
 		} else if (!anyRunning && scrubPoll) {
 			clearInterval(scrubPoll);
 			scrubPoll = null;
@@ -188,12 +193,14 @@
 	function scrubChip(s: ScrubStatus | undefined): { label: string; cls: string; title: string } {
 		if (!s) return { label: 'scrub: —', cls: 'text-muted-foreground', title: 'No scrub data' };
 		if (s.running) {
+			// Prefer the parsed bcachefs percent when we have one;
+			// fall back to elapsed time so a tools build that doesn't
+			// print percent (or hasn't yet) still shows motion.
 			const since = s.started_at ? humanAgo(s.started_at) : 'now';
-			return {
-				label: `scrubbing (${since})`,
-				cls: 'text-blue-400',
-				title: 'Scrub in progress',
-			};
+			const label = s.progress_percent != null
+				? `scrubbing ${s.progress_percent.toFixed(s.progress_percent >= 10 ? 0 : 1)}% (${since})`
+				: `scrubbing (${since})`;
+			return { label, cls: 'text-blue-400', title: 'Scrub in progress' };
 		}
 		if (!s.last_run_at) {
 			return { label: 'never scrubbed', cls: 'text-muted-foreground', title: 'This filesystem has not been scrubbed since the engine started tracking.' };


### PR DESCRIPTION
Follow-up to #422. Reporter on #419 posted a screenshot showing the Diagnostics → scrub tab still displaying the legacy "Scrub in progress..." string with no percent — fair.

## Engine

- `scrub_start` switches from blocking `cmd::run` to `tokio::process::Command::spawn` with piped stdout+stderr. A drain task reads both streams concurrently with a `tokio::select!` loop, splits on **both** `\n` AND `\r` (bcachefs uses carriage returns for in-place progress updates so `\n`-only splitting would never see most of them), and feeds each parsed line through `parse_percent`. The most recent `XX%` token is written back to the in-memory `ScrubStatus`.
- New `progress_percent: Option<f32>` field on `ScrubStatus`, marked `#[serde(skip_serializing_if = "Option::is_none")]` and deliberately **NOT persisted** — an engine restart while a scrub is in flight already records that scrub as `Failed`, and a stale percent from a child that's no longer being read would be misleading.
- In-memory capture buffer capped at 1 MiB during the run (front-trimmed to the trailing 75% when it overflows so the final summary survives whatever bcachefs prints next). Final transcript still truncated to the trailing 8 KiB on completion (existing `truncate_tail` path unchanged).
- `parse_percent` is shape-defensive — walks back from the rightmost `%`, skips optional whitespace, collects digits+dot. Rejects values outside [0, 100] so a malformed line can't push the progress bar past full.

## WebUI

- `ScrubStatus.progress_percent` plumbed through types.ts.
- Per-FS chip on /filesystems now reads **"scrubbing 47% (2h ago)"** when a percent is present, falls back to **"scrubbing (2h ago)"** when not (tools build that doesn't print percent, or before the first progress line arrives).
- Diagnostics → scrub tab gets a proper progress bar with smooth-transition width animation, the current percent below it, and a post-run summary line showing outcome + duration + "Nd ago" — plus the raw transcript as before.
- Running-scrub poller dropped from 5s to 2s on both the /filesystems chip and the Diagnostics tab so the bar feels live without hammering the engine.

## Sketch

While scrubbing (chip on /filesystems Manage):
```
tank  [Mounted] /fs/tank   ... · scrubbing 47.3% (2h ago)
```

While scrubbing (Diagnostics → scrub):
```
● Scrub in progress · started 2h ago
████████████████░░░░░░░░░░░░░░░░░░  47.3%
```

After completion (Diagnostics → scrub):
```
● Last scrub completed successfully · 30m ago · took 4h12m
<raw output here>
```

## Test plan

- [x] `cargo test -p nasty-storage --lib` — 52 pass, 3 new pinning `parse_percent` shape:
  - typical line: `data scrub: 32.5% complete` → 32.5
  - bare `47%`, `0%`, `100%`, `47 %` → expected
  - invalid: empty / no-percent / `150%` / `xxx%` → None
  - multiple percents in one line: rightmost wins (`errors: 0%, scrub: 47.5%` → 47.5)
- [x] `cargo clippy --workspace --no-deps --all-targets` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `npm run check` — 0 errors, 0 warnings.
- [ ] On nas.0f.ee: trigger Scrub, watch the chip on the FS row tick up through 0% → … → 100% over the run; cross-check against the journal where bcachefs's actual percent line lives.
- [ ] Open /filesystems → Diagnostics → scrub: progress bar animates, percent below it ticks, post-run state shows outcome + duration.
- [ ] If the bcachefs build in use doesn't print percent at all: chip falls back to "scrubbing (Nh ago)"; diagnostics tab still shows the spinner header without a bar. (Defensive fallback verified by the `parse_percent` returning None path.)

## Notes

- I don't have ground-truth on the exact bcachefs scrub output format across versions — `parse_percent` matches the rightmost `\d+(\.\d+)?\s*%` token in any output line, which should cover both `32.5% complete` and `(32%)` shapes operators have reported in the wild. If your build prints something the parser misses, the chip silently falls back to elapsed-time and we can teach the parser the new shape.