### PR TITLE
update: one-click "sync bcachefs to bundled version"

### DIFF
--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -31,6 +31,10 @@ struct CachedInfo {
     bcachefs_version: String,
     bcachefs_commit: Option<String>,
     bcachefs_pinned_ref: Option<String>,
+    /// The bcachefs-tools ref this NASty build ships with (baked from
+    /// nasty's flake.nix at compile time). The top-bar chip offers to
+    /// switch the operator's pin to this when they differ.
+    bcachefs_recommended_ref: Option<String>,
     debug_symbols: bool,
     /// Whether the RUNNING module is custom (version differs from default).
     bcachefs_is_custom_running: bool,
@@ -64,6 +68,12 @@ pub struct SystemInfo {
     pub bcachefs_commit: Option<String>,
     /// The ref currently pinned in `/etc/nixos/flake.lock` for `bcachefs-tools`.
     pub bcachefs_pinned_ref: Option<String>,
+    /// The bcachefs-tools ref this NASty build was shipped/tested with
+    /// (parsed from nasty's flake.nix baked into the engine at build
+    /// time). When this differs from `bcachefs_pinned_ref`, the WebUI's
+    /// top-bar chip offers a one-click switch of the operator's pin to
+    /// this ref. `None` if the embedded flake can't be parsed.
+    pub bcachefs_recommended_ref: Option<String>,
     /// True when the running bcachefs kernel module version doesn't
     /// match the wrapper's currently-pinned `bcachefs-tools` ref —
     /// i.e. an upgrade or pin change has activated a new generation
@@ -172,10 +182,15 @@ impl SystemService {
             }
             _ => false,
         };
+        // The bcachefs ref this engine build ships with — parsed from
+        // nasty's flake.nix baked in at compile time. Drives the chip's
+        // "sync to bundled bcachefs" offer when it differs from the pin.
+        let bcachefs_recommended_ref = crate::update::embedded_default_bcachefs_tools_ref().ok();
         let info = CachedInfo {
             bcachefs_version,
             bcachefs_commit,
             bcachefs_pinned_ref: pinned_ref,
+            bcachefs_recommended_ref,
             debug_symbols,
             bcachefs_is_custom_running,
             bcachefs_debug_checks: debug_checks,
@@ -198,6 +213,7 @@ impl SystemService {
             bcachefs_version: cached.bcachefs_version,
             bcachefs_commit: cached.bcachefs_commit,
             bcachefs_pinned_ref: cached.bcachefs_pinned_ref,
+            bcachefs_recommended_ref: cached.bcachefs_recommended_ref,
             bcachefs_is_custom: cached.bcachefs_is_custom_running,
             timezone,
             ntp_synced,

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -2004,7 +2004,7 @@ pub async fn bootstrap_system_flake_from_template(
 /// Returns `Err` if the embedded flake.nix doesn't parse or doesn't
 /// declare a `bcachefs-tools.url` — both of which should be caught
 /// by tests in this same module before any binary ships.
-fn embedded_default_bcachefs_tools_ref() -> Result<String, UpdateError> {
+pub(crate) fn embedded_default_bcachefs_tools_ref() -> Result<String, UpdateError> {
     let urls = parse_flake_input_urls(EMBEDDED_NASTY_FLAKE)?;
     let input = urls.get("bcachefs-tools").ok_or_else(|| {
         UpdateError::CommandFailed(

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -53,6 +53,9 @@ export interface SystemInfo {
 	bcachefs_version: string;
 	bcachefs_commit: string | null;
 	bcachefs_pinned_ref: string | null;
+	/** bcachefs-tools ref this NASty build ships with; the top-bar chip
+	 * offers to switch the operator's pin to this when they differ. */
+	bcachefs_recommended_ref: string | null;
 	bcachefs_is_custom: boolean;
 	timezone: string;
 	ntp_synced: boolean;

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -294,7 +294,7 @@
 	}
 
 	// Version info (loaded once after connect)
-	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
+	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_recommended_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
 	let clock24h = $state(true);
 
 	// Network rollback countdown — ticks once per second while a rollback is
@@ -1066,11 +1066,18 @@
 						</button>
 					{/if}
 					{#if sysInfo?.bcachefs_is_custom || sysInfo?.bcachefs_debug_checks}
+						{@const bcachefsSyncAvail = !!sysInfo.bcachefs_recommended_ref && sysInfo.bcachefs_recommended_ref !== sysInfo.bcachefs_pinned_ref}
 						<a
 							href="/update#bcachefs"
 							class="flex items-center gap-2 rounded-md border-2 border-blue-500/70 px-3 py-1.5 text-sm text-blue-400 no-underline transition-all hover:bg-blue-500/10 hover:border-blue-400 hover:shadow-[0_0_16px_rgba(96,165,250,0.5)]"
+							title={bcachefsSyncAvail
+								? `NASty ships bcachefs ${sysInfo.bcachefs_recommended_ref} (you're pinned at ${sysInfo.bcachefs_pinned_ref ?? '—'}) — click to switch`
+								: 'bcachefs status'}
 						>
 							<span>bcachefs</span>
+							{#if bcachefsSyncAvail}
+								<span class="font-mono text-xs">→ {sysInfo.bcachefs_recommended_ref}</span>
+							{/if}
 							<span class="flex items-center gap-1.5">
 								<span title="Reboot pending to load the new bcachefs kernel module"><Settings size={14} class={sysInfo.bcachefs_is_custom ? 'text-amber-400' : 'text-muted-foreground/30'} /></span>
 								<span title="Debug checks"><Bug size={14} class={sysInfo.bcachefs_debug_checks ? 'text-blue-400' : 'text-muted-foreground/30'} /></span>

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -77,6 +77,10 @@
 	let startingDevUpgrade = $state(false);
 	let taggedReleaseBanner: TaggedReleaseBannerState = $state({ kind: 'loading' });
 	let versionRows: VersionRow[] = $state([]);
+	/** bcachefs-tools ref this NASty build ships with (system.info). When
+	 * it differs from the pinned bcachefs row, we offer a one-click sync. */
+	let recommendedBcachefs = $state<string | null>(null);
+	let syncingBcachefs = $state(false);
 	let status: UpdateStatus | null = $state(null);
 	let loading = $state(true);
 	let startingSwitch = $state(false);
@@ -286,14 +290,16 @@
 
 	async function loadVersionPage() {
 		await withToast(async () => {
-			const [nextInfo, nextVersion, nextBuildDir] = await Promise.all([
+			const [nextInfo, nextVersion, nextBuildDir, sys] = await Promise.all([
 				client.call<VersionInfo>('system.version.get'),
 				client.call<UpdateInfo>('system.update.version'),
-				client.call<UpdateBuildDirConfig>('system.update.build_dir.get')
+				client.call<UpdateBuildDirConfig>('system.update.build_dir.get'),
+				client.call<{ bcachefs_recommended_ref: string | null }>('system.info').catch(() => null)
 			]);
 			info = nextVersion;
 			buildDir = nextBuildDir;
 			buildDirDraft = nextBuildDir.path ?? '';
+			recommendedBcachefs = sys?.bcachefs_recommended_ref ?? null;
 			syncVersionRows(nextInfo);
 			if (readVersionPageAction() === 'version-switch') {
 				taggedReleaseBanner = { kind: 'switching' };
@@ -383,6 +389,33 @@
 			void loadTaggedReleaseBanner();
 		}
 		startingSwitch = false;
+	}
+
+	// Offer a one-click bcachefs sync when the operator's pinned ref
+	// differs from the ref this NASty build ships with (#457-adjacent).
+	const bcachefsRow = $derived(versionRows.find((r) => r.name === 'bcachefs-tools'));
+	const bcachefsSyncAvailable = $derived(
+		!!recommendedBcachefs &&
+			!!bcachefsRow &&
+			trackingRef(bcachefsRow.initialUrl) !== recommendedBcachefs
+	);
+
+	async function syncBcachefsToBundled() {
+		const row = versionRows.find((r) => r.name === 'bcachefs-tools');
+		if (!recommendedBcachefs || !row) return;
+		if (
+			!(await confirm(
+				`Switch bcachefs to ${recommendedBcachefs}?`,
+				`This re-pins bcachefs-tools to ${recommendedBcachefs} — the version bundled with this NASty release — and rebuilds immediately. You may need to reboot afterward to load the new kernel module.`,
+				{ confirmLabel: 'Switch', cancelLabel: 'Cancel' }
+			))
+		)
+			return;
+		syncingBcachefs = true;
+		row.url = `github:koverstreet/bcachefs-tools/${recommendedBcachefs}`;
+		row.update = true;
+		await doVersionSwitch();
+		syncingBcachefs = false;
 	}
 
 	async function upgradeTaggedRelease() {
@@ -727,6 +760,12 @@
 										{#if checkInfo?.update_available}
 											<Button size="sm" onclick={upgradeDevBuild} disabled={startingDevUpgrade || status?.state === 'running'}>
 												{startingDevUpgrade ? 'Starting...' : 'Upgrade'}
+											</Button>
+										{/if}
+										{#if bcachefsSyncAvailable}
+											<Button size="sm" variant="secondary" onclick={syncBcachefsToBundled} disabled={syncingBcachefs || status?.state === 'running'}
+												title="Your bcachefs pin differs from the version bundled with this NASty release. Re-pin to it and rebuild.">
+												{syncingBcachefs ? 'Switching...' : `Sync bcachefs → ${recommendedBcachefs}`}
 											</Button>
 										{/if}
 									{:else if taggedReleaseBanner.kind === 'ready' && (!taggedReleaseBanner.current_is_latest_standard_url || info?.last_attempt === 'failed')}


### PR DESCRIPTION
Makes the top-bar bcachefs chip actionable, per the discussion on the bcachefs-version confusion.

**Problem:** the wrapper's `bcachefs-tools` pin is independent of nasty's, but the build uses nasty's pin. So after a NASty update bumps bcachefs, the operator's pin lags, the box silently runs the bundled (newer) version, and the chip flags a confusing "non-standard" state — with no obvious way to reconcile short of hand-editing the flake.

**Fix:** make "adopt what NASty shipped" one click. The operator still owns the pin — nothing changes without the click.

- **Engine:** new `bcachefs_recommended_ref` on `system.info` — the bcachefs-tools ref this build ships with, parsed from nasty's `flake.nix` baked into the engine at compile time (`embedded_default_bcachefs_tools_ref`, now `pub(crate)`).
- **Update page:** when the pinned ref ≠ recommended, a **"Sync bcachefs → <ref>"** button re-pins bcachefs-tools to the bundled ref and runs the existing `version-switch` flow — full progress tracker + reconnect-survival, no new rebuild plumbing.
- **Top-bar chip:** when a sync is available it shows **"→ <ref>"** with a tooltip (*"NASty ships bcachefs X, you're pinned at Y — click to switch"*) and links to `/update#bcachefs`.

## Tests
`cargo test`, clippy, `fmt --check`, `svelte-check` all green.

## Note
This is the pragmatic resolution we landed on: operator keeps ownership of the pin (no silent auto-bump, no build rewiring, CI invariant untouched), but catching up to the version NASty ships is now a single button instead of a manual flake edit.