### PR TITLE
Filesystems: disable device-action buttons while an action is in progress

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -799,6 +799,13 @@ pub struct FilesystemService {
     /// Per-filesystem fsck state, loaded from `FSCK_STATE_PATH`. Same
     /// shape as `scrub_state`: live "running" + last-run summary.
     fsck_state: FsckStateMap,
+    /// Device paths with a `bcachefs device evacuate` currently running
+    /// (spawned detached — it can take hours). Guards against a second
+    /// evacuation of the same device being spawned in the window before
+    /// bcachefs persists the `evacuating` state (#479). Not persisted:
+    /// an engine restart orphans the child anyway, and the state-based
+    /// check in `device_evacuate` covers re-submission after that.
+    evacuating: Arc<Mutex<std::collections::HashSet<String>>>,
 }
 
 impl Default for FilesystemService {
@@ -856,6 +863,7 @@ impl FilesystemService {
             scrub_state: Arc::new(Mutex::new(scrub)),
             mount_state: Arc::new(Mutex::new(mount)),
             fsck_state: Arc::new(Mutex::new(fsck)),
+            evacuating: Arc::new(Mutex::new(std::collections::HashSet::new())),
         }
     }
 
@@ -2480,8 +2488,30 @@ impl FilesystemService {
             ));
         }
 
+        // Refuse a second evacuation of the same device: either the
+        // spawned `bcachefs device evacuate` is still running (tracked
+        // in-process — bcachefs takes a moment to persist `evacuating`,
+        // and hammering the button in that window must not spawn
+        // parallel migrations, #479), or the device state already says
+        // so.
+        {
+            let mut inflight = self.evacuating.lock().await;
+            let state_says_evacuating = fs
+                .devices
+                .iter()
+                .any(|d| d.path == req.device && d.state.as_deref() == Some("evacuating"));
+            if state_says_evacuating || inflight.contains(&req.device) {
+                return Err(FilesystemError::CommandFailed(format!(
+                    "evacuation of {} is already in progress",
+                    req.device
+                )));
+            }
+            inflight.insert(req.device.clone());
+        }
+
         let device = req.device.clone();
         let fs_name = req.filesystem.clone();
+        let evacuating = self.evacuating.clone();
         info!(
             "Starting evacuation of device {} in filesystem '{}'",
             device, fs_name
@@ -2494,6 +2524,7 @@ impl FilesystemService {
                 Ok(_) => info!("Evacuation of {} in '{}' completed", device, fs_name),
                 Err(e) => warn!("Evacuation of {} in '{}' failed: {}", device, fs_name, e),
             }
+            evacuating.lock().await.remove(&device);
         });
 
         self.invalidate_list_cache().await;

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -360,6 +360,15 @@
 			filesystems = await client.call<Filesystem[]>('fs.list');
 			devices = await client.call<BlockDevice[]>('device.list');
 		});
+		// Drop pending-evacuation markers once the live state confirms
+		// them (or the device vanished, or the marker went stale — an
+		// evacuation that finished instantly never shows `evacuating`).
+		for (const [p, t] of Object.entries(pendingEvacuation)) {
+			const dev = filesystems.flatMap(f => f.devices).find(d => d.path === p);
+			if (!dev || dev.state === 'evacuating' || Date.now() - t > 30_000) {
+				delete pendingEvacuation[p];
+			}
+		}
 		// SMART health for the add-device candidate summaries (best-effort;
 		// virtual disks / no-SMART setups just render "no SMART").
 		diskHealth = await client.call<DiskHealth[]>('system.disks').catch(() => []);
@@ -790,35 +799,61 @@
 		await refresh();
 	}
 
