### PR TITLE
files: restore files/folders from a snapshot

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -695,6 +695,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/files/mkdir", post(files_mkdir_handler))
         .route("/api/files/rename", post(files_rename_handler))
         .route("/api/files/copy", post(files_copy_handler))
+        .route("/api/files/restore", post(files_restore_handler))
         .route(
             "/api/files/content",
             get(files_content_handler)
@@ -1713,6 +1714,16 @@ async fn files_mkdir_handler(
 }
 
 #[derive(serde::Deserialize)]
+struct RestoreRequest {
+    /// Snapshot paths (relative to /fs) to restore, e.g.
+    /// `tank/photos@daily/holiday/img.jpg`. The live destination is
+    /// derived server-side by stripping `@<snap>` from the snapshot
+    /// component, so a restore can only ever overwrite the snapshot's own
+    /// live subvolume — never an arbitrary path.
+    items: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
 struct RenameRequest {
     /// Existing path under /fs. Resolved to a canonical path; the
     /// rename is rejected if it falls outside FILES_ROOT or targets a
@@ -2059,6 +2070,260 @@ async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Res
         }
     }
     Ok(())
+}
+
+// ── Restore-from-snapshot endpoint ─────────────────────────────
+
+/// Given a snapshot path relative to `/fs` (e.g. `tank/photos@daily/x/y`),
+/// derive the *live* destination by stripping `@<snap>` from the snapshot
+/// component (index 1: `<subvol>@<snap>`). Returns the live relative path
+/// (`tank/photos/x/y`).
+///
+/// Errors when the path isn't inside a snapshot (component 1 has no `@`),
+/// is too short, or contains traversal/empty components. `@` is forbidden
+/// in subvolume and snapshot names (`validate_subvolume_name`), so the
+/// snapshot component is unambiguous even when a deeper *file* is named
+/// `a@b`. This is the safety pivot: a restore can only target the
+/// snapshot's own live subvolume, never an operator-supplied path.
+fn derive_restore_dest(rel: &str) -> Result<String, String> {
+    let rel = rel.trim_start_matches('/');
+    let comps: Vec<&str> = rel.split('/').collect();
+    if comps.len() < 2 {
+        return Err("not a snapshot path (expected <filesystem>/<subvol>@<snap>/…)".into());
+    }
+    for c in &comps {
+        if c.is_empty() || *c == "." || *c == ".." {
+            return Err("invalid path component".into());
+        }
+    }
+    let Some((subvol, _snap)) = comps[1].split_once('@') else {
+        return Err("source is not inside a snapshot".into());
+    };
+    if subvol.is_empty() {
+        return Err("invalid snapshot path".into());
+    }
+    let mut out = comps;
+    out[1] = subvol;
+    Ok(out.join("/"))
+}
+
+/// Remove whatever currently exists at `p` (file, symlink, or directory)
+/// so a restore can overwrite it. No-op when `p` doesn't exist.
+async fn remove_existing(p: &std::path::Path) -> Result<(), String> {
+    match tokio::fs::symlink_metadata(p).await {
+        Ok(m) if m.is_dir() => tokio::fs::remove_dir_all(p)
+            .await
+            .map_err(|e| format!("rm -r {}: {e}", p.display())),
+        Ok(_) => tokio::fs::remove_file(p)
+            .await
+            .map_err(|e| format!("rm {}: {e}", p.display())),
+        Err(_) => Ok(()),
+    }
+}
+
+/// Like [`copy_dir_recursive`] but with overwrite-merge semantics for
+/// restore: an existing destination directory is merged into (not
+/// rejected), files are overwritten, symlinks replaced. Files that exist
+/// in the live tree but not the snapshot are left untouched (additive —
+/// no `--delete`).
+async fn restore_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    let mut stack: Vec<(std::path::PathBuf, std::path::PathBuf)> =
+        vec![(src.to_path_buf(), dst.to_path_buf())];
+    while let Some((src_dir, dst_dir)) = stack.pop() {
+        match tokio::fs::symlink_metadata(&dst_dir).await {
+            Ok(m) if m.is_dir() => {} // merge into the existing directory
+            Ok(_) => {
+                // A non-directory is in the way — replace it with a dir.
+                remove_existing(&dst_dir).await?;
+                tokio::fs::create_dir(&dst_dir)
+                    .await
+                    .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?;
+            }
+            Err(_) => tokio::fs::create_dir_all(&dst_dir)
+                .await
+                .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?,
+        }
+        let mut entries = tokio::fs::read_dir(&src_dir)
+            .await
+            .map_err(|e| format!("read_dir {}: {e}", src_dir.display()))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?
+        {
+            let entry_src = entry.path();
+            let entry_dst = dst_dir.join(entry.file_name());
+            let meta = entry
+                .metadata()
+                .await
+                .map_err(|e| format!("metadata {}: {e}", entry_src.display()))?;
+            if meta.is_dir() {
+                stack.push((entry_src, entry_dst));
+            } else {
+                restore_leaf(&entry_src, &entry_dst, &meta).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Restore a single file or symlink onto `dst`, overwriting any existing
+/// entry there (including a directory or symlink in the way).
+async fn restore_leaf(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    meta: &std::fs::Metadata,
+) -> Result<(), String> {
+    if meta.file_type().is_symlink() {
+        remove_existing(dst).await?;
+        let target = tokio::fs::read_link(src)
+            .await
+            .map_err(|e| format!("read_link {}: {e}", src.display()))?;
+        tokio::fs::symlink(&target, dst)
+            .await
+            .map_err(|e| format!("symlink {}: {e}", dst.display()))
+    } else {
+        // `tokio::fs::copy` overwrites a regular file, but not a dir/symlink
+        // sitting at the destination — clear those first.
+        if let Ok(m) = tokio::fs::symlink_metadata(dst).await
+            && (m.is_dir() || m.file_type().is_symlink())
+        {
+            remove_existing(dst).await?;
+        }
+        tokio::fs::copy(src, dst)
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("copy {} -> {}: {e}", src.display(), dst.display()))
+    }
+}
+
+/// Restore files/folders from a read-only snapshot back over their live
+/// subvolume. POST /api/files/restore with `{ items: [<snapshot path>…] }`.
+///
+/// The destination is derived (see [`derive_restore_dest`]) — callers
+/// never supply it — so a restore can only ever overwrite the snapshot's
+/// own live subvolume. Overwrites existing files (the whole point); files
+/// created after the snapshot are left in place. The live destination's
+/// parent must already exist (restore a parent folder first if a whole
+/// directory tree was deleted).
+async fn files_restore_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RestoreRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_bearer(&headers, &state.auth).await {
+        return e.into_response();
+    }
+    if req.items.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "no items to restore"})),
+        )
+            .into_response();
+    }
+
+    let mut restored = 0u32;
+    for item in &req.items {
+        // Source: the snapshot path. safe_path canonicalises + jails to /fs.
+        let src = match safe_path(item) {
+            Ok(p) => p,
+            Err(status) => {
+                return (
+                    status,
+                    Json(serde_json::json!({"error": format!("invalid source path: {item}")})),
+                )
+                    .into_response();
+            }
+        };
+        if is_inside_block_subvolume(&src) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "cannot restore block subvolume contents — manage via the Subvolumes page"})),
+            )
+                .into_response();
+        }
+        let src_rel = src.strip_prefix(FILES_ROOT).unwrap_or(&src);
+        let live_rel = match derive_restore_dest(&src_rel.to_string_lossy()) {
+            Ok(r) => r,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": e})),
+                )
+                    .into_response();
+            }
+        };
+
+        let dest = std::path::Path::new(FILES_ROOT).join(&live_rel);
+        let (Some(dest_parent), Some(leaf)) = (dest.parent(), dest.file_name()) else {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid destination"})),
+            )
+                .into_response();
+        };
+        // The live parent must exist; canonicalising it also blocks symlink
+        // escapes. If it's gone, the live subvolume/folder was deleted.
+        let parent_rel = dest_parent.strip_prefix(FILES_ROOT).unwrap_or(dest_parent);
+        let parent_canon = match safe_path(&parent_rel.to_string_lossy()) {
+            Ok(p) => p,
+            Err(_) => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({"error": format!(
+                        "the live location for '{live_rel}' no longer exists — clone the snapshot instead"
+                    )})),
+                )
+                    .into_response();
+            }
+        };
+        if is_inside_block_subvolume(&parent_canon) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "cannot restore into block subvolume contents"})),
+            )
+                .into_response();
+        }
+        let final_dest = parent_canon.join(leaf);
+        if !final_dest.starts_with(FILES_ROOT) {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "invalid destination path"})),
+            )
+                .into_response();
+        }
+
+        let src_meta = match tokio::fs::symlink_metadata(&src).await {
+            Ok(m) => m,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("stat source: {e}")})),
+                )
+                    .into_response();
+            }
+        };
+        let result = if src_meta.is_dir() {
+            restore_dir_recursive(&src, &final_dest).await
+        } else {
+            restore_leaf(&src, &final_dest, &src_meta).await
+        };
+        if let Err(e) = result {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e})),
+            )
+                .into_response();
+        }
+        info!("Restored {} -> {}", src.display(), final_dest.display());
+        restored += 1;
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "restored": restored})),
+    )
+        .into_response()
 }
 
 // ── File content/download endpoint ─────────────────────────────
