### PR TITLE
update: fresh-install wrapper inherits bcachefs-tools ref from nasty's flake.nix

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1972,17 +1972,51 @@ pub async fn bootstrap_system_flake_from_template_path(
     bootstrap_system_flake_from_template(&template, dest_dir, nasty_version, local_system).await
 }
 
+/// Render a fresh-install wrapper flake from `template`, then inject the
+/// canonical bcachefs-tools ref read from nasty's own `flake.nix`
+/// (`embedded_default_bcachefs_tools_ref`) so the install inherits
+/// exactly the version the running system ships — single source of
+/// truth, no second pin to keep in sync.
+///
+/// The template carries a hardcoded bcachefs-tools ref too, but only as
+/// a self-consistent fallback for the (test-caught, should-never-happen)
+/// case where the embedded flake.nix can't be parsed; on the happy path
+/// this rewrite overrides it. The rewrite lives here, not in the
+/// renderer, to preserve the v0.0.8 invariant that the template grows no
+/// new `@PLACEHOLDER@` — same rewrite-after-render pattern the migration
+/// and tagged-release paths use. Pure (sync) so the inheritance is
+/// directly unit-testable without disk I/O.
+fn render_bootstrap_wrapper(
+    template: &str,
+    nasty_version: &str,
+    local_system: &str,
+) -> Result<String, UpdateError> {
+    let rendered = render_system_flake_template(template, nasty_version, local_system)?;
+    match embedded_default_bcachefs_tools_ref() {
+        Ok(bcachefs_ref) => rewrite_flake_input_urls(
+            &rendered,
+            &HashMap::from([(
+                String::from("bcachefs-tools"),
+                format!("github:koverstreet/bcachefs-tools/{bcachefs_ref}"),
+            )]),
+        ),
+        Err(e) => {
+            warn!(
+                "could not resolve canonical bcachefs-tools ref from embedded flake.nix \
+                 ({e}); bootstrapping wrapper with the template's hardcoded fallback"
+            );
+            Ok(rendered)
+        }
+    }
+}
+
 pub async fn bootstrap_system_flake_from_template(
     template: &str,
     dest_dir: &str,
     nasty_version: &str,
     local_system: &str,
 ) -> Result<BootstrapSystemFlakeResult, UpdateError> {
-    // Template carries a hardcoded bcachefs-tools URL default; no
-    // per-render substitution needed here. Caller can mutate the
-    // bcachefs ref later via `rewrite_flake_input_urls` if they
-    // need a non-default pin (the tagged-release path does this).
-    let rendered = render_system_flake_template(template, nasty_version, local_system)?;
+    let rendered = render_bootstrap_wrapper(template, nasty_version, local_system)?;
     tokio::fs::create_dir_all(dest_dir)
         .await
         .map_err(|e| UpdateError::CommandFailed(format!("mkdir {dest_dir}: {e}")))?;
@@ -3407,6 +3441,41 @@ outputs = { nixpkgs, nasty, ... }: {
         let rendered2 = super::render_system_flake_template(&template, "0.0.3", "x86_64-linux")
             .expect("rendered");
         assert_eq!(rendered, rendered2);
+    }
+
+    #[test]
+    fn bootstrap_wrapper_inherits_canonical_bcachefs_ref() {
+        // A fresh install must pin the bcachefs-tools the running system
+        // ships, inherited from nasty's flake.nix — not whatever stale
+        // ref the template happens to hardcode. Give the template a
+        // deliberately-wrong ref and assert render_bootstrap_wrapper
+        // overrides it to the canonical embedded one. Guards against the
+        // v0.0.11 ISO regression where the wrapper pinned v1.38.3 while
+        // the box ran v1.38.5. (Comparing against the function, not a
+        // literal, keeps this correct across future bumps.)
+        let template = r#"{
+  inputs = {
+    nixpkgs.follows = "nasty/nixpkgs";
+    nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v9.9.9-stale";
+  };
+  wrapperFlakeVersion = "@WRAPPER_FLAKE_VERSION@";
+  outputs = { self, nixpkgs, nasty, ... }: {
+    nixosConfigurations.nasty = nixpkgs.lib.nixosSystem { system = "@LOCAL_SYSTEM@"; };
+  };
+}"#;
+        let canonical =
+            super::embedded_default_bcachefs_tools_ref().expect("embedded flake.nix parses");
+        let rendered =
+            super::render_bootstrap_wrapper(template, "0.0.3", "x86_64-linux").expect("rendered");
+        assert!(
+            rendered.contains(&format!("github:koverstreet/bcachefs-tools/{canonical}")),
+            "wrapper should inherit the canonical bcachefs ref {canonical}; got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("v9.9.9-stale"),
+            "the template's stale ref must be overridden"
+        );
     }
 
     #[test]

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -59,7 +59,15 @@
     # aged out of the fleet (likely never matters again after a
     # tagged release everyone has updated past), this shim can be
     # removed safely.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    # FALLBACK ONLY — the engine normally overrides this. At render time
