### PR TITLE
Filesystems: compression levels for zstd/gzip

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1215,6 +1215,14 @@ impl FilesystemService {
             return Err(FilesystemError::NoDevices);
         }
 
+        // Reject a malformed compression spec before formatting — the
+        // string is interpolated straight into `bcachefs format
+        // --compression=…`, and a bad level there fails the format with
+        // an opaque error after we've already started touching disk.
+        if let Some(ref comp) = req.compression {
+            validate_compression(comp).map_err(FilesystemError::InvalidInput)?;
+        }
+
         // Upfront validation of `bind_to_tpm`. Fails the request before
         // touching disk when prerequisites aren't met, so the operator
         // doesn't end up with a half-baked FS (formatted but never
@@ -1945,6 +1953,16 @@ impl FilesystemService {
                 "filesystem must be mounted to update options".to_string(),
             ));
         }
+        // Validate compression specs up front so a typo in the level
+        // can't leave foreground set and background rejected halfway
+        // through the sysfs writes below.
+        for spec in [&req.compression, &req.background_compression]
+            .into_iter()
+            .flatten()
+        {
+            validate_compression(spec).map_err(FilesystemError::InvalidInput)?;
+        }
+
         let uuid = &fs.uuid;
         let base = format!("/sys/fs/bcachefs/{uuid}/options");
 
