### PR TITLE
files: make WebUI-created folders writable through SMB/NFS (#519)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1669,11 +1669,8 @@ async fn files_mkdir_handler(
             // subvolume-create chmod (#482) and the SMB share-root chmod.
             {
                 use std::os::unix::fs::PermissionsExt;
-                if let Err(e) = tokio::fs::set_permissions(
-                    &full,
-                    std::fs::Permissions::from_mode(0o777),
-                )
-                .await
+                if let Err(e) =
+                    tokio::fs::set_permissions(&full, std::fs::Permissions::from_mode(0o777)).await
                 {
                     tracing::warn!(
                         "chmod 0777 {} failed: {e} — SMB/NFS writes into the new folder may be denied",

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1658,6 +1658,30 @@ async fn files_mkdir_handler(
     match tokio::fs::create_dir(&full).await {
         Ok(()) => {
             info!("Created directory {}", full.display());
+
+            // Make the new directory writable through the sharing layer.
+            // The engine runs as root, so create_dir leaves it root:0755 —
+            // but Samba forces writes through a fixed identity (`nobody` on
+            // guest shares, the first valid user otherwise) and NFS through
+            // squashed uids, so a root:0755 directory rejects every write
+            // until it's chmod'd by hand (#519). Access control lives in the
+            // protocol layer, not POSIX bits — the same reasoning as the
+            // subvolume-create chmod (#482) and the SMB share-root chmod.
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Err(e) = tokio::fs::set_permissions(
+                    &full,
+                    std::fs::Permissions::from_mode(0o777),
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "chmod 0777 {} failed: {e} — SMB/NFS writes into the new folder may be denied",
+                        full.display()
+                    );
+                }
+            }
+
             (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
         }
         Err(e) => (


### PR DESCRIPTION
## What

Folders created via the WebUI **Files** browser's *New Folder* button (`POST /api/files/mkdir`) went through a bare `mkdir` and were left `root:0755`. Because Samba forces client writes through a fixed identity (`nobody`/`nogroup` on guest shares, the first valid user otherwise) and NFS squashes uids, those clients couldn't write into the new folder — it appeared "root access only" (#519).

## Fix

chmod the directory `0777` immediately after `create_dir` succeeds, mirroring the two folder-creating paths that already do this:
- subvolume create (#482, `subvolume.rs`)
- SMB share root (`write_share_conf`, `smb.rs`)

Access control stays in the protocol layer (Samba/NFS auth); POSIX bits are permissive underneath. A failed chmod logs a `warn!` and the mkdir still returns OK, same as the subvolume path.

## Testing

- `cargo clippy --all-targets -p nasty-engine` — clean
- Reporter (kdackiw) confirmed the repro was the *New Folder* button.

Closes #519