### PR TITLE
webui: hint to enable hypervisor guest-agent option (KVM guest-tools card)

### DIFF
--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -507,6 +507,11 @@
 						under KVM/Proxmox — graceful shutdown, time sync and guest IP reporting are
 						already on. No action needed.
 					</div>
+					<p class="mt-2 text-xs text-muted-foreground">
+						Not seeing the guest IP on your hypervisor? Enable the guest-agent option in
+						its VM settings (Proxmox: <span class="font-mono">Options → QEMU Guest Agent</span>)
+						and power-cycle the VM — the host only opens the agent channel once that's on.
+					</p>
 				{:else}
 					<p class="mb-3 text-xs text-muted-foreground">
 						{#if hv === 'vmware'}


### PR DESCRIPTION
Tiny follow-up to #550, from live-testing on Proxmox.

NASty correctly reports the QEMU guest agent as **Active**, but the hypervisor shows no guest IP until the VM's own guest-agent option is turned on (Proxmox: Options → QEMU Guest Agent) and the VM is **power-cycled** — that's when the host attaches the virtio-serial channel (`org.qemu.guest_agent.0`) the agent serves over. Confirmed on `10.10.10.38`: enabling the option made the channel appear and the IP show up.

Adds a one-line hint on the KVM/QEMU card so the next operator doesn't chase a non-bug. WebUI-only; svelte-check + build clean.