### PR TITLE
apps: parse port ranges in the paste-docker-run creator

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -222,7 +222,17 @@
 				const host = parts.length >= 2 ? parts[0] : '';
 				const container = parts.length >= 2 ? parts[1] : parts[0];
 				const proto = parts.length >= 3 ? parts[2]?.toUpperCase() : 'TCP';
-				ports.push({ name: `port-${ports.length}`, container_port: parseInt(container) || 80, host_port: host, protocol: proto || 'TCP' });
+				// Handle port ranges (e.g. `2301-2305:2301-2305`). `parseInt`
+				// alone stops at the dash and silently truncates a range to its
+				// first port — instead split start/end and emit a range row
+				// (container_port + container_port_end), which expands back on
+				// deploy. host_port stays blank for a 1:1 publish; a remapped
+				// range keeps the host start so the offset is preserved.
+				const [cStart, cEnd] = container.split('-');
+				const containerPort = parseInt(cStart) || 80;
+				const containerPortEnd = cEnd ? parseInt(cEnd) || undefined : undefined;
+				const hostPort = host && host !== container ? host.split('-')[0] : '';
+				ports.push({ name: `port-${ports.length}`, container_port: containerPort, container_port_end: containerPortEnd, host_port: hostPort, protocol: proto || 'TCP' });
 			} else if ((t === '-e' || t === '--env') && i + 1 < tokens.length) {
 				const val = tokens[++i];
 				const eq = val.indexOf('=');


### PR DESCRIPTION
## What

The **"paste docker run"** app creator now understands port **ranges**.

## The bug

Pasting `docker run -p 2301-2305:2301-2305 …` created an app that published **only port 2301**. The parser did `container_port: parseInt(container)`, and `parseInt("2301-2305")` returns `2301` (it stops at the dash) — so the range was silently truncated to its first port. The operator saw the env vars and the single `8080` parse correctly and reasonably assumed the whole range was published; in reality 2302–2305 were dropped, making a game server's match range unreachable.

## Fix

Split the host/container specs on `-` and emit a **range row** (`container_port` + `container_port_end`, the model #566 added), which expands back into individual mappings on deploy. `host_port` stays blank for a 1:1 publish (`A-B:A-B`); a remapped range (`A-B:C-D`) keeps the host start so the offset is preserved. Single ports are unchanged.

So `-p 2301-2305:2301-2305` now becomes one Internal `2301`–`2305` row that publishes all five.

## Tests

- `npm run check` (0 errors) + `npm run build` (clean).
