### PR TITLE
Apps: live compose validation in the editor

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/engine/nasty-apps/Cargo.toml
+++ b/engine/nasty-apps/Cargo.toml
@@ -16,5 +16,6 @@ schemars.workspace = true
 reqwest.workspace = true
 bollard = "0.21"
 serde_yaml_ng = "0.10"
+tempfile = "3"
 futures-util.workspace = true
 libc.workspace = true

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -562,6 +562,44 @@ pub fn extract_compose_binds(yaml: &str) -> Vec<ComposeBind> {
     binds
 }
 
+/// Parse `docker compose config` stderr into per-line diagnostics
+/// (#439). Strips the temp-file path (meaningless to the user) and
+/// extracts `line N` references where the YAML layer names one.
+/// Warning noise from the compose CLI is dropped — only the failure
+/// text survives. Pure; unit-tested.
+fn parse_compose_diagnostics(stderr: &str, tmp_path: &str) -> Vec<ComposeDiagnostic> {
+    let mut out = Vec::new();
+    for raw in stderr.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Progress/warning chatter ("WARN[0000] the attribute `version`
+        // is obsolete", `level=warning msg=…`), not validation findings.
+        if line.starts_with("WARN") || line.contains("level=warning") {
+            continue;
+        }
+        let message = line.replace(tmp_path, "docker-compose.yml");
+        out.push(ComposeDiagnostic {
+            line: extract_line_number(&message),
+            message,
+        });
+    }
+    out
+}
+
+/// Find a 1-based `line <N>` reference in a yaml error message
+/// ("yaml: line 9: did not find expected key", "  line 4: cannot
+/// unmarshal …"). go-yaml and serde_yaml both report 1-based lines.
+fn extract_line_number(msg: &str) -> Option<u32> {
+    let pos = msg.find("line ")?;
+    let digits: String = msg[pos + 5..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
 /// Best-effort 1-based line number of the first occurrence of `needle`
 /// in `haystack`. Used to underline the offending volume entry in the
 /// compose editor.
@@ -1621,6 +1659,38 @@ pub struct CheckVolumesRequest {
     /// server can correlate sources with their owning service's `user:`
     /// field — that's the comparison we make.
     pub compose: String,
+}
+
+// ── Compose lint types (#439) ─────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckComposeRequest {
+    /// Full docker-compose YAML text, as it sits in the editor.
+    pub compose: String,
+}
+
+/// One validation finding from `apps.check_compose`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ComposeDiagnostic {
+    /// 1-based line in the compose text, when the validator names one.
+    /// Schema-level findings (e.g. an unknown property) often don't.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    pub message: String,
+}
+
+/// Result of `apps.check_compose` — the same validation deploy runs,
+/// surfaced live so the editor can underline problems before the user
+/// commits to a deploy.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CheckComposeResult {
+    /// False when schema validation couldn't run (docker compose not
+    /// on PATH — apps disabled, or a stripped-down box). YAML syntax is
+    /// still checked in-process; the UI shouldn't claim "fully valid"
+    /// when this is false.
+    pub schema_checked: bool,
+    pub valid: bool,
+    pub diagnostics: Vec<ComposeDiagnostic>,
 }
 
 /// One bind-mount whose host owner doesn't match what the container
