### PR TITLE
webui: sortable columns on the main data tables (#531)

### DIFF
--- a/webui/src/lib/components/SortTh.svelte
+++ b/webui/src/lib/components/SortTh.svelte
@@ -7,6 +7,7 @@
 		dir,
 		onclick,
 		align = 'left',
+		thClass = 'border-b-2 border-border p-3',
 	}: {
 		label: string;
 		active: boolean;
@@ -15,10 +16,15 @@
 		/** Cell alignment. Defaults to "left"; pass "right" for numeric
 		 * columns so the label hugs the right edge of the cell. */
 		align?: 'left' | 'right';
+		/** Border + padding classes for the <th>. Defaults to the standard
+		 * heavy header (border-b-2 + p-3); override to match a table whose
+		 * cells use different padding (e.g. a denser "p-2" device table or a
+		 * borderless "pb-2 font-medium" header). */
+		thClass?: string;
 	} = $props();
 </script>
 
-<th class="border-b-2 border-border p-3 text-xs uppercase text-muted-foreground {align === 'right' ? 'text-right' : 'text-left'}">
+<th class="{thClass} text-xs uppercase text-muted-foreground {align === 'right' ? 'text-right' : 'text-left'}">
 	<button class="flex items-center gap-1 hover:text-foreground {align === 'right' ? 'ml-auto' : ''}" {onclick}>
 		{label}
 		{#if active}

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -11,6 +11,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import SortTh from '$lib/components/SortTh.svelte';
 
 	let rules: AlertRule[] = $state([]);
 	let activeAlerts: ActiveAlert[] = $state([]);
@@ -53,6 +54,30 @@
 		below: 'Below',
 		equals: 'Equals',
 	};
