### PR TITLE
guestshare: folder download as streaming ZIP (#474, PR 5/n)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +217,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +338,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -826,6 +859,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1653,6 +1711,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2784,6 +2852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2966,7 @@ version = "0.0.11"
 dependencies = [
  "anyhow",
  "argon2",
+ "async_zip",
  "axum",
  "base64 0.22.1",
  "bollard",
@@ -5590,6 +5669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5992,6 +6077,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/engine/nasty-engine/Cargo.toml
+++ b/engine/nasty-engine/Cargo.toml
@@ -27,14 +27,18 @@ rand.workspace = true
 base64.workspace = true
 thiserror.workspace = true
 portable-pty.workspace = true
-futures-util.workspace = true
+# `io` adds futures-style AsyncRead/Write helpers (futures_util::io::copy),
+# used to bridge a tokio file into async_zip's futures-io entry writer.
+futures-util = { workspace = true, features = ["io"] }
 schemars.workspace = true
 reqwest.workspace = true
 sha2 = "0.11"
 subtle = "2"
 bollard = "0.21"
 serde_yaml_ng = "0.10"
-tokio-util = { workspace = true, features = ["io"] }
+# `compat` exposes `.compat()` to adapt a tokio AsyncRead to futures-io for
+# async_zip's entry writer (see guestshare.rs).
+tokio-util = { workspace = true, features = ["io", "compat"] }
 openidconnect = { version = "4", default-features = false, features = ["accept-rfc3339-timestamps", "accept-string-booleans"] }
 http = "1"
 # Vendored Swagger UI assets, embedded into the binary at compile time
@@ -48,6 +52,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 # that's reserved for issue #17 (volume unlock via hmac-secret),
 # which is a separate user flow with different storage shape.
 webauthn-rs = "0.5"
+# Streaming ZIP for guest folder shares (#474). Async-native so a folder is
+# zipped straight into the HTTP response without buffering the archive in
+# RAM. `deflate` is pure Rust (flate2 → miniz_oxide); we intentionally do
+# NOT enable the optional bzip2/zstd/xz backends, which pull -sys crates the
+# Nix derivation would need to learn about.
+async_zip = { version = "0.0.17", default-features = false, features = ["tokio", "deflate"] }
 
 [dev-dependencies]
 # `test-util` enables tokio::time::pause/start_paused for fs_lock's

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -213,6 +213,56 @@ fn resolve_within(share: &GuestShare, rel: &str) -> Option<PathBuf> {
     None
 }
 
+/// Write a ZIP of every `root` into `writer`, entries named relative to each
+/// root's parent (so a share of `/fs/tank/photos` yields `photos/img.jpg`).
+/// Iterative DFS — no async recursion — and symlinks are skipped so the
+/// archive stays within the roots.
+async fn write_share_zip(
+    writer: tokio::io::DuplexStream,
+    roots: Vec<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    use async_zip::{Compression, ZipEntryBuilder};
+
+    let mut zip = async_zip::tokio::write::ZipFileWriter::with_tokio(writer);
+
+    for root in &roots {
+        // Entry names are relative to the root's parent so the root's own
+        // basename appears as the top-level archive folder.
+        let base = root.parent().unwrap_or(root.as_path());
+        let mut stack = vec![root.clone()];
+        while let Some(path) = stack.pop() {
+            let meta = match tokio::fs::symlink_metadata(&path).await {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            // Never follow symlinks — that's the escape guard.
+            if meta.is_symlink() {
+                continue;
+            }
+            if meta.is_dir() {
+                let mut rd = tokio::fs::read_dir(&path).await?;
+                while let Some(entry) = rd.next_entry().await? {
+                    stack.push(entry.path());
+                }
+            } else if meta.is_file() {
+                let rel = path.strip_prefix(base).unwrap_or(&path);
+                let name = rel.to_string_lossy().replace('\\', "/");
+                let builder = ZipEntryBuilder::new(name.into(), Compression::Deflate);
+                let mut entry = zip.write_entry_stream(builder).await?;
+                // async_zip's entry writer is futures-io; bridge the tokio
+                // file into it with `.compat()` + futures copy.
+                use tokio_util::compat::TokioAsyncReadCompatExt;
+                let mut f = tokio::fs::File::open(&path).await?.compat();
+                futures_util::io::copy(&mut f, &mut entry).await?;
+                entry.close().await?;
+            }
+        }
+    }
+
+    zip.close().await?;
+    Ok(())
+}
+
 fn now_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -427,6 +477,40 @@ impl GuestShareService {
         s.downloads = s.downloads.saturating_add(1);
         self.state_dir().save(id, &s).await?;
         Ok(())
+    }
+
+    /// Stream a ZIP of all the share's roots into a pipe, returning the read
+    /// end for the HTTP body. The archive is built lazily as the client
+    /// reads, so a multi-gigabyte folder is never buffered in memory.
+    ///
+    /// Symlinks are skipped (never followed), so the archive cannot escape a
+    /// share root — the ZIP-time analog of the download path guard.
+    pub fn zip_stream(&self, share: &GuestShare) -> tokio::io::DuplexStream {
+        let (reader, writer) = tokio::io::duplex(64 * 1024);
+        let roots: Vec<PathBuf> = share.paths.iter().map(PathBuf::from).collect();
+        tokio::spawn(async move {
+            if let Err(e) = write_share_zip(writer, roots).await {
+                // The client gets a truncated archive; nothing else we can do
+                // once the response body has started streaming.
+                tracing::warn!("guest share zip stream aborted: {e}");
+            }
+        });
+        reader
+    }
+
+    /// A filename for the downloaded archive, derived from the first shared
+    /// root's basename (e.g. "photos.zip"). Quotes are stripped so it's safe
+    /// in a `Content-Disposition` header.
+    pub fn zip_filename(share: &GuestShare) -> String {
+        let base = share
+            .paths
+            .first()
+            .map(Path::new)
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("share")
+            .replace(['"', '\\'], "");
+        format!("{base}.zip")
     }
 
     // ── Password-unlock grants (ephemeral, in-memory) ───────────────────
@@ -870,6 +954,55 @@ mod tests {
             .unwrap();
         assert!(!pdf.is_dir);
         assert_eq!(pdf.size, 8);
+    }
+
+    #[tokio::test]
+    async fn zip_stream_includes_files_and_skips_symlink_escape() {
+        use tokio::io::AsyncReadExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let folder = root.join("photos");
+        std::fs::create_dir_all(folder.join("sub")).unwrap();
+        std::fs::write(folder.join("a.txt"), b"alpha").unwrap();
+        std::fs::write(folder.join("sub/b.txt"), b"bravo").unwrap();
+
+        // A secret outside the share, reachable only via a symlink planted
+        // inside it. The walk must NOT follow the symlink.
+        let secret = root.join("secret.txt");
+        std::fs::write(&secret, b"TOPSECRET").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&secret, folder.join("leak.txt")).unwrap();
+
+        let svc = GuestShareService::with_dirs(root.join("state"), root.clone());
+        let share = GuestShare {
+            paths: vec![folder.to_string_lossy().into_owned()],
+            ..bare("z")
+        };
+
+        let mut reader = svc.zip_stream(&share);
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.unwrap();
+
+        // Filenames live verbatim in the (uncompressed) local file headers,
+        // so we can assert on the raw archive bytes without a zip reader.
+        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[..2], b"PK", "should be a zip archive");
+        let blob = String::from_utf8_lossy(&bytes);
+        assert!(
+            blob.contains("photos/a.txt"),
+            "expected top-level file entry"
+        );
+        assert!(
+            blob.contains("photos/sub/b.txt"),
+            "expected nested file entry"
+        );
+        // The symlink itself is skipped and its target's content never appears.
+        assert!(!blob.contains("leak.txt"), "symlink entry must be skipped");
+        assert!(
+            !blob.contains("TOPSECRET"),
+            "symlink target must never be archived"
+        );
     }
 
     /// A throwaway share with everything empty/default but a distinct id.

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -671,6 +671,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/public/share/{token}/download",
             get(public_share_download_handler),
         )
