### PR TITLE
ssh: let the engine override own PasswordAuthentication

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -121,12 +121,21 @@
   # Useful tools
   environment.systemPackages = with pkgs; [ vim file binutils git fwupd rsync iotop-c btop ];
 
-  # Allow SSH for management
+  # Allow SSH for management.
+  #
+  # PasswordAuthentication is owned entirely by the engine-managed
+  # override file (Include below), seeded to `yes` by tmpfiles and
+  # flipped via `system.ssh.set_password_auth`. It is deliberately NOT
+  # set in `settings` here: sshd_config uses the *first* value seen for
+  # each keyword, and `settings` lands before `extraConfig` in the
+  # generated config — so a `PasswordAuthentication no` here would win
+  # and the Include's value would never take effect. That's exactly the
+  # bug where the WebUI reported password auth enabled (reading the
+  # override) while sshd actually had it disabled (#516).
   services.openssh = {
     enable = true;
     settings = {
       PermitRootLogin = "yes";
-      PasswordAuthentication = false; # engine overrides at runtime via Include sshd_override.conf
     };
     extraConfig = ''
       Include /var/lib/nasty/sshd_override.conf


### PR DESCRIPTION
Closes #516.

## Bug
Fresh 0.0.11 install: the WebUI shows *Allow password authentication* checked, but `sshd_config` has `PasswordAuthentication no`. The two genuinely disagree.

## Cause
sshd uses the **first** value it sees for each keyword. The appliance config had both:

```nix
settings.PasswordAuthentication = false;          # base
extraConfig = "Include /var/lib/nasty/sshd_override.conf";   # engine override
```

NixOS writes `settings` *before* `extraConfig` in the generated `sshd_config`, so the base `PasswordAuthentication no` appears first and wins — the `Include`'s value is never used. Meanwhile the engine (and the UI) read `password_auth` straight from the override file, which is seeded to `yes`. So: UI/engine say enabled (override file), sshd says disabled (base line). Exactly the mismatch reported.

## Fix
Drop `PasswordAuthentication` from `settings` so the engine-managed override file is the **sole** source of that keyword. Its value is now both what the UI reports *and* what sshd actually enforces. Default stays `yes` (the tmpfiles seed), and `system.ssh.set_password_auth` flips it via the override as before — no engine change needed.

cloud.nix is unaffected (separate openssh block, no override Include, static `PasswordAuthentication = testingCreds`).

Config-only; `nix-instantiate --parse` clean. Existing installs pick it up on their next rebuild.