@@ -3441,4 +3706,50 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
             ),
         }
     });
+}
+
+#[cfg(test)]
+mod restore_tests {
+    use super::derive_restore_dest;
+
+    #[test]
+    fn derives_live_path_from_snapshot() {
+        // <fs>/<subvol>@<snap>/rel → <fs>/<subvol>/rel
+        assert_eq!(
+            derive_restore_dest("tank/photos@daily/holiday/img.jpg").unwrap(),
+            "tank/photos/holiday/img.jpg"
+        );
+        // The snapshot root restores the whole subvolume root.
+        assert_eq!(
+            derive_restore_dest("tank/photos@daily").unwrap(),
+            "tank/photos"
+        );
+        // A leading slash is tolerated.
+        assert_eq!(
+            derive_restore_dest("/tank/photos@daily/a").unwrap(),
+            "tank/photos/a"
+        );
+    }
+
+    #[test]
+    fn only_strips_the_snapshot_component() {
+        // A deeper file literally named `a@b` must NOT be touched — only
+        // component 1 (the snapshot dir) is rewritten.
+        assert_eq!(
+            derive_restore_dest("tank/photos@daily/a@b.txt").unwrap(),
+            "tank/photos/a@b.txt"
+        );
+    }
+
+    #[test]
+    fn rejects_non_snapshot_and_traversal() {
+        // Component 1 has no '@' — not a snapshot path.
+        assert!(derive_restore_dest("tank/photos/img.jpg").is_err());
+        // Too short (no subvolume component).
+        assert!(derive_restore_dest("tank").is_err());
+        // Traversal anywhere is rejected.
+        assert!(derive_restore_dest("tank/photos@daily/../etc").is_err());
+        // Empty snapshot subvolume name.
+        assert!(derive_restore_dest("tank/@daily/x").is_err());
+    }
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -3752,4 +3752,53 @@ mod restore_tests {
         // Empty snapshot subvolume name.
         assert!(derive_restore_dest("tank/@daily/x").is_err());
     }
+
+    // End-to-end round-trip of the actual byte-moving logic (the heart of
+    // the feature): build a fake snapshot tree + a diverged live tree, run
+    // the real restore copy, and assert the live tree matches the snapshot
+    // while files created after the snapshot survive (additive semantics).
+    #[tokio::test]
+    async fn restore_round_trip_overwrites_and_is_additive() {
+        use super::{restore_dir_recursive, restore_leaf};
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("photos@daily");
+        let live = tmp.path().join("photos");
+        tokio::fs::create_dir_all(snap.join("trip")).await.unwrap();
+        tokio::fs::create_dir_all(live.join("trip")).await.unwrap();
+
+        // Snapshot (the "good" past state).
+        tokio::fs::write(snap.join("a.txt"), b"v1").await.unwrap();
+        tokio::fs::write(snap.join("trip/b.txt"), b"keep")
+            .await
+            .unwrap();
+        // Live (diverged): a.txt modified, b.txt deleted, plus a new file.
+        tokio::fs::write(live.join("a.txt"), b"v2-modified")
+            .await
+            .unwrap();
+        tokio::fs::write(live.join("trip/after.txt"), b"new")
+            .await
+            .unwrap();
+
+        // Restore the whole snapshot tree over the live subvolume.
+        restore_dir_recursive(&snap, &live).await.unwrap();
+
+        // Modified file rolled back, deleted file restored…
+        assert_eq!(tokio::fs::read(live.join("a.txt")).await.unwrap(), b"v1");
+        assert_eq!(
+            tokio::fs::read(live.join("trip/b.txt")).await.unwrap(),
+            b"keep"
+        );
+        // …and the file created after the snapshot is left in place (additive).
+        assert!(live.join("trip/after.txt").exists());
+
+        // A single-file restore of a now-deleted file also reappears.
+        tokio::fs::remove_file(live.join("a.txt")).await.unwrap();
+        let meta = tokio::fs::symlink_metadata(snap.join("a.txt"))
+            .await
+            .unwrap();
+        restore_leaf(&snap.join("a.txt"), &live.join("a.txt"), &meta)
+            .await
+            .unwrap();
+        assert_eq!(tokio::fs::read(live.join("a.txt")).await.unwrap(), b"v1");
+    }
 }

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput, Share2, Check } from '@lucide/svelte';
+	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput, Share2, Check, RotateCcw } from '@lucide/svelte';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import PathPicker from '$lib/components/PathPicker.svelte';
 	import { getClient } from '$lib/client';
