### PR TITLE
webui: public guest share landing page (#474, PR 4/n)

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -398,7 +398,15 @@
 	let reconnectingTimer: ReturnType<typeof setTimeout> | null = null;
 	const RECONNECT_OVERLAY_DELAY_MS = 800;
 
+	// Public guest-share pages (/share/[token]) are the one route group that
+	// renders without a session: a recipient who was handed a link has no
+	// NASty account. We skip the auth probe + WebSocket entirely and render
+	// the page bare (no sidebar, no login gate) — it talks to the engine
+	// only through the unauthenticated /api/public/share/* endpoints.
+	const isPublicShare = $derived($page.url.pathname.startsWith('/share/'));
+
 	onMount(() => {
+		if (isPublicShare) return;
 		tryConnect();
 		const onReconnect = async () => {
 			dbg(`reconnect cb fired — clearing powering=${powering}, reconnecting=${reconnecting}, timer=${reconnectingTimer ? 'armed' : 'none'}`);
@@ -769,7 +777,13 @@
 <ConfirmDangerousDialog />
 <UnlockFsDialog />
 
-{#if bootStatus && bootStatus.overall === 'booting'}
+{#if isPublicShare}
+	<!--
+		Guest share landing — no sidebar, no login, no engine WebSocket.
+		The page owns its own chrome and uses only public endpoints.
+	-->
+	{@render children()}
+{:else if bootStatus && bootStatus.overall === 'booting'}
 	<!--
 		Engine is mid-startup. Show the per-phase checklist so the
 		operator sees motion and can spot whether a specific phase

--- a/webui/src/routes/share/[token]/+page.svelte
+++ b/webui/src/routes/share/[token]/+page.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { theme } from '$lib/theme.svelte';
+	import logoLight from '$lib/assets/nasty.svg';
+	import logoDark from '$lib/assets/nasty-white.svg';
+	import { File, Folder, Download, Lock } from '@lucide/svelte';
+
+	// Public, unauthenticated guest landing page for a share link. It talks
+	// to the engine only through /api/public/share/* — no session, no RPC.
+	// The root layout renders this route bare (no sidebar) via its
+	// `isPublicShare` bypass.
+
+	interface PublicEntry {
+		name: string;
+		is_dir: boolean;
+		size: number;
+	}
+	interface ShareMeta {
+		entries: PublicEntry[];
+		password_required: boolean;
+		expires_at: number | null;
+	}
+
+	const token = $derived($page.params.token);
+
+	let loading = $state(true);
+	let meta = $state<ShareMeta | null>(null);
+	let notAvailable = $state(false);
+
+	// Password unlock state.
+	let unlocked = $state(false);
+	let password = $state('');
+	let unlocking = $state(false);
+	let unlockError = $state('');
+
+	const needsUnlock = $derived(!!meta?.password_required && !unlocked);
+
+	function fmtSize(n: number): string {
+		if (n < 1024) return `${n} B`;
+		const units = ['KB', 'MB', 'GB', 'TB'];
+		let v = n / 1024;
+		let i = 0;
+		while (v >= 1024 && i < units.length - 1) {
+			v /= 1024;
+			i++;
+		}
+		return `${v.toFixed(1)} ${units[i]}`;
+	}
+
+	function fmtExpiry(secs: number | null): string {
+		if (!secs) return '';
+		return new Date(secs * 1000).toLocaleString();
+	}
+
+	async function loadMeta() {
+		loading = true;
+		notAvailable = false;
+		try {
+			const res = await fetch(`/api/public/share/${token}`);
+			if (!res.ok) {
+				notAvailable = true;
+				return;
+			}
+			meta = (await res.json()) as ShareMeta;
+			unlocked = !meta.password_required;
+		} catch {
+			notAvailable = true;
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function unlock(e: Event) {
+		e.preventDefault();
+		if (!password) return;
+		unlocking = true;
+		unlockError = '';
+		try {
+			const res = await fetch(`/api/public/share/${token}/unlock`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ password })
+			});
+			if (res.ok) {
+				// The grant cookie is now set; downloads will carry it.
+				unlocked = true;
+				password = '';
+			} else if (res.status === 429) {
+				unlockError = 'Too many attempts. Please try again later.';
+			} else if (res.status === 404) {
+				notAvailable = true;
+			} else {
+				unlockError = 'Incorrect password.';
+			}
+		} catch {
+			unlockError = 'Something went wrong. Please try again.';
+		} finally {
+			unlocking = false;
+		}
+	}
+
+	// Per-file download. Shares created from the WebUI have a single root, so
+	// a file entry downloads with no path (the share root *is* the file). The
+	// grant cookie, if any, rides along automatically (same-origin, same-site).
+	function downloadUrl(): string {
+		return `/api/public/share/${token}/download`;
+	}
+
+	onMount(loadMeta);
+</script>
+
+<svelte:head>
+	<title>Shared files — NASty</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center bg-background p-6">
+	<div class="w-full max-w-lg rounded-xl border border-border bg-card p-8">
+		<img src={theme.isDark ? logoDark : logoLight} alt="NASty" class="mb-6 h-16 mx-auto" />
+
+		{#if loading}
+			<p class="text-center text-sm text-muted-foreground">Loading…</p>
+		{:else if notAvailable}
+			<h1 class="text-center text-lg font-semibold">This share is not available</h1>
+			<p class="mt-2 text-center text-sm text-muted-foreground">
+				The link may have expired, been revoked, or reached its download limit.
+			</p>
+		{:else if meta}
+			<h1 class="text-center text-lg font-semibold">Shared with you</h1>
+			{#if meta.expires_at}
+				<p class="mt-1 text-center text-xs text-muted-foreground">
+					Available until {fmtExpiry(meta.expires_at)}
+				</p>
+			{/if}
+
+			{#if needsUnlock}
+				<form onsubmit={unlock} class="mx-auto mt-6 max-w-xs">
+					<div class="mb-2 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+						<Lock size={14} /> This share is password protected
+					</div>
+					<input
+						type="password"
+						bind:value={password}
+						placeholder="Password"
+						autocomplete="off"
+						class="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" />
+					{#if unlockError}
+						<p class="mt-2 text-sm text-destructive">{unlockError}</p>
+					{/if}
+					<button
+						type="submit"
+						disabled={unlocking || !password}
+						class="mt-3 h-9 w-full rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50">
+						{unlocking ? 'Unlocking…' : 'Unlock'}
+					</button>
+				</form>
+			{:else}
+				<ul class="mt-6 divide-y divide-border/60">
+					{#each meta.entries as entry (entry.name)}
+						<li class="flex items-center justify-between gap-3 py-3">
+							<div class="flex min-w-0 items-center gap-2">
+								{#if entry.is_dir}
+									<Folder size={16} class="shrink-0 text-muted-foreground" />
+								{:else}
+									<File size={16} class="shrink-0 text-muted-foreground" />
+								{/if}
+								<span class="truncate text-sm">{entry.name}</span>
+								{#if !entry.is_dir}
+									<span class="shrink-0 text-xs text-muted-foreground">{fmtSize(entry.size)}</span>
+								{/if}
+							</div>
+							{#if entry.is_dir}
+								<span class="shrink-0 text-xs text-muted-foreground">Folder download coming soon</span>
+							{:else}
+								<a
+									href={downloadUrl()}
+									download={entry.name}
+									class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">
+									<Download size={14} /> Download
+								</a>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		{/if}
+
+		<p class="mt-8 text-center text-xs text-muted-foreground">Powered by NASty</p>
+	</div>
+</div>


### PR DESCRIPTION
Makes the share links **real**: a recipient handed a link now lands on a page that lists the shared files and downloads them — with no NASty account, no sidebar, no login. Closes the loop on the WebUI flow started in #527, using the public endpoints from #526.

## What's here
- **Login-gate bypass for `/share/*`** (root layout): these routes render bare — a new `isPublicShare` branch short-circuits the boot/login/app chain, and `onMount` skips `tryConnect()`, so a guest opens **no auth probe and no engine WebSocket**. The global dialogs left mounted are inert until triggered and the RPC client constructs lazily, so nothing reaches for a session. `/shares` (the operator management page) does **not** match the `/share/` prefix, so it's unaffected.
- **Public page `/share/[token]`**: fetches metadata from the public endpoints, shows the file list + sizes + expiry, prompts for the password when the share is protected (`POST …/unlock` sets the grant cookie; 429 and not-available handled), and downloads each file via the public download endpoint. Every unavailable state collapses to one generic "not available" message, matching the engine's no-oracle design.

## Checks
`npm run check`, `npm run build`, and `npm run test` (144) all green. No new npm dependency.

## Scope note
Folder shares show "Folder download coming soon" — **single-file shares download fully now**; folder/multi-select ZIP is **PR5**. The `share.*` subdomain is **PR6**.