### PR TITLE
Manual disk-type override for VM environments (#552)

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -35,6 +35,7 @@ use nasty_sharing::smb::{
     CreateSmbShareRequest, CreateSmbUserRequest, DeleteSmbShareRequest, SmbGroup, SmbShare,
     SmbUser, UpdateSmbShareRequest,
 };
+use nasty_storage::disk_type::DiskTypeUpdate;
 use nasty_storage::filesystem::{
     BlockDevice, CreateFilesystemRequest, DestroyFilesystemRequest, DeviceActionRequest,
     DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem, FsUsage,
@@ -474,6 +475,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                         "path",
                         "Block device path (e.g. /dev/sdb).",
                     )),
+                    result: None,
+                },
+                Method {
+                    name: "device.set_type",
+                    desc: "Manually override a disk's type (ssd/hdd/nvme), or 'auto' to clear. For VMs where lsblk's rotational bit is wrong. Anchored to a stable by-id/by-path key so it survives reboots and /dev re-lettering.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<DiskTypeUpdate>(generator)),
                     result: None,
                 },
             ],

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -158,6 +158,13 @@ pub(super) async fn try_route(
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
+        "device.set_type" => match parse_params::<nasty_storage::disk_type::DiskTypeUpdate>(req) {
+            Ok(u) => match nasty_storage::disk_type::set(u).await {
+                Ok(key) => ok(req, serde_json::json!({ "stable_id": key })),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
         "device.wipe" => match parse_params::<serde_json::Value>(req) {
             Ok(p) => {
                 let path = p

--- a/engine/nasty-storage/src/disk_type.rs
+++ b/engine/nasty-storage/src/disk_type.rs
@@ -1,0 +1,276 @@
+//! Manual disk-type override for VM environments (#552).
+//!
+//! In VMs, `lsblk`'s ROTA bit is unreliable — virtio-scsi / VMware
+//! PVSCSI / LSI / Hyper-V virtual disks almost all report `ROTA=1`, so
+//! solid-state-backed storage is misclassified as `hdd`. This module
+//! lets an operator pin a disk's type from the `/disks` page.
+//!
+//! The hard part is **identity**: `/dev/sdX` drifts across reboots (a
+//! disk can move from `sdd` to `sda`), so an override must be keyed to
+//! something stable. Field data across hypervisors showed:
+//!   - Proxmox virtio / Hyper-V / VMware-SATA+NVMe: have a unique
+//!     `wwn-*` / `nvme-eui.*` / `scsi-3<NAA>` by-id link.
+//!   - VMware PVSCSI / LSI virtual disks: NO serial, NO WWN, no
+//!     whole-disk by-id link — but every disk still has a stable
+//!     `/dev/disk/by-path/` (`ID_PATH`) entry.
+//!   - VMware SATA serials are a constant `00000000000000000001`, so
+//!     serial-based keys can COLLIDE — they're deliberately not used.
+//!
+//! So the key is chosen first-present from:
+//!   1. a unique by-id link (`wwn-` / `nvme-eui.` / `scsi-3<NAA>`) — `hardware`
+//!   2. the `by-path` link — `slot` (reboot-stable; changes only if the
+//!      disk is re-slotted in the VM config)
+//!   3. the `/dev/sdX` name — `volatile` (last resort, won't survive
+//!      re-lettering; surfaced as such in the UI)
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+const STATE_PATH: &str = "/var/lib/nasty/disk-type-overrides.json";
+const BY_ID_DIR: &str = "/dev/disk/by-id";
+const BY_PATH_DIR: &str = "/dev/disk/by-path";
+
+/// Lock around the override state file so concurrent RPCs can't tear it.
+static STATE_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Request to set (or clear) a disk's type. `device_class` of `auto`
+/// (or empty) clears the override and restores detection.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct DiskTypeUpdate {
+    /// Current device path (e.g. `/dev/sda`) — resolved to a stable key.
+    pub path: String,
+    /// `ssd` | `hdd` | `nvme` | `auto`.
+    pub device_class: String,
+}
+
+/// Persisted overrides, keyed by the chosen stable identity string.
+pub type DiskTypeOverrides = HashMap<String, String>;
+
+pub async fn load() -> DiskTypeOverrides {
+    let _guard = STATE_LOCK.lock().await;
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
+}
+
+/// Map a stored class to `(device_class, rotational)`. `nvme`/`ssd` are
+/// non-rotational; `hdd` is rotational.
+pub fn class_to_fields(class: &str) -> Option<(String, bool)> {
+    match class {
+        "ssd" => Some(("ssd".to_string(), false)),
+        "hdd" => Some(("hdd".to_string(), true)),
+        "nvme" => Some(("nvme".to_string(), false)),
+        _ => None,
+    }
+}
+
+/// Pick the stable key + its kind for a disk, given the by-id link
+/// basenames that resolve to it, its by-path basename, and the `/dev`
+/// name. Pure so the priority logic is unit-tested. Returns
+/// `(key, kind)` where `kind` ∈ `hardware` | `slot` | `volatile`.
+pub fn choose_stable_id(
+    by_id_names: &[String],
+    by_path: Option<&str>,
+    dev_name: &str,
+) -> (String, &'static str) {
+    // Prefer a globally-unique hardware id. Deliberately skip serial- and
+    // model-based by-id links (ata-*, scsi-0ATA_*, scsi-SATA_*, nvme-<model>)
+    // because VMware reuses a constant serial across SATA disks.
+    let hardware = by_id_names
+        .iter()
+        .find(|n| n.starts_with("wwn-") || n.starts_with("nvme-eui.") || n.starts_with("scsi-3"));
+    if let Some(id) = hardware {
+        return (id.clone(), "hardware");
+    }
+    if let Some(p) = by_path {
+        return (p.to_string(), "slot");
+    }
+    (dev_name.to_string(), "volatile")
+}
+
+/// Read `/dev/disk/by-id` and `/dev/disk/by-path`, returning reverse maps
+/// from a disk's `/dev` basename (e.g. `sda`) to the link basenames that
+/// resolve to it. Partition links (`*-partN`) are excluded. Best-effort:
+/// a missing dir yields an empty map (e.g. a disk with no stable id).
+async fn read_link_maps() -> (HashMap<String, Vec<String>>, HashMap<String, String>) {
+    let by_id = read_link_dir(BY_ID_DIR).await;
+    let by_path = read_link_dir(BY_PATH_DIR).await;
+    // by-path is one-per-disk; collapse to a single basename.
+    let by_path_single: HashMap<String, String> = by_path
+        .into_iter()
+        .filter_map(|(dev, mut links)| {
+            links.sort();
+            links.into_iter().next().map(|l| (dev, l))
+        })
+        .collect();
+    (by_id, by_path_single)
+}
+
+async fn read_link_dir(dir: &str) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut rd = match tokio::fs::read_dir(dir).await {
+        Ok(rd) => rd,
+        Err(_) => return map,
+    };
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Skip partition links — we key whole disks only.
+        if name.contains("-part") {
+            continue;
+        }
+        let Ok(target) = tokio::fs::read_link(entry.path()).await else {
+            continue;
+        };
+        // Targets look like `../../sda`; take the final component.
+        if let Some(dev) = target.file_name().and_then(|s| s.to_str()) {
+            map.entry(dev.to_string()).or_default().push(name);
+        }
+    }
+    map
+}
+
+/// Identity (key + kind) for a single `/dev` path, recomputed live.
+/// Used by the set/clear RPC to resolve the override key.
+pub async fn identity_for_path(path: &str) -> (String, &'static str) {
+    let dev_name = path.trim_start_matches("/dev/").to_string();
+    let (by_id, by_path) = read_link_maps().await;
+    choose_stable_id(
+        by_id.get(&dev_name).map(|v| v.as_slice()).unwrap_or(&[]),
+        by_path.get(&dev_name).map(|s| s.as_str()),
+        &dev_name,
+    )
+}
+
+/// Resolver bound to one listing pass: precomputes the link maps once,
+/// then answers `(stable_id, kind)` per disk synchronously so the
+/// (sync) device-collection walk can attach identity without re-reading
+/// the dirs for every device.
+pub struct IdentityResolver {
+    by_id: HashMap<String, Vec<String>>,
+    by_path: HashMap<String, String>,
+}
+
+impl IdentityResolver {
+    pub async fn new() -> Self {
+        let (by_id, by_path) = read_link_maps().await;
+        Self { by_id, by_path }
+    }
+
+    pub fn resolve(&self, dev_name: &str) -> (String, &'static str) {
+        choose_stable_id(
+            self.by_id
+                .get(dev_name)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]),
+            self.by_path.get(dev_name).map(|s| s.as_str()),
+            dev_name,
+        )
+    }
+}
+
+/// Set or clear the override for `update.path`. Returns the resolved
+/// stable key so callers can confirm what was pinned.
+pub async fn set(update: DiskTypeUpdate) -> Result<String, String> {
+    let (key, kind) = identity_for_path(&update.path).await;
+    let clearing = update.device_class == "auto" || update.device_class.is_empty();
+
+    if !clearing && class_to_fields(&update.device_class).is_none() {
+        return Err(format!(
+            "invalid device class '{}': expected ssd, hdd, nvme, or auto",
+            update.device_class
+        ));
+    }
+
+    let _guard = STATE_LOCK.lock().await;
+    let mut overrides: DiskTypeOverrides =
+        nasty_common::load_singleton_or_recover(STATE_PATH).await;
+
+    if clearing {
+        overrides.remove(&key);
+    } else {
+        overrides.insert(key.clone(), update.device_class.clone());
+    }
+
+    let json = serde_json::to_string_pretty(&overrides).map_err(|e| format!("serialize: {e}"))?;
+    if let Some(parent) = std::path::Path::new(STATE_PATH).parent()
+        && let Err(e) = tokio::fs::create_dir_all(parent).await
+    {
+        warn!("create {}: {e}", parent.display());
+    }
+    tokio::fs::write(STATE_PATH, json)
+        .await
+        .map_err(|e| format!("write {STATE_PATH}: {e}"))?;
+
+    info!(
+        "Disk type override for {} ({kind} key '{key}'): {}",
+        update.path,
+        if clearing {
+            "cleared".to_string()
+        } else {
+            update.device_class.clone()
+        }
+    );
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_wwn_over_path_and_dev() {
+        let by_id = vec![
+            "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0".to_string(),
+            "wwn-0x5000c291082e5f93".to_string(),
+        ];
+        let (key, kind) = choose_stable_id(&by_id, Some("pci-0000:00:10.0-scsi-0:0:0:0"), "sdd");
+        assert_eq!(key, "wwn-0x5000c291082e5f93");
+        assert_eq!(kind, "hardware");
+    }
+
+    #[test]
+    fn nvme_eui_and_scsi_naa_count_as_hardware() {
+        let (k1, kind1) = choose_stable_id(
+            &["nvme-eui.9dfd990a196977a6000c296a31919277".to_string()],
+            Some("pci-0000:04:00.0-nvme-1"),
+            "nvme0n1",
+        );
+        assert_eq!(kind1, "hardware");
+        assert!(k1.starts_with("nvme-eui."));
+
+        let (k2, kind2) = choose_stable_id(&["scsi-35000c291082e5f93".to_string()], None, "sdd");
+        assert_eq!(kind2, "hardware");
+        assert_eq!(k2, "scsi-35000c291082e5f93");
+    }
+
+    #[test]
+    fn skips_serial_and_model_based_ids_then_falls_to_by_path() {
+        // VMware PVSCSI/LSI disk: only serial/model-ish by-id (or none) +
+        // a by-path. Serial-based links must be skipped (constant serial
+        // collides), so we land on the by-path key.
+        let by_id = vec![
+            "scsi-0ATA_VMware_Virtual_S_00000000000000000001".to_string(),
+            "scsi-SATA_VMware_Virtual_S_00000000000000000001".to_string(),
+        ];
+        let (key, kind) = choose_stable_id(&by_id, Some("pci-0000:13:00.0-sas-phy0-lun-0"), "sdc");
+        assert_eq!(key, "pci-0000:13:00.0-sas-phy0-lun-0");
+        assert_eq!(kind, "slot");
+    }
+
+    #[test]
+    fn falls_back_to_dev_name_when_nothing_stable() {
+        let (key, kind) = choose_stable_id(&[], None, "sda");
+        assert_eq!(key, "sda");
+        assert_eq!(kind, "volatile");
+    }
+
+    #[test]
+    fn class_mapping_sets_rotational_correctly() {
+        assert_eq!(class_to_fields("ssd"), Some(("ssd".to_string(), false)));
+        assert_eq!(class_to_fields("nvme"), Some(("nvme".to_string(), false)));
+        assert_eq!(class_to_fields("hdd"), Some(("hdd".to_string(), true)));
+        assert_eq!(class_to_fields("auto"), None);
+        assert_eq!(class_to_fields("garbage"), None);
+    }
+}

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2210,11 +2210,14 @@ impl FilesystemService {
                     })
                     .collect();
 
