### PR TITLE
apps: remove per-app sidecar manifest on compose_remove

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -4160,6 +4160,18 @@ impl AppsService {
             return Err(AppsError::AppNotFound(name.to_string()));
         }
 
+        // Drop the per-app sidecar manifest (`<name>.json`). It holds
+        // ingress_subdomain + startup config (#437) and lives BESIDE the
+        // project dir, so the `remove_dir_all` above doesn't catch it.
+        // Without this, a stack later recreated with the same name silently
+        // inherits stale startup enrollment / ingress settings. Best-effort.
+        let sidecar = format!("{}/{}.json", COMPOSE_DIR, name);
+        if let Err(e) = tokio::fs::remove_file(&sidecar).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!("compose_remove: could not remove sidecar {sidecar}: {e}");
+        }
+
         if let Err(e) = self.ingress_remove(name).await {
             warn!("ingress_remove({name}) failed during compose app removal: {e}");
         }


### PR DESCRIPTION
`compose_remove` deleted a compose stack's project dir but left its `/var/lib/nasty/apps/<name>.json` **sidecar** behind — the sidecar lives *beside* the project dir, not inside it, so `remove_dir_all` never caught it.

That sidecar holds `ingress_subdomain` and the #437 startup config (`startup_managed` / `startup_order` / `startup_delay_secs`), so a stack later **recreated with the same name silently inherited stale** startup enrollment and ingress settings.

Found while live-testing #437 on a real box: after tearing down 3 test stacks via `apps.compose.remove`, their `<name>.json` sidecars were orphaned. Fix: `compose_remove` now also removes the sidecar (best-effort, `NotFound` ignored — mirrors the existing sidecar handling). The `restart:"no"` override needed no extra handling; it lives inside the project dir and was already removed.

`cargo fmt` + `clippy --all-targets` + `nasty-apps` tests (121) green. One-file, ~12-line change.