### PR TITLE
discovery: rebind avahi/wsdd on SMB enable and hostname change

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -1714,7 +1714,16 @@ async fn apply_config(
     Ok(outcome)
 }
 
-async fn rebind_discovery_daemons() {
+/// Restart the LAN-discovery daemons (`samba-wsdd`, `avahi-daemon`) that
+/// are currently active, so they re-announce on the box's present
+/// interface/IP set. Called after a network apply (the daemons strand on
+/// the pre-change interface set, #270) and after the SMB protocol is
+/// enabled (a freshly-started `samba-wsdd` can lose its startup
+/// WS-Discovery Hello before multicast membership settles, leaving the
+/// box invisible to Windows Explorer until a reboot, #291). Best-effort;
+/// only touches daemons already running so it never starts one a
+/// protocol toggle left off.
+pub(crate) async fn rebind_discovery_daemons() {
     for unit in ["samba-wsdd.service", "avahi-daemon.service"] {
         let is_active = tokio::process::Command::new("systemctl")
             .args(["is-active", "--quiet", unit])

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -368,6 +368,18 @@ impl ProtocolService {
             started.push(*svc);
         }
 
+        // Enabling SMB just started samba-wsdd (Windows WS-Discovery) and
+        // smbd, but avahi-daemon has been running since boot announcing
+        // its pre-SMB state, and a cold wsdd can miss its first multicast
+        // Hello before IGMP membership settles. Rebind both onto the
+        // current network so the box is discoverable from Windows
+        // Explorer immediately, instead of only after a reboot (#291).
+        // Same remedy the network-apply path uses; restarts only the
+        // daemons already active.
+        if proto == Protocol::Smb {
+            crate::network::rebind_discovery_daemons().await;
+        }
+
         let running = is_protocol_running(proto).await;
         Ok(ProtocolStatus {
             name: proto.name().to_string(),

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -629,6 +629,14 @@ impl SettingsService {
         if let Some(name) = update.hostname {
             apply_hostname(&name).await?;
             settings.hostname = Some(name);
+            // avahi-daemon and samba-wsdd announce the *old* hostname
+            // until restarted — they don't pick up the live kernel
+            // hostname change, so the box vanishes from file-manager
+            // network views (announced under a name that no longer
+            // resolves) until a reboot. Rebind them onto the new name
+            // now. Same remedy the network-apply and SMB-enable paths
+            // use; restarts only daemons already active (#291).
+            crate::network::rebind_discovery_daemons().await;
         }
         if let Some(h24) = update.clock_24h {
             settings.clock_24h = h24;


### PR DESCRIPTION
Closes the discovery regression in #291 ([comment](https://github.com/nasty-project/nasty/issues/291#issuecomment-4699455934)).

## Symptoms (fresh v0.0.11)
1. Create a volume + SMB share → NASty doesn't appear in the Windows file-manager network view until the server is restarted.
2. Rename the host (e.g. `nasty` → `tasty`) → the box disappears from **every** network view until reboot.

## Diagnosis (verified on a live box)
The LAN-discovery daemons capture state at start and don't react to later changes:

- **avahi-daemon** runs from boot and advertises `_smb._tcp` correctly — so **mac/Linux clients are fine**. But it does **not** pick up a live kernel-hostname change: after writing a new `/proc/sys/kernel/hostname`, `avahi-browse` still showed the *old* name until I restarted avahi. That's symptom #2.
- **samba-wsdd** (what **Windows** Explorer queries) only runs while the SMB protocol is enabled. When SMB is toggled on at runtime it starts, but a cold wsdd can lose its first multicast Hello before IGMP membership settles — so Windows doesn't see the box until something restarts it. That's symptom #1. A reboot fixes both because it re-runs everything on a settled network/name.

This is the same class of bug the #270 network-apply fix already solved with `rebind_discovery_daemons()` — restart the *currently-active* discovery daemons so they re-announce on the box's present interface/name set. It was just never wired into these two events.

## Fix
Call `rebind_discovery_daemons()` at the two missing triggers:
- **protocol enable**, when the protocol is SMB (`protocol.rs`) — after smbd/wsdd are up, rebind so Windows discovery works immediately.
- **settings update**, right after a hostname apply (`settings.rs`) — so avahi/wsdd re-announce under the new name.

`rebind_discovery_daemons` is now `pub(crate)`; it already no-ops daemons that aren't running, so it never starts one a protocol toggle left off, and it's best-effort (discovery is UX, not the data path).

## Validation
- Live box: confirmed avahi keeps the stale hostname until restarted, and a rebind re-registers it. wsdd confirmed to bind `0.0.0.0:3702` + the WS-Discovery multicast group when started.
- `cargo fmt` / clippy / full workspace tests clean.

Worth folding into the next ISO alongside the bcachefs-ref fix (#498). Happy to deploy this to the test box for end-to-end Windows confirmation if you want — it needs an engine rebuild + `nixos-rebuild`.