@@ -4546,6 +4616,101 @@ impl AppsService {
 
     // ── Compose validation ──────────────────────────────────
 
+    /// Live-lint a compose file for the editor (#439). Two stages:
+    ///
+    /// 1. In-process YAML parse (`serde_yaml_ng`) — catches the
+    ///    syntax/indentation class of error with a precise line number,
+    ///    without spawning anything. Most keystrokes that break a file
+    ///    break it here.
+    /// 2. `docker compose config --quiet` against a temp copy — the
+    ///    exact validator [`Self::validate_compose`] runs at deploy
+    ///    time, so the live lint can't drift from what deploy enforces.
+    ///    Skipped (with `schema_checked: false`) when the YAML doesn't
+    ///    parse or the docker CLI isn't available.
+    pub async fn check_compose(&self, req: CheckComposeRequest) -> CheckComposeResult {
+        if req.compose.trim().is_empty() {
+            return CheckComposeResult {
+                schema_checked: false,
+                valid: true,
+                diagnostics: Vec::new(),
+            };
+        }
+
+        // Stage 1: YAML syntax.
+        if let Err(e) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&req.compose) {
+            return CheckComposeResult {
+                schema_checked: false,
+                valid: false,
+                diagnostics: vec![ComposeDiagnostic {
+                    line: e.location().map(|l| l.line() as u32),
+                    message: format!("YAML syntax: {e}"),
+                }],
+            };
+        }
+
+        // Stage 2: compose schema, via the deploy-time validator. An
+        // isolated temp dir keeps `docker compose` from picking up a
+        // stray `.env` and keeps concurrent checks from colliding.
+        let tmp = match tempfile::tempdir() {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("check_compose: tempdir failed: {e} — skipping schema check");
+                return CheckComposeResult {
+                    schema_checked: false,
+                    valid: true,
+                    diagnostics: Vec::new(),
+                };
+            }
+        };
+        let file_path = tmp.path().join("docker-compose.yml");
+        if let Err(e) = tokio::fs::write(&file_path, &req.compose).await {
+            warn!("check_compose: temp write failed: {e} — skipping schema check");
+            return CheckComposeResult {
+                schema_checked: false,
+                valid: true,
+                diagnostics: Vec::new(),
+            };
+        }
+
+        let output = Command::new("docker")
+            .args([
+                "compose",
+                "-f",
+                &file_path.to_string_lossy(),
+                "config",
+                "--quiet",
+            ])
+            .output()
+            .await;
+        match output {
+            Ok(out) if out.status.success() => CheckComposeResult {
+                schema_checked: true,
+                valid: true,
+                diagnostics: Vec::new(),
+            },
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let diagnostics = parse_compose_diagnostics(&stderr, &file_path.to_string_lossy());
+                CheckComposeResult {
+                    schema_checked: true,
+                    // A non-zero exit with all-noise stderr still means invalid.
+                    valid: false,
+                    diagnostics,
+                }
+            }
+            Err(e) => {
+                // docker CLI not present (apps disabled) — YAML stage
+                // already passed, report that much honestly.
+                info!("check_compose: docker unavailable ({e}) — YAML-only check");
+                CheckComposeResult {
+                    schema_checked: false,
+                    valid: true,
+                    diagnostics: Vec::new(),
+                }
+            }
+        }
+    }
+
     async fn validate_compose(compose_file_path: &str) -> Result<(), AppsError> {
         let output = Command::new("docker")
             .args(["compose", "-f", compose_file_path, "config", "--quiet"])
@@ -5502,7 +5667,8 @@ mod tests {
     }
 
     use super::{
-        AppsService, CheckDevicesRequest, CheckVolumesRequest, extract_compose_binds,
+        AppsService, CheckComposeRequest, CheckDevicesRequest, CheckVolumesRequest,
+        extract_compose_binds, extract_line_number, parse_compose_diagnostics,
         validate_chown_target,
     };
 
@@ -5741,6 +5907,83 @@ services:
             e.contains("this-filesystem-does-not-exist-nasty-test"),
             "error should name the missing fs: {e}",
         );
