### PR TITLE
deps: bump rustic_core to 0.12

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -676,14 +676,13 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cached"
-version = "0.59.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b6f5d101f0f6322c8646a45b7c581a673e476329040d97565815c2461dd0c4"
+checksum = "4863037a22757575c62f4f52c71bc833c7989c696c35eda5c83a4f36599b2bbd"
 dependencies = [
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.16.1",
- "once_cell",
  "parking_lot",
  "thiserror 2.0.18",
  "web-time",
@@ -691,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.27.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebcf9c75f17a17d55d11afc98e46167d4790a263f428891b8705ab2f793eca3"
+checksum = "8b7a89b3ceb2f9166826b0d21b670a8720dbaeb3397428d1c7603e0ffacdfd37"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -703,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro_types"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cachedir"
@@ -796,6 +795,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer 0.12.0",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "ecow"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+checksum = "62bac48c16a993694c703f2991527d422d9efb8ec5625756004ba30e97683720"
 
 [[package]]
 name = "ed25519"
@@ -4024,6 +4024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,8 +4163,8 @@ dependencies = [
  "aes",
  "cbc",
  "der",
- "pbkdf2",
- "scrypt",
+ "pbkdf2 0.12.2",
+ "scrypt 0.11.0",
  "sha2 0.10.9",
  "spki",
 ]
@@ -4978,9 +4988,9 @@ checksum = "fbcebf2228827bc4b61cb54dfd84cf43aacf06ca2dfe4c014b136a0e32b876e2"
 
 [[package]]
 name = "rustic_core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00462e6166e20b6870f85b59728caa8756ec4b078b330769d41ed7c928785164"
+checksum = "d44b5077fe2f68a056bfac60255e661e84175ac5b138f3c5601e91fa2903d3e5"
 dependencies = [
  "aes256ctr_poly1305aes",
  "backon",
@@ -5014,14 +5024,15 @@ dependencies = [
  "rayon",
  "runtime-format",
  "rustic_cdc",
- "scrypt",
+ "scrypt 0.12.0",
  "serde",
  "serde-aux",
  "serde_derive",
  "serde_json",
  "serde_with",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "shell-words",
+ "smallvec",
  "strum",
  "thiserror 2.0.18",
  "walkdir",
@@ -5150,6 +5161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,10 +5237,21 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
+ "pbkdf2 0.12.2",
+ "salsa20 0.10.2",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0",
+ "salsa20 0.11.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -5486,7 +5518,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
- "sha2-asm",
 ]
 
 [[package]]
@@ -5498,15 +5529,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/engine/nasty-backup/Cargo.toml
+++ b/engine/nasty-backup/Cargo.toml
@@ -16,7 +16,7 @@ schemars.workspace = true
 uuid.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cron = "0.16"
-rustic_core = "0.11"
+rustic_core = "0.12"
 rustic_backend = "0.6"
 jiff = "0.2"
 url = "2"


### PR DESCRIPTION
Follow-up to #493. You were right to push on this — with the async-std advisory suppressed, rustic_core 0.12 is effectively unblocked, and it turns out **source-compatible** (my earlier deferral was an untested assumption).

## API compatibility
nasty-backup imports a broad rustic_core surface — `BackupOptions`, `CheckOptions`, `ConfigOptions`, `Credentials`, `ForgetGroups`, `Grouped`, `KeepOptions`, `KeyOptions`, `PathList`, `Repository`, `RepositoryOptions`, `SnapshotGroupCriterion`, `SnapshotOptions`, `repofile::SnapshotFile` — and it all compiles unchanged against 0.12.0. No source edits needed.

## Behavioral risk: none for us
0.12.0's [changelog](https://github.com/rustic-rs/rustic_core/blob/main/crates/core/CHANGELOG.md) has exactly one `[**breaking**]` item — rustic-rs/rustic_core#493, scoping the **restore** destination scan to snapshot-relevant paths. nasty-backup does backup / check / forget only and never invokes restore (verified — the only "restore" in the crate is a serde round-trip test), so it's a no-op for us. The rest of 0.12 is additive (#518 generic ReadSource) or internal (smallvec, parallel dump). No repo on-disk format change — existing backup repositories stay readable.

## Verification
`cargo fmt` / clippy / full workspace tests clean; 46 nasty-backup tests pass; workspace builds.

This closes out the rustic dependency chain — #386 stays open only as the tracker for eventually removing the async-std suppression (independent of these version bumps).