### PR TITLE
Filesystems: re-attach offline members instead of forcing wipe+add

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2121,7 +2121,7 @@ impl FilesystemService {
             "lsblk",
             &[
                 "-Jbno",
-                "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,ROTA,MODEL,SERIAL,VENDOR,TRAN",
+                "NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,ROTA,MODEL,SERIAL,VENDOR,TRAN,UUID",
             ],
         )
         .await
@@ -2213,6 +2213,7 @@ impl FilesystemService {
                     let serial = pick("serial");
                     let vendor = pick("vendor");
                     let transport = pick("tran");
+                    let fs_uuid = pick("uuid");
 
                     // Transport needs to be resolved before classify so the
                     // SAS path can use it.
@@ -2228,6 +2229,7 @@ impl FilesystemService {
                             dev_type: dev_type.to_string(),
                             mount_point: mountpoint,
                             fs_type: fstype,
+                            fs_uuid,
                             in_use: in_fs || actually_mounted,
                             rotational,
                             device_class,
@@ -2314,6 +2316,7 @@ impl FilesystemService {
                             dev_type: "free".to_string(),
                             mount_point: None,
                             fs_type: None,
+                            fs_uuid: None,
                             in_use: false,
                             rotational,
                             device_class,
@@ -2376,12 +2379,30 @@ impl FilesystemService {
             return Err(FilesystemError::DeviceInUse(req.device.path.clone()));
         }
         // Reject if the device has a filesystem signature (including stale bcachefs superblocks
-        // left over after removal). The user must explicitly wipe it via Disks → Wipe first.
+        // left over after removal). The user must explicitly wipe it via Disks → Wipe first —
+        // unless the superblock belongs to *this* filesystem and a member slot is offline, in
+        // which case the right move is a re-attach, not a wipe (#472).
         if is_device_bcachefs(&req.device.path).await {
-            return Err(FilesystemError::CommandFailed(format!(
-                "{} has an existing bcachefs superblock. Go to Disks → Wipe to erase it before adding it to a filesystem.",
-                req.device.path
-            )));
+            let same_fs = get_fs_uuid(&req.device.path).await.as_deref() == Some(fs.uuid.as_str());
+            let has_missing_member = fs.devices.iter().any(|d| d.missing == Some(true));
+            return Err(FilesystemError::CommandFailed(
+                if same_fs && has_missing_member {
+                    format!(
+                        "{} is an offline member of this filesystem. Use \"Bring online\" to re-attach it with its data intact instead of adding it as a new device.",
+                        req.device.path
+                    )
+                } else if same_fs {
+                    format!(
+                        "{} is a former member of this filesystem. Go to Disks → Wipe to erase its old superblock before re-adding it as a new device.",
+                        req.device.path
+                    )
+                } else {
+                    format!(
+                        "{} has an existing bcachefs superblock. Go to Disks → Wipe to erase it before adding it to a filesystem.",
+                        req.device.path
+                    )
+                },
+            ));
         }
 
         let mut args: Vec<String> = vec!["device".into(), "add".into()];
@@ -3256,6 +3277,12 @@ pub struct BlockDevice {
     pub mount_point: Option<String>,
     /// Filesystem type detected on the device (e.g. `bcachefs`, `ext4`).
     pub fs_type: Option<String>,
+    /// Filesystem UUID from lsblk — for bcachefs members this is the
+    /// *external* (whole-filesystem) UUID, so a candidate disk can be
+    /// matched against an existing pool's `Filesystem.uuid` to tell an
+    /// offline/former member apart from a foreign disk (#472).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fs_uuid: Option<String>,
     /// Whether the device is currently in use (mounted, in a filesystem, or has partitions in use).
     pub in_use: bool,
     /// Whether the underlying disk spins (false for NVMe/SSD, true for HDD).
@@ -3436,6 +3463,9 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
     };
 
     let mut devices: Vec<FilesystemDevice> = Vec::new();
+    // Phantom slots already represented by a bound /proc/mounts row,
+    // skipped by the missing-member loop below.
+    let mut bound_slots: std::collections::HashSet<Option<u32>> = std::collections::HashSet::new();
 
     for dev_path in device_paths {
         // Mounted pool: sysfs is the authoritative, correctly-mapped
@@ -3488,6 +3518,41 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
             .and_then(|b| b.first())
             .and_then(|hdr| parse_device_index(hdr));
 
+        // On a mounted pool every *attached* member is in sysfs_by_path,
+        // so reaching here with a non-empty sysfs tree means this
+        // /proc/mounts path dropped out after mount. Its slot lives on as
+        // a phantom dev-N — bind the two into one row carrying the real
+        // path (so the re-attach affordance has a device to act on) and
+        // the phantom's live sysfs fields, flagged missing, instead of a
+        // stale-`rw` superblock row plus a separate "(missing dev-N)"
+        // placeholder for the same member (#472).
+        if !sysfs_members.is_empty() {
+            let phantom = member_index.and_then(|idx| {
+                sysfs_members
+                    .iter()
+                    .find(|m| m.path.is_none() && m.member_index == Some(idx))
+            });
+            if let Some(m) = phantom {
+                bound_slots.insert(m.member_index);
+                devices.push(FilesystemDevice {
+                    path: dev_path.clone(),
+                    label: m.label.clone(),
+                    durability: m.durability,
+                    state: m.state.clone(),
+                    data_allowed: m.data_allowed.clone(),
+                    has_data: m.has_data.clone(),
+                    discard: m.discard,
+                    read_errors: m.read_errors,
+                    write_errors: m.write_errors,
+                    checksum_errors: m.checksum_errors,
+                    member_index: m.member_index,
+                    uuid: m.uuid.clone(),
+                    missing: Some(true),
+                });
+                continue;
+            }
+        }
+
         devices.push(FilesystemDevice {
             path: dev_path.clone(),
             label,
@@ -3501,7 +3566,13 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
             checksum_errors: None,
             member_index,
             uuid: None,
-            missing: None,
+            // No phantom slot matched, but on a mounted pool this device
+            // is still detached — don't pretend it's a healthy member.
+            missing: if sysfs_members.is_empty() {
+                None
+            } else {
+                Some(true)
+            },
         });
     }
 
@@ -3511,7 +3582,7 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
     // (which comes from /proc/mounts = present devices), so add them here
     // so the operator can see the dead member and force-remove it.
     for m in &sysfs_members {
-        if m.path.is_some() {
+        if m.path.is_some() || bound_slots.contains(&m.member_index) {
             continue;
         }
         let slot = m

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -326,9 +326,12 @@ export interface FilesystemDevice {
 	member_index?: number | null;
 	/** Stable per-device bcachefs UUID (mounted pools only). */
 	uuid?: string | null;
-	/** True for a missing/dead member: the superblock still lists it but
-	 * the block device is gone. `path` is a synthetic placeholder; remove
-	 * it by member_index with force. */
+	/** True for a missing member: the superblock still lists it but the
+	 * device is detached (pulled, dead, or offlined). `path` is the real
+	 * /dev node when the dropped device is still named in /proc/mounts,
+	 * else a synthetic `(missing dev-N)` placeholder. Re-attach via
+	 * fs.device.online if the disk is back (#472), or remove it by
+	 * member_index with force. */
 	missing?: boolean | null;
 }
 
@@ -465,6 +468,10 @@ export interface BlockDevice {
 	dev_type: string;
 	mount_point: string | null;
 	fs_type: string | null;
+	/** Filesystem UUID from lsblk — for bcachefs members this is the
+	 * *external* (whole-pool) UUID, matchable against `Filesystem.uuid`
+	 * to tell an offline/former member from a foreign disk (#472). */
+	fs_uuid?: string;
 	in_use: boolean;
 	rotational: boolean;
 	/** "nvme" | "ssd" | "hdd" */

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -1043,6 +1043,31 @@
 		return devices.filter(d => !d.in_use && (showAddPartitions || d.dev_type !== 'part'));
 	}
 
+	/** Classify an Add Device candidate against the target pool (#472).
+	 * A bcachefs disk whose superblock UUID matches this filesystem is
+	 * either an offline member (re-attach it — wiping would destroy a
+	 * disk that could just be brought back online) or a former, removed
+	 * member (its data was evacuated; wipe is the correct path). Other
+	 * bcachefs disks belong to a foreign pool. */
+	function addCandidateKind(dev: BlockDevice, fs: Filesystem): 'plain' | 'offline_member' | 'former_member' | 'foreign' {
+		if (dev.fs_type !== 'bcachefs') return 'plain';
+		if (dev.fs_uuid && dev.fs_uuid === fs.uuid) {
+			return fs.devices.some(d => d.missing) ? 'offline_member' : 'former_member';
+		}
+		return 'foreign';
+	}
+
+	/** Device path to hand fs.device.online to re-attach this missing
+	 * member (#472): its own path when that disk is currently detected
+	 * (e.g. it was offlined in place), else any available disk whose
+	 * superblock UUID matches this pool — the member may have reappeared
+	 * under a new kernel name. Null when no matching disk is present. */
+	function reattachPath(fs: Filesystem, dev: FilesystemDevice): string | null {
+		if (deviceBlock(dev.path)) return dev.path;
+		const cand = devices.find(d => !d.in_use && d.fs_uuid && d.fs_uuid === fs.uuid);
+		return cand?.path ?? null;
+	}
+
 	/** SMART health for a candidate disk, matched by path (whole-disk
 	 * only; partitions inherit nothing). `undefined` when smartctl has
 	 * no data — virtual disks, USB bridges, or SMART service disabled. */
@@ -2321,6 +2346,12 @@
 										<td class="p-2 w-px whitespace-nowrap">
 											<div class="flex gap-1.5 items-center">
 											{#if fs.mounted && dev.missing}
+												{@const reattach = reattachPath(fs, dev)}
+												{#if reattach}
+													<Button size="xs" onclick={() => onlineDevice(fs.name, reattach)} title="Re-attach {reattach} to this pool with its data intact">Bring online</Button>
+												{:else}
+													<span class="text-xs italic text-muted-foreground" title="The disk for this member slot is not currently detected. Reconnect it — it may reappear under a different name, in which case Bring online and Add Device will offer to re-attach it.">disk not detected</span>
+												{/if}
 												<Button variant="destructive" size="xs" onclick={() => removeMissingDevice(fs.name, dev)}>Remove (force)</Button>
 											{:else if fs.mounted}
 												{@const ds = devDisplayState(dev)}
@@ -2359,15 +2390,23 @@
 									{:else}
 										{#each availableDevicesForAdd() as dev}
 											{@const smart = smartFor(dev.path)}
-											<label class="flex cursor-pointer items-start gap-2 rounded-md border border-border/50 p-2 text-sm hover:bg-secondary/40 {addDevicePath === dev.path ? 'border-primary bg-primary/5' : ''}">
-												<input type="radio" name="add-device" value={dev.path} bind:group={addDevicePath} class="mt-0.5 h-4 w-4 shrink-0" />
+											{@const kind = addCandidateKind(dev, fs)}
+											{@const selectable = kind === 'plain' || kind === 'foreign'}
+											<label class="flex items-start gap-2 rounded-md border border-border/50 p-2 text-sm {selectable ? 'cursor-pointer hover:bg-secondary/40' : ''} {addDevicePath === dev.path ? 'border-primary bg-primary/5' : ''}">
+												<input type="radio" name="add-device" value={dev.path} bind:group={addDevicePath} disabled={!selectable} class="mt-0.5 h-4 w-4 shrink-0" />
 												<span class="min-w-0 flex-1">
 													<span class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
 														<span class="font-mono">{dev.path}</span>
 														<span class="text-muted-foreground">{formatBytes(dev.size_bytes)}</span>
 														<span class="rounded bg-secondary px-1 py-0.5 text-[10px] uppercase text-muted-foreground">{dev.device_class}</span>
 														{#if dev.dev_type === 'part'}<span class="rounded bg-secondary px-1 py-0.5 text-[10px] text-muted-foreground">part</span>{/if}
-														{#if dev.fs_type}<span class="rounded bg-amber-950 px-1 py-0.5 text-[10px] text-amber-400" title="Already has a filesystem — adding will wipe it">{dev.fs_type}</span>{/if}
+														{#if kind === 'offline_member'}
+															<span class="rounded bg-sky-950 px-1.5 py-0.5 text-[10px] text-sky-400" title="This disk's superblock belongs to this filesystem and a member slot is offline — bring it back online with its data intact. Do not wipe it.">offline member of this pool</span>
+														{:else if kind === 'former_member'}
+															<span class="rounded bg-amber-950 px-1.5 py-0.5 text-[10px] text-amber-400" title="This disk used to belong to this filesystem but its member slot was removed (data evacuated). Wipe it in Disks before re-adding it as a new device.">former member of this pool · wipe to re-add</span>
+														{:else if dev.fs_type}
+															<span class="rounded bg-amber-950 px-1 py-0.5 text-[10px] text-amber-400" title="Already has a filesystem — wipe it in Disks first">{dev.fs_type}</span>
+														{/if}
 													</span>
 													<span class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.7rem] text-muted-foreground">
 														{#if dev.model}<span class="font-mono">{dev.model}</span>{/if}
@@ -2381,6 +2420,9 @@
 														{/if}
 													</span>
 												</span>
+												{#if kind === 'offline_member'}
+													<Button size="xs" class="shrink-0" onclick={() => onlineDevice(fs.name, dev.path)}>Bring online</Button>
+												{/if}
 											</label>
 										{/each}
 									{/if}


### PR DESCRIPTION
Closes #472.

When a disk drops out of a pool (cable, transient fault, or an explicit Offline), it keeps valid data — but the Add Device flow treated it like any stranger disk, showing a generic "bcachefs" badge that pushes the operator toward a wipe that would destroy a disk they could have just re-attached.

> Rebased on #476, which added the missing-member surfacing (sysfs phantom dev-N, `missing: true`, force-remove). This PR builds the *re-attach* half on top of that model.

## Engine

- **`BlockDevice.fs_uuid`** (lsblk `UUID`): the external bcachefs UUID, so the UI can match a candidate disk's superblock against an existing pool — the per-device identity groundwork from #452 extended to *candidates*.
- **Dropped-after-mount paths bind to their phantom slot.** A `/proc/mounts` path with no attached sysfs member is detached; if its show-super slot matches a phantom dev-N, the two merge into one row carrying the **real path** (so re-attach has a device to act on) and the phantom's live sysfs fields, flagged `missing` — instead of a stale-`rw` superblock row *plus* a separate `(missing dev-N)` placeholder for the same member.
- **`device_add` rejection is now diagnostic**: same-pool superblock + missing slot → *"use Bring online to re-attach with its data intact"*; same-pool, no missing slot → *"former member — wipe to re-add"*; foreign superblock → unchanged message.

## WebUI

- Missing member rows get a one-click **Bring online** (`fs.device.online`) next to Remove (force) — using the member's own path when that disk is detected (e.g. offlined in place), else any available disk whose superblock UUID matches the pool (it may have reappeared under a new kernel name). When no matching disk is present, a *disk not detected* hint explains what to do.
- Add Device picker: a candidate whose superblock UUID matches this pool is labeled **"offline member of this pool"** with an inline **Bring online** button (add-radio disabled — adding would be rejected anyway), or **"former member of this pool · wipe to re-add"** when no slot is missing. Foreign-disk badge title corrected ("wipe it in Disks first" — adding never silently wiped).

## Tests

`cargo fmt` / `clippy --workspace --all-targets` / `cargo test --workspace` clean; `svelte-check` 0 errors, 144 webui tests pass.