### PR TITLE
firewall: surface Docker-published app ports on the Firewall page

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1696,7 +1696,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "system.firewall.status",
-                    desc: "Return the current firewall rules and per-service source/interface restrictions.",
+                    desc: "Return the current firewall rules, per-service source/interface restrictions, and the host ports Docker-managed apps publish (read-only — these bypass the nftables firewall and are listed for visibility only).",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<FirewallStatus>(generator)),

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -714,7 +714,36 @@ pub(super) async fn try_route(
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
         },
-        "system.firewall.status" => ok(req, state.firewall.status().await),
+        "system.firewall.status" => {
+            // Enrich the service-rule view with the host ports Docker apps
+            // publish. These bypass the nftables firewall (DNAT in
+            // prerouting), so the firewall module can't see them — but
+            // surfacing them here gives the operator a complete
+            // "what's listening on this box" picture in one place.
+            let mut status = state.firewall.status().await;
+            if let Ok(apps) = state.apps.list().await {
+                let mut published: Vec<nasty_system::firewall::PublishedAppPort> = apps
+                    .iter()
+                    .flat_map(|app| {
+                        app.ports
+                            .iter()
+                            .map(move |p| nasty_system::firewall::PublishedAppPort {
+                                app: app.name.clone(),
+                                host_port: p.host_port,
+                                container_port: p.container_port,
+                                transport: p.protocol.clone(),
+                            })
+                    })
+                    .collect();
+                published.sort_by(|a, b| {
+                    a.host_port
+                        .cmp(&b.host_port)
+                        .then_with(|| a.app.cmp(&b.app))
+                });
+                status.published_app_ports = published;
+            }
+            ok(req, status)
+        }
         "system.firewall.restrict" => {
             let service = match require_str(req, "service") {
                 Ok(s) => s.to_string(),

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -110,6 +110,31 @@ pub struct FirewallStatus {
     pub restrictions: HashMap<String, Vec<String>>,
     /// Per-service interface restrictions.
     pub interface_restrictions: HashMap<String, Vec<String>>,
+    /// Ports that Docker-managed apps publish on the host. These are NOT
+    /// governed by this firewall — Docker DNATs published ports in
+    /// `prerouting` straight to the container, so they bypass the `inet
+    /// nasty` input chain entirely. Listed here for visibility only, so an
+    /// operator sees the full "what's open on this box" picture in one
+    /// place; their only real gate is the upstream/cloud firewall. The
+    /// engine layer fills this from `apps.list`; the firewall module
+    /// itself has no knowledge of Docker.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub published_app_ports: Vec<PublishedAppPort>,
+}
+
+/// One host port published by a Docker-managed app. Read-only; surfaced
+/// on the firewall page alongside the service rules. See
+/// [`FirewallStatus::published_app_ports`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PublishedAppPort {
+    /// App that published the port.
+    pub app: String,
+    /// Host-side port (bound on 0.0.0.0).
+    pub host_port: u16,
+    /// Container-side port the host port maps to.
+    pub container_port: u16,
+    /// Transport ("tcp" / "udp").
+    pub transport: String,
 }
 
 // ── Port mapping ───────────────────────────────────────────────
@@ -283,6 +308,9 @@ impl FirewallService {
             rules: state.rules.clone(),
             restrictions: restrictions.services.clone(),
             interface_restrictions: restrictions.interfaces.clone(),
+            // Populated by the engine layer (router) which has the apps
+            // handle; the firewall module has no Docker knowledge.
+            published_app_ports: Vec::new(),
         }
     }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1255,11 +1255,21 @@ export interface FirewallRule {
 	active: boolean;
 }
 
