### PR TITLE
apps: render the Networks section below the apps table

### DIFF
--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -2385,7 +2385,9 @@
 		</div>
 	{/if}
 
-	<!-- Docker networks (#435 / #438) -->
+	<!-- Networks — defined as a snippet here, rendered below the apps table
+	     (see {@render networksSection()}) so the apps stay the primary section. -->
+	{#snippet networksSection()}
 	{#if status?.running}
 		<div class="mt-6 flex items-center justify-between">
 			<h3 class="text-lg font-semibold">Networks</h3>
@@ -2426,6 +2428,7 @@
 			</table>
 		{/if}
 	{/if}
+	{/snippet}
 
 	<!-- Startup order (#437): NASty-managed boot ordering for compose stacks -->
 	{#if composeStacks.length > 0}
@@ -2682,6 +2685,9 @@
 			</tbody>
 		</table>
 	{/if}
+
+	<!-- Networks render below the apps table — apps are the primary actors. -->
+	{@render networksSection()}
 {/if}
 
 <!-- Subdomain ingress dialog (per-app "···" → "Subdomain…") -->


### PR DESCRIPTION
The Networks panel sat **above** the installed-apps table, pushing the apps — the page's main actors — down the page.

Move it below: the Networks markup is wrapped in a Svelte `{#snippet networksSection()}` defined in place and `{@render}`ed after the apps table. So apps lead, Networks follows, with no large block relocation (snippet boundaries only).

Order is now: Install App → **Installed Apps** → Networks (→ Compose Startup Order when present).

A dedicated Apps/Networks **tab** is an easy follow-up if you'd prefer that, but this is the low-risk fix for the prominence issue.

svelte-check 0 errors, build clean.