### PR TITLE
guestshare: engine spine for guest file sharing (#474, PR 1/n)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2 0.11.0",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/engine/nasty-engine/Cargo.toml
+++ b/engine/nasty-engine/Cargo.toml
@@ -54,3 +54,7 @@ webauthn-rs = "0.5"
 # wait-with-timeout tests. The `tokio = { features = ["full"] }`
 # workspace dep doesn't include test-util.
 tokio = { workspace = true, features = ["test-util"] }
+# Temp dirs for guestshare's path-canonicalization + state-store tests
+# (same version nasty-common's tests already use). Test-only; not in the
+# binary closure, so no Nix derivation impact.
+tempfile = "3"

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -1269,7 +1269,7 @@ pub async fn read_audit_log(limit: usize) -> Vec<serde_json::Value> {
     entries
 }
 
-fn hash_password(password: &str) -> Result<String, AuthError> {
+pub(crate) fn hash_password(password: &str) -> Result<String, AuthError> {
     // Generate 16 random bytes for salt, encode as base64ct for SaltString
     let mut salt_bytes = [0u8; 16];
     rand::fill(&mut salt_bytes);
@@ -1282,7 +1282,7 @@ fn hash_password(password: &str) -> Result<String, AuthError> {
     Ok(hash.to_string())
 }
 
-fn verify_password(password: &str, hash: &str) -> Result<(), AuthError> {
+pub(crate) fn verify_password(password: &str, hash: &str) -> Result<(), AuthError> {
     let parsed = PasswordHash::new(hash).map_err(|e| AuthError::HashError(e.to_string()))?;
     Argon2::default()
         .verify_password(password.as_bytes(), &parsed)
@@ -1360,7 +1360,7 @@ pub fn parse_role_str(s: &str) -> Option<Role> {
     }
 }
 
-fn generate_token() -> String {
+pub(crate) fn generate_token() -> String {
     let mut bytes = [0u8; 32];
     rand::fill(&mut bytes);
     base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes)

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -1,0 +1,410 @@
+//! Guest file sharing — share records + the authenticated CRUD that the
+//! public access surface (a later PR) will read.
+//!
+//! This module is the *spine* of #474: it persists a [`GuestShare`] per
+//! share and exposes [`GuestShareService`] for the operator-only
+//! `guestshare.*` RPCs. There is deliberately **no public/unauthenticated
+//! surface here** — no download endpoint, no password *verification*, no
+//! download/view counting. Those land in the next PR. The record already
+//! carries the fields they need (`downloads`, `views`, `max_downloads`,
+//! `expires_at`, `password_hash`) so that follow-up needs no migration.
+//!
+//! Security shape, mirroring the issue's design notes:
+//!   * The URL token IS the credential. Only its SHA-256 is stored, so a
+//!     leak of `/var/lib/nasty/guest-shares` cannot reconstruct a working
+//!     link. The plaintext token is returned from [`create`] exactly once.
+//!   * Share paths are canonicalized and must resolve under `/fs` — the
+//!     same guard NFS export creation uses (`nasty-sharing` `nfs.rs`).
+//!   * Passwords reuse the login Argon2 hasher (`crate::auth`), so there is
+//!     one crypto path, not two.
+//!
+//! [`create`]: GuestShareService::create
+
+use std::path::{Path, PathBuf};
+
+use nasty_common::{HasId, StateDir};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Where share records live, one JSON file per share keyed by UUID.
+const STATE_DIR: &str = "/var/lib/nasty/guest-shares";
+/// Root every shared path must canonicalize under.
+const FILES_ROOT: &str = "/fs";
+
+#[derive(Debug, Error)]
+pub enum GuestShareError {
+    #[error("share not found: {0}")]
+    NotFound(String),
+    #[error("no paths supplied")]
+    NoPaths,
+    #[error("path does not exist: {0}")]
+    PathNotFound(String),
+    #[error("path is not within a NASty filesystem: {0}")]
+    PathNotInFilesystem(String),
+    #[error("invalid path: {0}")]
+    InvalidPath(String),
+    #[error("password hashing failed: {0}")]
+    Hash(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// A guest share record. Persisted verbatim; the plaintext token never is.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GuestShare {
+    /// Unique share identifier (UUID) — also the on-disk filename.
+    pub id: String,
+    /// SHA-256 (lowercase hex) of the URL token. The link is the
+    /// credential; storing only its hash means a state-file leak leaks no
+    /// working links.
+    pub token_hash: String,
+    /// Absolute, canonicalized paths being shared. Each is under `/fs`.
+    pub paths: Vec<String>,
+    /// Username of the operator/admin who created the share.
+    pub created_by: String,
+    /// Unix seconds at creation.
+    pub created_at: i64,
+    /// Unix seconds after which the share stops working (enforced by the
+    /// public surface in a later PR). `None` = never expires.
+    pub expires_at: Option<i64>,
+    /// Argon2 hash of the share password (same hasher as login). `None` =
+    /// no password.
+    pub password_hash: Option<String>,
+    /// Maximum number of downloads before the share stops working. `None` =
+    /// unlimited.
+    pub max_downloads: Option<u32>,
+    /// Downloads served so far. Always 0 in this PR (no public surface yet).
+    pub downloads: u32,
+    /// Metadata views so far. Always 0 in this PR.
+    pub views: u32,
+    /// Whether the share has been revoked. Revoked records are kept (not
+    /// deleted) so history/audit survive.
+    pub revoked: bool,
+    /// Optional free-text note for the management UI.
+    pub note: Option<String>,
+}
+
+impl HasId for GuestShare {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateGuestShareRequest {
+    /// One or more absolute paths to share. Each must exist and resolve
+    /// under `/fs`.
+    pub paths: Vec<String>,
+    /// Optional expiry, Unix seconds.
+    pub expires_at: Option<i64>,
+    /// Optional password. When present, hashed with the login Argon2.
+    pub password: Option<String>,
+    /// Optional download cap.
+    pub max_downloads: Option<u32>,
+    /// Optional free-text note.
+    pub note: Option<String>,
+}
+
+/// Result of [`GuestShareService::create`]. Carries the plaintext token
+/// **once** — it is never stored and never returned by `list`/`get`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CreateGuestShareResult {
+    pub share: GuestShare,
+    /// Plaintext URL token. Show it to the operator now; it cannot be
+    /// recovered later (only its hash is persisted).
+    pub token: String,
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+fn sha256_hex(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Reject control characters, then canonicalize and confirm the path stays
+/// under `root` (resolving `.`/`..`/symlinks). Returns the canonical path.
+///
+/// `Path::starts_with` is component-wise, so a sibling like `/fsxyz` does
+/// not match the `/fs` root.
+fn canonicalize_under(root: &Path, requested: &str) -> Result<String, GuestShareError> {
+    if requested
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '\t' | '\n' | '\r' | '"' | '\'' | '\\'))
+    {
+        return Err(GuestShareError::InvalidPath(requested.to_string()));
+    }
+    let canonical = std::fs::canonicalize(requested)
+        .map_err(|_| GuestShareError::PathNotFound(requested.to_string()))?;
+    if !canonical.starts_with(root) {
+        return Err(GuestShareError::PathNotInFilesystem(requested.to_string()));
+    }
+    Ok(canonical.to_string_lossy().into_owned())
+}
+
+/// Operator-facing guest-share store. Holds its state directory and the
+/// filesystem root so tests can point both at a tempdir.
+pub struct GuestShareService {
+    dir: PathBuf,
+    fs_root: PathBuf,
+}
+
+impl Default for GuestShareService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GuestShareService {
+    pub fn new() -> Self {
+        Self {
+            dir: PathBuf::from(STATE_DIR),
+            fs_root: PathBuf::from(FILES_ROOT),
+        }
+    }
+
+    /// Test seam: store records under `dir` and require paths under `fs_root`.
+    #[cfg(test)]
+    fn with_dirs(dir: PathBuf, fs_root: PathBuf) -> Self {
+        Self { dir, fs_root }
+    }
+
+    fn state_dir(&self) -> StateDir {
+        StateDir::new(self.dir.clone())
+    }
+
+    /// List every share (including revoked ones). Never includes a
+    /// plaintext token — only the hash is persisted.
+    pub async fn list(&self) -> Result<Vec<GuestShare>, GuestShareError> {
+        Ok(self.state_dir().load_all().await)
+    }
+
+    /// Fetch a single share by id.
+    pub async fn get(&self, id: &str) -> Result<GuestShare, GuestShareError> {
+        self.state_dir()
+            .load::<GuestShare>(id)
+            .await
+            .ok_or_else(|| GuestShareError::NotFound(id.to_string()))
+    }
+
+    /// Create a share. Validates every path under `/fs`, mints a token,
+    /// stores only its hash, and returns the plaintext token once.
+    pub async fn create(
+        &self,
+        req: CreateGuestShareRequest,
+        created_by: &str,
+    ) -> Result<CreateGuestShareResult, GuestShareError> {
+        if req.paths.is_empty() {
+            return Err(GuestShareError::NoPaths);
+        }
+        let mut canonical_paths = Vec::with_capacity(req.paths.len());
+        for p in &req.paths {
+            canonical_paths.push(canonicalize_under(&self.fs_root, p)?);
+        }
+
+        let password_hash = match req.password.as_deref() {
+            Some(pw) if !pw.is_empty() => Some(
+                crate::auth::hash_password(pw).map_err(|e| GuestShareError::Hash(e.to_string()))?,
+            ),
+            _ => None,
+        };
+
+        let token = crate::auth::generate_token();
+        let share = GuestShare {
+            id: Uuid::new_v4().to_string(),
+            token_hash: sha256_hex(&token),
+            paths: canonical_paths,
+            created_by: created_by.to_string(),
+            created_at: now_secs(),
+            expires_at: req.expires_at,
+            password_hash,
+            max_downloads: req.max_downloads,
+            downloads: 0,
+            views: 0,
+            revoked: false,
+            note: req.note,
+        };
+
+        self.state_dir().save(&share.id, &share).await?;
+        Ok(CreateGuestShareResult { share, token })
+    }
+
+    /// Revoke a share. The record is kept (marked `revoked`) so history and
+    /// audit survive — only the public surface stops honoring it.
+    pub async fn revoke(&self, id: &str) -> Result<GuestShare, GuestShareError> {
+        let mut share = self.get(id).await?;
+        if !share.revoked {
+            share.revoked = true;
+            self.state_dir().save(&share.id, &share).await?;
+        }
+        Ok(share)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service(tmp: &std::path::Path) -> (GuestShareService, PathBuf) {
+        let state = tmp.join("state");
+        std::fs::create_dir_all(tmp.join("fs")).unwrap();
+        // Canonicalized so the symlinked-`/var` tempdir on macOS matches
+        // what `canonicalize_under` resolves to (a test-only concern; `/fs`
+        // is canonical on the appliance).
+        let fs_root = std::fs::canonicalize(tmp.join("fs")).unwrap();
+        (
+            GuestShareService::with_dirs(state, fs_root.clone()),
+            fs_root,
+        )
+    }
+
+    #[test]
+    fn sha256_is_stable_and_distinct() {
+        assert_eq!(sha256_hex("hello"), sha256_hex("hello"));
+        assert_ne!(sha256_hex("hello"), sha256_hex("hellp"));
+        // 32 bytes -> 64 hex chars.
+        assert_eq!(sha256_hex("anything").len(), 64);
+    }
+
+    #[test]
+    fn canonicalize_accepts_inside_rejects_escape_and_outside() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("fs")).unwrap();
+        // Canonicalize the root up front: on macOS the tempdir lives under
+        // a symlinked `/var` → `/private/var`, so `canonicalize` inside the
+        // function resolves it while a raw `tmp.path()` would not. On the
+        // appliance `/fs` is already canonical, so this is a test concern.
+        let root = std::fs::canonicalize(tmp.path().join("fs")).unwrap();
+        let inside = root.join("share");
+        std::fs::create_dir_all(&inside).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        // Inside the root: accepted, returns a canonical path under root.
+        let got = canonicalize_under(&root, inside.to_str().unwrap()).unwrap();
+        assert!(Path::new(&got).starts_with(&root));
+
+        // `..`-escape that resolves outside the root (inside is root/share,
+        // so ../.. lands at the tempdir root where `outside` lives): rejected.
+        let escape = format!("{}/../../outside", inside.display());
+        assert!(matches!(
+            canonicalize_under(&root, &escape),
+            Err(GuestShareError::PathNotInFilesystem(_))
+        ));
+
+        // A path entirely outside the root: rejected.
+        assert!(matches!(
+            canonicalize_under(&root, outside.to_str().unwrap()),
+            Err(GuestShareError::PathNotInFilesystem(_))
+        ));
+
+        // A non-existent path: rejected as not-found, never canonicalized.
+        assert!(matches!(
+            canonicalize_under(&root, &root.join("nope").to_string_lossy()),
+            Err(GuestShareError::PathNotFound(_))
+        ));
+
+        // Embedded newline: rejected before touching the filesystem.
+        assert!(matches!(
+            canonicalize_under(&root, "/fs/a\nb"),
+            Err(GuestShareError::InvalidPath(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_list_revoke_lifecycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, fs_root) = service(tmp.path());
+        let shared = fs_root.join("docs");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let res = svc
+            .create(
+                CreateGuestShareRequest {
+                    paths: vec![shared.to_string_lossy().into_owned()],
+                    expires_at: None,
+                    password: None,
+                    max_downloads: Some(5),
+                    note: Some("quarterly report".into()),
+                },
+                "alice",
+            )
+            .await
+            .unwrap();
+
+        // The plaintext token is returned but never equals what's stored.
+        assert!(!res.token.is_empty());
+        assert_eq!(res.share.token_hash, sha256_hex(&res.token));
+        assert_ne!(res.share.token_hash, res.token);
+        assert_eq!(res.share.created_by, "alice");
+        assert!(res.share.password_hash.is_none());
+        assert_eq!(res.share.downloads, 0);
+        assert!(!res.share.revoked);
+
+        // list shows it; the stored record carries the hash, not the token.
+        let listed = svc.list().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, res.share.id);
+        let serialized = serde_json::to_string(&listed[0]).unwrap();
+        assert!(
+            !serialized.contains(&res.token),
+            "plaintext token must not be persisted/listed"
+        );
+
+        // revoke flips the flag but keeps the record.
+        let revoked = svc.revoke(&res.share.id).await.unwrap();
+        assert!(revoked.revoked);
+        assert_eq!(svc.list().await.unwrap().len(), 1);
+        assert!(svc.list().await.unwrap()[0].revoked);
+    }
+
+    #[tokio::test]
+    async fn create_hashes_password_and_rejects_no_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, fs_root) = service(tmp.path());
+        let shared = fs_root.join("private");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let res = svc
+            .create(
+                CreateGuestShareRequest {
+                    paths: vec![shared.to_string_lossy().into_owned()],
+                    expires_at: None,
+                    password: Some("hunter2".into()),
+                    max_downloads: None,
+                    note: None,
+                },
+                "bob",
+            )
+            .await
+            .unwrap();
+
+        let hash = res.share.password_hash.expect("password should be hashed");
+        assert!(crate::auth::verify_password("hunter2", &hash).is_ok());
+        assert!(crate::auth::verify_password("wrong", &hash).is_err());
+
+        // Empty path list is rejected outright.
+        assert!(matches!(
+            svc.create(
+                CreateGuestShareRequest {
+                    paths: vec![],
+                    expires_at: None,
+                    password: None,
+                    max_downloads: None,
+                    note: None,
+                },
+                "bob",
+            )
+            .await,
+            Err(GuestShareError::NoPaths)
+        ));
+    }
+}

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -22,6 +22,7 @@ mod auth_webauthn;
 mod boot_status;
 mod fs_dependents;
 mod fs_lock;
+mod guestshare;
 mod ingress_conflict;
 mod log_stream;
 mod registry;
@@ -75,6 +76,7 @@ pub struct AppState {
     pub subvolumes: Arc<nasty_storage::SubvolumeService>,
     pub snapshots: nasty_snapshot::SnapshotService,
     pub nfs: nasty_sharing::NfsService,
+    pub guest_shares: guestshare::GuestShareService,
     pub smb: nasty_sharing::SmbService,
     pub iscsi: nasty_sharing::IscsiService,
     pub nvmeof: Arc<nasty_sharing::NvmeofService>,
@@ -213,6 +215,7 @@ async fn main() -> anyhow::Result<()> {
         snapshots: nasty_snapshot::SnapshotService::new(subvolumes.clone()),
         subvolumes,
         nfs: nasty_sharing::NfsService::new(),
+        guest_shares: guestshare::GuestShareService::new(),
         smb: nasty_sharing::SmbService::new(),
         iscsi: nasty_sharing::IscsiService::new(),
         nvmeof,

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use super::{Method, MethodParams, MethodRole, ad_hoc_one, ad_hoc_two, gen_schema};
 use crate::auth::{ApiToken, ApiTokenInfo, Role, Session, UserInfo};
 use crate::fs_dependents::FsDependents;
+use crate::guestshare::{CreateGuestShareRequest, CreateGuestShareResult, GuestShare};
 use crate::subvolume_dependents::SubvolumeDependents;
 use nasty_apps::{
     App, AppConfig, AppIngress, AppStats, AppdataRelocateStatus, AppsStatus, CaddyRouteSummary,
@@ -1012,6 +1013,39 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<RemoveHostRequest>(generator)),
                     result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+            ],
+        ),
+        (
+            "Guest Shares",
+            vec![
+                Method {
+                    name: "guestshare.list",
+                    desc: "List all guest file shares (including revoked ones). Never returns plaintext tokens.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<GuestShare>>(generator)),
+                },
+                Method {
+                    name: "guestshare.get",
+                    desc: "Fetch a single guest share by id.",
+                    role: MethodRole::Any,
+                    params: MethodParams::AdHoc(ad_hoc_one("id", "Share id (UUID).")),
+                    result: Some(gen_schema::<GuestShare>(generator)),
+                },
+                Method {
+                    name: "guestshare.create",
+                    desc: "Create a guest share for one or more paths under /fs. Returns the plaintext URL token exactly once — only its hash is stored.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::Schema(gen_schema::<CreateGuestShareRequest>(generator)),
+                    result: Some(gen_schema::<CreateGuestShareResult>(generator)),
+                },
+                Method {
+                    name: "guestshare.revoke",
+                    desc: "Revoke a guest share. The record is kept (marked revoked) so history survives.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::AdHoc(ad_hoc_one("id", "Share id (UUID) to revoke.")),
+                    result: Some(gen_schema::<GuestShare>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/guestshare.rs
+++ b/engine/nasty-engine/src/router/guestshare.rs
@@ -1,0 +1,51 @@
+//! RPC arms in the `guestshare.*` domain — operator-managed guest file
+//! shares (#474). The public, unauthenticated access surface lives
+//! elsewhere (a later PR); these methods are admin/operator-only CRUD.
+//!
+//! `guestshare.list` / `guestshare.get` are reads (auto-allowed by
+//! `is_read_only`); `guestshare.create` / `guestshare.revoke` are gated on
+//! `is_operator_allowed` in `super`.
+
+#![allow(unused_imports, unused_variables)]
+
+use nasty_common::{ErrorCode, Request, Response};
+use serde::Deserialize;
+
+use super::*;
+use crate::AppState;
+use crate::auth::{Role, Session};
+
+pub(super) async fn try_route(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+) -> Option<Response> {
+    Some(match req.method.as_str() {
+        "guestshare.list" => match state.guest_shares.list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "guestshare.get" => match require_str(req, "id") {
+            Ok(id) => match state.guest_shares.get(id).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "guestshare.create" => match parse_params(req) {
+            Ok(p) => match state.guest_shares.create(p, &session.username).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "guestshare.revoke" => match require_str(req, "id") {
+            Ok(id) => match state.guest_shares.revoke(id).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        _ => return None,
+    })
+}

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -8,6 +8,7 @@ mod auth;
 mod backup;
 mod bcachefs;
 mod fs;
+mod guestshare;
 mod notifications;
 mod service;
 mod share;
@@ -66,6 +67,13 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "share.nfs.create"
                 | "share.nfs.update"
                 | "share.nfs.delete"
+                // Guest file sharing (#474). Reads (`guestshare.list`/
+                // `.get`) are already covered by `is_read_only`; only the
+                // mutations need listing here. v1 is operator/admin-only
+                // because the engine reads shared files as root — see the
+                // #475 note in the issue.
+                | "guestshare.create"
+                | "guestshare.revoke"
                 | "share.smb.create"
                 | "share.smb.update"
                 | "share.smb.delete"
@@ -454,6 +462,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "subvolume" => subvolume::try_route(req, state, session).await,
         "snapshot" => snapshot::try_route(req, state, session).await,
         "share" => share::try_route(req, state, session).await,
+        "guestshare" => guestshare::try_route(req, state, session).await,
         "smb" => smb::try_route(req, state, session).await,
         "service" => service::try_route(req, state, session).await,
         "system" => {


### PR DESCRIPTION
First, self-contained slice of **guest file sharing (#474)** — building the feature slowly, one reviewable PR at a time (see the phasing in the issue's design comment).

This PR is the **engine spine only, with no public surface**. It adds the persistent share model and the operator-only CRUD that everything else hangs off. Nothing is wired to an unauthenticated route, so it adds no public attack surface and is fully unit-testable.

## What's here
- **`guestshare` module** — `GuestShare` record persisted one-file-per-share via the house `StateDir` (like `nfs.rs`), and `GuestShareService` (`create` / `list` / `get` / `revoke`).
- **Token = credential** — only the token's SHA-256 is stored; a leak of `/var/lib/nasty/guest-shares` leaks no working links. The plaintext token is returned from `create` exactly once.
- **Path safety** — shared paths are canonicalized and must resolve under `/fs`, the same guard NFS export creation uses (rejects `..`-escape, symlink-escape, control chars).
- **One crypto path** — passwords reuse the login Argon2 hasher (`auth::hash_password`), now `pub(crate)`; no second hashing implementation.
- **RPCs** — `guestshare.{create,list,get,revoke}` wired into the router. `list`/`get` are reads (`is_read_only`); `create`/`revoke` are operator-gated. v1 is operator/admin-only because the engine reads files as root — user-scoped shares are the #475 integration point.
- **Registry** — registered as a "Guest Shares" group so the methods get REST routes + OpenAPI docs alongside the other share families.

## Out of scope (later PRs)
Public download endpoint, password *verify* at access time, download/view counting, rate-limiting, ZIP, audit-on-access, and all WebUI. The record already carries `downloads`/`views`/`max_downloads`/`expires_at`/`password_hash` so the follow-up needs no migration.

Roadmap: PR2 public read + single-file download + password/expiry/limit + rate-limit · PR3 WebUI Files "Share" dialog + `/shares` page · PR4 public `/share/[token]` guest page · PR5 folder/multi ZIP · PR6 `share.*` subdomain.

## Tests
New unit tests cover token hashing, path canonicalization (inside accepted; `..`-escape / outside-root / nonexistent / newline rejected), the create→list→revoke lifecycle (no plaintext token persisted/listed), and password hash+verify. Full `nasty-engine` suite (115 tests) green; `cargo fmt --all`, `cargo clippy --workspace --all-targets --no-deps` clean.

## Notes
No new external dependency or `-sys` crate — `uuid`/`argon2`/`rand`/`base64`/`sha2` are already in `nasty-engine`; `tempfile` is added test-only. No Nix derivation impact.