### PR TITLE
webui: guest-share creation dialog + management page (#474, PR 3/n)

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
 		Database,
 		Layers,
 		Share2,
+		Link2,
 		HardDrive,
 		Archive,
 		Bell,
@@ -650,6 +651,7 @@
 				{ href: '/subvolumes', label: 'Subvolumes', icon: Layers },
 				{ href: '/disks',      label: 'Disks',       icon: HardDrive },
 				{ href: '/files',      label: 'Files',       icon: FolderOpen },
+				{ href: '/shares',     label: 'Guest Shares', icon: Link2 },
 			]},
 			{ href: '/sharing', label: 'Sharing', icon: Share2 },
 			{ label: 'Protection', icon: Shield, children: [

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -3,9 +3,11 @@
 	import { goto } from '$app/navigation';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput } from '@lucide/svelte';
+	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput, Share2, Check } from '@lucide/svelte';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import PathPicker from '$lib/components/PathPicker.svelte';
+	import { getClient } from '$lib/client';
+	import { withToast, error as toastError } from '$lib/toast.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 
 	interface FileEntry {
@@ -128,6 +130,68 @@
 
 	// Delete confirmation
 	let deleteTarget: FileEntry | null = $state(null);
+
+	// Guest share creation (#474). `shareTarget` opens the dialog; once the
+	// link is minted `shareUrl` holds the one-time URL (the engine never
+	// returns it again).
+	let shareTarget: FileEntry | null = $state(null);
+	let shareExpiry = $state('7'); // days; '0' = never
+	let sharePassword = $state('');
+	let shareMaxDownloads = $state('');
+	let shareNote = $state('');
+	let shareBusy = $state(false);
+	let shareUrl: string | null = $state(null);
+	let shareCopied = $state(false);
+
+	function openShare(entry: FileEntry) {
+		shareTarget = entry;
+		shareExpiry = '7';
+		sharePassword = '';
+		shareMaxDownloads = '';
+		shareNote = '';
+		shareUrl = null;
+		shareCopied = false;
+	}
+
+	async function createShare() {
+		if (!shareTarget) return;
+		const rel = currentPath ? `${currentPath}/${shareTarget.name}` : shareTarget.name;
+		// The engine takes absolute paths under /fs; the browser works in
+		// /fs-relative paths, so re-add the prefix here.
+		const abs = `/fs/${rel}`;
+		const days = parseInt(shareExpiry, 10);
+		const expires_at = days > 0 ? Math.floor(Date.now() / 1000) + days * 86400 : null;
+		const maxDl = shareMaxDownloads.trim() ? parseInt(shareMaxDownloads, 10) : null;
+		if (maxDl != null && (!Number.isFinite(maxDl) || maxDl < 1)) {
+			toastError('Download limit must be a positive number');
+			return;
+		}
+		shareBusy = true;
+		const res = await withToast(
+			() =>
+				getClient().call<{ share: unknown; token: string }>('guestshare.create', {
+					paths: [abs],
+					expires_at,
+					password: sharePassword ? sharePassword : null,
+					max_downloads: maxDl,
+					note: shareNote.trim() ? shareNote.trim() : null
+				}),
+			'Share link created'
+		);
+		shareBusy = false;
+		if (res) shareUrl = `${location.origin}/share/${res.token}`;
+	}
+
+	async function copyShareUrl() {
+		if (!shareUrl) return;
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			shareCopied = true;
+			setTimeout(() => (shareCopied = false), 2000);
+		} catch {
+			toastError('Could not copy to clipboard');
+		}
+	}
 
 	// Rename inline
 	let renameTarget: FileEntry | null = $state(null);
@@ -646,6 +710,12 @@
 								{/if}
 								<button
 									class="text-muted-foreground/40 hover:text-foreground transition-colors"
+									onclick={() => openShare(entry)}
+									title="Create guest share link">
+									<Share2 size={14} />
+								</button>
+								<button
+									class="text-muted-foreground/40 hover:text-foreground transition-colors"
 									onclick={() => startRename(entry)}
 									title="Rename">
 									<Pencil size={14} />
@@ -720,6 +790,89 @@
 					<Button variant="destructive" onclick={confirmDelete}>Delete</Button>
 					<Button variant="secondary" onclick={() => deleteTarget = null}>Cancel</Button>
 				</div>