+export interface PublishedAppPort {
+	app: string;
+	host_port: number;
+	container_port: number;
+	transport: string;
+}
+
 export interface FirewallStatus {
 	active: boolean;
 	rules: FirewallRule[];
 	restrictions: Record<string, string[]>;
 	interface_restrictions: Record<string, string[]>;
+	/** Host ports Docker apps publish. NOT governed by this firewall (Docker
+	 * DNATs them past the input chain) — shown read-only for visibility. */
+	published_app_ports?: PublishedAppPort[];
 }
 
 export interface AlertRule {

--- a/webui/src/routes/firewall/+page.svelte
+++ b/webui/src/routes/firewall/+page.svelte
@@ -135,5 +135,30 @@
 				Ports open/close automatically with services. Click a service to restrict access by source IP or interface.
 			</p>
 		</section>
+
+		{#if firewallStatus.published_app_ports?.length}
+			<section class="mt-6 rounded-lg border border-border p-5">
+				<h2 class="text-sm font-semibold">App ports (published by Docker)</h2>
+				<p class="mt-1 text-xs text-muted-foreground">
+					These host ports are opened directly by Docker for your apps and bypass this firewall —
+					Docker forwards them straight to the container, so the rules above don't apply.
+					Their only gate is your upstream/cloud firewall. Shown here so you can see everything
+					that's reachable on this box in one place.
+				</p>
+				<div class="mt-3 space-y-1">
+					{#each firewallStatus.published_app_ports as p}
+						<div class="flex items-center gap-3 rounded px-3 py-2 text-sm">
+							<span class="h-2 w-2 rounded-full shrink-0 bg-sky-400"></span>
+							<span class="font-mono text-xs w-28">{p.host_port}/{p.transport}</span>
+							<a href="/apps" class="font-medium text-primary hover:underline">{p.app}</a>
+							{#if p.container_port !== p.host_port}
+								<span class="text-xs text-muted-foreground">→ container {p.container_port}</span>
+							{/if}
+							<span class="ml-auto text-xs text-sky-400">Open (Docker)</span>
+						</div>
+					{/each}
+				</div>
+			</section>
+		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
## What

The **Firewall** page now also lists the host ports your **Docker-managed apps publish**, in a read-only "App ports (published by Docker)" section — so the page answers "what's reachable on this box?" completely, not just for NASty's own services.

## Why

NASty's firewall (`table inet nasty`, `input` hook, policy drop) governs only NASty's own service surface (SSH, SMB, NFS, iSCSI, NVMe-oF, WebUI…). Docker-published app ports **bypass it entirely**: Docker DNATs a published port in `prerouting` straight to the container, so the packet never traverses the input chain. The firewall module therefore has no knowledge of those ports and (correctly) can't gate them — their only real gate is the upstream/cloud firewall (e.g. an Oracle/AWS security list).

That left a genuine blind spot: an operator on the Firewall page saw the service rules but nothing about app ports, and no hint that app ports live under Docker + the cloud SG rather than NASty. (This came straight out of a real "can I open my game-server's ports in NASty?" question — the answer being "no, and you don't need to, because Docker already published them and the cloud SG is the gate" — which was impossible to see from the UI.)

## Change

- **Engine** — `system.firewall.status` now also returns `published_app_ports`. The firewall module stays Docker-agnostic; the **router** fills the field from `apps.list` (each app's published host ports, which `extract_ports` already derives from Docker's `public_port` bindings — i.e. published, not merely `EXPOSE`d). `FirewallStatus` gains an optional `published_app_ports: Vec<PublishedAppPort>` (`app`, `host_port`, `container_port`, `transport`), sorted by port.
- **WebUI** — new read-only section on the Firewall page listing each published port → its app, with a note that these bypass the firewall and are gated only upstream. Hidden when no app publishes ports.

**No netfilter behaviour change** — visibility only. The field is optional/empty on older engine state or when nothing's published, so it degrades cleanly.

## Notes / scope

- Only **published** ports appear (Docker `public_port` set). `EXPOSE`-only ports (no host binding, e.g. the game's `2301-2399/tcp`) are deliberately omitted — they aren't reachable, so listing them would be misleading.
- The list reflects live Docker state via `apps.list`; the Firewall page loads once (no polling), so this adds one `docker ps`-class call per page open.

## Tests

- `cargo fmt`, `cargo clippy -p nasty-engine -p nasty-system --all-targets --no-deps` (clean), `cargo test -p nasty-system -p nasty-engine` (126 + 306 pass).
- WebUI `npm run check` (0 errors) + `npm run build` (clean).
