### PR TITLE
Alerts: make the reconcile-stalled detection progress-based

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1105,23 +1105,15 @@ pub(crate) async fn evaluate_active_alerts(
             };
 
             let reconcile_stalled = match reconcile_result {
-                Ok(s) => {
-                    let raw = s.raw.to_lowercase();
-                    let scan_pending = raw
-                        .lines()
-                        .find(|l| l.contains("scan pending"))
-                        .and_then(|l| l.split_whitespace().last())
-                        .and_then(|n| n.parse::<u64>().ok())
-                        .unwrap_or(0)
-                        > 0;
-                    let work_pending = raw
-                        .lines()
-                        .find(|l| l.trim().starts_with("pending:"))
-                        .map(|l| l.split_whitespace().skip(1).any(|n| n != "0"))
-                        .unwrap_or(false);
-                    (scan_pending || work_pending) && !raw.contains("running")
+                // An operator-disabled reconcile is expected to sit on
+                // pending work indefinitely — never a stall (#487).
+                Ok(s) if s.enabled => {
+                    reconcile_stall_check(&fs.name, &alerts::parse_reconcile_sample(&s.raw))
                 }
-                Err(_) => false,
+                Ok(_) | Err(_) => {
+                    clear_reconcile_tracker(&fs.name);
+                    false
+                }
             };
 
             alerts::BcachefsHealth {
@@ -1219,6 +1211,47 @@ pub(crate) async fn evaluate_active_alerts(
     }
 
     active
+}
+
+/// How long reconcile must sit on *unchanged* pending counters, in a
+/// non-active state, before it counts as stalled (#487). Generous on
+/// purpose: bcachefs paces background work in throttled bursts with
+/// long `waiting` gaps, and a heavily-loaded pool can legitimately go
+/// many minutes without the counters moving.
+const RECONCILE_STALL_WINDOW: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Per-filesystem fingerprint of the last reconcile pending counters +
+/// when that fingerprint was first seen. Process-lifetime state for
+/// the stall detector; an engine restart just restarts the window.
+static RECONCILE_STALL_TRACKER: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>,
+> = std::sync::LazyLock::new(Default::default);
+
+/// Stall decision for one reconcile sample (#487): pending work exists,
+/// the thread isn't actively progressing, and the pending counters
+/// haven't changed for [`RECONCILE_STALL_WINDOW`]. Anything else —
+/// no pending work, an active state, or counters that moved — resets
+/// the window.
+fn reconcile_stall_check(fs_name: &str, sample: &nasty_system::alerts::ReconcileSample) -> bool {
+    let mut tracker = RECONCILE_STALL_TRACKER.lock().unwrap();
+    let Some(fingerprint) = sample.pending.as_ref().filter(|_| !sample.active) else {
+        tracker.remove(fs_name);
+        return false;
+    };
+    match tracker.get(fs_name) {
+        Some((prev, since)) if prev == fingerprint => since.elapsed() >= RECONCILE_STALL_WINDOW,
+        _ => {
+            tracker.insert(
+                fs_name.to_string(),
+                (fingerprint.clone(), std::time::Instant::now()),
+            );
+            false
+        }
+    }
+}
+
+fn clear_reconcile_tracker(fs_name: &str) {
+    RECONCILE_STALL_TRACKER.lock().unwrap().remove(fs_name);
 }
 
 /// Read bcachefs error counters from sysfs. Returns total read+write error count.

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -542,7 +542,7 @@ fn evaluate_rules(
                                 severity: rule.severity.clone(),
                                 metric: rule.metric.clone(),
                                 message: format!(
-                                    "Filesystem \"{}\" reconcile is stalled — background work not progressing",
+                                    "Filesystem \"{}\" reconcile looks stalled — pending background work hasn't progressed in over 30 minutes",
                                     fs.fs_name
                                 ),
                                 current_value: 1.0,
@@ -735,6 +735,60 @@ pub struct BcachefsDeviceHealth {
     pub state: String,
     /// Whether the device has IO errors reported in sysfs
     pub has_errors: bool,
+}
+
+/// One parsed `bcachefs reconcile status` snapshot, for stall tracking
+/// (#487). A single snapshot can't distinguish "stalled" from
+/// bcachefs's normal pacing — the rebalance thread sits in `waiting`
+/// with pending work between throttled bursts *by design* — so the
+/// caller compares fingerprints across samples and only declares a
+/// stall when the counters haven't moved for a full window.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReconcileSample {
+    /// Fingerprint of the pending-work counters (the raw `pending:` /
+    /// `scan pending` lines). `None` when no work is pending — nothing
+    /// to stall on.
+    pub pending: Option<String>,
+    /// The thread reported an actively-progressing state.
+    pub active: bool,
+}
+
+/// Parse the raw `bcachefs reconcile status` text into a
+/// [`ReconcileSample`]. Pure; unit-tested.
+pub fn parse_reconcile_sample(raw: &str) -> ReconcileSample {
+    let lower = raw.to_lowercase();
+    let scan_pending_line = lower.lines().find(|l| l.contains("scan pending"));
+    let scan_pending = scan_pending_line
+        .and_then(|l| l.split_whitespace().last())
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0)
+        > 0;
+    let pending_line = lower
+        .lines()
+        .find(|l| l.trim().starts_with("pending:"))
+        .map(str::trim);
+    let work_pending = pending_line
+        .map(|l| l.split_whitespace().skip(1).any(|n| n != "0"))
+        .unwrap_or(false);
+    let pending = (scan_pending || work_pending).then(|| {
+        let mut fp = String::new();
+        if let Some(l) = scan_pending_line {
+            fp.push_str(l.trim());
+            fp.push('\n');
+        }
+        if let Some(l) = pending_line {
+            fp.push_str(l);
+        }
+        fp
+    });
+    // Anything bcachefs reports as in-flight counts as progressing —
+    // the exact wording has shifted across versions, so accept all of
+    // them rather than gating on one (`running` alone flagged actively
+    // working pools as stalled, #487).
+    let active = ["running", "working", "scanning"]
+        .iter()
+        .any(|s| lower.contains(s));
+    ReconcileSample { pending, active }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1026,6 +1080,49 @@ mod tests {
     use super::*;
     use crate::SystemStats;
     use nasty_common::metrics_types::{CpuStats, MemoryStats};
+
+    // ── reconcile stall sampling (#487) ────────────────────────
+
+    #[test]
+    fn reconcile_sample_no_pending_work() {
+        let s = parse_reconcile_sample("pending: 0\nscan pending 0\nwaiting\n");
+        assert_eq!(s.pending, None);
+    }
+
+    #[test]
+    fn reconcile_sample_waiting_with_pending_is_not_active() {
+        // The over-eager case from #487: pending work + `waiting` is
+        // bcachefs's normal pacing, not (yet) a stall. The sample must
+        // carry a fingerprint so the caller can watch for progress.
+        let s = parse_reconcile_sample("pending: 12 GiB\nscan pending 0\nwaiting\n");
+        assert!(s.pending.is_some());
+        assert!(!s.active);
+    }
+
+    #[test]
+    fn reconcile_sample_working_counts_as_active() {
+        // `working`/`scanning` never matched the old `running`-only
+        // check, flagging actively-progressing pools as stalled.
+        for state in ["working", "scanning", "running"] {
+            let s = parse_reconcile_sample(&format!("pending: 12 GiB\n{state}\n"));
+            assert!(s.active, "{state} must count as active");
+        }
+    }
+
+    #[test]
+    fn reconcile_sample_fingerprint_tracks_counter_changes() {
+        let a = parse_reconcile_sample("pending: 12 GiB\nwaiting\n");
+        let b = parse_reconcile_sample("pending: 11 GiB\nwaiting\n");
+        let a2 = parse_reconcile_sample("pending: 12 GiB\nwaiting\n");
+        assert_ne!(a.pending, b.pending, "progress must change the fingerprint");
+        assert_eq!(a.pending, a2.pending, "same counters, same fingerprint");
+    }
+
+    #[test]
+    fn reconcile_sample_scan_pending_counts_as_pending() {
+        let s = parse_reconcile_sample("pending: 0\nscan pending 3\nwaiting\n");
+        assert!(s.pending.is_some());
+    }
 
     fn rule(metric: AlertMetric, condition: AlertCondition, threshold: f64) -> AlertRule {
         AlertRule {


### PR DESCRIPTION
Closes #487.

Kev asked *"under what basis does this message pop up?"* — and the basis was wrong. The detection was a **single status snapshot**: pending work present AND the raw text not containing the word `running` → "stalled". Three separate problems:

1. **bcachefs sits in `waiting` with pending work by design.** Background rebalancing is paced — throttled bursts with long waits in between. A pool grinding through a big tiering drain at its own pace (exactly Kev's setup) looks "pending + not running" most of the time.
2. **Active states don't say `running`.** bcachefs reports `working`/`scanning` while actively moving data, so even a pool mid-copy was flagged.
3. **`reconcile_enabled` was ignored** — a deliberately paused reconcile would alert forever.

## Fix

Stall detection is now **progress-based**: each snapshot is parsed into a fingerprint of the pending counters (`parse_reconcile_sample`, pure + unit-tested), and a per-filesystem tracker only declares a stall when pending work exists, the thread reports no active state (`running`/`working`/`scanning`), **and the counters haven't moved for 30 minutes**. Any progress, any active state, the work draining to zero, or the operator disabling reconcile resets the window. The alert message now states the basis: *"pending background work hasn't progressed in over 30 minutes"*.

The window is deliberately generous — a loaded pool can legitimately go minutes without counter movement; a true stall (the #467-era "why is nothing happening" case) still gets caught, just without crying wolf every evaluation cycle.

5 new unit tests covering the over-eager cases: waiting+pending is not active, working/scanning/running all count as active, fingerprints track counter changes, scan-pending counts as pending work.

288 nasty-system + 111 nasty-engine tests green, clippy clean.