@@ -336,7 +336,48 @@
 		}
 	}
 
-	onMount(() => browse(''));
+	// Optional `?path=` deep-link (used by the Subvolumes page's
+	// "Restore files…" to drop the operator straight into a snapshot).
+	onMount(() => {
+		const initial = new URLSearchParams(window.location.search).get('path');
+		browse(initial ? initial.replace(/^\/fs\/?/, '') : '');
+	});
+
+	// True when the current path is inside a read-only snapshot, i.e. the
+	// component after the filesystem (`<fs>/<subvol>@<snap>/…`) contains '@'.
+	// In this mode the action bar offers Restore (copy back to the live
+	// subvolume) and hides Move/Delete, which can't work on a RO snapshot.
+	const inSnapshot = $derived.by(() => {
+		const parts = currentPath.split('/').filter(Boolean);
+		return parts.length >= 2 && parts[1].includes('@');
+	});
+
+	let restoreConfirm = $state(false);
+	async function runRestore() {
+		restoreConfirm = false;
+		const targets = selectedEntries();
+		if (targets.length === 0) return;
+		const items = targets.map((e) => (currentPath ? `${currentPath}/${e.name}` : e.name));
+		bulkActionRunning = true;
+		bulkActionStatus = `restoring ${items.length} item${items.length === 1 ? '' : 's'}…`;
+		try {
+			const res = await fetch('/api/files/restore', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ items }),
+			});
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				alert(`Restore failed: ${data.error || res.statusText}`);
+			}
+		} catch (e) {
+			alert(`Restore failed: ${e instanceof Error ? e.message : String(e)}`);
+		}
+		bulkActionRunning = false;
+		bulkActionStatus = '';
+		clearSelection();
+		await browse(currentPath);
+	}
 
 	async function browse(path: string) {
 		loading = true;
@@ -573,19 +614,39 @@
 </div>
 
 <!-- Bulk action bar (visible only when at least one row is selected) -->
+{#if inSnapshot}
+	<div class="mb-3 flex items-start gap-2 rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-sm text-sky-300">
+		<RotateCcw size={16} class="mt-0.5 shrink-0" />
+		<span>
+			You're viewing a <span class="font-medium">read-only snapshot</span>. Select files or folders and click
+			<span class="font-medium">Restore</span> to copy them back over the live subvolume — this overwrites the
+			current version. Files created after the snapshot are left in place.
+		</span>
+	</div>
+{/if}
+
 {#if selected.size > 0 && !isRoot}
 	<div class="mb-3 flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
 		<span class="text-sm font-medium">{selected.size} selected</span>
 		<div class="ml-auto flex items-center gap-2">
-			<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'copy')} disabled={bulkActionRunning}>
-				<Copy size={14} class="mr-1" /> Copy
-			</Button>
-			<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'move')} disabled={bulkActionRunning}>
-				<FolderInput size={14} class="mr-1" /> Move
-			</Button>
-			<Button size="sm" variant="destructive" onclick={() => bulkDeleteConfirm = true} disabled={bulkActionRunning}>
-				<Trash2 size={14} class="mr-1" /> Delete
-			</Button>
+			{#if inSnapshot}
+				<Button size="sm" onclick={() => restoreConfirm = true} disabled={bulkActionRunning}>
+					<RotateCcw size={14} class="mr-1" /> Restore
+				</Button>
+				<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'copy')} disabled={bulkActionRunning}>
+					<Copy size={14} class="mr-1" /> Copy
+				</Button>
+			{:else}
+				<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'copy')} disabled={bulkActionRunning}>
+					<Copy size={14} class="mr-1" /> Copy
+				</Button>
+				<Button size="sm" variant="outline" onclick={() => openPicker(selectedEntries(), 'move')} disabled={bulkActionRunning}>
+					<FolderInput size={14} class="mr-1" /> Move
+				</Button>
+				<Button size="sm" variant="destructive" onclick={() => bulkDeleteConfirm = true} disabled={bulkActionRunning}>
+					<Trash2 size={14} class="mr-1" /> Delete
+				</Button>
+			{/if}
 			<Button size="sm" variant="ghost" onclick={clearSelection} disabled={bulkActionRunning}>
 				Clear
 			</Button>
