### PR TITLE
guestshare: remove revoked shares from the list, kept for audit (#474)

### DIFF
--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -49,6 +49,8 @@ const UNLOCK_WINDOW_SECS: i64 = 15 * 60;
 pub enum GuestShareError {
     #[error("share not found: {0}")]
     NotFound(String),
+    #[error("share must be revoked before it can be removed: {0}")]
+    NotRevoked(String),
     #[error("no paths supplied")]
     NoPaths,
     #[error("path does not exist: {0}")]
@@ -94,6 +96,12 @@ pub struct GuestShare {
     /// Whether the share has been revoked. Revoked records are kept (not
     /// deleted) so history/audit survive.
     pub revoked: bool,
+    /// Soft "removed" — hidden from the default management list while the
+    /// record is kept on disk for audit/history. Only a *revoked* share can
+    /// be hidden (the UI revokes first). `#[serde(default)]` so shares
+    /// written before this field load as not-hidden.
+    #[serde(default)]
+    pub hidden: bool,
     /// Optional free-text note for the management UI.
     pub note: Option<String>,
 }
@@ -397,6 +405,7 @@ impl GuestShareService {
             downloads: 0,
             views: 0,
             revoked: false,
+            hidden: false,
             note: req.note,
         };
 
@@ -413,6 +422,22 @@ impl GuestShareService {
             self.state_dir().save(&share.id, &share).await?;
         }
         Ok(share)
+    }
+
+    /// Soft-remove a share: hide it from the default management list while
+    /// keeping the record on disk for audit/history. Only a *revoked* share
+    /// can be removed — the UI revokes first, so a live link is never
+    /// silently dropped. Idempotent.
+    pub async fn remove(&self, id: &str) -> Result<(), GuestShareError> {
+        let mut share = self.get(id).await?;
+        if !share.revoked {
+            return Err(GuestShareError::NotRevoked(id.to_string()));
+        }
+        if !share.hidden {
+            share.hidden = true;
+            self.state_dir().save(&share.id, &share).await?;
+        }
+        Ok(())
     }
 
     // ── Public access surface ───────────────────────────────────────────
@@ -685,6 +710,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn remove_requires_revoke_then_hides_but_keeps_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, fs_root) = service(tmp.path());
+        let shared = fs_root.join("doc");
+        std::fs::create_dir_all(&shared).unwrap();
+        let res = svc
+            .create(
+                CreateGuestShareRequest {
+                    paths: vec![shared.to_string_lossy().into_owned()],
+                    expires_at: None,
+                    password: None,
+                    max_downloads: None,
+                    note: None,
+                },
+                "admin",
+            )
+            .await
+            .unwrap();
+        let id = res.share.id;
+
+        // An active share cannot be removed — must be revoked first.
+        assert!(matches!(
+            svc.remove(&id).await,
+            Err(GuestShareError::NotRevoked(_))
+        ));
+
+        svc.revoke(&id).await.unwrap();
+        svc.remove(&id).await.unwrap();
+
+        // The record is kept on disk and still returned by list() (the WebUI
+        // hides it behind a "Show removed" toggle), but marked hidden.
+        let rec = svc.get(&id).await.unwrap();
+        assert!(rec.hidden);
+        assert!(rec.revoked);
+        assert!(
+            svc.list()
+                .await
+                .unwrap()
+                .iter()
+                .any(|s| s.id == id && s.hidden)
+        );
+        // remove is idempotent.
+        svc.remove(&id).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn create_hashes_password_and_rejects_no_paths() {
         let tmp = tempfile::tempdir().unwrap();
         let (svc, fs_root) = service(tmp.path());
@@ -745,6 +816,7 @@ mod tests {
             downloads: 0,
             views: 0,
             revoked: false,
+            hidden: false,
             note: None,
         };
         mutate(&mut s);
@@ -867,6 +939,7 @@ mod tests {
             downloads: 0,
             views: 0,
             revoked: false,
+            hidden: false,
             note: None,
         };
         assert!(GuestShareService::needs_password(&protected));
@@ -1019,6 +1092,7 @@ mod tests {
             downloads: 0,
             views: 0,
             revoked: false,
+            hidden: false,
             note: None,
         }
     }

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1047,6 +1047,16 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Share id (UUID) to revoke.")),
                     result: Some(gen_schema::<GuestShare>(generator)),
                 },
