### PR TITLE
filesystems: optional Rotational column (bcachefs superblock flag)

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -347,6 +347,17 @@ pub struct FilesystemDevice {
     pub has_data: Option<String>,
     /// Whether TRIM/discard is enabled on this device.
     pub discard: Option<bool>,
+    /// bcachefs's own per-member `Rotational` flag from the superblock
+    /// (`show-super -f members_v2`). This is what bcachefs uses for its
+    /// SSD-vs-HDD optimization decisions — NOT the live hardware type
+    /// (that's `BlockDevice.rotational`, derived from sysfs/lsblk). The
+    /// two can disagree: bcachefs latches this on first mount and can
+    /// get it wrong (an SSD stuck at `Rotational: 1`), so surfacing it
+    /// lets the operator spot the mis-latch (#501, upstream
+    /// koverstreet/bcachefs-tools#594). Sourced from show-super (not
+    /// sysfs) keyed by member index so it means the same persisted thing
+    /// whether or not the pool is mounted.
+    pub rotational: Option<bool>,
     /// Cumulative read IO errors (since filesystem creation), from
     /// `/sys/fs/bcachefs/<uuid>/dev-N/io_errors`. Only populated while
     /// the filesystem is mounted (sysfs is absent otherwise).
@@ -1115,6 +1126,7 @@ impl FilesystemService {
                     data_allowed: None,
                     has_data: None,
                     discard: None,
+                    rotational: None,
                     read_errors: None,
                     write_errors: None,
                     checksum_errors: None,
@@ -1492,6 +1504,7 @@ impl FilesystemService {
                 data_allowed: None,
                 has_data: None,
                 discard: None,
+                rotational: None,
                 read_errors: None,
                 write_errors: None,
                 checksum_errors: None,
@@ -1528,6 +1541,7 @@ impl FilesystemService {
                 data_allowed: None,
                 has_data: None,
                 discard: None,
+                rotational: None,
                 read_errors: None,
                 write_errors: None,
                 checksum_errors: None,
@@ -3579,6 +3593,23 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
         None
     };
 
+    // bcachefs's own `Rotational` flag per member slot, from the
+    // superblock (#501). Keyed by member index, not device path, so it
+    // stays correct across a remove/re-add reshuffle and means the same
+    // persisted thing whether or not the pool is mounted — and so the
+    // value is consistent with the sysfs-vs-show-super divergence the
+    // latch bug (#594) can cause: we always report the persisted
+    // superblock value here.
+    let rotational_by_slot: std::collections::HashMap<u32, bool> = blocks
+        .iter()
+        .filter_map(|b| {
+            let idx = b.first().and_then(|h| parse_device_index(h))?;
+            let rot = extract_value(b, "rotational")?;
+            Some((idx, rot == "1" || rot == "true"))
+        })
+        .collect();
+    let rotational_of = |slot: Option<u32>| slot.and_then(|i| rotational_by_slot.get(&i).copied());
+
     let mut devices: Vec<FilesystemDevice> = Vec::new();
     // Phantom slots already represented by a bound /proc/mounts row,
     // skipped by the missing-member loop below.
@@ -3602,6 +3633,7 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
                 data_allowed: sy.data_allowed.clone(),
                 has_data: sy.has_data.clone(),
                 discard: sy.discard,
+                rotational: rotational_of(sy.member_index),
                 read_errors: sy.read_errors,
                 write_errors: sy.write_errors,
                 checksum_errors: sy.checksum_errors,
@@ -3659,6 +3691,7 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
                     data_allowed: m.data_allowed.clone(),
                     has_data: m.has_data.clone(),
                     discard: m.discard,
+                    rotational: rotational_of(m.member_index),
                     read_errors: m.read_errors,
                     write_errors: m.write_errors,
                     checksum_errors: m.checksum_errors,
@@ -3678,6 +3711,7 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
             data_allowed,
             has_data,
             discard,
+            rotational: rotational_of(member_index),
             read_errors: None,
             write_errors: None,
             checksum_errors: None,
@@ -3715,6 +3749,7 @@ async fn read_fs_devices(uuid: &str, device_paths: &[String]) -> Vec<FilesystemD
             data_allowed: m.data_allowed.clone(),
             has_data: m.has_data.clone(),
             discard: m.discard,
+            rotational: rotational_of(m.member_index),
             read_errors: m.read_errors,
             write_errors: m.write_errors,
             checksum_errors: m.checksum_errors,

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -316,6 +316,10 @@ export interface FilesystemDevice {
 	has_data: string | null;
 	/** Whether TRIM/discard is enabled */
 	discard: boolean | null;
+	/** bcachefs's own per-device Rotational flag from the superblock —
+	 * what it uses for SSD optimizations. Distinct from the hardware
+	 * type; can disagree if mis-latched (bcachefs-tools #594). */
+	rotational?: boolean | null;
 	/** Cumulative read IO errors since fs creation (mounted pools only). */
 	read_errors?: number | null;
 	/** Cumulative write IO errors since fs creation. */

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -1209,6 +1209,7 @@
 		{ id: 'uuid', label: 'UUID' },
 		{ id: 'size', label: 'Size' },
 		{ id: 'type', label: 'Type' },
+		{ id: 'rotational', label: 'Rotational' },
 		{ id: 'model', label: 'Model' },
 		{ id: 'serial', label: 'Serial' },
 		{ id: 'clean', label: 'Clean' },
@@ -2370,6 +2371,7 @@
 									{#if colOn('uuid')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">UUID</th>{/if}
 									{#if colOn('size')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Size</th>{/if}
 									{#if colOn('type')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Type</th>{/if}
+									{#if colOn('rotational')}<th class="p-2 text-left text-xs uppercase text-muted-foreground" title="bcachefs's own per-device Rotational flag — what it uses for SSD optimizations. Can disagree with the hardware Type if mis-latched (bcachefs-tools #594).">Rotational</th>{/if}
 									{#if colOn('model')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Model</th>{/if}
 									{#if colOn('serial')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Serial</th>{/if}
 									{#if colOn('clean')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Clean</th>{/if}
@@ -2441,6 +2443,19 @@
 										{#if colOn('type')}
 											{@const blk = deviceBlock(dev.path)}
 											<td class="p-2 text-xs text-muted-foreground uppercase">{blk?.device_class ?? '—'}</td>
+										{/if}
+										{#if colOn('rotational')}
+											{@const blk = deviceBlock(dev.path)}
+											{@const mismatch = dev.rotational === true && blk != null && !blk.rotational}
+											<td class="p-2 text-xs">
+												{#if dev.rotational == null}
+													<span class="text-muted-foreground">—</span>
+												{:else if mismatch}
+													<span class="text-amber-500" title="bcachefs has this device marked rotational, but the hardware is solid-state — likely a mis-latched superblock flag (bcachefs-tools #594).">yes ⚠</span>
+												{:else}
+													<span class="text-muted-foreground">{dev.rotational ? 'yes' : 'no'}</span>
+												{/if}
+											</td>
 										{/if}
 										{#if colOn('model')}
 											{@const blk = deviceBlock(dev.path)}


### PR DESCRIPTION
Closes #501.

The device table already shows hardware HDD/SSD via the **Type** column (from lsblk/sysfs). This adds an optional **Rotational** column surfacing bcachefs's *own* per-device `Rotational` flag — the one it uses for SSD optimizations, and the one it can mis-latch on first mount (an SSD stuck at `Rotational: 1`, upstream koverstreet/bcachefs-tools#594). Read-only — it just surfaces the value so you can spot the divergence; changing it stays an upstream/CLI concern (per @fenio's note on the issue).

## Source: show-super, not sysfs (deliberate)
bcachefs exposes this in *both* sysfs (`dev-N/rotational`) and `show-super -f members_v2` (`Rotational: 0/1`), and — as flagged — **the two can disagree** because of the #594 latch. I source it from **show-super, keyed by member index**:
- show-super is the persisted superblock value the latch bug is actually about — the meaningful thing to "double-check."
- One source means the column can't silently mean different things depending on whether the pool is mounted (sysfs path) vs not (show-super fallback).
- Keying by member index sidesteps the stale-device-path problem that made us prefer sysfs for the *other* member attrs.

`members_v2` is already fetched in `read_fs_devices`, so no extra command.

## UI
Opt-in column (off by default). Shows `yes`/`no`, and when bcachefs reports rotational but the hardware Type is solid-state it flags the cell (`yes ⚠`) with a tooltip — the exact mis-latch double-check Kev asked for.

`cargo fmt` / clippy / full workspace tests clean; `svelte-check` 0 errors, build OK. Purely informational — no alert or behaviour change.