### PR TITLE
smb: macOS Time Machine destination support

### DIFF
--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -11,6 +11,9 @@ use uuid::Uuid;
 const NASTY_SMB_CONF_PATH: &str = "/etc/samba/smb.nasty.conf";
 const NASTY_SMB_SHARE_DIR: &str = "/etc/samba/nasty.d";
 const STATE_DIR: &str = "/var/lib/nasty/shares/smb";
+/// Engine-written Avahi service file advertising `_adisk._tcp` so Time
+/// Machine shares appear in the macOS picker. Avahi auto-reloads this dir.
+const NASTY_TIMEMACHINE_AVAHI_PATH: &str = "/etc/avahi/services/nasty-timemachine.service";
 
 #[derive(Debug, Error)]
 pub enum SmbError {
@@ -24,6 +27,8 @@ pub enum SmbError {
     PathNotInFilesystem(String),
     #[error("invalid share name: {0}")]
     InvalidName(String),
+    #[error("a Time Machine share must be authenticated and writable (not guest, not read-only)")]
+    TimeMachineRequiresAuth,
     #[error("samba reload failed: {0}")]
     ReloadFailed(String),
     #[error("io error: {0}")]
@@ -50,6 +55,16 @@ pub struct SmbShare {
     pub valid_users: Vec<String>,
     /// Additional raw Samba parameters written to the share section.
     pub extra_params: HashMap<String, String>,
+    /// Whether this share is a macOS Time Machine destination. When true the
+    /// share section gets the `vfs_fruit` Time Machine options. Requires an
+    /// authenticated, writable share (not guest, not read-only).
+    #[serde(default)]
+    pub time_machine: bool,
+    /// Optional Time Machine size cap in GiB, written as
+    /// `fruit:time machine max size` so macOS self-limits and thins old
+    /// backups. `None` = no advertised cap (pair with a subvolume quota).
+    #[serde(default)]
+    pub time_machine_max_size_gib: Option<u32>,
     /// Whether the share is active in `smb.nasty.conf`.
     pub enabled: bool,
 }
@@ -78,6 +93,11 @@ pub struct CreateSmbShareRequest {
     pub valid_users: Option<Vec<String>>,
     /// Additional raw Samba parameters for this share section.
     pub extra_params: Option<HashMap<String, String>>,
+    /// Make this a macOS Time Machine destination (default: false). Requires
+    /// an authenticated, writable share.
+    pub time_machine: Option<bool>,
+    /// Optional Time Machine size cap in GiB.
+    pub time_machine_max_size_gib: Option<u32>,
     /// Whether to enable the share immediately (default: true).
     pub enabled: Option<bool>,
 }
@@ -100,6 +120,10 @@ pub struct UpdateSmbShareRequest {
     pub valid_users: Option<Vec<String>>,
     /// Replacement extra Samba parameters (optional).
     pub extra_params: Option<HashMap<String, String>>,
+    /// Toggle Time Machine destination (optional).
+    pub time_machine: Option<bool>,
+    /// Update the Time Machine size cap in GiB (optional). Send 0 to clear.
+    pub time_machine_max_size_gib: Option<u32>,
     /// Enable or disable the share (optional).
     pub enabled: Option<bool>,
 }
@@ -170,13 +194,17 @@ impl SmbService {
             guest_ok: req.guest_ok.unwrap_or(false),
             valid_users: req.valid_users.unwrap_or_default(),
             extra_params: req.extra_params.unwrap_or_default(),
+            time_machine: req.time_machine.unwrap_or(false),
+            time_machine_max_size_gib: req.time_machine_max_size_gib.filter(|&n| n > 0),
             enabled: req.enabled.unwrap_or(true),
         };
+        validate_time_machine(&share)?;
 
         state_dir().save(&share.id, &share).await?;
         write_share_conf(&share).await?;
         rebuild_include_list().await?;
         reload_samba().await?;
+        sync_timemachine_avahi().await;
         wait_for_share_ready(&share.name).await;
 
         info!("Created SMB share '{}' at {}", share.name, share.path);
@@ -222,14 +250,23 @@ impl SmbService {
         if let Some(extra_params) = req.extra_params {
             share.extra_params = extra_params;
         }
+        if let Some(time_machine) = req.time_machine {
+            share.time_machine = time_machine;
+        }
+        if let Some(n) = req.time_machine_max_size_gib {
+            // 0 clears the cap.
+            share.time_machine_max_size_gib = if n > 0 { Some(n) } else { None };
+        }
         if let Some(enabled) = req.enabled {
             share.enabled = enabled;
         }
+        validate_time_machine(&share)?;
 
         state_dir().save(&share.id, &share).await?;
         write_share_conf(&share).await?;
         rebuild_include_list().await?;
         reload_samba().await?;
+        sync_timemachine_avahi().await;
 
         info!("Updated SMB share '{}'", share.name);
         Ok(share)
@@ -245,6 +282,7 @@ impl SmbService {
         remove_share_conf(&req.id).await;
         rebuild_include_list().await?;
         reload_samba().await?;
+        sync_timemachine_avahi().await;
 
         info!("Deleted SMB share '{}'", req.id);
         Ok(())
@@ -362,7 +400,33 @@ fn render_share_conf(share: &SmbShare) -> String {
         ));
     }
 
+    // Time Machine block last so it can't be silently overridden by an
+    // extra_params entry. The recommended vfs_fruit options for a macOS
+    // Time Machine destination over SMB (streams_xattr is backed by bcachefs
+    // xattrs).
+    if share.time_machine {
+        conf.push_str("    vfs objects = catia fruit streams_xattr\n");
+        conf.push_str("    fruit:time machine = yes\n");
+        conf.push_str("    fruit:metadata = stream\n");
+        conf.push_str("    fruit:posix_rename = yes\n");
+        conf.push_str("    fruit:veto_appledouble = no\n");
+        conf.push_str("    fruit:wipe_intentionally_left_blank_rfork = yes\n");
+        conf.push_str("    fruit:delete_empty_adfiles = yes\n");
+        if let Some(gib) = share.time_machine_max_size_gib {
+            conf.push_str(&format!("    fruit:time machine max size = {gib}G\n"));
+        }
+    }
+
     conf
+}
+
+/// A Time Machine share must be authenticated and writable — guest access or
+/// read-only would make it unusable as a backup target.
+fn validate_time_machine(share: &SmbShare) -> Result<(), SmbError> {
+    if share.time_machine && (share.guest_ok || share.read_only) {
+        return Err(SmbError::TimeMachineRequiresAuth);
+    }
+    Ok(())
 }
 
 /// Write a single share config file: /etc/samba/nasty.d/{id}.conf
@@ -429,6 +493,92 @@ async fn rebuild_include_list() -> Result<(), SmbError> {
 /// Path to the per-share SMB config file.
 fn share_conf_path(id: &str) -> String {
     format!("{NASTY_SMB_SHARE_DIR}/{id}.conf")
+}
+
+/// Build the `_adisk._tcp` Avahi service-group XML for the given Time Machine
+/// share names, or `None` when there are none (caller removes the file).
+///
+/// Each share becomes a `dkN=adVN=<name>,adVF=0x82` TXT record — that's how
+/// macOS Time Machine discovers selectable destinations; `adVF=0x82` flags
+/// the disk as Time Machine capable. The companion `sys=…adVF=0x100` record
+/// advertises the host's overall Time Machine support.
+fn build_timemachine_avahi_xml(tm_share_names: &[String]) -> Option<String> {
+    if tm_share_names.is_empty() {
+        return None;
+    }
+    let mut dk = String::new();
+    for (i, name) in tm_share_names.iter().enumerate() {
+        // Share names are already validated to a safe character set, but
+        // escape XML metacharacters defensively.
+        let safe = xml_escape(name);
+        dk.push_str(&format!(
+            "    <txt-record>dk{i}=adVN={safe},adVF=0x82</txt-record>\n"
+        ));
+    }
+    Some(format!(
+        "<?xml version=\"1.0\" standalone='no'?>\n\
+         <!DOCTYPE service-group SYSTEM \"avahi-service.dtd\">\n\
+         <!-- Managed by NASty — do not edit manually -->\n\
+         <service-group>\n\
+         \x20 <name replace-wildcards=\"yes\">%h</name>\n\
+         \x20 <service>\n\
+         \x20\x20\x20 <type>_adisk._tcp</type>\n\
+         \x20\x20\x20 <port>9</port>\n\
+         \x20\x20\x20 <txt-record>sys=waMa=0,adVF=0x100</txt-record>\n\
+         {dk}\
+         \x20 </service>\n\
+         </service-group>\n"
+    ))
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Recompute the `_adisk` advertisement from current state: write the Avahi
+/// service file listing every enabled Time Machine share, or remove it when
+/// there are none. Best-effort — discovery is a convenience, not correctness,
+/// so failures are logged, not propagated.
+async fn sync_timemachine_avahi() {
+    let shares: Vec<SmbShare> = state_dir().load_all().await;
+    let names: Vec<String> = shares
+        .into_iter()
+        .filter(|s| s.enabled && s.time_machine)
+        .map(|s| s.name)
+        .collect();
+
+    match build_timemachine_avahi_xml(&names) {
+        Some(xml) => {
+            if let Some(parent) = Path::new(NASTY_TIMEMACHINE_AVAHI_PATH).parent()
+                && let Err(e) = tokio::fs::create_dir_all(parent).await
+            {
+                tracing::warn!("Time Machine: could not ensure {}: {e}", parent.display());
+                return;
+            }
+            if let Err(e) = tokio::fs::write(NASTY_TIMEMACHINE_AVAHI_PATH, &xml).await {
+                tracing::warn!("Time Machine: could not write Avahi service file: {e}");
+                return;
+            }
+        }
+        None => {
+            if let Err(e) = tokio::fs::remove_file(NASTY_TIMEMACHINE_AVAHI_PATH).await
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!("Time Machine: could not remove Avahi service file: {e}");
+            }
+        }
+    }
+
+    // Avahi auto-reloads /etc/avahi/services via inotify; nudge it as a
+    // best-effort fallback (no-op if avahi isn't running).
+    let _ = tokio::process::Command::new("systemctl")
+        .args(["reload", "avahi-daemon"])
+        .output()
+        .await;
 }
 
 /// Wait for an SMB share to be visible after smbcontrol reload.
@@ -828,6 +978,8 @@ mod tests {
             guest_ok: false,
             valid_users: vec![],
             extra_params: HashMap::new(),
+            time_machine: false,
+            time_machine_max_size_gib: None,
             enabled: true,
         }
     }
@@ -965,5 +1117,76 @@ mod tests {
         assert!(alpha_pos < middle_pos && middle_pos < zeta_pos);
         // Injection chars in the value got stripped.
         assert!(out.contains("    middle = vinjectedx\n"));
+    }
+
+    // ── Time Machine ───────────────────────────────────────────────────
+
+    #[test]
+    fn render_share_conf_time_machine_emits_fruit_block() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["alice".to_string()];
+        share.time_machine = true;
+        let out = render_share_conf(&share);
+        assert!(out.contains("    vfs objects = catia fruit streams_xattr\n"));
+        assert!(out.contains("    fruit:time machine = yes\n"));
+        assert!(out.contains("    fruit:metadata = stream\n"));
+        // No cap unless one is set.
+        assert!(!out.contains("fruit:time machine max size"));
+    }
+
+    #[test]
+    fn render_share_conf_time_machine_max_size() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["alice".to_string()];
+        share.time_machine = true;
+        share.time_machine_max_size_gib = Some(500);
+        let out = render_share_conf(&share);
+        assert!(out.contains("    fruit:time machine max size = 500G\n"));
+    }
+
+    #[test]
+    fn render_share_conf_without_time_machine_emits_no_fruit() {
+        let out = render_share_conf(&minimal_share());
+        assert!(!out.contains("fruit:"));
+        assert!(!out.contains("vfs objects"));
+    }
+
+    #[test]
+    fn validate_time_machine_rejects_guest_and_readonly() {
+        let mut share = minimal_share();
+        share.time_machine = true;
+        share.valid_users = vec!["alice".to_string()];
+        assert!(validate_time_machine(&share).is_ok());
+
+        let mut guest = share.clone();
+        guest.guest_ok = true;
+        assert!(matches!(
+            validate_time_machine(&guest),
+            Err(SmbError::TimeMachineRequiresAuth)
+        ));
+
+        let mut ro = share.clone();
+        ro.read_only = true;
+        assert!(matches!(
+            validate_time_machine(&ro),
+            Err(SmbError::TimeMachineRequiresAuth)
+        ));
+
+        // Non-TM shares are unaffected by guest/read-only.
+        let mut plain = minimal_share();
+        plain.guest_ok = true;
+        assert!(validate_time_machine(&plain).is_ok());
+    }
+
+    #[test]
+    fn timemachine_avahi_xml_lists_one_dk_per_share_or_none() {
+        // No shares → no file.
+        assert!(build_timemachine_avahi_xml(&[]).is_none());
+
+        let xml = build_timemachine_avahi_xml(&["TimeMachine".into(), "Backups".into()]).unwrap();
+        assert!(xml.contains("<type>_adisk._tcp</type>"));
+        assert!(xml.contains("sys=waMa=0,adVF=0x100"));
+        assert!(xml.contains("dk0=adVN=TimeMachine,adVF=0x82"));
+        assert!(xml.contains("dk1=adVN=Backups,adVF=0x82"));
     }
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1444,6 +1444,10 @@ in {
       "d /etc/target 0750 root root -"
       "f /etc/samba/smb.nasty.conf 0644 root root -"
       "d /etc/samba/nasty.d 0755 root root -"
+      # Real, engine-writable dir for the dynamic Time Machine `_adisk`
+      # Avahi service file (otherwise only populated by static
+      # extraServiceFiles). See nasty-sharing smb.rs::sync_timemachine_avahi.
+      "d /etc/avahi/services 0755 root root -"
       "d /var/lib/nasty/nut 0750 root root -"
       "d /var/state/ups 0750 root root -"
     ];