+
+	// ── Column sorting ──────────────────────────────────────────────────
+	type RuleSortKey = 'name' | 'metric' | 'severity' | 'status';
+	let ruleSortKey = $state<RuleSortKey>('name');
+	let ruleSortDir = $state<'asc' | 'desc'>('asc');
+	function toggleRuleSort(key: RuleSortKey) {
+		if (ruleSortKey === key) ruleSortDir = ruleSortDir === 'asc' ? 'desc' : 'asc';
+		else { ruleSortKey = key; ruleSortDir = 'asc'; }
+	}
+	const sortedRules = $derived.by(() => {
+		const sign = ruleSortDir === 'asc' ? 1 : -1;
+		// critical sorts above warning when descending.
+		const sevRank = (s: AlertSeverity) => (s === 'critical' ? 2 : 1);
+		return [...rules].sort((a, b) => {
+			let cmp = 0;
+			if (ruleSortKey === 'name') cmp = a.name.localeCompare(b.name, undefined, { numeric: true });
+			else if (ruleSortKey === 'metric')
+				cmp = (metricLabels[a.metric] ?? a.metric).localeCompare(metricLabels[b.metric] ?? b.metric);
+			else if (ruleSortKey === 'severity') cmp = sevRank(a.severity) - sevRank(b.severity);
+			else cmp = Number(a.enabled) - Number(b.enabled);
+			if (cmp === 0) cmp = a.name.localeCompare(b.name, undefined, { numeric: true });
+			return sign * cmp;
+		});
+	});
 
 	function handleEvent(_: string, params: unknown) {
 		const p = params as { collection?: string };
@@ -203,16 +228,16 @@
 	<table class="w-full text-sm">
 		<thead>
 			<tr>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Name</th>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Metric</th>
+				<SortTh label="Name" active={ruleSortKey === 'name'} dir={ruleSortDir} onclick={() => toggleRuleSort('name')} />
+				<SortTh label="Metric" active={ruleSortKey === 'metric'} dir={ruleSortDir} onclick={() => toggleRuleSort('metric')} />
 				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Condition</th>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Severity</th>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Status</th>
+				<SortTh label="Severity" active={ruleSortKey === 'severity'} dir={ruleSortDir} onclick={() => toggleRuleSort('severity')} />
+				<SortTh label="Status" active={ruleSortKey === 'status'} dir={ruleSortDir} onclick={() => toggleRuleSort('status')} />
 				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Actions</th>
 			</tr>
 		</thead>
 		<tbody>
-			{#each rules as rule}
+			{#each sortedRules as rule}
 				<tr class="border-b border-border {!rule.enabled ? 'opacity-50' : ''}">
 					<td class="p-3"><strong>{rule.name}</strong></td>
 					<td class="p-3">{metricLabels[rule.metric] ?? rule.metric}</td>

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -19,6 +19,7 @@
 	import { summarizeDependents } from '$lib/fs-dependents';
 	import type { Filesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, FsckStatus, ReconcileStatus, TieringProfile, TieringProfileId, FsDependents, TpmBindStatus, DiskHealth } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
+	import SortTh from '$lib/components/SortTh.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
@@ -1243,6 +1244,54 @@
 		return (dev.read_errors ?? 0) + (dev.write_errors ?? 0) + (dev.checksum_errors ?? 0);
 	}
 
+	// ── Device-table column sorting (#531) ──────────────────────────────
+	// One shared sort key applies to every filesystem's device table.
+	type DevSortKey =
+		| 'path' | 'label' | 'state' | 'slot' | 'uuid' | 'size' | 'type'
+		| 'rotational' | 'model' | 'serial' | 'clean'
+		| 'read_err' | 'write_err' | 'csum_err' | 'data_allowed' | 'has_data';
+	let devSortKey = $state<DevSortKey>('slot');
+	let devSortDir = $state<'asc' | 'desc'>('asc');
+	function toggleDevSort(key: DevSortKey) {
+		if (devSortKey === key) devSortDir = devSortDir === 'asc' ? 'desc' : 'asc';
+		else { devSortKey = key; devSortDir = 'asc'; }
+	}
+	/** Comparable value for a device under the given sort key (number or string). */
+	function devSortVal(dev: FilesystemDevice, key: DevSortKey): string | number {
+		switch (key) {
+			case 'path': return dev.path ?? '';
+			case 'label': return dev.label ?? '';
+			case 'state': return dev.missing ? 'missing' : (devDisplayState(dev) ?? '');
+			case 'slot': return dev.member_index ?? -1;
+			case 'uuid': return dev.uuid ?? '';
+			case 'size': return deviceBlock(dev.path)?.size_bytes ?? -1;
+			case 'type': return deviceBlock(dev.path)?.device_class ?? '';
+			case 'rotational': return dev.rotational == null ? -1 : (dev.rotational ? 1 : 0);
+			case 'model': return deviceBlock(dev.path)?.model ?? '';
+			case 'serial': return deviceBlock(dev.path)?.serial ?? '';
+			case 'clean': return devErrorTotal(dev) ?? -1;
+			case 'read_err': return dev.read_errors ?? -1;
+			case 'write_err': return dev.write_errors ?? -1;
+			case 'csum_err': return dev.checksum_errors ?? -1;
+			case 'data_allowed': return dev.data_allowed ?? '';
+			case 'has_data': return dev.has_data ?? '';
+		}
+	}
+	/** A sorted copy of a filesystem's devices under the current key/dir. */
+	function sortedDevices(devs: FilesystemDevice[]): FilesystemDevice[] {
+		const sign = devSortDir === 'asc' ? 1 : -1;
+		return [...devs].sort((a, b) => {
+			const av = devSortVal(a, devSortKey);
+			const bv = devSortVal(b, devSortKey);
+			let cmp =
+				typeof av === 'number' && typeof bv === 'number'
+					? av - bv
+					: String(av).localeCompare(String(bv), undefined, { numeric: true });
+			if (cmp === 0) cmp = (a.path ?? '').localeCompare(b.path ?? '', undefined, { numeric: true });
+			return sign * cmp;
+		});
+	}
+
 	function classColor(cls: string): string {
 		switch (cls) {
 			case 'nvme': return 'bg-violet-950 text-violet-300';
@@ -2364,27 +2413,27 @@
 						<table class="w-full text-sm">
 							<thead>
 								<tr>
-									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Device</th>
-									<th class="p-2 text-left text-xs uppercase text-muted-foreground">Label</th>
-									<th class="p-2 text-left text-xs uppercase text-muted-foreground">State</th>
-									{#if colOn('slot')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Slot</th>{/if}
-									{#if colOn('uuid')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">UUID</th>{/if}
-									{#if colOn('size')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Size</th>{/if}
-									{#if colOn('type')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Type</th>{/if}
-									{#if colOn('rotational')}<th class="p-2 text-left text-xs uppercase text-muted-foreground" title="bcachefs's own per-device Rotational flag — what it uses for SSD optimizations. Can disagree with the hardware Type if mis-latched (bcachefs-tools #594).">Rotational</th>{/if}
-									{#if colOn('model')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Model</th>{/if}
-									{#if colOn('serial')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Serial</th>{/if}
-									{#if colOn('clean')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Clean</th>{/if}
-									{#if colOn('read_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Read err</th>{/if}
-									{#if colOn('write_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Write err</th>{/if}
-									{#if colOn('csum_err')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Cksum err</th>{/if}
-									{#if colOn('data_allowed')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Data Allowed</th>{/if}
-									{#if colOn('has_data')}<th class="p-2 text-left text-xs uppercase text-muted-foreground">Has Data</th>{/if}
+									<SortTh label="Device" active={devSortKey === 'path'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('path')} />
+									<SortTh label="Label" active={devSortKey === 'label'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('label')} />
+									<SortTh label="State" active={devSortKey === 'state'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('state')} />
+									{#if colOn('slot')}<SortTh label="Slot" active={devSortKey === 'slot'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('slot')} />{/if}
+									{#if colOn('uuid')}<SortTh label="UUID" active={devSortKey === 'uuid'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('uuid')} />{/if}
+									{#if colOn('size')}<SortTh label="Size" active={devSortKey === 'size'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('size')} />{/if}
+									{#if colOn('type')}<SortTh label="Type" active={devSortKey === 'type'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('type')} />{/if}
+									{#if colOn('rotational')}<SortTh label="Rotational" active={devSortKey === 'rotational'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('rotational')} />{/if}
+									{#if colOn('model')}<SortTh label="Model" active={devSortKey === 'model'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('model')} />{/if}
+									{#if colOn('serial')}<SortTh label="Serial" active={devSortKey === 'serial'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('serial')} />{/if}
+									{#if colOn('clean')}<SortTh label="Clean" active={devSortKey === 'clean'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('clean')} />{/if}
+									{#if colOn('read_err')}<SortTh label="Read err" active={devSortKey === 'read_err'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('read_err')} />{/if}
+									{#if colOn('write_err')}<SortTh label="Write err" active={devSortKey === 'write_err'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('write_err')} />{/if}
+									{#if colOn('csum_err')}<SortTh label="Cksum err" active={devSortKey === 'csum_err'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('csum_err')} />{/if}
+									{#if colOn('data_allowed')}<SortTh label="Data Allowed" active={devSortKey === 'data_allowed'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('data_allowed')} />{/if}
+									{#if colOn('has_data')}<SortTh label="Has Data" active={devSortKey === 'has_data'} dir={devSortDir} thClass="p-2" onclick={() => toggleDevSort('has_data')} />{/if}
 									<th class="p-2 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 								</tr>
 							</thead>
 							<tbody>
-								{#each fs.devices as dev (dev.path)}
+								{#each sortedDevices(fs.devices) as dev (dev.path)}
 									<tr class="border-b border-border">
 										<td class="p-2 font-mono text-xs">
 											{dev.path}

--- a/webui/src/routes/shares/+page.svelte
+++ b/webui/src/routes/shares/+page.svelte
@@ -6,6 +6,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { Link2, Lock, Ban, Trash2 } from '@lucide/svelte';
+	import SortTh from '$lib/components/SortTh.svelte';
 
 	// Mirrors the engine's GuestShare (engine/nasty-engine/src/guestshare.rs).
 	// Note: only `token_hash` is stored, never the plaintext token — so a
@@ -56,6 +57,42 @@
 	function isExhausted(s: GuestShare): boolean {
 		return s.max_downloads != null && s.downloads >= s.max_downloads;
 	}
+
+	function statusLabel(s: GuestShare): string {
+		if (s.hidden) return 'Removed';
+		if (s.revoked) return 'Revoked';
+		if (isExpired(s)) return 'Expired';
+		if (isExhausted(s)) return 'Exhausted';
+		return 'Active';
+	}
+
+	// ── Column sorting ──────────────────────────────────────────────────
+	type ShareSortKey = 'shared' | 'created_by' | 'created' | 'expires' | 'downloads' | 'views' | 'status';
+	let shareSortKey = $state<ShareSortKey>('created');
+	let shareSortDir = $state<'asc' | 'desc'>('desc');
+	function toggleShareSort(key: ShareSortKey) {
+		if (shareSortKey === key) shareSortDir = shareSortDir === 'asc' ? 'desc' : 'asc';
+		else { shareSortKey = key; shareSortDir = key === 'created' ? 'desc' : 'asc'; }
+	}
+	const sortedShares = $derived.by(() => {
+		if (!visibleShares) return [];
+		const sign = shareSortDir === 'asc' ? 1 : -1;
+		const sharedName = (s: GuestShare) => s.paths.map(basename).join(', ');
+		return [...visibleShares].sort((a, b) => {
+			let cmp = 0;
+			switch (shareSortKey) {
+				case 'shared': cmp = sharedName(a).localeCompare(sharedName(b), undefined, { numeric: true }); break;
+				case 'created_by': cmp = a.created_by.localeCompare(b.created_by); break;
+				case 'created': cmp = a.created_at - b.created_at; break;
+				case 'expires': cmp = (a.expires_at ?? Infinity) - (b.expires_at ?? Infinity); break;
+				case 'downloads': cmp = a.downloads - b.downloads; break;
+				case 'views': cmp = a.views - b.views; break;
+				case 'status': cmp = statusLabel(a).localeCompare(statusLabel(b)); break;
+			}
+			if (cmp === 0) cmp = b.created_at - a.created_at;
+			return sign * cmp;
+		});
+	});
 
 	async function load() {
 		shares = (await getClient().call<GuestShare[]>('guestshare.list')) ?? [];
@@ -109,18 +146,18 @@
 		<table class="w-full text-sm">
 			<thead>
 				<tr>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Shared</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Created by</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Created</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Expires</th>
-					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground">Downloads</th>
-					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground">Views</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Status</th>
+					<SortTh label="Shared" active={shareSortKey === 'shared'} dir={shareSortDir} onclick={() => toggleShareSort('shared')} />
+					<SortTh label="Created by" active={shareSortKey === 'created_by'} dir={shareSortDir} onclick={() => toggleShareSort('created_by')} />
+					<SortTh label="Created" active={shareSortKey === 'created'} dir={shareSortDir} onclick={() => toggleShareSort('created')} />
+					<SortTh label="Expires" active={shareSortKey === 'expires'} dir={shareSortDir} onclick={() => toggleShareSort('expires')} />
+					<SortTh label="Downloads" align="right" active={shareSortKey === 'downloads'} dir={shareSortDir} onclick={() => toggleShareSort('downloads')} />
+					<SortTh label="Views" align="right" active={shareSortKey === 'views'} dir={shareSortDir} onclick={() => toggleShareSort('views')} />
+					<SortTh label="Status" active={shareSortKey === 'status'} dir={shareSortDir} onclick={() => toggleShareSort('status')} />
 					<th class="border-b-2 border-border p-3 text-right text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 				</tr>
 			</thead>
 			<tbody>
-				{#each visibleShares ?? [] as s (s.id)}
+				{#each sortedShares as s (s.id)}
 					<tr class="border-b border-border {s.hidden ? 'opacity-50' : ''}">
 						<td class="p-3">
 							<div class="flex items-center gap-2">

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -776,6 +776,27 @@
 		return sv.subvolume_type === 'block' ? (sv.volsize_bytes ?? 0) : (sv.used_bytes ?? 0);
 	}
 
+	// ── Snapshots-table column sorting (separate from the subvolumes table
+	// above). Applied to each filesystem group's items. ─────────────────
+	type SnapSortKey = 'name' | 'parent' | 'read_only';
+	let snapSortKey = $state<SnapSortKey>('name');
+	let snapSortDir = $state<'asc' | 'desc'>('asc');
+	function toggleSnapSort(key: SnapSortKey) {
+		if (snapSortKey === key) snapSortDir = snapSortDir === 'asc' ? 'desc' : 'asc';
+		else { snapSortKey = key; snapSortDir = 'asc'; }
+	}
+	function sortedSnaps<T extends { name: string; subvolume: string; read_only?: boolean }>(items: T[]): T[] {
+		const sign = snapSortDir === 'asc' ? 1 : -1;
+		return [...items].sort((a, b) => {
+			let cmp = 0;
+			if (snapSortKey === 'name') cmp = a.name.localeCompare(b.name, undefined, { numeric: true });
+			else if (snapSortKey === 'parent') cmp = a.subvolume.localeCompare(b.subvolume, undefined, { numeric: true });
+			else cmp = Number(a.read_only ?? false) - Number(b.read_only ?? false);
+			if (cmp === 0) cmp = a.name.localeCompare(b.name, undefined, { numeric: true });
+			return sign * cmp;
+		});
+	}
+
 	const filtered = $derived.by(() => {
 		let items = subvolumes;
 		if (selectedFs) items = items.filter(sv => sv.filesystem === selectedFs);
@@ -1527,15 +1548,15 @@
 		<table class="w-full text-sm">
 			<thead>
 				<tr>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Snapshot Name</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Parent Subvolume</th>
-					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Read-only</th>
+					<SortTh label="Snapshot Name" active={snapSortKey === 'name'} dir={snapSortDir} onclick={() => toggleSnapSort('name')} />
+					<SortTh label="Parent Subvolume" active={snapSortKey === 'parent'} dir={snapSortDir} onclick={() => toggleSnapSort('parent')} />
+					<SortTh label="Read-only" active={snapSortKey === 'read_only'} dir={snapSortDir} onclick={() => toggleSnapSort('read_only')} />
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Type</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 				</tr>
 			</thead>
 			<tbody>
-				{#each group.items as snap (`${snap.filesystem}|${snap.subvolume}|${snap.name}`)}
+				{#each sortedSnaps(group.items) as snap (`${snap.filesystem}|${snap.subvolume}|${snap.name}`)}
 					<tr class="border-b border-border">
 						<td class="p-3">
 							<span class="font-mono text-sm">{snap.name}</span>

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -4,6 +4,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import type { Settings } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
+	import SortTh from '$lib/components/SortTh.svelte';
 
 	const client = getClient();
 
@@ -87,6 +88,31 @@
 
 	let hostStatuses: HostTlsStatus[] = $state([]);
 	let hostStatusPollHandle: number | null = $state(null);
+
+	// ── Column sorting ──────────────────────────────────────────────────
+	type HostSortKey = 'host' | 'state' | 'expires';
+	let hostSortKey = $state<HostSortKey>('host');
+	let hostSortDir = $state<'asc' | 'desc'>('asc');
+	function toggleHostSort(key: HostSortKey) {
+		if (hostSortKey === key) hostSortDir = hostSortDir === 'asc' ? 'desc' : 'asc';
+		else { hostSortKey = key; hostSortDir = 'asc'; }
+	}
+	const sortedHostStatuses = $derived.by(() => {
+		const sign = hostSortDir === 'asc' ? 1 : -1;
+		return [...hostStatuses].sort((a, b) => {
+			let cmp = 0;
+			if (hostSortKey === 'host') cmp = a.host.localeCompare(b.host, undefined, { numeric: true });
+			else if (hostSortKey === 'state') cmp = a.state.localeCompare(b.state);
+			else {
+				// Sort by days-to-expiry; unknown expiry sorts last.
+				const av = a.expires_in_days ?? Infinity;
+				const bv = b.expires_in_days ?? Infinity;
+				cmp = av - bv;
+			}
+			if (cmp === 0) cmp = a.host.localeCompare(b.host, undefined, { numeric: true });
+			return sign * cmp;
+		});
+	});
 	// Page-scoped handles for the post-save / Retry ACME-status pollers so
 	// onDestroy can cancel them on SPA navigation — otherwise the 2-second
 	// interval (plus its 5-min setTimeout backstop) keeps hammering
@@ -505,15 +531,15 @@
 		{:else}
 			<table class="w-full text-sm">
 				<thead>
-					<tr class="text-left text-xs uppercase text-muted-foreground">
-						<th class="pb-2 font-medium">Host</th>
-						<th class="pb-2 font-medium">State</th>
-						<th class="pb-2 font-medium">Issuer / Expires</th>
-						<th class="pb-2 font-medium">Detail</th>
+					<tr>
+						<SortTh label="Host" active={hostSortKey === 'host'} dir={hostSortDir} onclick={() => toggleHostSort('host')} thClass="pb-2 font-medium" />
+						<SortTh label="State" active={hostSortKey === 'state'} dir={hostSortDir} onclick={() => toggleHostSort('state')} thClass="pb-2 font-medium" />
+						<SortTh label="Issuer / Expires" active={hostSortKey === 'expires'} dir={hostSortDir} onclick={() => toggleHostSort('expires')} thClass="pb-2 font-medium" />
+						<th class="pb-2 font-medium text-left text-xs uppercase text-muted-foreground">Detail</th>
 					</tr>
 				</thead>
 				<tbody>
-					{#each hostStatuses as h}
+					{#each sortedHostStatuses as h}
 						{@const badge = badgeForState(h.state)}
 						<tr class="border-t border-border">
 							<td class="py-2 pr-3 font-mono text-xs">{h.host}</td>

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -21,12 +21,35 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import SortTh from '$lib/components/SortTh.svelte';
 	import { Trash2, Plus } from '@lucide/svelte';
 	import { startRegistration } from '@simplewebauthn/browser';
 
 	let activeTab: 'users' | 'tokens' | 'sso' = $state('users');
 
 	let users: UserInfo[] = $state([]);
+
+	// ── Column sorting (main users table) ───────────────────────────────
+	type UserSortKey = 'username' | 'role';
+	let userSortKey = $state<UserSortKey>('username');
+	let userSortDir = $state<'asc' | 'desc'>('asc');
+	function toggleUserSort(key: UserSortKey) {
+		if (userSortKey === key) userSortDir = userSortDir === 'asc' ? 'desc' : 'asc';
+		else { userSortKey = key; userSortDir = 'asc'; }
+	}
+	const sortedUsers = $derived.by(() => {
+		const sign = userSortDir === 'asc' ? 1 : -1;
+		// admin > operator > read-only when descending.
+		const roleRank = (r: string) => (r === 'admin' ? 3 : r === 'operator' ? 2 : 1);
+		return [...users].sort((a, b) => {
+			let cmp =
+				userSortKey === 'role'
+					? roleRank(a.role) - roleRank(b.role)
+					: a.username.localeCompare(b.username, undefined, { numeric: true });
+			if (cmp === 0) cmp = a.username.localeCompare(b.username, undefined, { numeric: true });
+			return sign * cmp;
+		});
+	});
 	let apiTokens: ApiTokenInfo[] = $state([]);
 	let filesystems: Filesystem[] = $state([]);
 	let loading = $state(true);
@@ -592,13 +615,13 @@
 	<table class="mb-10 w-full text-sm">
 		<thead>
 			<tr>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Username</th>
-				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Role</th>
+				<SortTh label="Username" active={userSortKey === 'username'} dir={userSortDir} onclick={() => toggleUserSort('username')} />
+				<SortTh label="Role" active={userSortKey === 'role'} dir={userSortDir} onclick={() => toggleUserSort('role')} />
 				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 			</tr>
 		</thead>
 		<tbody>
-			{#each users as user}
+			{#each sortedUsers as user}
 				<tr class="border-b border-border">
 					<td class="p-3"><strong>{user.username}</strong></td>
 					<td class="p-3">


### PR DESCRIPTION
Closes #531. The Filesystems device table couldn't be sorted — Huxy hit this when a replaced drive landed in a new slot at the bottom with no way to sort by `DEVICE`/`LABEL`. This fixes that table and extends column sorting across the primary record-list views.

## Approach
Reuses the existing `SortTh` header component (already used by Files, Subvolumes, Apps, VMs, and the Sharing panels). Each table gets the same small pattern: `sortKey`/`sortDir` state, a `toggleSort` that flips direction on re-click, and a `$derived` sorted copy with a per-key comparator (numeric `localeCompare` for text, subtract for numbers, rank for severity/role/status). **Default order is each table's current order**, so nothing looks reordered until you click a header.

## Tables made sortable
- **Filesystems device table** (#531) — Device, Label, State + the optional columns. One shared key applies to each filesystem's device list.
- **Alerts** — Name, Metric, Severity, Status.
- **Guest Shares** — Shared, Created by, Created, Expires, Downloads, Views, Status (sorts the visible set; default Created↓).
- **TLS certs** — Host, State, Expires (by days-to-expiry).
- **Users** (main table) — Username, Role.
- **Snapshots** table (Subvolumes page) — Name, Parent, Read-only (separate state from that page's existing subvolume-table sort).

## SortTh tweak
Added an optional `thClass` prop (default unchanged, so all existing users are untouched) so the header can match each table's padding/border — the dense `p-2` device table and the borderless TLS header now align with their cells instead of being forced to the standard `p-3` style.

## Deliberately skipped (with reason)
- **Disks** — disk→partition nesting is intrinsic; flat sorting would break the hierarchy.
- **Services / Ingress** — grouped by category/server; the grouping *is* the order.
- **Hardware / Licenses / Update** — static reference / fixed tables.
- Users sub-tables (API tokens, SMB users, SSH keys, WebAuthn) and the Backups modal — the wider tier, out of this scope.

Pure WebUI change — no engine, no new dependency. `npm run check` (0 errors), `npm run build`, and `npm run test` (144) all green.