### PR TITLE
filesystems: richer per-device table with selectable columns (#457)

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -347,6 +347,17 @@ pub struct FilesystemDevice {
     pub has_data: Option<String>,
     /// Whether TRIM/discard is enabled on this device.
     pub discard: Option<bool>,
+    /// Cumulative read IO errors (since filesystem creation), from
+    /// `/sys/fs/bcachefs/<uuid>/dev-N/io_errors`. Only populated while
+    /// the filesystem is mounted (sysfs is absent otherwise).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_errors: Option<u64>,
+    /// Cumulative write IO errors (since filesystem creation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_errors: Option<u64>,
+    /// Cumulative checksum errors (since filesystem creation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checksum_errors: Option<u64>,
 }
 
 /// Specifies a device and its per-device options for filesystem creation.
@@ -1070,6 +1081,9 @@ impl FilesystemService {
                     data_allowed: None,
                     has_data: None,
                     discard: None,
+                    read_errors: None,
+                    write_errors: None,
+                    checksum_errors: None,
                 })
                 .collect();
 
@@ -1433,6 +1447,9 @@ impl FilesystemService {
                 data_allowed: None,
                 has_data: None,
                 discard: None,
+                read_errors: None,
+                write_errors: None,
+                checksum_errors: None,
             })
             .collect();
         if let Some(ref sched) = req.io_scheduler
@@ -1463,6 +1480,9 @@ impl FilesystemService {
                 data_allowed: None,
                 has_data: None,
                 discard: None,
+                read_errors: None,
+                write_errors: None,
+                checksum_errors: None,
             })
             .collect();
 
@@ -3295,7 +3315,7 @@ pub async fn create_partition_on_free_space(disk_path: &str) -> Result<String, F
 
 /// Read per-device info (labels, durability) for a mounted bcachefs filesystem.
 /// Uses `bcachefs show-super` on the first device to extract member info.
-async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<FilesystemDevice> {
+async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemDevice> {
     let first_dev = match device_paths.first() {
         Some(d) => d.as_str(),
         None => return Vec::new(),
@@ -3304,6 +3324,9 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
     let member_info = cmd::run_ok("bcachefs", &["show-super", "-f", "members_v2", first_dev])
         .await
         .unwrap_or_default();
+
+    // Per-device IO error counters live in sysfs (mounted pools only).
+    let io_errors = read_device_io_errors(uuid).await;
 
     // show-super -f members_v2 output comes in two formats:
     //
@@ -3382,6 +3405,11 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
             (None, None, None, None, None, None)
         };
 
+        let (read_errors, write_errors, checksum_errors) = io_errors
+            .get(dev_path)
+            .copied()
+            .unwrap_or((None, None, None));
+
         devices.push(FilesystemDevice {
             path: dev_path.clone(),
             label,
@@ -3390,10 +3418,81 @@ async fn read_fs_devices(_uuid: &str, device_paths: &[String]) -> Vec<Filesystem
             data_allowed,
             has_data,
             discard,
+            read_errors,
+            write_errors,
+            checksum_errors,
         });
     }
 
     devices
+}
+
+/// Parse `/sys/fs/bcachefs/<uuid>/dev-N/io_errors`, returning the
+/// cumulative `(read, write, checksum)` counts from the "since
+/// filesystem creation" block. A later "since … ago" block reports
+/// counts since the last reset and is ignored. Pure; unit-tested.
+fn parse_io_errors(s: &str) -> (Option<u64>, Option<u64>, Option<u64>) {
+    let (mut read, mut write, mut checksum) = (None, None, None);
+    for line in s.lines() {
+        let l = line.trim();
+        // Once we've started filling the first block, a second
+        // "IO errors since …" header marks the reset block — stop.
+        if l.starts_with("IO errors since")
+            && (read.is_some() || write.is_some() || checksum.is_some())
+        {
+            break;
+        }
+        let val = |key: &str| -> Option<u64> {
+            l.strip_prefix(key)
+                .map(|r| r.trim_start_matches([':', ' ', '\t']))
+                .and_then(|r| r.split_whitespace().next())
+                .and_then(|t| t.parse().ok())
+        };
+        // "checksum:0" has no space; "read:    0" does — `val` handles both.
+        if read.is_none() && l.starts_with("read") {
+            read = val("read");
+        } else if write.is_none() && l.starts_with("write") {
+            write = val("write");
+        } else if checksum.is_none() && l.starts_with("checksum") {
+            checksum = val("checksum");
+        }
+    }
+    (read, write, checksum)
+}
+
+/// Map each member device path → its cumulative `(read, write, checksum)`
+/// IO error counts, by scanning `/sys/fs/bcachefs/<uuid>/dev-*/`. Empty
+/// when the filesystem isn't mounted (the sysfs tree is absent).
+async fn read_device_io_errors(
+    uuid: &str,
+) -> HashMap<String, (Option<u64>, Option<u64>, Option<u64>)> {
+    let base = format!("/sys/fs/bcachefs/{uuid}");
+    let mut out = HashMap::new();
+    let mut rd = match tokio::fs::read_dir(&base).await {
+        Ok(r) => r,
+        Err(_) => return out,
+    };
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("dev-") {
+            continue;
+        }
+        let dir = format!("{base}/{name}");
+        // dev-N/block is a symlink whose basename is the kernel device name.
+        let dev_name = match tokio::fs::read_link(format!("{dir}/block")).await {
+            Ok(target) => target.file_name().map(|s| s.to_string_lossy().into_owned()),
+            Err(_) => None,
+        };
+        let Some(dev_name) = dev_name else { continue };
+        match tokio::fs::read_to_string(format!("{dir}/io_errors")).await {
+            Ok(s) => {
+                out.insert(format!("/dev/{dev_name}"), parse_io_errors(&s));
+            }
+            Err(_) => continue,
+        }
+    }
+    out
 }
 
 /// Read filesystem options from sysfs for a mounted bcachefs filesystem.
