### PR TITLE
engine: report build commit via /health and --version

### DIFF
--- a/engine/nasty-engine/build.rs
+++ b/engine/nasty-engine/build.rs
@@ -6,4 +6,35 @@ fn main() {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=NASTY_BUILD_DATE={}", now.trim());
+
+    // Bake the git commit this engine was built from into the binary as
+    // `NASTY_GIT_SHA`, readable at runtime via `option_env!`. The engine
+    // already relied on this for telemetry, but only `nasty-system`'s
+    // build.rs emitted it — so a plain `cargo build` of `nasty-engine`
+    // left `option_env!("NASTY_GIT_SHA")` as `None` in *this* crate, and
+    // `/health` / `--version` couldn't report the commit. Emit it here too
+    // so cargo dev builds carry the SHA, not just Nix builds.
+    //
+    // Sources, in priority order (mirrors nasty-system/build.rs):
+    //   1. `NASTY_GIT_SHA` env var — Nix passes the flake rev (mkEngine),
+    //      the only source that works in the sandbox (no .git there).
+    //   2. `git rev-parse HEAD` — local cargo builds outside Nix.
+    // On total failure the SHA is just absent; builds always succeed.
+    let sha = std::env::var("NASTY_GIT_SHA")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
+    if let Some(sha) = sha {
+        println!("cargo:rustc-env=NASTY_GIT_SHA={sha}");
+    }
+    println!("cargo:rerun-if-env-changed=NASTY_GIT_SHA");
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -101,9 +101,14 @@ async fn main() -> anyhow::Result<()> {
     let built = env!("NASTY_BUILD_DATE");
     let args = std::env::args().collect::<Vec<_>>();
 
-    // --version flag
+    // --version flag. Includes the git commit so it can be matched
+    // against a deployed branch/commit — the version alone (0.0.10 on
+    // every branch) can't tell two builds apart.
     if args.iter().any(|a| a == "--version" || a == "-V") {
-        println!("nasty-engine {version} (built: {built})");
+        match telemetry::build_commit() {
+            Some(commit) => println!("nasty-engine {version} ({commit}, built: {built})"),
+            None => println!("nasty-engine {version} (built: {built})"),
+        }
         return Ok(());
     }
 
@@ -703,6 +708,12 @@ async fn health() -> impl IntoResponse {
     Json(serde_json::json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
+        // The git commit is the only field that distinguishes two builds
+        // of the same version (every branch on 0.0.10 reports version
+        // 0.0.10) — so a deploy can poll /health and confirm the running
+        // engine is the exact commit it shipped. `null` on cargo builds
+        // with no SHA available.
+        "commit": telemetry::build_commit(),
         "built": env!("NASTY_BUILD_DATE"),
     }))
 }

--- a/engine/nasty-engine/src/telemetry.rs
+++ b/engine/nasty-engine/src/telemetry.rs
@@ -29,7 +29,9 @@ struct Report {
 /// Short git SHA this engine was built from. `None` for dev cargo
 /// builds outside Nix where `NASTY_GIT_SHA` wasn't injected. Matches
 /// the 7-char form used elsewhere (see `nasty-system::update`).
-fn build_commit() -> Option<String> {
+/// Reused by `/health` and `--version` so all three report the same
+/// commit from the same compile-time source.
+pub(crate) fn build_commit() -> Option<String> {
     let raw = option_env!("NASTY_GIT_SHA")?.trim();
     if raw.is_empty() || raw == "unknown" {
         return None;


### PR DESCRIPTION
## Summary

Surfaces the git commit the engine was built from, so a deploy can confirm the running engine is the exact commit it shipped — and so tooling can auto-detect when a new engine is live after a branch switch.

Follow-up to the #425/#426 verification work: while testing on hardware, there was no clean way to tell *which* commit the box was running. `version` is `CARGO_PKG_VERSION`, identical across every branch on a release (all `0.0.10`), and `built` (a timestamp) can't identify the code. The **git commit** is the precise identifier — already baked in as `NASTY_GIT_SHA` (Nix flake rev) and used by telemetry, just never surfaced locally.

## Changes

1. **`nasty-engine/build.rs`** now also emits `NASTY_GIT_SHA` (env var from Nix `mkEngine`, else `git rev-parse HEAD`), mirroring `nasty-system/build.rs`. Previously only `nasty-system` emitted it, so a plain `cargo build` of `nasty-engine` left `option_env!("NASTY_GIT_SHA")` as `None` in this crate.
2. **`telemetry::build_commit()`** is now `pub(crate)` and reused, so every caller reports the same 7-char SHA from the same compile-time source.
3. **`/health`** gains a `"commit"` field (unauthenticated, same as the rest of that endpoint).
4. **`--version`** now includes the commit.

```
$ nasty-engine --version
nasty-engine 0.0.10 (28a9e95, built: 2026-06-06T21:06:22Z)

$ curl -sk https://<box>/health
{"status":"ok","version":"0.0.10","commit":"28a9e95","built":"2026-06-06T21:06:22Z"}
```

`commit` is `null`/absent on cargo builds with no SHA available; builds always succeed (the `git` fallback no-ops in the Nix sandbox, env-var path taken first — the same pattern `nasty-system/build.rs` already uses safely). Embeds at compile time — no reading back through booted-system / `flake.lock` chains that lag activation.

## Test plan

- [x] `cargo build -p nasty-engine` → `--version` prints the commit, matches `git rev-parse --short=7 HEAD`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p nasty-engine --all-targets --no-deps` clean
- [ ] Nix build still injects the flake rev into `/health.commit` (CI Nix engine build)