### PR TITLE
Device management UX (#554): stable ordering + guided force-remove

### DIFF
--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1215,6 +1215,20 @@ impl FilesystemService {
             }
         }
 
+        // Deterministic order so the WebUI doesn't shuffle rows on every
+        // poll: the mounted set comes from HashMap iteration (unordered)
+        // and the unmounted set is appended after, so without this the
+        // pool list — and each pool's device table — "bounces" between
+        // refreshes (#554). Sort pools by name, members by slot then path.
+        filesystems.sort_by(|a, b| a.name.cmp(&b.name));
+        for fs in &mut filesystems {
+            fs.devices.sort_by(|a, b| {
+                a.member_index
+                    .cmp(&b.member_index)
+                    .then(a.path.cmp(&b.path))
+            });
+        }
+
         Ok(filesystems)
     }
 

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -8,7 +8,7 @@
 		formatBytes,
 		formatPercent
 	} from '$lib/format';
-	import { withToast } from '$lib/toast.svelte';
+	import { withToast, success as toastSuccess } from '$lib/toast.svelte';
 
 	let pageTab = $state<'manage' | 'diagnostics'>(
 		typeof window !== 'undefined' && window.location.hash === '#diagnostics' ? 'diagnostics' : 'manage'
@@ -859,11 +859,30 @@
 	async function removeDevice(fsName: string, devicePath: string) {
 		if (!await confirm(`Remove ${devicePath}?`, `Data will be evacuated from filesystem "${fsName}" first.`)) return;
 		await runDeviceAction(devicePath, async () => {
-			await withToast(
-				() => client.call('fs.device.remove', { filesystem: fsName, device: devicePath }),
-				`Device ${devicePath} removed from "${fsName}"`
-			);
-			await refresh();
+			try {
+				await client.call('fs.device.remove', { filesystem: fsName, device: devicePath }, 120000);
+				toastSuccess(`Device ${devicePath} removed from "${fsName}"`);
+				await refresh();
+			} catch (e) {
+				// The safe remove was refused — typically the device still
+				// holds data/metadata bcachefs won't migrate on its own (e.g.
+				// removal would drop below the configured replicas). Rather
+				// than dead-end the user in the terminal with `--force` (#554),
+				// surface the real reason and offer a deliberately-gated force
+				// remove that the engine already supports.
+				const reason = String((e as Error)?.message ?? e).replace(/^Error:\s*/, '');
+				const forced = await confirmDangerous(
+					`Force-remove ${devicePath}?`,
+					`bcachefs refused to remove ${devicePath} safely:\n\n${reason}\n\nForce-remove pulls the device out anyway, skipping the migrate-off and redundancy checks. If the pool no longer has enough replicas on the remaining devices, this loses data. Type the device path below to confirm you understand.`,
+					devicePath
+				);
+				if (!forced) return;
+				const ok = await withToast(
+					() => client.call('fs.device.remove', { filesystem: fsName, device: devicePath, force: true }, 120000),
+					`Force-removed ${devicePath} from "${fsName}"`
+				);
+				if (ok !== undefined) await refresh();
+			}
 		});
 	}
 


### PR DESCRIPTION
Closes both halves of #554, which Kev hit while pulling a device.

## 1. Stable pool/device ordering (the "bouncing" UI)
`list_uncached` built the mounted set from `HashMap` iteration (unordered) and appended unmounted pools after, so `fs.list`/`device.list` could return pools — and each pool's device table — in a different order on every poll, and the WebUI faithfully re-rendered the shuffle. Now sorted by pool name, members by slot then path. *(engine)*

## 2. Guided force-remove when safe removal is refused
A present device whose data won't fully migrate (e.g. removal would drop below the configured replicas) makes `bcachefs device remove` refuse without `--force`. The WebUI just showed the error and dead-ended — so Kev had to drop to the terminal and force it by hand. Now: catch the failure, surface bcachefs's **actual reason**, and offer a deliberately-gated force-remove (`confirmDangerous` — you type the device path) that calls the force path **the engine already supported but the UI never reached** for present devices. *(webui)*

Engine: clippy `--all-targets` clean, 82 tests pass, fmt clean. WebUI: svelte-check 0 errors, build clean.

Not in scope (deeper, tracked separately): clearer *evacuation-completion* visibility — that's the bcachefs "no /proc/mdstat" gap (overlaps #540); best tackled via `internal/moving_ctxts`.