### PR TITLE
apps/network: host↔container macvlan shim (#448)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -138,6 +138,10 @@ pub struct ManagedNetwork {
     /// macvlan only: create a host-side shim so host↔container works.
     #[serde(default)]
     pub host_shim: bool,
+    /// The host's address on the container subnet (CIDR) for the shim.
+    /// Required when `host_shim` is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shim_ip: Option<String>,
 }
 
 /// On-disk shape for [`NETWORKS_PATH`].
@@ -188,7 +192,7 @@ fn mask_ip(ip: std::net::IpAddr, prefix: u8) -> u128 {
 }
 
 /// True iff `ip` falls within `cidr`. `None` on malformed input.
-fn cidr_contains_ip(cidr: &str, ip: &str) -> Option<bool> {
+pub fn cidr_contains_ip(cidr: &str, ip: &str) -> Option<bool> {
     let (net, prefix) = parse_cidr(cidr)?;
     let addr: std::net::IpAddr = ip.trim().parse().ok()?;
     if net.is_ipv4() != addr.is_ipv4() {
@@ -239,14 +243,38 @@ fn validate_network_spec(spec: &ManagedNetwork, ifaces: &[IfaceInfo]) -> Result<
     if !matches!(spec.driver.as_str(), "bridge" | "macvlan" | "ipvlan") {
         return Err(invalid_net("driver must be bridge, macvlan, or ipvlan"));
     }
-    // The host↔container macvlan shim mutates host networking and is
-    // deferred to a follow-up (it needs the confirm-or-rollback rail +
-    // real-hardware validation). Reserve the field but reject it for now
-    // so callers don't think it does something.
+    // Host↔container shim (#448): only valid on macvlan, needs a subnet to
+    // route and a host address (shim_ip) inside it, distinct from the
+    // gateway. The mgmt-interface refusal lives in the engine RPC arm,
+    // which knows the management iface.
     if spec.host_shim {
-        return Err(invalid_net(
-            "host↔container shim is not implemented yet — leave it disabled (tracked separately)",
-        ));
+        if spec.driver != "macvlan" {
+            return Err(invalid_net(
+                "host shim is only supported on macvlan networks",
+            ));
+        }
+        let subnet = spec
+            .subnet
+            .as_deref()
+            .ok_or_else(|| invalid_net("host shim requires the network to have a subnet"))?;
+        let shim_ip = spec
+            .shim_ip
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                invalid_net("host shim requires a shim_ip (the host's address on the subnet)")
+            })?;
+        // shim_ip is stored as a static host address (CIDR, e.g. 192.168.1.2/24);
+        // the containment and gateway checks compare the bare address.
+        let shim_addr = shim_ip.split('/').next().unwrap_or(shim_ip);
+        if cidr_contains_ip(subnet, shim_addr) != Some(true) {
+            return Err(invalid_net(format!(
+                "shim_ip '{shim_ip}' is not within subnet '{subnet}'"
+            )));
+        }
+        if spec.gateway.as_deref() == Some(shim_addr) {
+            return Err(invalid_net("shim_ip must differ from the gateway"));
+        }
     }
     let needs_parent = matches!(spec.driver.as_str(), "macvlan" | "ipvlan");
     match (&spec.parent, needs_parent) {
@@ -1768,6 +1796,7 @@ impl AppsService {
                         ip_range,
                         vlan: None,
                         host_shim: false,
+                        shim_ip: None,
                     }
                 }
             };
@@ -1922,6 +1951,7 @@ impl AppsService {
             ip_range: None,
             vlan: None,
             host_shim: false,
+            shim_ip: None,
         })
     }
 