+            #[allow(clippy::too_many_arguments)]
             fn collect_devices(
                 devs: &[serde_json::Value],
                 fs_devices: &std::collections::HashSet<String>,
                 mounted_devices: &std::collections::HashSet<String>,
                 out: &mut Vec<BlockDevice>,
+                resolver: &crate::disk_type::IdentityResolver,
+                overrides: &std::collections::HashMap<String, String>,
             ) {
                 for dev in devs {
                     let name = dev.get("name").and_then(|v| v.as_str()).unwrap_or("");
@@ -2257,12 +2260,32 @@ impl FilesystemService {
 
                     // Transport needs to be resolved before classify so the
                     // SAS path can use it.
-                    let (rotational, device_class) = classify(name, rota, transport.as_deref());
+                    let (mut rotational, mut device_class) =
+                        classify(name, rota, transport.as_deref());
 
                     if dev_type == "disk" || dev_type == "part" {
                         let path = format!("/dev/{name}");
                         let in_fs = fs_devices.contains(&path);
                         let actually_mounted = mounted_devices.contains(&path);
+
+                        // Manual disk-type override (#552) applies to whole
+                        // disks only — partitions inherit nothing here.
+                        let (mut stable_id, mut id_kind) = (None, None);
+                        let mut type_source = "detected".to_string();
+                        if dev_type == "disk" {
+                            let (key, kind) = resolver.resolve(name);
+                            if let Some(class) = overrides.get(&key)
+                                && let Some((c, rota_override)) =
+                                    crate::disk_type::class_to_fields(class)
+                            {
+                                device_class = c;
+                                rotational = rota_override;
+                                type_source = "manual".to_string();
+                            }
+                            stable_id = Some(key);
+                            id_kind = Some(kind.to_string());
+                        }
+
                         out.push(BlockDevice {
                             path,
                             size_bytes: size,
@@ -2277,15 +2300,36 @@ impl FilesystemService {
                             serial,
                             vendor,
                             transport,
+                            stable_id,
+                            id_kind,
+                            type_source,
                         });
                     }
 
                     if let Some(children) = dev.get("children").and_then(|v| v.as_array()) {
-                        collect_devices(children, fs_devices, mounted_devices, out);
+                        collect_devices(
+                            children,
+                            fs_devices,
+                            mounted_devices,
+                            out,
+                            resolver,
+                            overrides,
+                        );
                     }
                 }
             }
-            collect_devices(blockdevices, &used_devices, &mounted_devices, &mut devices);
+            // Identity (by-id/by-path) + persisted type overrides are read
+            // once per listing, then applied per whole-disk inside the walk.
+            let resolver = crate::disk_type::IdentityResolver::new().await;
+            let overrides = crate::disk_type::load().await;
+            collect_devices(
+                blockdevices,
+                &used_devices,
+                &mounted_devices,
+                &mut devices,
+                &resolver,
+                &overrides,
+            );
         }
 
         // Mark parent disks as in_use if any of their partitions are in_use.
@@ -2345,7 +2389,15 @@ impl FilesystemService {
                     info!("Free space on {disk_path}: {free_bytes} bytes");
                     if free_bytes >= MIN_FREE_BYTES {
                         let disk = devices.iter().find(|d| &d.path == disk_path);
-                        let (rotational, device_class, model, serial, vendor, transport) = disk
+                        let (
+                            rotational,
+                            device_class,
+                            model,
+                            serial,
+                            vendor,
+                            transport,
+                            type_source,
+                        ) = disk
                             .map(|d| {
                                 (
                                     d.rotational,
@@ -2354,9 +2406,18 @@ impl FilesystemService {
                                     d.serial.clone(),
                                     d.vendor.clone(),
                                     d.transport.clone(),
+                                    d.type_source.clone(),
                                 )
                             })
-                            .unwrap_or((false, "ssd".to_string(), None, None, None, None));
+                            .unwrap_or((
+                                false,
+                                "ssd".to_string(),
+                                None,
+                                None,
+                                None,
+                                None,
+                                "detected".to_string(),
+                            ));
                         devices.push(BlockDevice {
                             path: format!("{disk_path}:free"),
                             size_bytes: free_bytes,
@@ -2371,6 +2432,11 @@ impl FilesystemService {
                             serial,
                             vendor,
                             transport,
+                            // Free-space pseudo-entries carry no identity of
+                            // their own; they mirror the parent disk's class.
+                            stable_id: None,
+                            id_kind: None,
+                            type_source,
                         });
                     }
                 }
@@ -3433,6 +3499,24 @@ pub struct BlockDevice {
     /// Transport bus from lsblk (e.g. "sata", "nvme", "usb").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transport: Option<String>,
+    /// Stable identity key this disk's type override is anchored to —
+    /// a unique by-id link, a by-path link, or (last resort) the /dev
+    /// name. None for partitions and synthetic "free" entries. (#552)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_id: Option<String>,
+    /// How durable `stable_id` is: `hardware` (by-id, survives re-slot),
+    /// `slot` (by-path, reboot-stable but tied to the VM disk slot), or
+    /// `volatile` (/dev name only — won't survive re-lettering).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_kind: Option<String>,
+    /// `detected` when `device_class` came from lsblk/sysfs, `manual`
+    /// when an operator override is in effect (#552).
+    #[serde(default = "default_type_source")]
+    pub type_source: String,
+}
+
+fn default_type_source() -> String {
+    "detected".to_string()
 }
 
 /// Get the largest contiguous free space on a partitioned disk using sgdisk.

--- a/engine/nasty-storage/src/lib.rs
+++ b/engine/nasty-storage/src/lib.rs
@@ -4,6 +4,7 @@
 //! to provide storage filesystem lifecycle operations.
 
 pub mod cmd;
+pub mod disk_type;
 pub mod filesystem;
 pub mod subvolume;
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -520,6 +520,14 @@ export interface BlockDevice {
 	vendor?: string;
 	/** Transport bus from lsblk (e.g. "sata", "nvme", "usb"). */
 	transport?: string;
+	/** Stable identity a manual type override is anchored to (by-id /
+	 * by-path / dev name). Absent on partitions and "free" entries (#552). */
+	stable_id?: string;
+	/** Durability of `stable_id`: "hardware" (by-id) | "slot" (by-path) |
+	 * "volatile" (/dev name). */
+	id_kind?: string;
+	/** "detected" (from lsblk/sysfs) | "manual" (operator override). */
+	type_source: string;
 }
 
 export type TieringProfileId = 'single' | 'write_cache' | 'full_tiering' | 'none' | 'manual';

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -88,6 +88,25 @@
 		if (ok !== undefined) await loadBlockDevices();
 	}
 
+	// Manual disk-type override (#552): for VMs where lsblk's rotational
+	// bit is wrong. `device_class` of 'auto' clears the override.
+	async function setDiskType(dev: BlockDevice, deviceClass: string) {
+		const ok = await withToast(
+			() => client.call('device.set_type', { path: dev.path, device_class: deviceClass }),
+			deviceClass === 'auto'
+				? `${dev.path} type reset to auto-detect`
+				: `${dev.path} type set to ${deviceClass.toUpperCase()}`
+		);
+		if (ok !== undefined) await loadBlockDevices();
+	}
+
+	// Human note about how durable an override on this disk is.
+	function idKindNote(kind: string | undefined): string {
+		if (kind === 'hardware') return 'Anchored to a stable hardware ID — survives reboots and disk re-slotting.';
+		if (kind === 'slot') return 'Anchored to the disk\'s bus slot (no hardware ID on this disk) — survives reboots, but re-applies if you move the disk to another controller/slot in the VM.';
+		return 'No stable ID on this disk — the override is tied to the /dev name and may not survive a reboot.';
+	}
+
 	function formatHours(hours: number): string {
 		const days = Math.floor(hours / 24);
 		const years = Math.floor(days / 365);
@@ -277,9 +296,29 @@
 						<td class="p-3 font-mono text-sm {dev.dev_type === 'part' ? 'pl-8' : ''}">{dev.path}</td>
 						<td class="p-3">{formatBytes(dev.size_bytes)}</td>
 						<td class="p-3">
-							<span class="rounded px-1.5 py-0.5 text-xs font-semibold {deviceClassBadge(dev.device_class)}">
-								{dev.device_class.toUpperCase()}
-							</span>
+							<div class="flex items-center gap-2">
+								<span class="rounded px-1.5 py-0.5 text-xs font-semibold {deviceClassBadge(dev.device_class)}">
+									{dev.device_class.toUpperCase()}
+								</span>
+								{#if dev.dev_type === 'disk'}
+									<select
+										class="rounded border border-border bg-background px-1 py-0.5 text-xs text-foreground"
+										value={dev.type_source === 'manual' ? dev.device_class : 'auto'}
+										title="Override the detected disk type (for VMs where it's wrong)"
+										onchange={(e) => setDiskType(dev, e.currentTarget.value)}
+									>
+										<option value="auto">Auto</option>
+										<option value="ssd">SSD</option>
+										<option value="hdd">HDD</option>
+										<option value="nvme">NVMe</option>
+									</select>
+									{#if dev.type_source === 'manual'}
+										<span class="text-xs text-amber-400" title={idKindNote(dev.id_kind)}>
+											manual{dev.id_kind === 'volatile' ? ' ⚠' : ''}
+										</span>
+									{/if}
+								{/if}
+							</div>
 						</td>
 						<td class="p-3 font-mono text-xs text-muted-foreground">{dev.fs_type ?? '—'}</td>
 						<td class="p-3">


### PR DESCRIPTION
Closes #552.

In VMs, `lsblk`'s `ROTA` bit is unreliable — virtio-scsi / VMware PVSCSI / LSI / Hyper-V virtual disks almost all report `ROTA=1`, so SSD/NVMe-backed storage is misclassified as **hdd**. This adds a per-disk type override on the `/disks` page.

## The identity problem (the actual hard part)

`/dev/sdX` drifts across reboots — confirmed in field data gathered from real Proxmox/Hyper-V/VMware guests (a disk literally moved `sdd`→`sda` between boots). So an override must be keyed to something stable. Findings across hypervisors:

| Disk kind | unique by-id (wwn/eui/NAA) | by-path |
|---|---|---|
| Proxmox virtio, Hyper-V, VMware SATA/NVMe | yes | yes |
| VMware PVSCSI / LSI (no serial, no WWN) | no | yes |

Also: VMware reuses a **constant SATA serial** (`00000000000000000001`) across disks, so serial-based keys can collide — deliberately not used.

**Key chosen first-present from:**
1. a unique by-id link (`wwn-` / `nvme-eui.` / `scsi-3<NAA>`) → `hardware` (survives re-slotting)
2. the **by-path** link → `slot` (universal fallback — present on every disk, reboot-stable; re-applies only if the disk is moved to another controller/slot)
3. the `/dev` name → `volatile` (last resort, flagged in the UI)

## Changes

- **Engine**: new `nasty-storage::disk_type` module — identity from `/dev/disk/by-id` + `/dev/disk/by-path`, override store at `/var/lib/nasty/disk-type-overrides.json`, applied in `list_devices`. `BlockDevice` gains `stable_id` / `id_kind` / `type_source`. New `device.set_type` RPC (Admin; `device_class: "auto"` clears).
- **WebUI**: `/disks` Type column gets an Auto/SSD/HDD/NVMe selector, a `manual` marker, and a tooltip explaining how durable the override's anchor is (hardware/slot/volatile).

## Validation

- Engine: builds, clippy `--all-targets` clean, tests pass incl. 5 new (id-priority: wwn>path>dev, NAA/EUI as hardware, serial-skip→by-path, dev fallback, class→rotational), REST path test (`device.set_type`→PUT).
- WebUI: svelte-check 0 errors, build clean.
- Identity scheme grounded in real `udevadm`/`by-id`/`by-path` output from Proxmox, Hyper-V, and a multi-controller VMware guest.
