### PR TITLE
Subvolume: make new subvolumes permissive (0777) at creation

### DIFF
--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -907,6 +907,26 @@ impl SubvolumeService {
             .await
             .map_err(SubvolumeError::CommandFailed)?;
 
+        // New subvolumes must be writable through the sharing layer:
+        // Samba forces writes through a fixed identity (`nobody` on
+        // guest shares, the first valid user otherwise) and NFS through
+        // squashed uids — access control lives in the protocol layer,
+        // not POSIX bits, the same philosophy as the share-root chmod
+        // in nasty-sharing::smb. Without this, a subvolume created
+        // after the share stays root:0755 and every write into it is
+        // denied until the operator chmods it by hand (#482).
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Err(e) =
+                tokio::fs::set_permissions(&subvol_path, std::fs::Permissions::from_mode(0o777))
+                    .await
+            {
+                warn!(
+                    "chmod 0777 {subvol_path} failed: {e} — SMB/NFS writes into the new subvolume may be denied"
+                );
+            }
+        }
+
         // Set compression if specified
         if let Some(ref comp) = req.compression {
             info!("Setting compression={} on subvolume '{}'", comp, req.name);


### PR DESCRIPTION
Closes #482.

**Root cause** — `subvolume.create` runs `bcachefs subvolume create` as root and never touches the mode, so new subvolumes are `root:root` 0755. NASty's access-control model puts authorization in the protocol layer, not POSIX bits: Samba forces every write through a fixed identity (`force user = nobody` on guest shares, the first valid user otherwise — `smb.rs:324`) and NFS writes arrive as squashed uids. The SMB layer even enforces the permissive-filesystem philosophy already (`chmod 0777` with an explanatory comment in `write_share_conf`) — **but only on the share root, only at share create/update time**. Every subvolume created afterwards inside a shared tree stayed 0755 and was read-only over SMB/NFS until the operator chmodded it by hand. Exactly Kev's repro: "chmod 777 opens them up."

**Fix** — chmod the new subvolume to 0777 right after `bcachefs subvolume create`, matching the existing share-root behaviour and fixing SMB and NFS at once. Failure is logged loudly but non-fatal (the subvolume itself was created fine).

**Deliberately not changed**: clone-from-snapshot and clone-subvolume keep inheriting the source's permissions — copy semantics. A per-subvolume owner/mode setting is future work that dovetails with the per-user file manager (#475).

`cargo fmt` / clippy / tests clean.