### PR TITLE
engine: surface subprocess failures in the journal (nasty::cmd)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1382,9 +1382,10 @@ fn compose_file_args(app_name: &str) -> Vec<String> {
 }
 
 /// `docker compose up -d --no-build` for one stack, with the right `-f` set
-/// (override included for managed stacks). Best-effort: `try_run` logs
-/// failures to the journal so a stack that won't come up is debuggable.
-async fn compose_up_stack(app_name: &str) {
+/// (override included for managed stacks). Returns whether it succeeded;
+/// `cmd::run` logs the underlying failure (program/args/stderr) so a stack
+/// that won't come up is debuggable from the journal.
+async fn compose_up_stack(app_name: &str) -> bool {
     let mut args = vec!["compose".to_string()];
     args.extend(compose_file_args(app_name));
     args.extend([
@@ -1395,7 +1396,7 @@ async fn compose_up_stack(app_name: &str) {
         "--no-build".to_string(),
     ]);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    nasty_common::cmd::try_run("docker", &arg_refs).await;
+    matches!(nasty_common::cmd::run("docker", &arg_refs).await, Ok(o) if o.status.success())
 }
 
 /// Validate a subdomain hostname before we hand it to Caddy. RFC 1123-ish:
@@ -4799,7 +4800,7 @@ impl AppsService {
                     continue;
                 }
                 info!("Restoring compose app '{name}'");
-                compose_up_stack(&name).await;
+                let _ = compose_up_stack(&name).await;
             }
         }
 
@@ -4814,7 +4815,16 @@ impl AppsService {
             tokio::spawn(async move {
                 for (name, cfg) in managed {
                     info!("Starting managed stack '{name}' (order {})", cfg.order);
-                    compose_up_stack(&name).await;
+                    if !compose_up_stack(&name).await {
+                        // The underlying error is logged by `cmd::run`; this
+                        // is the ordered-startup-context line so the operator
+                        // sees which managed stack failed and that the
+                        // sequence carried on.
+                        warn!(
+                            "Managed stack '{name}' (order {}) failed to start; continuing with the rest",
+                            cfg.order
+                        );
+                    }
                     if cfg.delay_secs > 0 {
                         info!(
                             "Settling {}s after '{name}' before the next stack",

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -130,7 +130,11 @@ in {
 
       logLevel = mkOption {
         type = types.str;
-        default = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,tower_http=info";
+        # `nasty::cmd` carries every subprocess failure (run/try_run/run_ok
+        # log non-zero exits + spawn errors there). Without it in the
+        # allowlist those warnings are dropped — e.g. a compose stack that
+        # fails to come up at boot logged nothing engine-side (#437 testing).
+        default = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,nasty::cmd=info,tower_http=info";
         description = "RUST_LOG filter for engine";
       };
     };


### PR DESCRIPTION
## The bug
`cmd.rs` logs every subprocess failure (non-zero exit / spawn error) under the **`nasty::cmd`** tracing target — its comment even promises *"a non-zero exit always lands in the journal at warn!"*. But the appliance's `RUST_LOG` allowlist (`nasty.nix` `logLevel` default) doesn't include `nasty::cmd`, so EnvFilter **drops all of them** — `0` such lines in all journal history on a live box. Every failing engine shell-out (compose up, exportfs, smbcontrol, …) was failing silently engine-side.

## How it surfaced
Live-testing #437 on 10.10.10.36: a managed compose stack with a bad image failed to start at boot. The ordered sequence correctly carried on (good), but the engine logged **nothing** about the failure — only dockerd's own line existed. That's precisely the "I can't see what's happening" problem the feature was meant to help with.

## Fix
1. **`nasty.nix`** — add `nasty::cmd=info` to the engine `RUST_LOG` default. Low volume (cmd only logs on failure), restores subprocess-failure visibility engine-wide as cmd.rs always intended. The o2 case now logs e.g. `WARN nasty::cmd: non-zero exit (1): docker compose … --project-name o2 … — stderr: pull access denied…`.
2. **`nasty-apps`** — `compose_up_stack` now returns success; the managed boot sequence logs a clear `nasty_apps` warning naming the stack + order when one fails (`"…failed to start; continuing with the rest"`), so the ordered-startup context is legible even independent of the cmd-target filter.

## Verification
`cargo fmt` + `clippy --all-targets` + `nasty-apps` tests (121) green; `nix-instantiate --parse` OK. The "warn now appears" behavior is a config-allowlist change; it'll show on a box once it updates (the NixOS smoke/sandbox build covers that the module still evaluates/builds).

Separate from #437's feature — a pre-existing observability bug the testing exposed.