--- a/webui/src/lib/sharing/smb.svelte.ts
+++ b/webui/src/lib/sharing/smb.svelte.ts
@@ -29,6 +29,8 @@ export const smb = $state({
 	newComment: '',
 	newReadOnly: false,
 	newGuestOk: false,
+	newTimeMachine: false,
+	newTmMaxSize: null as number | null,
 	expanded: {} as Record<string, boolean>,
 	addUserShare: null as string | null,
 	addUserName: '',
@@ -93,6 +95,8 @@ export async function smbCreate() {
 			comment: smb.newComment || undefined,
 			read_only: smb.newReadOnly,
 			guest_ok: smb.newGuestOk,
+			time_machine: smb.newTimeMachine,
+			time_machine_max_size_gib: smb.newTmMaxSize ?? undefined,
 		}),
 		'SMB share created'
 	);
@@ -101,6 +105,8 @@ export async function smbCreate() {
 		smb.newSubvolume = '';
 		smb.newName = '';
 		smb.newComment = '';
+		smb.newTimeMachine = false;
+		smb.newTmMaxSize = null;
 		await smbRefresh();
 	}
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -561,6 +561,8 @@ export interface SmbShare {
 	guest_ok: boolean;
 	valid_users: string[];
 	extra_params: Record<string, string>;
+	time_machine: boolean;
+	time_machine_max_size_gib: number | null;
 	enabled: boolean;
 }
 

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -65,6 +65,8 @@
 	let shareSmbGuestOk = $state(false);
 	let shareSmbReadOnly = $state(false);
 	let shareSmbValidUsers: string[] = $state([]);