+			</CardContent>
+		</Card>
+	</div>
+{/if}
+
+<!-- Guest share creation -->
+{#if shareTarget}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<Card class="w-full max-w-md">
+			<CardContent class="pt-6">
+				{#if shareUrl}
+					<h3 class="mb-2 text-lg font-semibold">Share link ready</h3>
+					<p class="mb-3 text-sm text-muted-foreground">
+						Copy it now — for security it can't be shown again. Manage or revoke it later under
+						<a href="/shares" class="underline">Guest Shares</a>.
+					</p>
+					<div class="mb-4 flex items-center gap-2">
+						<input
+							class="h-9 w-full rounded-md border border-input bg-transparent px-3 font-mono text-xs"
+							readonly
+							value={shareUrl} />
+						<Button variant="secondary" size="sm" onclick={copyShareUrl}>
+							{#if shareCopied}<Check size={14} class="mr-1" /> Copied{:else}<Copy size={14} class="mr-1" /> Copy{/if}
+						</Button>
+					</div>
+					<div class="flex justify-end">
+						<Button onclick={() => (shareTarget = null)}>Done</Button>
+					</div>
+				{:else}
+					<h3 class="mb-1 text-lg font-semibold">Share {shareTarget.is_dir ? 'folder' : 'file'}</h3>
+					<p class="mb-4 text-sm text-muted-foreground">
+						Create a public link to <span class="font-mono font-medium text-foreground">{shareTarget.name}</span>.
+					</p>
+
+					<div class="mb-4">
+						<label for="share-expiry" class="text-sm font-medium">Expires</label>
+						<select
+							id="share-expiry"
+							bind:value={shareExpiry}
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+							<option value="1">In 1 day</option>
+							<option value="7">In 7 days</option>
+							<option value="30">In 30 days</option>
+							<option value="0">Never</option>
+						</select>
+					</div>
+
+					<div class="mb-4">
+						<label for="share-password" class="text-sm font-medium">Password <span class="text-muted-foreground">(optional)</span></label>
+						<input
+							id="share-password"
+							type="password"
+							autocomplete="new-password"
+							bind:value={sharePassword}
+							placeholder="No password"
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" />
+					</div>
+
+					<div class="mb-4">
+						<label for="share-maxdl" class="text-sm font-medium">Download limit <span class="text-muted-foreground">(optional)</span></label>
+						<input
+							id="share-maxdl"
+							type="number"
+							min="1"
+							bind:value={shareMaxDownloads}
+							placeholder="Unlimited"
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" />
+					</div>
+
+					<div class="mb-4">
+						<label for="share-note" class="text-sm font-medium">Note <span class="text-muted-foreground">(optional)</span></label>
+						<input
+							id="share-note"
+							bind:value={shareNote}
+							placeholder="For your reference"
+							class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" />
+					</div>
+
+					<div class="flex justify-end gap-2">
+						<Button variant="secondary" onclick={() => (shareTarget = null)} disabled={shareBusy}>Cancel</Button>
+						<Button onclick={createShare} disabled={shareBusy}>{shareBusy ? 'Creating…' : 'Create link'}</Button>
+					</div>
+				{/if}
 			</CardContent>
 		</Card>
 	</div>

--- a/webui/src/routes/shares/+page.svelte
+++ b/webui/src/routes/shares/+page.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { Link2, Lock, Ban } from '@lucide/svelte';
+
+	// Mirrors the engine's GuestShare (engine/nasty-engine/src/guestshare.rs).
+	// Note: only `token_hash` is stored, never the plaintext token — so a
+	// share's link cannot be reconstructed here. Links are shown once, at
+	// creation time, in the Files-page Share dialog.
+	interface GuestShare {
+		id: string;
+		token_hash: string;
+		paths: string[];
+		created_by: string;
+		created_at: number;
+		expires_at: number | null;
+		password_hash: string | null;
+		max_downloads: number | null;
+		downloads: number;
+		views: number;
+		revoked: boolean;
+		note: string | null;
+	}
+
+	let shares = $state<GuestShare[] | null>(null);
+
+	const nowSecs = () => Math.floor(Date.now() / 1000);
+
+	function basename(p: string): string {
+		const parts = p.split('/').filter(Boolean);
+		return parts.length ? parts[parts.length - 1] : p;
+	}
+
+	function fmtDate(secs: number | null): string {
+		if (!secs) return '—';
+		return new Date(secs * 1000).toLocaleString();
+	}
+
+	function isExpired(s: GuestShare): boolean {
+		return s.expires_at != null && s.expires_at <= nowSecs();
+	}
+
+	function isExhausted(s: GuestShare): boolean {
+		return s.max_downloads != null && s.downloads >= s.max_downloads;
+	}
+
+	async function load() {
+		shares = (await getClient().call<GuestShare[]>('guestshare.list')) ?? [];
+	}
+
+	async function revoke(s: GuestShare) {
+		const names = s.paths.map(basename).join(', ');
+		if (!(await confirm(`Revoke share of "${names}"?`, 'The link will stop working immediately. This cannot be undone.'))) {
+			return;
+		}
+		await withToast(() => getClient().call('guestshare.revoke', { id: s.id }), 'Share revoked');
+		await load();
+	}
+
+	onMount(load);
+</script>
+
+<div class="mx-auto max-w-6xl p-6">
+	<h1 class="text-2xl font-semibold">Guest Shares</h1>
+	<p class="mt-1 mb-6 text-sm text-muted-foreground">
+		Public links to files and folders under <code>/fs</code>. Create one from the
+		<a href="/files" class="underline">Files</a> page. For security the link itself is shown only
+		once, when it's created, and can't be retrieved here.
+	</p>
+
+	{#if shares === null}
+		<p class="text-muted-foreground">Loading…</p>
+	{:else if shares.length === 0}
+		<p class="text-muted-foreground">No guest shares yet.</p>
+	{:else}
+		<table class="w-full text-sm">
+			<thead>
+				<tr>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Shared</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Created by</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Created</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Expires</th>
+					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground">Downloads</th>
+					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground">Views</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Status</th>
+					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each shares as s (s.id)}
+					<tr class="border-b border-border">
+						<td class="p-3">
+							<div class="flex items-center gap-2">
+								<Link2 size={14} class="text-muted-foreground shrink-0" />
+								<span class="font-medium">{s.paths.map(basename).join(', ')}</span>
+								{#if s.password_hash}
+									<Lock size={13} class="text-amber-500 shrink-0" />
+								{/if}
+							</div>
+							{#if s.note}
+								<div class="text-xs text-muted-foreground">{s.note}</div>
+							{/if}
+						</td>
+						<td class="p-3">{s.created_by}</td>
+						<td class="p-3 text-muted-foreground text-xs tabular-nums">{fmtDate(s.created_at)}</td>
+						<td class="p-3 text-xs tabular-nums {isExpired(s) ? 'text-destructive' : 'text-muted-foreground'}">
+							{s.expires_at ? fmtDate(s.expires_at) : 'Never'}
+						</td>
+						<td class="p-3 text-right tabular-nums">{s.downloads}{s.max_downloads != null ? ` / ${s.max_downloads}` : ''}</td>
+						<td class="p-3 text-right tabular-nums text-muted-foreground">{s.views}</td>
+						<td class="p-3">
+							{#if s.revoked}
+								<Badge variant="secondary">Revoked</Badge>
+							{:else if isExpired(s)}
+								<Badge variant="secondary">Expired</Badge>
+							{:else if isExhausted(s)}
+								<Badge variant="secondary">Exhausted</Badge>
+							{:else}
+								<Badge class="bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/15">Active</Badge>
+							{/if}
+						</td>
+						<td class="p-3 text-right">
+							{#if !s.revoked}
+								<Button variant="ghost" size="sm" onclick={() => revoke(s)} title="Revoke">
+									<Ban size={14} class="mr-1" /> Revoke
+								</Button>
+							{:else}
+								<span class="text-xs text-muted-foreground">—</span>
+							{/if}
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
+</div>


### PR DESCRIPTION
First **WebUI** slice of guest file sharing (#474). Operators can now mint and manage share links from the browser, on top of the engine spine (#525) and public download surface (#526).

## What's here
- **Files page — Share action**: a new Share button on each file/folder row opens a dialog with an expiry preset (1 / 7 / 30 days or never), optional password, optional download limit, and an optional note. On create it shows the link **once** (`${origin}/share/<token>`) with a copy button — the engine never returns the token again, so this is the only chance to copy it. The browser works in `/fs`-relative paths, so the call re-adds the `/fs` prefix the engine expects.
- **New `/shares` management page** (`guestshare.list`): shared names, creator, created/expiry dates, a password-protected indicator, download/view counts, and a live status badge (Active / Expired / Exhausted / Revoked), with a **revoke** action behind a confirm. By design it **cannot show the link** — only the token hash is stored — so it states that links are shown once at creation.
- **Sidebar**: a "Guest Shares" entry under Storage.

## Checks
`npm run check` (svelte-check) and `npm run build` both clean. No new npm dependency, so the npmDepsHash gate is unaffected.

## Notes / out of scope
Until **PR4** (the public `/share/[token]` guest landing page) the copied link has no page to land on — but the underlying metadata/unlock/download endpoints from #526 are already live, so the link is functional at the API level. Remaining: **PR4** guest page · **PR5** folder/multi-select ZIP · **PR6** `share.*` subdomain.