### PR TITLE
apps: compose startup ordering UI + read RPC (#437, PR 2/2)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1787,6 +1787,15 @@ pub struct SetComposeStartupRequest {
     pub delay_secs: u32,
 }
 
+/// Startup config of one compose stack, for the WebUI's Startup-order view.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ComposeStartupEntry {
+    pub name: String,
+    pub managed: bool,
+    pub order: u32,
+    pub delay_secs: u32,
+}
+
 // ── Ingress types ──────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -4094,6 +4103,29 @@ impl AppsService {
             "Compose stack '{name}' startup: managed={managed} order={order} delay={delay_secs}s"
         );
         Ok(())
+    }
+
+    /// Startup config of every compose stack, sorted by (order, name), for
+    /// the WebUI's Startup-order view. Read-only; best-effort.
+    pub async fn compose_list_startup(&self) -> Vec<ComposeStartupEntry> {
+        let mut out = Vec::new();
+        if let Ok(mut entries) = tokio::fs::read_dir(COMPOSE_DIR).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                if !entry.path().join("docker-compose.yml").exists() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                let cfg = load_startup_config(&name).await;
+                out.push(ComposeStartupEntry {
+                    name,
+                    managed: cfg.managed,
+                    order: cfg.order,
+                    delay_secs: cfg.delay_secs,
+                });
+            }
+        }
+        out.sort_by(|a, b| a.order.cmp(&b.order).then_with(|| a.name.cmp(&b.name)));
+        out
     }
 
     pub async fn compose_remove(&self, name: &str) -> Result<(), AppsError> {

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -13,9 +13,10 @@ use crate::subvolume_dependents::SubvolumeDependents;
 use nasty_apps::{
     App, AppConfig, AppIngress, AppStats, AppdataRelocateStatus, AppsStatus, CaddyRouteSummary,
     CheckComposeRequest, CheckComposeResult, CheckDevicesRequest, CheckPortsRequest,
-    CheckVolumesRequest, DeviceMissing, EnableAppsRequest, FixVolumePermsRequest,
-    ImageInspectResult, InstallAppRequest, InstallComposeRequest, ManagedNetwork, NetworkSummary,
-    PortConflict, PruneResult, SetComposeStartupRequest, SetIngressRequest, VolumeMismatch,
+    CheckVolumesRequest, ComposeStartupEntry, DeviceMissing, EnableAppsRequest,
+    FixVolumePermsRequest, ImageInspectResult, InstallAppRequest, InstallComposeRequest,
+    ManagedNetwork, NetworkSummary, PortConflict, PruneResult, SetComposeStartupRequest,
+    SetIngressRequest, VolumeMismatch,
 };
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
@@ -2672,6 +2673,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<SetComposeStartupRequest>(generator)),
                     result: None,
+                },
+                Method {
+                    name: "apps.compose.startup.list",
+                    desc: "List every compose stack's startup config (managed flag, order, delay), sorted by order then name — powers the WebUI's Startup-order view.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<ComposeStartupEntry>>(generator)),
                 },
                 Method {
                     name: "apps.ingress.list",

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -253,6 +253,7 @@ pub(super) async fn try_route(
                 Err(e) => invalid(req, e),
             }
         }
+        "apps.compose.startup.list" => ok(req, state.apps.compose_list_startup().await),
         "apps.ingress.list" => match state.apps.ingress_list().await {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1507,6 +1507,14 @@ export interface PruneResult {
 	space_reclaimed_bytes: number;
 }
 
+/** A compose stack's NASty-managed startup config (#437). */
+export interface ComposeStartupEntry {
+	name: string;
+	managed: boolean;
+	order: number;
+	delay_secs: number;
+}
+
 export interface App {
 	name: string;
 	image: string;

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -5,7 +5,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
-	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe, NetworkSummary, ManagedNetwork, NetworkState } from '$lib/types';
+	import type { AppsStatus, App, AppIngress, AppConfig, ImageInspectResult, AppContainer, AppStats, MappedPort, PruneResult, SubPathRecipe, NetworkSummary, ManagedNetwork, NetworkState, ComposeStartupEntry } from '$lib/types';
 	import { formatBytes } from '$lib/format';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -134,6 +134,8 @@
 
 	let status: AppsStatus | null = $state(null);
 	let apps: App[] = $state([]);
+	// Compose stack startup config (#437), for the Startup-order card.
+	let composeStartup: ComposeStartupEntry[] = $state([]);
 	// Map of app-name → locked-FS-name. Populated from
 	// `fs.locked_dependents` so each app row can show a "🔒 on tank"
 	// badge that opens the global unlock dialog. Stays empty when
@@ -995,6 +997,9 @@
 			if (status.enabled && status.running) {
 				await loadIngresses();
 				await loadAppNetworks();
+				try {
+					composeStartup = await client.call<ComposeStartupEntry[]>('apps.compose.startup.list');
+				} catch { composeStartup = []; }
 				if (!statsPoll) startStatsPolling();
 				// Also lift the idle list-poll here so Docker coming up
 				// after the page loaded (e.g. user enabled apps from this
@@ -1010,6 +1015,28 @@
 			}
 		} catch { /* ignore */ }
 		await loadLockedFsByApp();