+        .route(
+            "/api/public/share/{token}/zip",
+            get(public_share_zip_handler),
+        )
         .route("/api/auth/oidc/start", get(oidc_start_handler))
         .route("/api/auth/oidc/callback", get(oidc_callback_handler))
         .route(
@@ -2739,6 +2743,68 @@ async fn public_share_download_handler(
     resp_headers.insert(
         axum::http::header::CONTENT_DISPOSITION,
         format!("attachment; filename=\"{name}\"").parse().unwrap(),
+    );
+    (StatusCode::OK, resp_headers, body).into_response()
+}
+
+/// `GET /api/public/share/{token}/zip` → stream a ZIP of the whole share
+/// (folders walked recursively, symlinks skipped). Same gates as download;
+/// counts as a single download against `max_downloads`.
+async fn public_share_zip_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let client_ip = share_client_ip(&headers);
+
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+
+    if guestshare::GuestShareService::needs_password(&share) {
+        let granted = share_grant_from_cookie(&headers)
+            .map(|g| state.guest_shares.check_grant(&g, &share.id, now))
+            .unwrap_or(false);
+        if !granted {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Password required"})),
+            )
+                .into_response();
+        }
+    }
+
+    if state
+        .guest_shares
+        .register_download(&share.id, now)
+        .await
+        .is_err()
+    {
+        return share_not_available();
+    }
+
+    let filename = guestshare::GuestShareService::zip_filename(&share);
+    crate::auth::audit(
+        "guest_share_zip",
+        "guest",
+        &client_ip,
+        &format!("share_id={} name={filename}", share.id),
+    );
+
+    let reader = state.guest_shares.zip_stream(&share);
+    let body = axum::body::Body::from_stream(tokio_util::io::ReaderStream::new(reader));
+    let mut resp_headers = axum::http::HeaderMap::new();
+    resp_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        "application/zip".parse().unwrap(),
+    );
+    // Streamed: length is unknown up front, so no Content-Length (chunked).
+    resp_headers.insert(
+        axum::http::header::CONTENT_DISPOSITION,
+        format!("attachment; filename=\"{filename}\"")
+            .parse()
+            .unwrap(),
     );
     (StatusCode::OK, resp_headers, body).into_response()
 }

