### PR TITLE
Caddy: refresh withPlugins source hash for caddy 2.11.4

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2005,7 +2005,7 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-DdsEXZczcIgqazKCGebEVrDJ6jEZM1AHZkvJAPAAA9U=";
+        hash = "sha256-IHsh+QoPbsp9HIl9WBDBO03YmSNt6A6VYt/hmAnwPJo=";
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
Fixes the Integration failure on main ([run 27433794392](https://github.com/nasty-project/nasty/actions/runs/27433794392)) introduced by the weekly nixpkgs bump (#441): `pkgs.caddy` moved to 2.11.4, which changes the `caddy.withPlugins` fixed-output source derivation, so the pinned `hash` in `nixos/modules/nasty.nix` no longer matched:

```
specified: sha256-DdsEXZczcIgqazKCGebEVrDJ6jEZM1AHZkvJAPAAA9U=
   got:    sha256-IHsh+QoPbsp9HIl9WBDBO03YmSNt6A6VYt/hmAnwPJo=
```

Updated to the `got` hash, per the maintenance note documented above the plugin list. Plugin set unchanged. The Integration workflow on this PR is the verification.