+                Method {
+                    name: "guestshare.remove",
+                    desc: "Remove a *revoked* guest share from the management list. The record is kept on disk (hidden) for audit/history; revoke the share first.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "id",
+                        "Share id (UUID) to remove. Must already be revoked.",
+                    )),
+                    result: None,
+                },
             ],
         ),
         // ── Authentication adjuncts ────────────────────────────────────

--- a/engine/nasty-engine/src/router/guestshare.rs
+++ b/engine/nasty-engine/src/router/guestshare.rs
@@ -41,11 +41,35 @@ pub(super) async fn try_route(
         },
         "guestshare.revoke" => match require_str(req, "id") {
             Ok(id) => match state.guest_shares.revoke(id).await {
-                Ok(v) => ok(req, v),
+                Ok(v) => {
+                    audit_share(session, "guest_share_revoked", id);
+                    ok(req, v)
+                }
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "guestshare.remove" => match require_str(req, "id") {
+            Ok(id) => match state.guest_shares.remove(id).await {
+                Ok(()) => {
+                    audit_share(session, "guest_share_removed", id);
+                    ok(req, "ok")
+                }
                 Err(e) => err(req, e),
             },
             Err(r) => r,
         },
         _ => return None,
     })
+}
+
+/// Append an audit entry for an operator action on a guest share, attributed
+/// to the session user + their client IP.
+fn audit_share(session: &Session, event: &str, share_id: &str) {
+    crate::auth::audit(
+        event,
+        &session.username,
+        session.client_ip.as_deref().unwrap_or("unknown"),
+        &format!("share_id={share_id}"),
+    );
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -74,6 +74,7 @@ fn is_operator_allowed(method: &str) -> bool {
                 // #475 note in the issue.
                 | "guestshare.create"
                 | "guestshare.revoke"
+                | "guestshare.remove"
                 | "share.smb.create"
                 | "share.smb.update"
                 | "share.smb.delete"

--- a/webui/src/routes/shares/+page.svelte
+++ b/webui/src/routes/shares/+page.svelte
@@ -5,7 +5,7 @@
 	import { confirm } from '$lib/confirm.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
-	import { Link2, Lock, Ban } from '@lucide/svelte';
+	import { Link2, Lock, Ban, Trash2 } from '@lucide/svelte';
 
 	// Mirrors the engine's GuestShare (engine/nasty-engine/src/guestshare.rs).
 	// Note: only `token_hash` is stored, never the plaintext token — so a
@@ -23,10 +23,19 @@
 		downloads: number;
 		views: number;
 		revoked: boolean;
+		hidden: boolean;
 		note: string | null;
 	}
 
 	let shares = $state<GuestShare[] | null>(null);
+	// Removed shares are kept (for audit/history) but hidden by default; the
+	// toggle reveals them without a refetch since list() returns them all.
+	let showRemoved = $state(false);
+
+	const visibleShares = $derived(
+		shares === null ? null : showRemoved ? shares : shares.filter((s) => !s.hidden)
+	);
+	const removedCount = $derived(shares?.filter((s) => s.hidden).length ?? 0);
 
 	const nowSecs = () => Math.floor(Date.now() / 1000);
 
@@ -61,6 +70,17 @@
 		await load();
 	}
 
+	// Remove only applies to already-revoked shares; the record is kept on
+	// disk (and in the audit log) but hidden from the default list.
+	async function remove(s: GuestShare) {
+		const names = s.paths.map(basename).join(', ');
+		if (!(await confirm(`Remove "${names}" from the list?`, 'It stays in the audit log; the row is hidden until you toggle "Show removed".'))) {
+			return;
+		}
+		await withToast(() => getClient().call('guestshare.remove', { id: s.id }), 'Share removed');
+		await load();
+	}
+
 	onMount(load);
 </script>
 