--- a/webui/src/routes/share/[token]/+page.svelte
+++ b/webui/src/routes/share/[token]/+page.svelte
@@ -107,6 +107,11 @@
 		return `/api/public/share/${token}/download`;
 	}
 
+	// Folder shares download as a streamed ZIP of the whole folder.
+	function zipUrl(): string {
+		return `/api/public/share/${token}/zip`;
+	}
+
 	onMount(loadMeta);
 </script>
 
@@ -170,7 +175,12 @@
 								{/if}
 							</div>
 							{#if entry.is_dir}
-								<span class="shrink-0 text-xs text-muted-foreground">Folder download coming soon</span>
+								<a
+									href={zipUrl()}
+									download={`${entry.name}.zip`}
+									class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">
+									<Download size={14} /> Download as ZIP
+								</a>
 							{:else}
 								<a
 									href={downloadUrl()}


### PR DESCRIPTION
Completes **folder shares**. A folder share previously showed "Folder download coming soon" on the guest page (#529); it now downloads as a ZIP built on the fly.

## What's here
- **`GuestShareService::zip_stream`**: walks each shared root (iterative DFS — no async recursion) and deflates every file into a duplex pipe whose read end becomes the HTTP body, so a multi-gigabyte folder is **never buffered in memory**. **Symlinks are skipped, never followed** — the archive can't escape a share root (the ZIP-time analog of the download path guard). Entry names are relative to each root's parent, so a share of `/fs/tank/photos` yields `photos/…` inside the archive.
- **New public endpoint** `GET /api/public/share/{token}/zip` with the same gates as download (token active → password grant if protected → `max_downloads`), streamed as `application/zip` attachment. One ZIP counts as one download.
- **WebUI guest page**: folder entries now offer "Download as ZIP".

## Dependency (the one new Rust dep in this feature)
`async_zip` — **pure Rust** (`async-compression` → `flate2` → `miniz_oxide`/`crc32fast`). The optional `bzip2`/`zstd`/`xz` backends are intentionally **not** enabled. `cargo tree` confirms **no new `-sys` crates** (new lock entries: async_zip, async-compression, compression-codecs/-core, flate2, miniz_oxide, crc32fast, adler2, simd-adler32 — all pure Rust), so `mkEngine` needs no change; the sandbox-build gate verifies. Also enabled the pure-Rust adapter features tokio-util `compat` and futures-util `io` to bridge the tokio file reader into async_zip's futures-io entry writer.

## Tests
A unit test zips a folder containing a symlink that points at an outside secret, and asserts the inner files are present while the **symlink entry and its target's bytes are absent**. Full `nasty-engine` suite (125) green; `cargo fmt` + `cargo clippy --workspace --all-targets` clean; WebUI check + build clean.

## Scope
Whole-folder ZIP covers the issue's folder-download ask. Guest *multi-select* of individual files within a folder would need a public folder-listing surface and is out of scope here. Remaining: **PR6** the `share.*` subdomain.