### PR TITLE
guestshare: public download surface with password unlock (#474, PR 2/n)

### DIFF
--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -20,7 +20,9 @@
 //!
 //! [`create`]: GuestShareService::create
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex as StdMutex;
 
 use nasty_common::{HasId, StateDir};
 use schemars::JsonSchema;
@@ -33,6 +35,15 @@ use uuid::Uuid;
 const STATE_DIR: &str = "/var/lib/nasty/guest-shares";
 /// Root every shared path must canonicalize under.
 const FILES_ROOT: &str = "/fs";
+
+/// How long a password-unlock grant stays valid. Short by design — a guest
+/// re-enters the password if it lapses (the share itself is long-lived; the
+/// proof-of-password is ephemeral, mirroring a session).
+const GRANT_TTL_SECS: i64 = 3600;
+/// Failed unlock attempts (per IP+token) before the unlock endpoint locks
+/// out, and the window those attempts are counted over.
+const UNLOCK_MAX_FAILURES: usize = 10;
+const UNLOCK_WINDOW_SECS: i64 = 15 * 60;
 
 #[derive(Debug, Error)]
 pub enum GuestShareError {
@@ -118,6 +129,90 @@ pub struct CreateGuestShareResult {
     pub token: String,
 }
 
+/// One entry shown to a guest on the public share page.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PublicEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+/// Public metadata for a share — deliberately minimal and leaks no absolute
+/// server paths. Returned only for shares that exist and are still active.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PublicShareMeta {
+    pub entries: Vec<PublicEntry>,
+    pub password_required: bool,
+    pub expires_at: Option<i64>,
+}
+
+/// Whether a share may still be served: not revoked, not past expiry, not
+/// over its download cap. Every "no" collapses to the same caller response,
+/// so a guesser can't tell *why* a token is unavailable.
+fn is_accessible(s: &GuestShare, now: i64) -> bool {
+    !s.revoked
+        && s.expires_at.is_none_or(|e| now < e)
+        && s.max_downloads.is_none_or(|m| s.downloads < m)
+}
+
+/// Build the guest-visible metadata for a share. Lists each shared root by
+/// basename only (name/is_dir/size) — never the absolute `/fs/...` path.
+fn public_meta(share: &GuestShare) -> PublicShareMeta {
+    let entries = share
+        .paths
+        .iter()
+        .map(|p| {
+            let path = Path::new(p);
+            let md = std::fs::metadata(path).ok();
+            PublicEntry {
+                name: path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("file")
+                    .to_string(),
+                is_dir: md.as_ref().map(|m| m.is_dir()).unwrap_or(false),
+                size: md.as_ref().map(|m| m.len()).unwrap_or(0),
+            }
+        })
+        .collect();
+    PublicShareMeta {
+        entries,
+        password_required: share.password_hash.is_some(),
+        expires_at: share.expires_at,
+    }
+}
+
+/// Resolve a guest-supplied relative path to a concrete file inside one of
+/// the share's roots. Returns `None` unless the canonicalized target is a
+/// regular file that stays within a root — the download-time analog of the
+/// create-time `/fs` guard, blocking `..`/symlink escape out of the share.
+///
+/// `rel` is relative to the share (empty = a single-file share's own file),
+/// so absolute server paths never cross the wire.
+fn resolve_within(share: &GuestShare, rel: &str) -> Option<PathBuf> {
+    if rel
+        .chars()
+        .any(|c| c.is_control() || matches!(c, '"' | '\'' | '\\'))
+    {
+        return None;
+    }
+    for root in &share.paths {
+        let root = Path::new(root);
+        let candidate = if rel.is_empty() {
+            root.to_path_buf()
+        } else {
+            root.join(rel.trim_start_matches('/'))
+        };
+        let Ok(canonical) = std::fs::canonicalize(&candidate) else {
+            continue;
+        };
+        if canonical.starts_with(root) && canonical.is_file() {
+            return Some(canonical);
+        }
+    }
+    None
+}
+
 fn now_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -150,11 +245,31 @@ fn canonicalize_under(root: &Path, requested: &str) -> Result<String, GuestShare
     Ok(canonical.to_string_lossy().into_owned())
 }
 
