### PR TITLE
vm: fix 'Add ISO' persisting an empty CD-ROM path on edit

### DIFF
--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -555,7 +555,13 @@ impl VmService {
             (Some(list), _) => list,
             (None, Some(iso)) if !iso.is_empty() => vec![iso],
             _ => Vec::new(),
-        };
+        }
+        // Drop blank entries — a placeholder "add a CD-ROM" row in the
+        // UI can arrive as an empty path and would otherwise fail the
+        // existence check below ("CD-ROM ISO  does not exist", #514).
+        .into_iter()
+        .filter(|iso| !iso.trim().is_empty())
+        .collect();
         for iso in &cdroms {
             if !Path::new(iso).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
@@ -676,6 +682,11 @@ impl VmService {
                 _ => None,
             };
             if let Some(list) = new_cdroms {
+                // Drop blank entries (e.g. an unfilled "add ISO" row), #514.
+                let list: Vec<String> = list
+                    .into_iter()
+                    .filter(|iso| !iso.trim().is_empty())
+                    .collect();
                 for iso in &list {
                     if !Path::new(iso).exists() {
                         return Err(VmError::InvalidDiskPath(format!(

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -29,6 +29,11 @@
 	let wizardStep: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 = $state(0); // 0=hidden, -1=prerequisites
 	let loading = $state(true);
 	let editTab: 'general' | 'system' | 'storage' | 'network' | 'passthrough' = $state('general');
+	/** Pending (not-yet-picked) CD-ROM rows per VM in the edit panel.
+	 * "Add ISO" adds a local empty row instead of persisting an empty
+	 * cdrom path — the engine rejects a blank path ("CD-ROM ISO does not
+	 * exist", #514). The row is persisted only once a real ISO is picked. */
+	let pendingCdromRows = $state<Record<string, number>>({});
 
 	const WIZARD_STEPS: [string, string][] = [
 		['1', 'General'],
@@ -1640,13 +1645,17 @@
 											<span class="text-xs text-muted-foreground">CD-ROM ISOs</span>
 											{#if !vm.running}
 												{@const currentCdroms = vm.cdroms ?? (vm.boot_iso ? [vm.boot_iso] : [])}
-												{#each currentCdroms as iso, i (i)}
+												{@const rows = [...currentCdroms, ...Array(pendingCdromRows[vm.id] ?? 0).fill('')]}
+												{#each rows as iso, i (i)}
 													<div class="mt-0.5 flex items-center gap-1">
 														<select value={iso}
 															class="h-8 flex-1 rounded-md border border-input bg-transparent px-2 text-xs"
 															onchange={(e) => {
-																const next = [...currentCdroms];
+																const next = [...rows];
 																next[i] = (e.target as HTMLSelectElement).value;
+																// The pick is now persisted into cdroms; clear the
+																// local empty rows so we don't double-render them.
+																pendingCdromRows[vm.id] = 0;
 																updateVmField(vm.id, 'cdroms', next.filter(Boolean));
 															}}>
 															<option value="">None</option>
@@ -1655,11 +1664,18 @@
 															{/each}
 														</select>
 														<Button size="xs" variant="outline"
-															onclick={() => updateVmField(vm.id, 'cdroms', currentCdroms.filter((_, idx) => idx !== i))}>×</Button>
+															onclick={() => {
+																if (i < currentCdroms.length) {
+																	updateVmField(vm.id, 'cdroms', currentCdroms.filter((_, idx) => idx !== i));
+																} else {
+																	// A still-empty pending row — drop it locally, no save.
+																	pendingCdromRows[vm.id] = Math.max(0, (pendingCdromRows[vm.id] ?? 0) - 1);
+																}
+															}}>×</Button>
 													</div>
 												{/each}
 												<Button size="xs" variant="outline" class="mt-1"
-													onclick={() => updateVmField(vm.id, 'cdroms', [...currentCdroms, ''])}>+ Add ISO</Button>
+													onclick={() => pendingCdromRows[vm.id] = (pendingCdromRows[vm.id] ?? 0) + 1}>+ Add ISO</Button>
 											{:else}
 												{@const cdroms = vm.cdroms ?? (vm.boot_iso ? [vm.boot_iso] : [])}
 												{#if cdroms.length === 0}


### PR DESCRIPTION
Closes #514.

## Bug
Clicking **Add ISO** while editing a VM immediately errors:

```
invalid disk path: CD-ROM ISO  does not exist
```

## Cause
The edit panel's *Add ISO* button called `vm.update` with `cdroms = [...current, '']` — it persisted an **empty** CD-ROM entry on the spot. The engine validates every cdrom path with `Path::exists()`, and an empty string fails → the error. (Note the double space in the message: the path is blank.) The empty slot was meant to be a placeholder for the user to then pick an ISO, but it was being sent to the backend before any ISO was chosen.

## Fix
**WebUI** — *Add ISO* now adds a **local** pending row (a per-VM counter) instead of saving an empty entry. The pending row renders as an empty ISO picker; it's persisted (with empties filtered out) only when a real ISO is selected. Removing a still-empty pending row just drops it locally with no save; removing a real one persists as before. Mirrors how the create wizard already handles its `newIsos` list.

**Engine (defensive)** — drop blank cdrom entries before the existence check in both the create and update paths, so a stray empty path from any client can't 500 the request again.

`cargo fmt` / clippy / nasty-vm tests clean; `svelte-check` 0 errors, build OK.