### PR TITLE
flake: bump default bcachefs-tools to v1.38.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781062167,
-        "narHash": "sha256-JFTs+7CfsY2Oc3Vo02cI82LBgEB4l3jUjf6a3EJSTFQ=",
+        "lastModified": 1781105933,
+        "narHash": "sha256-EXd+BOTAFUddK/4Vwi7GqRqndi2x4bb5gs7IIkMX6HU=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "522562bff4980c0938bce54804bb5b6364cdb5dc",
+        "rev": "aa15745636f5853279a338b30c33c98894e37579",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.38.4",
+        "ref": "v1.38.5",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.38.4 release tag.
+    # Pinned to v1.38.5 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.4";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.5";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────


### PR DESCRIPTION
Bumps the pinned `bcachefs-tools` flake input **v1.38.4 → v1.38.5** (released today).

- `version`/`cargoDeps` derive from the input, so the only changes are the tag in `flake.nix` + refreshed `flake.lock`.
- `nix eval .#packages.x86_64-linux.bcachefs-tools.version` → **1.38.5**; derivation evaluates clean. The **Nix engine build** CI job does the real linux compile (and catches any new build dep).
- Good chance to exercise the new switch flow: once this is in a build a box updates to, the top-bar chip should offer **"bcachefs → v1.38.5"**, the one-click sync should re-pin + rebuild, and the chip should auto-clear when done (#462/#464).