### PR TITLE
apps: preserve subdomain on Edit, widen form for port ranges

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1221,6 +1221,19 @@ async fn load_ingress_subdomain(app_name: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// Decide which subdomain a (re)install should apply. An explicit, non-empty
+/// `requested` value wins; otherwise fall back to `existing` (what the
+/// manifest already had) so an update that omits the field preserves the
+/// ingress instead of dropping it. A fresh install has no existing manifest
+/// ⇒ `None` ⇒ path-prefix mode. To *clear* a subdomain, use the dedicated
+/// ingress-remove path, not an empty Edit field.
+fn resolve_ingress_subdomain(requested: Option<&str>, existing: Option<String>) -> Option<String> {
+    match requested.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => Some(s.to_string()),
+        None => existing,
+    }
+}
+
 // ── Compose stack startup ordering (#437) ──────────────────────────────
 // Opt-in: enrolled stacks are brought up by the engine in a defined order
 // with a settle delay after each, and get `restart: "no"` (via a generated
@@ -1611,6 +1624,11 @@ pub struct AppConfig {
     /// from a live auto-assigned address — re-applied verbatim on reinstall.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub static_ip: Option<String>,
+    /// The app's subdomain-ingress hostname, if any (from the manifest).
+    /// Round-tripped through Edit so changing other fields and saving
+    /// preserves the ingress instead of silently dropping it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdomain: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -2666,6 +2684,13 @@ impl AppsService {
 
         let cname = container_name(&req.name);
 
+        // Capture any existing subdomain ingress BEFORE the manifest is
+        // rewritten below — a reinstall (apps.update) that doesn't carry a
+        // subdomain in the request should preserve the one already in place
+        // rather than silently dropping the ingress. The manifest write
+        // later in this fn clobbers `ingress_subdomain`, so read it now.
+        let prior_subdomain = load_ingress_subdomain(&req.name).await;
+
         // Check if already exists
         if self.container_exists(&cname).await {
             return Err(AppsError::AppAlreadyExists(req.name));
@@ -2965,12 +2990,8 @@ impl AppsService {
             // (None / empty) keeps path-prefix mode as the historical
             // default. Conflict detection runs upstream in
             // deploy_simple — see app_deploy.rs.
-            let install_subdomain = req
-                .subdomain
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
+            let install_subdomain =
+                resolve_ingress_subdomain(req.subdomain.as_deref(), prior_subdomain);
             let chose_subdomain = install_subdomain.is_some();
             if let Err(e) = self
                 .ingress_set(SetIngressRequest {
@@ -3712,6 +3733,7 @@ impl AppsService {
             allow_unsafe,
             network,
             static_ip,
+            subdomain: load_ingress_subdomain(name).await,
         })
     }
 
@@ -7314,6 +7336,41 @@ services:
         // 254-char total
         let too_long_total = format!("{}.example.com", "a".repeat(254 - ".example.com".len()));
         assert!(validate_subdomain(&too_long_total).is_err());
+    }
+
+    // ── resolve_ingress_subdomain ──
+
+    use super::resolve_ingress_subdomain;
+
+    #[test]
+    fn resolve_subdomain_explicit_request_wins() {
+        // Operator typed a subdomain → use it, regardless of what existed.
+        assert_eq!(
+            resolve_ingress_subdomain(Some("z.0f.ee"), Some("old.example.com".into())),
+            Some("z.0f.ee".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_subdomain_absent_request_preserves_existing() {
+        // The Edit→Save bug: form sends no subdomain, but one is already
+        // assigned — preserve it instead of dropping the ingress.
+        assert_eq!(
+            resolve_ingress_subdomain(None, Some("z.0f.ee".into())),
+            Some("z.0f.ee".to_string())
+        );
+        // Empty/whitespace request is treated as "not provided".
+        assert_eq!(
+            resolve_ingress_subdomain(Some("   "), Some("z.0f.ee".into())),
+            Some("z.0f.ee".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_subdomain_fresh_install_is_path_prefix() {
+        // No request, no existing manifest → path-prefix mode (None).
+        assert_eq!(resolve_ingress_subdomain(None, None), None);
+        assert_eq!(resolve_ingress_subdomain(Some(""), None), None);
     }
 }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1642,6 +1642,9 @@ export interface AppConfig {
 	network?: string | null;
 	/** Static IP requested at install (round-tripped on Edit). */
 	static_ip?: string | null;
+	/** Subdomain-ingress hostname, if any (round-tripped on Edit so saving
+	 * other fields doesn't drop the ingress). */
+	subdomain?: string | null;
 }
 
 /** A NASty-managed Docker network spec (apps.networks.create payload). */

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -1259,6 +1259,9 @@
 		newAllowUnsafe = config.allow_unsafe ?? false;
 		newNetwork = config.network ?? '';
 		newStaticIp = config.static_ip ?? '';
+		// Pre-fill the existing subdomain so it's visible and round-trips on
+		// Save — otherwise an empty field would drop the ingress.
+		newSubdomain = config.subdomain ?? '';
 		loadAppNetworks();
 		installMode = 'simple';
 		showInstall = true;
@@ -1296,6 +1299,10 @@
 		// Round-trip the managed-network attachment so Edit doesn't detach it.
 		if (newNetwork) params.network = newNetwork;
 		if (newStaticIp.trim()) params.static_ip = newStaticIp.trim();
+		// Round-trip (or change) the subdomain ingress. A blank field is left
+		// to the engine, which preserves the existing subdomain rather than
+		// dropping it; clear a subdomain via the dedicated Subdomain dialog.
+		if (newSubdomain.trim() && !installLanIp) params.subdomain = newSubdomain.trim();
 
 		const result = await withToast(
 			() => client.call('apps.update', params, 300_000),
@@ -1869,7 +1876,7 @@
 	{/if}
 
 	{#if showInstall || showCompose}
-		<Card class="mb-6 {(showCompose || editingCompose) ? 'max-w-6xl' : 'max-w-2xl'}">
+		<Card class="mb-6 {(showCompose || editingCompose) ? 'max-w-6xl' : 'max-w-4xl'}">
 			<CardContent class="pt-6">
 				<h3 class="mb-4 text-lg font-semibold">{editingApp ? `Edit ${editingApp}` : editingCompose ? `Edit ${editingCompose}` : 'Install App'}</h3>
 
@@ -1988,7 +1995,7 @@
 						     The listing and the dropdown elsewhere on this page
 						     also read host:container, so all three surfaces line
 						     up. See issue #271. -->
-						<div class="grid grid-cols-[1fr_80px_128px_56px_auto] gap-2 mb-1">
+						<div class="grid grid-cols-[1fr_90px_176px_64px_auto] gap-2 mb-1">
 							<span class="text-[0.65rem] text-muted-foreground">Name</span>
 							<span class="text-[0.65rem] text-muted-foreground">Exposed</span>
 							<span class="text-[0.65rem] text-muted-foreground">Internal (+ range)</span>
@@ -1998,13 +2005,13 @@
 					{/if}
 					{#each newPorts as port, i}
 						{@const hasConflict = portConflicts.some(c => c.port === (parseInt(port.host_port) || port.container_port))}
-						<div class="grid grid-cols-[1fr_80px_128px_56px_auto] gap-2 mt-1 items-center">
+						<div class="grid grid-cols-[1fr_90px_176px_64px_auto] gap-2 mt-1 items-center">
 							<Input bind:value={port.name} placeholder="e.g. http" class="h-8 text-xs" />
 							<Input bind:value={port.host_port} placeholder={String(port.container_port)} class="h-8 text-xs {hasConflict ? 'border-amber-500 ring-1 ring-amber-500/50' : ''}" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 							<div class="flex items-center gap-1">
-								<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 text-xs" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
+								<Input type="number" bind:value={port.container_port} placeholder="Port" class="h-8 min-w-0 w-full text-xs" oninput={() => checkPortConflicts(editingApp ?? undefined)} />
 								<span class="text-muted-foreground text-xs">–</span>
-								<Input type="number" bind:value={port.container_port_end} placeholder="end" class="h-8 text-xs" />
+								<Input type="number" bind:value={port.container_port_end} placeholder="end" class="h-8 min-w-0 w-full text-xs" />
 							</div>
 							<select bind:value={port.protocol} class="h-8 rounded-md border border-input bg-transparent px-1 text-xs">
 								<option>TCP</option>


### PR DESCRIPTION
Two Apps-page fixes found while dogfousing a game-server app with a wide port range.

## 1. Fix: Edit silently dropped an app's subdomain ingress

An app served at a subdomain (e.g. `z.0f.ee`) showed the **Edit** form's Subdomain field **empty** ("no subdomain assigned"), and **Save dropped the ingress**.

Root cause: `AppConfig` carried no subdomain, so the form couldn't pre-fill it, and `install()` resolved the subdomain **only** from `req.subdomain`. `apps.update` (Edit→Save) sends no subdomain, so `install()` set path-prefix mode and cleared it. (The **Pull** path already preserved it via `current?.subdomain` — the two reinstall paths disagreed.) Worse, `install()` *full-overwrites* the manifest mid-fn, clobbering `ingress_subdomain` before any later read.

Fix:
- **Engine** (`nasty-apps`): capture the existing subdomain at the **top** of `install()` (before the manifest is rewritten); resolve the effective subdomain via a new pure helper `resolve_ingress_subdomain(requested, existing)` — an explicit non-empty request wins, otherwise preserve the existing one (fresh install ⇒ none ⇒ path-prefix). `AppConfig` gains a `subdomain` field (from `load_ingress_subdomain`) so the form can show/round-trip it.
- **WebUI**: `editApp` pre-fills the Subdomain field from `config.subdomain`; `updateApp` sends it so it round-trips and can be changed. Clearing a subdomain stays on the dedicated "⋯ → Subdomain" dialog.

Now Edit shows the real subdomain and Save preserves (or changes) it — the engine also preserves on *any* update that omits the field, closing the wipe for all callers.

## 2. UX: widen the app form so the port range inputs are usable

The simple-app form was `max-w-2xl`, which truncated the new start/–/end range inputs (from #566) to unreadable stubs. Bumped to `max-w-4xl` and widened the ports grid's Internal column (`176px`, inputs `w-full`) so the range is fully visible and editable.

## Tests

- New `resolve_ingress_subdomain` unit tests (request-wins / preserve-existing / fresh-install).
- `cargo fmt`, `cargo clippy -p nasty-apps -p nasty-engine --all-targets --no-deps`, `cargo test -p nasty-apps` (pass).
- WebUI `npm run check` (0 errors) + `npm run build`.

## Note (out of scope)

`install()`'s manifest write also clobbers `startup_*` / `proxy_disabled_reason` on every reinstall and only the ingress path restores its field — making that write a key-preserving splice would be a cleaner root fix, tracked separately.