-/// Operator-facing guest-share store. Holds its state directory and the
-/// filesystem root so tests can point both at a tempdir.
+/// A live password-unlock grant: proof a guest entered the right password
+/// for `share_id`, valid until `expires_at` (Unix seconds).
+struct GrantEntry {
+    share_id: String,
+    expires_at: i64,
+}
+
+/// Operator-facing guest-share store + the ephemeral state the public
+/// access surface needs: password-unlock grants and an unlock rate-limiter.
+///
+/// Grants and the rate-limiter live in memory only — they're intentionally
+/// ephemeral (a restart just makes guests re-enter the password) and never
+/// touch disk, so a state-file leak exposes neither.
 pub struct GuestShareService {
     dir: PathBuf,
     fs_root: PathBuf,
+    /// grant token -> what it unlocks. Opaque random tokens, exactly like
+    /// the engine's session model.
+    grants: StdMutex<HashMap<String, GrantEntry>>,
+    /// "ip|token" -> failed-unlock timestamps (Unix seconds), pruned to the
+    /// window on each touch.
+    unlock_failures: StdMutex<HashMap<String, Vec<i64>>>,
+    /// Serializes the load→increment→save of download counters so the
+    /// `max_downloads` cap can't be raced past under concurrent downloads.
+    download_lock: tokio::sync::Mutex<()>,
 }
 
 impl Default for GuestShareService {
@@ -165,16 +280,18 @@ impl Default for GuestShareService {
 
 impl GuestShareService {
     pub fn new() -> Self {
-        Self {
-            dir: PathBuf::from(STATE_DIR),
-            fs_root: PathBuf::from(FILES_ROOT),
-        }
+        Self::with_dirs(PathBuf::from(STATE_DIR), PathBuf::from(FILES_ROOT))
     }
 
     /// Test seam: store records under `dir` and require paths under `fs_root`.
-    #[cfg(test)]
     fn with_dirs(dir: PathBuf, fs_root: PathBuf) -> Self {
-        Self { dir, fs_root }
+        Self {
+            dir,
+            fs_root,
+            grants: StdMutex::new(HashMap::new()),
+            unlock_failures: StdMutex::new(HashMap::new()),
+            download_lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     fn state_dir(&self) -> StateDir {
@@ -246,6 +363,123 @@ impl GuestShareService {
             self.state_dir().save(&share.id, &share).await?;
         }
         Ok(share)
+    }
+
+    // ── Public access surface ───────────────────────────────────────────
+    // These back the unauthenticated `/api/public/share/*` HTTP handlers.
+
+    /// Resolve a URL token to its share, but only if the share is still
+    /// active. Returns `None` for unknown / expired / revoked / exhausted
+    /// tokens alike — the caller turns every case into the same generic
+    /// "not available", giving a token-guesser no oracle.
+    pub async fn lookup_active(&self, token: &str, now: i64) -> Option<GuestShare> {
+        let hash = sha256_hex(token);
+        self.state_dir()
+            .load_all::<GuestShare>()
+            .await
+            .into_iter()
+            .find(|s| s.token_hash == hash && is_accessible(s, now))
+    }
+
+    /// Public metadata for the guest landing page.
+    pub fn meta(share: &GuestShare) -> PublicShareMeta {
+        public_meta(share)
+    }
+
+    /// Resolve a guest's relative path to a real file inside a share root,
+    /// or `None` if it escapes / isn't a file.
+    pub fn resolve_download(share: &GuestShare, rel: &str) -> Option<PathBuf> {
+        resolve_within(share, rel)
+    }
+
+    /// Whether `share` is password-protected.
+    pub fn needs_password(share: &GuestShare) -> bool {
+        share.password_hash.is_some()
+    }
+
+    /// Verify a guest-supplied password against the share. `true` when the
+    /// share has no password (nothing to prove).
+    pub fn verify_share_password(share: &GuestShare, password: &str) -> bool {
+        match &share.password_hash {
+            Some(h) => crate::auth::verify_password(password, h).is_ok(),
+            None => true,
+        }
+    }
+
+    /// Count a metadata view. Best-effort; a lost increment is harmless.
+    pub async fn record_view(&self, id: &str) {
+        if let Some(mut s) = self.state_dir().load::<GuestShare>(id).await {
+            s.views = s.views.saturating_add(1);
+            let _ = self.state_dir().save(id, &s).await;
+        }
+    }
+
+    /// Count a download, enforcing `max_downloads`. Serialized via
+    /// `download_lock` so concurrent downloads can't race past the cap.
+    /// Returns `Err(NotFound)` if the share went inactive between lookup and
+    /// here — the handler maps that to the same generic "not available".
+    pub async fn register_download(&self, id: &str, now: i64) -> Result<(), GuestShareError> {
+        let _guard = self.download_lock.lock().await;
+        let mut s = self.get(id).await?;
+        if !is_accessible(&s, now) {
+            return Err(GuestShareError::NotFound(id.to_string()));
+        }
+        s.downloads = s.downloads.saturating_add(1);
+        self.state_dir().save(id, &s).await?;
+        Ok(())
+    }
+
+    // ── Password-unlock grants (ephemeral, in-memory) ───────────────────
+
+    /// Mint a grant proving the guest unlocked `share_id`. Opportunistically
+    /// prunes expired grants. The returned opaque token goes in a cookie.
+    pub fn mint_grant(&self, share_id: &str, now: i64) -> String {
+        let token = crate::auth::generate_token();
+        let mut grants = self.grants.lock().unwrap();
+        grants.retain(|_, e| e.expires_at > now);
+        grants.insert(
+            token.clone(),
+            GrantEntry {
+                share_id: share_id.to_string(),
+                expires_at: now + GRANT_TTL_SECS,
+            },
+        );
+        token
+    }
+
+    /// Whether `grant` is a live unlock for `share_id`.
+    pub fn check_grant(&self, grant: &str, share_id: &str, now: i64) -> bool {
+        let mut grants = self.grants.lock().unwrap();
+        grants.retain(|_, e| e.expires_at > now);
+        grants
+            .get(grant)
+            .is_some_and(|e| e.share_id == share_id && e.expires_at > now)
+    }
+
+    // ── Unlock rate-limiting (per IP+token sliding window) ──────────────
+
+    /// Whether unlock attempts for this (ip, token) are currently locked out.
+    pub fn unlock_locked(&self, ip: &str, token: &str, now: i64) -> bool {
+        let key = format!("{ip}|{token}");
+        let mut m = self.unlock_failures.lock().unwrap();
+        let v = m.entry(key).or_default();
+        v.retain(|&t| now - t < UNLOCK_WINDOW_SECS);
+        v.len() >= UNLOCK_MAX_FAILURES
+    }
+
+    /// Record a failed unlock attempt for this (ip, token).
+    pub fn record_unlock_failure(&self, ip: &str, token: &str, now: i64) {
+        let key = format!("{ip}|{token}");
+        let mut m = self.unlock_failures.lock().unwrap();
+        let v = m.entry(key).or_default();
+        v.retain(|&t| now - t < UNLOCK_WINDOW_SECS);
+        v.push(now);
+    }
+
+    /// Clear the failure counter for this (ip, token) after a success.
+    pub fn clear_unlock_failures(&self, ip: &str, token: &str) {
+        let key = format!("{ip}|{token}");
+        self.unlock_failures.lock().unwrap().remove(&key);
     }
 }
 
@@ -406,5 +640,253 @@ mod tests {
             .await,
             Err(GuestShareError::NoPaths)
         ));
+    }
+
+    /// Build and persist a share with field overrides, returning it. Lets a
+    /// test set expiry/downloads/revoked directly without driving `create`.
+    async fn put_share(
+        svc: &GuestShareService,
+        token: &str,
+        mutate: impl FnOnce(&mut GuestShare),
+    ) -> GuestShare {
+        let mut s = GuestShare {
+            id: format!("id-{token}"),
+            token_hash: sha256_hex(token),
+            paths: vec![],
+            created_by: "t".into(),
+            created_at: 0,
+            expires_at: None,
+            password_hash: None,
+            max_downloads: None,
+            downloads: 0,
+            views: 0,
+            revoked: false,
+            note: None,
+        };
+        mutate(&mut s);
+        svc.state_dir().save(&s.id, &s).await.unwrap();
+        s
+    }
+
+    #[tokio::test]
+    async fn lookup_active_gates_on_token_expiry_revoke_and_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        let now = 1000;
+
+        put_share(&svc, "ok", |_| {}).await;
+        put_share(&svc, "exp", |s| s.expires_at = Some(500)).await;
+        put_share(&svc, "rev", |s| s.revoked = true).await;
+        put_share(&svc, "lim", |s| {
+            s.max_downloads = Some(3);
+            s.downloads = 3;
+        })
+        .await;
+        put_share(&svc, "under", |s| {
+            s.max_downloads = Some(3);
+            s.downloads = 2;
+        })
+        .await;
+
+        assert!(svc.lookup_active("ok", now).await.is_some());
+        // Unknown token, expired, revoked, and exhausted all look identical.
+        assert!(svc.lookup_active("nope", now).await.is_none());
+        assert!(svc.lookup_active("exp", now).await.is_none());
+        assert!(svc.lookup_active("rev", now).await.is_none());
+        assert!(svc.lookup_active("lim", now).await.is_none());
+        // Not-yet-expired and under-cap remain available.
+        assert!(svc.lookup_active("exp", 100).await.is_some());
+        assert!(svc.lookup_active("under", now).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn register_download_enforces_cap_atomically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        let now = 10;
+        let s = put_share(&svc, "dl", |s| s.max_downloads = Some(2)).await;
+
+        assert!(svc.register_download(&s.id, now).await.is_ok());
+        assert!(svc.register_download(&s.id, now).await.is_ok());
+        // Third exceeds the cap and is refused; share is now exhausted.
+        assert!(svc.register_download(&s.id, now).await.is_err());
+        assert!(svc.lookup_active("dl", now).await.is_none());
+        assert_eq!(svc.get(&s.id).await.unwrap().downloads, 2);
+    }
+
+    #[tokio::test]
+    async fn record_view_increments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        let s = put_share(&svc, "v", |_| {}).await;
+        svc.record_view(&s.id).await;
+        svc.record_view(&s.id).await;
+        assert_eq!(svc.get(&s.id).await.unwrap().views, 2);
+    }
+
+    #[test]
+    fn grants_bind_to_share_and_expire() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        let now = 1000;
+        let grant = svc.mint_grant("share-a", now);
+
+        assert!(svc.check_grant(&grant, "share-a", now));
+        // Wrong share, unknown grant, and past-expiry all fail.
+        assert!(!svc.check_grant(&grant, "share-b", now));
+        assert!(!svc.check_grant("bogus", "share-a", now));
+        assert!(!svc.check_grant(&grant, "share-a", now + GRANT_TTL_SECS + 1));
+    }
+
+    #[test]
+    fn unlock_rate_limit_locks_then_clears() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        let now = 1000;
+
+        assert!(!svc.unlock_locked("1.2.3.4", "tok", now));
+        for _ in 0..UNLOCK_MAX_FAILURES {
+            svc.record_unlock_failure("1.2.3.4", "tok", now);
+        }
+        assert!(svc.unlock_locked("1.2.3.4", "tok", now));
+        // A different IP is unaffected; a successful clear resets the counter.
+        assert!(!svc.unlock_locked("5.6.7.8", "tok", now));
+        svc.clear_unlock_failures("1.2.3.4", "tok");
+        assert!(!svc.unlock_locked("1.2.3.4", "tok", now));
+    }
+
+    #[test]
+    fn unlock_rate_limit_prunes_outside_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, _) = service(tmp.path());
+        // Failures older than the window don't count toward the lockout.
+        let old = 1000;
+        for _ in 0..UNLOCK_MAX_FAILURES {
+            svc.record_unlock_failure("1.2.3.4", "tok", old);
+        }
+        let later = old + UNLOCK_WINDOW_SECS + 1;
+        assert!(!svc.unlock_locked("1.2.3.4", "tok", later));
+    }
+
+    #[test]
+    fn verify_share_password_matches_and_open_when_unset() {
+        let hash = crate::auth::hash_password("s3cret").unwrap();
+        let protected = GuestShare {
+            id: "p".into(),
+            token_hash: String::new(),
+            paths: vec![],
+            created_by: String::new(),
+            created_at: 0,
+            expires_at: None,
+            password_hash: Some(hash),
+            max_downloads: None,
+            downloads: 0,
+            views: 0,
+            revoked: false,
+            note: None,
+        };
+        assert!(GuestShareService::needs_password(&protected));
+        assert!(GuestShareService::verify_share_password(
+            &protected, "s3cret"
+        ));
+        assert!(!GuestShareService::verify_share_password(
+            &protected, "wrong"
+        ));
+
+        let mut open = protected;
+        open.password_hash = None;
+        assert!(!GuestShareService::needs_password(&open));
+        // No password set => nothing to prove, any input "passes".
+        assert!(GuestShareService::verify_share_password(&open, "anything"));
+    }
+
+    #[test]
+    fn resolve_download_stays_within_share_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let dir = root.join("folder");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.txt"), b"hi").unwrap();
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        std::fs::write(dir.join("sub/b.txt"), b"yo").unwrap();
+        let outside = root.join("secret.txt");
+        std::fs::write(&outside, b"nope").unwrap();
+        let single = root.join("lone.txt");
+        std::fs::write(&single, b"solo").unwrap();
+
+        let folder_share = GuestShare {
+            paths: vec![dir.to_string_lossy().into_owned()],
+            ..bare("f")
+        };
+        // Relative file inside the shared folder (including a subdir): ok.
+        assert!(resolve_within(&folder_share, "a.txt").is_some());
+        assert!(resolve_within(&folder_share, "sub/b.txt").is_some());
+        // Escapes and non-files: rejected.
+        assert!(resolve_within(&folder_share, "../secret.txt").is_none());
+        assert!(resolve_within(&folder_share, "sub").is_none()); // a dir, not a file
+        assert!(resolve_within(&folder_share, "missing.txt").is_none());
+        assert!(resolve_within(&folder_share, "a\\b").is_none()); // backslash rejected
+
+        // Single-file share: empty path resolves to the file itself.
+        let file_share = GuestShare {
+            paths: vec![single.to_string_lossy().into_owned()],
+            ..bare("s")
+        };
+        assert!(resolve_within(&file_share, "").is_some());
+    }
+
+    #[test]
+    fn public_meta_lists_basenames_not_abspaths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let dir = root.join("docs");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = root.join("report.pdf");
+        std::fs::write(&file, b"%PDF-1.4").unwrap();
+
+        let hash = crate::auth::hash_password("x").unwrap();
+        let share = GuestShare {
+            paths: vec![
+                dir.to_string_lossy().into_owned(),
+                file.to_string_lossy().into_owned(),
+            ],
+            password_hash: Some(hash),
+            expires_at: Some(42),
+            ..bare("m")
+        };
+        let meta = public_meta(&share);
+        assert!(meta.password_required);
+        assert_eq!(meta.expires_at, Some(42));
+        assert_eq!(meta.entries.len(), 2);
+        let names: Vec<&str> = meta.entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"docs"));
+        assert!(names.contains(&"report.pdf"));
+        // No entry leaks an absolute path.
+        assert!(meta.entries.iter().all(|e| !e.name.contains('/')));
+        let pdf = meta
+            .entries
+            .iter()
+            .find(|e| e.name == "report.pdf")
+            .unwrap();
+        assert!(!pdf.is_dir);
+        assert_eq!(pdf.size, 8);
+    }
+
+    /// A throwaway share with everything empty/default but a distinct id.
+    fn bare(id: &str) -> GuestShare {
+        GuestShare {
+            id: id.into(),
+            token_hash: String::new(),
+            paths: vec![],
+            created_by: String::new(),
+            created_at: 0,
+            expires_at: None,
+            password_hash: None,
+            max_downloads: None,
+            downloads: 0,
+            views: 0,
+            revoked: false,
+            note: None,
+        }
     }
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -660,6 +660,17 @@ async fn main() -> anyhow::Result<()> {
             get(webauthn_available_handler),
         )
         .route("/api/boot_status", get(boot_status_handler))
