### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.38.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781105933,
-        "narHash": "sha256-EXd+BOTAFUddK/4Vwi7GqRqndi2x4bb5gs7IIkMX6HU=",
+        "lastModified": 1781720951,
+        "narHash": "sha256-VNY9kURuXky504utCZ0Ye76mDG2TFAdzrgYI2iup/PI=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "aa15745636f5853279a338b30c33c98894e37579",
+        "rev": "a0527526f098ff833faf9199278938ea1d5e48f6",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.38.5",
+        "ref": "v1.38.6",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.38.5 release tag.
+    # Pinned to v1.38.6 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.5";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.6";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.5";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.6";
 
     # NOTE: lanzaboote is intentionally NOT declared as a top-level
     # input here. Secure Boot is per-box opt-in: when the operator


### PR DESCRIPTION
## What

Bumps the pinned `bcachefs-tools` flake input from **v1.38.5 → v1.38.6**, which moves both the userspace tools and the out-of-tree DKMS kernel module (built from the same source tree).

## Changes

- `flake.nix` — input ref `v1.38.5` → `v1.38.6` (+ comment).
- `flake.lock` — regenerated via `nix flake update bcachefs-tools` (rev `aa15745` → `a052752`, ref `v1.38.6`).
- `nixos/system-flake/flake.nix.template` — fallback ref bumped to match. (This line is normally rewritten at render time from the canonical ref in the repo-root flake.nix; the comment asks to keep the fallback matching, so it moves too.)

## Why it's a clean bump

- The derivation derives `version` and `cargoDeps` from the pinned source (`fromTOML` / `importCargoLock`), so no manual vendor hash to bump.
- `Makefile` `PKGCONFIG_LIBS` is **byte-identical** between v1.38.5 and v1.38.6 — the `libunwind` buildInputs workaround still applies and no new system inputs are needed.
- The wrapper-render test reads the canonical ref dynamically (no hardcoded version), so it's unaffected.

## Validation

- `nix eval .#packages.x86_64-linux.bcachefs-tools.version` → `1.38.6`.
- `nix flake lock` is idempotent after the update.
- Local builds of the Linux DKMS/tools derivation aren't possible on the dev box (darwin) — the **Integration workflow** is the real sandbox-build validation.