@@ -951,6 +1012,25 @@
 {/if}
 
 <!-- Bulk delete confirm modal -->
+{#if restoreConfirm}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+		<Card class="w-full max-w-md">
+			<CardContent class="pt-6">
+				<h3 class="mb-2 text-lg font-semibold">Restore {selected.size} item{selected.size === 1 ? '' : 's'} from snapshot?</h3>
+				<p class="mb-4 text-sm text-muted-foreground">
+					This copies the selected item{selected.size === 1 ? '' : 's'} from the snapshot back over the live
+					subvolume, <span class="font-medium text-foreground">overwriting the current version</span>. Files
+					created after the snapshot are left in place. This can't be undone — take a snapshot first if you want a way back.
+				</p>
+				<div class="flex gap-2">
+					<Button onclick={runRestore}>Restore {selected.size}</Button>
+					<Button variant="secondary" onclick={() => restoreConfirm = false}>Cancel</Button>
+				</div>
+			</CardContent>
+		</Card>
+	</div>
+{/if}
+
 {#if bulkDeleteConfirm}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
 		<Card class="w-full max-w-sm">

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -14,7 +14,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import SortTh from '$lib/components/SortTh.svelte';
-	import { Camera, Copy, Trash2, Pencil, Check, X, AlertTriangle } from '@lucide/svelte';
+	import { Camera, Copy, Trash2, Pencil, Check, X, AlertTriangle, RotateCcw } from '@lucide/svelte';
 
 	let pageTab = $state<'subvolumes' | 'snapshots'>(
 		typeof window !== 'undefined' && window.location.hash === '#snapshots' ? 'snapshots' : 'subvolumes'
@@ -1380,7 +1380,8 @@
 														<span class="ml-2 text-xs text-muted-foreground">{snap.read_only ? 'read-only' : 'writable'}</span>
 													</div>
 													<div class="flex gap-1">
-														<Button variant="secondary" size="xs" onclick={() => { showClone = { filesystem: detailSv!.filesystem, name: detailSv!.name, snapshot: snap.name }; cloneName = ''; }}>
+														<Button variant="secondary" size="xs" onclick={() => goto(`/files?path=${encodeURIComponent(`${detailSv!.filesystem}/${detailSv!.name}@${snap.name}`)}`)} title="Browse this snapshot and restore files back over the live subvolume"><RotateCcw class="mr-1 h-3 w-3" />Restore files…</Button>
+															<Button variant="secondary" size="xs" onclick={() => { showClone = { filesystem: detailSv!.filesystem, name: detailSv!.name, snapshot: snap.name }; cloneName = ''; }}>
 															<Copy class="mr-1 h-3 w-3" />Clone
 														</Button>
 														<Button variant="destructive" size="xs" onclick={() => deleteSnapshot(detailSv!, snap.name)}>


### PR DESCRIPTION
## What

The everyday **"roll this file/folder back to yesterday's version"** — restore selected files/folders from a read-only snapshot back over the live subvolume.

## Why

NASty could create/list/delete/clone snapshots but had **no restore**. Cloning makes a whole new subvolume; there was no way to get *this file* back.

The exploration paid off: the file manager already **browses and serves snapshot dirs** (`/fs/<fs>/<subvol>@<snap>` pass `safe_path`) and has a recursive copy. The **only** missing capability was overwrite — `/api/files/copy` rejects an existing destination, so it could restore a *deleted* file but not roll back a *modified* one.

## Change

- **Engine** — new `POST /api/files/restore` (constrained sibling of `/api/files/copy`):
  - Callers pass **snapshot paths only**. The live destination is **derived server-side** by stripping `@<snap>` from the snapshot path component (`derive_restore_dest`, unit-tested). So a restore can *only* overwrite the snapshot's own live subvolume — the WebUI can never misdirect an overwrite. (`@` is forbidden in subvol/snap names, so the snapshot component is unambiguous even when a deeper *file* is named `a@b`.)
  - **Overwrite-merge** semantics: files replaced, directories merged, symlinks replaced. Files created *after* the snapshot are left in place (additive — no `--delete`).
  - Reuses `safe_path` (jail to `/fs`, block `..`/symlink escapes) and the `is_inside_block_subvolume` guard. The live parent must exist (restore the parent folder first if a whole tree was deleted; clear error otherwise).
- **WebUI**:
  - **Files page** auto-detects snapshot context (path component after the filesystem contains `@`), shows a read-only banner, and offers **Restore** on the multi-select bar — hiding Move/Delete, which can't work on a read-only snapshot. New `?path=` deep-link support. Typed confirm warns it overwrites current versions.
  - **Subvolumes page** gains a **"Restore files…"** button per snapshot that drops you into the file browser scoped to that snapshot.

## Scope (v1)

Restore is **to the original location** (overwrite) only; "restore elsewhere" is already the existing copy. No exact-mirror (`--delete`) mode. Whole-subvolume rollback (the heavier quiesce-and-swap) is the separate feature B, not this.

## Tests

`derive_restore_dest` unit tests (snapshot→live strip, only-strips-snapshot-component, reject non-snapshot/traversal). `cargo fmt`, `clippy -p nasty-engine --all-targets` clean, `cargo test -p nasty-engine` pass. WebUI `npm run check` (0 errors) + `npm run build` clean. Path math verified against the live box (`/fs/<fs>/<subvol>@<snap>`).

**Not yet live-verified** end-to-end (the box runs 0.0.12, no endpoint yet) — happy to deploy and confirm a real restore round-trip on request.