+	let shareSmbTimeMachine = $state(false);
+	let shareSmbTmMaxSize: number | null = $state(null);
 	// SMB inline user/group creation moved into <SmbWizardForm>.
 	// iSCSI access
 	let shareIscsiName = $state('');
@@ -135,6 +137,7 @@
 		shareSubvolume = '';
 		shareNfsHost = ''; shareNfsOptions = 'rw,sync,no_subtree_check';
 		shareSmbName = ''; shareSmbGuestOk = false; shareSmbReadOnly = false; shareSmbValidUsers = [];
+		shareSmbTimeMachine = false; shareSmbTmMaxSize = null;
 		shareIscsiName = ''; shareNvmeofName = '';
 		shareNvmeofAddr = '0.0.0.0'; shareNvmeofPort = '4420';
 		showInlineCreate = false;
@@ -178,6 +181,8 @@
 				guest_ok: shareSmbGuestOk,
 				read_only: shareSmbReadOnly,
 				valid_users: shareSmbValidUsers,
+				time_machine: shareSmbTimeMachine,
+				time_machine_max_size_gib: shareSmbTmMaxSize ?? undefined,
 			}),
 			'SMB share created',
 		),
@@ -437,6 +442,8 @@
 					bind:guestOk={shareSmbGuestOk}
 					bind:readOnly={shareSmbReadOnly}
 					bind:validUsers={shareSmbValidUsers}
