### PR TITLE
appliance: actually enable nasty::cmd logging (completes #543)

### DIFF
--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -85,7 +85,12 @@
     engine = {
       package = nasty-engine;
       port = 2137;
-      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,tower_http=info";
+      # NOTE: the appliance sets logLevel explicitly here, which OVERRIDES the
+      # `mkOption` default in modules/nasty.nix — so any allowlist change must
+      # be made in BOTH places (a default-only change is dead code on a real
+      # box). `nasty::cmd` carries every subprocess failure (run/try_run/
+      # run_ok); without it those warnings are dropped from the journal (#543).
+      logLevel = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,nasty::cmd=info,tower_http=info";
     };
 
     webui = {


### PR DESCRIPTION
## The bug behind the bug
#543 added `nasty::cmd=info` to the engine `logLevel` **default** in `modules/nasty.nix`. But the appliance imports **`appliance-base.nix`, which sets `services.nasty.engine.logLevel` explicitly** (line 88) — and an explicit value overrides a `mkOption` default. So on every real box the #543 change was **dead code**: subprocess-failure warnings (`run`/`try_run`/`run_ok` → `nasty::cmd`) stayed dropped from the journal.

## How it was caught
Live-digging on the test box after it updated to the commit carrying #543: the box had correctly built from that commit (its fetched nasty source *does* contain the `nasty.nix` change), yet `nasty-engine`'s `RUST_LOG` still lacked `nasty::cmd`. Evaluating `…services."nasty-engine".environment.RUST_LOG` returned the old value, and `options.…logLevel.definitionsWithLocations` pointed the active definition at **`appliance-base.nix`**, not the module default.

## Fix
Add `nasty::cmd=info` to the `logLevel` value in `appliance-base.nix` (the one the appliance actually uses), with a comment that the two definitions must stay in sync so a default-only change can't be silently overridden again.

`nix-instantiate --parse` OK. After this lands and a box updates, a failing engine shell-out (e.g. a managed compose stack failing at boot) will appear under `nasty::cmd` in `journalctl -u nasty-engine` as #543 intended — I'll re-verify on the box once it carries this.