### PR TITLE
net/nm: disable bridge multicast-snooping via NM property (#291)

### DIFF
--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -476,6 +476,16 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
             if let Some(fd) = forward_delay {
                 out.push_str(&format!("forward-delay={fd}\n"));
             }
+            // Disable bridge multicast snooping (#291). The Linux bridge
+            // defaults to multicast_snooping=1 + multicast_querier=0; with
+            // no querier on a typical home LAN, the bridge stops forwarding
+            // multicast ~5 min after the last IGMP membership times out.
+            // That silently kills mDNS (avahi/Finder) and WSD (Windows
+            // Explorer) discovery once a NASty link is enslaved to a bridge:
+            // the SMB data path keeps working but the box vanishes from file
+            // managers. Snooping buys nothing without a querier, so turn it
+            // off on every bridge we manage.
+            out.push_str("multicast-snooping=false\n");
             // Bridge-master MTU lives here, not in [ethernet] (NM ≥1.20).
             if let Some(mtu) = p.mtu {
                 out.push_str(&format!("mtu={mtu}\n"));
@@ -617,6 +627,11 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
                 // NM expects forward-delay as a u32 in seconds.
                 bridge.insert("forward-delay".into(), into_value(u32::from(*fd)));
             }
+            // Disable multicast snooping (#291) — see the keyfile
+            // serializer for the full rationale. Without a querier on the
+            // LAN the bridge stops forwarding multicast after ~5 min,
+            // which kills mDNS/WSD discovery while leaving SMB working.
+            bridge.insert("multicast-snooping".into(), into_value(false));
             // Bridge-master MTU lives in [bridge] (NM ≥1.20). Reported
             // in #96: bond/bridge MTU was being silently dropped because
             // we only emitted MTU under [802-3-ethernet] for Ethernet
@@ -1186,6 +1201,8 @@ mod tests {
         assert!(keyfile.contains("[bridge]"));
         assert!(keyfile.contains("stp=true"));
         assert!(keyfile.contains("forward-delay=4"));
+        // #291: snooping disabled so mDNS/WSD keep flowing without a querier.
+        assert!(keyfile.contains("multicast-snooping=false"));
     }
 
     #[test]
@@ -1465,6 +1482,13 @@ mod tests {
             .unwrap();
         assert!(stp);
         assert_eq!(fd, 7);
+        // #291: multicast snooping disabled on every managed bridge.
+        let snooping: bool = bridge["multicast-snooping"]
+            .try_clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert!(!snooping);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sets `bridge.multicast-snooping=no` on every NASty-managed bridge profile, in both the keyfile and D-Bus serializers (`engine/nasty-system/src/network/nm.rs`). This is the permanent fix for #291 (NASty vanishing from file managers once configured behind a Linux bridge) — and the correction to #356, which looked done but didn't hold.

## Root cause (verified on hardware — dev box, NM 1.56)

The Linux bridge enables multicast snooping by default. With no IGMP querier on a typical home LAN, memberships time out ~5 min after the last join and the bridge stops forwarding multicast — including mDNS (avahi/Finder) and WS-Discovery (Windows Explorer). The SMB data path keeps working, so the box stays reachable by IP but vanishes from file managers. That's the #291 symptom.

#356 tried to fix this with a udev rule writing `multicast_snooping=0` on the bridge's `add` event. I reproduced **why it doesn't hold**, on a real box with a portless vs. port-enslaved bridge:

| Scenario | `multicast_snooping` |
|----------|----------------------|
| portless bridge, default property | `0` (udev write holds) |
| **default property + first port enslaved** | **`1`** ← the bug |
| explicit property = `no` + port enslaved | `0` ← the fix |
| explicit `no`, after NM down/up re-activation + port | `0` (persists) |

The udev rule's `add`-time write holds only until the **first port is enslaved** — adding a port re-enables the bridge's multicast snooping, and the `add`-only rule never re-fires to catch it. So a naive portless test passes while a real deployment (interface enslaved to the bridge) stays broken — exactly the #291 reporter's case. (My earlier "NM clobbers the udev 0 on every activation" framing was wrong; the trigger is port enslavement, confirmed empirically.)

An explicit `bridge.multicast-snooping=no` is the only thing that forces `0` **after** a port joins: NM programs the explicit property into the kernel on every activation (verified: explicit `yes` → `1`, explicit `no` → `0`), so the value survives port enslavement and reboots.

## Scope

- **NM property (this PR)** → every NASty/WebUI bridge, on every activation and reboot, including with ports enslaved. Fixes the reporter's case.
- **#356 udev rule (kept as-is)** → still useful for hand-created `brN` bridges NM doesn't manage; harmless alongside this.

## Test plan

- [x] `cargo test -p nasty-system network::nm::` — 58 passed (keyfile + D-Bus assertions added)
- [x] `cargo clippy -p nasty-system --all-targets --no-deps` — clean
- [x] **Live (dev box 10.10.10.32, NM 1.56):** explicit `no` → kernel `multicast_snooping=0` with a port enslaved and across NM re-activation (table above). Bug reproduced with the default property + enslaved port.
- [ ] Live soak: from a LAN client, box stays visible in `avahi-browse -art | grep -i smb` past the ~5-min IGMP timeout window (needs SMB enabled + a client on the same L2)

Closes #291.