### PR TITLE
appliance: build NUT systemd units so the UPS protocol can be enabled

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -98,6 +98,13 @@
     smb.enable = true;
     iscsi.enable = true;
     nvmeof.enable = true;
+    # Build the NUT systemd units (driver/server/monitor) into the
+    # appliance so the engine can start them when the operator enables
+    # the UPS protocol. They carry `wantedBy = []`, so they only run
+    # when toggled on — same engine-managed pattern as smb/iscsi above.
+    # Without this the units don't exist and enabling NUT fails with
+    # "Unit nut-driver.service not found" (#512).
+    nut.enable = true;
     tailscale.enable = true;
   };
 

--- a/nixos/cloud.nix
+++ b/nixos/cloud.nix
@@ -54,6 +54,10 @@ in
     smb.enable = true;
     iscsi.enable = true;
     nvmeof.enable = true;
+    # Build the NUT units so enabling the UPS protocol works (engine-
+    # managed, only run when toggled on). Valid on cloud for remote-mode
+    # monitoring of a network UPS. See #512.
+    nut.enable = true;
   };
 
   # No mDNS/Avahi on cloud — no local network discovery needed


### PR DESCRIPTION
Closes #512.

## Bug
On a fresh 0.0.11 install, enabling the UPS (NUT) protocol fails:

```
Failed to start UPS (NUT): systemctl start nut-driver.service failed:
  Unit nut-driver.service not found.
```

## Root cause
NASty's NUT units (`nut-driver`, `nut-server`, `nut-monitor`) are defined in `nasty.nix` under `mkIf cfg.nut.enable` and carry `wantedBy = lib.mkForce []`, so the engine starts them on the runtime protocol toggle — the same engine-managed pattern as SMB and iSCSI. But while `appliance-base.nix` sets `smb.enable`/`iscsi.enable`/`nvmeof.enable = true`, **`nut.enable` was never set**. `mkEnableOption` defaults it to false, so `cfg.nut.enable` was false on the appliance and the units were never built. The engine's `service.protocol.enable nut` then tried to start a unit that doesn't exist.

(Exactly the build-time-gate-vs-runtime-toggle split we hit with SMB discovery — the unit has to exist for the toggle to start it.)

## Fix
Set `nut.enable = true` in `appliance-base.nix` and `cloud.nix`, next to the other protocols. The units now exist but still don't auto-start (`wantedBy = []`); the engine owns start/stop via the protocol toggle. The engine's service names (`nut-driver/nut-server/nut-monitor.service`) already match the unit names, so no engine change is needed.

Config-only; both files parse clean. Needs an ISO/rebuild to take effect (it's a build-time module gate), so existing 0.0.11 installs won't pick it up until they rebuild.