### PR TITLE
update: auto-clear bcachefs chip after a version switch

### DIFF
--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -22,6 +22,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
+	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 
 	type Tab = 'version' | 'generations' | 'firmware';
 	type VersionRow = {
@@ -343,6 +344,14 @@
 				} else {
 					writeVersionPageAction(null);
 					void loadTaggedReleaseBanner();
+					// The switch finished. A bcachefs-tools-only switch
+					// rebuilds + activates without restarting the engine, so
+					// the WS never drops and the layout's reconnect-driven
+					// sysInfo refresh never fires — the top-bar bcachefs chip
+					// would stay stale until a manual reload. Nudge it, and
+					// reload our rows so the pinned ref / sync button update.
+					sysInfoRefresh.trigger();
+					void loadVersionPage();
 				}
 			}
 			if (status?.state === 'running') startPolling();


### PR DESCRIPTION
Follow-up to #462. The chip-refresh fix was pushed to #462's branch *after* it had already merged, so it never made it into main — this PR lands it properly.

**Problem:** a bcachefs-tools-only switch rebuilds + activates the new generation without restarting the engine binary, so the WebSocket never drops and the layout's reconnect-driven `sysInfo` refresh never fires. The top-bar **"bcachefs → vX"** chip stayed up after a successful switch until a manual `cmd+R`.

**Fix:** when `loadStatus` sees a version-switch reach a terminal state, fire `sysInfoRefresh.trigger()` (re-fetches `system.info` → the chip re-evaluates pinned-vs-recommended and clears) and reload the version-page rows so the locked ref / Sync button update in place too.

`svelte-check` green. WebUI-only.