@@ -6130,6 +6160,7 @@ mod network_tests {
             ip_range: None,
             vlan: None,
             host_shim: false,
+            shim_ip: None,
         }
     }
     fn macvlan_on(parent: &str) -> ManagedNetwork {
@@ -6194,10 +6225,47 @@ mod network_tests {
         n.subnet = Some("not-a-cidr".into());
         assert!(validate_network_spec(&n, &ifaces()).is_err());
     }
-    #[test]
-    fn host_shim_rejected_for_now() {
-        let mut n = macvlan_on("br0");
+    fn macvlan_shim(parent: &str) -> ManagedNetwork {
+        let mut n = macvlan_on(parent);
+        n.subnet = Some("192.168.1.0/24".into());
         n.host_shim = true;
+        n.shim_ip = Some("192.168.1.2/24".into());
+        n
+    }
+
+    #[test]
+    fn host_shim_accepted_with_valid_shim_ip() {
+        assert!(validate_network_spec(&macvlan_shim("br0"), &ifaces()).is_ok());
+    }
+
+    #[test]
+    fn host_shim_rejected_without_shim_ip() {
+        let mut n = macvlan_shim("br0");
+        n.shim_ip = None;
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+
+    #[test]
+    fn host_shim_rejected_shim_ip_outside_subnet() {
+        let mut n = macvlan_shim("br0");
+        n.shim_ip = Some("10.9.9.9/24".into());
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+
+    #[test]
+    fn host_shim_rejected_without_subnet() {
+        let mut n = macvlan_shim("br0");
+        n.subnet = None;
+        assert!(validate_network_spec(&n, &ifaces()).is_err());
+    }
+
+    #[test]
+    fn host_shim_rejected_on_bridge_driver() {
+        // bridge driver can't carry a host shim (and forbids a parent anyway).
+        let mut n = net("x", "bridge");
+        n.host_shim = true;
+        n.subnet = Some("192.168.1.0/24".into());
+        n.shim_ip = Some("192.168.1.2/24".into());
         assert!(validate_network_spec(&n, &ifaces()).is_err());
     }
 

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -726,6 +726,114 @@ pub(crate) async fn system_network_ifaces(state: &AppState) -> Vec<nasty_apps::I
         .collect()
 }
 
+/// Add a host-side macvlan shim for a macvlan Docker network (#448) so the
+/// host can reach containers on it. Threads a `MacvlanConfig` into the
+/// operator's `NetworkConfig` and applies it via the existing network rail
+/// (which rolls back risky changes; a non-mgmt-parent shim is classified
+/// safe so it applies without a confirm timer). Refuses when the parent
+/// already carries a host IP in the container subnet (route conflict).
+pub(crate) async fn add_macvlan_shim(
+    state: &AppState,
+    spec: &nasty_apps::ManagedNetwork,
+    mgmt: Option<&str>,
+) -> Result<(), String> {
+    use nasty_system::network::{IpConfig, IpMethod, MacvlanConfig, UpdateRequest};
+    let parent = spec
+        .parent
+        .as_deref()
+        .ok_or("macvlan network has no parent")?;
+    let subnet = spec
+        .subnet
+        .as_deref()
+        .ok_or("host shim requires the network to have a subnet")?;
+    let shim_ip = spec
+        .shim_ip
+        .as_deref()
+        .ok_or("host shim requires a shim_ip")?;
+    // The kernel parent matches Docker's (parent.<vlan> when tagged).
+    let eff_parent = match spec.vlan {
+        Some(v) => format!("{parent}.{v}"),
+        None => parent.to_string(),
+    };
+    let shim_name = format!("shim-{}", spec.name);
+    if shim_name.len() > 15 {
+        return Err(format!(
+            "network name too long for a shim interface ('{shim_name}' exceeds 15 chars)"
+        ));
+    }
+
+    let st = state.network.get(mgmt.map(|s| s.to_string())).await;
+    // Route-conflict guard: a host already on the container subnet via the
+    // parent would get a second on-link route through the shim.
+    if let Some(iface) = st.interfaces.iter().find(|i| i.name == eff_parent) {
+        for a in &iface.ipv4_addresses {
+            let ip = a.split('/').next().unwrap_or(a);
+            if nasty_apps::cidr_contains_ip(subnet, ip) == Some(true) {
+                return Err(format!(
+                    "parent '{eff_parent}' already has an address ({a}) in {subnet}; a host shim \
+                     would create a conflicting route — give the macvlan network a dedicated subnet"
+                ));
+            }
+        }
+    }
+
+    let route = spec.ip_range.clone().unwrap_or_else(|| subnet.to_string());
+    let mut config = st.config.clone();
+    config.macvlans.retain(|m| m.name != shim_name);
+    config.macvlans.push(MacvlanConfig {
+        name: shim_name.clone(),
+        parent: eff_parent,
+        mode: "bridge".to_string(),
+        ipv4: IpConfig {
+            method: IpMethod::Static,
+            addresses: vec![shim_ip.to_string()],
+            gateway: None,
+        },
+        mtu: None,
+        routes: vec![route],
+    });
+    let resp = state
+        .network
+        .update(
+            UpdateRequest {
+                config,
+                confirm_within_secs: Some(0),
+            },
+            mgmt.map(|s| s.to_string()),
+        )
+        .await?;
+    if !resp.apply_errors.is_empty() {
+        return Err(format!(
+            "network apply reported errors creating the shim: {:?}",
+            resp.apply_errors
+        ));
+    }
+    Ok(())
+}
+
+/// Remove the host macvlan shim for a Docker network (best-effort).
+pub(crate) async fn remove_macvlan_shim(state: &AppState, net_name: &str) -> Result<(), String> {
+    use nasty_system::network::UpdateRequest;
+    let shim_name = format!("shim-{net_name}");
+    let st = state.network.get(None).await;
+    if !st.config.macvlans.iter().any(|m| m.name == shim_name) {
+        return Ok(()); // nothing to remove
+    }
+    let mut config = st.config.clone();
+    config.macvlans.retain(|m| m.name != shim_name);
+    state
+        .network
+        .update(
+            UpdateRequest {
+                config,
+                confirm_within_secs: Some(0),
+            },
+            None,
+        )
+        .await
+        .map(|_| ())
+}
+
 async fn run_bootstrap_system_flake_cli(args: &[String]) -> anyhow::Result<()> {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         println!(

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -335,16 +335,50 @@ pub(super) async fn try_route(
         "apps.networks.create" => match parse_params::<nasty_apps::ManagedNetwork>(req) {
             Ok(spec) => {
                 let ifaces = crate::system_network_ifaces(state).await;
-                match state.apps.network_create(spec, &ifaces).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
+                // Resolve the management interface from the caller's peer so we
+                // can refuse a host shim on it (lockout guard, #448).
+                let mgmt = match session.client_ip.as_deref() {
+                    Some(peer) => nasty_system::network::mgmt_iface_for_peer(peer).await,
+                    None => None,
+                };
+                if spec.host_shim && spec.parent.as_deref() == mgmt.as_deref() {
+                    err(
+                        req,
+                        "refusing a host shim on the management interface (would risk lockout)"
+                            .to_string(),
+                    )
+                } else {
+                    match state.apps.network_create(spec.clone(), &ifaces).await {
+                        Ok(()) => {
+                            if spec.host_shim {
+                                // Apply the host-side shim; on failure undo the
+                                // Docker network so we don't leave a half-state.
+                                match crate::add_macvlan_shim(state, &spec, mgmt.as_deref()).await {
+                                    Ok(()) => ok(req, "ok"),
+                                    Err(e) => {
+                                        let _ = state.apps.network_remove(&spec.name).await;
+                                        err(req, format!("host shim failed: {e}"))
+                                    }
+                                }
+                            } else {
+                                ok(req, "ok")
+                            }
+                        }
+                        Err(e) => err(req, e),
+                    }
                 }
             }
             Err(e) => invalid(req, e),
         },
         "apps.networks.remove" => match require_str(req, "name") {
             Ok(name) => match state.apps.network_remove(name).await {
-                Ok(()) => ok(req, "ok"),
+                Ok(()) => {
+                    // Tear down the host shim too (best-effort).
+                    if let Err(e) = crate::remove_macvlan_shim(state, name).await {
+                        tracing::warn!("apps: failed to remove macvlan shim for '{name}': {e}");
+                    }
+                    ok(req, "ok")
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -174,6 +174,34 @@ fn inherit_ip() -> IpConfig {
     }
 }
 
+fn default_macvlan_mode() -> String {
+    "bridge".to_string()
+}
+
+/// A host-side macvlan sub-interface on `parent` — the "shim" that lets
+/// the NASty host reach macvlan Docker containers it would otherwise be
+/// isolated from (#448). Engine-managed: created when an operator enables
+/// the host shim on a macvlan Docker network, removed when the network is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct MacvlanConfig {
+    /// Kernel interface name (e.g. `nasty-shim-lan`).
+    pub name: String,
+    /// Parent interface/bridge the macvlan attaches to.
+    pub parent: String,
+    /// NM macvlan mode; only "bridge" is created today.
+    #[serde(default = "default_macvlan_mode")]
+    pub mode: String,
+    /// The host's static address on the container subnet.
+    #[serde(default)]
+    pub ipv4: IpConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtu: Option<u16>,
+    /// Container subnet(s)/ip-range the host should reach via this shim
+    /// (on-link routes). CIDR strings.
+    #[serde(default)]
+    pub routes: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 pub struct NetworkConfig {
     #[serde(default)]
@@ -186,6 +214,10 @@ pub struct NetworkConfig {
     pub vlans: Vec<VlanConfig>,
     #[serde(default)]
     pub bridges: Vec<BridgeConfig>,
+    /// Engine-managed macvlan host shims (#448). Not surfaced in the
+    /// network editor UI — added/removed by the apps macvlan-network flow.
+    #[serde(default)]
+    pub macvlans: Vec<MacvlanConfig>,
 }
 
 /// Live interface state — read-only, populated at query time.
@@ -421,6 +453,21 @@ impl NetworkService {
             }
             validate_ip_config(&bridge.ipv4, "IPv4")?;
             validate_ip_config(&bridge.ipv6, "IPv6")?;
+        }
+        for mv in &config.macvlans {
+            if mv.name.is_empty() || mv.parent.is_empty() {
+                return Err("macvlan name and parent are required".to_string());
+            }
+            // Lockout guard (defense in depth; the apps RPC arm enforces
+            // this too with the peer-resolved mgmt iface): never put a
+            // host macvlan shim on the management interface.
+            if mgmt_iface.as_deref() == Some(mv.parent.as_str()) {
+                return Err(format!(
+                    "refusing macvlan shim on management interface '{}'",
+                    mv.parent
+                ));
+            }
+            validate_ip_config(&mv.ipv4, "IPv4")?;
         }
 
         // Resolve `IpMethod::Inherit` against the prior config and live

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -884,6 +884,15 @@ async fn persist_config(config: &NetworkConfig) -> Result<(), String> {
     let json =
         serde_json::to_string_pretty(config).map_err(|e| format!("serialization error: {e}"))?;
 
+    // Layered validation is authoritative: a structurally-broken
+    // config (cycle, dangling reference, double enslavement, macvlan with
+    // an undeclared parent, ...) is rejected *before* we touch disk, so a
+    // rejected update can't poison networking.json — the next apply/boot
+    // must never read a config the validator would refuse.
+    let layered_cfg = layered::to_layered(config);
+    layered::validate(&layered_cfg)
+        .map_err(|e| format!("network config rejected by validator: {e}"))?;
+
     // Snapshot the existing config to history before overwriting, so a bad
     // apply can be rolled back. Best-effort: a missing/unreadable prior file
     // is fine (first-run case).
@@ -897,12 +906,6 @@ async fn persist_config(config: &NetworkConfig) -> Result<(), String> {
         .await
         .map_err(|e| format!("failed to write {JSON_PATH}: {e}"))?;
 
-    // Layered validation is authoritative: a structurally-broken
-    // config (cycle, dangling reference, double enslavement, ...) is
-    // rejected here before NM ever sees it.
-    let layered_cfg = layered::to_layered(config);
-    layered::validate(&layered_cfg)
-        .map_err(|e| format!("network config rejected by validator: {e}"))?;
     match serde_json::to_string_pretty(&layered_cfg) {
         Ok(layered_json) => {
             if let Err(e) = atomic_write(JSON_PATH_V2, layered_json.as_bytes()).await {

--- a/engine/nasty-system/src/network/layered.rs
+++ b/engine/nasty-system/src/network/layered.rs
@@ -15,8 +15,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BondConfig, BondMode, BridgeConfig, InterfaceConfig, IpConfig, IpMethod, NetworkConfig,
-    VlanConfig,
+    BondConfig, BondMode, BridgeConfig, InterfaceConfig, IpConfig, IpMethod, MacvlanConfig,
+    NetworkConfig, VlanConfig,
 };
 
 // ── Types ──────────────────────────────────────────────────────
@@ -94,6 +94,12 @@ pub enum LinkKind {
         parent: String,
         id: u16,
     },
+    /// A macvlan sub-interface on `parent` (host↔container shim). Only
+    /// `mode = "bridge"` is created today.
+    Macvlan {
+        parent: String,
+        mode: String,
+    },
 }
 
 /// L3 address binding. Multiple `Address` rows can target the same link
@@ -163,6 +169,7 @@ pub struct Rule {
 pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
     let mut links = Vec::new();
     let mut addresses = Vec::new();
+    let mut routes = Vec::new();
 
     for iface in &legacy.interfaces {
         links.push(Link {
@@ -217,6 +224,30 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
         });
         push_addresses(&mut addresses, &name, &vlan.ipv4, &vlan.ipv6);
     }
+    for mv in &legacy.macvlans {
+        links.push(Link {
+            name: mv.name.clone(),
+            enabled: true,
+            mtu: mv.mtu,
+            mac: None,
+            kind: LinkKind::Macvlan {
+                parent: mv.parent.clone(),
+                mode: mv.mode.clone(),
+            },
+        });
+        // The shim's host address on the container subnet (IPv4 only for v1).
+        push_addresses(&mut addresses, &mv.name, &mv.ipv4, &IpConfig::default());
+        // On-link routes so the host reaches the container subnet via the shim.
+        for dst in &mv.routes {
+            routes.push(Route {
+                table: 254,
+                dst: dst.clone(),
+                via: None,
+                dev: mv.name.clone(),
+                metric: None,
+            });
+        }
+    }
 
     // Synthesize Physical links for any bond/bridge member that isn't
     // declared in the top-level interfaces list (#348).
@@ -263,7 +294,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
     LayeredConfig {
         links,
         addresses,
-        routes: Vec::new(),
+        routes,
         rules: Vec::new(),
         dns: legacy.dns.clone(),
     }
@@ -308,6 +339,15 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
     let mut bonds = Vec::new();
     let mut bridges = Vec::new();
     let mut vlans = Vec::new();
+    let mut macvlans = Vec::new();
+    // Reconstruct per-macvlan routes from the (dev-keyed) layered routes.
+    let mut routes_by_dev: HashMap<&str, Vec<String>> = HashMap::new();
+    for r in &layered.routes {
+        routes_by_dev
+            .entry(r.dev.as_str())
+            .or_default()
+            .push(r.dst.clone());
+    }
 
     for link in &layered.links {
         let (ipv4, ipv6) = addrs_by_link
@@ -358,6 +398,17 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 ipv6,
                 mtu: link.mtu,
             }),
+            LinkKind::Macvlan { parent, mode } => macvlans.push(MacvlanConfig {
+                name: link.name.clone(),
+                parent: parent.clone(),
+                mode: mode.clone(),
+                ipv4,
+                mtu: link.mtu,
+                routes: routes_by_dev
+                    .get(link.name.as_str())
+                    .cloned()
+                    .unwrap_or_default(),
+            }),
         }
     }
 
@@ -367,6 +418,7 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
         bonds,
         vlans,
         bridges,
+        macvlans,
     }
 }
 
@@ -424,6 +476,18 @@ pub fn validate(layered: &LayeredConfig) -> Result<(), String> {
                 if !names.contains(parent.as_str()) {
                     return Err(format!(
                         "vlan '{}' references missing parent '{parent}'",
+                        link.name
+                    ));
+                }
+            }
+            LinkKind::Macvlan { parent, .. } => {
+                if parent == &link.name {
+                    return Err(format!("macvlan '{}' is its own parent", link.name));
+                }
+                if !names.contains(parent.as_str()) {
+                    return Err(format!(
+                        "macvlan '{}' references missing parent '{parent}' \
+                         (declare the parent interface/bridge first)",
                         link.name
                     ));
                 }
@@ -502,6 +566,7 @@ fn deps(link: &Link) -> Vec<&str> {
             members.iter().map(String::as_str).collect()
         }
         LinkKind::Vlan { parent, .. } => vec![parent.as_str()],
+        LinkKind::Macvlan { parent, .. } => vec![parent.as_str()],
         LinkKind::Physical => Vec::new(),
     }
 }
@@ -627,6 +692,7 @@ mod tests {
             bonds: vec![legacy_bond("bond0", &["eth0", "eth1"])],
             vlans: vec![vlan],
             bridges: vec![br],
+            macvlans: vec![],
         });
     }
 
@@ -904,6 +970,106 @@ mod tests {
         };
         let err = validate(&cfg).unwrap_err();
         assert!(err.contains("own parent"));
+    }
+
+    fn link_macvlan(name: &str, parent: &str) -> Link {
+        Link {
+            name: name.into(),
+            enabled: true,
+            mtu: None,
+            mac: None,
+            kind: LinkKind::Macvlan {
+                parent: parent.into(),
+                mode: "bridge".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_passes_macvlan_with_existing_parent() {
+        let cfg = LayeredConfig {
+            links: vec![link_phys("eth1"), link_macvlan("shim-lan", "eth1")],
+            addresses: vec![Address {
+                link: "shim-lan".into(),
+                family: Family::V4,
+                method: IpMethod::Static,
+                cidr: vec!["192.168.1.2/24".into()],
+                gateway: None,
+            }],
+            ..Default::default()
+        };
+        validate(&cfg).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_macvlan_with_missing_parent() {
+        let cfg = LayeredConfig {
+            links: vec![link_macvlan("shim-lan", "ghost")],
+            ..Default::default()
+        };
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.contains("missing parent"));
+        assert!(err.contains("ghost"));
+    }
+
+    #[test]
+    fn validate_rejects_macvlan_as_own_parent() {
+        let cfg = LayeredConfig {
+            links: vec![link_macvlan("shim", "shim")],
+            ..Default::default()
+        };
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.contains("own parent"));
+    }
+
+    #[test]
+    fn to_layered_emits_macvlan_link_address_and_route() {
+        let cfg = NetworkConfig {
+            interfaces: vec![legacy_iface("eth1")],
+            macvlans: vec![MacvlanConfig {
+                name: "shim-lan".into(),
+                parent: "eth1".into(),
+                mode: "bridge".into(),
+                ipv4: IpConfig {
+                    method: IpMethod::Static,
+                    addresses: vec!["192.168.1.2/24".into()],
+                    ..Default::default()
+                },
+                mtu: None,
+                routes: vec!["192.168.1.0/24".into()],
+            }],
+            ..Default::default()
+        };
+        let layered = to_layered(&cfg);
+
+        let shim = layered
+            .links
+            .iter()
+            .find(|l| l.name == "shim-lan")
+            .expect("shim link present");
+        match &shim.kind {
+            LinkKind::Macvlan { parent, mode } => {
+                assert_eq!(parent, "eth1");
+                assert_eq!(mode, "bridge");
+            }
+            other => panic!("expected Macvlan, got {other:?}"),
+        }
+        assert!(
+            layered
+                .addresses
+                .iter()
+                .any(|a| a.link == "shim-lan" && a.cidr == vec!["192.168.1.2/24".to_string()]),
+            "shim address present"
+        );
+        assert!(
+            layered
+                .routes
+                .iter()
+                .any(|r| r.dev == "shim-lan" && r.dst == "192.168.1.0/24" && r.via.is_none()),
+            "on-link shim route present"
+        );
+
+        validate(&layered).unwrap();
     }
 
     #[test]

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -70,6 +70,7 @@ pub enum NmConnectionType {
     Bond,
     Bridge,
     Vlan,
+    Macvlan,
 }
 
 impl NmConnectionType {
@@ -80,6 +81,7 @@ impl NmConnectionType {
             NmConnectionType::Bond => "bond",
             NmConnectionType::Bridge => "bridge",
             NmConnectionType::Vlan => "vlan",
+            NmConnectionType::Macvlan => "macvlan",
         }
     }
 }
@@ -103,6 +105,12 @@ pub struct NmIpSettings {
     /// presence of a colon.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dns: Vec<String>,
+    /// On-link static routes (bare destination CIDRs) for this family.
+    /// Emitted as `routeN=<dst>` (keyfile) / `route-data` (DBus) with no
+    /// next-hop, i.e. scope-link via this connection's device — used by
+    /// the macvlan host shim to reach container subnets.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -153,6 +161,11 @@ pub enum NmTypeSpecific {
     Vlan {
         parent: String,
         id: u16,
+    },
+    Macvlan {
+        parent: String,
+        /// NM macvlan mode; we only emit "bridge" (host↔child shim).
+        mode: String,
     },
 }
 
@@ -229,6 +242,18 @@ pub fn to_nm_profiles_with_macs(layered: &LayeredConfig, ctx: &MacContext) -> Ve
         }
     }
 
+    // On-link static routes grouped by device, split into v4/v6 by the
+    // destination's form, so each goes in the right [ipv4]/[ipv6] section.
+    let mut routes_by_dev: HashMap<&str, (Vec<String>, Vec<String>)> = HashMap::new();
+    for r in &layered.routes {
+        let entry = routes_by_dev.entry(r.dev.as_str()).or_default();
+        if r.dst.contains(':') {
+            entry.1.push(r.dst.clone());
+        } else {
+            entry.0.push(r.dst.clone());
+        }
+    }
+
     // Split user-configured DNS into v4/v6 buckets so we put each
     // entry in the right [ipv4]/[ipv6] section. NM accepts only
     // family-matching addresses in each section.
@@ -246,6 +271,11 @@ pub fn to_nm_profiles_with_macs(layered: &LayeredConfig, ctx: &MacContext) -> Ve
             if conn.controller.is_none() {
                 conn.ipv4.dns.clone_from(&dns_v4);
                 conn.ipv6.dns.clone_from(&dns_v6);
+            }
+            // Attach any on-link routes targeted at this device (macvlan shim).
+            if let Some((v4, v6)) = routes_by_dev.get(link.name.as_str()) {
+                conn.ipv4.routes.clone_from(v4);
+                conn.ipv6.routes.clone_from(v6);
             }
             // Bond/bridge masters: inherit the primary member's MAC
             // *if the user opted in* (default for new bridges/bonds;
@@ -373,6 +403,13 @@ fn profile_for_link(
                 id: *id,
             },
         ),
+        LinkKind::Macvlan { parent, mode } => (
+            NmConnectionType::Macvlan,
+            NmTypeSpecific::Macvlan {
+                parent: parent.clone(),
+                mode: mode.clone(),
+            },
+        ),
     };
 
     NmConnection {
@@ -398,6 +435,7 @@ fn address_to_nm_settings(addr: &Address) -> NmIpSettings {
         addresses: addr.cidr.clone(),
         gateway: addr.gateway.clone(),
         dns: Vec::new(),
+        routes: Vec::new(),
     }
 }
 
