### PR TITLE
filesystems: read mounted device facts from sysfs (fixes #455) + pencil affordance

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -3402,14 +3402,39 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
     let mut devices: Vec<FilesystemDevice> = Vec::new();
 
     for dev_path in device_paths {
-        let dev_short = dev_path.trim_start_matches("/dev/");
+        // Mounted pool: sysfs is the authoritative, correctly-mapped
+        // source. It's keyed by the kernel's live `block` symlink, so it
+        // stays correct after a remove/re-add reshuffle, and it doesn't
+        // need the passphrase on encrypted pools. show-super, by contrast,
+        // reports the device PATHS stored in the superblock — which go
+        // stale on reshuffle and made labels/slots land on the wrong row
+        // (#455). So prefer sysfs; only fall back to show-super when the
+        // filesystem isn't mounted (no sysfs tree).
+        if let Some(sy) = sysfs.get(dev_path) {
+            devices.push(FilesystemDevice {
+                path: dev_path.clone(),
+                label: sy.label.clone(),
+                durability: sy.durability,
+                state: sy.state.clone(),
+                data_allowed: sy.data_allowed.clone(),
+                has_data: sy.has_data.clone(),
+                discard: sy.discard,
+                read_errors: sy.read_errors,
+                write_errors: sy.write_errors,
+                checksum_errors: sy.checksum_errors,
+                member_index: sy.member_index,
+                uuid: sy.uuid.clone(),
+            });
+            continue;
+        }
 
-        // Find the block that mentions this device path
+        // Unmounted: fall back to show-super's per-device blocks, matched
+        // by device path (best-effort; sysfs is absent here).
+        let dev_short = dev_path.trim_start_matches("/dev/");
         let block = blocks.iter().find(|b| {
             b.iter()
                 .any(|l| l.contains(dev_path.as_str()) || l.contains(dev_short))
         });
-
         let (label, durability, state, data_allowed, has_data, discard) = if let Some(block) = block
         {
             let label = extract_value(block, "label");
@@ -3422,19 +3447,9 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
         } else {
             (None, None, None, None, None, None)
         };
-
-        // Member slot from the show-super block header ("Device N:") —
-        // works mounted or not; fall back to the sysfs dev-N index.
         let member_index = block
             .and_then(|b| b.first())
-            .and_then(|hdr| parse_device_index(hdr))
-            .or_else(|| sysfs.get(dev_path).and_then(|s| s.member_index));
-
-        let sy = sysfs.get(dev_path);
-        let (read_errors, write_errors, checksum_errors) = sy
-            .map(|s| (s.read_errors, s.write_errors, s.checksum_errors))
-            .unwrap_or((None, None, None));
-        let uuid = sy.and_then(|s| s.uuid.clone());
+            .and_then(|hdr| parse_device_index(hdr));
 
         devices.push(FilesystemDevice {
             path: dev_path.clone(),
@@ -3444,11 +3459,11 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
             data_allowed,
             has_data,
             discard,
-            read_errors,
-            write_errors,
-            checksum_errors,
+            read_errors: None,
+            write_errors: None,
+            checksum_errors: None,
             member_index,
-            uuid,
+            uuid: None,
         });
     }
 
@@ -3514,6 +3529,22 @@ struct DeviceSysfs {
     uuid: Option<String>,
     /// Member slot — the `N` in `dev-N`.
     member_index: Option<u32>,
+    label: Option<String>,
+    state: Option<String>,
+    durability: Option<u32>,
+    data_allowed: Option<String>,
+    has_data: Option<String>,
+    discard: Option<bool>,
+}
+
+/// Read one sysfs attribute file, trimmed; `None` if absent/empty or the
+/// bcachefs "unset" sentinel `(none)`.
+async fn read_sysfs_attr(dir: &str, attr: &str) -> Option<String> {
+    tokio::fs::read_to_string(format!("{dir}/{attr}"))
+        .await
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "(none)" && s != "none")
 }
 
 async fn read_device_sysfs(uuid: &str) -> HashMap<String, DeviceSysfs> {
@@ -3532,6 +3563,9 @@ async fn read_device_sysfs(uuid: &str) -> HashMap<String, DeviceSysfs> {
         let member_index = idx.parse::<u32>().ok();
         let dir = format!("{base}/{name}");
         // dev-N/block is a symlink whose basename is the kernel device name.
+        // This is the kernel's *live* mapping, so it stays correct across a
+        // remove/re-add reshuffle — unlike the device paths recorded in the
+        // superblock that `show-super` reports.
         let dev_name = match tokio::fs::read_link(format!("{dir}/block")).await {
             Ok(target) => target.file_name().map(|s| s.to_string_lossy().into_owned()),
             Err(_) => None,
@@ -3542,19 +3576,28 @@ async fn read_device_sysfs(uuid: &str) -> HashMap<String, DeviceSysfs> {
                 Ok(s) => parse_io_errors(&s),
                 Err(_) => (None, None, None),
             };
-        let dev_uuid = tokio::fs::read_to_string(format!("{dir}/uuid"))
+        // `state` is the bracketed-enum form: `[rw] ro evacuating spare`.
+        let state = read_sysfs_attr(&dir, "state")
             .await
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+            .map(|s| parse_bcachefs_opt(&s));
         out.insert(
             format!("/dev/{dev_name}"),
             DeviceSysfs {
                 read_errors,
                 write_errors,
                 checksum_errors,
-                uuid: dev_uuid,
+                uuid: read_sysfs_attr(&dir, "uuid").await,
                 member_index,
+                label: read_sysfs_attr(&dir, "label").await,
+                state,
+                durability: read_sysfs_attr(&dir, "durability")
+                    .await
+                    .and_then(|s| s.parse().ok()),
+                data_allowed: read_sysfs_attr(&dir, "data_allowed").await,
+                has_data: read_sysfs_attr(&dir, "has_data").await,
+                discard: read_sysfs_attr(&dir, "discard")
+                    .await
+                    .map(|s| s == "1" || s == "true"),
             },
         );
     }

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -23,7 +23,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { RefreshCw } from '@lucide/svelte';
+	import { RefreshCw, Pencil } from '@lucide/svelte';
 
 	let filesystems: Filesystem[] = $state([]);
 	let devices: BlockDevice[] = $state([]);
@@ -2228,11 +2228,14 @@
 											/>
 										{:else}
 											<button
-												class="rounded px-1 py-0.5 text-left hover:bg-secondary {dev.label ? '' : 'text-muted-foreground'} {fs.mounted ? 'cursor-text' : 'cursor-default'}"
+												class="group inline-flex items-center gap-1 rounded px-1 py-0.5 text-left hover:bg-secondary {dev.label ? '' : 'text-muted-foreground'} {fs.mounted ? 'cursor-text' : 'cursor-default'}"
 												onclick={() => { if (fs.mounted) startEditLabel(fs.name, dev); }}
 												title={fs.mounted ? 'Click to edit label' : ''}
 											>
-												{dev.label ?? '—'}
+												<span>{dev.label ?? '—'}</span>
+												{#if fs.mounted}
+													<Pencil size={11} class="shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />
+												{/if}
 											</button>
 										{/if}
 									</td>


### PR DESCRIPTION
## The real #455 root cause

@kdackiw reported a device label rename **not sticking** (showed "first" even after reload), on the `first` pool — which had a device removed and re-added, **reshuffling the kernel device names** (sdb=scsi1, sdc=scsi3, sdd=scsi2; member slots 0, 2, 3).

Investigated live: `set_label` was working fine — it writes the correctly-mapped sysfs `dev-N/label` (confirmed `dev-3`/sdd = `second`). The bug was the **read** path: `read_fs_devices` matched `show-super`'s per-device blocks to devices **by path string**, but `show-super` reports the device paths recorded in the superblock, which go **stale after a reshuffle**. So `sdd` matched `sdb`'s block → label "first", `member_index` 0 (duplicating sdb). On encrypted pools `show-super` also needs the passphrase.

## Fix

For a **mounted** pool, read each device's facts — label, state, durability, data_allowed, has_data, discard, uuid, member_index, IO errors — from `/sys/fs/bcachefs/<fs>/dev-N/`, keyed by the kernel's **live `block` symlink** (authoritative, correctly mapped across reshuffles, no passphrase). `show-super` remains the fallback only when the fs is **unmounted** (no sysfs). This also fixes the duplicate-`member_index` from #452 on reshuffled pools and makes per-device state correct (helps #456).

## Plus (#429)
A faint **pencil icon** next to each device label so it's discoverable that it's click-to-edit (Kev: *"I didn't even realize the items under Label are editable"*).

`cargo test`, clippy, `fmt`, `svelte-check` green. I'd like to deploy this to the box and confirm the rename now reflects live (read-only verification) — will do once it's mergeable / you OK it.

Closes #455.