### PR TITLE
webui: add r/bcachefs to the Help menu community links

### DIFF
--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -1187,6 +1187,12 @@
 									bcachefs Matrix
 									<ExternalLink size={12} class="ml-auto text-muted-foreground" />
 								</a>
+								<a href="https://www.reddit.com/r/bcachefs/" target="_blank" rel="noopener noreferrer"
+									class="flex items-center gap-2 rounded px-3 py-2 text-sm text-popover-foreground no-underline hover:bg-accent transition-colors">
+									<MessageCircle size={15} />
+									r/bcachefs
+									<ExternalLink size={12} class="ml-auto text-muted-foreground" />
+								</a>
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
Adds the bcachefs subreddit (https://www.reddit.com/r/bcachefs/) to the Help menu, alongside the existing IRC and Matrix community links. A lot of real-world usage and troubleshooting discussion lives there — including the reconcile-stuck thread referenced in #528.

Reuses the existing community-link styling and `MessageCircle` icon (no new import). svelte-check + build clean.