### PR TITLE
webui+engine: persistent system-status band in the sidebar (#528)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -87,6 +87,10 @@ pub struct AppState {
     /// Cached alerts result (timestamp, json value). Avoids re-evaluating
     /// all alert checks on every WebUI poll (called every few seconds).
     pub alerts_cache: tokio::sync::Mutex<Option<(std::time::Instant, serde_json::Value)>>,
+    /// Short-TTL cache for the aggregated `system.status` band (#528) — the
+    /// sidebar polls it frequently and each miss re-scans per-fs scrub /
+    /// reconcile / device state.
+    pub status_cache: tokio::sync::Mutex<Option<(std::time::Instant, nasty_system::SystemStatus)>>,
     /// Boot-time per-phase status. Populated by main()'s restoration
     /// sequence; read by `/api/boot_status` so the WebUI can render
     /// a TrueNAS-style "starting up" overlay on the login screen
@@ -224,6 +228,7 @@ async fn main() -> anyhow::Result<()> {
         backups: nasty_backup::BackupService::new(),
         firmware: nasty_system::firmware::FirmwareService::new(),
         alerts_cache: tokio::sync::Mutex::new(None),
+        status_cache: tokio::sync::Mutex::new(None),
         // Pre-register every phase name we'll feed into `run_phase`
         // below. Pre-registering makes the WebUI's checklist fully
         // visible from the moment the engine starts answering

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -64,7 +64,7 @@ use nasty_system::update::{
     Generation, ReleaseChannel, UpdateBuildDirConfig, UpdateInfo, UpdateStatus, VersionInfo,
     VersionSwitchRequest, VersionTaggedReleaseStatus,
 };
-use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats};
+use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats, SystemStatus};
 use nasty_vm::{
     CloneVmRequest, CreateVmRequest, SnapshotVmRequest, UpdateVmRequest, VmCapabilities, VmConfig,
     VmDiskSubvolume, VmStatus,
@@ -212,6 +212,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<SystemHealth>(generator)),
+                },
+                Method {
+                    name: "system.status",
+                    desc: "Aggregated system status for the sidebar band (#528): one level (healthy / activity / critical), a headline, the in-progress array operations (device evacuation, scrub, reconcile), and active alert counts. Cached ~10s.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<SystemStatus>(generator)),
                 },
                 Method {
                     name: "system.stats",

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -19,6 +19,21 @@ pub(super) async fn try_route(
     Some(match req.method.as_str() {
         "system.info" => ok(req, state.system.info().await),
         "system.health" => ok(req, state.system.health().await),
+        "system.status" => {
+            // Cheap path for the sidebar band, which polls frequently: serve a
+            // cached result when it's <10s old, else rebuild and cache.
+            {
+                let cache = state.status_cache.lock().await;
+                if let Some((ts, ref cached)) = *cache
+                    && ts.elapsed() < std::time::Duration::from_secs(10)
+                {
+                    return Some(ok(req, cached.clone()));
+                }
+            }
+            let status = build_system_status(state).await;
+            *state.status_cache.lock().await = Some((std::time::Instant::now(), status.clone()));
+            ok(req, status)
+        }
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
         "system.secure_boot.readiness" => ok(req, nasty_system::secure_boot::readiness().await),
@@ -717,4 +732,87 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+/// Aggregate the sidebar status band (#528): current alert counts (reusing the
+/// shared alert evaluation) plus a scan of every filesystem for in-progress
+/// array operations (device evacuation, running scrub, active reconcile).
+async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
+    use nasty_system::alerts::AlertSeverity;
+
+    // Alert side: reuse the canonical evaluation, then split by severity.
+    let alerts = super::evaluate_active_alerts(state).await;
+    let mut critical_count = 0u32;
+    let mut warning_count = 0u32;
+    let mut top_critical: Option<String> = None;
+    let mut top_warning: Option<String> = None;
+    for a in &alerts {
+        match a.severity {
+            AlertSeverity::Critical => {
+                critical_count += 1;
+                top_critical.get_or_insert_with(|| a.message.clone());
+            }
+            AlertSeverity::Warning => {
+                warning_count += 1;
+                top_warning.get_or_insert_with(|| a.message.clone());
+            }
+        }
+    }
+
+    // Operation side: scan filesystems for what's actively running.
+    let mut operations: Vec<nasty_system::ActiveOperation> = Vec::new();
+    if let Ok(filesystems) = state.filesystems.list().await {
+        for fs in &filesystems {
+            // Device evacuation — bcachefs sets the member state to
+            // "evacuating" while data drains off it.
+            for dev in &fs.devices {
+                if dev.state.as_deref() == Some("evacuating") {
+                    let short = dev.path.rsplit('/').next().unwrap_or(&dev.path);
+                    operations.push(nasty_system::ActiveOperation {
+                        kind: "evacuate".to_string(),
+                        fs: fs.name.clone(),
+                        target: Some(dev.path.clone()),
+                        progress_percent: None,
+                        detail: format!("Evacuating {short}"),
+                    });
+                }
+            }
+            // Running scrub.
+            if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await
+                && scrub.running
+            {
+                let detail = match scrub.progress_percent {
+                    Some(p) => format!("Scrubbing {} ({:.0}%)", fs.name, p),
+                    None => format!("Scrubbing {}", fs.name),
+                };
+                operations.push(nasty_system::ActiveOperation {
+                    kind: "scrub".to_string(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    progress_percent: scrub.progress_percent,
+                    detail,
+                });
+            }
+            // Reconcile actively working (vs idle/waiting).
+            if let Ok(rec) = state.filesystems.reconcile_status(&fs.name).await
+                && nasty_system::alerts::parse_reconcile_sample(&rec.raw).active
+            {
+                operations.push(nasty_system::ActiveOperation {
+                    kind: "reconcile".to_string(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    progress_percent: None,
+                    detail: format!("Reconcile running on {}", fs.name),
+                });
+            }
+        }
+    }
+
+    nasty_system::SystemStatus::from_parts(
+        critical_count,
+        warning_count,
+        top_critical,
+        top_warning,
+        operations,
+    )
 }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -129,6 +129,81 @@ pub struct ServiceStatus {
     pub pid: Option<u32>,
 }
 
+/// A long-running array operation currently in progress (#528). Surfaced in
+/// the WebUI's persistent status band so an evacuation / scrub / reconcile is
+/// always visible while it runs.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ActiveOperation {
+    /// "evacuate" | "scrub" | "reconcile".
+    pub kind: String,
+    /// Filesystem the operation is running on.
+    pub fs: String,
+    /// Device path for an evacuation; `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Progress 0–100 when known (scrub); `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_percent: Option<f32>,
+    /// Short operator-facing line, e.g. "Evacuating sdc" or "Scrub 42%".
+    pub detail: String,
+}
+
+/// Aggregated system status for the sidebar band (#528): one colored level
+/// plus a headline and the in-progress operations and alert counts behind it.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SystemStatus {
+    /// "healthy" (green) | "activity" (amber) | "critical" (red).
+    pub level: String,
+    /// One-line summary shown in the band.
+    pub headline: String,
+    /// Array operations currently running.
+    pub operations: Vec<ActiveOperation>,
+    /// Number of active critical alerts.
+    pub critical_count: u32,
+    /// Number of active warning alerts.
+    pub warning_count: u32,
+}
+
+impl SystemStatus {
+    /// Build the band state from the gathered inputs. Pure (no I/O) so the
+    /// level/headline precedence is unit-testable:
+    /// critical alert → reconcile/scrub/evacuate activity → warning → healthy.
+    pub fn from_parts(
+        critical_count: u32,
+        warning_count: u32,
+        top_critical: Option<String>,
+        top_warning: Option<String>,
+        operations: Vec<ActiveOperation>,
+    ) -> Self {
+        let (level, headline) = if critical_count > 0 {
+            (
+                "critical",
+                top_critical.unwrap_or_else(|| "Attention needed".to_string()),
+            )
+        } else if !operations.is_empty() {
+            let mut h = operations[0].detail.clone();
+            if operations.len() > 1 {
+                h.push_str(&format!(" (+{} more)", operations.len() - 1));
+            }
+            ("activity", h)
+        } else if warning_count > 0 {
+            (
+                "activity",
+                top_warning.unwrap_or_else(|| "Warning".to_string()),
+            )
+        } else {
+            ("healthy", "Healthy".to_string())
+        };
+        Self {
+            level: level.to_string(),
+            headline,
+            operations,
+            critical_count,
+            warning_count,
+        }
+    }
+}
+
 // SystemStats, CpuStats, MemoryStats, NetIfStats, DiskIoStats,
 // DiskHealth, SmartAttribute — now defined in nasty_common::metrics_types
 // and re-exported via `pub use` at the top of this file.
@@ -483,4 +558,60 @@ async fn read_proc_stats(pid: u32) -> (u64, f64, u64) {
     };
 
     (memory_bytes, cpu_seconds, uptime_secs)
+}
+
+#[cfg(test)]
+mod status_tests {
+    use super::{ActiveOperation, SystemStatus};
+
+    fn op(detail: &str) -> ActiveOperation {
+        ActiveOperation {
+            kind: "scrub".into(),
+            fs: "tank".into(),
+            target: None,
+            progress_percent: None,
+            detail: detail.into(),
+        }
+    }
+
+    #[test]
+    fn healthy_when_nothing_is_happening() {
+        let s = SystemStatus::from_parts(0, 0, None, None, vec![]);
+        assert_eq!(s.level, "healthy");
+        assert_eq!(s.headline, "Healthy");
+    }
+
+    #[test]
+    fn critical_alert_wins_over_activity_and_warning() {
+        let s = SystemStatus::from_parts(
+            1,
+            2,
+            Some("Filesystem degraded".into()),
+            Some("Disk 85% full".into()),
+            vec![op("Scrubbing tank")],
+        );
+        assert_eq!(s.level, "critical");
+        assert_eq!(s.headline, "Filesystem degraded");
+    }
+
+    #[test]
+    fn activity_wins_over_warning_when_no_critical() {
+        let s = SystemStatus::from_parts(
+            0,
+            1,
+            None,
+            Some("Disk 85% full".into()),
+            vec![op("Evacuating sdc"), op("Scrubbing tank")],
+        );
+        assert_eq!(s.level, "activity");
+        // First op leads, with a "+N more" suffix.
+        assert_eq!(s.headline, "Evacuating sdc (+1 more)");
+    }
+
+    #[test]
+    fn warning_shows_as_activity_when_nothing_running() {
+        let s = SystemStatus::from_parts(0, 1, None, Some("Disk 85% full".into()), vec![]);
+        assert_eq!(s.level, "activity");
+        assert_eq!(s.headline, "Disk 85% full");
+    }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -66,6 +66,24 @@ export interface SystemHealth {
 	services: ServiceStatus[];
 }
 
+/** A long-running array operation in progress (#528). */
+export interface ActiveOperation {
+	kind: string; // "evacuate" | "scrub" | "reconcile"
+	fs: string;
+	target?: string | null;
+	progress_percent?: number | null;
+	detail: string;
+}
+
+/** Aggregated system status for the sidebar band (#528). */
+export interface SystemStatus {
+	level: string; // "healthy" | "activity" | "critical"
+	headline: string;
+	operations: ActiveOperation[];
+	critical_count: number;
+	warning_count: number;
+}
+
 /** One IOMMU group with its constituent PCI devices, returned by
  * `system.hardware.iommu`. The id is the kernel's group number;
  * devices are sorted by BDF. Empty list = IOMMU is off in BIOS. */

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 	import ReconnectSpinner from '$lib/components/ReconnectSpinner.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
-	import type { BootStatus, BootPhase } from '$lib/types';
+	import type { BootStatus, BootPhase, SystemStatus } from '$lib/types';
 	import favicon from '$lib/assets/favicon.svg';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
@@ -365,8 +365,39 @@
 		}
 	}
 
+	// Persistent sidebar status band (#528): poll the aggregated system status
+	// (level + headline + in-progress array operations). Null = hide the band
+	// (e.g. older engine without the RPC), so it degrades gracefully.
+	let systemStatus = $state<SystemStatus | null>(null);
+	let statusExpanded = $state(false);
+	// Literal Tailwind classes (purge-safe) chosen by level — green Healthy /
+	// amber Activity / red Critical, per #528.
+	const statusDot = $derived(
+		systemStatus?.level === 'critical' ? 'bg-red-500'
+		: systemStatus?.level === 'activity' ? 'bg-amber-500'
+		: 'bg-green-500'
+	);
+	const statusText = $derived(
+		systemStatus?.level === 'critical' ? 'text-red-400'
+		: systemStatus?.level === 'activity' ? 'text-amber-400'
+		: 'text-green-400'
+	);
+	const statusHasDetail = $derived(
+		!!systemStatus && (systemStatus.operations.length > 0
+			|| systemStatus.critical_count + systemStatus.warning_count > 0)
+	);
+	function refreshSystemStatus() {
+		if (!connected || document.hidden) return;
+		getClient().call<SystemStatus>('system.status')
+			.then((s) => { systemStatus = s; })
+			.catch(() => {});
+	}
+
 	$effect(() => {
 		if (connected) checkRebootRequired();
+	});
+	$effect(() => {
+		if (connected) refreshSystemStatus();
 	});
 
 	// Recover any pending rollback the server is tracking — covers the
@@ -447,6 +478,7 @@
 		getClient().onDisconnect(onDisconnect);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
 		const rebootPoll = setInterval(checkRebootRequired, 30_000);
+		const statusPoll = setInterval(refreshSystemStatus, 20_000);
 		const authPoll = setInterval(checkAuth, 60_000);
 		const sshPoll = setInterval(checkSshStatus, 30_000);
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
@@ -459,6 +491,7 @@
 			clearInterval(backupPoll);
 			clearInterval(tick);
 			clearInterval(rebootPoll);
+			clearInterval(statusPoll);
 			clearInterval(authPoll);
 		};
 	});
