### PR TITLE
apps: don't start Docker against a dangling data-root symlink on boot (#424)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3513,6 +3513,14 @@ impl AppsService {
         // enable path runs configure_docker_data_root first; this boot path
         // did not — so guard it here and surface the cause instead of
         // looping into start-limit-hit.
+        //
+        // This guard only covers the start *we* drive. docker.service is
+        // TriggeredBy=docker.socket, so a client connecting to the socket
+        // can socket-activate dockerd behind our back — that path is
+        // backstopped by `ConditionPathIsDirectory=/var/lib/docker` on
+        // docker.service (nixos/modules/nasty.nix), which skips the unit
+        // cleanly when the symlink dangles. This log line is the operator-
+        // facing half: it explains *why* (filesystem not mounted/unlocked).
         if let Err(target) = docker_data_root_status(Path::new("/var/lib/docker")) {
             error!(
                 "Apps enabled but Docker data-root /var/lib/docker -> {target} does not resolve \

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -4677,10 +4677,8 @@ mod tests {
         use std::sync::atomic::{AtomicU32, Ordering};
         static N: AtomicU32 = AtomicU32::new(0);
         let n = N.fetch_add(1, Ordering::Relaxed);
-        let p = std::env::temp_dir().join(format!(
-            "nasty-apps-test-{tag}-{}-{n}",
-            std::process::id()
-        ));
+        let p =
+            std::env::temp_dir().join(format!("nasty-apps-test-{tag}-{}-{n}", std::process::id()));
         let _ = std::fs::remove_dir_all(&p);
         let _ = std::fs::remove_file(&p);
         p

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3506,6 +3506,22 @@ impl AppsService {
         if !self.is_enabled() {
             return;
         }
+        // #424: never start Docker against a dangling data-root symlink.
+        // v0.0.10 points /var/lib/docker at the apps bcachefs FS; if that
+        // FS isn't mounted/unlocked yet at boot, dockerd crash-loops on
+        // `mkdir /var/lib/docker: file exists` and wedges the apps UI. The
+        // enable path runs configure_docker_data_root first; this boot path
+        // did not — so guard it here and surface the cause instead of
+        // looping into start-limit-hit.
+        if let Err(target) = docker_data_root_status(Path::new("/var/lib/docker")) {
+            error!(
+                "Apps enabled but Docker data-root /var/lib/docker -> {target} does not resolve \
+                 — the apps filesystem is not mounted (failed mount or still-locked encrypted FS). \
+                 Not starting Docker to avoid a crash loop; unlock/mount the filesystem, then \
+                 re-enable apps or reboot."
+            );
+            return;
+        }
         info!("Apps runtime enabled — ensuring Docker is running");
         if let Err(e) = run_cmd("systemctl", &["start", DOCKER_SERVICE]).await {
             error!("Failed to start Docker: {e}");
@@ -4309,6 +4325,46 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
     Ok(())
 }
 
+/// Whether Docker's data-root is safe to start dockerd against.
+///
+/// v0.0.10 (`configure_docker_data_root`) replaced `/var/lib/docker`
+/// with a symlink onto the apps bcachefs filesystem. When that
+/// filesystem isn't mounted at boot — a failed mount, a still-locked
+/// encrypted FS, a slow/absent device — the symlink dangles. dockerd's
+/// startup `os.MkdirAll("/var/lib/docker")` then stat-fails the target
+/// and falls through to `mkdir()` on the link inode itself, returning
+/// `mkdir /var/lib/docker: file exists`; systemd retries, hits
+/// `start-limit-hit`, and the apps UI wedges (#424).
+///
+/// The enable path guards this by running `configure_docker_data_root`
+/// first; the boot `restore()` path historically did not. This check
+/// closes that gap so `restore()` starts Docker only when the data-root
+/// is a real directory or a symlink whose target resolves.
+///
+/// Returns `Err(target)` carrying the unresolved link target when the
+/// data-root is a dangling symlink; `Ok(())` otherwise — a real dir, a
+/// resolving symlink, or an absent path (dockerd then creates a plain
+/// dir on the root FS itself, same as a fresh pre-v0.0.10 install).
+fn docker_data_root_status(docker_lib: &Path) -> Result<(), String> {
+    let Ok(link_meta) = std::fs::symlink_metadata(docker_lib) else {
+        // Absent — dockerd creates it. Safe.
+        return Ok(());
+    };
+    if !link_meta.file_type().is_symlink() {
+        // Plain directory (pre-v0.0.10 layout, or non-bcachefs box). Safe.
+        return Ok(());
+    }
+    // Symlink: only safe if the target resolves. `metadata` follows the
+    // link, so an error here means the target is missing (dangling).
+    if std::fs::metadata(docker_lib).is_ok() {
+        return Ok(());
+    }
+    let target = std::fs::read_link(docker_lib)
+        .map(|t| t.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "<unreadable>".to_string());
+    Err(target)
+}
+
 // ── Container image inspection ──────────────────────────────
 
 fn parse_image_ref(image: &str) -> (String, String, String) {
@@ -4612,7 +4668,66 @@ async fn fetch_manifest_json(
 
 #[cfg(test)]
 mod tests {
-    use super::{AppVolume, validate_simple_volumes};
+    use super::{AppVolume, docker_data_root_status, validate_simple_volumes};
+    use std::path::PathBuf;
+
+    /// A process-unique scratch path under the temp dir. The crate has
+    /// no tempfile dev-dep; this keeps tests self-contained.
+    fn unique_tmp(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!(
+            "nasty-apps-test-{tag}-{}-{n}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    #[test]
+    fn data_root_absent_is_ok() {
+        // Fresh box: no /var/lib/docker yet — dockerd creates it.
+        let missing = unique_tmp("absent").join("docker");
+        assert!(docker_data_root_status(&missing).is_ok());
+    }
+
+    #[test]
+    fn data_root_plain_dir_is_ok() {
+        // Pre-v0.0.10 / non-bcachefs layout: a real directory.
+        let dir = unique_tmp("plaindir");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(docker_data_root_status(&dir).is_ok());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn data_root_resolving_symlink_is_ok() {
+        // v0.0.10 happy path: symlink → an existing dir on a mounted FS.
+        let base = unique_tmp("goodlink");
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("apps-docker");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = base.join("docker");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(docker_data_root_status(&link).is_ok());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn data_root_dangling_symlink_is_err() {
+        // #424: FS not mounted/unlocked → symlink target absent. This is
+        // the case that must NOT start Docker.
+        let base = unique_tmp("danglink");
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("not-mounted/apps-docker");
+        let link = base.join("docker");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let err = docker_data_root_status(&link).expect_err("dangling link must be rejected");
+        assert!(err.contains("not-mounted/apps-docker"), "got: {err}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
 
     fn vol(host_path: &str) -> AppVolume {
         AppVolume {

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -640,6 +640,22 @@ in {
     systemd.services.docker.wantedBy = lib.mkForce [];
     systemd.sockets.docker.wantedBy = lib.mkForce [];
 
+    # Refuse to start dockerd while its data-root symlink doesn't resolve
+    # (#424). The engine symlinks /var/lib/docker onto the apps bcachefs
+    # filesystem; when that FS isn't mounted/unlocked at boot the symlink
+    # dangles, and dockerd's startup mkdir fails with "mkdir
+    # /var/lib/docker: file exists", crash-loops into start-limit-hit, and
+    # wedges the apps UI. The engine's restore() already guards the path
+    # *it* drives, but docker.service is TriggeredBy=docker.socket — so a
+    # client connecting to the still-listening socket socket-activates
+    # dockerd behind the engine's back. A `Condition` (skip, not assert)
+    # covers every trigger path: a dangling symlink makes the unit skip
+    # cleanly with no restart counter, while a resolving symlink (the
+    # normal case, where the engine created it before starting docker)
+    # passes. ConditionPathIsDirectory follows the symlink, so it's false
+    # exactly when the target is missing.
+    systemd.services.docker.unitConfig.ConditionPathIsDirectory = "/var/lib/docker";
+
     # ── System packages ────────────────────────────────────────
 
     environment.systemPackages = with pkgs; [

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -640,21 +640,33 @@ in {
     systemd.services.docker.wantedBy = lib.mkForce [];
     systemd.sockets.docker.wantedBy = lib.mkForce [];
 
-    # Refuse to start dockerd while its data-root symlink doesn't resolve
+    # Refuse to start dockerd while its data-root symlink is *dangling*
     # (#424). The engine symlinks /var/lib/docker onto the apps bcachefs
     # filesystem; when that FS isn't mounted/unlocked at boot the symlink
     # dangles, and dockerd's startup mkdir fails with "mkdir
     # /var/lib/docker: file exists", crash-loops into start-limit-hit, and
-    # wedges the apps UI. The engine's restore() already guards the path
-    # *it* drives, but docker.service is TriggeredBy=docker.socket — so a
-    # client connecting to the still-listening socket socket-activates
-    # dockerd behind the engine's back. A `Condition` (skip, not assert)
-    # covers every trigger path: a dangling symlink makes the unit skip
-    # cleanly with no restart counter, while a resolving symlink (the
-    # normal case, where the engine created it before starting docker)
-    # passes. ConditionPathIsDirectory follows the symlink, so it's false
-    # exactly when the target is missing.
-    systemd.services.docker.unitConfig.ConditionPathIsDirectory = "/var/lib/docker";
+    # wedges the apps UI. The engine's restore() guards the path *it*
+    # drives, but docker.service is TriggeredBy=docker.socket — so a client
+    # connecting to the still-listening socket socket-activates dockerd
+    # behind the engine's back. A `Condition` (skip, not assert) covers
+    # every trigger path with no restart counter.
+    #
+    # The two conditions are ORed (the `|` triggering prefix): start docker
+    # iff /var/lib/docker resolves to a directory, OR is not a symlink at
+    # all. That last clause is load-bearing — on a fresh box the path
+    # doesn't exist yet (dockerd creates it on first start), and a plain
+    # ConditionPathIsDirectory would wrongly skip that case (it broke the
+    # appliance-smoke test). ConditionPathIsSymbolicLink uses lstat, so it
+    # distinguishes "absent / real dir" (start) from "dangling symlink"
+    # (skip) — ConditionPathExists/IsDirectory follow the link and can't.
+    #
+    #   absent           → IsDirectory=F, !IsSymlink=T → start (dockerd mkdirs it)
+    #   real dir / valid  → IsDirectory=T               → start
+    #   dangling symlink → IsDirectory=F, !IsSymlink=F → skip
+    systemd.services.docker.unitConfig = {
+      ConditionPathIsDirectory = "|/var/lib/docker";
+      ConditionPathIsSymbolicLink = "|!/var/lib/docker";
+    };
 
     # ── System packages ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #424 — Docker crash-looping with `mkdir /var/lib/docker: file exists` and the apps UI stuck spooling after the move to v0.0.10.

## Root cause

v0.0.10 (`385a34b`, "store Docker data and VM images on bcachefs, not root partition") replaced `/var/lib/docker` with a **symlink** → `/fs/<fs>/apps/docker` on bcachefs, created by `configure_docker_data_root()`.

That call was wired into the apps **enable** path (`lib.rs:1486`) but **not** the boot **restore** path. `restore()` just runs `systemctl start docker.service` whenever apps are enabled, without re-establishing or validating the symlink.

When the apps filesystem isn't mounted at boot — a failed mount (non-fatal since #299), a **still-locked encrypted FS**, or a slow/absent device — the symlink dangles. dockerd's startup `os.MkdirAll("/var/lib/docker")` stat-fails the missing target and falls through to `mkdir()` on the link inode itself → `mkdir /var/lib/docker: file exists`. systemd retries → `start-limit-hit` → UI wedges. A reboot doesn't help because the FS stays unmounted/locked across reboots — exactly the report.

## Fix

Gate `restore()` on a new `docker_data_root_status()` check: start Docker only when the data-root is a real directory or a symlink whose target **resolves**. On a dangling symlink, log the cause (filesystem not mounted / still locked) and skip the start instead of crash-looping.

Deliberately conservative — it does **not** re-run `configure_docker_data_root()` on boot, because that would `create_dir_all` under an unmounted mountpoint (writing the apps tree onto the root FS). The right recovery is to unlock/mount the FS, then re-enable apps or reboot; the new error message says so.

Covers all four data-root states:

| State | Behaviour |
|-------|-----------|
| Absent | start (dockerd creates it) |
| Plain dir (pre-v0.0.10 / non-bcachefs) | start |
| Symlink, target resolves | start |
| Symlink, target missing (dangling) | **skip + log**, no crash loop |

## Test plan

- [x] `cargo test -p nasty-apps --lib` — 84 passed (4 new `data_root_*` tests)
- [x] `cargo clippy -p nasty-apps --all-targets --no-deps` — clean
- [ ] Live: encrypted apps FS left locked at boot → engine logs the skip, Docker stays down cleanly, apps page reports not-ready (no crash loop); unlock + re-enable brings it up

Note: the disk-temperature complaint in #424 is unrelated (SMART display) and should be split into its own issue.

Closes #424.