@@ -5515,5 +5614,36 @@ Device 1:\t/dev/sdb
     fn fsck_error_markers_flag_errors_even_on_zero_exit() {
         let out = "checking extents\nerrors: 2\n";
         assert_eq!(classify_fsck(true, out), FsckOutcome::Errors);
+    }
+
+    // ── Per-device IO error counters (#457) ───────────────────
+
+    #[test]
+    fn parse_io_errors_reads_creation_block_only() {
+        // The sysfs file has two blocks; only the cumulative
+        // "since filesystem creation" one should be parsed. Note the
+        // "checksum:0" form has no space after the colon.
+        let s = "\
+IO errors since filesystem creation
+  read:    3
+  write:   1
+  checksum:2
+IO errors since 8 y ago
+  read:    99
+  write:   99
+  checksum:99
+";
+        assert_eq!(parse_io_errors(s), (Some(3), Some(1), Some(2)));
+    }
+
+    #[test]
+    fn parse_io_errors_clean_device_is_all_zero() {
+        let s = "IO errors since filesystem creation\n  read:    0\n  write:   0\n  checksum:0\n";
+        assert_eq!(parse_io_errors(s), (Some(0), Some(0), Some(0)));
+    }
+
+    #[test]
+    fn parse_io_errors_empty_input_is_none() {
+        assert_eq!(parse_io_errors(""), (None, None, None));
     }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -313,6 +313,12 @@ export interface FilesystemDevice {
 	has_data: string | null;
 	/** Whether TRIM/discard is enabled */
 	discard: boolean | null;
+	/** Cumulative read IO errors since fs creation (mounted pools only). */
+	read_errors?: number | null;
+	/** Cumulative write IO errors since fs creation. */
+	write_errors?: number | null;
+	/** Cumulative checksum errors since fs creation. */
+	checksum_errors?: number | null;
 }
 
 export type DeviceState = 'rw' | 'ro' | 'failed' | 'spare';

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -322,6 +322,13 @@
 
 	onMount(async () => {
 		client.onEvent(handleEvent);
+		try {
+			const saved = localStorage.getItem('fsDeviceCols');
+			if (saved) {
+				const parsed = JSON.parse(saved);
+				if (Array.isArray(parsed)) visibleDeviceCols = parsed.filter((c) => typeof c === 'string');
+			}
+		} catch { /* ignore malformed pref */ }
 		await refresh();
 		loading = false;
 		if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('create')) {
@@ -1010,6 +1017,47 @@
 			case 'evacuating': return 'bg-yellow-950 text-yellow-400 animate-pulse';
 			default: return 'bg-secondary text-muted-foreground';
 		}
+	}
+
+	// ── Filesystem device table: user-selectable columns (#457) ──
+	// Device / Label / State / Actions are always shown; these are
+	// optional and persisted per-browser. Size/Type/Model/Serial join
+	// the BlockDevice list (device.list); Clean + error counts come from
+	// the per-device bcachefs IO error counters.
+	const DEVICE_COLUMNS = [
+		{ id: 'size', label: 'Size' },
+		{ id: 'type', label: 'Type' },
+		{ id: 'model', label: 'Model' },
+		{ id: 'serial', label: 'Serial' },
+		{ id: 'clean', label: 'Clean' },
+		{ id: 'read_err', label: 'Read err' },
+		{ id: 'write_err', label: 'Write err' },
+		{ id: 'csum_err', label: 'Cksum err' },
+		{ id: 'data_allowed', label: 'Data allowed' },
+		{ id: 'has_data', label: 'Has data' }
+	] as const;
+	const DEFAULT_DEVICE_COLS = ['size', 'type', 'clean', 'has_data'];
+	let visibleDeviceCols = $state<string[]>([...DEFAULT_DEVICE_COLS]);
+
+	function colOn(id: string): boolean {
+		return visibleDeviceCols.includes(id);
+	}
+	function toggleCol(id: string) {
+		visibleDeviceCols = colOn(id)
+			? visibleDeviceCols.filter((c) => c !== id)
+			: [...visibleDeviceCols, id];
+		try { localStorage.setItem('fsDeviceCols', JSON.stringify(visibleDeviceCols)); } catch { /* ignore */ }
+	}
+
+	/** The BlockDevice (device.list) backing a filesystem member, by path. */
+	function deviceBlock(path: string): BlockDevice | undefined {
+		return devices.find((d) => d.path === path);
+	}
+	/** Total IO errors across read/write/checksum, or null if unknown (unmounted). */
+	function devErrorTotal(dev: FilesystemDevice): number | null {
+		if (dev.read_errors == null && dev.write_errors == null && dev.checksum_errors == null)
+			return null;
+		return (dev.read_errors ?? 0) + (dev.write_errors ?? 0) + (dev.checksum_errors ?? 0);
 	}
 
 	function classColor(cls: string): string {
@@ -2045,14 +2093,35 @@
 							</div>
 						</div>
 
+						<div class="mb-1 flex justify-end">
+							<details class="relative text-xs">
+								<summary class="cursor-pointer list-none rounded border border-border px-2 py-0.5 text-muted-foreground hover:bg-secondary">Columns ▾</summary>
+								<div class="absolute right-0 z-10 mt-1 w-40 rounded-md border border-border bg-popover p-2 shadow-md">
+									{#each DEVICE_COLUMNS as col}
+										<label class="flex cursor-pointer items-center gap-2 py-0.5">
+											<input type="checkbox" checked={colOn(col.id)} onchange={() => toggleCol(col.id)} class="h-3.5 w-3.5" />
+											<span>{col.label}</span>
+										</label>
+									{/each}
+								</div>
+							</details>
+						</div>
 						<table class="w-full text-sm">
 							<thead>
 								<tr>
 									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Device</th>
 									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Label</th>
 									<th class="p-2 text-left text-xs uppercase text-muted-foreground">State</th>
-									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Data Allowed</th>
-									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Has Data</th>
+									{#if colOn('size')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Size</th>{/if}
+									{#if colOn('type')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Type</th>{/if}
+									{#if colOn('model')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Model</th>{/if}
+									{#if colOn('serial')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Serial</th>{/if}
+									{#if colOn('clean')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Clean</th>{/if}
+									{#if colOn('read_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Read err</th>{/if}
+									{#if colOn('write_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Write err</th>{/if}
+									{#if colOn('csum_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Cksum err</th>{/if}
+									{#if colOn('data_allowed')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Data Allowed</th>{/if}
+									{#if colOn('has_data')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Has Data</th>{/if}
 									<th class="p-2 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 								</tr>
 							</thead>
@@ -2098,8 +2167,49 @@
 												<span class="text-muted-foreground">—</span>
 											{/if}
 										</td>
-										<td class="p-2 font-mono text-xs text-muted-foreground">{dev.data_allowed ?? '—'}</td>
-										<td class="p-2 font-mono text-xs text-muted-foreground">{dev.has_data ?? '—'}</td>
+										{#if colOn('size')}
+											{@const blk = deviceBlock(dev.path)}
+											<td class="p-2 font-mono text-xs text-muted-foreground">{blk ? formatBytes(blk.size_bytes) : '—'}</td>
+										{/if}
+										{#if colOn('type')}
+											{@const blk = deviceBlock(dev.path)}
+											<td class="p-2 text-xs text-muted-foreground uppercase">{blk?.device_class ?? '—'}</td>
+										{/if}
+										{#if colOn('model')}
+											{@const blk = deviceBlock(dev.path)}
+											<td class="p-2 text-xs text-muted-foreground">{blk?.model ?? '—'}</td>
+										{/if}
+										{#if colOn('serial')}
+											{@const blk = deviceBlock(dev.path)}
+											<td class="p-2 font-mono text-xs text-muted-foreground">{blk?.serial ?? '—'}</td>
+										{/if}
+										{#if colOn('clean')}
+											{@const errTotal = devErrorTotal(dev)}
+											<td class="p-2 text-xs">
+												{#if errTotal === null}
+													<span class="text-muted-foreground">—</span>
+												{:else if errTotal === 0}
+													<span class="text-green-500" title="No read/write/checksum errors since creation">✓</span>
+												{:else}
+													<span class="text-red-500" title="read {dev.read_errors ?? 0}, write {dev.write_errors ?? 0}, checksum {dev.checksum_errors ?? 0}">{errTotal} ✗</span>
+												{/if}
+											</td>
+										{/if}
+										{#if colOn('read_err')}
+											<td class="p-2 font-mono text-xs {dev.read_errors ? 'text-red-500' : 'text-muted-foreground'}">{dev.read_errors ?? '—'}</td>
+										{/if}
+										{#if colOn('write_err')}
+											<td class="p-2 font-mono text-xs {dev.write_errors ? 'text-red-500' : 'text-muted-foreground'}">{dev.write_errors ?? '—'}</td>
+										{/if}
+										{#if colOn('csum_err')}
+											<td class="p-2 font-mono text-xs {dev.checksum_errors ? 'text-red-500' : 'text-muted-foreground'}">{dev.checksum_errors ?? '—'}</td>
+										{/if}
+										{#if colOn('data_allowed')}
+											<td class="p-2 font-mono text-xs text-muted-foreground">{dev.data_allowed ?? '—'}</td>
+										{/if}
+										{#if colOn('has_data')}
+											<td class="p-2 font-mono text-xs text-muted-foreground">{dev.has_data ?? '—'}</td>
+										{/if}
 										<td class="p-2 w-px whitespace-nowrap">
 											<div class="flex gap-1.5 items-center">
 											{#if fs.mounted}


### PR DESCRIPTION
From @kdackiw's #440 feedback — surface operator-relevant per-device info inline on the Filesystems page so you don't have to keep bouncing to Disks / SMART / Topology.

## Engine
`FilesystemDevice` gains **read / write / checksum error counters**, read from `/sys/fs/bcachefs/<uuid>/dev-N/io_errors` (the cumulative *"since filesystem creation"* block; mounted pools only — sysfs is absent otherwise). `parse_io_errors` is pure + unit-tested (3 tests, incl. the spaceless `checksum:0` form and the two-block file). The sysfs scan maps each `dev-N` to its `/dev` path via the `dev-N/block` symlink.

## WebUI
The device table gains **optional columns**, toggled by a **"Columns ▾"** picker and persisted per-browser in localStorage:
- **Size / Type / Model / Serial** — joined from the existing `device.list` `BlockDevice` data by path (no extra engine work).
- **Clean** — a green ✓ / red ✗ summarizing the three error counters, with a per-counter tooltip (`read N, write N, checksum N`).
- **Read err / Write err / Cksum err** — the raw counters, red when non-zero.
- **Data allowed / Has data** — the existing bcachefs columns, now also toggleable.

Defaults on: Size, Type, Clean, Has Data. Device / Label / State / Actions are always shown.

Covers Kev's requested columns (size, clean, read/write/checksum errors, type via rotational→device_class, model, serial) and the "as detailed or not as the user wishes" ask via the picker.

## Tests
`cargo test` (3 new pure tests), clippy, `fmt --check`, `svelte-check` all green.

## Not included (deferred)
- "Last write time" on the pool info line — that's FS-level data needing a separate field; small follow-up.
- Live hardware check of the error-counter read path is pending (read-only; worst case the columns show `—`). Happy to validate on the test box.

Closes #457.