@@ -909,6 +942,40 @@
 						<PanelLeftClose size={15} />
 					</button>
 				</div>
+			{/if}
+
+			<!-- System status band (#528): always-visible health / activity / critical -->
+			{#if systemStatus}
+				{#if sidebarCollapsed}
+					<div class="shrink-0 border-b border-border flex items-center justify-center py-2.5" title={systemStatus.headline}>
+						<span class="h-2.5 w-2.5 rounded-full {statusDot}"></span>
+					</div>
+				{:else}
+					<div class="shrink-0 border-b border-border px-2 py-1.5">
+						<button
+							class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors {statusHasDetail ? 'cursor-pointer hover:bg-accent/50' : 'cursor-default'}"
+							onclick={() => { if (statusHasDetail) statusExpanded = !statusExpanded; }}
+						>
+							<span class="h-2 w-2 shrink-0 rounded-full {statusDot}"></span>
+							<span class="min-w-0 flex-1 truncate font-medium {statusText}">{systemStatus.headline}</span>
+							{#if statusHasDetail}
+								<span class="shrink-0 text-muted-foreground/60">{statusExpanded ? '−' : '+'}</span>
+							{/if}
+						</button>
+						{#if statusExpanded && statusHasDetail}
+							<div class="mt-1 space-y-1 px-2 pb-1 text-[0.7rem] text-muted-foreground">
+								{#each systemStatus.operations as op}
+									<a href="/filesystems" class="block truncate hover:text-foreground">• {op.detail}</a>
+								{/each}
+								{#if systemStatus.critical_count + systemStatus.warning_count > 0}
+									<a href="/alerts" class="block hover:text-foreground">
+										{systemStatus.critical_count} critical · {systemStatus.warning_count} warning
+									</a>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/if}
 			{/if}
 
 			<!-- Search bar -->


### PR DESCRIPTION
Implements Kev's ask on #528: a **persistent, always-visible status area** at the top of the sidebar so "there's no mistaking an action is going on" while navigating — green **Healthy**, amber for **activity** (a device evacuating, scrub/reconcile running…), red for **critical**. The existing dismissible alert boxes don't surface ongoing array operations, and the reconcile-stall flap made an evacuation look like an error rather than work in progress. (The stall itself is upstream — Kent has Kev's tick-counter fix.)

Placement confirmed with the user: a band **below the logo, above the search**.

## Engine — new `system.status` read RPC (cached ~10s)
- `SystemStatus { level, headline, operations, critical_count, warning_count }` + `ActiveOperation { kind, fs, target, progress_percent, detail }` in `nasty-system`, with a pure `from_parts` builder — precedence **critical > activity > warning > healthy** — that's unit-tested.
- The handler reuses `evaluate_active_alerts` for the alert counts/messages, then scans filesystems for in-progress operations: **device evacuation** (member `state == "evacuating"`), a **running scrub**, and an **active reconcile** (`parse_reconcile_sample().active`). The `.status` suffix makes it read-only / Any role automatically; registered for OpenAPI via `gen_schema`.

## WebUI — the band
- A colored status dot + `headline` under the logo. Click to expand the in-progress operations (each links to **Filesystems**) and the alert counts (link to **Alerts**). Collapsed sidebar shows just the dot with the headline as a tooltip. Polls `system.status` every 20s (visibility-paused), and **hides itself if the RPC is absent**, so it degrades gracefully on an older engine.

## Scope (v1)
Additive — the dashboard alert boxes stay for now; folding alerts entirely into the band (per Kev's dislike of the boxes) is a deliberate follow-up once this proves out.

## Verification
Engine `fmt` + `clippy --workspace --all-targets` + tests (126 + 4 status tests) green; WebUI `check` + `build` + `vitest` (144) green. Live verification (band turns amber on a running scrub/evacuation, green when idle) is pending the test box carrying this build — the aggregation precedence is unit-tested and the WebUI is null-safe in the meantime.