### PR TITLE
deps: routine in-range refresh (chrono, webui patch/minor)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-Sa7qk897tXfIUR87E6/aD8bbUo/my8CAfOIkitULN9s=";
+      npmDepsHash = "sha256-NxfqqvilXLmXavV/zEKa84L4QJOji6MHMUi4TqVIpXw=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -45,9 +45,9 @@
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
-			"version": "6.20.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
-			"integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+			"version": "6.20.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+			"integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -108,9 +108,9 @@
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.9.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
-			"integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+			"integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -151,9 +151,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
-			"integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+			"version": "6.43.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
+			"integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.6.0",
@@ -395,9 +395,9 @@
 			}
 		},
 		"node_modules/@lucide/svelte": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.17.0.tgz",
-			"integrity": "sha512-q06YCFBN5CO8cd1ADmLCxWRVMVb7xxvHzqC0lvNoxGa+FLW6Cd1Y1AOxgbQk4Iwe68vkAMCRveNHint4WoaVKg==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.18.0.tgz",
+			"integrity": "sha512-S1cjiJflMLIirDZtZ8ou2Vy0xMrOqEQzYzDo29AUxoJiOjUfMHUeClvprJsGUEr60RYDJzEgkjSkWm1nlN9iyQ==",
 			"dev": true,
 			"license": "ISC",
 			"peerDependencies": {
@@ -411,14 +411,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -768,9 +768,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.63.0.tgz",
-			"integrity": "sha512-1DrR7vQ9brXLrNE2sLtFXApwr7AUXPfpbIFYc+CQRf2+iURaZbXGU+7TG/RLr+9fdFkoRdyCAVUOHCChw11LFA==",
+			"version": "2.65.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.65.0.tgz",
+			"integrity": "sha512-nUWJ4dSKNo8mIOh+HTL+XyRj8FX9Dyb1ayBxj4q9+WrTJfn4jfTt21p3WUFTnnmdnt9xAXpBKLQ+H9y41x0X7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -850,49 +850,49 @@
 			}
 		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-			"integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+			"integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
-				"enhanced-resolve": "^5.21.0",
-				"jiti": "^2.6.1",
+				"enhanced-resolve": "5.21.6",
+				"jiti": "^2.7.0",
 				"lightningcss": "1.32.0",
 				"magic-string": "^0.30.21",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.3.0"
+				"tailwindcss": "4.3.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-			"integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+			"integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.3.0",
-				"@tailwindcss/oxide-darwin-arm64": "4.3.0",
-				"@tailwindcss/oxide-darwin-x64": "4.3.0",
-				"@tailwindcss/oxide-freebsd-x64": "4.3.0",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-				"@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-				"@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+				"@tailwindcss/oxide-android-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-x64": "4.3.1",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.1",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-			"integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+			"integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -907,9 +907,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-			"integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+			"integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
 			"cpu": [
 				"arm64"
 			],
@@ -924,9 +924,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-			"integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+			"integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
 			"cpu": [
 				"x64"
 			],
@@ -941,9 +941,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-			"integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+			"integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
 			"cpu": [
 				"x64"
 			],
@@ -958,9 +958,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-			"integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+			"integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
 			"cpu": [
 				"arm"
 			],
@@ -975,9 +975,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-			"integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+			"integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -995,9 +995,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-			"integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+			"integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1015,9 +1015,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-			"integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+			"integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
 			"cpu": [
 				"x64"
 			],
@@ -1035,9 +1035,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-			"integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+			"integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1055,9 +1055,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-			"integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+			"integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -1077,7 +1077,7 @@
 				"@emnapi/runtime": "^1.10.0",
 				"@emnapi/wasi-threads": "^1.2.1",
 				"@napi-rs/wasm-runtime": "^1.1.4",
-				"@tybys/wasm-util": "^0.10.1",
+				"@tybys/wasm-util": "^0.10.2",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -1085,9 +1085,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-			"integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+			"integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1102,9 +1102,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-			"integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+			"integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
 			"cpu": [
 				"x64"
 			],
@@ -1119,15 +1119,15 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-			"integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+			"integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.3.0",
-				"@tailwindcss/oxide": "4.3.0",
-				"tailwindcss": "4.3.0"
+				"@tailwindcss/node": "4.3.1",
+				"@tailwindcss/oxide": "4.3.1",
+				"tailwindcss": "4.3.1"
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -1177,9 +1177,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+			"version": "25.9.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1328,9 +1328,9 @@
 			]
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1859,9 +1859,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-			"integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+			"version": "5.21.6",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2460,15 +2460,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -2703,9 +2706,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.2",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.2.tgz",
-			"integrity": "sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==",
+			"version": "5.56.3",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
+			"integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2815,9 +2818,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-			"integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+			"integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
 			"dev": true,
 			"license": "MIT"
 		},


### PR DESCRIPTION
Zero-risk dependency housekeeping — no source or API changes, just pulling current patch/minor releases within existing version ranges.

## Rust
- `chrono` 0.4.44 → 0.4.45 (patch). Workspace builds clean.

## webui
`npm update` within the existing `package.json` semver ranges — `package.json` itself is unchanged, only `package-lock.json` moved:
- `@sveltejs/kit` 2.63 → 2.65
- `svelte` 5.56.2 → 5.56.3
- `tailwindcss` + `@tailwindcss/vite` 4.3.0 → 4.3.1
- `@codemirror/lint` + `@codemirror/view`, `@lucide/svelte` 1.17 → 1.18, `@types/node`

`flake.nix` `npmDepsHash` regenerated for the new lockfile (via `prefetch-npm-deps`) so the Nix build and CI's npmDepsHash-freshness check pass.

## Deliberately left alone
- `layerchart` — intentionally on the `2.0.0-next` prerelease (npm compares it against the 1.x stable channel).
- `rustic_backend` / `rustic_core` — separate concern, handled in #493 / tracked by #386.
- `bcrypt` 0.17→0.19, `rand` 0.9→0.10 — breaking 0.x bumps that need a small `rest_server.rs` review; worth their own reviewed PR, not folded into a mechanical refresh.

`svelte-check` 0 errors, 144 webui tests, production build OK; engine workspace builds.