### PR TITLE
appliance: smartd reports raw disk temperature, not normalized (#424)

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -140,6 +140,19 @@
 
   # Enable SMART monitoring; skip silently on VMs (no SMART-capable devices)
   services.smartd.enable = true;
+  # smartd's default `-a` tracks attribute changes by *normalized* value, so
+  # Temperature_Celsius (194) and Airflow_Temperature_Cel (190) hit the journal
+  # as a 0–253 health value — e.g. "194 Temperature_Celsius changed from 119 to
+  # 120" — which reads like 120 °C and alarms operators who think their disks
+  # are cooking (#424). The real temperature is the attribute's *raw* value
+  # (~30 °C). `-r 194 -r 190` appends that raw value to the change lines so the
+  # actual temperature is visible (e.g. "... [Raw 30]"). NASty's own disk-temp
+  # alerting already reads smartctl's raw °C, so this only de-confuses the log.
+  #
+  # `-r` (report raw alongside the normalized value) — deliberately NOT `-R`,
+  # which would *trigger* a journal line on every raw change, i.e. spam one
+  # entry per 1 °C of drift.
+  services.smartd.defaults.monitored = "-a -r 194 -r 190";
   systemd.services.smartd.unitConfig.ConditionVirtualization = "no";
 
   system.stateVersion = "24.11";


### PR DESCRIPTION
## Summary

Fixes the alarming "120 °C" disk-temperature lines in the journal reported in #424. **The disks were never hot** (~30 °C) and NASty's own UI/alerting was always correct — this is purely smartd journal noise.

## Cause

smartd's default `-a` directive tracks SMART attribute changes by their **normalized** value (a 0–253 health score), not the raw reading. For the temperature attributes that score isn't degrees, so the journal fills with:

```
smartd[…]: Device: /dev/sda [SAT], SMART Usage Attribute: 194 Temperature_Celsius changed from 119 to 120
smartd[…]: Device: /dev/sda [SAT], SMART Usage Attribute: 190 Airflow_Temperature_Cel changed from 73 to 71
```

`119`/`120` is the normalized health value, not °C — the actual temperature is the attribute's **raw** value (~30 °C). The same #424 log even shows attribute 194 reading "changed from 27 to 29" on a drive whose normalized value happens to equal the temp, next to the "120" lines — same attribute, two scales.

## Fix

Add `-r 194 -r 190` to `services.smartd.defaults.monitored` so smartd appends the **raw** value to those change lines (e.g. `… changed from 119 [Raw 30] to 120 [Raw 29]`), making the real temperature visible.

- `-r` = *report raw alongside normalized*. Deliberately **not** `-R`, which would *trigger* a journal line on every raw change — i.e. spam one entry per 1 °C of drift.
- `-r` is ATA-only, which is exactly the reporter's `[SAT]` drives.
- NASty's disk-temperature alerting already reads smartctl's raw °C (`collect_system.rs:1062: temperature_c: json.temperature.current`), so the **displayed and alerted** temperature was never affected — this only de-confuses the smartd journal.

## Validation

On a box running smartd 7.5:

```
$ smartd -c <conf-with: DEVICESCAN -a -r 194 -r 190> -q onecheck
Configuration file ... was parsed, found DEVICESCAN, scanning devices   # accepted
$ smartd -c <conf-with: DEVICESCAN -a -r 999x> -q onecheck
Configuration file ... has fatal syntax errors.                          # control: bad directive caught
```

`services.smartd.defaults.monitored` default is `"-a"` (confirmed via `nixos-option`); this changes it to `"-a -r 194 -r 190"`.

Note: this is a journal-clarity fix only — the Docker-not-starting bug in #424 is separate (handled in #426).