### PR TITLE
apps: manage Docker networks + attach apps to them (macvlan/ipvlan)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -15,11 +15,12 @@ use std::path::Path;
 
 use bollard::Docker;
 use bollard::models::{
-    ContainerCreateBody, HostConfig, PortBinding, RestartPolicy, RestartPolicyNameEnum,
+    ContainerCreateBody, EndpointIpamConfig, EndpointSettings, HostConfig, Ipam, IpamConfig,
+    NetworkCreateRequest, NetworkingConfig, PortBinding, RestartPolicy, RestartPolicyNameEnum,
 };
 use bollard::query_parameters::{
-    CreateContainerOptions, CreateImageOptions, ListContainersOptions, LogsOptions,
-    RemoveContainerOptions, StatsOptions, StopContainerOptions,
+    CreateContainerOptions, CreateImageOptions, InspectNetworkOptions, ListContainersOptions,
+    ListNetworksOptions, LogsOptions, RemoveContainerOptions, StatsOptions, StopContainerOptions,
 };
 use futures_util::{StreamExt, TryStreamExt};
 use schemars::JsonSchema;
@@ -36,6 +37,8 @@ pub use caddy::{CaddyRouteSummary, HostCert};
 const STATE_PATH: &str = "/var/lib/nasty/apps-enabled";
 const COMPOSE_DIR: &str = "/var/lib/nasty/apps";
 const DOCKER_SERVICE: &str = "docker.service";
+/// Persisted definitions of NASty-managed Docker networks.
+const NETWORKS_PATH: &str = "/var/lib/nasty/apps-networks.json";
 
 /// Label applied to all NASty-managed containers.
 const LABEL_MANAGED: &str = "nasty.managed";
@@ -45,6 +48,14 @@ const LABEL_APP_NAME: &str = "nasty.app.name";
 const LABEL_APP_KIND: &str = "nasty.app.kind";
 /// Label set to "true" when the app was deployed with allow_unsafe.
 const LABEL_APP_UNSAFE: &str = "nasty.app.unsafe";
+/// Label marking a NASty-managed Docker network (value "true").
+const LABEL_NET_MANAGED: &str = "nasty.managed";
+/// Label storing a managed network's parent host interface.
+const LABEL_NET_PARENT: &str = "nasty.net.parent";
+/// Label on a container recording the managed network it's attached to.
+const LABEL_APP_NETWORK: &str = "nasty.app.network";
+/// Label on a container recording its static IP on the managed network.
+const LABEL_APP_NETWORK_IP: &str = "nasty.app.network_ip";
 
 // ── Errors ──────────────────────────────────────────────────────
 
@@ -68,6 +79,8 @@ pub enum AppsError {
     Io(#[from] std::io::Error),
     #[error("forbidden bind mount: {0}")]
     ForbiddenBind(String),
+    #[error("invalid network: {0}")]
+    InvalidNetwork(String),
 }
 
 impl AppsError {
@@ -82,8 +95,258 @@ impl AppsError {
             Self::CommandFailed(_) => -33007,
             Self::Io(_) => -33008,
             Self::ForbiddenBind(_) => -33009,
+            Self::InvalidNetwork(_) => -33010,
         }
     }
+}
+
+// ── Managed Docker networks ─────────────────────────────────────
+
+/// Lightweight host-interface fact the network validator needs. Built
+/// by the engine layer from `nasty-system`'s interface list so this
+/// crate stays free of a `nasty-system` dependency.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IfaceInfo {
+    pub name: String,
+    /// "physical" | "bond" | "vlan" | "bridge" | "virtual".
+    pub kind: String,
+    /// True when this NIC is enslaved to a bridge (so it's an invalid
+    /// macvlan/ipvlan parent — the bridge should be used instead).
+    pub bridge_member: bool,
+}
+
+/// A NASty-managed Docker network. Persisted to [`NETWORKS_PATH`] and
+/// materialized via bollard. `host_shim` is honored only for macvlan
+/// (see the engine's shim wiring) and defaults off.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ManagedNetwork {
+    pub name: String,
+    /// "bridge" | "macvlan" | "ipvlan".
+    pub driver: String,
+    /// Host interface/bridge for macvlan/ipvlan; absent for bridge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subnet: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ip_range: Option<String>,
+    /// 802.1q tag; the effective docker parent becomes `parent.vlan`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vlan: Option<u16>,
+    /// macvlan only: create a host-side shim so host↔container works.
+    #[serde(default)]
+    pub host_shim: bool,
+}
+
+/// On-disk shape for [`NETWORKS_PATH`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ManagedNetworksFile {
+    #[serde(default)]
+    networks: Vec<ManagedNetwork>,
+}
+
+/// `apps.networks.list` row: the spec plus live-state annotations.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct NetworkSummary {
+    #[serde(flatten)]
+    pub spec: ManagedNetwork,
+    /// Present in Docker right now.
+    pub exists: bool,
+    /// Created/labeled by NASty (vs a pre-existing Docker network).
+    pub managed: bool,
+    /// Container names currently attached (drives remove-refusal + UI).
+    #[serde(default)]
+    pub attached_apps: Vec<String>,
+}
+
+fn invalid_net(msg: impl Into<String>) -> AppsError {
+    AppsError::InvalidNetwork(msg.into())
+}
+
+/// Parse `addr/prefix` into `(IpAddr, prefix_len)`.
+fn parse_cidr(s: &str) -> Option<(std::net::IpAddr, u8)> {
+    let (addr, prefix) = s.split_once('/')?;
+    let ip: std::net::IpAddr = addr.trim().parse().ok()?;
+    let p: u8 = prefix.trim().parse().ok()?;
+    let max = if ip.is_ipv4() { 32 } else { 128 };
+    (p <= max).then_some((ip, p))
+}
+
+/// Network address of `ip` masked to `prefix` bits, as a u128 (v4 in low bits).
+fn mask_ip(ip: std::net::IpAddr, prefix: u8) -> u128 {
+    let (bits, total) = match ip {
+        std::net::IpAddr::V4(v4) => (u32::from(v4) as u128, 32u8),
+        std::net::IpAddr::V6(v6) => (u128::from(v6), 128u8),
+    };
+    if prefix == 0 {
+        return 0;
+    }
+    let shift = total - prefix;
+    (bits >> shift) << shift
+}
+
+/// True iff `ip` falls within `cidr`. `None` on malformed input.
+fn cidr_contains_ip(cidr: &str, ip: &str) -> Option<bool> {
+    let (net, prefix) = parse_cidr(cidr)?;
+    let addr: std::net::IpAddr = ip.trim().parse().ok()?;
+    if net.is_ipv4() != addr.is_ipv4() {
+        return Some(false);
+    }
+    Some(mask_ip(net, prefix) == mask_ip(addr, prefix))
+}
+
+/// True iff `inner` CIDR is fully contained in `outer` CIDR. `None` on malformed input.
+fn cidr_contains_net(outer: &str, inner: &str) -> Option<bool> {
+    let (_, outer_prefix) = parse_cidr(outer)?;
+    let (inner_ip, inner_prefix) = parse_cidr(inner)?;
+    if inner_prefix < outer_prefix {
+        return Some(false);
+    }
+    cidr_contains_ip(outer, &inner_ip.to_string())
+}
+
+/// macvlan/ipvlan containers get their own LAN IP and have no presence
+/// at `127.0.0.1:<host_port>`, so published host ports (and the Caddy
+/// ingress that depends on them) are meaningless. Returns the rejection
+/// reason when the combination is incompatible.
+fn ingress_incompatible(driver: &str, has_host_ports: bool) -> Option<&'static str> {
+    if matches!(driver, "macvlan" | "ipvlan") && has_host_ports {
+        Some(
+            "macvlan/ipvlan apps get their own LAN IP and cannot also publish host ports; \
+             remove host-port mappings or choose a bridge network",
+        )
+    } else {
+        None
+    }
+}
+
+/// Validate a network spec against the set of host interfaces. Pure +
+/// dependency-free for unit testing.
+fn validate_network_spec(spec: &ManagedNetwork, ifaces: &[IfaceInfo]) -> Result<(), AppsError> {
+    if spec.name.is_empty()
+        || spec.name.len() > 64
+        || !spec
+            .name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+    {
+        return Err(invalid_net(
+            "network name must be 1-64 chars of [A-Za-z0-9._-]",
+        ));
+    }
+    if !matches!(spec.driver.as_str(), "bridge" | "macvlan" | "ipvlan") {
+        return Err(invalid_net("driver must be bridge, macvlan, or ipvlan"));
+    }
+    // The host↔container macvlan shim mutates host networking and is
+    // deferred to a follow-up (it needs the confirm-or-rollback rail +
+    // real-hardware validation). Reserve the field but reject it for now
+    // so callers don't think it does something.
+    if spec.host_shim {
+        return Err(invalid_net(
+            "host↔container shim is not implemented yet — leave it disabled (tracked separately)",
+        ));
+    }
+    let needs_parent = matches!(spec.driver.as_str(), "macvlan" | "ipvlan");
+    match (&spec.parent, needs_parent) {
+        (Some(p), true) => {
+            if let Some(v) = spec.vlan
+                && !(1..=4094).contains(&v)
+            {
+                return Err(invalid_net("vlan tag must be 1-4094"));
+            }
+            match ifaces.iter().find(|i| &i.name == p) {
+                None => return Err(invalid_net(format!("parent interface '{p}' not found"))),
+                Some(i) if i.bridge_member => {
+                    return Err(invalid_net(format!(
+                        "'{p}' is enslaved to a bridge; use the bridge itself as the parent"
+                    )));
+                }
+                Some(_) => {}
+            }
+        }
+        (Some(_), false) => return Err(invalid_net("bridge driver does not take a parent")),
+        (None, true) => {
+            return Err(invalid_net(format!(
+                "{} requires a parent interface",
+                spec.driver
+            )));
+        }
+        (None, false) => {}
+    }
+    match &spec.subnet {
+        Some(subnet) => {
+            if parse_cidr(subnet).is_none() {
+                return Err(invalid_net(format!("invalid subnet CIDR '{subnet}'")));
+            }
+            if let Some(gw) = &spec.gateway
+                && cidr_contains_ip(subnet, gw) != Some(true)
+            {
+                return Err(invalid_net(format!(
+                    "gateway '{gw}' is not within subnet '{subnet}'"
+                )));
+            }
+            if let Some(range) = &spec.ip_range
+                && cidr_contains_net(subnet, range) != Some(true)
+            {
+                return Err(invalid_net(format!(
+                    "ip_range '{range}' is not within subnet '{subnet}'"
+                )));
+            }
+        }
+        None if spec.gateway.is_some() || spec.ip_range.is_some() => {
+            return Err(invalid_net("gateway/ip_range require a subnet"));
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+/// Boot-reconcile decision (pure, testable): which persisted networks
+/// are missing from Docker and recreatable, vs skipped because their
+/// parent interface is gone.
+#[derive(Debug, PartialEq, Default)]
+struct ReconcilePlan {
+    to_create: Vec<String>,
+    skipped_missing_parent: Vec<String>,
+}
+
+fn reconcile_plan(
+    persisted: &[ManagedNetwork],
+    docker_names: &[String],
+    iface_names: &[String],
+) -> ReconcilePlan {
+    let mut plan = ReconcilePlan::default();
+    for n in persisted {
+        if docker_names.iter().any(|d| d == &n.name) {
+            continue; // already present
+        }
+        match &n.parent {
+            Some(p) if !iface_names.iter().any(|i| i == p) => {
+                plan.skipped_missing_parent.push(n.name.clone());
+            }
+            _ => plan.to_create.push(n.name.clone()),
+        }
+    }
+    plan
+}
+
+fn load_networks() -> ManagedNetworksFile {
+    match std::fs::read_to_string(NETWORKS_PATH) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
+            warn!("failed to parse {NETWORKS_PATH}, ignoring: {e}");
+            ManagedNetworksFile::default()
+        }),
+        Err(_) => ManagedNetworksFile::default(),
+    }
+}
+
+async fn save_networks(f: &ManagedNetworksFile) -> Result<(), AppsError> {
+    let json = serde_json::to_string_pretty(f)
+        .map_err(|e| AppsError::CommandFailed(format!("serialize networks: {e}")))?;
+    tokio::fs::write(NETWORKS_PATH, json).await?;
+    Ok(())
 }
 
 /// Validate the `host_path` of every volume in a simple-app install/update.