+					bind:timeMachine={shareSmbTimeMachine}
+					bind:maxSizeGib={shareSmbTmMaxSize}
 				/>
 			{:else if shareProtocol === 'iscsi'}
 				<IscsiWizardForm bind:name={shareIscsiName} />
@@ -469,6 +476,8 @@
 						guestOk={shareSmbGuestOk}
 						readOnly={shareSmbReadOnly}
 						validUsers={shareSmbValidUsers}
+						timeMachine={shareSmbTimeMachine}
+						maxSizeGib={shareSmbTmMaxSize}
 					/>
 				{:else if shareProtocol === 'iscsi'}
 					<IscsiWizardReview name={shareIscsiName} fallbackName={sv?.name ?? ''} />

--- a/webui/src/routes/sharing/SmbPanel.svelte
+++ b/webui/src/routes/sharing/SmbPanel.svelte
@@ -88,14 +88,38 @@
 				<Label for="smb-comment">Comment</Label>
 				<Input id="smb-comment" bind:value={smb.newComment} placeholder="Optional description" class="mt-1" />
 			</div>
-			<div class="mb-4 flex gap-6">
+			<div class="mb-4">
 				<label class="flex cursor-pointer items-center gap-2">
-					<input type="checkbox" bind:checked={smb.newReadOnly} class="h-4 w-4" /> Read-only
+					<input
+						type="checkbox"
+						bind:checked={smb.newTimeMachine}
+						onchange={() => { if (smb.newTimeMachine) { smb.newGuestOk = false; smb.newReadOnly = false; } }}
+						class="h-4 w-4" />
+					Time Machine — macOS backup destination
 				</label>
