### PR TITLE
update: drop stale "remove once public" TODOs

### DIFF
--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -1061,7 +1061,10 @@ echo "==> Update complete!"
         let token = read_github_token().await;
         let nasty_input = read_nasty_input_source().await;
 
-        // TODO: Remove token env var once the repo access model is finalized.
+        // `token` is always None today (the source repo is public), so this
+        // stays empty and no `access-tokens` line is injected into the
+        // rebuild's NIX_CONFIG. Kept so a future private-source build only
+        // has to flip read_github_token, not re-thread the env plumbing.
         let token_env = token
             .as_ref()
             .map(|t| format!("access-tokens = github.com={t}"))
@@ -2798,7 +2801,13 @@ async fn is_reboot_required() -> bool {
     false
 }
 
-/// TODO: Remove once repo is public.
+/// Source-repo auth token for self-update fetches and git operations.
+///
+/// Returns `None`: the Nasty source repo is public, so update checks
+/// (latest-tag lookup, flake.lock fetch) and the nixos-rebuild git ops all
+/// run unauthenticated. Kept as the single chokepoint so re-introducing
+/// source auth (a private mirror / enterprise build) is a one-function
+/// change rather than threading a new lookup through every call site.
 async fn read_github_token() -> Option<String> {
     None
 }


### PR DESCRIPTION
Both self-update TODOs referenced making the source repo public — done months ago.

`read_github_token()` already returns `None` unconditionally, and the token plumbing it feeds (latest-tag lookup, flake.lock fetch, git ops, the `access-tokens` NIX_CONFIG line) is inert and handles `None` gracefully.

Rather than rip out the harmless, param-based plumbing in the cross-version-sensitive update path (no behavior change, but a large diff in the riskiest code), I replaced the TODOs with accurate docs: `read_github_token` is intentionally a no-op now, kept as the single chokepoint for re-introducing source auth (private mirror / enterprise) without re-threading a lookup through every call site.

No behavior change. `cargo fmt`, `clippy -p nasty-system` clean.

If you'd rather fully remove the inert plumbing, that's a mechanical (behavior-identical) follow-up — say the word.