### PR TITLE
Operations panel: cancel scrub/evacuate, pause reconcile/copygc (#553)

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -66,7 +66,7 @@ use nasty_system::update::{
     Generation, ReleaseChannel, UpdateBuildDirConfig, UpdateInfo, UpdateStatus, VersionInfo,
     VersionSwitchRequest, VersionTaggedReleaseStatus,
 };
-use nasty_system::{DiskHealth, SystemHealth, SystemInfo, SystemStats, SystemStatus};
+use nasty_system::{DiskHealth, Operation, SystemHealth, SystemInfo, SystemStats, SystemStatus};
 use nasty_vm::{
     CloneVmRequest, CreateVmRequest, SnapshotVmRequest, UpdateVmRequest, VmCapabilities, VmConfig,
     VmDiskSubvolume, VmStatus,
@@ -221,6 +221,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<SystemStatus>(generator)),
+                },
+                Method {
+                    name: "system.operations.list",
+                    desc: "List controllable data operations across mounted filesystems for the Operations panel (#553): running scrubs/evacuations (cancellable) and the pausable background jobs reconcile and copygc, each with the action the UI can take.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<Operation>>(generator)),
                 },
                 Method {
                     name: "system.stats",
@@ -560,6 +567,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<ScrubStatus>(generator)),
+                },
+                Method {
+                    name: "fs.scrub.cancel",
+                    desc: "Cancel a running scrub by terminating its bcachefs process (#553).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
+                    result: None,
                 },
                 Method {
                     name: "fs.fsck.start",
@@ -2002,6 +2016,27 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     desc: "Turn off bcachefs background reconcile work on a mounted filesystem by writing `0` to its sysfs `reconcile_enabled` knob.",
                     role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
+                    result: None,
+                },
+                Method {
+                    name: "fs.copygc.enable",
+                    desc: "Resume bcachefs copy garbage collection on a mounted filesystem by writing `1` to its sysfs `copygc_enabled` knob (#553).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
+                    result: None,
+                },
+                Method {
+                    name: "fs.copygc.disable",
+                    desc: "Pause bcachefs copy garbage collection on a mounted filesystem by writing `0` to its sysfs `copygc_enabled` knob — the same lever nasty-top's advisor pulls on write-stalls (#553).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
+                    result: None,
+                },
+                Method {
+                    name: "fs.device.evacuate.cancel",
+                    desc: "Cancel a running device evacuation: terminate the bcachefs process and return the device to read-write. Migrated data stays migrated (#553).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<DeviceActionRequest>(generator)),
                     result: None,
                 },
             ],

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -329,6 +329,40 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
+        "fs.copygc.enable" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.set_copygc_enabled(name, true).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "fs.copygc.disable" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.set_copygc_enabled(name, false).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "fs.scrub.cancel" => match require_str(req, "name") {
+            Ok(name) => match state.filesystems.scrub_cancel(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "fs.device.evacuate.cancel" => {
+            match parse_params::<nasty_storage::filesystem::DeviceActionRequest>(req) {
+                Ok(p) => match state
+                    .filesystems
+                    .device_evacuate_cancel(&p.filesystem, &p.device)
+                    .await
+                {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         _ => return None,
     })
 }

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -34,6 +34,7 @@ pub(super) async fn try_route(
             *state.status_cache.lock().await = Some((std::time::Instant::now(), status.clone()));
             ok(req, status)
         }
+        "system.operations.list" => ok(req, build_operations(state).await),
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
         "system.secure_boot.readiness" => ok(req, nasty_system::secure_boot::readiness().await),
@@ -825,4 +826,99 @@ async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
         top_warning,
         operations,
     )
+}
+
+/// Gather the controllable data operations across all mounted filesystems
+/// for the Operations panel (#553): running scrubs and evacuations (Cancel),
+/// plus the pausable background jobs reconcile and copygc (Pause/Resume),
+/// shown even when idle so they can be toggled.
+async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
+    let mut ops: Vec<nasty_system::Operation> = Vec::new();
+    let Ok(filesystems) = state.filesystems.list().await else {
+        return ops;
+    };
+    for fs in &filesystems {
+        if !fs.mounted {
+            continue;
+        }
+        // Running evacuations (bcachefs marks the member "evacuating").
+        for dev in &fs.devices {
+            if dev.state.as_deref() == Some("evacuating") {
+                let short = dev.path.rsplit('/').next().unwrap_or(&dev.path);
+                ops.push(nasty_system::Operation {
+                    kind: "evacuate".into(),
+                    fs: fs.name.clone(),
+                    target: Some(dev.path.clone()),
+                    state: "running".into(),
+                    progress_percent: None,
+                    detail: format!("Evacuating {short} from {}", fs.name),
+                    control: "cancel".into(),
+                });
+            }
+        }
+        // Running scrub.
+        if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await
+            && scrub.running
+        {
+            let detail = match scrub.progress_percent {
+                Some(p) => format!("Scrub {} — {p:.0}%", fs.name),
+                None => format!("Scrub {}", fs.name),
+            };
+            ops.push(nasty_system::Operation {
+                kind: "scrub".into(),
+                fs: fs.name.clone(),
+                target: None,
+                state: "running".into(),
+                progress_percent: scrub.progress_percent,
+                detail,
+                control: "cancel".into(),
+            });
+        }
+        // Reconcile — pausable background rebalance.
+        if let Ok(rec) = state.filesystems.reconcile_status(&fs.name).await {
+            let active = nasty_system::alerts::parse_reconcile_sample(&rec.raw).active;
+            let (st, ctrl, detail) = if !rec.enabled {
+                (
+                    "paused",
+                    "resume",
+                    format!("Reconcile paused on {}", fs.name),
+                )
+            } else if active {
+                (
+                    "active",
+                    "pause",
+                    format!("Reconcile running on {}", fs.name),
+                )
+            } else {
+                ("idle", "pause", format!("Reconcile enabled on {}", fs.name))
+            };
+            ops.push(nasty_system::Operation {
+                kind: "reconcile".into(),
+                fs: fs.name.clone(),
+                target: None,
+                state: st.into(),
+                progress_percent: None,
+                detail,
+                control: ctrl.into(),
+            });
+        }
+        // Copygc — pausable; skipped when the kernel doesn't expose it.
+        if let Ok(Some(enabled)) = state.filesystems.copygc_status(&fs.name).await {
+            let (st, ctrl, detail) = if enabled {
+                ("idle", "pause", format!("Copygc enabled on {}", fs.name))
+            } else {
+                ("paused", "resume", format!("Copygc paused on {}", fs.name))
+            };
+            ops.push(nasty_system::Operation {
+                kind: "copygc".into(),
+                fs: fs.name.clone(),
+                target: None,
+                state: st.into(),
+                progress_percent: None,
+                detail,
+                control: ctrl.into(),
+            });
+        }
+    }
+    ops
 }

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -623,6 +623,9 @@ pub enum ScrubOutcome {
     Errors,
     /// Non-zero exit, spawn failure, or the engine restarted mid-scrub.
     Failed,
+    /// The operator cancelled the scrub (process terminated via
+    /// `scrub_cancel`); not an error condition (#553).
+    Cancelled,
 }
 
 /// Scrub operation status — both live state ("am I running, since when")