+    }
+
+    // ── compose lint (#439) ────────────────────────────────────
+
+    #[test]
+    fn parse_compose_diagnostics_extracts_yaml_line() {
+        let d = parse_compose_diagnostics("yaml: line 9: did not find expected key\n", "/tmp/x");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].line, Some(9));
+        assert!(d[0].message.contains("did not find expected key"));
+    }
+
+    #[test]
+    fn parse_compose_diagnostics_strips_temp_path() {
+        let stderr = "validating /tmp/.tmpAb12/docker-compose.yml: services.web Additional property foo is not allowed\n";
+        let d = parse_compose_diagnostics(stderr, "/tmp/.tmpAb12/docker-compose.yml");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].line, None);
+        assert!(
+            d[0].message.starts_with("validating docker-compose.yml:"),
+            "temp path should be replaced: {}",
+            d[0].message
+        );
+    }
+
+    #[test]
+    fn parse_compose_diagnostics_drops_warning_noise() {
+        let stderr = "WARN[0000] the attribute `version` is obsolete\n\
+                      time=\"x\" level=warning msg=\"foo\"\n\
+                      yaml: line 3: mapping values are not allowed in this context\n";
+        let d = parse_compose_diagnostics(stderr, "/tmp/x");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].line, Some(3));
+    }
+
+    #[test]
+    fn parse_compose_diagnostics_handles_unmarshal_block() {
+        let stderr = "yaml: unmarshal errors:\n  line 4: cannot unmarshal !!str `80` into int\n";
+        let d = parse_compose_diagnostics(stderr, "/tmp/x");
+        assert_eq!(d.len(), 2);
+        assert_eq!(d[0].line, None);
+        assert_eq!(d[1].line, Some(4));
+    }
+
+    #[test]
+    fn extract_line_number_ignores_non_numeric() {
+        assert_eq!(extract_line_number("a line of text"), None);
+        assert_eq!(extract_line_number("no reference at all"), None);
+    }
+
+    /// Broken indentation is caught by the in-process YAML stage with a
+    /// line number — no docker spawn involved, so this is CI-safe.
+    #[tokio::test]
+    async fn check_compose_flags_yaml_syntax_with_line() {
+        let svc = AppsService::new();
+        let r = svc
+            .check_compose(CheckComposeRequest {
+                compose: "services:\n  app:\n   image: foo\n  bad indent: [\n".to_string(),
+            })
+            .await;
+        assert!(!r.valid);
+        assert!(!r.schema_checked);
+        assert_eq!(r.diagnostics.len(), 1);
+        assert!(r.diagnostics[0].line.is_some(), "got {:?}", r.diagnostics);
+        assert!(r.diagnostics[0].message.starts_with("YAML syntax:"));
+    }
+
+    #[tokio::test]
+    async fn check_compose_empty_input_is_quietly_valid() {
+        let svc = AppsService::new();
+        let r = svc
+            .check_compose(CheckComposeRequest {
+                compose: "   \n".to_string(),
+            })
+            .await;
+        assert!(r.valid);
+        assert!(r.diagnostics.is_empty());
     }
 
     #[tokio::test]

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -10,10 +10,11 @@ use crate::auth::{ApiToken, ApiTokenInfo, Role, Session, UserInfo};
 use crate::fs_dependents::FsDependents;
 use crate::subvolume_dependents::SubvolumeDependents;
 use nasty_apps::{
-    App, AppConfig, AppIngress, AppStats, AppsStatus, CaddyRouteSummary, CheckDevicesRequest,
-    CheckPortsRequest, CheckVolumesRequest, DeviceMissing, EnableAppsRequest,
-    FixVolumePermsRequest, ImageInspectResult, InstallAppRequest, InstallComposeRequest,
-    ManagedNetwork, NetworkSummary, PortConflict, PruneResult, SetIngressRequest, VolumeMismatch,
+    App, AppConfig, AppIngress, AppStats, AppsStatus, CaddyRouteSummary, CheckComposeRequest,
+    CheckComposeResult, CheckDevicesRequest, CheckPortsRequest, CheckVolumesRequest, DeviceMissing,
+    EnableAppsRequest, FixVolumePermsRequest, ImageInspectResult, InstallAppRequest,
+    InstallComposeRequest, ManagedNetwork, NetworkSummary, PortConflict, PruneResult,
+    SetIngressRequest, VolumeMismatch,
 };
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
@@ -2462,6 +2463,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::Schema(gen_schema::<CheckVolumesRequest>(generator)),
                     result: Some(gen_schema::<Vec<VolumeMismatch>>(generator)),
