### PR TITLE
Storage: zap backup GPT on wipe; quiet the free-space scan

### DIFF
--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1105,23 +1105,15 @@ pub(crate) async fn evaluate_active_alerts(
             };
 
             let reconcile_stalled = match reconcile_result {
-                Ok(s) => {
-                    let raw = s.raw.to_lowercase();
-                    let scan_pending = raw
-                        .lines()
-                        .find(|l| l.contains("scan pending"))
-                        .and_then(|l| l.split_whitespace().last())
-                        .and_then(|n| n.parse::<u64>().ok())
-                        .unwrap_or(0)
-                        > 0;
-                    let work_pending = raw
-                        .lines()
-                        .find(|l| l.trim().starts_with("pending:"))
-                        .map(|l| l.split_whitespace().skip(1).any(|n| n != "0"))
-                        .unwrap_or(false);
-                    (scan_pending || work_pending) && !raw.contains("running")
+                // An operator-disabled reconcile is expected to sit on
+                // pending work indefinitely — never a stall (#487).
+                Ok(s) if s.enabled => {
+                    reconcile_stall_check(&fs.name, &alerts::parse_reconcile_sample(&s.raw))
                 }
-                Err(_) => false,
+                Ok(_) | Err(_) => {
+                    clear_reconcile_tracker(&fs.name);
+                    false
+                }
             };
 
             alerts::BcachefsHealth {
@@ -1219,6 +1211,47 @@ pub(crate) async fn evaluate_active_alerts(
     }
 
     active
+}
+
+/// How long reconcile must sit on *unchanged* pending counters, in a
+/// non-active state, before it counts as stalled (#487). Generous on
+/// purpose: bcachefs paces background work in throttled bursts with
+/// long `waiting` gaps, and a heavily-loaded pool can legitimately go
+/// many minutes without the counters moving.
+const RECONCILE_STALL_WINDOW: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Per-filesystem fingerprint of the last reconcile pending counters +
+/// when that fingerprint was first seen. Process-lifetime state for
+/// the stall detector; an engine restart just restarts the window.
+static RECONCILE_STALL_TRACKER: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>,
+> = std::sync::LazyLock::new(Default::default);
+
+/// Stall decision for one reconcile sample (#487): pending work exists,
+/// the thread isn't actively progressing, and the pending counters
+/// haven't changed for [`RECONCILE_STALL_WINDOW`]. Anything else —
+/// no pending work, an active state, or counters that moved — resets
+/// the window.
+fn reconcile_stall_check(fs_name: &str, sample: &nasty_system::alerts::ReconcileSample) -> bool {
+    let mut tracker = RECONCILE_STALL_TRACKER.lock().unwrap();
+    let Some(fingerprint) = sample.pending.as_ref().filter(|_| !sample.active) else {
+        tracker.remove(fs_name);
+        return false;
+    };
+    match tracker.get(fs_name) {
+        Some((prev, since)) if prev == fingerprint => since.elapsed() >= RECONCILE_STALL_WINDOW,
+        _ => {
+            tracker.insert(
+                fs_name.to_string(),
+                (fingerprint.clone(), std::time::Instant::now()),
+            );
+            false
+        }
+    }
+}
+
+fn clear_reconcile_tracker(fs_name: &str) {
+    RECONCILE_STALL_TRACKER.lock().unwrap().remove(fs_name);
 }
 
 /// Read bcachefs error counters from sysfs. Returns total read+write error count.

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::cmd;
 
@@ -2290,6 +2290,13 @@ impl FilesystemService {
                     Some(format!("/dev/{base}"))
                 }
             })
+            // A disk that is itself a filesystem member (whole-disk
+            // bcachefs) can't host a new partition, and probing it with
+            // sgdisk only produces GPT lectures — the member superblock
+            // sits where a partition table would be. Partition nodes on
+            // such a disk are stale kernel state from a pre-wipe table
+            // (#488).
+            .filter(|parent| !used_devices.contains(parent))
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
             .collect();
@@ -2335,7 +2342,11 @@ impl FilesystemService {
                         });
                     }
                 }