@@ -503,6 +541,12 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
             out.push_str(&format!("parent={parent}\n"));
             out.push_str(&format!("id={id}\n\n"));
         }
+        NmTypeSpecific::Macvlan { parent, mode } => {
+            out.push_str("[macvlan]\n");
+            out.push_str(&format!("parent={parent}\n"));
+            // NM stores macvlan mode as the numeric NMSettingMacvlanMode.
+            out.push_str(&format!("mode={}\n\n", macvlan_mode_num(mode)));
+        }
     }
 
     // [ethernet] carries MTU and cloned-mac for ethernet-like types
@@ -567,6 +611,24 @@ fn serialize_ip_section(out: &mut String, ip: &NmIpSettings) {
             out.push(';');
         }
         out.push('\n');
+    }
+    // On-link static routes: `routeN=<dst>` with no next-hop ⇒ scope-link
+    // route via this connection's device (the macvlan shim).
+    for (i, dst) in ip.routes.iter().enumerate() {
+        out.push_str(&format!("route{}={dst}\n", i + 1));
+    }
+}
+
+/// NM `NMSettingMacvlanMode` numeric value. We only create "bridge"
+/// shims, but map the rest for completeness/forward-compat.
+fn macvlan_mode_num(mode: &str) -> u32 {
+    match mode {
+        "vepa" => 1,
+        "bridge" => 2,
+        "private" => 3,
+        "passthru" => 4,
+        "source" => 5,
+        _ => 2,
     }
 }
 