@@ -72,10 +92,19 @@
 		once, when it's created, and can't be retrieved here.
 	</p>
 
+	{#if removedCount > 0}
+		<label class="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+			<input type="checkbox" bind:checked={showRemoved} class="h-4 w-4" />
+			Show removed ({removedCount})
+		</label>
+	{/if}
+
 	{#if shares === null}
 		<p class="text-muted-foreground">Loading…</p>
-	{:else if shares.length === 0}
-		<p class="text-muted-foreground">No guest shares yet.</p>
+	{:else if visibleShares && visibleShares.length === 0}
+		<p class="text-muted-foreground">
+			{shares.length === 0 ? 'No guest shares yet.' : 'No shares to show.'}
+		</p>
 	{:else}
 		<table class="w-full text-sm">
 			<thead>
@@ -91,8 +120,8 @@
 				</tr>
 			</thead>
 			<tbody>
-				{#each shares as s (s.id)}
-					<tr class="border-b border-border">
+				{#each visibleShares ?? [] as s (s.id)}
+					<tr class="border-b border-border {s.hidden ? 'opacity-50' : ''}">
 						<td class="p-3">
 							<div class="flex items-center gap-2">
 								<Link2 size={14} class="text-muted-foreground shrink-0" />
@@ -113,7 +142,9 @@
 						<td class="p-3 text-right tabular-nums">{s.downloads}{s.max_downloads != null ? ` / ${s.max_downloads}` : ''}</td>
 						<td class="p-3 text-right tabular-nums text-muted-foreground">{s.views}</td>
 						<td class="p-3">
-							{#if s.revoked}
+							{#if s.hidden}
+								<Badge variant="secondary">Removed</Badge>
+							{:else if s.revoked}
 								<Badge variant="secondary">Revoked</Badge>
 							{:else if isExpired(s)}
 								<Badge variant="secondary">Expired</Badge>
@@ -127,6 +158,10 @@
 							{#if !s.revoked}
 								<Button variant="ghost" size="sm" onclick={() => revoke(s)} title="Revoke">
 									<Ban size={14} class="mr-1" /> Revoke
+								</Button>
+							{:else if !s.hidden}
+								<Button variant="ghost" size="sm" onclick={() => remove(s)} title="Remove from list (kept for audit)">
+									<Trash2 size={14} class="mr-1" /> Remove
 								</Button>
 							{:else}
 								<span class="text-xs text-muted-foreground">—</span>


### PR DESCRIPTION
Follow-up to the guest-sharing feature (#525–#530). Revoking a share previously left it in the `/shares` list forever with `—` in Actions; operators can now clear revoked rows **without losing the audit trail**.

## Design (per the discussion)
- **Soft remove, not hard delete.** `guestshare.remove` sets a new `hidden` flag and keeps the record on disk for audit/history — nothing is destroyed.
- **Revoke-first.** Only a *revoked* share can be removed (the engine returns `NotRevoked` otherwise), so a live link is never silently dropped. Active rows show only Revoke; once revoked, a Remove action appears.
- **"Show removed" toggle**, not permanent hiding. Removed rows drop out of the default view but a `Show removed (N)` toggle reveals them. `list()` keeps returning every record, so toggling is instant (no refetch).
- **Audit logging.** Both revoke *and* remove now append an audit-log entry attributed to the operator + client IP (revoke wasn't logged before).

## Details
- `hidden` is `#[serde(default)]`, so shares written before this change load unchanged.
- Status column gains a "Removed" badge; removed rows render muted.
- Records are kept indefinitely (tiny JSON files); an auto-purge after N days would be an easy future add — noted, not built.

## Tests
New engine test: an active share can't be removed (`NotRevoked`), and after revoke→remove the record is hidden but still on disk and listed. Full `nasty-engine` suite (126) + `clippy --all-targets` green; WebUI `check` + `build` clean. `guestshare.remove` added to the method registry (OpenAPI/REST) and the operator role gate.