@@ -1002,6 +1265,14 @@ pub struct App {
     /// why only the direct host-port link is offered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_disabled_reason: Option<String>,
+    /// Name of the NASty-managed Docker network this app is attached to,
+    /// if any. The WebUI shows a badge and (for macvlan/ipvlan) suppresses
+    /// the reverse-proxy "Open" link since the app is reached on its own IP.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    /// The app's IP on that network, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_ip: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1066,6 +1337,14 @@ pub struct AppConfig {
     /// Whether the app was deployed with allow_unsafe (read from container label).
     #[serde(default)]
     pub allow_unsafe: bool,
+    /// NASty-managed Docker network the app is attached to (from label).
+    /// Round-tripped through Edit/pull so a reinstall keeps the attachment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    /// The static IP requested at install (from label), if any. Distinct
+    /// from a live auto-assigned address — re-applied verbatim on reinstall.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub static_ip: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -1159,6 +1438,16 @@ pub struct InstallAppRequest {
     /// hostname is taken.
     #[serde(default)]
     pub subdomain: Option<String>,
+    /// Attach the container to a NASty-managed Docker network instead of
+    /// (only) the default bridge. For a macvlan/ipvlan network the
+    /// container gets its own LAN IP and is *not* reachable at
+    /// `127.0.0.1:<host_port>`, so publishing host ports and reverse-proxy
+    /// ingress are rejected/skipped for it (see install's mutual-exclusion).
+    #[serde(default)]
+    pub network: Option<String>,
+    /// Optional static IPv4 within the chosen network's subnet.
+    #[serde(default)]
+    pub static_ip: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1432,6 +1721,244 @@ impl AppsService {
         self.docker_conn()
     }
 
+    // ── Managed Docker networks ─────────────────────────────
+
+    /// List Docker networks (excluding the host/null built-ins),
+    /// annotated with managed/exists/attached_apps. Managed networks
+    /// show their authoritative persisted spec; others are derived from
+    /// live Docker state. Persisted networks absent from Docker are
+    /// appended with `exists=false` (boot reconcile will recreate them).
+    pub async fn network_list(&self) -> Result<Vec<NetworkSummary>, AppsError> {
+        self.require_ready().await?;
+        let docker = self.docker()?;
+        let nets = docker
+            .list_networks(None::<ListNetworksOptions>)
+            .await
+            .map_err(|e| AppsError::DockerFailed(format!("list networks: {e}")))?;
+        let persisted = load_networks().networks;
+        let mut out = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for n in nets {
+            let name = match &n.name {
+                Some(s) if !s.is_empty() => s.clone(),
+                _ => continue,
+            };
+            let driver = n.driver.clone().unwrap_or_default();
+            if matches!(driver.as_str(), "host" | "null") {
+                continue;
+            }
+            let labels = n.labels.clone().unwrap_or_default();
+            let managed = labels.get(LABEL_NET_MANAGED).map(|v| v == "true") == Some(true);
+            let spec = match persisted.iter().find(|p| p.name == name) {
+                Some(p) => p.clone(),
+                None => {
+                    let (subnet, gateway, ip_range) = n
+                        .ipam
+                        .as_ref()
+                        .and_then(|i| i.config.as_ref())
+                        .and_then(|c| c.first())
+                        .map(|c| (c.subnet.clone(), c.gateway.clone(), c.ip_range.clone()))
+                        .unwrap_or((None, None, None));
+                    ManagedNetwork {
+                        name: name.clone(),
+                        driver,
+                        parent: n.options.as_ref().and_then(|o| o.get("parent")).cloned(),
+                        subnet,
+                        gateway,
+                        ip_range,
+                        vlan: None,
+                        host_shim: false,
+                    }
+                }
+            };
+            let attached_apps = if managed {
+                docker
+                    .inspect_network(&name, None::<InspectNetworkOptions>)
+                    .await
+                    .ok()
+                    .and_then(|ni| ni.containers)
+                    .map(|c| c.into_values().filter_map(|e| e.name).collect())
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            seen.insert(name);
+            out.push(NetworkSummary {
+                spec,
+                exists: true,
+                managed,
+                attached_apps,
+            });
+        }
+        for spec in persisted {
+            if !seen.contains(&spec.name) {
+                out.push(NetworkSummary {
+                    spec,
+                    exists: false,
+                    managed: true,
+                    attached_apps: Vec::new(),
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Create a NASty-managed Docker network and persist its spec.
+    pub async fn network_create(
+        &self,
+        spec: ManagedNetwork,
+        host_ifaces: &[IfaceInfo],
+    ) -> Result<(), AppsError> {
+        self.require_ready().await?;
+        validate_network_spec(&spec, host_ifaces)?;
+        let docker = self.docker()?;
+        if docker
+            .inspect_network(&spec.name, None::<InspectNetworkOptions>)
+            .await
+            .is_ok()
+        {
+            return Err(invalid_net(format!(
+                "a Docker network named '{}' already exists",
+                spec.name
+            )));
+        }
+
+        let mut options = std::collections::HashMap::new();
+        if let Some(p) = &spec.parent {
+            let parent = match spec.vlan {
+                Some(v) => format!("{p}.{v}"),
+                None => p.clone(),
+            };
+            options.insert("parent".to_string(), parent);
+        }
+        let ipam = spec.subnet.as_ref().map(|subnet| Ipam {
+            driver: Some("default".to_string()),
+            config: Some(vec![IpamConfig {
+                subnet: Some(subnet.clone()),
+                gateway: spec.gateway.clone(),
+                ip_range: spec.ip_range.clone(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(LABEL_NET_MANAGED.to_string(), "true".to_string());
+        if let Some(p) = &spec.parent {
+            labels.insert(LABEL_NET_PARENT.to_string(), p.clone());
+        }
+        let body = NetworkCreateRequest {
+            name: spec.name.clone(),
+            driver: Some(spec.driver.clone()),
+            options: (!options.is_empty()).then_some(options),
+            ipam,
+            labels: Some(labels),
+            ..Default::default()
+        };
+        docker
+            .create_network(body)
+            .await
+            .map_err(|e| AppsError::DockerFailed(format!("create network '{}': {e}", spec.name)))?;
+
+        let mut f = load_networks();
+        f.networks.retain(|n| n.name != spec.name);
+        f.networks.push(spec);
+        save_networks(&f).await
+    }
+
+    /// Remove a managed network. Refuses while containers are attached.
+    pub async fn network_remove(&self, name: &str) -> Result<(), AppsError> {
+        self.require_ready().await?;
+        let docker = self.docker()?;
+        if let Ok(ni) = docker
+            .inspect_network(name, None::<InspectNetworkOptions>)
+            .await
+        {
+            if ni.containers.map(|c| !c.is_empty()) == Some(true) {
+                return Err(invalid_net(format!(
+                    "network '{name}' is in use by attached containers"
+                )));
+            }
+            docker
+                .remove_network(name)
+                .await
+                .map_err(|e| AppsError::DockerFailed(format!("remove network '{name}': {e}")))?;
+        }
+        // Drop the persisted spec whether or not Docker still had it.
+        let mut f = load_networks();
+        let before = f.networks.len();
+        f.networks.retain(|n| n.name != name);
+        if f.networks.len() != before {
+            save_networks(&f).await?;
+        }
+        Ok(())
+    }
+
+    /// Resolve a network name to its spec — persisted first, else a
+    /// pre-existing (unmanaged) Docker network. Errors if neither.
+    async fn resolve_managed_network(&self, name: &str) -> Result<ManagedNetwork, AppsError> {
+        if let Some(spec) = load_networks()
+            .networks
+            .into_iter()
+            .find(|n| n.name == name)
+        {
+            return Ok(spec);
+        }
+        let ni = self
+            .docker()?
+            .inspect_network(name, None::<InspectNetworkOptions>)
+            .await
+            .map_err(|_| invalid_net(format!("network '{name}' does not exist")))?;
+        Ok(ManagedNetwork {
+            name: name.to_string(),
+            driver: ni.driver.unwrap_or_default(),
+            parent: ni.options.as_ref().and_then(|o| o.get("parent")).cloned(),
+            subnet: ni
+                .ipam
+                .as_ref()
+                .and_then(|i| i.config.as_ref())
+                .and_then(|c| c.first())
+                .and_then(|c| c.subnet.clone()),
+            gateway: None,
+            ip_range: None,
+            vlan: None,
+            host_shim: false,
+        })
+    }
+
+    /// Boot reconcile: recreate persisted managed networks missing from
+    /// Docker; skip (warn) any whose parent interface has vanished.
+    /// No-op when Docker is off or there's nothing persisted.
+    pub async fn reconcile_networks(&self, host_ifaces: Vec<IfaceInfo>) {
+        if !self.is_enabled() || !self.is_docker_ready().await {
+            return;
+        }
+        let persisted = load_networks().networks;
+        if persisted.is_empty() {
+            return;
+        }
+        let docker = match self.docker() {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        let docker_names: Vec<String> = docker
+            .list_networks(None::<ListNetworksOptions>)
+            .await
+            .map(|v| v.into_iter().filter_map(|n| n.name).collect())
+            .unwrap_or_default();
+        let iface_names: Vec<String> = host_ifaces.iter().map(|i| i.name.clone()).collect();
+        let plan = reconcile_plan(&persisted, &docker_names, &iface_names);
+        for name in &plan.skipped_missing_parent {
+            warn!("apps: managed network '{name}' parent interface is gone; not recreating");
+        }
+        for name in plan.to_create {
+            if let Some(spec) = persisted.iter().find(|n| n.name == name).cloned()
+                && let Err(e) = self.network_create(spec, &host_ifaces).await
+            {
+                warn!("apps: failed to reconcile network '{name}': {e}");
+            }
+        }
+    }
+
     // ── Enable/Disable ──────────────────────────────────────
 
     pub fn is_enabled(&self) -> bool {
@@ -1661,6 +2188,36 @@ impl AppsService {
             return Err(AppsError::AppAlreadyExists(req.name));
         }
 
+        // Resolve a requested managed network up front. A macvlan/ipvlan
+        // network gives the container its own LAN IP, which is incompatible
+        // with published host ports + reverse-proxy ingress (it has no
+        // presence at 127.0.0.1:<port>) — reject early and skip ingress.
+        let net_spec = match req.network.as_deref().filter(|s| !s.is_empty()) {
+            Some(name) => Some(self.resolve_managed_network(name).await?),
+            None => None,
+        };
+        let net_driver = net_spec
+            .as_ref()
+            .map(|s| s.driver.as_str())
+            .unwrap_or("bridge");
+        let lan_ip_network = matches!(net_driver, "macvlan" | "ipvlan");
+        if let Some(reason) = ingress_incompatible(net_driver, !req.ports.is_empty()) {
+            return Err(invalid_net(reason));
+        }
+        match (&req.static_ip, &net_spec) {
+            (Some(_), None) => return Err(invalid_net("static_ip requires a network")),
+            (Some(ip), Some(spec)) => {
+                if let Some(subnet) = &spec.subnet
+                    && cidr_contains_ip(subnet, ip) != Some(true)
+                {
+                    return Err(invalid_net(format!(
+                        "static_ip '{ip}' is not within network subnet '{subnet}'"
+                    )));
+                }
+            }
+            (None, _) => {}
+        }
+
         // Validate bind mounts before we pull anything. Engine state and the
         // host root are blocked unconditionally; the broader allowlist only
         // applies in safe mode.
@@ -1768,6 +2325,37 @@ impl AppsService {
         if req.allow_unsafe {
             labels.insert(LABEL_APP_UNSAFE.to_string(), "true".to_string());
         }
+        if let Some(spec) = &net_spec {
+            labels.insert(LABEL_APP_NETWORK.to_string(), spec.name.clone());
+            if let Some(ip) = req.static_ip.as_deref().filter(|s| !s.is_empty()) {
+                labels.insert(LABEL_APP_NETWORK_IP.to_string(), ip.to_string());
+            }
+        }
+
+        // Attach to the chosen managed network (with an optional static
+        // IP). Supplying endpoints_config at create time attaches the
+        // container to that network instead of the default bridge.
+        let networking_config = net_spec.as_ref().map(|spec| {
+            let ipam_config = req
+                .static_ip
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|ip| EndpointIpamConfig {
+                    ipv4_address: Some(ip.to_string()),
+                    ..Default::default()
+                });
+            let mut endpoints = HashMap::new();
+            endpoints.insert(
+                spec.name.clone(),
+                EndpointSettings {
+                    ipam_config,
+                    ..Default::default()
+                },
+            );
+            NetworkingConfig {
+                endpoints_config: Some(endpoints),
+            }
+        });
 
         let host_config = HostConfig {
             port_bindings: if port_bindings.is_empty() {
@@ -1795,6 +2383,7 @@ impl AppsService {
             },
             labels: Some(labels),
             host_config: Some(host_config),
+            networking_config,
             ..Default::default()
         };
 
@@ -1870,10 +2459,15 @@ impl AppsService {
         // — picking it would publish a dead /apps/<name>/ route. If
         // the app exposes only UDP, no ingress is created; the user
         // can still reach the container directly on the LAN.
-        if let Some(first_port) = req
-            .ports
-            .iter()
-            .find(|p| p.protocol.eq_ignore_ascii_case("tcp"))
+        // ...but never for a LAN-IP (macvlan/ipvlan) app: it has its own
+        // address and no presence at 127.0.0.1:<port> for Caddy to proxy.
+        if let Some(first_port) = (!lan_ip_network)
+            .then(|| {
+                req.ports
+                    .iter()
+                    .find(|p| p.protocol.eq_ignore_ascii_case("tcp"))
+            })
+            .flatten()
         {
             let host_port = if let Some(hp) = first_port.host_port {
                 hp
@@ -2212,6 +2806,8 @@ impl AppsService {
                         ports: Vec::new(),
                         unsafe_mode,
                         proxy_disabled_reason,
+                        network: None,
+                        network_ip: None,
                     });
                 }
             } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
@@ -2262,6 +2858,8 @@ impl AppsService {
                         ports: Vec::new(),
                         unsafe_mode,
                         proxy_disabled_reason,
+                        network: None,
+                        network_ip: None,
                     });
                 }
             }
@@ -2309,6 +2907,21 @@ impl AppsService {
                 .unwrap_or(false);
 
             let proxy_disabled_reason = load_proxy_disabled_reason(&app_name).await;
+            // Managed-network attachment: name from our label, IP from the
+            // live endpoint (real assigned address) falling back to the
+            // static-IP label.
+            let network = labels.and_then(|l| l.get(LABEL_APP_NETWORK)).cloned();
+            let network_ip = network
+                .as_ref()
+                .and_then(|net| {
+                    c.network_settings
+                        .as_ref()
+                        .and_then(|ns| ns.networks.as_ref())
+                        .and_then(|nets| nets.get(net))
+                        .and_then(|ep| ep.ip_address.clone())
+                        .filter(|s| !s.is_empty())
+                })
+                .or_else(|| labels.and_then(|l| l.get(LABEL_APP_NETWORK_IP)).cloned());
             apps.push(App {
                 name: app_name,
                 image: c.image.as_deref().unwrap_or("").to_string(),
@@ -2319,6 +2932,8 @@ impl AppsService {
                 ports: extract_ports(c),
                 unsafe_mode,
                 proxy_disabled_reason,
+                network,
+                network_ip,
             });
         }
 
@@ -2420,6 +3035,8 @@ impl AppsService {
                     ports: all_ports,
                     unsafe_mode,
                     proxy_disabled_reason,
+                    network: None,
+                    network_ip: None,
                 });
             }
         }
@@ -2588,6 +3205,18 @@ impl AppsService {
             .and_then(|l| l.get(LABEL_APP_UNSAFE))
             .map(|v| v == "true")
             .unwrap_or(false);
+        // Managed-network attachment + the *requested* static IP (label,
+        // not the live address) so a reinstall re-applies it verbatim.
+        let network = config
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(LABEL_APP_NETWORK))
+            .cloned();
+        let static_ip = config
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(LABEL_APP_NETWORK_IP))
+            .cloned();
 
         Ok(AppConfig {
             name: name.to_string(),
@@ -2598,6 +3227,8 @@ impl AppsService {
             cpu_limit,
             memory_limit,
             allow_unsafe,
+            network,
+            static_ip,
         })
     }
 
@@ -3844,6 +4475,10 @@ impl AppsService {
                 memory_limit: config.memory_limit,
                 allow_unsafe: config.allow_unsafe,
                 subdomain: existing_subdomain,
+                // Preserve the managed-network attachment + static IP across
+                // pull-and-reinstall (else apps.pull would detach the app).
+                network: config.network,
+                static_ip: config.static_ip,
             };
             return self.install(req).await;
         }
@@ -5459,5 +6094,186 @@ services:
         // 254-char total
         let too_long_total = format!("{}.example.com", "a".repeat(254 - ".example.com".len()));
         assert!(validate_subdomain(&too_long_total).is_err());
+    }
+}
+
+#[cfg(test)]
+mod network_tests {
+    use super::*;
+
+    fn ifaces() -> Vec<IfaceInfo> {
+        vec![
+            IfaceInfo {
+                name: "eth0".into(),
+                kind: "physical".into(),
+                bridge_member: true,
+            },
+            IfaceInfo {
+                name: "br0".into(),
+                kind: "bridge".into(),
+                bridge_member: false,
+            },
+            IfaceInfo {
+                name: "eth1".into(),
+                kind: "physical".into(),
+                bridge_member: false,
+            },
+        ]
+    }
+    fn net(name: &str, driver: &str) -> ManagedNetwork {
+        ManagedNetwork {
+            name: name.into(),
+            driver: driver.into(),
+            parent: None,
+            subnet: None,
+            gateway: None,
+            ip_range: None,
+            vlan: None,
+            host_shim: false,
+        }
+    }
+    fn macvlan_on(parent: &str) -> ManagedNetwork {
+        let mut n = net("x", "macvlan");
+        n.parent = Some(parent.into());
+        n
+    }
+
+    #[test]
+    fn bridge_driver_rejects_parent() {
+        let mut n = net("x", "bridge");
+        n.parent = Some("br0".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+    #[test]
+    fn macvlan_requires_parent() {
+        assert!(validate_network_spec(&net("x", "macvlan"), &ifaces()).is_err());
+    }
+    #[test]
+    fn unknown_parent_rejected() {
+        assert!(validate_network_spec(&macvlan_on("eth9"), &ifaces()).is_err());
+    }
+    #[test]
+    fn bridge_member_parent_rejected() {
+        // eth0 is enslaved to a bridge — must use the bridge instead.
+        assert!(validate_network_spec(&macvlan_on("eth0"), &ifaces()).is_err());
+    }
+    #[test]
+    fn macvlan_on_bridge_ok() {
+        let mut n = macvlan_on("br0");
+        n.subnet = Some("192.168.1.0/24".into());
+        n.gateway = Some("192.168.1.1".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_ok());
+    }
+    #[test]
+    fn macvlan_on_standalone_nic_ok() {
+        assert!(validate_network_spec(&macvlan_on("eth1"), &ifaces()).is_ok());
+    }
+    #[test]
+    fn gateway_outside_subnet_rejected() {
+        let mut n = macvlan_on("br0");
+        n.subnet = Some("192.168.1.0/24".into());
+        n.gateway = Some("10.0.0.1".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+    #[test]
+    fn ip_range_outside_subnet_rejected() {
+        let mut n = macvlan_on("br0");
+        n.subnet = Some("192.168.1.0/24".into());
+        n.ip_range = Some("10.0.0.0/28".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+    #[test]
+    fn vlan_range_enforced() {
+        let mut n = macvlan_on("br0");
+        n.vlan = Some(5000);
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+    #[test]
+    fn bad_subnet_rejected() {
+        let mut n = macvlan_on("br0");
+        n.subnet = Some("not-a-cidr".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+    #[test]
+    fn host_shim_rejected_for_now() {
+        let mut n = macvlan_on("br0");
+        n.host_shim = true;
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+
+    #[test]
+    fn cidr_contains_ip_v4() {
+        assert_eq!(
+            cidr_contains_ip("192.168.1.0/24", "192.168.1.50"),
+            Some(true)
+        );
+        assert_eq!(
+            cidr_contains_ip("192.168.1.0/24", "192.168.2.50"),
+            Some(false)
+        );
+        assert_eq!(cidr_contains_ip("10.0.0.0/8", "10.255.1.2"), Some(true));
+        assert_eq!(cidr_contains_ip("192.168.1.0/24", "nope"), None);
+    }
+    #[test]
+    fn cidr_contains_net_v4() {
+        assert_eq!(
+            cidr_contains_net("192.168.1.0/24", "192.168.1.64/27"),
+            Some(true)
+        );
+        // less-specific inner can't be contained
+        assert_eq!(
+            cidr_contains_net("192.168.1.0/24", "192.168.0.0/23"),
+            Some(false)
+        );
+        assert_eq!(
+            cidr_contains_net("192.168.1.0/24", "10.0.0.0/28"),
+            Some(false)
+        );
+    }
+    #[test]
+    fn cidr_family_mismatch_is_false() {
+        assert_eq!(cidr_contains_ip("192.168.1.0/24", "fd00::1"), Some(false));
+        assert_eq!(cidr_contains_ip("fd00::/64", "fd00::1"), Some(true));
+    }
+
+    #[test]
+    fn ingress_incompatible_only_lan_ip_with_ports() {
+        assert!(ingress_incompatible("macvlan", true).is_some());
+        assert!(ingress_incompatible("ipvlan", true).is_some());
+        assert!(ingress_incompatible("macvlan", false).is_none());
+        assert!(ingress_incompatible("bridge", true).is_none());
+    }
+
+    #[test]
+    fn reconcile_recreates_missing_skips_vanished_parent() {
+        let persisted = vec![macvlan_named("present"), macvlan_named("missing"), {
+            let mut n = macvlan_named("orphan");
+            n.parent = Some("gone0".into());
+            n
+        }];
+        let docker_names = vec!["present".to_string()];
+        let iface_names = vec!["br0".to_string(), "eth1".to_string()];
+        let plan = reconcile_plan(&persisted, &docker_names, &iface_names);
+        assert_eq!(plan.to_create, vec!["missing".to_string()]);
+        assert_eq!(plan.skipped_missing_parent, vec!["orphan".to_string()]);
+    }
+    fn macvlan_named(name: &str) -> ManagedNetwork {
+        let mut n = net(name, "macvlan");
+        n.parent = Some("br0".into());
+        n
+    }
+
+    #[test]
+    fn serde_omits_unset_optionals_and_roundtrips() {
+        let n = net("x", "bridge");
+        let j = serde_json::to_string(&n).unwrap();
+        assert!(!j.contains("\"parent\""));
+        assert!(!j.contains("\"subnet\""));
+        assert_eq!(serde_json::from_str::<ManagedNetwork>(&j).unwrap(), n);
+        // Minimal/legacy JSON loads with defaults.
+        let min: ManagedNetwork =
+            serde_json::from_str(r#"{"name":"y","driver":"macvlan","parent":"br0"}"#).unwrap();
+        assert!(!min.host_shim);
+        assert!(min.subnet.is_none());
     }
 }

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -67,12 +67,19 @@ struct DeployRequest {
     ingress_host_port: Option<u16>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct DeployMessage {
-    /// "log" for output lines, "error" for errors, "done" for completion
+    /// "log" for output lines, "error" for errors, "done" for completion,
+    /// "action" for a structured actionable hint the UI can render as a button.
     #[serde(rename = "type")]
     msg_type: String,
     data: String,
+    /// Action key for `type:"action"` messages (e.g. "create_macvlan").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action: Option<String>,
+    /// Host bridge name the action applies to (for "create_macvlan").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bridge: Option<String>,
 }
 
 impl DeployMessage {
@@ -80,6 +87,7 @@ impl DeployMessage {
         serde_json::to_string(&Self {
             msg_type: "log".into(),
             data: s.to_string(),
+            ..Default::default()
         })
         .unwrap()
     }
@@ -88,6 +96,7 @@ impl DeployMessage {
         serde_json::to_string(&Self {
             msg_type: "error".into(),
             data: s.to_string(),
+            ..Default::default()
         })
         .unwrap()
     }
@@ -96,6 +105,21 @@ impl DeployMessage {
         serde_json::to_string(&Self {
             msg_type: "done".into(),
             data: s.to_string(),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    /// Actionable hint (#429/#435): the referenced external network is a
+    /// host bridge, so offer to create a macvlan network on it and retry.
+    fn action_create_macvlan(bridge: &str) -> String {
+        serde_json::to_string(&Self {
+            msg_type: "action".into(),
+            data: format!(
+                "Create a macvlan network on '{bridge}' to put this app on your LAN, then retry."
+            ),
+            action: Some("create_macvlan".into()),
+            bridge: Some(bridge.to_string()),
         })
         .unwrap()
     }
@@ -519,6 +543,15 @@ async fn deploy_compose(
                     DeployMessage::log(&format!("Hint: {hint}")).into(),
                 ))
                 .await;
+            // Structured signal so the UI can offer a one-click "create
+            // macvlan on <bridge> and retry" instead of just prose.
+            if let Some(bridge) = external_network_name(&e) {
+                let _ = socket
+                    .send(Message::Text(
+                        DeployMessage::action_create_macvlan(bridge).into(),
+                    ))
+                    .await;
+            }
         }
         let msg = match hint {
             Some(hint) => format!("deploy failed: {e}\n\nHint: {hint}"),

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -241,6 +241,7 @@ async fn main() -> anyhow::Result<()> {
             "network.reconcile_orphans",
             "subvolumes.reconcile_project_ids",
             "apps.reconcile_app_routes",
+            "apps.reconcile_networks",
             "backups.migrate_secrets",
             "nut.migrate_secrets",
             "oidc.migrate_secrets",
@@ -485,6 +486,20 @@ async fn main() -> anyhow::Result<()> {
         )
         .await;
 
+    // Recreate NASty-managed Docker networks missing from Docker (e.g.
+    // after a fresh data-root); skips any whose parent interface vanished.
+    {
+        let ifaces = system_network_ifaces(&state).await;
+        state
+            .boot_status
+            .run_phase(
+                "apps.reconcile_networks",
+                secs(30),
+                state.apps.reconcile_networks(ifaces),
+            )
+            .await;
+    }
+
     // TLS automation reconcile — push the policy set (main domain +
     // every app subdomain) so Caddy issues certs after a fresh boot or
     // restart, the same way ingress routes get re-pushed above.
@@ -688,6 +703,27 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     Ok(())
+}
+
+/// Host interface facts for the apps Docker-network validator: each live
+/// interface's name + kind, plus whether it's enslaved to a bridge (which
+/// makes it an invalid macvlan/ipvlan parent — the bridge should be used).
+pub(crate) async fn system_network_ifaces(state: &AppState) -> Vec<nasty_apps::IfaceInfo> {
+    let st = state.network.get(None).await;
+    let members: std::collections::HashSet<String> = st
+        .config
+        .bridges
+        .iter()
+        .flat_map(|b| b.members.iter().cloned())
+        .collect();
+    st.interfaces
+        .into_iter()
+        .map(|i| nasty_apps::IfaceInfo {
+            bridge_member: members.contains(&i.name),
+            name: i.name,
+            kind: i.kind,
+        })
+        .collect()
 }
 
 async fn run_bootstrap_system_flake_cli(args: &[String]) -> anyhow::Result<()> {

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -13,7 +13,7 @@ use nasty_apps::{
     App, AppConfig, AppIngress, AppStats, AppsStatus, CaddyRouteSummary, CheckDevicesRequest,
     CheckPortsRequest, CheckVolumesRequest, DeviceMissing, EnableAppsRequest,
     FixVolumePermsRequest, ImageInspectResult, InstallAppRequest, InstallComposeRequest,
-    PortConflict, PruneResult, SetIngressRequest, VolumeMismatch,
+    ManagedNetwork, NetworkSummary, PortConflict, PruneResult, SetIngressRequest, VolumeMismatch,
 };
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
@@ -2616,6 +2616,27 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     result: Some(
                         serde_json::json!({"type": "string", "description": "Conflict reason, or empty when no conflict."}),
                     ),
+                },
+                Method {
+                    name: "apps.networks.list",
+                    desc: "List Docker networks NASty can manage — merges live Docker state with persisted managed-network specs and annotates each with exists/managed/attached_apps.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<NetworkSummary>>(generator)),
+                },
+                Method {
+                    name: "apps.networks.create",
+                    desc: "Create a NASty-managed Docker network (bridge/macvlan/ipvlan) on a validated host parent interface and persist the spec for boot reconcile.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::Schema(gen_schema::<ManagedNetwork>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "apps.networks.remove",
+                    desc: "Remove a NASty-managed Docker network. Refuses while any container is still attached.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Network name.")),
+                    result: None,
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -326,6 +326,29 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
+
+        // ── Managed Docker networks ──────────────────────────
+        "apps.networks.list" => match state.apps.network_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "apps.networks.create" => match parse_params::<nasty_apps::ManagedNetwork>(req) {
+            Ok(spec) => {
+                let ifaces = crate::system_network_ifaces(state).await;
+                match state.apps.network_create(spec, &ifaces).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
+            Err(e) => invalid(req, e),
+        },
+        "apps.networks.remove" => match require_str(req, "name") {
+            Ok(name) => match state.apps.network_remove(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         _ => return None,
     })
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1444,6 +1444,10 @@ export interface App {
 	 * apps list shows a "Direct port only" badge with this as a tooltip
 	 * and hides the "Open" link. */
 	proxy_disabled_reason?: string | null;
+	/** NASty-managed Docker network the app is attached to, if any. */
+	network?: string | null;
+	/** The app's IP on that network, when known (LAN-IP apps). */
+	network_ip?: string | null;
 }
 
 export interface AppContainer {
@@ -1485,6 +1489,29 @@ export interface AppConfig {
 	memory_limit: string | null;
 	/** True if app was originally deployed with allow_unsafe. */
 	allow_unsafe?: boolean;
+	/** Managed network the app is attached to (round-tripped on Edit). */
+	network?: string | null;
+	/** Static IP requested at install (round-tripped on Edit). */
+	static_ip?: string | null;
+}
+
+/** A NASty-managed Docker network spec (apps.networks.create payload). */
+export interface ManagedNetwork {
+	name: string;
+	driver: string; // "bridge" | "macvlan" | "ipvlan"
+	parent?: string | null;
+	subnet?: string | null;
+	gateway?: string | null;
+	ip_range?: string | null;
+	vlan?: number | null;
+	host_shim?: boolean;
+}
+
+/** apps.networks.list row: spec + live-state annotations. */
+export interface NetworkSummary extends ManagedNetwork {
+	exists: boolean;
+	managed: boolean;
+	attached_apps: string[];
 }
 
 export interface ImageInspectResult {

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -5,7 +5,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
-	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe } from '$lib/types';
+	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe, NetworkSummary, ManagedNetwork, NetworkState } from '$lib/types';
 	import { formatBytes } from '$lib/format';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -32,6 +32,7 @@
 			deployDone = false;
 			deployError = '';
 			deployLog = [];
+			deployAction = null;
 
 			const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 			const ws = new WebSocket(`${wsProto}//${window.location.host}/ws/apps/deploy`);
@@ -67,6 +68,11 @@
 						deploying = false;
 						resolve(true);
 						ws.close();
+					} else if (msg.type === 'action' && msg.action === 'create_macvlan' && msg.bridge) {
+						// Structured hint (#429): the referenced external network
+						// is a host bridge. Surface a "create macvlan + retry" button.
+						deployAction = { action: msg.action, bridge: msg.bridge };
+						deployLog = [...deployLog, msg.data];
 					}
 				} catch { /* ignore */ }
 			};
@@ -303,6 +309,113 @@
 	let newAllowUnsafe = $state(false);
 	/** Same flag, separate state for the compose dialog. */
 	let composeAllowUnsafe = $state(false);
+
+	// ── Docker networks (#435 / #438) ─────────────────────────
+	/** Managed-network attachment in the simple-app install/edit form. */
+	let newNetwork = $state('');
+	let newStaticIp = $state('');
+	/** All NASty-manageable Docker networks (apps.networks.list). */
+	let appNetworks = $state<NetworkSummary[]>([]);
+	/** Host interfaces/bridges for the create-network parent picker. */
+	let netState = $state<NetworkState | null>(null);
+	/** True when the chosen install network gives the app its own LAN IP
+	 * (macvlan/ipvlan) — published host ports + reverse-proxy ingress don't
+	 * apply, so the form hides those sections to match the engine. */
+	let installLanIp = $derived(
+		appNetworks.some(
+			(n) => n.name === newNetwork && (n.driver === 'macvlan' || n.driver === 'ipvlan'),
+		),
+	);
+	// Create-network dialog state.
+	let showNetCreate = $state(false);
+	let ncName = $state('');
+	let ncDriver = $state('macvlan');
+	let ncParent = $state('');
+	let ncSubnet = $state('');
+	let ncGateway = $state('');
+	let ncIpRange = $state('');
+	let ncVlan = $state('');
+	let ncError = $state('');
+	let ncSaving = $state(false);
+	/** Actionable hint surfaced by the deploy stream (#429): the compose
+	 * referenced a host bridge — offer to create a macvlan on it + retry. */
+	let deployAction = $state<{ action: string; bridge: string } | null>(null);
+
+	async function loadAppNetworks() {
+		try {
+			appNetworks = await client.call<NetworkSummary[]>('apps.networks.list');
+		} catch {
+			appNetworks = [];
+		}
+	}
+
+	/** Parent candidates for macvlan/ipvlan: bridges (preferred) + standalone
+	 * NICs, each labeled with its role. Bridge-member NICs are excluded — the
+	 * bridge itself is the correct parent (engine rejects otherwise). */
+	let parentChoices = $derived.by(() => {
+		const out: { name: string; label: string }[] = [];
+		if (!netState) return out;
+		const members = new Set(netState.config.bridges.flatMap((b) => b.members));
+		for (const b of netState.config.bridges) {
+			const role = b.members.length ? b.members.join(', ') : 'host-internal';
+			const mgmt = netState.mgmt_iface === b.name ? '; management' : '';
+			out.push({ name: b.name, label: `${b.name} — bridge (${role}${mgmt})` });
+		}
+		for (const i of netState.interfaces) {
+			if (members.has(i.name) || i.kind === 'bridge' || i.kind === 'virtual') continue;
+			const mgmt = netState.mgmt_iface === i.name ? ' — management' : '';
+			out.push({ name: i.name, label: `${i.name} — ${i.kind}${mgmt}` });
+		}
+		return out;
+	});
+
+	async function openNetCreate(prefillBridge?: string) {
+		ncName = prefillBridge ?? '';
+		ncDriver = 'macvlan';
+		ncParent = prefillBridge ?? '';
+		ncSubnet = '';
+		ncGateway = '';
+		ncIpRange = '';
+		ncVlan = '';
+		ncError = '';
+		try {
+			netState = await client.call<NetworkState>('system.network.get');
+		} catch {
+			netState = null;
+		}
+		showNetCreate = true;
+	}
+
+	async function createNetwork() {
+		ncSaving = true;
+		ncError = '';
+		const spec: ManagedNetwork = {
+			name: ncName.trim(),
+			driver: ncDriver,
+			parent: ncDriver === 'bridge' ? null : ncParent || null,
+			subnet: ncSubnet.trim() || null,
+			gateway: ncGateway.trim() || null,
+			ip_range: ncIpRange.trim() || null,
+			vlan: ncVlan.trim() ? parseInt(ncVlan) : null,
+		};
+		try {
+			await client.call('apps.networks.create', spec);
+			showNetCreate = false;
+			await loadAppNetworks();
+		} catch (e) {
+			ncError = e instanceof Error ? e.message : String(e);
+		} finally {
+			ncSaving = false;
+		}
+	}
+
+	async function removeNetwork(name: string) {
+		const r = await withToast(
+			() => client.call('apps.networks.remove', { name }),
+			'Network removed',
+		);
+		if (r !== undefined) await loadAppNetworks();
+	}
 	/** Has the operator clicked Install / Deploy on this form at least
 	 * once? Gates the amber required-field decoration so a fresh form
 	 * opens clean rather than lit up with "required" everywhere. Set
@@ -791,6 +904,7 @@
 			apps = await client.call<App[]>('apps.list');
 			if (status.enabled && status.running) {
 				await loadIngresses();
+				await loadAppNetworks();
 				if (!statsPoll) startStatsPolling();
 				// Also lift the idle list-poll here so Docker coming up
 				// after the page loaded (e.g. user enabled apps from this
@@ -899,7 +1013,9 @@
 			name: appName,
 			image: newImage,
 		};
-		if (newPorts.length > 0) {
+		// A LAN-IP (macvlan/ipvlan) app gets its own address — published host
+		// ports and reverse-proxy ingress don't apply (engine rejects them).
+		if (newPorts.length > 0 && !installLanIp) {
 			params.ports = newPorts.map(p => ({
 				name: p.name,
 				container_port: p.container_port,
@@ -930,7 +1046,10 @@
 		// operator typed a hostname that became taken between the live
 		// conflict check and Save, install fails with a clear error.
 		const subdomainTrimmed = newSubdomain.trim();
-		if (subdomainTrimmed) params.subdomain = subdomainTrimmed;
+		if (subdomainTrimmed && !installLanIp) params.subdomain = subdomainTrimmed;
+		// Managed-network attachment (+ optional static IP).
+		if (newNetwork) params.network = newNetwork;
+		if (newStaticIp.trim()) params.static_ip = newStaticIp.trim();
 
 		const ok = await streamDeploy({
 			kind: 'simple',
@@ -971,6 +1090,9 @@
 		newCpuLimit = config.cpu_limit ?? '';
 		newMemoryLimit = config.memory_limit ?? '';
 		newAllowUnsafe = config.allow_unsafe ?? false;
+		newNetwork = config.network ?? '';
+		newStaticIp = config.static_ip ?? '';
+		loadAppNetworks();
 		installMode = 'simple';
 		showInstall = true;
 	}
@@ -981,7 +1103,7 @@
 			name: editingApp,
 			image: newImage,
 		};
-		if (newPorts.length > 0) {
+		if (newPorts.length > 0 && !installLanIp) {
 			params.ports = newPorts.map(p => ({
 				name: p.name,
 				container_port: p.container_port,
@@ -1008,6 +1130,9 @@
 		if (newCpuLimit) params.cpu_limit = newCpuLimit;
 		if (newMemoryLimit) params.memory_limit = newMemoryLimit;
 		params.allow_unsafe = newAllowUnsafe;
+		// Round-trip the managed-network attachment so Edit doesn't detach it.
+		if (newNetwork) params.network = newNetwork;
+		if (newStaticIp.trim()) params.static_ip = newStaticIp.trim();
 
 		const result = await withToast(
 			() => client.call('apps.update', params, 300_000),
@@ -1036,6 +1161,8 @@
 		newAllowUnsafe = false;
 		newSubdomain = '';
 		newSubdomainConflict = '';
+		newNetwork = '';
+		newStaticIp = '';
 		installTried = false;
 		lastInspectedImage = '';
 		subpathRecipe = null;
@@ -1621,6 +1748,28 @@
 					{/if}
 				</div>
 
+				<!-- Network attachment (#435 / #438) -->
+				<div class="mb-4">
+					<div class="flex items-center justify-between mb-1">
+						<Label for="app-network">Network</Label>
+						<Button size="xs" variant="outline" onclick={() => openNetCreate()}>+ New network</Button>
+					</div>
+					<select id="app-network" bind:value={newNetwork} class="h-9 w-full rounded-md border border-input bg-background px-2 text-sm">
+						<option value="">Default bridge (reverse-proxy ingress)</option>
+						{#each appNetworks as n}
+							<option value={n.name}>{n.name} ({n.driver}{n.parent ? ` on ${n.parent}` : ''})</option>
+						{/each}
+					</select>
+					{#if installLanIp}
+						<p class="mt-1 text-xs text-amber-500">This app gets its own LAN IP — host ports and reverse-proxy ingress don't apply and are hidden below.</p>
+						<div class="mt-2">
+							<Label for="app-static-ip">Static IP (optional)</Label>
+							<Input id="app-static-ip" bind:value={newStaticIp} placeholder="e.g. 192.168.1.50" class="mt-1" />
+						</div>
+					{/if}
+				</div>
+
+				{#if !installLanIp}
 				<!-- Ports -->
 				<div class="mb-4">
 					<div class="flex items-center justify-between mb-1">
@@ -1664,6 +1813,7 @@
 					{/if}
 					<p class="mt-1 text-[0.6rem] text-muted-foreground">Exposed = port on the host (what clients connect to). Internal = port inside the container. Leave Exposed blank to use the same number as Internal. App is also accessible at /apps/{'{name}'}/ via reverse proxy.</p>
 				</div>
+				{/if}
 
 				<!-- Environment Variables -->
 				<div class="mb-4">
@@ -1741,6 +1891,7 @@
 					</div>
 				</div>
 
+				{#if !installLanIp}
 				<!-- Subdomain (optional) — opt into subdomain-mode ingress from
 				     day one. Empty = path-prefix mode + post-install probe (the
 				     historical default). Non-empty = host-match Caddy route +
@@ -1764,6 +1915,7 @@
 						</p>
 					{/if}
 				</div>
+				{/if}
 
 				<!-- Allow unsafe — opt out of strict bind-mount sandbox -->
 				<div class="mb-4 rounded-md border border-border p-3">
@@ -1985,6 +2137,48 @@
 		</div>
 	{/if}
 
+	<!-- Docker networks (#435 / #438) -->
+	{#if status?.running}
+		<div class="mt-6 flex items-center justify-between">
+			<h3 class="text-lg font-semibold">Networks</h3>
+			<Button size="xs" variant="outline" onclick={() => openNetCreate()}>+ Create network</Button>
+		</div>
+		{#if appNetworks.length === 0}
+			<p class="mt-1 text-xs text-muted-foreground">No managed networks. Create a macvlan/ipvlan network to give apps their own LAN IP, or a user bridge for inter-container DNS.</p>
+		{:else}
+			<table class="mt-2 w-full text-sm">
+				<thead>
+					<tr class="text-left text-xs uppercase text-muted-foreground">
+						<th class="p-2">Name</th>
+						<th class="p-2">Driver</th>
+						<th class="p-2">Parent</th>
+						<th class="p-2">Subnet</th>
+						<th class="p-2">Attached</th>
+						<th class="p-2"></th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each appNetworks as n}
+						<tr class="border-t border-border/40">
+							<td class="p-2 font-mono">{n.name}{#if !n.exists} <span class="text-amber-500" title="Persisted but missing from Docker — recreated on boot">(missing)</span>{/if}</td>
+							<td class="p-2">{n.driver}</td>
+							<td class="p-2 font-mono">{n.parent ?? '—'}{#if n.vlan}.{n.vlan}{/if}</td>
+							<td class="p-2 font-mono">{n.subnet ?? '—'}</td>
+							<td class="p-2">{n.attached_apps.length > 0 ? n.attached_apps.join(', ') : '—'}</td>
+							<td class="p-2 text-right">
+								{#if n.managed}
+									<Button size="xs" variant="ghost" disabled={n.attached_apps.length > 0} title={n.attached_apps.length > 0 ? 'Detach all apps first' : 'Remove network'} onclick={() => removeNetwork(n.name)}>Remove</Button>
+								{:else}
+									<span class="text-xs text-muted-foreground" title="Not created by NASty">external</span>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	{/if}
+
 	<!-- Installed apps table -->
 	{#if apps.length > 0}
 		<h3 class="text-lg font-semibold mt-6 mb-3">Installed Apps</h3>
@@ -2112,6 +2306,14 @@
 									<a href="http://{window.location.hostname}:{pp.host_port}" target="_blank" class="inline-flex items-center whitespace-nowrap rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted" title="Direct port access (LAN)">
 										:{pp.host_port}
 									</a>
+								{/if}
+								{#if app.network}
+									<!-- App on a managed Docker network — show the network (and
+									     its own LAN IP for macvlan/ipvlan). No reverse-proxy
+									     "Open" link: it's reached directly on its IP. -->
+									<span class="inline-flex items-center whitespace-nowrap rounded-md border border-purple-500/30 bg-purple-500/10 px-2 py-0.5 text-xs text-purple-300" title="Docker network: {app.network}">
+										{app.network}{app.network_ip ? ` @ ${app.network_ip}` : ''}
+									</span>
 								{/if}
 								{#if status?.running}
 									<!-- Stop also for "restarting" — that is the crash-loop state, and Start would be a no-op. -->
@@ -2256,6 +2458,74 @@
 				class="flex-1 p-4 overflow-auto text-xs font-mono whitespace-pre-wrap {deployError ? 'text-red-400' : 'text-green-400'}"
 				id="deploy-output"
 			>{deployLog.join('\n')}</pre>
+			{#if deployAction && deployAction.action === 'create_macvlan'}
+				<div class="flex items-center justify-between gap-2 border-t border-border px-4 py-2">
+					<span class="text-xs text-amber-300">'{deployAction.bridge}' is a host bridge — create a macvlan network on it to put this app on your LAN.</span>
+					<Button size="xs" onclick={() => { const b = deployAction!.bridge; closeDeployLog(); openNetCreate(b); }}>
+						Create macvlan on {deployAction.bridge}
+					</Button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<!-- Create Docker network dialog (#435 / #438) -->
+{#if showNetCreate}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" role="presentation" onclick={(e) => { if (e.target === e.currentTarget) showNetCreate = false; }}>
+		<div class="w-[90vw] max-w-md rounded-lg border border-border bg-card p-5 shadow-2xl">
+			<h3 class="mb-3 text-lg font-semibold">Create Docker network</h3>
+			<div class="space-y-3">
+				<div>
+					<Label for="nc-name">Name</Label>
+					<Input id="nc-name" bind:value={ncName} placeholder="lan" class="mt-1" />
+				</div>
+				<div>
+					<Label for="nc-driver">Driver</Label>
+					<select id="nc-driver" bind:value={ncDriver} class="mt-1 h-9 w-full rounded-md border border-input bg-background px-2 text-sm">
+						<option value="macvlan">macvlan — own LAN IP (separate MAC)</option>
+						<option value="ipvlan">ipvlan — own LAN IP (shared MAC; WiFi/MAC-limited)</option>
+						<option value="bridge">bridge — NAT'd, reached via ingress</option>
+					</select>
+				</div>
+				{#if ncDriver !== 'bridge'}
+					<div>
+						<Label for="nc-parent">Parent interface</Label>
+						<select id="nc-parent" bind:value={ncParent} class="mt-1 h-9 w-full rounded-md border border-input bg-background px-2 text-sm">
+							<option value="" disabled>Select a bridge or NIC…</option>
+							{#each parentChoices as p}
+								<option value={p.name}>{p.label}</option>
+							{/each}
+						</select>
+						<p class="mt-1 text-[0.65rem] text-muted-foreground">Pick the bridge your VMs use to share the same LAN segment. Bridge-member NICs are excluded — use the bridge itself.</p>
+					</div>
+					<div>
+						<Label for="nc-vlan">VLAN tag (optional)</Label>
+						<Input id="nc-vlan" bind:value={ncVlan} placeholder="e.g. 10" class="mt-1" />
+					</div>
+				{/if}
+				<div>
+					<Label for="nc-subnet">Subnet (optional)</Label>
+					<Input id="nc-subnet" bind:value={ncSubnet} placeholder="192.168.1.0/24" class="mt-1" />
+				</div>
+				<div class="grid grid-cols-2 gap-2">
+					<div>
+						<Label for="nc-gw">Gateway (optional)</Label>
+						<Input id="nc-gw" bind:value={ncGateway} placeholder="192.168.1.1" class="mt-1" />
+					</div>
+					<div>
+						<Label for="nc-range">IP range (optional)</Label>
+						<Input id="nc-range" bind:value={ncIpRange} placeholder="192.168.1.64/27" class="mt-1" />
+					</div>
+				</div>
+				{#if ncError}<p class="text-xs text-red-500">{ncError}</p>{/if}
+			</div>
+			<div class="mt-4 flex justify-end gap-2">
+				<Button variant="secondary" size="sm" onclick={() => showNetCreate = false}>Cancel</Button>
+				<Button size="sm" onclick={createNetwork} disabled={ncSaving || !ncName.trim() || (ncDriver !== 'bridge' && !ncParent)}>
+					{ncSaving ? 'Creating…' : 'Create'}
+				</Button>
+			</div>
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
Closes #435. Closes #438.

Gives Docker apps the capability VMs already have — sitting directly on the LAN — by letting NASty **manage Docker networks** and **attach an app to one** (with its own IP). Implemented per the approved plan; the host↔container shim is deferred (see below).

## Backend (`nasty-apps`)
- **`ManagedNetwork` model** + `apps.networks.{list,create,remove}` over **bollard** — bridge/macvlan/ipvlan, labeled `nasty.managed`, persisted to `apps-networks.json`, **boot-reconciled** (recreate missing; skip a vanished parent). Pure `validate_network_spec` (driver/parent/subnet/gateway/ip_range/vlan; **rejects a bridge-member NIC as parent** — steers to the bridge) + hand-rolled CIDR helpers (no new dep).
- **Per-app attach**: `InstallAppRequest` gains `network`/`static_ip`; `install()` resolves the network, enforces **macvlan/ipvlan ⇄ host-ports + ingress mutual exclusion**, sets `NetworkingConfig` (with `EndpointIpamConfig` static IP) + labels. `App`/`AppConfig` surface the attachment and `apps.pull`/`update` round-trip it so a reinstall never silently detaches.
- **Actionable #429 hint**: the compose host-bridge failure also emits a structured `create_macvlan` `DeployMessage`.

## WebUI
- Install-form **network picker + static IP**, hiding Ports/Subdomain for a LAN-IP app (mirrors the engine). App card shows a `network @ ip` badge and drops the reverse-proxy **Open** link (the app is reached on its own IP).
- **Networks management table** (create dialog with a role-labeled parent picker reusing `system.network.get`; remove, disabled while containers are attached).
- Deploy-log **"create macvlan on `<bridge>`"** button.

## Interaction with VMs / host networking
The "shared bridge" is the integration: pick the bridge your VMs use as the macvlan **parent** and containers join the same L2 segment. Parents come from the same `system.network.get` source as VMs/Settings → Network; macvlan over a bridge-member NIC is rejected.

## Deferred — host↔container shim (own follow-up)
The macvlan shim (so the NASty host and a macvlan container can reach each other) mutates the **NM host-networking core** and rides the confirm-or-rollback rail — it needs real-hardware validation given NASty's connectivity-loss history (#74). `host_shim` is reserved in the model but **rejected by the validator** for now (no UI checkbox). I'll file a follow-up issue.

## Tests / status
- 17 pure-logic unit tests (validator incl. bridge-member rejection, CIDR contains, ingress mutual-exclusion, reconcile planner, serde). Full `nasty-apps`/`nasty-engine` suites pass; clippy + `cargo fmt --check` clean; `svelte-check` 0/0.
- **Not done: end-to-end on hardware** (needs the engine deployed via a NixOS rebuild). The bollard network-create / container-attach paths are exercised manually, not in CI (same "no live docker in CI" constraint as prior work). Worth a manual pass on a box before/after merge — see the plan's verification section.