@@ -817,6 +820,11 @@ pub struct FilesystemService {
     /// an engine restart orphans the child anyway, and the state-based
     /// check in `device_evacuate` covers re-submission after that.
     evacuating: Arc<Mutex<std::collections::HashSet<String>>>,
+    /// Filesystem names whose running scrub has a pending cancel request.
+    /// Set by `scrub_cancel` before it signals the process; the scrub's
+    /// completion path consumes it to record a `Cancelled` outcome rather
+    /// than a misleading `Failed` (#553).
+    scrub_cancels: Arc<Mutex<std::collections::HashSet<String>>>,
 }
 
 impl Default for FilesystemService {
@@ -875,6 +883,7 @@ impl FilesystemService {
             mount_state: Arc::new(Mutex::new(mount)),
             fsck_state: Arc::new(Mutex::new(fsck)),
             evacuating: Arc::new(Mutex::new(std::collections::HashSet::new())),
+            scrub_cancels: Arc::new(Mutex::new(std::collections::HashSet::new())),
         }
     }
 
@@ -2657,6 +2666,34 @@ impl FilesystemService {
         Ok(())
     }
 
+    /// Cancel a running device evacuation: terminate the
+    /// `bcachefs device evacuate <device>` process and return the device
+    /// to `rw` so it rejoins normal operation. Data already migrated off
+    /// stays migrated; the device simply keeps what's left. Both steps
+    /// are best-effort (`pkill` exits 1 when the child already finished).
+    /// (#553)
+    pub async fn device_evacuate_cancel(
+        &self,
+        name: &str,
+        device: &str,
+    ) -> Result<(), FilesystemError> {
+        let fs = self.get(name).await?;
+        if !fs.devices.iter().any(|d| d.path == device) {
+            return Err(FilesystemError::CommandFailed(format!(
+                "{device} is not a member of filesystem '{name}'"
+            )));
+        }
+        let pattern = format!("bcachefs device evacuate {device}");
+        info!("Cancelling evacuation of {device} on '{name}' via pkill -TERM -f '{pattern}'");
+        nasty_common::cmd::try_run("pkill", &["-TERM", "-f", &pattern]).await;
+        self.evacuating.lock().await.remove(device);
+        // Return the device to read-write so it's usable again; the
+        // partial drain is harmless (replicas were preserved throughout).
+        nasty_common::cmd::try_run("bcachefs", &["device", "set-state", "rw", device]).await;
+        self.invalidate_list_cache().await;
+        Ok(())
+    }
+
     /// Change the persistent state of a device (rw, ro, failed, spare).
     /// bcachefs device set-state <new_state> <device> [path]
     pub async fn device_set_state(
@@ -2938,6 +2975,7 @@ impl FilesystemService {
         persist_scrub_state(&self.scrub_state).await;
 
         let store = self.scrub_state.clone();
+        let cancels = self.scrub_cancels.clone();
         info!("Starting scrub on filesystem '{}'", name);
         tokio::spawn(async move {
             let mount = mount_point;
@@ -2947,6 +2985,17 @@ impl FilesystemService {
             // binary doesn't print percent at all — the chip just
             // shows "scrubbing (Nh ago)" via the elapsed timestamp.
             let (outcome, captured) = stream_scrub_and_collect(&mount, &fs_name, &store).await;
+            // Honor a cancel request: a terminated scrub exits non-zero
+            // (Failed), but if the operator asked for it, record it as
+            // Cancelled rather than a misleading failure (#553).
+            let outcome = {
+                let mut c = cancels.lock().await;
+                if c.remove(&fs_name) {
+                    ScrubOutcome::Cancelled
+                } else {
+                    outcome
+                }
+            };
             let end = unix_now_secs();
             let duration = (end - now).max(0) as u64;
 
@@ -2958,6 +3007,9 @@ impl FilesystemService {
                 ScrubOutcome::Failed => {
                     warn!("Scrub on '{fs_name}' failed after {duration}s: {captured}",)
                 }
+                ScrubOutcome::Cancelled => {
+                    info!("Scrub on '{fs_name}' cancelled after {duration}s")
+                }
             }
 
             let truncated = truncate_tail(&captured, SCRUB_OUTPUT_KEEP_BYTES);
@@ -2965,6 +3017,7 @@ impl FilesystemService {
                 ScrubOutcome::Ok => "Last scrub: ok".to_string(),
                 ScrubOutcome::Errors => "Last scrub: errors detected".to_string(),
                 ScrubOutcome::Failed => "Last scrub: failed".to_string(),
+                ScrubOutcome::Cancelled => "Last scrub: cancelled".to_string(),
             };
             {
                 let mut state = store.lock().await;
@@ -2990,6 +3043,42 @@ impl FilesystemService {
             persist_scrub_state(&store).await;
         });
 
+        Ok(())
+    }
+
+    /// Cancel a running scrub by terminating its `bcachefs scrub <mount>`
+    /// process. Pattern-based (`pkill -f`) rather than a stored PID, for
+    /// the same reason `scrub_status` uses a `pgrep` cross-check: an
+    /// engine restart orphans the child, and a pattern still finds it.
+    /// Flags the cancel first so the completion path records a
+    /// `Cancelled` outcome instead of `Failed` (#553).
+    pub async fn scrub_cancel(&self, name: &str) -> Result<(), FilesystemError> {
+        let fs = self.get(name).await?;
+        let mount = fs.mount_point.clone().ok_or_else(|| {
+            FilesystemError::CommandFailed("filesystem is not mounted".to_string())
+        })?;
+
+        // Refuse if nothing is running, so the UI button can't fire a
+        // stray pkill against an unrelated future scrub.
+        let running = self
+            .scrub_state
+            .lock()
+            .await
+            .get(name)
+            .map(|s| s.running)
+            .unwrap_or(false);
+        if !running {
+            return Err(FilesystemError::CommandFailed(
+                "no scrub is running on this filesystem".to_string(),
+            ));
+        }
+
+        self.scrub_cancels.lock().await.insert(name.to_string());
+        let pattern = format!("bcachefs scrub {mount}");
+        info!("Cancelling scrub on '{name}' via pkill -TERM -f '{pattern}'");
+        // pkill exits 1 when nothing matched — fine; the child may have
+        // just finished. The completion path still clears `running`.
+        nasty_common::cmd::try_run("pkill", &["-TERM", "-f", &pattern]).await;
         Ok(())
     }
 
@@ -3255,6 +3344,45 @@ impl FilesystemService {
         let path = format!("/sys/fs/bcachefs/{}/options/reconcile_enabled", fs.uuid);
         let val = if enabled { "1" } else { "0" };
         info!("Setting reconcile_enabled={val} on filesystem '{name}'");
+        tokio::fs::write(&path, val)
+            .await
+            .map_err(|e| FilesystemError::CommandFailed(format!("failed to write {path}: {e}")))
+    }
+
+    /// Whether copygc (copy garbage collection) is enabled for a mounted
+    /// filesystem. `None` when the kernel doesn't expose the option, so
+    /// callers can hide the control rather than guess (forward-compat —
+    /// e.g. `rebalance_enabled` was dropped upstream in favour of
+    /// `reconcile_enabled`). (#553)
+    pub async fn copygc_status(&self, name: &str) -> Result<Option<bool>, FilesystemError> {
+        let fs = self.get(name).await?;
+        if !fs.mounted {
+            return Ok(None);
+        }
+        let path = format!("/sys/fs/bcachefs/{}/options/copygc_enabled", fs.uuid);
+        Ok(match tokio::fs::read_to_string(&path).await {
+            Ok(s) => Some(s.trim() != "0"),
+            Err(_) => None,
+        })
+    }
+
+    /// Enable or disable copygc on a mounted filesystem via sysfs.
+    /// Pausing copygc (`enabled=false`) is the same lever nasty-top's
+    /// advisor pulls on write-stalls. (#553)
+    pub async fn set_copygc_enabled(
+        &self,
+        name: &str,
+        enabled: bool,
+    ) -> Result<(), FilesystemError> {
+        let fs = self.get(name).await?;
+        if !fs.mounted {
+            return Err(FilesystemError::CommandFailed(
+                "filesystem must be mounted to toggle copygc".to_string(),
+            ));
+        }
+        let path = format!("/sys/fs/bcachefs/{}/options/copygc_enabled", fs.uuid);
+        let val = if enabled { "1" } else { "0" };
+        info!("Setting copygc_enabled={val} on filesystem '{name}'");
         tokio::fs::write(&path, val)
             .await
             .map_err(|e| FilesystemError::CommandFailed(format!("failed to write {path}: {e}")))

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -149,6 +149,33 @@ pub struct ActiveOperation {
     pub detail: String,
 }
 
+/// A controllable data operation for the Operations panel (#553). Unlike
+/// [`ActiveOperation`] (band-only, active jobs), this carries the action the
+/// UI can take, and includes pausable background jobs even when idle so they
+/// can be resumed.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Operation {
+    /// "scrub" | "evacuate" | "reconcile" | "copygc".
+    pub kind: String,
+    /// Filesystem the operation belongs to.
+    pub fs: String,
+    /// Device path for an evacuation; `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// "running" (scrub/evacuate in flight) | "active" (background job
+    /// working) | "idle" (enabled, not currently working) | "paused"
+    /// (disabled).
+    pub state: String,
+    /// Progress 0–100 when known (scrub); `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_percent: Option<f32>,
+    /// Short operator-facing line, e.g. "Evacuating sdc" or "Scrub 42%".
+    pub detail: String,
+    /// Action the UI offers: "cancel" (scrub/evacuate) | "pause" |
+    /// "resume" (reconcile/copygc) | "none".
+    pub control: String,
+}
+
 /// Aggregated system status for the sidebar band (#528): one colored level
 /// plus a headline and the in-progress operations and alert counts behind it.
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -84,6 +84,18 @@ export interface SystemStatus {
 	warning_count: number;
 }
 
+/** A controllable data operation for the Operations panel (#553), from
+ * `system.operations.list`. Carries the action the UI can take. */
+export interface Operation {
+	kind: string; // "scrub" | "evacuate" | "reconcile" | "copygc"
+	fs: string;
+	target?: string | null;
+	state: string; // "running" | "active" | "idle" | "paused"
+	progress_percent?: number | null;
+	detail: string;
+	control: string; // "cancel" | "pause" | "resume" | "none"
+}
+
 /** One IOMMU group with its constituent PCI devices, returned by
  * `system.hardware.iommu`. The id is the kernel's group number;
  * devices are sorted by BDF. Empty list = IOMMU is off in BIOS. */
@@ -454,7 +466,7 @@ export interface FsDeviceUsage {
 	total_bytes: number;
 }
 
-export type ScrubOutcome = 'ok' | 'errors' | 'failed';
+export type ScrubOutcome = 'ok' | 'errors' | 'failed' | 'cancelled';
 
 export interface ScrubStatus {
 	running: boolean;

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
 		LayoutDashboard,
 		Database,
 		Layers,
+		Activity,
 		Share2,
 		HardDrive,
 		Archive,
@@ -690,6 +691,7 @@
 				{ href: '/filesystems', label: 'Filesystems', icon: Database },
 				{ href: '/subvolumes', label: 'Subvolumes', icon: Layers },
 				{ href: '/disks',      label: 'Disks',       icon: HardDrive },
+				{ href: '/operations', label: 'Operations',  icon: Activity },
 				{ href: '/files',      label: 'Files',       icon: FolderOpen },
 			]},
 			{ href: '/sharing', label: 'Sharing', icon: Share2 },
@@ -965,7 +967,7 @@
 						{#if statusExpanded && statusHasDetail}
 							<div class="mt-1 space-y-1 px-2 pb-1 text-[0.7rem] text-muted-foreground">
 								{#each systemStatus.operations as op}
-									<a href="/filesystems" class="block truncate hover:text-foreground">• {op.detail}</a>
+									<a href="/operations" class="block truncate hover:text-foreground">• {op.detail}</a>
 								{/each}
 								{#if systemStatus.critical_count + systemStatus.warning_count > 0}
 									<a href="/alerts" class="block hover:text-foreground">

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -224,11 +224,14 @@
 		const cls =
 			outcome === 'ok' ? 'text-green-500' :
 			outcome === 'errors' ? 'text-amber-500' :
+			outcome === 'cancelled' ? 'text-muted-foreground' :
 			'text-red-500';
 		const label = outcome === 'ok'
 			? `scrubbed ${ago}, ok`
 			: outcome === 'errors'
 			? `scrubbed ${ago}, errors`
+			: outcome === 'cancelled'
+			? `scrub cancelled ${ago}`
 			: `scrub failed ${ago}`;
 		return { label, cls, title: `${dur ? `Took ${dur}. ` : ''}Click Diagnostics for full output.` };
 	}

--- a/webui/src/routes/operations/+page.svelte
+++ b/webui/src/routes/operations/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
+	import type { Operation } from '$lib/types';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { RefreshCw } from '@lucide/svelte';
+
+	let operations: Operation[] = $state([]);
+	let loading = $state(true);
+	let busy = $state<string | null>(null);
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+	const client = getClient();
+
+	// Stable key per operation so the busy-state and {#each} track correctly.
+	function opKey(op: Operation): string {
+		return `${op.kind}:${op.fs}:${op.target ?? ''}`;
+	}
+
+	async function load() {
+		try {
+			operations = await client.call<Operation[]>('system.operations.list');
+		} catch {
+			operations = [];
+		}
+		loading = false;
+	}
+
+	onMount(() => {
+		load();
+		// Poll fairly often — scrub progress and pause/resume should feel live.
+		pollInterval = setInterval(load, 4000);
+	});
+	onDestroy(() => {
+		if (pollInterval) clearInterval(pollInterval);
+	});
+
+	function kindLabel(kind: string): string {
+		return (
+			{ scrub: 'Scrub', evacuate: 'Evacuate', reconcile: 'Reconcile', copygc: 'Copygc' }[kind] ??
+			kind
+		);
+	}
+
+	function stateClass(state: string): string {
+		return (
+			{
+				running: 'text-amber-400',
+				active: 'text-amber-400',
+				idle: 'text-emerald-400',
+				paused: 'text-muted-foreground',
+			}[state] ?? 'text-muted-foreground'
+		);
+	}
+
+	async function act(op: Operation) {
+		const key = opKey(op);
+		if (op.control === 'cancel') {
+			const what =
+				op.kind === 'scrub'
+					? `the scrub on ${op.fs}`
+					: `evacuation of ${op.target} on ${op.fs}`;
+			const body =
+				op.kind === 'scrub'
+					? 'The scrub stops where it is; already-checked data stays verified. You can start a fresh scrub later.'
+					: 'The device stops draining and returns to read-write. Data already moved off stays moved; the device keeps what is left.';
+			if (!(await confirm(`Cancel ${what}?`, body))) return;
+		}
+
+		busy = key;
+		const method =
+			op.kind === 'scrub'
+				? 'fs.scrub.cancel'
+				: op.kind === 'evacuate'
+					? 'fs.device.evacuate.cancel'
+					: op.kind === 'reconcile'
+						? op.control === 'resume'
+							? 'fs.reconcile.enable'
+							: 'fs.reconcile.disable'
+						: op.control === 'resume'
+							? 'fs.copygc.enable'
+							: 'fs.copygc.disable';
+		const params =
+			op.kind === 'evacuate' ? { filesystem: op.fs, device: op.target } : { name: op.fs };
+
+		const verb =
+			op.control === 'cancel' ? 'cancelled' : op.control === 'resume' ? 'resumed' : 'paused';
+		const ok = await withToast(
+			() => client.call(method, params),
+			`${kindLabel(op.kind)} on ${op.fs} ${verb}`
+		);
+		if (ok !== undefined) await load();
+		busy = null;
+	}
+
+	function actionLabel(op: Operation): string {
+		return (
+			{ cancel: 'Cancel', pause: 'Pause', resume: 'Resume' }[op.control] ?? ''
+		);
+	}
+</script>
+
+<div class="mx-auto max-w-4xl p-6">
+	<div class="mb-1 flex items-center gap-2">
+		<h1 class="text-2xl font-semibold">Operations</h1>
+		{#if loading}
+			<RefreshCw class="h-4 w-4 animate-spin text-muted-foreground" />
+		{/if}
+	</div>
+	<p class="mb-6 text-muted-foreground">
+		Live array operations across your pools — cancel a scrub or evacuation, pause or resume
+		background reconcile and copy-GC.
+	</p>
+
+	{#if !loading && operations.length === 0}
+		<Card>
+			<CardContent class="py-10 text-center text-muted-foreground">
+				Nothing running. Scrubs and evacuations appear here while in progress; reconcile and
+				copy-GC appear when a pool exposes them.
+			</CardContent>
+		</Card>
+	{:else}
+		<div class="space-y-2">
+			{#each operations as op (opKey(op))}
+				<Card>
+					<CardContent class="flex items-center gap-4 py-3">
+						<div class="w-24 shrink-0">
+							<span class="text-sm font-semibold">{kindLabel(op.kind)}</span>
+						</div>
+						<div class="min-w-0 flex-1">
+							<div class="truncate text-sm">{op.detail}</div>
+							<div class="text-xs {stateClass(op.state)}">{op.state}</div>
+							{#if op.progress_percent != null}
+								<div class="mt-1 h-1.5 w-full overflow-hidden rounded bg-muted">
+									<div
+										class="h-full bg-amber-500 transition-all"
+										style="width: {Math.max(0, Math.min(100, op.progress_percent))}%"
+									></div>
+								</div>
+							{/if}
+						</div>
+						{#if op.control !== 'none'}
+							<Button
+								variant={op.control === 'cancel' ? 'destructive' : 'outline'}
+								size="sm"
+								disabled={busy === opKey(op)}
+								onclick={() => act(op)}
+							>
+								{actionLabel(op)}
+							</Button>
+						{/if}
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
Closes #553 (Kev's "cancel a scrub" — and he loves the status chip 🎉), and adds the unified operations visibility we were missing.

A dedicated **Operations** panel (`/operations`) lists the live bcachefs data jobs across all pools, each with the action its mechanism actually supports:

| Operation | How it runs | Control |
|---|---|---|
| **scrub** | spawned `bcachefs scrub` | **Cancel** |
| **evacuate** | spawned `bcachefs device evacuate` | **Cancel** |
| **reconcile** | kernel thread | **Pause / Resume** (`reconcile_enabled`) |
| **copygc** | kernel thread | **Pause / Resume** (`copygc_enabled`) |

- **Cancel** terminates the `bcachefs` process via `pkill -f` (not a stored PID — mirrors `scrub_status`'s existing `pgrep` cross-check, so it still works after an engine restart orphaned the child). A cancelled scrub records a distinct `Cancelled` outcome instead of a misleading `Failed`. Cancelling an evacuation also returns the device to `rw`; data already migrated stays migrated.
- **copygc** is the `copygc_enabled` sysfs knob — the same lever nasty-top's advisor pulls on write-stalls. It's existence-gated, so the control hides cleanly on kernels that don't expose it. (Verified on NASty's 6.18.35 kernel that `copygc_enabled` *is* present — the option that's actually gone upstream is `rebalance_enabled`, which `reconcile_enabled` replaced.)
- Built on the #545 `ActiveOperation` aggregation; the status band's expanded operations now link to this panel.

## Changes
- **Engine**: `ScrubOutcome::Cancelled`; `scrub_cancel`; `device_evacuate_cancel`; `copygc_status` / `set_copygc_enabled`; `Operation` model + `build_operations`; RPCs `system.operations.list`, `fs.scrub.cancel`, `fs.device.evacuate.cancel`, `fs.copygc.enable/disable`.
- **WebUI**: `/operations` panel (live 4s poll, Cancel/Pause/Resume), nav entry, band links, `cancelled` scrub badge.

## Validation
- Engine: builds, clippy `--all-targets` clean, 508 tests pass, fmt clean, REST paths test passes.
- WebUI: svelte-check 0 errors, build clean.

## ✅ Verified live (.38, kernel 6.18.35, real pool)

Confirmed that killing the userspace `bcachefs scrub` process **does tear down the kernel job** — staged a 12 G temp file, scrubbed, and `pkill -TERM`'d mid-pass (`scrub.out` at `51% 361M/sec`):

| | process | scrub ctx (`moving_ctxts`) | device reads / 2s |
|---|---|---|---|
| during scrub | 4 | 1 (active) | 4,146,688 sectors (~2 GB) |
| after `pkill -TERM` | 0 | 0 (gone) | 0 |

The scrub move-context disappears and device reads drop to exactly zero — the fd-tied data-job cancellation holds. (Evacuate uses the same `bcachefs device` data-job machinery, so the same teardown applies.) Temp file cleaned up.