+	}
+
+	// ── Compose startup ordering (#437) ──────────────────────────────
+	let startupBusy = $state<string | null>(null);
+	const composeStacks = $derived(apps.filter((a) => a.kind === 'compose'));
+	/** Startup config for a stack, defaulting to unmanaged when absent. */
+	function startupOf(name: string): ComposeStartupEntry {
+		return composeStartup.find((e) => e.name === name) ?? { name, managed: false, order: 0, delay_secs: 0 };
+	}
+	async function setComposeStartup(name: string, managed: boolean, order: number, delay_secs: number) {
+		startupBusy = name;
+		await withToast(
+			() => client.call('apps.compose.set_startup', {
+				name,
+				managed,
+				order: Math.max(0, Math.floor(order) || 0),
+				delay_secs: Math.max(0, Math.floor(delay_secs) || 0),
+			}),
+			managed ? 'Startup updated' : 'Removed from managed startup'
+		);
+		startupBusy = null;
+		await refresh();
 	}
 
 	/** Build the {appName: lockedFsName} map for the per-row badge.
@@ -2323,6 +2350,58 @@
 				</tbody>
 			</table>
 		{/if}
+	{/if}
+
+	<!-- Startup order (#437): NASty-managed boot ordering for compose stacks -->
+	{#if composeStacks.length > 0}
+		<h3 class="text-lg font-semibold mt-6 mb-1">Compose Startup Order</h3>
+		<p class="mb-3 max-w-3xl text-xs text-muted-foreground">
+			Let NASty bring compose stacks up at boot in a set order, waiting a few seconds after each
+			to let things settle (e.g. a stack that creates shared Docker networks before the stacks
+			that use them). Managed stacks are pinned to <code>restart: "no"</code> so Docker won't
+			race the engine — your compose files are left untouched.
+		</p>
+		<table class="w-full max-w-3xl text-sm">
+			<thead>
+				<tr>
+					<th class="border-b-2 border-border p-2 text-left text-xs uppercase text-muted-foreground">Managed</th>
+					<th class="border-b-2 border-border p-2 text-left text-xs uppercase text-muted-foreground">Stack</th>
+					<th class="border-b-2 border-border p-2 text-right text-xs uppercase text-muted-foreground">Order</th>
+					<th class="border-b-2 border-border p-2 text-right text-xs uppercase text-muted-foreground">Delay (s)</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each composeStacks.map((a) => startupOf(a.name)).sort((x, y) => x.managed === y.managed ? (x.order - y.order || x.name.localeCompare(y.name)) : (x.managed ? -1 : 1)) as e (e.name)}
+					<tr class="border-b border-border {e.managed ? '' : 'opacity-60'}">
+						<td class="p-2">
+							<input
+								type="checkbox"
+								class="h-4 w-4"
+								checked={e.managed}
+								disabled={startupBusy === e.name}
+								onchange={(ev) => setComposeStartup(e.name, (ev.target as HTMLInputElement).checked, e.order, e.delay_secs)} />
+						</td>
+						<td class="p-2 font-medium">{e.name}</td>
+						<td class="p-2 text-right">
+							<input
+								type="number" min="0"
+								class="h-8 w-20 rounded-md border border-input bg-transparent px-2 text-right text-sm disabled:opacity-50"
+								value={e.order}
+								disabled={!e.managed || startupBusy === e.name}
+								onchange={(ev) => setComposeStartup(e.name, true, Number((ev.target as HTMLInputElement).value), e.delay_secs)} />
+						</td>
+						<td class="p-2 text-right">
+							<input
+								type="number" min="0" max="300"
+								class="h-8 w-20 rounded-md border border-input bg-transparent px-2 text-right text-sm disabled:opacity-50"
+								value={e.delay_secs}
+								disabled={!e.managed || startupBusy === e.name}
+								onchange={(ev) => setComposeStartup(e.name, true, e.order, Number((ev.target as HTMLInputElement).value))} />
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
 	{/if}
 
 	<!-- Installed apps table -->


### PR DESCRIPTION
WebUI half of #437, on top of the engine in #539. Gives operators the "small Startup order list with order + delay" Kev asked for.

## What's here
- **Engine**: new read RPC `apps.compose.startup.list` → every compose stack's startup config (`managed`/`order`/`delay_secs`), sorted by `(order, name)`. New `ComposeStartupEntry` type; `gen_schema` → OpenAPI. The `.list` suffix classifies it as a read (Any role); the existing `apps.compose.set_startup` mutation is unchanged.
- **WebUI**: a **"Compose Startup Order"** card on the Apps page listing every compose stack with a **Managed** checkbox + **Order** + **Delay (s)** inline inputs.
  - Ticking *Managed* enrolls the stack (engine writes the `restart: "no"` override and converges the running containers); unticking reverts it to the compose file's own policy.
  - Order/delay edits are instant metadata updates (no redeploy).
  - Managed stacks sort to the top by order; unmanaged are dimmed. A note explains the `restart: "no"` behavior and that compose files are left untouched.
  - Integrates with the existing `refresh()` so the list reflects state after each change.

## Verification
`npm run check` + `build` + `vitest` (144) green; engine `fmt` + `clippy --all-targets` + tests (126, incl. the OpenAPI render check) green. No new dependency.

Together with #539 this closes #437. The end-to-end acceptance (reboot → stacks come up in order with delays, `docker inspect` shows `restart: "no"` on enrolled stacks) is the live-box check noted on #539.