### PR TITLE
iso: xz-compress installer squashfs to stay under GitHub's 2 GiB asset cap

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -119,6 +119,16 @@ in
   isoImage.makeUsbBootable = true;
   isoImage.grubTheme = nasty-grub-theme;
 
+  # Compress the squashfs with xz instead of the nixpkgs default
+  # (`zstd -Xcompression-level 19`). The store closure grew past ~2 GiB
+  # at v0.0.12 and the resulting .iso crossed GitHub's hard 2 GiB
+  # per-release-asset limit, so `gh release upload` 422'd ("size must be
+  # less than 2147483648"). xz buys ~8-12% over zstd-19 on a Nix store
+  # image — well over 100 MB of headroom — at the cost of a slightly
+  # slower installer live-boot. The *installed* appliance runs from
+  # bcachefs, not this squashfs, so runtime performance is unaffected.
+  isoImage.squashfsCompression = lib.mkForce "xz -Xdict-size 100%";
+
   environment.systemPackages = with pkgs; [
     bcachefs-tools
     parted


### PR DESCRIPTION
The v0.0.12 store closure pushed the installer .iso past 2 GiB (aarch64 came out ~2.005 GiB), so `gh release upload` 422'd on GitHub's hard per-asset limit — `size must be less than 2147483648`. The ISO **built fine**; only the upload failed, and no release was published.

v0.0.11 was already at 99.7% of the cap (~6 MB headroom), so this was effectively unavoidable on the next release.

**Fix:** switch the installer squashfs from the nixpkgs default `zstd -Xcompression-level 19` to `xz -Xdict-size 100%`, reclaiming >100 MB (xz beats zstd-19 ~8–12% on a Nix store image). No functionality removed — only the installer *live-boot* is marginally slower; the installed appliance runs from bcachefs, not this squashfs.

Validated by re-running the ISO build against the v0.0.12 tag after merge.