### PR TITLE
apps: Edit shows only published ports, not every EXPOSEd port

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -3615,31 +3615,43 @@ impl AppsService {
         } else {
             host_config.port_bindings.as_ref().unwrap_or(&network_ports)
         };
-        for (idx, (key, bindings)) in port_source.iter().enumerate() {
+        for (key, bindings) in port_source.iter() {
             let parts: Vec<&str> = key.split('/').collect();
             let container_port: u16 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
             let protocol = parts
                 .get(1)
                 .map(|p| p.to_uppercase())
                 .unwrap_or_else(|| "TCP".to_string());
-            let host_port = bindings
+            // Surface only PUBLISHED ports — those with a host binding. A
+            // container that EXPOSEs a wide range (e.g. a game image's
+            // 2300-2399) lists every one of those in NetworkSettings.Ports
+            // with a null binding; including them floods the Edit form with
+            // one row per exposed-but-unpublished port, and saving would
+            // publish the whole range 1:1. EXPOSE ≠ publish.
+            let Some(host_port) = bindings
                 .as_ref()
                 .and_then(|b| b.first())
                 .and_then(|b| b.host_port.as_ref())
-                .and_then(|p| p.parse::<u16>().ok());
-            let port_name = if idx == 0 {
-                "http".to_string()
-            } else {
-                format!("port-{idx}")
+                .and_then(|p| p.parse::<u16>().ok())
+            else {
+                continue;
             };
             ports.push(AppPort {
-                name: port_name,
+                name: String::new(),
                 container_port,
-                host_port,
+                host_port: Some(host_port),
                 protocol,
             });
         }
         ports.sort_by_key(|p| p.container_port);
+        // Name after sorting so the lowest published port is the "http" row.
+        for (idx, p) in ports.iter_mut().enumerate() {
+            p.name = if idx == 0 {
+                "http".to_string()
+            } else {
+                format!("port-{idx}")
+            };
+        }
 
         // Parse env. The container's `Config.Env` is `image defaults
         // + values we passed at create_container` with no marker for


### PR DESCRIPTION
## What

The app **Edit** form now lists only the ports an app actually **publishes**, not every port its image `EXPOSE`s.

## The bug

`get_config` built the port rows from the container's `NetworkSettings.Ports`, which includes **every `EXPOSE`d port** with a null host binding for the unpublished ones. A game image that `EXPOSE`s `2300-2399` produced ~100 rows in Edit — none of which the app actually published (only, say, `2301` + `8080` were). It read like leftover state from a previous deploy, when it's really just the image's `EXPOSE` declaration surfaced in full.

It was also a footgun: those ~100 rows carry no host binding (blank Exposed), so **saving the Edit form would publish the whole range 1:1**.

## Fix

Skip `NetworkSettings.Ports` entries with no host binding — only ports with a resolved `host_port` (i.e. genuinely published) become rows. `EXPOSE` ≠ publish. Rows are named after sorting so the lowest published port is the `http` row.

Verified against the live container: it `EXPOSE`s 102 ports but publishes 2 (`2301`, `8080`) — Edit will now show those two instead of 102.

## Tests

- `cargo fmt`, `cargo clippy -p nasty-apps --all-targets --no-deps` (clean), `cargo test -p nasty-apps` (124 pass).