+                },
+                Method {
+                    name: "apps.check_compose",
+                    desc: "Validate a docker-compose YAML the way deploy will: in-process YAML syntax check, then `docker compose config` schema validation, returning per-line diagnostics for the editor to underline.",
+                    role: MethodRole::Any,
+                    params: MethodParams::Schema(gen_schema::<CheckComposeRequest>(generator)),
+                    result: Some(gen_schema::<CheckComposeResult>(generator)),
                 },
                 Method {
                     name: "apps.enable",

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -84,6 +84,10 @@ pub(super) async fn try_route(
             Ok(p) => ok(req, state.apps.check_volumes(p).await),
             Err(e) => invalid(req, e),
         },
+        "apps.check_compose" => match parse_params(req) {
+            Ok(p) => ok(req, state.apps.check_compose(p).await),
+            Err(e) => invalid(req, e),
+        },
         "apps.fix_volume_perms" => match parse_params(req) {
             Ok(p) => match state.apps.fix_volume_perms(p).await {
                 Ok(()) => ok(req, serde_json::json!({"ok": true})),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -248,6 +248,7 @@ fn is_read_only(method: &str) -> bool {
                 | "apps.check_ports"
                 | "apps.check_devices"
                 | "apps.check_volumes"
+                | "apps.check_compose"
                 | "apps.status"
                 // Live CPU / mem / network stats per container.
                 // Pure read; the WebUI polls it from the Apps page

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -539,8 +539,25 @@
 		return out;
 	}
 
-	// Editor underlines port-conflict, missing-device, and existing-but-wrong-owner lines.
+	// ── Live compose lint (#439): YAML syntax + compose schema, checked
+	// server-side with the same `docker compose config` deploy runs, so
+	// the editor can't approve something deploy would reject. ──
+	type ComposeDiagnostic = { line?: number | null; message: string };
+	type CheckComposeResult = {
+		schema_checked: boolean;
+		valid: boolean;
+		diagnostics: ComposeDiagnostic[];
+	};
+	let composeLint = $state<CheckComposeResult | null>(null);
+	let composeLintTimer: ReturnType<typeof setTimeout> | null = null;
+	let composeLintErrorLines = $derived(
+		(composeLint?.diagnostics ?? []).filter(d => d.line != null).map(d => d.line as number)
+	);
+
+	// Editor underlines syntax/schema, port-conflict, missing-device,
+	// and existing-but-wrong-owner lines.
 	const composeErrorLines = $derived([
+		...composeLintErrorLines,
 		...composePortErrorLines,
 		...composeDeviceErrorLines,
 		...composeVolumeErrorLines,
@@ -670,6 +687,18 @@
 		checkComposePortConflicts();
 		checkComposeDeviceConflicts();
 		checkComposeVolumePerms();
+		scheduleComposeLint();
+	}
+
+	function scheduleComposeLint() {
+		// Schema validation spawns `docker compose config` server-side —
+		// debounce so we lint typing pauses, not every keystroke.
+		if (composeLintTimer) clearTimeout(composeLintTimer);
+		composeLintTimer = setTimeout(() => {
+			client.call<CheckComposeResult>('apps.check_compose', { compose: composeContent })
+				.then(r => { composeLint = r; })
+				.catch(() => { composeLint = null; });
+		}, 500);
 	}
 
 	function checkComposeVolumePerms() {
@@ -1384,6 +1413,8 @@
 		composeDeviceErrorLines = [];
 		composeDeviceLineMap = new Map();
 		volumeMismatches = [];
+		composeLint = null;
+		if (composeLintTimer) { clearTimeout(composeLintTimer); composeLintTimer = null; }
 		composeTcpPorts = [];
 		newIngressPort = null;
 		composeName = ''; composeContent = ''; composeTried = false;
@@ -1985,6 +2016,19 @@
 								oninput={checkComposeConflicts}
 								class="mt-1 h-96 {composeContentMissing ? 'ring-1 ring-amber-500/50 rounded-md' : ''}"
 							/>
+							{#if composeLint && !composeLint.valid}
+								<div class="mt-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+									<p class="mb-1 font-medium">Compose file is not valid — deploy will fail with this content.</p>
+									{#each composeLint.diagnostics as d}
+										<div class="font-mono">
+											{#if d.line != null}<span class="font-semibold">Line {d.line}:</span>{/if}
+											{d.message}
+										</div>
+									{/each}
+								</div>
+							{:else if composeLint?.valid && composeLint.schema_checked && composeContent.trim()}
+								<p class="mt-1 text-xs text-green-600">✓ Valid compose file</p>
+							{/if}
 						</div>
 						<!-- Allow unsafe — opt out of strict compose sandbox -->
 						<div class="mb-4 rounded-md border border-border p-3">


### PR DESCRIPTION
Closes #439.

Kev's ask from #429: *"Perhaps more syntax checking in the yamls? I am the worst for spacing."* The issue text predates the CodeMirror editor (which already underlines port/device/volume conflicts) — what was still missing is the actual YAML-syntax and compose-schema layer. This adds it.

## Design

New read-only RPC **`apps.check_compose`** validating in two stages:

1. **In-process YAML parse** (`serde_yaml_ng`, already a dependency) — catches the syntax/indentation class of error with a precise 1-based line number, without spawning anything. Most keystrokes that break a file break it here.
2. **`docker compose config --quiet`** against a copy in an isolated temp dir — the *exact* validator deploy runs (`validate_compose`), so the live lint can never approve something deploy would reject. stderr is parsed into per-line diagnostics (`line N` references extracted, temp path stripped, `WARN` chatter dropped).

Degrades honestly: when the docker CLI isn't on PATH (apps disabled), the result says `schema_checked: false` and the UI doesn't claim full validity — YAML syntax is still checked.

## Editor

- Lint runs debounced (500 ms) alongside the existing port/device/volume checks on every edit.
- Diagnostic lines join the existing CodeMirror error-underline plumbing; messages render in the house-style red panel below the editor ("Compose file is not valid — deploy will fail with this content"), each prefixed with its line number when known.
- A small **✓ Valid compose file** note shows when the full check passes — for the spacing-anxious among us.

## Tests

7 new unit tests: stderr parsing (yaml line extraction, temp-path stripping, WARN filtering, unmarshal blocks), line-number extraction, and the in-process YAML stage end-to-end (CI-safe — the docker spawn is only reached with syntactically valid YAML, and a spawn failure degrades to `schema_checked: false`).

`cargo fmt` / clippy / workspace tests clean; `svelte-check` 0 errors, 144 webui tests pass, production build OK.