+        // Public guest-share access (#474) — unauthenticated by design; the
+        // URL token + optional unlock grant are the only credentials.
+        .route("/api/public/share/{token}", get(public_share_meta_handler))
+        .route(
+            "/api/public/share/{token}/unlock",
+            post(public_share_unlock_handler),
+        )
+        .route(
+            "/api/public/share/{token}/download",
+            get(public_share_download_handler),
+        )
         .route("/api/auth/oidc/start", get(oidc_start_handler))
         .route("/api/auth/oidc/callback", get(oidc_callback_handler))
         .route(
@@ -2520,6 +2531,216 @@ async fn logout_handler(
         Json(serde_json::json!({"ok": true})),
     )
         .into_response()
+}
+
+// ── Public guest-share access surface (#474) ────────────────────────────
+// Unauthenticated handlers backing `/api/public/share/*`. Auth is by the
+// URL token (the link is the credential) plus, for protected shares, a
+// short-lived unlock grant cookie. Every "unavailable" reason collapses to
+// one generic response so a token-guesser gets no oracle.
+
+const SHARE_GRANT_COOKIE: &str = "nasty_share_grant";
+
+fn build_share_grant_cookie(token: &str) -> String {
+    // Scoped to the public share path and short-lived to match the grant
+    // TTL. SameSite=Strict is fine while shares are served same-origin
+    // (path-based); the future share.* subdomain work revisits this.
+    format!(
+        "{SHARE_GRANT_COOKIE}={token}; HttpOnly; Secure; SameSite=Strict; Path=/api/public/share; Max-Age=3600"
+    )
+}
+
+fn share_grant_from_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
+    let raw = headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())?;
+    let prefix = format!("{SHARE_GRANT_COOKIE}=");
+    raw.split(';')
+        .map(|p| p.trim())
+        .find_map(|p| p.strip_prefix(&prefix))
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+}
+
+fn now_unix_i64() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+fn share_client_ip(headers: &axum::http::HeaderMap) -> String {
+    headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// One generic "not available" for unknown / expired / revoked / exhausted /
+/// unresolvable — no oracle for token or path guessing.
+fn share_not_available() -> axum::response::Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"error": "This share is not available"})),
+    )
+        .into_response()
+}
+
+/// `GET /api/public/share/{token}` → guest landing metadata. Counts a view.
+async fn public_share_meta_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+    state.guest_shares.record_view(&share.id).await;
+    Json(guestshare::GuestShareService::meta(&share)).into_response()
+}
+
+#[derive(Deserialize)]
+struct ShareUnlockRequest {
+    password: String,
+}
+
+/// `POST /api/public/share/{token}/unlock` → verify the password once and
+/// hand back a short-lived grant cookie. Rate-limited per (IP, token).
+async fn public_share_unlock_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<ShareUnlockRequest>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let client_ip = share_client_ip(&headers);
+
+    if state.guest_shares.unlock_locked(&client_ip, &token, now) {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({"error": "Too many attempts; try again later"})),
+        )
+            .into_response();
+    }
+
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+
+    if guestshare::GuestShareService::verify_share_password(&share, &body.password) {
+        state.guest_shares.clear_unlock_failures(&client_ip, &token);
+        let grant = state.guest_shares.mint_grant(&share.id, now);
+        crate::auth::audit(
+            "guest_share_unlock",
+            "guest",
+            &client_ip,
+            &format!("share_id={}", share.id),
+        );
+        let mut resp_headers = axum::http::HeaderMap::new();
+        resp_headers.insert(
+            axum::http::header::SET_COOKIE,
+            build_share_grant_cookie(&grant).parse().unwrap(),
+        );
+        return (
+            StatusCode::OK,
+            resp_headers,
+            Json(serde_json::json!({"ok": true})),
+        )
+            .into_response();
+    }
+
+    state
+        .guest_shares
+        .record_unlock_failure(&client_ip, &token, now);
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({"error": "Incorrect password"})),
+    )
+        .into_response()
+}
+
+/// `GET /api/public/share/{token}/download?path=…` → stream one file as an
+/// attachment. Enforces token validity → password grant (if protected) →
+/// path stays in a share root → `max_downloads` cap, then counts + audits.
+async fn public_share_download_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let client_ip = share_client_ip(&headers);
+
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+
+    if guestshare::GuestShareService::needs_password(&share) {
+        let granted = share_grant_from_cookie(&headers)
+            .map(|g| state.guest_shares.check_grant(&g, &share.id, now))
+            .unwrap_or(false);
+        if !granted {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Password required"})),
+            )
+                .into_response();
+        }
+    }
+
+    let rel = params.get("path").map(|s| s.as_str()).unwrap_or("");
+    let Some(target) = guestshare::GuestShareService::resolve_download(&share, rel) else {
+        return share_not_available();
+    };
+
+    // Count + enforce the cap before opening the stream. A failure here means
+    // the share went inactive (e.g. hit its cap) between lookup and now.
+    if state
+        .guest_shares
+        .register_download(&share.id, now)
+        .await
+        .is_err()
+    {
+        return share_not_available();
+    }
+
+    let file = match tokio::fs::File::open(&target).await {
+        Ok(f) => f,
+        Err(_) => return share_not_available(),
+    };
+    let size = file.metadata().await.map(|m| m.len()).unwrap_or(0);
+    let name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("file")
+        .to_string();
+
+    crate::auth::audit(
+        "guest_share_download",
+        "guest",
+        &client_ip,
+        &format!("share_id={} name={name} bytes={size}", share.id),
+    );
+
+    let stream = tokio_util::io::ReaderStream::new(file);
+    let body = axum::body::Body::from_stream(stream);
+    let mut resp_headers = axum::http::HeaderMap::new();
+    resp_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        "application/octet-stream".parse().unwrap(),
+    );
+    resp_headers.insert(
+        axum::http::header::CONTENT_LENGTH,
+        size.to_string().parse().unwrap(),
+    );
+    // Always an attachment — never inline. Shared HTML must not render on the
+    // app origin (stored-XSS), so we never hand the browser a renderable type.
+    resp_headers.insert(
+        axum::http::header::CONTENT_DISPOSITION,
+        format!("attachment; filename=\"{name}\"").parse().unwrap(),
+    );
+    (StatusCode::OK, resp_headers, body).into_response()
 }
 
 /// 8h, matches SESSION_TTL_SECS in auth.rs (kept in sync by hand).