+	// ── Per-device action busy state (#479) ──
+	// While a device action RPC is in flight, every button on that
+	// row disables — a slow operation must not be hammerable, and the
+	// ghosted row is itself the "something is happening" signal.
+	let busyDevices = $state<Record<string, boolean>>({});
+	/** Devices we just told the engine to evacuate, displayed as
+	 * `evacuating` until a refresh observes the real state flip.
+	 * bcachefs takes a moment to persist the state, and in that gap
+	 * the row would otherwise re-offer Evacuate (#479). Value is the
+	 * time the marker was set, so a stuck marker (instant-finish
+	 * evacuation that never shows `evacuating`) expires. */
+	let pendingEvacuation = $state<Record<string, number>>({});
+
+	async function runDeviceAction(devicePath: string, fn: () => Promise<unknown>) {
+		busyDevices[devicePath] = true;
+		try {
+			await fn();
+		} finally {
+			delete busyDevices[devicePath];
+		}
+	}
+
 	async function addDevice(fsName: string) {
 		if (!addDevicePath) return;
-		const ok = await withToast(
-			() => client.call('fs.device.add', {
-				filesystem: fsName,
-				device: {
-					path: addDevicePath,
-					label: addDeviceLabel || undefined,
-					durability: addDeviceDurability !== '' ? parseInt(addDeviceDurability) : undefined,
-				},
-			}),
-			`Device ${addDevicePath} added to "${fsName}"`
-		);
-		if (ok !== undefined) {
-			addDeviceFs = null;
-			addDevicePath = '';
-			addDeviceLabel = '';
-			addDeviceDurability = '1';
-			await refresh();
-		}
+		await runDeviceAction(addDevicePath, async () => {
+			const ok = await withToast(
+				() => client.call('fs.device.add', {
+					filesystem: fsName,
+					device: {
+						path: addDevicePath,
+						label: addDeviceLabel || undefined,
+						durability: addDeviceDurability !== '' ? parseInt(addDeviceDurability) : undefined,
+					},
+				}),
+				`Device ${addDevicePath} added to "${fsName}"`
+			);
+			if (ok !== undefined) {
+				addDeviceFs = null;
+				addDevicePath = '';
+				addDeviceLabel = '';
+				addDeviceDurability = '1';
+				await refresh();
+			}
+		});
 	}
 
 	async function removeDevice(fsName: string, devicePath: string) {
 		if (!await confirm(`Remove ${devicePath}?`, `Data will be evacuated from filesystem "${fsName}" first.`)) return;
-		await withToast(
-			() => client.call('fs.device.remove', { filesystem: fsName, device: devicePath }),
-			`Device ${devicePath} removed from "${fsName}"`
-		);
-		await refresh();
+		await runDeviceAction(devicePath, async () => {
+			await withToast(
+				() => client.call('fs.device.remove', { filesystem: fsName, device: devicePath }),
+				`Device ${devicePath} removed from "${fsName}"`
+			);
+			await refresh();
+		});
 	}
 
 	/** Force-remove a missing/dead member by its slot index (#466/#473).
@@ -832,49 +867,64 @@
 			`Removes the missing device from "${fsName}". Its data can't be migrated (the disk is gone), so this relies on the replicas still present on the remaining devices. Don't do this if the pool is already at minimum redundancy.`,
 			{ confirmLabel: 'Force remove', cancelLabel: 'Cancel' }
 		)) return;
-		await withToast(
-			() => client.call('fs.device.remove', { filesystem: fsName, device: String(idx), force: true }, 120000),
-			`Removed dead member (slot ${idx}) from "${fsName}"`
-		);
-		await refresh();
+		await runDeviceAction(dev.path, async () => {
+			await withToast(
+				() => client.call('fs.device.remove', { filesystem: fsName, device: String(idx), force: true }, 120000),
+				`Removed dead member (slot ${idx}) from "${fsName}"`
+			);
+			await refresh();
+		});
 	}
 
 	async function evacuateDevice(fsName: string, devicePath: string) {
 		if (!await confirm(`Evacuate all data from ${devicePath}?`)) return;
-		await withToast(
-			() => client.call('fs.device.evacuate', { filesystem: fsName, device: devicePath }),
-			`Evacuating ${devicePath} — this may take several minutes`
-		);
-		await refresh();
-		startEvacuationPolling();
+		await runDeviceAction(devicePath, async () => {
+			let started = false;
+			await withToast(
+				async () => {
+					await client.call('fs.device.evacuate', { filesystem: fsName, device: devicePath });
+					started = true;
+				},
+				`Evacuating ${devicePath} — this may take several minutes`
+			);
+			if (started) pendingEvacuation[devicePath] = Date.now();
+			await refresh();
+			startEvacuationPolling();
+		});
 	}
 
 	async function setDeviceState(fsName: string, devicePath: string, state: DeviceState) {
 		if (state === 'ro') {
 			if (!await confirm(`Set ${devicePath} read-only?`, `The device will stop accepting writes. Use Set RW to revert.`)) return;
 		}
-		await withToast(
-			() => client.call('fs.device.set_state', { filesystem: fsName, device: devicePath, state }),
-			`Device ${devicePath} set to ${state}`
-		);
-		await refresh();
+		await runDeviceAction(devicePath, async () => {
+			await withToast(
+				() => client.call('fs.device.set_state', { filesystem: fsName, device: devicePath, state }),
+				`Device ${devicePath} set to ${state}`
+			);
+			await refresh();
+		});
 	}
 
 	async function onlineDevice(fsName: string, devicePath: string) {
-		await withToast(
-			() => client.call('fs.device.online', { filesystem: fsName, device: devicePath }),
-			`Device ${devicePath} online`
-		);
-		await refresh();
+		await runDeviceAction(devicePath, async () => {
+			await withToast(
+				() => client.call('fs.device.online', { filesystem: fsName, device: devicePath }),
+				`Device ${devicePath} online`
+			);
+			await refresh();
+		});
 	}
 
 	async function offlineDevice(fsName: string, devicePath: string) {
 		if (!await confirm(`Take ${devicePath} offline?`)) return;
-		await withToast(
-			() => client.call('fs.device.offline', { filesystem: fsName, device: devicePath }),
-			`Device ${devicePath} offline`
-		);
-		await refresh();
+		await runDeviceAction(devicePath, async () => {
+			await withToast(
+				() => client.call('fs.device.offline', { filesystem: fsName, device: devicePath }),
+				`Device ${devicePath} offline`
+			);
+			await refresh();
+		});
 	}
 
 	function openEditOptions(fs: Filesystem) {
@@ -1083,6 +1133,12 @@
 		// came back empty, and could land on the wrong row. There's no
 		// real "evacuated" device state — once a device is drained the
 		// operator removes it and it disappears from the list. (#456)
+		//
+		// One exception: a just-started evacuation may not be visible in
+		// dev.state yet (bcachefs persists it asynchronously). Show it
+		// optimistically until refresh() confirms or expires the marker,
+		// so the row doesn't re-offer Evacuate in the gap. (#479)
+		if (pendingEvacuation[dev.path] && dev.state !== 'evacuating') return 'evacuating';
 		return dev.state;
 	}
 
@@ -2347,25 +2403,27 @@
 											<div class="flex gap-1.5 items-center">
 											{#if fs.mounted && dev.missing}
 												{@const reattach = reattachPath(fs, dev)}
+												{@const busy = !!busyDevices[dev.path] || (reattach != null && !!busyDevices[reattach])}
 												{#if reattach}
-													<Button size="xs" onclick={() => onlineDevice(fs.name, reattach)} title="Re-attach {reattach} to this pool with its data intact">Bring online</Button>
+													<Button size="xs" disabled={busy} onclick={() => onlineDevice(fs.name, reattach)} title="Re-attach {reattach} to this pool with its data intact">Bring online</Button>
 												{:else}
 													<span class="text-xs italic text-muted-foreground" title="The disk for this member slot is not currently detected. Reconnect it — it may reappear under a different name, in which case Bring online and Add Device will offer to re-attach it.">disk not detected</span>
 												{/if}
-												<Button variant="destructive" size="xs" onclick={() => removeMissingDevice(fs.name, dev)}>Remove (force)</Button>
+												<Button variant="destructive" size="xs" disabled={busy} onclick={() => removeMissingDevice(fs.name, dev)}>Remove (force)</Button>
 											{:else if fs.mounted}
 												{@const ds = devDisplayState(dev)}
+												{@const busy = !!busyDevices[dev.path]}
 												{#if ds === 'evacuating'}
-													<Button variant="destructive" size="xs" onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
+													<Button variant="destructive" size="xs" disabled={busy} onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
 												{:else}
 													{#if ds === 'rw'}
-														<Button variant="secondary" size="xs" onclick={() => setDeviceState(fs.name, dev.path, 'ro')}>Set RO</Button>
-														<Button variant="secondary" size="xs" onclick={() => offlineDevice(fs.name, dev.path)}>Offline</Button>
+														<Button variant="secondary" size="xs" disabled={busy} onclick={() => setDeviceState(fs.name, dev.path, 'ro')}>Set RO</Button>
+														<Button variant="secondary" size="xs" disabled={busy} onclick={() => offlineDevice(fs.name, dev.path)}>Offline</Button>
 													{:else if ds === 'ro'}
-														<Button variant="secondary" size="xs" onclick={() => setDeviceState(fs.name, dev.path, 'rw')}>Set RW</Button>
+														<Button variant="secondary" size="xs" disabled={busy} onclick={() => setDeviceState(fs.name, dev.path, 'rw')}>Set RW</Button>
 													{/if}
-													<Button variant="secondary" size="xs" onclick={() => evacuateDevice(fs.name, dev.path)}>Evacuate</Button>
-													<Button variant="destructive" size="xs" onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
+													<Button variant="secondary" size="xs" disabled={busy} onclick={() => evacuateDevice(fs.name, dev.path)}>Evacuate</Button>
+													<Button variant="destructive" size="xs" disabled={busy} onclick={() => removeDevice(fs.name, dev.path)}>Remove</Button>
 												{/if}
 											{/if}
 											</div>
@@ -2421,7 +2479,7 @@
 													</span>
 												</span>
 												{#if kind === 'offline_member'}
-													<Button size="xs" class="shrink-0" onclick={() => onlineDevice(fs.name, dev.path)}>Bring online</Button>
+													<Button size="xs" class="shrink-0" disabled={!!busyDevices[dev.path]} onclick={() => onlineDevice(fs.name, dev.path)}>Bring online</Button>
 												{/if}
 											</label>
 										{/each}
@@ -2445,7 +2503,7 @@
 										</div>
 									{/if}
 									<div class="mt-2 flex items-center gap-2">
-										<Button size="xs" onclick={() => addDevice(fs.name)} disabled={!addDevicePath}>Add</Button>
+										<Button size="xs" onclick={() => addDevice(fs.name)} disabled={!addDevicePath || !!busyDevices[addDevicePath]}>Add</Button>
 										<Button variant="secondary" size="xs" onclick={() => { addDeviceFs = null; addDevicePath = ''; addDeviceLabel = ''; }}>Cancel</Button>
 										{#if availableDevicesForAdd().length > 0}
 											<span class="ml-auto text-xs text-muted-foreground">Need to wipe a disk first?</span>


### PR DESCRIPTION
Closes #479.

Kev's report: device action buttons (Evacuate in his screenshot) stay clickable while a long operation runs — nothing indicates the click landed, and hammering is possible. Two real problems under that:

1. **No in-flight state.** Action handlers fired RPCs with no per-row busy tracking, so buttons stayed live during the call.
2. **The evacuate gap.** `fs.device.evacuate` returns immediately (the engine spawns the hours-long `bcachefs device evacuate` detached) but bcachefs persists the `evacuating` device state asynchronously — so the next refresh could still show `rw` and happily re-offer the Evacuate button. Worse, each extra click **spawned another parallel `bcachefs device evacuate` process** for the same device.

## WebUI

- Per-device busy tracking (`runDeviceAction` wrapper around all eight device actions: add, remove, force-remove, evacuate, set RO/RW, offline, bring-online): while one RPC for a device is in flight, every button on that row is disabled — the ghosted row doubles as the "action received" signal Kev asked for.
- Optimistic `evacuating` display: after a successful evacuate call the row immediately renders as evacuating (badge + Remove-only actions) instead of re-offering Evacuate during the persistence gap. The marker self-clears when a refresh observes the real state, the device disappears, or after 30 s (covers an instant-finish evacuation that never shows the state).

## Engine (defense in depth)

`fs.device.evacuate` now refuses a second evacuation of the same device — an in-process set tracks the spawned child for its whole runtime (cleared on completion), and the device-state check covers resubmission after an engine restart. Double-fire from any API client, not just the WebUI, now gets a clean *"evacuation of /dev/sdX is already in progress"* instead of a second migration process.

## Not covered (pre-existing, separate concern)

`fs.device.remove` runs its data migration synchronously inside the RPC — for a data-heavy device that's its own UX problem (client timeout while the engine keeps working) and deserves the same spawn-detached treatment as evacuate in a follow-up.

`cargo fmt`/clippy/tests clean; `svelte-check` 0 errors, 144 webui tests pass, production build OK.