### PR TITLE
webui: pin native <select> option colors so dropdown text stays legible

### DIFF
--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -130,6 +130,19 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Native <select> popup legibility. `color-scheme` (set on :root /
+   * .dark above) is the first line of defence, but some Chromium-on-
+   * Linux + GTK theme combinations still render the dropdown's option
+   * rows with no background, leaving the labels invisible — only the
+   * highlighted row shows (#377, recurred in #507). Pin explicit colors
+   * on the options themselves so the popup is legible regardless of
+   * whether the browser honours color-scheme. Scoped to option/optgroup
+   * so the *closed* control keeps its Tailwind `bg-transparent`. */
+  option,
+  optgroup {
+    background-color: var(--popover);
+    color: var(--popover-foreground);
+  }
 }
 
 @keyframes indeterminate {


### PR DESCRIPTION
Addresses the recurring invisible-dropdown-text part of #507.

## Why it came back
#377 fixed white-on-white `<select>` options by adding a `color-scheme` hint to `:root` / `.dark`, so Chromium renders the native popup in the matching theme. That covers most setups — but it leans entirely on the browser honouring `color-scheme`, and some **Chromium-on-Linux + GTK theme** combinations still render the option rows with no background, so the labels are invisible (only the highlighted row shows). Kev hit it again on the Filesystems data-target pulldowns.

## Fix
Pin explicit colors on the options themselves, from the popover theme tokens:

```css
option, optgroup {
  background-color: var(--popover);
  color: var(--popover-foreground);
}
```

Now the popup is legible whether or not the browser respects `color-scheme` (Chromium applies these; Firefox/Safari already rendered fine and ignore them harmlessly). Scoped to `option`/`optgroup` so the *closed* control keeps its `bg-transparent` blend with the card. Applies app-wide, so every native select benefits, not just the target dropdowns.

`svelte-check` 0 errors, build OK. CSS-only.

> Note: the *other* half of #507 — selecting multiple devices / a whole label group per target role, instead of one device per role — is a separate feature ask and not part of this PR.