### PR DESCRIPTION
Second slice of **guest file sharing (#474)**, on top of the engine spine in #525. A share link is now actually usable by a guest — passwords, expiry, and download caps are enforced.

## Public HTTP endpoints (unauthenticated — the URL token is the credential)
- `GET /api/public/share/{token}` — guest metadata (entry names, sizes, `password_required`, expiry); counts a view. **Basenames only**, never absolute `/fs` paths.
- `POST /api/public/share/{token}/unlock` — argon2-verify the password **once**, then set a short-lived httpOnly grant cookie. Rate-limited per (IP, token).
- `GET /api/public/share/{token}/download?path=…` — stream one file as an **attachment** after: token active → password grant (if protected) → path stays inside a share root → `max_downloads` not exhausted. Counts the download + writes an audit entry.

## Access model — Option B (verify-once, server-side grant)
As discussed: password proof is a one-time unlock that mints an **opaque in-memory grant** bound to the share id, carried in a path-scoped httpOnly cookie — the same opaque-token model the engine already uses for sessions. No new signing key, no plaintext password resent per request. Grants are ephemeral (lost on restart → re-enter password) and never touch disk.

## Security properties
- **No oracle**: missing / expired / revoked / over-limit / unresolvable all return the same generic "not available". Wrong password is a distinct 401 (rate-limited) since it's on an already-valid token, not a token-guessing surface.
- **Always `attachment`** — shared content never renders inline on the app origin (stored-XSS).
- **Path containment**: download paths are relative to the share and canonicalized, blocking `..`/symlink escape out of a share root (the download-time analog of the create-time `/fs` guard).
- **Atomic cap**: `max_downloads` is enforced under a lock so concurrent downloads can't race past it.

## Tests
New unit tests: token/expiry/revoke/limit gating, the atomic cap, grant bind + expiry, unlock rate-limit lockout + window pruning, password verify, relative-path containment (`..`/backslash/dir/missing rejected), and metadata basename-only leakage. Full `nasty-engine` suite (124) green; `cargo fmt --all` + `cargo clippy --workspace --all-targets --no-deps` clean.

## Notes
No new dependency. These are dedicated HTTP endpoints (like `/api/files/*`), not JSON-RPC methods, so nothing to add to the method registry.

Roadmap: **PR3** WebUI Files "Share" dialog + `/shares` management page · **PR4** public `/share/[token]` guest page · **PR5** folder/multi-select ZIP · **PR6** `share.*` subdomain.