### PR TITLE
tls: register + surface app ingress host certs on deploy

### DIFF
--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -309,8 +309,25 @@ async fn deploy_simple(
             .await;
     }
 
+    // Did this deploy opt into a subdomain ingress? install() wires the
+    // Caddy route internally, but the TLS-automation layer lives in
+    // nasty-system (which nasty-apps can't call without a dep cycle), so
+    // the refresh has to be kicked from here — mirroring the
+    // apps.ingress.set arm. Without it a deploy-time subdomain wouldn't
+    // land in Caddy's certificates.automate until the next engine
+    // restart, leaving the host on Caddy's default automation policy
+    // (no configured DNS-01 provider ⇒ no cert at all on a DNS-challenge
+    // box).
+    let chose_subdomain = params
+        .subdomain
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty());
     match state.apps.install(params).await {
         Ok(app) => {
+            if chose_subdomain {
+                tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+            }
             let _ = socket
                 .send(Message::Text(
                     DeployMessage::log(&format!("Container '{}' started", app.name)).into(),

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -51,11 +51,27 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
-        "apps.install" => match parse_params(req) {
-            Ok(p) => match state.apps.install(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "apps.install" => match parse_params::<nasty_apps::InstallAppRequest>(req) {
+            Ok(p) => {
+                // Refresh Caddy TLS automation when the install opts into
+                // a subdomain ingress — install() wires the route but the
+                // TLS layer is reached from here (see the matching note in
+                // app_deploy.rs::deploy_simple).
+                let chose_subdomain = p
+                    .subdomain
+                    .as_deref()
+                    .map(str::trim)
+                    .is_some_and(|s| !s.is_empty());
+                match state.apps.install(p).await {
+                    Ok(v) => {
+                        if chose_subdomain {
+                            tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                        }
+                        ok(req, v)
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
         "apps.update" => match parse_params(req) {

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -139,6 +139,24 @@ pub async fn read_caddy_local_ca_root() -> Option<String> {
 /// any read or parse failure is logged at debug and skipped — a
 /// malformed app.json shouldn't block the main-domain cert refresh.
 async fn load_app_subdomains() -> Vec<String> {
+    load_app_ingress_hosts()
+        .await
+        .into_iter()
+        .map(|(host, _app)| host)
+        .collect()
+}
+
+/// Like [`load_app_subdomains`] but keeps the owning app name alongside
+/// each ingress hostname. The TLS-status path uses this so the WebUI can
+/// label a stuck cert with the deployment it belongs to, and so an
+/// ingress host shows up on the TLS page even when it hasn't yet been
+/// written into Caddy's `certificates.automate` set (Caddy still harvests
+/// the host from the route matcher and attempts issuance — we want that
+/// attempt, and any failure, to be visible regardless).
+///
+/// The app name is the manifest's `name` field, falling back to the
+/// file stem. Best-effort, same as [`load_app_subdomains`].
+async fn load_app_ingress_hosts() -> Vec<(String, String)> {
     let dir = "/var/lib/nasty/apps";
     let mut out = Vec::new();
     let mut entries = match tokio::fs::read_dir(dir).await {
@@ -158,11 +176,27 @@ async fn load_app_subdomains() -> Vec<String> {
             Ok(v) => v,
             Err(_) => continue,
         };
-        if let Some(host) = v.get("ingress_subdomain").and_then(|s| s.as_str())
-            && !host.trim().is_empty()
-        {
-            out.push(host.trim().to_string());
-        }
+        let Some(host) = v
+            .get("ingress_subdomain")
+            .and_then(|s| s.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let name = v
+            .get("name")
+            .and_then(|s| s.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_default();
+        out.push((host.to_string(), name));
     }
     out
 }
@@ -1386,6 +1420,12 @@ pub struct HostTlsStatus {
     /// line, verbatim. `pending` ⇒ None.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    /// Name of the app whose ingress owns this hostname, when the host
+    /// is an app subdomain (vs. the WebUI's own TLS domain or an
+    /// internal-CA IP). Lets the TLS page label the row so an operator
+    /// can tell at a glance which deployment a stuck cert belongs to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
 }
 
 /// Build a [`HostTlsStatus`] for one managed hostname.
@@ -1412,6 +1452,7 @@ pub async fn host_tls_status(host: &str) -> HostTlsStatus {
             expires: info.expires,
             expires_in_days: info.expires_in_days,
             message: Some(info.path),
+            app: None,
         };
     }
 
@@ -1441,6 +1482,7 @@ pub async fn host_tls_status(host: &str) -> HostTlsStatus {
             expires: None,
             expires_in_days: None,
             message: None,
+            app: None,
         };
     };
 
@@ -1461,40 +1503,78 @@ pub async fn host_tls_status(host: &str) -> HostTlsStatus {
         expires: None,
         expires_in_days: None,
         message: Some(extract_log_message(line)),
+        app: None,
     }
 }
 
-/// Return the list of all managed hostnames Caddy is currently
-/// tracking, with each one's current TLS status. Reads
-/// `apps.tls.certificates.automate` from Caddy's admin API (the
-/// authoritative "what hosts should Caddy be obtaining certs for"
-/// list — set by our `set_tls_automation` flow) and resolves status
-/// per host.
-///
-/// Skips `nasty.local` (the internal-CA fallback) — that one is
-/// always active and not interesting on the /tls page.
-pub async fn list_host_tls_statuses() -> Vec<HostTlsStatus> {
+/// Fetch the `certificates.automate` list from Caddy's admin API — the
+/// authoritative "what hosts should Caddy be obtaining certs for" set,
+/// written by our `set_tls_automation` flow. Empty on any error (admin
+/// API down, parse failure); callers still surface app ingress hosts.
+async fn fetch_caddy_automate_hosts() -> Vec<String> {
     let url = "http://127.0.0.1:2019/config/apps/tls/certificates/automate";
-    let client = reqwest::Client::builder()
+    let Ok(client) = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
-        .build();
-    let Ok(client) = client else {
+        .build()
+    else {
         return Vec::new();
     };
-    let resp = match client.get(url).send().await {
-        Ok(r) => r,
-        Err(_) => return Vec::new(),
+    let Ok(resp) = client.get(url).send().await else {
+        return Vec::new();
     };
-    let hosts: Vec<String> = match resp.json().await {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
+    resp.json().await.unwrap_or_default()
+}
+
+/// Merge Caddy's formally-automated host list with app ingress hosts
+/// into an ordered, de-duplicated `(host, app_name)` list.
+///
+/// Automate hosts come first (preserving Caddy's order); each app
+/// ingress host not already present is appended. `nasty.local` (the
+/// internal-CA fallback — always active, uninteresting on the /tls
+/// page) is dropped. Every host carries its owning app name when known,
+/// so an ingress cert can be labelled with its deployment.
+///
+/// The union is the point: an app ingress host that never made it into
+/// `certificates.automate` (registration race, or a config pushed
+/// before the app was deployed) is still being harvested by Caddy from
+/// its route matcher and attempted — so it belongs on the TLS page with
+/// its issuance status, not hidden because one list happened to lack it.
+fn merge_host_lists(
+    automate: Vec<String>,
+    app_hosts: Vec<(String, String)>,
+) -> Vec<(String, Option<String>)> {
+    let app_map: std::collections::HashMap<String, String> = app_hosts.iter().cloned().collect();
+    let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
-    for host in hosts {
+    for host in automate
+        .into_iter()
+        .chain(app_hosts.into_iter().map(|(host, _)| host))
+    {
         if host == "nasty.local" {
             continue;
         }
-        out.push(host_tls_status(&host).await);
+        if seen.insert(host.clone()) {
+            let app = app_map.get(&host).cloned();
+            out.push((host, app));
+        }
+    }
+    out
+}
+
+/// Return the list of all managed hostnames Caddy is currently
+/// tracking, with each one's current TLS status. Unions Caddy's
+/// `certificates.automate` set with the box's app ingress hosts (see
+/// [`merge_host_lists`]) and resolves status per host, so every
+/// hostname Caddy is serving or attempting — including app ingresses
+/// not yet in the automate set — appears on the /tls page.
+pub async fn list_host_tls_statuses() -> Vec<HostTlsStatus> {
+    let automate = fetch_caddy_automate_hosts().await;
+    let app_hosts = load_app_ingress_hosts().await;
+    let mut out = Vec::new();
+    for (host, app) in merge_host_lists(automate, app_hosts) {
+        let mut status = host_tls_status(&host).await;
+        status.app = app;
+        out.push(status);
     }
     out
 }
@@ -1619,12 +1699,54 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        EncryptedBlob, OidcSettings, Settings, build_policy_set, caddy_acme_env,
+        EncryptedBlob, OidcSettings, Settings, build_policy_set, caddy_acme_env, merge_host_lists,
         redact_oidc_secret, resolve_dns_credentials, to_nix_string,
     };
 
     fn fake_blob() -> EncryptedBlob {
         serde_json::from_str("\"c2VhbGVkLWJsb2I=\"").unwrap()
+    }
+
+    #[test]
+    fn merge_host_lists_unions_automate_with_app_ingress() {
+        // The WebUI domain is in Caddy's automate set; the app ingress
+        // host (z.0f.ee) is NOT yet — but must still surface, labelled
+        // with its app. nasty.local is dropped.
+        let out = merge_host_lists(
+            vec!["nasty.0f.ee".into(), "nasty.local".into()],
+            vec![("z.0f.ee".into(), "zod-mp".into())],
+        );
+        assert_eq!(
+            out,
+            vec![
+                ("nasty.0f.ee".to_string(), None),
+                ("z.0f.ee".to_string(), Some("zod-mp".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_host_lists_dedupes_and_attaches_app_when_already_automated() {
+        // Once registration has happened the host is in BOTH lists; it
+        // should appear once, still carrying its app name.
+        let out = merge_host_lists(
+            vec!["z.0f.ee".into()],
+            vec![("z.0f.ee".into(), "zod-mp".into())],
+        );
+        assert_eq!(
+            out,
+            vec![("z.0f.ee".to_string(), Some("zod-mp".to_string()))]
+        );
+    }
+
+    #[test]
+    fn merge_host_lists_preserves_automate_order_first() {
+        let out = merge_host_lists(
+            vec!["a.example".into(), "b.example".into()],
+            vec![("c.example".into(), "app-c".into())],
+        );
+        let hosts: Vec<_> = out.iter().map(|(h, _)| h.as_str()).collect();
+        assert_eq!(hosts, vec!["a.example", "b.example", "c.example"]);
     }
 
     #[test]

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -84,6 +84,7 @@
 		expires?: string;
 		expires_in_days?: number;
 		message?: string;
+		app?: string;
 	};
 
 	let hostStatuses: HostTlsStatus[] = $state([]);
@@ -533,6 +534,7 @@
 				<thead>
 					<tr>
 						<SortTh label="Host" active={hostSortKey === 'host'} dir={hostSortDir} onclick={() => toggleHostSort('host')} thClass="pb-2 font-medium" />
+						<th class="pb-2 font-medium text-left text-xs uppercase text-muted-foreground">App</th>
 						<SortTh label="State" active={hostSortKey === 'state'} dir={hostSortDir} onclick={() => toggleHostSort('state')} thClass="pb-2 font-medium" />
 						<SortTh label="Issuer / Expires" active={hostSortKey === 'expires'} dir={hostSortDir} onclick={() => toggleHostSort('expires')} thClass="pb-2 font-medium" />
 						<th class="pb-2 font-medium text-left text-xs uppercase text-muted-foreground">Detail</th>
@@ -543,6 +545,13 @@
 						{@const badge = badgeForState(h.state)}
 						<tr class="border-t border-border">
 							<td class="py-2 pr-3 font-mono text-xs">{h.host}</td>
+							<td class="py-2 pr-3 text-xs">
+								{#if h.app}
+									<a href="/apps" class="text-primary hover:underline">{h.app}</a>
+								{:else}
+									<span class="text-muted-foreground">—</span>
+								{/if}
+							</td>
 							<td class="py-2 pr-3">
 								<span class="inline-flex items-center rounded-md border px-2 py-0.5 text-[0.65rem] {badge.cls}">{badge.label}</span>
 							</td>


### PR DESCRIPTION
Two related fixes for app-ingress TLS, found while debugging a real "cert stuck pending" report.

## 1. Fix: deploy-with-subdomain never refreshed Caddy TLS automation

`install()` wires an app's Caddy reverse-proxy route internally (including subdomain mode chosen at deploy time), but the **TLS-automation layer lives in `nasty-system`**, which `nasty-apps` can't call without a dependency cycle — so the `reapply_tls_from_disk()` refresh is kicked from the **router layer**. The `apps.ingress.set` / `ingress.remove` / `apps.remove` arms all do this; the two **deploy** entry points did not:

- `app_deploy.rs::deploy_simple` (the streaming WS deploy)
- the `apps.install` RPC arm

Result: a subdomain chosen at deploy time installed the route but never landed in Caddy's `certificates.automate`. The host only got there on the **next engine restart** (startup reapply). In the meantime Caddy still issued via route-matcher harvest using its **default** automation policy — which on a **DNS-01 box carries no DNS provider**, so the app ingress would get **no cert at all** until a restart or a manual ingress re-save.

Fix: both deploy entry points now spawn `reapply_tls_from_disk()` after a successful install **when the deploy opted into a subdomain** (gated, so path-prefix deploys don't pay an admin-API round-trip). Mirrors the existing ingress.set pattern.

## 2. Visibility: app ingress hosts now appear on the Managed Certificates table

Independently, `system.tls.host_statuses` was built solely from Caddy's `certificates.automate` set — so a host that *isn't* in that set (e.g. before fix #1's restart, or any harvest-only host) never showed up, even while Caddy was actively attempting issuance. The Ingress page's "pending" badge says *"see Managed certificates on the TLS page for live status"* — but the host wasn't listed, so the actual reason (e.g. `DNS problem: NXDOMAIN looking up A for <host>`) was buried in `journalctl -u caddy`.

- **Engine** (`nasty-system/src/settings.rs`): `list_host_tls_statuses` now **unions** Caddy's automate set with the box's app ingress hosts (walked from `/var/lib/nasty/apps/*.json`), deduped and ordered automate-first. Each host carries its owning app name. The existing journal-based classification (active / issuing / failed + verbatim error) then applies to every host for free. `merge_host_lists` factored out as a pure, unit-tested helper; `HostTlsStatus` gains an optional `app` field.
- **WebUI** (`routes/tls/+page.svelte`): new **App** column linking to the app.

So even if a host is harvest-only, its issuance status and error are visible on the page the Ingress badge already points to.

## Why both together

Same area, same incident: #1 makes ingress hosts register (and issue) correctly; #2 makes their status visible when anything still goes wrong (a DNS record not yet pointed, a rate-limit, etc.). The visibility is the defensive backstop for the registration path.

## Tests

- `merge_host_lists` unit tests: union+label, dedup when already automated, automate-order-first.
- `cargo fmt`, `cargo clippy --workspace --all-targets --no-deps` (clean), `cargo test -p nasty-system -p nasty-engine` (pass).
- WebUI `npm run check` (0 errors) + `npm run build` (clean).

## Verified in the field

The originating box (`nasty.0f.ee`, a game-server app on `z.0f.ee`) had its ingress cert stuck because the A record wasn't pointed yet; absent from the TLS table, the NXDOMAIN was invisible. With DNS now pointed the cert issued (Let's Encrypt, serving on 443). This PR makes that whole loop legible — and ensures the next deploy-time subdomain registers its ACME policy immediately rather than waiting for a restart.
