### PR TITLE
alerts: scope HDD-failure SMART alert to spinning disks; catch blank diagnostics

### DIFF
--- a/engine/nasty-common/src/metrics_types.rs
+++ b/engine/nasty-common/src/metrics_types.rs
@@ -135,6 +135,13 @@ pub struct DiskHealth {
     pub health_passed: bool,
     /// Human-readable SMART health status (`PASSED` or `FAILED`).
     pub smart_status: String,
+    /// Whether the drive spins: `Some(true)` for an HDD, `Some(false)`
+    /// for an SSD (smartctl reports rotation rate 0 / "Solid State
+    /// Device"), `None` when unknown (NVMe dumps carry no rotation_rate,
+    /// and SMART-unavailable drives have nothing to read). Used to scope
+    /// the HDD-failure SMART-attribute alert to spinning disks (#503).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotational: Option<bool>,
     /// ATA SMART attribute table (empty for NVMe and SAS drives).
     pub attributes: Vec<SmartAttribute>,
     /// NVMe SMART health information log (`Some` only on NVMe drives).

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1052,19 +1052,11 @@ pub(crate) async fn evaluate_active_alerts(
             // construction in that case, but the filter still costs
             // a closure allocation per attribute and per drive, so
             // the early-out matters when N drives × ~30 attributes.
-            let critical_attrs_with_value = if d.smart_status == "UNAVAILABLE" {
-                Vec::new()
-            } else {
-                d.attributes
-                    .iter()
-                    .filter_map(|a| {
-                        alerts::CRITICAL_ATA_ATTRIBUTES
-                            .iter()
-                            .any(|(id, _)| *id == a.id)
-                            .then_some((a.id, a.raw_value))
-                    })
-                    .collect()
-            };
+            // Gate the critical-attribute set to spinning disks — the
+            // table is HDD failure data and false-fires on SSDs (#503).
+            // See alerts::collect_critical_ata_attrs.
+            let critical_attrs_with_value =
+                alerts::collect_critical_ata_attrs(&d.smart_status, d.rotational, &d.attributes);
             alerts::DiskHealthSummary {
                 device: d.device,
                 transport: d.transport,

--- a/engine/nasty-metrics/src/collect_system.rs
+++ b/engine/nasty-metrics/src/collect_system.rs
@@ -859,6 +859,7 @@ async fn build_disk_health(
             } else {
                 "FAILED".to_string()
             },
+            rotational: s.rotational,
             attributes: s.attributes,
             nvme: s.nvme,
             scsi: s.scsi,
@@ -904,6 +905,7 @@ fn build_disk_health_unreachable_for_endpoint(
         // rules can skip. See SMART_STATUS_UNAVAILABLE.
         health_passed: false,
         smart_status: SMART_STATUS_UNAVAILABLE.to_string(),
+        rotational: None,
         attributes: Vec::new(),
         nvme: None,
         scsi: None,
@@ -929,6 +931,7 @@ struct SmartReport {
     temperature_c: Option<i32>,
     power_on_hours: Option<u64>,
     health_passed: bool,
+    rotational: Option<bool>,
     attributes: Vec<SmartAttribute>,
     nvme: Option<NvmeHealth>,
     scsi: Option<ScsiHealth>,
@@ -1062,6 +1065,9 @@ async fn query_smartctl(device: &str, transport: Option<&str>) -> Option<SmartRe
         temperature_c: json.temperature.and_then(|t| t.current),
         power_on_hours: json.power_on_time.and_then(|p| p.hours),
         health_passed,
+        // HDD reports its RPM; SSD reports 0 / "Solid State Device";
+        // NVMe dumps omit the field entirely (None).
+        rotational: json.rotation_rate.map(|r| r > 0),
         attributes,
         nvme,
         scsi,

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -663,6 +663,39 @@ pub const CRITICAL_ATA_ATTRIBUTES: &[(u32, &str)] = &[
     (201, "Soft Read Error Rate"),
 ];
 
+/// Pick the critical SMART attributes (with raw values) the
+/// `SmartAttribute` alert should evaluate for one drive. The router
+/// calls this when building each [`DiskHealthSummary`].
+///
+/// Returns empty for two kinds of drive:
+/// - **UNAVAILABLE SMART** — `attributes` is empty by construction
+///   anyway, but the early-out skips the per-attribute scan.
+/// - **non-rotational** (SSD / NVMe) — [`CRITICAL_ATA_ATTRIBUTES`] is
+///   Backblaze *HDD* failure data, and the same attribute IDs carry
+///   benign or vendor-specific values on solid-state drives. e.g. id
+///   201 ("Soft Read Error Rate" on a disk) is a cumulative counter
+///   reading in the trillions on Intel/other SATA SSDs, which
+///   false-fired the "drive needs attention" alert (#503). Only
+///   spinning disks (rotation_rate > 0) contribute. Pure; unit-tested.
+pub fn collect_critical_ata_attrs(
+    smart_status: &str,
+    rotational: Option<bool>,
+    attributes: &[nasty_common::metrics_types::SmartAttribute],
+) -> Vec<(u32, i64)> {
+    if smart_status == "UNAVAILABLE" || rotational != Some(true) {
+        return Vec::new();
+    }
+    attributes
+        .iter()
+        .filter_map(|a| {
+            CRITICAL_ATA_ATTRIBUTES
+                .iter()
+                .any(|(id, _)| *id == a.id)
+                .then_some((a.id, a.raw_value))
+        })
+        .collect()
+}
+
 /// Minimal disk info for alert evaluation
 #[derive(Debug)]
 pub struct DiskHealthSummary {
@@ -1430,6 +1463,39 @@ mod tests {
             alerts.is_empty(),
             "UNAVAILABLE smart_status must not trigger SmartHealth alerts"
         );
+    }
+
+    #[test]
+    fn collect_critical_attrs_skips_ssd_and_nvme() {
+        use nasty_common::metrics_types::SmartAttribute;
+        let attr = |id: u32, raw: i64| SmartAttribute {
+            id,
+            name: String::new(),
+            value: 100,
+            worst: 100,
+            threshold: 0,
+            raw_value: raw,
+            failing: false,
+        };
+        // The #503 case: a SATA SSD (rotation_rate 0) with id 201
+        // ("Soft Read Error Rate" on a disk) reading 1.4 trillion as a
+        // benign vendor counter must NOT contribute.
+        let ssd_attrs = vec![attr(201, 1_400_188_371_581), attr(5, 0)];
+        assert!(
+            collect_critical_ata_attrs("PASSED", Some(false), &ssd_attrs).is_empty(),
+            "SSD (rotational=false) must not yield critical attrs"
+        );
+        // NVMe / unknown rotation → None → skipped.
+        assert!(collect_critical_ata_attrs("PASSED", None, &ssd_attrs).is_empty());
+        // A spinning disk with a real reallocated-sector count DOES.
+        let hdd_attrs = vec![attr(5, 3), attr(9, 58314)];
+        assert_eq!(
+            collect_critical_ata_attrs("PASSED", Some(true), &hdd_attrs),
+            vec![(5, 3)],
+            "HDD critical attr id 5 should fire; non-critical id 9 should not"
+        );
+        // UNAVAILABLE SMART yields nothing even on a spinning disk.
+        assert!(collect_critical_ata_attrs("UNAVAILABLE", Some(true), &hdd_attrs).is_empty());
     }
 
     #[test]

--- a/nasty-0.0.11-reddit.md
+++ b/nasty-0.0.11-reddit.md
@@ -1,0 +1,29 @@
+This one's all about driving your bcachefs pool from the WebUI instead of dropping to a terminal, plus a much stronger Docker story.
+
+## bcachefs device lifecycle, fully in the UI
+
+* Scrub with a live progress bar, plus offline fsck (dry-run or repair) right from the browser
+* Mount failures now tell you *why* - naming the missing disk by slot and label - and offer a guarded degraded mount
+* Richer per-device table with selectable columns (size, errors, type, model, serial), and SMART/disk info shown before you add a candidate disk
+* Pull a disk and it shows up as **missing** with a force-remove; reconnect one that belongs to the pool and you get **Bring online / re-attach** instead of being pushed toward a wipe
+* Editable tiering targets (foreground/background/promote/metadata) and per-device durability
+* Compression levels for zstd and gzip - quick on ingress, deep in the background
+
+## Docker, for real
+
+* Manage Docker networks from the UI, including putting a container directly on your LAN with its own IP (macvlan/ipvlan) - and the host-container shim that normally makes that painful is wired up for you
+* Live compose validation in the editor - YAML and schema checked as you type, using the same check deploy runs
+* A first-class, relocatable **/appdata** location: bind it in compose and your container data survives moving to another filesystem. One click relocates it onto a new SSD. Snapshot-clean and separate from Docker's internals.
+
+## Security
+
+* Encryption-at-rest sweep is finished - every stored secret (SMB/CHAP, OIDC, NUT, notification channels, DNS-API tokens) is now sealed with systemd-creds, TPM-backed where available
+
+## Quality-of-life
+
+* Reconcile "stalled" alerts stopped crying wolf - they only fire on genuine lack of progress now
+* Wiping a disk leaves it actually clean (no more "repair the disk!" lectures from leftover GPT tables)
+* Discovery fixes so NASty shows up in your file manager's network view right after enabling SMB or renaming the host - no reboot needed
+* Dependency tree brought fully current
+
+Fresh ISOs (x86_64 + aarch64) are on the releases page. **Proxmox users:** NASty needs UEFI - switch the VM from SeaBIOS to OVMF before installing.

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -707,6 +707,9 @@ export interface DiskHealth {
 	power_on_hours: number | null;
 	health_passed: boolean;
 	smart_status: string;
+	/** true = spinning HDD, false = SSD, null/undefined = unknown (NVMe
+	 * dumps carry no rotation rate). */
+	rotational?: boolean | null;
 	attributes: SmartAttribute[];
 	nvme?: NvmeHealth;
 	scsi?: ScsiHealth;

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -1249,8 +1249,20 @@
 </div>
 
 {#if pageTab === 'diagnostics'}
-	{#await import('$lib/components/BcachefsDiagnostics.svelte') then module}
+	{#await import('$lib/components/BcachefsDiagnostics.svelte')}
+		<p class="p-6 text-sm text-muted-foreground">Loading diagnostics…</p>
+	{:then module}
 		<module.default />
+	{:catch}
+		<!-- A failed dynamic import is almost always a stale app shell
+		     after an in-place upgrade: the cached page references asset
+		     filenames that no longer exist, so the chunk 404s. Without
+		     this catch the panel silently rendered blank (#503). -->
+		<div class="rounded-lg border border-border bg-card p-6 text-sm">
+			<p class="font-medium">Couldn't load the diagnostics panel.</p>
+			<p class="mt-1 text-muted-foreground">NASty was likely updated in the background — reload to pick up the new version.</p>
+			<Button size="sm" class="mt-3" onclick={() => location.reload()}>Reload</Button>
+		</div>
 	{/await}
 {:else}
 


### PR DESCRIPTION
Closes #503. Two issues from HuxyUK's fresh-0.0.11 report, confirmed via the smartctl output they posted.

## 1. False "drive needs attention" alerts on SSDs

The SMART *predictive-attribute* alert watches `CRITICAL_ATA_ATTRIBUTES` — Backblaze drive-stats **HDD** failure signatures (reallocated / pending / offline-uncorrectable sectors, etc.). Those same attribute IDs are repurposed on solid-state drives. The reporter's three flagged drives (`/dev/sda`, `/dev/sdh`, `/dev/sdi` — all SATA SSDs) tripped on **id 201**, which is *"Soft Read Error Rate"* on a spinning disk but a benign cumulative vendor counter reading **~1.4 trillion** on Intel SATA SSDs:

```
201 Unknown_SSD_Attribute  ...  RAW_VALUE 1400188371581
```

Their actual NVMe drives never fired (NVMe has an empty ATA attribute table), which pinned it as an SSD-vs-HDD problem rather than anything wrong with the hardware.

**Fix:** a new top-level `DiskHealth.rotational` (`Some(true)` HDD / `Some(false)` SSD / `None` unknown), derived from smartctl's `rotation_rate` — the one universal signal (HDD reports RPM, SSD reports 0 / "Solid State Device", NVMe omits it). The critical-attribute collection now lives in a pure, unit-tested `alerts::collect_critical_ata_attrs` that returns empty unless the drive is rotational. SSD/NVMe get an empty critical set, same as SMART-UNAVAILABLE drives.

> SSDs aren't unmonitored: NVMe already has its own health-log alert (spare/critical-warning), and SATA-SSD wear monitoring is a reasonable future enhancement — just not via the HDD-sector attribute table.

## 2. Blank Diagnostics tab

`Filesystems → Diagnostics` lazy-loads its component with `{#await import(...) then module}` — **no `:catch`**. After an in-place upgrade the browser can still hold the old app shell, which references asset filenames that no longer exist; the chunk 404s and the panel silently renders blank. Added a `:catch` with a *Reload* prompt. The reporter confirmed a hard refresh already fixes it, which matches the stale-cache diagnosis exactly.

## Tests
- `collect_critical_ata_attrs`: SSD (`rotational=false`) and NVMe (`None`) with the id-201 trillion-value yield empty; HDD with id 5 fires; non-critical id 9 doesn't; UNAVAILABLE yields empty.
- `cargo fmt` / clippy / full workspace tests clean; `svelte-check` 0 errors, 144 webui tests, build OK.