### PR TITLE
Live operation progress from bcachefs moving_ctxts (#540)

### DIFF
--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -841,29 +841,49 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
         if !fs.mounted {
             continue;
         }
+        // Live byte counters from bcachefs's data-move framework (#540) —
+        // the reliable signal for "is this actually moving data, and how
+        // much" across all four operation kinds, read once per fs.
+        let ctxts = state.filesystems.moving_ctxts(&fs.name).await;
+        let moved = |kind: &str| {
+            ctxts
+                .iter()
+                .find(|c| c.kind == kind)
+                .map(|c| (c.bytes_seen, c.bytes_moved))
+        };
+
         // Running evacuations (bcachefs marks the member "evacuating").
         for dev in &fs.devices {
             if dev.state.as_deref() == Some("evacuating") {
                 let short = dev.path.rsplit('/').next().unwrap_or(&dev.path);
+                let mut detail = format!("Evacuating {short} from {}", fs.name);
+                if let Some((_, m)) = moved("evacuate").filter(|&(_, m)| m > 0) {
+                    detail += &format!(" — {} drained", human_bytes(m));
+                }
                 ops.push(nasty_system::Operation {
                     kind: "evacuate".into(),
                     fs: fs.name.clone(),
                     target: Some(dev.path.clone()),
                     state: "running".into(),
                     progress_percent: None,
-                    detail: format!("Evacuating {short} from {}", fs.name),
+                    detail,
                     control: "cancel".into(),
                 });
             }
         }
-        // Running scrub.
+        // Running scrub. Percent stays from the CLI (bcachefs computes it
+        // with the replication denominator); moving_ctxts adds a reliable
+        // live "scanned" figure on top.
         if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await
             && scrub.running
         {
-            let detail = match scrub.progress_percent {
+            let mut detail = match scrub.progress_percent {
                 Some(p) => format!("Scrub {} — {p:.0}%", fs.name),
                 None => format!("Scrub {}", fs.name),
             };
+            if let Some((seen, _)) = moved("scrub").filter(|&(s, _)| s > 0) {
+                detail += &format!(" ({} scanned)", human_bytes(seen));
+            }
             ops.push(nasty_system::Operation {
                 kind: "scrub".into(),
                 fs: fs.name.clone(),
@@ -874,10 +894,12 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                 control: "cancel".into(),
             });
         }
-        // Reconcile — pausable background rebalance.
+        // Reconcile — pausable background rebalance. moving_ctxts confirms
+        // whether it's actually moving data right now.
         if let Ok(rec) = state.filesystems.reconcile_status(&fs.name).await {
-            let active = nasty_system::alerts::parse_reconcile_sample(&rec.raw).active;
-            let (st, ctrl, detail) = if !rec.enabled {
+            let bytes = moved("reconcile").map(|(_, m)| m).unwrap_or(0);
+            let active = bytes > 0 || nasty_system::alerts::parse_reconcile_sample(&rec.raw).active;
+            let (st, ctrl, mut detail) = if !rec.enabled {
                 (
                     "paused",
                     "resume",
@@ -892,6 +914,9 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
             } else {
                 ("idle", "pause", format!("Reconcile enabled on {}", fs.name))
             };
+            if bytes > 0 {
+                detail += &format!(" — {} moved", human_bytes(bytes));
+            }
             ops.push(nasty_system::Operation {
                 kind: "reconcile".into(),
                 fs: fs.name.clone(),
@@ -903,12 +928,19 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
             });
         }
         // Copygc — pausable; skipped when the kernel doesn't expose it.
+        // moving_ctxts gives us real active-vs-idle detection here.
         if let Ok(Some(enabled)) = state.filesystems.copygc_status(&fs.name).await {
-            let (st, ctrl, detail) = if enabled {
-                ("idle", "pause", format!("Copygc enabled on {}", fs.name))
-            } else {
+            let bytes = moved("copygc").map(|(_, m)| m).unwrap_or(0);
+            let (st, ctrl, mut detail) = if !enabled {
                 ("paused", "resume", format!("Copygc paused on {}", fs.name))
+            } else if bytes > 0 {
+                ("active", "pause", format!("Copygc running on {}", fs.name))
+            } else {
+                ("idle", "pause", format!("Copygc enabled on {}", fs.name))
             };
+            if bytes > 0 {
+                detail += &format!(" — {} moved", human_bytes(bytes));
+            }
             ops.push(nasty_system::Operation {
                 kind: "copygc".into(),
                 fs: fs.name.clone(),
@@ -921,4 +953,20 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
         }
     }
     ops
+}
+
+/// Compact binary byte formatter for operation detail strings.
+fn human_bytes(b: u64) -> String {
+    const U: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut v = b as f64;
+    let mut i = 0;
+    while v >= 1024.0 && i < U.len() - 1 {
+        v /= 1024.0;
+        i += 1;
+    }
+    if i == 0 {
+        format!("{b} B")
+    } else {
+        format!("{v:.1} {}", U[i])
+    }
 }

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -3388,6 +3388,21 @@ impl FilesystemService {
             .map_err(|e| FilesystemError::CommandFailed(format!("failed to write {path}: {e}")))
     }
 
+    /// Active data-move operations from `internal/moving_ctxts` — live
+    /// progress for scrub / reconcile / copygc / evacuate (#540). Empty on
+    /// an unmounted fs or when the debug file is absent/unreadable.
+    pub async fn moving_ctxts(&self, name: &str) -> Vec<MoveCtx> {
+        let Ok(fs) = self.get(name).await else {
+            return Vec::new();
+        };
+        if !fs.mounted {
+            return Vec::new();
+        }
+        let path = format!("/sys/fs/bcachefs/{}/internal/moving_ctxts", fs.uuid);
+        let raw = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+        parse_moving_ctxts(&raw)
+    }
+
     /// Raw output of `bcachefs fs usage <mount>` — space breakdown by data type and device.
     pub async fn bcachefs_usage(&self, name: &str) -> Result<String, FilesystemError> {
         let fs = self.get(name).await?;
@@ -3561,6 +3576,68 @@ fn validate_compression(spec: &str) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+/// One active data-move operation parsed from a bcachefs filesystem's
+/// `internal/moving_ctxts` (#540). bcachefs runs scrub, reconcile,
+/// copygc, and device evacuation on a shared data-move framework; each
+/// registers a context here with live byte counters. This is the closest
+/// thing bcachefs exposes to a `/proc/mdstat` for those operations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MoveCtx {
+    /// Normalized kind: `scrub` | `reconcile` | `copygc` | `evacuate` | `other`.
+    pub kind: String,
+    /// Bytes the operation has scanned/considered so far.
+    pub bytes_seen: u64,
+    /// Bytes it has actually relocated so far.
+    pub bytes_moved: u64,
+}
+
+/// Parse `internal/moving_ctxts`. Each context is a non-indented header
+/// (`scrub: ...`, `reconcile_work: ...`) followed by indented counter
+/// lines (`bytes seen:`, `bytes moved:`). This is a debug interface with
+/// no stability guarantee, so parse defensively: unrecognized headers
+/// become `other`, missing counters stay 0, and unknown lines are ignored.
+pub fn parse_moving_ctxts(raw: &str) -> Vec<MoveCtx> {
+    let mut out = Vec::new();
+    let mut cur: Option<MoveCtx> = None;
+    for line in raw.lines() {
+        let is_header =
+            !line.is_empty() && !line.starts_with(char::is_whitespace) && line.contains(':');
+        if is_header {
+            if let Some(c) = cur.take() {
+                out.push(c);
+            }
+            let label = line.split(':').next().unwrap_or("").trim().to_lowercase();
+            let kind = if label.contains("scrub") {
+                "scrub"
+            } else if label.contains("reconcile") || label.contains("rebalance") {
+                "reconcile"
+            } else if label.contains("copygc") || label.contains("copy_gc") {
+                "copygc"
+            } else if label.contains("evac") || label.contains("migrate") {
+                "evacuate"
+            } else {
+                "other"
+            };
+            cur = Some(MoveCtx {
+                kind: kind.to_string(),
+                bytes_seen: 0,
+                bytes_moved: 0,
+            });
+        } else if let Some(c) = cur.as_mut() {
+            let t = line.trim();
+            if let Some(v) = t.strip_prefix("bytes seen:") {
+                c.bytes_seen = parse_human_bytes(v.trim()).unwrap_or(0);
+            } else if let Some(v) = t.strip_prefix("bytes moved:") {
+                c.bytes_moved = parse_human_bytes(v.trim()).unwrap_or(0);
+            }
+        }
+    }
+    if let Some(c) = cur.take() {
+        out.push(c);
+    }
+    out
 }
 
 /// Parse human-readable byte strings like "109.8M", "2.3G", "512K", "1024".
@@ -5719,6 +5796,71 @@ mod tests {
         // `bcachefs show-super` prints "Superblock size: 7.85k/1.00M" — the
         // slash form isn't a unit and shouldn't parse.
         assert_eq!(parse_human_bytes("7.85k/1.00M"), None);
+    }
+
+    // ── parse_moving_ctxts (#540) ──────────────────────────────────
+    // Samples are verbatim from a real bcachefs 6.18.35 pool.
+
+    #[test]
+    fn moving_ctxts_parses_active_scrub() {
+        // Trimmed from a mid-pass scrub captured on .38.
+        let raw = "\
+scrub: data type==(unknown data_type 254) pos=extents:5764607:9038848:U32_MAX
+  keys moved:                  5886
+  keys raced:                  0
+  bytes seen:                  1.44G
+  bytes moved:                 1.43G
+  bytes raced:                 0
+  reads: ios 64/64 sectors 32768/131072
+";
+        let ctxs = parse_moving_ctxts(raw);
+        assert_eq!(ctxs.len(), 1);
+        assert_eq!(ctxs[0].kind, "scrub");
+        assert_eq!(ctxs[0].bytes_seen, (1.44 * 1024.0 * 1024.0 * 1024.0) as u64);
+        assert_eq!(
+            ctxs[0].bytes_moved,
+            (1.43 * 1024.0 * 1024.0 * 1024.0) as u64
+        );
+    }
+
+    #[test]
+    fn moving_ctxts_parses_idle_reconcile_baseline() {
+        let raw = "\
+reconcile_work: data type==user pos=extents:POS_MIN
+  keys moved:                  0
+  bytes seen:                  0
+  bytes moved:                 0
+";
+        let ctxs = parse_moving_ctxts(raw);
+        assert_eq!(ctxs.len(), 1);
+        assert_eq!(ctxs[0].kind, "reconcile");
+        assert_eq!(ctxs[0].bytes_seen, 0);
+        assert_eq!(ctxs[0].bytes_moved, 0);
+    }
+
+    #[test]
+    fn moving_ctxts_handles_multiple_and_unknown_kinds() {
+        let raw = "\
+scrub: ...
+  bytes seen:                  512M
+copygc: ...
+  bytes moved:                 8.0M
+weird_future_op: ...
+  bytes moved:                 1.0M
+";
+        let ctxs = parse_moving_ctxts(raw);
+        assert_eq!(ctxs.len(), 3);
+        assert_eq!(ctxs[0].kind, "scrub");
+        assert_eq!(ctxs[0].bytes_seen, 512 * 1024 * 1024);
+        assert_eq!(ctxs[1].kind, "copygc");
+        assert_eq!(ctxs[1].bytes_moved, 8 * 1024 * 1024);
+        // Unrecognized header → "other", still parsed (forward-compat).
+        assert_eq!(ctxs[2].kind, "other");
+    }
+
+    #[test]
+    fn moving_ctxts_empty_when_idle() {
+        assert!(parse_moving_ctxts("").is_empty());
     }
 
     // ── validate_compression (#491) ────────────────────────────────


### PR DESCRIPTION
Addresses #540 (no live scrub progress) by using the signal we found while building #553/#556.

bcachefs has no `/proc/mdstat` for these operations, so today NASty scrapes the `bcachefs scrub` CLI's terminal output for a percent — fragile, and it gives **nothing** for reconcile/copygc/evacuate. But bcachefs runs all four on one **data-move framework** and exposes the live ones in `internal/moving_ctxts` with byte counters — the closest thing to a status file it has.

## What this does
- **`parse_moving_ctxts`** — defensive parser (it's a debug interface with no stability guarantee: unknown headers → `other`, missing counters → `0`, unknown lines ignored) + a `moving_ctxts(name)` reader.
- **Wires it into the Operations panel** (`build_operations`):
  - **scrub** — keeps the CLI percent (bcachefs computes it correctly with the replication denominator) and adds a reliable live **"X scanned"**.
  - **evacuate** — **"X drained"**.
  - **reconcile / copygc** — real **active-vs-idle** detection (a context actually moving bytes) + **"X moved"**. This finally gives copygc a true active state, which it lacked.

## Why the Operations panel
It's the canonical live-operations surface now (#556), and it renders the enriched `detail` string as-is — so this is **engine-only**, no WebUI change.

## Validation
- clippy `--all-targets` clean, fmt clean, full storage+engine suites pass (212 tests) incl. 4 new parser tests built from **verbatim samples off a real 6.18.35 pool** (active scrub at 1.44 G seen; idle reconcile baseline; multi-context + unknown-kind; empty).

## Notes / scope
- The reliable signal now lives in the **Operations panel**. The legacy Diagnostics **scrub tab** (the surface #540 was reported on) still shows the CLI-percent progress; piping `scanned` bytes into `ScrubStatus` for that tab too is a trivial follow-up if you want it — left out here to keep the model change small. Say the word.
- Still subject to bcachefs's interface stability (it's `internal/`), hence the defensive parser + graceful empty fallback.
