### PR TITLE
apps: add host-network option for deploys

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2700,7 +2700,18 @@ impl AppsService {
         // network gives the container its own LAN IP, which is incompatible
         // with published host ports + reverse-proxy ingress (it has no
         // presence at 127.0.0.1:<port>) — reject early and skip ingress.
-        let net_spec = match req.network.as_deref().filter(|s| !s.is_empty()) {
+        // `"host"` is a sentinel for sharing the host network namespace
+        // (--net=host), not a managed Docker network — handle it without a
+        // net_spec lookup. Like LAN-IP, it has no presence at
+        // 127.0.0.1:<port> for a per-app published mapping, so published
+        // ports and reverse-proxy ingress don't apply; the container binds
+        // host ports directly.
+        let host_network = req.network.as_deref() == Some("host");
+        let net_spec = match req
+            .network
+            .as_deref()
+            .filter(|s| !s.is_empty() && *s != "host")
+        {
             Some(name) => Some(self.resolve_managed_network(name).await?),
             None => None,
         };
@@ -2751,23 +2762,28 @@ impl AppsService {
         let mut port_bindings: HashMap<String, Option<Vec<PortBinding>>> = HashMap::new();
         let mut exposed_ports: Vec<String> = Vec::new();
 
-        for p in &req.ports {
-            let host_port = p.host_port.unwrap_or(p.container_port);
-            if used_ports.contains(&host_port) {
-                return Err(AppsError::DockerFailed(format!(
-                    "host port {} is already in use by another app",
-                    host_port
-                )));
+        // Host networking publishes nothing — the container shares the
+        // host namespace and binds host ports directly, so `-p` mappings
+        // don't apply (Docker rejects them with --net=host).
+        if !host_network {
+            for p in &req.ports {
+                let host_port = p.host_port.unwrap_or(p.container_port);
+                if used_ports.contains(&host_port) {
+                    return Err(AppsError::DockerFailed(format!(
+                        "host port {} is already in use by another app",
+                        host_port
+                    )));
+                }
+                let key = format!("{}/{}", p.container_port, p.protocol.to_lowercase());
+                exposed_ports.push(key.clone());
+                port_bindings.insert(
+                    key,
+                    Some(vec![PortBinding {
+                        host_ip: Some("0.0.0.0".to_string()),
+                        host_port: Some(host_port.to_string()),
+                    }]),
+                );
             }
-            let key = format!("{}/{}", p.container_port, p.protocol.to_lowercase());
-            exposed_ports.push(key.clone());
-            port_bindings.insert(
-                key,
-                Some(vec![PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(host_port.to_string()),
-                }]),
-            );
         }
 
         // Build mounts
@@ -2838,6 +2854,9 @@ impl AppsService {
             if let Some(ip) = req.static_ip.as_deref().filter(|s| !s.is_empty()) {
                 labels.insert(LABEL_APP_NETWORK_IP.to_string(), ip.to_string());
             }
+        } else if host_network {
+            // Round-trip the host-network choice so Edit/Pull re-apply it.
+            labels.insert(LABEL_APP_NETWORK.to_string(), "host".to_string());
         }
 
         // Attach to the chosen managed network (with an optional static
@@ -2871,6 +2890,7 @@ impl AppsService {
             } else {
                 Some(port_bindings)
             },
+            network_mode: host_network.then(|| "host".to_string()),
             binds: if binds.is_empty() { None } else { Some(binds) },
             nano_cpus,
             memory,
@@ -2969,7 +2989,7 @@ impl AppsService {
         // can still reach the container directly on the LAN.
         // ...but never for a LAN-IP (macvlan/ipvlan) app: it has its own
         // address and no presence at 127.0.0.1:<port> for Caddy to proxy.
-        if let Some(first_port) = (!lan_ip_network)
+        if let Some(first_port) = (!lan_ip_network && !host_network)
             .then(|| {
                 req.ports
                     .iter()

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -379,6 +379,10 @@
 			(n) => n.name === newNetwork && (n.driver === 'macvlan' || n.driver === 'ipvlan'),
 		),
 	);
+	/** True when the app shares the NAS's network namespace (--net=host).
+	 * Like LAN-IP, published host ports + reverse-proxy ingress don't apply
+	 * (the app binds host ports directly), so those sections are hidden. */
+	let installHostNet = $derived(newNetwork === 'host');
 	// Create-network dialog state.
 	let showNetCreate = $state(false);
 	let ncName = $state('');
@@ -1186,7 +1190,7 @@
 		};
 		// A LAN-IP (macvlan/ipvlan) app gets its own address — published host
 		// ports and reverse-proxy ingress don't apply (engine rejects them).
-		if (newPorts.length > 0 && !installLanIp) {
+		if (newPorts.length > 0 && !installLanIp && !installHostNet) {
 			// Expand any range rows into individual port mappings for the API.
 			params.ports = expandPortRows(newPorts);
 		}
@@ -1213,7 +1217,7 @@
 		// operator typed a hostname that became taken between the live
 		// conflict check and Save, install fails with a clear error.
 		const subdomainTrimmed = newSubdomain.trim();
-		if (subdomainTrimmed && !installLanIp) params.subdomain = subdomainTrimmed;
+		if (subdomainTrimmed && !installLanIp && !installHostNet) params.subdomain = subdomainTrimmed;
 		// Managed-network attachment (+ optional static IP).
 		if (newNetwork) params.network = newNetwork;
 		if (newStaticIp.trim()) params.static_ip = newStaticIp.trim();
@@ -1273,7 +1277,7 @@
 			name: editingApp,
 			image: newImage,
 		};
-		if (newPorts.length > 0 && !installLanIp) {
+		if (newPorts.length > 0 && !installLanIp && !installHostNet) {
 			// Expand any range rows into individual port mappings for the API.
 			params.ports = expandPortRows(newPorts);
 		}
@@ -1302,7 +1306,7 @@
 		// Round-trip (or change) the subdomain ingress. A blank field is left
 		// to the engine, which preserves the existing subdomain rather than
 		// dropping it; clear a subdomain via the dedicated Subdomain dialog.
-		if (newSubdomain.trim() && !installLanIp) params.subdomain = newSubdomain.trim();
+		if (newSubdomain.trim() && !installLanIp && !installHostNet) params.subdomain = newSubdomain.trim();
 
 		const result = await withToast(
 			() => client.call('apps.update', params, 300_000),
@@ -1972,6 +1976,7 @@
 						{#each appNetworks as n}
 							<option value={n.name}>{n.name} ({n.driver}{n.parent ? ` on ${n.parent}` : ''})</option>
 						{/each}
+						<option value="host">Host network (share the NAS's network)</option>
 					</select>
 					{#if installLanIp}
 						<p class="mt-1 text-xs text-amber-500">This app gets its own LAN IP — host ports and reverse-proxy ingress don't apply and are hidden below.</p>
@@ -1980,9 +1985,12 @@
 							<Input id="app-static-ip" bind:value={newStaticIp} placeholder="e.g. 192.168.1.50" class="mt-1" />
 						</div>
 					{/if}
+					{#if installHostNet}
+						<p class="mt-1 text-xs text-amber-500">The app shares the NAS's network namespace — every port it binds is reachable directly on the NAS's IP, with no per-port mapping. It can bind any host port (including ones NASty's own services use), so only enable this for trusted apps. Published ports and reverse-proxy ingress don't apply and are hidden below.</p>
+					{/if}
 				</div>
 
-				{#if !installLanIp}
+				{#if !installLanIp && !installHostNet}
 				<!-- Ports -->
 				<div class="mb-4">
 					<div class="flex items-center justify-between mb-1">
@@ -2108,7 +2116,7 @@
 					</div>
 				</div>
 
-				{#if !installLanIp}
+				{#if !installLanIp && !installHostNet}
 				<!-- Subdomain (optional) — opt into subdomain-mode ingress from
 				     day one. Empty = path-prefix mode + post-install probe (the
 				     historical default). Non-empty = host-match Caddy route +


### PR DESCRIPTION
## What

A **Host network** option for app deploys. The container shares the NAS's network namespace (`--net=host`), so every port it binds is reachable directly on the NAS's IP — **zero per-port mapping**.

## Why

Game-server-class apps that need a wide port range (e.g. a match range like 2300–2399) otherwise have to publish dozens of individual ports — each one a DNAT rule **and** a `docker-proxy` process. Host networking is the right tool: one toggle, the whole range live, no per-port overhead.

## Change

- **Engine** (`nasty-apps`): `req.network == "host"` is a sentinel (not a managed Docker network). Sets `HostConfig.network_mode = "host"`, skips port bindings and managed-network endpoints, and labels the app `network=host` so Edit/Pull re-apply it. Like LAN-IP, host mode has no `127.0.0.1:<port>` presence for a per-app published mapping, so **published ports and reverse-proxy ingress don't apply** and are skipped.
- **WebUI** (`apps`): a "Host network (share the NAS's network)" entry in the Network selector; a derived `installHostNet` hides the published-ports and subdomain sections and shows a warning. Round-trips via `config.network === 'host'`.

## Scope note — deviation from the approved plan

The plan said *keep* reverse-proxy ingress in host mode. I cut that for v1: with a multi-port app there's no unambiguous single port for the reverse-proxy to target, and it'd need a dedicated "ingress port" selector. So **host mode mirrors LAN-IP** — reached directly at the NAS IP:port, no reverse-proxy. The primary use case (a game server) wants direct access anyway. Ingress-for-host-net (with an explicit target port) can be a follow-up.

## Caveat surfaced in the UI

Host networking lets the container bind **any** host port, including ones NASty's own services use (Caddy 443, SMB 445, the engine, …). The warning says trusted-apps-only.

## Tests

- `cargo fmt`, `cargo clippy -p nasty-apps -p nasty-engine --all-targets --no-deps` (clean), engine builds.
- WebUI `npm run check` (0 errors) + `npm run build` (clean).
- Live verification pending on the box (deploy a host-net app → `docker inspect` NetworkMode=host, ports reachable, no docker-proxy).
