### PR TITLE
system/secure-boot: stop blocking readiness on absent lanzaboote input

### DIFF
--- a/engine/nasty-system/src/secure_boot.rs
+++ b/engine/nasty-system/src/secure_boot.rs
@@ -78,11 +78,12 @@ pub struct ReadinessReport {
     /// number on its side.
     pub esp_required_bytes: u64,
     /// `Some(true)` when `/etc/nixos/flake.nix` declares
-    /// `lanzaboote.url = ...` at top level. `Some(false)` on pre-
-    /// this-PR wrappers (operator needs to upgrade once so the
-    /// engine re-renders the template). `None` when we couldn't
-    /// read /etc/nixos/flake.nix (operator running an unusual
-    /// install or read failed).
+    /// `lanzaboote.url = ...` at top level — i.e. this box is already
+    /// enrolled (the engine injects the input during the enrollment
+    /// ceremony). `Some(false)` is the normal pre-enrollment state:
+    /// the wrapper template omits the input on purpose and enrollment
+    /// adds it, so this is *not* a blocker. `None` when we couldn't
+    /// read /etc/nixos/flake.nix. Surfaced purely for the checklist.
     pub wrapper_has_lanzaboote_input: Option<bool>,
     /// True iff `/var/lib/sbctl/keys/db/db.key` exists. Purely
     /// informational — when lanzaboote turns on with
@@ -183,21 +184,16 @@ fn compute_blocker(r: &ReadinessReport) -> Option<String> {
         }
         Some(_) => {}
     }
-    match r.wrapper_has_lanzaboote_input {
-        Some(false) => {
-            return Some(
-                "wrapper flake at /etc/nixos/flake.nix doesn't declare the lanzaboote input — \
-                 run any upgrade once on the new engine to re-render it"
-                    .into(),
-            );
-        }
-        None => {
-            return Some(
-                "could not read /etc/nixos/flake.nix to check for the lanzaboote input".into(),
-            );
-        }
-        Some(true) => {}
-    }
+    // NOTE: the `lanzaboote` input in /etc/nixos/flake.nix is
+    // deliberately NOT a readiness precondition. Secure Boot is
+    // per-box opt-in: the wrapper template omits the input, and the
+    // engine injects it as part of the enrollment ceremony (and the
+    // upgrade migration only re-injects it when the SB overlay is
+    // already present). So a non-enrolled box correctly has no input —
+    // blocking on its absence stranded operators who "upgrade to
+    // re-render" forever with nothing to re-render. `readiness` still
+    // surfaces `wrapper_has_lanzaboote_input` for the checklist, but
+    // its absence is normal pre-enrollment state, not a blocker.
     None
 }
 
@@ -335,16 +331,21 @@ mod tests {
     }
 
     #[test]
-    fn blocker_no_lanzaboote_in_wrapper() {
-        let r = ReadinessReport {
-            wrapper_has_lanzaboote_input: Some(false),
-            ..base_report()
-        };
-        assert!(
-            compute_blocker(&r)
-                .unwrap()
-                .contains("doesn't declare the lanzaboote input")
-        );
+    fn lanzaboote_absence_is_not_a_blocker() {
+        // Pre-enrollment boxes have no lanzaboote input by design —
+        // enrollment injects it. Its absence (or an unreadable flake)
+        // must not block readiness, otherwise operators see a "run an
+        // upgrade to re-render" nag that nothing can ever clear.
+        for state in [Some(false), None] {
+            let r = ReadinessReport {
+                wrapper_has_lanzaboote_input: state,
+                ..base_report()
+            };
+            assert!(
+                compute_blocker(&r).is_none(),
+                "lanzaboote state {state:?} should not block readiness",
+            );
+        }
     }
 
     #[test]

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -501,14 +501,17 @@
 				<div class="flex items-start gap-3 py-1 text-xs">
 					<span class="w-4 shrink-0 font-mono">
 						{#if sbReadiness.wrapper_has_lanzaboote_input === true}<span class="text-emerald-400">✓</span>
-						{:else if sbReadiness.wrapper_has_lanzaboote_input === false}<span class="text-amber-500">✗</span>
 						{:else}<span class="text-muted-foreground">—</span>{/if}
 					</span>
 					<span class="flex-1">
 						Wrapper flake declares lanzaboote input
 						{#if sbReadiness.wrapper_has_lanzaboote_input === false}
 							<span class="ml-1 text-muted-foreground">
-								· run any upgrade once to re-render /etc/nixos/flake.nix
+								· added automatically when you enable Secure Boot
+							</span>
+						{:else if sbReadiness.wrapper_has_lanzaboote_input === null}
+							<span class="ml-1 text-muted-foreground">
+								· /etc/nixos/flake.nix could not be read
 							</span>
 						{/if}
 					</span>


### PR DESCRIPTION
## Problem
The Hardware → Secure Boot readiness checklist showed an unclearable blocker on non-enrolled boxes:

> Blocker: wrapper flake at /etc/nixos/flake.nix doesn't declare the lanzaboote input — run any upgrade once on the new engine to re-render it

Secure Boot is **per-box opt-in**: the wrapper flake template intentionally omits the `lanzaboote` input, and the engine injects it during the enrollment ceremony (the upgrade migration only re-injects it when the SB overlay is already present). So a non-enrolled box correctly has no `lanzaboote.url` line — and "run any upgrade to re-render" never adds it, so the blocker could **never clear no matter how often the operator updated**. The check + message were leftovers from an earlier design where the template rendered lanzaboote unconditionally.

## Fix
- **Engine** (`secure_boot.rs`): drop the lanzaboote-input case from `compute_blocker()` — it's an *output* of enrollment, not a precondition. Keep the field for the checklist; update its doc.
- **Frontend** (`hardware/+page.svelte`): checklist item is neutral (`—`) when the input is absent, with "· added automatically when you enable Secure Boot" instead of an amber ✗ + the re-render nag.

A non-enrolled box passing every real prerequisite (UEFI, firmware SB support, SB off, TPM2, ESP headroom) now reports **Ready**.

## Verification
- 11/11 `nasty-system` secure_boot tests pass (stale blocker test replaced with `lanzaboote_absence_is_not_a_blocker` covering `Some(false)` and `None`), clippy clean.
- Frontend svelte-check: 0 errors / 0 warnings.