@@ -3295,6 +3313,46 @@ fn extract_first_bytes(line: &str) -> Option<u64> {
     let after_colon = line.split_once(':')?.1.trim();
     let token = after_colon.split_whitespace().next()?;
     parse_human_bytes(token)
+}
+
+/// Validate a bcachefs compression spec before it's interpolated into
+/// `bcachefs format --compression=…` or written to the sysfs
+/// `compression` / `background_compression` option (#491).
+///
+/// Accepts `none`, or `lz4` / `zstd` / `gzip` optionally followed by
+/// `:<level>`. Levels are bounded to the algorithm's real range so a
+/// typo gets a clear message instead of an opaque format/sysfs error:
+/// zstd 1–22, gzip 1–9. lz4 has no tunable level in bcachefs, so a
+/// level on lz4 (or none) is rejected. Pure; unit-tested.
+fn validate_compression(spec: &str) -> Result<(), String> {
+    let spec = spec.trim();
+    if spec.is_empty() || spec == "none" {
+        return Ok(());
+    }
+    let (algo, level) = match spec.split_once(':') {
+        Some((a, l)) => (a, Some(l)),
+        None => (spec, None),
+    };
+    let max_level = match algo {
+        "lz4" => None, // valid algorithm, but no level knob
+        "zstd" => Some(22u32),
+        "gzip" => Some(9u32),
+        other => return Err(format!("unknown compression algorithm '{other}'")),
+    };
+    if let Some(level) = level {
+        let Some(max) = max_level else {
+            return Err(format!("{algo} does not take a compression level"));
+        };
+        let n: u32 = level
+            .parse()
+            .map_err(|_| format!("compression level '{level}' is not a number"))?;
+        if n < 1 || n > max {
+            return Err(format!(
+                "{algo} compression level must be between 1 and {max} (got {n})"
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Parse human-readable byte strings like "109.8M", "2.3G", "512K", "1024".
@@ -5414,6 +5472,42 @@ mod tests {
         // `bcachefs show-super` prints "Superblock size: 7.85k/1.00M" — the
         // slash form isn't a unit and shouldn't parse.
         assert_eq!(parse_human_bytes("7.85k/1.00M"), None);
+    }
+
+    // ── validate_compression (#491) ────────────────────────────────
+
+    #[test]
+    fn validate_compression_accepts_bare_algorithms_and_none() {
+        for s in ["none", "", "lz4", "zstd", "gzip", "  zstd  "] {
+            assert!(validate_compression(s).is_ok(), "should accept {s:?}");
+        }
+    }
+
+    #[test]
+    fn validate_compression_accepts_levels_in_range() {
+        for s in ["zstd:1", "zstd:15", "zstd:22", "gzip:1", "gzip:9"] {
+            assert!(validate_compression(s).is_ok(), "should accept {s:?}");
+        }
+    }
+
+    #[test]
+    fn validate_compression_rejects_out_of_range_levels() {
+        assert!(validate_compression("zstd:0").is_err());
+        assert!(validate_compression("zstd:23").is_err());
+        assert!(validate_compression("gzip:10").is_err());
+    }
+
+    #[test]
+    fn validate_compression_rejects_level_on_lz4() {
+        // bcachefs lz4 has no tunable level.
+        assert!(validate_compression("lz4:5").is_err());
+    }
+
+    #[test]
+    fn validate_compression_rejects_unknown_algo_and_garbage() {
+        assert!(validate_compression("snappy").is_err());
+        assert!(validate_compression("zstd:high").is_err());
+        assert!(validate_compression("zstd:").is_err());
     }
 
     // ── parse_device_table_line ────────────────────────────────────

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -58,6 +58,7 @@
 	let wizardProfile: TieringProfileId = $state('single');
 	let replicas = $state(1);
 	let compression = $state('');
+	let compressionLevel = $state('');
 	let showPartitions = $state(false);
 	let erasureCode = $state(false);
 	let versionUpgrade = $state('');
@@ -87,7 +88,9 @@
 	let expandedFs: string | null = $state(null);
 	let editOptionsFs: string | null = $state(null);
 	let editCompression = $state('');
+	let editCompressionLevel = $state('');
 	let editBgCompression = $state('');
+	let editBgCompressionLevel = $state('');
 	// bcachefs tiering targets (#434) — each points at a device label.
 	let editForegroundTarget = $state('');
 	let editBackgroundTarget = $state('');
@@ -594,7 +597,10 @@
 		const args = ['bcachefs', 'format'];
 
 		if (replicas > 1) args.push(`--replicas=${replicas}`);
-		if (compression) args.push(`--compression=${compression}`);
+		{
+			const comp = combineCompression(compression, compressionLevel);
+			if (comp) args.push(`--compression=${comp}`);
+		}
 		if (profile.foreground_target) args.push(`--foreground_target=${profile.foreground_target}`);
 		if (profile.metadata_target) args.push(`--metadata_target=${profile.metadata_target}`);
 		if (profile.background_target) args.push(`--background_target=${profile.background_target}`);
@@ -670,7 +676,7 @@
 					label: profile.device_labels[path] || undefined,
 				})),
 				replicas,
-				compression: compression || undefined,
+				compression: combineCompression(compression, compressionLevel) || undefined,
 				foreground_target: profile.foreground_target || undefined,
 				metadata_target: profile.metadata_target || undefined,
 				background_target: profile.background_target || undefined,
@@ -727,6 +733,7 @@
 		wizardProfile = 'single';
 		replicas = 1;
 		compression = '';
+		compressionLevel = '';
 		// Auto-show partitions if no full disks are available
 		const hasFullDisks = devices.some(d => !d.in_use && d.dev_type !== 'part');
 		showPartitions = !hasFullDisks;
@@ -933,8 +940,8 @@
 			return;
 		}
 		editOptionsFs = fs.name;
-		editCompression = fs.options.compression ?? '';
-		editBgCompression = fs.options.background_compression ?? '';
+		({ algo: editCompression, level: editCompressionLevel } = splitCompression(fs.options.compression));
+		({ algo: editBgCompression, level: editBgCompressionLevel } = splitCompression(fs.options.background_compression));
 		editForegroundTarget = fs.options.foreground_target ?? '';
 		editBackgroundTarget = fs.options.background_target ?? '';
 		editMetadataTarget = fs.options.metadata_target ?? '';
@@ -1008,8 +1015,8 @@
 		await withToast(
 			() => client.call('fs.options.update', {
 				name: fsName,
-				compression: editCompression || 'none',
-				background_compression: editBgCompression || 'none',
+				compression: combineCompression(editCompression, editCompressionLevel) || 'none',
+				background_compression: combineCompression(editBgCompression, editBgCompressionLevel) || 'none',
 				foreground_target: editForegroundTarget || 'none',
 				background_target: editBackgroundTarget || 'none',
 				metadata_target: editMetadataTarget || 'none',
@@ -1081,6 +1088,25 @@
 
 	function availableDevices(): BlockDevice[] {
 		return devices.filter(d => !d.in_use && (showPartitions || d.dev_type !== 'part'));
+	}
+
+	// ── Compression algorithm:level helpers (#491) ──
+	// bcachefs accepts `<algo>:<level>` — a quick level on ingress
+	// (foreground) and a deeper level for background recompression.
+	// Only zstd and gzip have a level knob; lz4 doesn't.
+	function compressionMaxLevel(algo: string): number | null {
+		return algo === 'zstd' ? 22 : algo === 'gzip' ? 9 : null;
+	}
+	/** Split a stored spec ("zstd:15") into its algorithm and level. */
+	function splitCompression(spec: string | null | undefined): { algo: string; level: string } {
+		if (!spec || spec === 'none') return { algo: '', level: '' };
+		const [algo, level] = spec.split(':');
+		return { algo, level: level ?? '' };
+	}
+	/** Combine an algorithm + level back into a spec the engine accepts. */
+	function combineCompression(algo: string, level: string): string {
+		if (!algo) return '';
+		return level && compressionMaxLevel(algo) !== null ? `${algo}:${level}` : algo;
 	}
 
 	/** Distinct device labels in a filesystem — the candidate tiering
@@ -1561,13 +1587,23 @@
 					</div>
 					<div>
 						<Label for="compression">Compression</Label>
-						<select id="compression" bind:value={compression}
-							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
-							<option value="">None</option>
-							<option value="lz4">LZ4</option>
-							<option value="zstd">Zstd</option>
-							<option value="gzip">Gzip</option>
-						</select>
+						<div class="mt-1 flex gap-2">
+							<select id="compression" bind:value={compression}
+								onchange={() => compressionLevel = ''}
+								class="h-9 flex-1 rounded-md border border-input bg-transparent px-3 text-sm">
+								<option value="">None</option>
+								<option value="lz4">LZ4</option>
+								<option value="zstd">Zstd</option>
+								<option value="gzip">Gzip</option>
+							</select>
+							{#if compressionMaxLevel(compression) !== null}
+								<input type="number" bind:value={compressionLevel}
+									min="1" max={compressionMaxLevel(compression)}
+									placeholder="level"
+									title="Optional {compression} level (1–{compressionMaxLevel(compression)}). Leave blank for the default."
+									class="h-9 w-24 rounded-md border border-input bg-transparent px-3 text-sm" />
+							{/if}
+						</div>
 					</div>
 				</div>
 
@@ -2029,21 +2065,31 @@
 							<div class="grid grid-cols-2 gap-3">
 								<div>
 									<label for="edit-compression-{fs.name}" class="mb-1 block text-xs text-muted-foreground">Foreground</label>
-									<select id="edit-compression-{fs.name}" bind:value={editCompression} class="h-8 w-full rounded-md border border-input bg-transparent px-2 text-sm">
-										<option value="">None</option>
-										<option value="lz4">LZ4</option>
-										<option value="zstd">Zstd</option>
-										<option value="gzip">Gzip</option>
-									</select>
+									<div class="flex gap-2">
+										<select id="edit-compression-{fs.name}" bind:value={editCompression} onchange={() => editCompressionLevel = ''} class="h-8 flex-1 rounded-md border border-input bg-transparent px-2 text-sm">
+											<option value="">None</option>
+											<option value="lz4">LZ4</option>
+											<option value="zstd">Zstd</option>
+											<option value="gzip">Gzip</option>
+										</select>
+										{#if compressionMaxLevel(editCompression) !== null}
+											<input type="number" bind:value={editCompressionLevel} min="1" max={compressionMaxLevel(editCompression)} placeholder="lvl" title="Optional {editCompression} level (1–{compressionMaxLevel(editCompression)}). Blank = default." class="h-8 w-16 rounded-md border border-input bg-transparent px-2 text-sm" />
+										{/if}
+									</div>
 								</div>
 								<div>
 									<label for="edit-bg-compression-{fs.name}" class="mb-1 block text-xs text-muted-foreground">Background</label>
-									<select id="edit-bg-compression-{fs.name}" bind:value={editBgCompression} class="h-8 w-full rounded-md border border-input bg-transparent px-2 text-sm">
-										<option value="">None</option>
-										<option value="lz4">LZ4</option>
-										<option value="zstd">Zstd</option>
-										<option value="gzip">Gzip</option>
-									</select>
+									<div class="flex gap-2">
+										<select id="edit-bg-compression-{fs.name}" bind:value={editBgCompression} onchange={() => editBgCompressionLevel = ''} class="h-8 flex-1 rounded-md border border-input bg-transparent px-2 text-sm">
+											<option value="">None</option>
+											<option value="lz4">LZ4</option>
+											<option value="zstd">Zstd</option>
+											<option value="gzip">Gzip</option>
+										</select>
+										{#if compressionMaxLevel(editBgCompression) !== null}
+											<input type="number" bind:value={editBgCompressionLevel} min="1" max={compressionMaxLevel(editBgCompression)} placeholder="lvl" title="Optional {editBgCompression} level (1–{compressionMaxLevel(editBgCompression)}). Blank = default." class="h-8 w-16 rounded-md border border-input bg-transparent px-2 text-sm" />
+										{/if}
+									</div>
 								</div>
 							</div>
 						</fieldset>


### PR DESCRIPTION
Closes #491.

bcachefs accepts compression as `<algo>:<level>` — and as Kev noted from the bcachefs docs, the useful pattern is a *quick* level on ingress (foreground) and a *deeper* level for the background recompression pass. NASty's UI only ever sent the bare algorithm (`zstd`), so the level always fell back to the library default and there was no way to tune it.

## WebUI

A compact level input appears beside the compression algorithm selector — in the **create wizard** and in **edit-options** for both **foreground** and **background** — and only when the selected algorithm actually has a level knob (zstd 1–22, gzip 1–9; lz4 has none, so no input shows). The stored spec round-trips cleanly: `zstd:15` is split into algorithm + level on load and recombined on save. Switching algorithm clears a stale level.

## Engine

`bcachefs format --compression=…` and the sysfs `compression`/`background_compression` options both already accepted the `:level` syntax verbatim — but nothing validated it, and the create path *touches disk before* the format runs. Added `validate_compression`: accepts `none` / `lz4` / `zstd[:1-22]` / `gzip[:1-9]`, rejects out-of-range levels, a level on lz4, and unknown algorithms. Called at create (before formatting) and in set-options (before any sysfs write, so a typo in the background level can't leave foreground applied and background rejected halfway through). 5 new unit tests.

`cargo fmt`/clippy/tests clean (77 nasty-storage tests); `svelte-check` 0 errors, 144 webui tests, production build OK.