@@ -656,6 +718,12 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
             vlan.insert("parent".into(), into_value(parent.clone()));
             vlan.insert("id".into(), into_value(u32::from(*id)));
             out.insert("vlan".into(), vlan);
+        }
+        NmTypeSpecific::Macvlan { parent, mode } => {
+            let mut mv = HashMap::new();
+            mv.insert("parent".into(), into_value(parent.clone()));
+            mv.insert("mode".into(), into_value(macvlan_mode_num(mode)));
+            out.insert("macvlan".into(), mv);
         }
     }
 
@@ -765,6 +833,21 @@ fn ip_section_dict(ip: &NmIpSettings, family: Family) -> HashMap<String, OwnedVa
                     s.insert("dns".into(), into_value(packed));
                 }
             }
+        }
+    }
+    // route-data (aa{sv}): on-link routes — dest + prefix, no next-hop.
+    if !ip.routes.is_empty() {
+        let mut rd: Vec<HashMap<String, OwnedValue>> = Vec::new();
+        for cidr in &ip.routes {
+            if let Some((dest, prefix)) = parse_cidr(cidr, family) {
+                let mut e = HashMap::new();
+                e.insert("dest".into(), into_value(dest));
+                e.insert("prefix".into(), into_value(prefix));
+                rd.push(e);
+            }
+        }
+        if !rd.is_empty() {
+            s.insert("route-data".into(), into_value(rd));
         }
     }
     s