-                Err(e) => warn!("Failed to get free space for {disk_path}: {e}"),
+                // Routine for foreign or half-wiped partition tables —
+                // the disk simply gets no free-space entry. sgdisk's
+                // multi-line GPT lecture at warn level flooded the
+                // journal on every device.list refresh (#488).
+                Err(e) => debug!("Failed to get free space for {disk_path}: {e}"),
             }
         }
 
@@ -2359,6 +2370,23 @@ impl FilesystemService {
         cmd::run_ok("wipefs", &["-a", path])
             .await
             .map_err(FilesystemError::CommandFailed)?;
+        if dev.dev_type == "disk" {
+            // wipefs erases the signatures libblkid probes for (primary
+            // GPT, protective MBR, filesystem superblocks) but NOT the
+            // backup GPT at the end of the disk. Leaving it behind makes
+            // every GPT-aware tool from then on lecture about "invalid
+            // main header, valid backup — you should repair the disk!"
+            // (#488). Zap both tables explicitly; best-effort because
+            // sgdisk exits non-zero while cleaning up exactly the
+            // half-wiped state we're fixing.
+            if let Err(e) = cmd::run_ok("sgdisk", &["--zap-all", path]).await {
+                debug!("sgdisk --zap-all {path}: {e} (expected on a half-wiped GPT)");
+            }
+            // Drop stale kernel partition nodes from the pre-wipe table
+            // so the device list (and the free-space scan) stop seeing
+            // partitions that no longer exist on disk.
+            let _ = cmd::run_ok("partprobe", &[path]).await;
+        }
         self.invalidate_list_cache().await;
         Ok(())
     }

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -542,7 +542,7 @@ fn evaluate_rules(
                                 severity: rule.severity.clone(),
                                 metric: rule.metric.clone(),
                                 message: format!(
-                                    "Filesystem \"{}\" reconcile is stalled — background work not progressing",
+                                    "Filesystem \"{}\" reconcile looks stalled — pending background work hasn't progressed in over 30 minutes",
                                     fs.fs_name
                                 ),
                                 current_value: 1.0,
@@ -735,6 +735,60 @@ pub struct BcachefsDeviceHealth {
     pub state: String,
     /// Whether the device has IO errors reported in sysfs
     pub has_errors: bool,
+}
+
+/// One parsed `bcachefs reconcile status` snapshot, for stall tracking
+/// (#487). A single snapshot can't distinguish "stalled" from
+/// bcachefs's normal pacing — the rebalance thread sits in `waiting`
+/// with pending work between throttled bursts *by design* — so the
+/// caller compares fingerprints across samples and only declares a
+/// stall when the counters haven't moved for a full window.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReconcileSample {
+    /// Fingerprint of the pending-work counters (the raw `pending:` /
+    /// `scan pending` lines). `None` when no work is pending — nothing
+    /// to stall on.
+    pub pending: Option<String>,
+    /// The thread reported an actively-progressing state.
+    pub active: bool,
+}
+
+/// Parse the raw `bcachefs reconcile status` text into a
+/// [`ReconcileSample`]. Pure; unit-tested.
+pub fn parse_reconcile_sample(raw: &str) -> ReconcileSample {
+    let lower = raw.to_lowercase();
+    let scan_pending_line = lower.lines().find(|l| l.contains("scan pending"));
+    let scan_pending = scan_pending_line
+        .and_then(|l| l.split_whitespace().last())
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0)
+        > 0;
+    let pending_line = lower
+        .lines()
+        .find(|l| l.trim().starts_with("pending:"))
+        .map(str::trim);
+    let work_pending = pending_line
+        .map(|l| l.split_whitespace().skip(1).any(|n| n != "0"))
+        .unwrap_or(false);
+    let pending = (scan_pending || work_pending).then(|| {
+        let mut fp = String::new();
+        if let Some(l) = scan_pending_line {
+            fp.push_str(l.trim());
+            fp.push('\n');
+        }
+        if let Some(l) = pending_line {
+            fp.push_str(l);
+        }
+        fp
+    });
+    // Anything bcachefs reports as in-flight counts as progressing —
+    // the exact wording has shifted across versions, so accept all of
+    // them rather than gating on one (`running` alone flagged actively
+    // working pools as stalled, #487).
+    let active = ["running", "working", "scanning"]
+        .iter()
+        .any(|s| lower.contains(s));
+    ReconcileSample { pending, active }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1026,6 +1080,49 @@ mod tests {
     use super::*;
     use crate::SystemStats;
     use nasty_common::metrics_types::{CpuStats, MemoryStats};
+
+    // ── reconcile stall sampling (#487) ────────────────────────
+
+    #[test]
+    fn reconcile_sample_no_pending_work() {
+        let s = parse_reconcile_sample("pending: 0\nscan pending 0\nwaiting\n");
+        assert_eq!(s.pending, None);
+    }
+
+    #[test]
+    fn reconcile_sample_waiting_with_pending_is_not_active() {
+        // The over-eager case from #487: pending work + `waiting` is
+        // bcachefs's normal pacing, not (yet) a stall. The sample must
+        // carry a fingerprint so the caller can watch for progress.
+        let s = parse_reconcile_sample("pending: 12 GiB\nscan pending 0\nwaiting\n");
+        assert!(s.pending.is_some());
+        assert!(!s.active);
+    }
+
+    #[test]
+    fn reconcile_sample_working_counts_as_active() {
+        // `working`/`scanning` never matched the old `running`-only
+        // check, flagging actively-progressing pools as stalled.
+        for state in ["working", "scanning", "running"] {
+            let s = parse_reconcile_sample(&format!("pending: 12 GiB\n{state}\n"));
+            assert!(s.active, "{state} must count as active");
+        }
+    }
+
+    #[test]
+    fn reconcile_sample_fingerprint_tracks_counter_changes() {
+        let a = parse_reconcile_sample("pending: 12 GiB\nwaiting\n");
+        let b = parse_reconcile_sample("pending: 11 GiB\nwaiting\n");
+        let a2 = parse_reconcile_sample("pending: 12 GiB\nwaiting\n");
+        assert_ne!(a.pending, b.pending, "progress must change the fingerprint");
+        assert_eq!(a.pending, a2.pending, "same counters, same fingerprint");
+    }
+
+    #[test]
+    fn reconcile_sample_scan_pending_counts_as_pending() {
+        let s = parse_reconcile_sample("pending: 0\nscan pending 3\nwaiting\n");
+        assert!(s.pending.is_some());
+    }
 
     fn rule(metric: AlertMetric, condition: AlertCondition, threshold: f64) -> AlertRule {
         AlertRule {


### PR DESCRIPTION
Closes #488.

**Why Kev saw this:** his four 4 TB drives were wiped with NASty's Wipe (`wipefs -a`) and added to the pool. `wipefs` erases the signatures libblkid probes for — primary GPT header, protective MBR, filesystem superblocks — **but not the backup GPT table at the end of the disk**. The disks are fine and his data is fine; but from that point on, every GPT-aware tool that looks at the disk says *"invalid main header, valid backup — you should repair the disk!"*. The tool doing the looking, repeatedly, was NASty's own free-space scan (`sgdisk --print` during `device.list`), which also logged each failure at **warn with sgdisk's full multi-line lecture embedded** — once per disk per refresh. The drives even ended up in the scan only because the kernel still held stale partition nodes from the pre-wipe table (nothing ever asked it to re-read).

Three fixes:

1. **Wipe now actually finishes the job**: `wipefs -a` is followed by `sgdisk --zap-all` (destroys primary + backup GPT + PMBR; best-effort since sgdisk exits non-zero while cleaning up exactly this half-wiped state) and a `partprobe` so stale kernel partition nodes vanish immediately. Whole disks only — partition wipes are unchanged.
2. **The free-space scan skips whole-disk filesystem members** — nothing can be partitioned on a disk whose entire surface is a bcachefs member, and probing it just generates the lecture (the superblock sits where a GPT would be).
3. **Per-disk scan failures are debug, not warn** — a foreign or garbled table is routine; the disk simply gets no free-space entry.

For disks already in Kev's half-wiped state: they're members now, so fix 2 silences them immediately; any future wipe leaves no backup table behind.

`cargo fmt`/clippy/tests clean (72 nasty-storage tests).