+    # `bootstrap_system_flake_from_template` rewrites this line to the
+    # canonical bcachefs-tools ref read from nasty's own flake.nix
+    # (`embedded_default_bcachefs_tools_ref`), so a fresh install always
+    # inherits exactly the version the running system ships — one source
+    # of truth, no second pin to bump. This hardcoded value is used only
+    # if that embedded flake.nix can't be parsed; keep it sane (matching
+    # the repo-root flake.nix) so even that fallback is correct.
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.5";
 
     # NOTE: lanzaboote is intentionally NOT declared as a top-level
     # input here. Secure Boot is per-box opt-in: when the operator


### PR DESCRIPTION
## The bug (spotted on a fresh v0.0.11 install)

The Update page showed `bcachefs-tools` **locked to v1.38.3** while the box actually ran **v1.38.5** — a fresh install pinned a stale bcachefs-tools in its wrapper flake.

**Root cause:** the installer template (`nixos/system-flake/flake.nix.template`) hardcodes its *own* `bcachefs-tools.url`, separate from the repo-root `flake.nix`. The version bumps (#460 → 1.38.4, #470 → 1.38.5) updated the root flake but left the template at v1.38.3. The migration and tagged-release render paths rewrite the bcachefs ref after rendering, but the **fresh-install bootstrap path didn't** — it shipped the template's literal verbatim.

> Why CI didn't catch it: the `installer-flake-template` job asserts the template's bcachefs-tools is a *hardcoded semver* (no `follows`, no `@PLACEHOLDER@` — both deliberately forbidden for backward-compat reasons). It never checked the ref *matched* the root flake, so a forgotten template bump sailed through.

## The fix — inherit from one place

Rather than add a second pin to keep in sync, the bootstrap now **inherits** the ref. `render_bootstrap_wrapper` (new sync helper) renders the template, then injects the canonical ref read from nasty's *own* embedded `flake.nix` (`embedded_default_bcachefs_tools_ref`) via the same post-render `rewrite_flake_input_urls` pass the migration/upgrade paths already use. So:

- **Single source of truth** = the repo-root `flake.nix`. Bump it (as #460/#470 did), and every fresh install inherits the new ref automatically — no template edit needed.
- The template's hardcoded ref is now a **documented fallback**, used only if the embedded flake.nix can't be parsed (a case the existing tests catch before any binary ships). Bumped to v1.38.5 so even that fallback is correct.
- The renderer grows **no new placeholder**, preserving the v0.0.8 invariant (old engines silently ship unknown `@FOO@` literals — that's why substitution can't go in the renderer).

## Guard — "only if something went wrong"

No cosmetic file-equality CI check (that would just re-enforce the duplication this removes). Instead a unit test feeds a deliberately-stale template ref and asserts the bootstrap overrides it to the canonical embedded ref — it fails only if the inheritance logic genuinely breaks. Compares against `embedded_default_bcachefs_tools_ref()`, not a literal, so it stays correct across future bumps.

`cargo fmt` / clippy / full workspace tests clean (289 nasty-system tests incl. the new one).

Closes the v0.0.11 ISO drift; existing installs are unaffected (their wrapper already has whatever ref they pinned; migrations preserve it).