@@ -975,6 +1058,63 @@ mod tests {
             NmTypeSpecific::Bond { mode } => assert_eq!(mode, "802.3ad"),
             other => panic!("expected Bond type_specific, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn macvlan_shim_serializes_with_parent_mode_and_route() {
+        let layered = LayeredConfig {
+            links: vec![
+                link_phys("eth1"),
+                Link {
+                    name: "shim-lan".into(),
+                    enabled: true,
+                    mtu: None,
+                    mac: None,
+                    kind: LinkKind::Macvlan {
+                        parent: "eth1".into(),
+                        mode: "bridge".into(),
+                    },
+                },
+            ],
+            addresses: vec![Address {
+                link: "shim-lan".into(),
+                family: Family::V4,
+                method: IpMethod::Static,
+                cidr: vec!["192.168.1.2/24".into()],
+                gateway: None,
+            }],
+            routes: vec![crate::network::layered::Route {
+                table: 254,
+                dst: "192.168.1.0/24".into(),
+                via: None,
+                dev: "shim-lan".into(),
+                metric: None,
+            }],
+            ..Default::default()
+        };
+        let profiles = to_nm_profiles(&layered);
+        let shim = find(&profiles, "shim-lan");
+        assert_eq!(shim.conn_type, NmConnectionType::Macvlan);
+        match &shim.type_specific {
+            NmTypeSpecific::Macvlan { parent, mode } => {
+                assert_eq!(parent, "eth1");
+                assert_eq!(mode, "bridge");
+            }
+            other => panic!("expected Macvlan, got {other:?}"),
+        }
+        assert_eq!(shim.ipv4.routes, vec!["192.168.1.0/24".to_string()]);
+
+        let keyfile = serialize_keyfile(shim);
+        assert!(keyfile.contains("[macvlan]"), "{keyfile}");
+        assert!(keyfile.contains("parent=eth1"));
+        assert!(keyfile.contains("mode=2")); // NMSettingMacvlanMode bridge
+        assert!(keyfile.contains("route1=192.168.1.0/24"));
+        // On-link: no next-hop appended to the route.
+        assert!(!keyfile.contains("route1=192.168.1.0/24,"));
+
+        let dict = to_settings_dict(shim);
+        assert!(dict.contains_key("macvlan"));
+        assert!(dict["ipv4"].contains_key("route-data"));
     }
 
     #[test]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1505,6 +1505,8 @@ export interface ManagedNetwork {
 	ip_range?: string | null;
 	vlan?: number | null;
 	host_shim?: boolean;
+	/** Host's address on the container subnet (CIDR) — required with host_shim. */
+	shim_ip?: string | null;
 }
 
 /** apps.networks.list row: spec + live-state annotations. */

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -335,8 +335,13 @@
 	let ncGateway = $state('');
 	let ncIpRange = $state('');
 	let ncVlan = $state('');
