### PR TITLE
filesystems: key device/fs lists + drop fake 'evacuated' badge (#455, #456)

### DIFF
--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -991,8 +991,13 @@
 	}
 
 	function devDisplayState(dev: FilesystemDevice): string | null {
-		if (dev.state === 'evacuating' && (!dev.has_data || dev.has_data === '(none)' || dev.has_data === '–'))
-			return 'evacuated';
+		// Show the device's actual bcachefs state (rw/ro/failed/spare/
+		// evacuating). We used to synthesize an "evacuated" badge when
+		// `has_data` parsed empty, but that lied: a still-evacuating disk
+		// flipped to "evacuated" the moment the (fragile) has_data parse
+		// came back empty, and could land on the wrong row. There's no
+		// real "evacuated" device state — once a device is drained the
+		// operator removes it and it disappears from the list. (#456)
 		return dev.state;
 	}
 
@@ -1003,7 +1008,6 @@
 			case 'failed': return 'bg-red-950 text-red-400';
 			case 'spare': return 'bg-amber-950 text-amber-400';
 			case 'evacuating': return 'bg-yellow-950 text-yellow-400 animate-pulse';
-			case 'evacuated': return 'bg-teal-950 text-teal-400';
 			default: return 'bg-secondary text-muted-foreground';
 		}
 	}
@@ -1635,7 +1639,7 @@
 		<p class="mt-1 text-sm text-muted-foreground">Use the <strong>Create Filesystem</strong> button above to get started.</p>
 	</div>
 {:else}
-	{#each filesystems as fs}
+	{#each filesystems as fs (fs.name)}
 		<Card class="mb-4">
 			<CardContent class="pt-4">
 				<div class="flex flex-wrap items-center justify-between gap-4">
@@ -2053,7 +2057,7 @@
 								</tr>
 							</thead>
 							<tbody>
-								{#each fs.devices as dev}
+								{#each fs.devices as dev (dev.path)}
 									<tr class="border-b border-border">
 										<td class="p-2 font-mono text-xs">
 											{dev.path}
@@ -2101,8 +2105,6 @@
 											{#if fs.mounted}
 												{@const ds = devDisplayState(dev)}
 												{#if ds === 'evacuating'}
-													<Button variant="destructive" size="xs" onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
-												{:else if ds === 'evacuated'}
 													<Button variant="destructive" size="xs" onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
 												{:else}
 													{#if ds === 'rw'}


### PR DESCRIPTION
Two device-table fixes from @kdackiw's #440 feedback. **WebUI-only.**

## #455 — last member device's label didn't refresh in the UI
The engine is correct (verified live on a box): `device_set_label` invalidates the list cache, and `fs.get` reads the new label back for both 2- and 3-device pools after renaming the *last* member. The bug was the **unkeyed** `{#each fs.devices}` (and the outer `{#each filesystems}`): each device row hosts a stateful inline-edit `<input>` (`bind:value`/`autofocus`/`onblur`), and an unkeyed `{#each}` lets Svelte reuse the wrong row's DOM node when the list is reassigned after refresh — the tail row is the classic victim.

Fix: key both loops — `{#each filesystems as fs (fs.name)}` and `{#each fs.devices as dev (dev.path)}`.

## #456 — device shown "evacuated" while still evacuating (wrong device)
`devDisplayState` synthesized an **"evacuated"** badge whenever `has_data` parsed empty:
```js
if (dev.state === 'evacuating' && (!dev.has_data || dev.has_data === '(none)' || dev.has_data === '–')) return 'evacuated';
```
That lied the moment the (fragile) `has_data` parse came back empty, and could render on the wrong row. There's no real "evacuated" bcachefs device state (states are rw/ro/failed/spare/evacuating) — once a device is drained the operator removes it and it leaves the list.

Fix: show the device's **actual** state; drop the synthetic badge plus the now-dead `'evacuated'` template branch and color case. The wrong-device part is covered by the keying fix above.

## Verification
`svelte-check` clean. The **#455 symptom only reproduces in a browser** (it's invisible at the RPC layer — the API returns correct data), so I've intentionally written this as **"Addresses"** rather than "Closes": please confirm in the WebUI that renaming the last device's label updates live, and that an evacuating device no longer flips to "evacuated" prematurely, before merging/closing.