-				<label class="flex cursor-pointer items-center gap-2">
-					<input type="checkbox" bind:checked={smb.newGuestOk} class="h-4 w-4" /> Allow guests
-				</label>
+				{#if smb.newTimeMachine}
+					<div class="mt-2 ml-6 flex items-center gap-2 text-sm">
+						<span class="text-muted-foreground">Max size (GiB)</span>
+						<input
+							type="number"
+							min="1"
+							placeholder="unlimited"
+							value={smb.newTmMaxSize ?? ''}
+							oninput={(e) => { const v = (e.target as HTMLInputElement).value; smb.newTmMaxSize = v === '' ? null : Number(v); }}
+							class="h-8 w-32 rounded-md border border-input bg-transparent px-2 text-sm" />
+					</div>
+				{/if}
 			</div>
+			{#if !smb.newTimeMachine}
+				<div class="mb-4 flex gap-6">
+					<label class="flex cursor-pointer items-center gap-2">
+						<input type="checkbox" bind:checked={smb.newReadOnly} class="h-4 w-4" /> Read-only
+					</label>
+					<label class="flex cursor-pointer items-center gap-2">
+						<input type="checkbox" bind:checked={smb.newGuestOk} class="h-4 w-4" /> Allow guests
+					</label>
+				</div>
+			{/if}
 			<Button onclick={smbCreateGuarded}>Create</Button>
 		</CardContent>
 	</Card>
@@ -124,6 +148,9 @@
 				>
 					<td class="p-3">
 						<strong>{share.name}</strong>
+						{#if share.time_machine}
+							<Badge variant="secondary" class="ml-2 bg-blue-950 text-blue-300">Time Machine</Badge>
+						{/if}
 						{#if share.comment}<br /><span class="text-xs text-muted-foreground">{share.comment}</span>{/if}
 					</td>
 					<td class="p-3 font-mono text-sm">{share.path}</td>

--- a/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
@@ -14,12 +14,16 @@
 		guestOk: boolean;
 		readOnly: boolean;
 		validUsers: string[];
+		timeMachine: boolean;
+		maxSizeGib: number | null;
 	}
 	let {
 		name = $bindable(),
 		guestOk = $bindable(),
 		readOnly = $bindable(),
 		validUsers = $bindable(),
+		timeMachine = $bindable(),
+		maxSizeGib = $bindable(),
 	}: Props = $props();
 
 	const client = getClient();
@@ -78,16 +82,50 @@
 	<Label>Share Name</Label>
 	<Input bind:value={name} placeholder="documents" class="mt-1" />
 </div>
-<div class="mb-4 flex gap-4">
+<div class="mb-4">
 	<label class="flex items-center gap-2 text-sm cursor-pointer">
-		<input type="checkbox" bind:checked={guestOk} class="rounded border-input" />
-		Allow guests
+		<input
+			type="checkbox"
+			bind:checked={timeMachine}
+			onchange={() => { if (timeMachine) { guestOk = false; readOnly = false; } }}
+			class="rounded border-input" />
+		Time Machine — macOS backup destination
 	</label>
-	<label class="flex items-center gap-2 text-sm cursor-pointer">
-		<input type="checkbox" bind:checked={readOnly} class="rounded border-input" />
-		Read-only
-	</label>
+	{#if timeMachine}
+		<div class="mt-2 ml-6 space-y-2">
+			<div class="flex items-center gap-2 text-sm">
+				<Label class="font-normal">Max size (GiB)</Label>
+				<input
+					type="number"
+					min="1"
+					placeholder="unlimited"
+					value={maxSizeGib ?? ''}
+					oninput={(e) => {
+						const v = (e.target as HTMLInputElement).value;
+						maxSizeGib = v === '' ? null : Number(v);
+					}}
+					class="h-8 w-32 rounded-md border border-input bg-transparent px-2 text-sm" />
+			</div>
+			<p class="text-xs text-muted-foreground">
+				macOS thins old backups to stay under this. Pair it with a subvolume quota
+				as a hard cap. Time Machine shares are authenticated and writable — add the
+				one user who will back up below.
+			</p>
+		</div>
+	{/if}
 </div>
+{#if !timeMachine}
+	<div class="mb-4 flex gap-4">
+		<label class="flex items-center gap-2 text-sm cursor-pointer">
+			<input type="checkbox" bind:checked={guestOk} class="rounded border-input" />
+			Allow guests
+		</label>
+		<label class="flex items-center gap-2 text-sm cursor-pointer">
+			<input type="checkbox" bind:checked={readOnly} class="rounded border-input" />
+			Read-only
+		</label>
+	</div>
+{/if}
 {#if !guestOk}
 	<div class="mb-4">
 		<Label>Allowed Users & Groups</Label>

--- a/webui/src/routes/sharing/wizard/SmbWizardReview.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardReview.svelte
@@ -5,12 +5,18 @@
 		guestOk: boolean;
 		readOnly: boolean;
 		validUsers: string[];
+		timeMachine?: boolean;
+		maxSizeGib?: number | null;
 	}
-	let { name, fallbackName, guestOk, readOnly, validUsers }: Props = $props();
+	let { name, fallbackName, guestOk, readOnly, validUsers, timeMachine = false, maxSizeGib = null }: Props = $props();
 </script>
 
 <span class="text-muted-foreground">Share Name</span>
 <span>{name || fallbackName}</span>
+{#if timeMachine}
+	<span class="text-muted-foreground">Time Machine</span>
+	<span>Enabled{maxSizeGib ? ` — max ${maxSizeGib} GiB` : ''}</span>
+{/if}
 {#if guestOk}
 	<span class="text-muted-foreground">Guests</span>
 	<span>Allowed</span>


### PR DESCRIPTION
Makes a NASty SMB share usable as a **macOS Time Machine** target, with auto-discovery in the Time Machine picker. (Requested by a user; today the SMB stack has no `vfs_fruit` and no `_adisk` mDNS.)

## Engine — `nasty-sharing/src/smb.rs`
- **Model**: new `time_machine` flag + optional `time_machine_max_size_gib` on the SMB share (serde-default → existing records load unchanged).
- **Conf**: when `time_machine`, `render_share_conf` emits the recommended `vfs_fruit` block (`vfs objects = catia fruit streams_xattr`, `fruit:time machine = yes`, `fruit:metadata = stream`, `posix_rename`, …) and, if a cap is set, `fruit:time machine max size = NG`. Rendered **after** `extra_params` so it can't be silently overridden. (`streams_xattr` is backed by bcachefs xattrs.)
- **Validation**: a TM share must be authenticated + writable — create/update reject it combined with guest or read-only.
- **Discovery**: on every SMB mutation the engine (re)writes `/etc/avahi/services/nasty-timemachine.service` advertising `_adisk._tcp` with one `dkN=adVN=<share>,adVF=0x82` per enabled TM share (file removed when there are none), so the share **auto-appears in System Settings → Time Machine** without mounting first. Avahi auto-reloads the dir; best-effort `systemctl reload avahi-daemon` as a fallback.
- **Tests**: fruit block + max-size rendering, no-fruit-when-off, validation rejects guest/read-only, and the `_adisk` XML builder (one dk per share / none).

## NixOS — `nasty.nix`
One `systemd.tmpfiles.rules` entry makes `/etc/avahi/services` a real, engine-writable dir (mirrors the existing `/etc/samba/nasty.d`, `/etc/exports.d` rules). No other nix change — avahi already publishes user service files (the existing `_smb`/`_device-info` ads prove the path) and is gated on `smb.enable`, which TM requires.

## WebUI
A **"Time Machine"** toggle + optional **"Max size (GiB)"** on both SMB create paths (the share wizard and the SmbPanel quick-create); turning it on forces the share authenticated + writable. SmbPanel shows a Time Machine badge; the wizard review reflects it. SMB method schemas are `gen_schema`-derived, so the new fields reach REST/OpenAPI automatically.

## Verification
Engine `fmt` + `clippy --all-targets` + tests green (126+52); WebUI `check` + `build` + `vitest` (144) green; `nix-instantiate --parse` OK. **Recommend the appliance-smoke VM test** for the tmpfiles/systemd change, and a **live same-subnet Mac** check (create a TM share with one user + a max size on a quota'd subvolume → confirm it auto-appears in the TM picker and a backup + incremental run).

## Notes
- v1 targets the common **single-user** TM share (`force user` = that user). Multi-user-per-share (no force user) is a later refinement.
- `fruit:model` (custom Finder icon) intentionally omitted — `_adisk` already marks it a TM target.