+	let ncHostShim = $state(false);
+	let ncShimIp = $state('');
 	let ncError = $state('');
 	let ncSaving = $state(false);
+	/** True when the chosen parent is the management interface — a host
+	 * shim there risks lockout, so the engine refuses it and we disable it. */
+	let ncParentIsMgmt = $derived(!!netState && netState.mgmt_iface === ncParent);
 	/** Actionable hint surfaced by the deploy stream (#429): the compose
 	 * referenced a host bridge — offer to create a macvlan on it + retry. */
 	let deployAction = $state<{ action: string; bridge: string } | null>(null);
@@ -377,6 +382,8 @@
 		ncGateway = '';
 		ncIpRange = '';
 		ncVlan = '';
+		ncHostShim = false;
+		ncShimIp = '';
 		ncError = '';
 		try {
 			netState = await client.call<NetworkState>('system.network.get');
@@ -397,6 +404,8 @@
 			gateway: ncGateway.trim() || null,
 			ip_range: ncIpRange.trim() || null,
 			vlan: ncVlan.trim() ? parseInt(ncVlan) : null,
+			host_shim: ncDriver === 'macvlan' && ncHostShim && !ncParentIsMgmt,
+			shim_ip: ncDriver === 'macvlan' && ncHostShim ? ncShimIp.trim() || null : null,
 		};
 		try {
 			await client.call('apps.networks.create', spec);
@@ -2518,11 +2527,30 @@
 						<Input id="nc-range" bind:value={ncIpRange} placeholder="192.168.1.64/27" class="mt-1" />
 					</div>
 				</div>
+				{#if ncDriver === 'macvlan'}
+					<!-- Host↔container shim (#448): advanced, mutates host networking. -->
+					<div class="rounded-md border border-border p-2">
+						<label class="flex items-start gap-2 text-xs {ncParentIsMgmt ? 'opacity-50' : 'cursor-pointer'}">
+							<input type="checkbox" class="mt-0.5" bind:checked={ncHostShim} disabled={ncParentIsMgmt} />
+							<span>
+								<span class="font-medium">Host shim</span> — let this host reach containers on this network.
+								<span class="block text-[0.65rem] text-amber-300">Advanced: adds a macvlan interface + route on the host. May affect host networking.{#if ncParentIsMgmt} Disabled — parent is the management interface.{/if}</span>
+							</span>
+						</label>
+						{#if ncHostShim && !ncParentIsMgmt}
+							<div class="mt-2">
+								<Label for="nc-shim-ip">Host shim IP</Label>
+								<Input id="nc-shim-ip" bind:value={ncShimIp} placeholder="192.168.1.2/24" class="mt-1" />
+								<p class="mt-1 text-[0.65rem] text-muted-foreground">The host's own address on the container subnet (inside the subnet, outside the IP range/gateway).</p>
+							</div>
+						{/if}
+					</div>
+				{/if}
 				{#if ncError}<p class="text-xs text-red-500">{ncError}</p>{/if}
 			</div>
 			<div class="mt-4 flex justify-end gap-2">
 				<Button variant="secondary" size="sm" onclick={() => showNetCreate = false}>Cancel</Button>
-				<Button size="sm" onclick={createNetwork} disabled={ncSaving || !ncName.trim() || (ncDriver !== 'bridge' && !ncParent)}>
+				<Button size="sm" onclick={createNetwork} disabled={ncSaving || !ncName.trim() || (ncDriver !== 'bridge' && !ncParent) || (ncHostShim && !ncParentIsMgmt && !ncShimIp.trim())}>
 					{ncSaving ? 'Creating…' : 'Create'}
 				</Button>
 			</div>


### PR DESCRIPTION
## What

PR #447 shipped Docker macvlan/ipvlan networks, but the kernel **isolates a macvlan parent from its own children** — the NASty host can't reach a macvlan container and vice-versa. This adds an opt-in **host shim**: a host-side `macvlan` (mode=bridge) sub-interface on the same parent + an on-link route to the container subnet, so host↔container traffic works.

`host_shim` already existed in the `ManagedNetwork` model but was rejected by the validator; this wires it up end to end.

## How

The shim is built as a **first-class macvlan link in the desired-state graph** (`NetworkConfig.macvlans[]`), not a standalone connection — NASty's NM apply deletes any `nasty-*` connection not in the desired set on every operator change and at boot, so a side-band connection wouldn't survive. It rides the existing persist→validate→apply→**confirm-or-rollback** rail. A non-mgmt-parent shim touches nothing in the management diff, so `classify_risk` applies it directly (`confirm_within_secs: 0`, since an apps-triggered change has no human to click Confirm).

- **nasty-system** — `LinkKind::Macvlan` + `NmConnectionType::Macvlan` with keyfile/DBus serializers (`[macvlan] parent/mode`, on-link `routeN=`/`route-data`, **net-new `NmIpSettings.routes`**). `MacvlanConfig` + `NetworkConfig.macvlans` (`#[serde(default)]`, old `networking.json` still parses). Layered `to_layered`/`from_layered` + `validate` (reject self/missing parent — the parent must be declared, **not** synthesized, so it can't silently take over a NIC's L3).
- **nasty-apps** — `ManagedNetwork.shim_ip`; `validate_network_spec` accepts `host_shim` only on macvlan with a subnet and a `shim_ip` inside it, distinct from the gateway.
- **nasty-engine** — `add_/remove_macvlan_shim` mediation in the apps-network RPC arms: refuse the **mgmt interface as parent** (lockout guard), refuse a **route conflict** when the parent already holds an address in the subnet, and roll back the Docker network if the shim apply fails.
- **webui** — host-shim checkbox (disabled when the parent is the mgmt iface) + shim-IP input in the create-network dialog.

## Safety

- mgmt-parent refused in two places (validator-adjacent RPC arm + the network-layer update).
- route-conflict refused **pre-apply**.
- `shim_ip` is operator-supplied (CIDR); no auto-pick in v1.
- VLAN-tagged parent resolves to `parent.<vlan>` and requires that link to already exist.

## Tests

Pure-logic unit tests (no live NM/Docker): nm.rs macvlan converter + `[macvlan]` keyfile (`mode=2`, on-link `route1=` with no next-hop) + DBus `macvlan`/`route-data`; layered.rs macvlan validate (pass with parent / reject missing+self) and `to_layered` link+address+route; nasty-apps validator accept/reject matrix (no shim_ip / outside subnet / no subnet / bridge driver). `cargo test` workspace, clippy, `fmt --check`, and `svelte-check` all green.

## Verification (pending — needs a non-management parent)

`10.10.20.100` only has the mgmt NIC, which the shim refuses as a parent, so it can't be validated there. Needs a box/NIC with a non-management parent to confirm: shim active (`nmcli`/`ip route`), host↔container ping both ways, mgmt session stays up, mgmt-parent + route-conflict refused, remove tears it down.

Closes #448.