### PR TITLE
subvolume: whole-subvolume rollback to a snapshot (quiesce → swap → resume)

### DIFF
--- a/engine/nasty-engine/src/fs_lock.rs
+++ b/engine/nasty-engine/src/fs_lock.rs
@@ -125,7 +125,11 @@ async fn is_vm_running(state: &AppState, name: &str) -> bool {
 /// when the predicate first becomes true, false on timeout. Pulled
 /// out so the timeout/poll math is unit-testable without spinning up
 /// real services.
-async fn wait_until_stopped<F, Fut>(predicate: F, timeout: Duration, interval: Duration) -> bool
+pub(crate) async fn wait_until_stopped<F, Fut>(
+    predicate: F,
+    timeout: Duration,
+    interval: Duration,
+) -> bool
 where
     F: Fn() -> Fut,
     Fut: std::future::Future<Output = bool>,

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -28,6 +28,7 @@ mod log_stream;
 mod registry;
 mod rest_gateway;
 mod router;
+mod subvol_rollback;
 mod subvolume_dependents;
 mod swagger_ui;
 mod telemetry;

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -44,7 +44,8 @@ use nasty_storage::filesystem::{
 use nasty_storage::subvolume::{
     CloneSnapshotRequest, CloneSubvolumeRequest, CreateSnapshotRequest, CreateSubvolumeRequest,
     DeleteSnapshotRequest, DeleteSubvolumeRequest, FindByPropertyRequest, RemovePropertiesRequest,
-    ResizeSubvolumeRequest, SetPropertiesRequest, Snapshot, Subvolume, UpdateSubvolumeRequest,
+    ResizeSubvolumeRequest, RollbackResult, RollbackSnapshotRequest, SetPropertiesRequest,
+    Snapshot, Subvolume, UpdateSubvolumeRequest,
 };
 use nasty_system::alerts::{ActiveAlert, AlertRule, AlertRuleUpdate};
 use nasty_system::firewall::FirewallStatus;
@@ -814,6 +815,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<CloneSnapshotRequest>(generator)),
                     result: Some(gen_schema::<Subvolume>(generator)),
+                },
+                Method {
+                    name: "snapshot.rollback",
+                    desc: "Roll a subvolume back to a snapshot: quiesce its apps/VMs/shares, take a safety snapshot of the current state, swap the subvolume to the snapshot, and resume. Destructive; filesystem subvolumes only.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::Schema(gen_schema::<RollbackSnapshotRequest>(generator)),
+                    result: Some(gen_schema::<RollbackResult>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -64,6 +64,7 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "snapshot.create"
                 | "snapshot.delete"
                 | "snapshot.clone"
+                | "snapshot.rollback"
                 | "share.nfs.create"
                 | "share.nfs.update"
                 | "share.nfs.delete"

--- a/engine/nasty-engine/src/router/snapshot.rs
+++ b/engine/nasty-engine/src/router/snapshot.rs
@@ -59,6 +59,34 @@ pub(super) async fn try_route(
             },
             Err(e) => invalid(req, e),
         },
+        // Whole-subvolume rollback: quiesce dependents (apps/VMs/shares),
+        // swap the subvolume to the snapshot, resume. Destructive — takes a
+        // safety snapshot first. Orchestrated in the engine layer.
+        "snapshot.rollback" => {
+            match parse_params::<nasty_storage::subvolume::RollbackSnapshotRequest>(req) {
+                Ok(p) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .is_some_and(|f| f != p.filesystem)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        match crate::subvol_rollback::rollback_with_dependents(
+                            state,
+                            p,
+                            session.owner.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
+                    }
+                }
+                Err(e) => invalid(req, e),
+            }
+        }
         _ => return None,
     })
 }

--- a/engine/nasty-engine/src/subvol_rollback.rs
+++ b/engine/nasty-engine/src/subvol_rollback.rs
@@ -1,0 +1,265 @@
+//! Whole-subvolume rollback orchestration (feature B).
+//!
+//! Rolling a subvolume back to a snapshot deletes the live subvolume and
+//! recreates it from the snapshot — so everything currently using it must
+//! be quiesced first and resumed after. The storage layer
+//! (`SubvolumeService::rollback`) does the pure swap (and takes a safety
+//! snapshot of the current state for undo); this engine layer wraps it
+//! with the dependent cascade, mirroring `fs_lock::lock_with_dependents`.
+//!
+//! Order: stop apps → graceful-stop VMs (kill on timeout) → disable SMB/NFS
+//! exports → swap → resume in reverse (best-effort). Backup jobs are left
+//! alone (idempotent, like fs_lock). Block subvolumes (iSCSI/NVMe-oF/VM
+//! disks via loop) are refused for now — their loop-detach + target quiesce
+//! is a riskier follow-up.
+
+use std::time::Duration;
+
+use nasty_sharing::nfs::UpdateNfsShareRequest;
+use nasty_sharing::smb::UpdateSmbShareRequest;
+use nasty_storage::subvolume::{RollbackResult, RollbackSnapshotRequest, SubvolumeType};
+use tracing::{info, warn};
+
+use crate::AppState;
+use crate::fs_lock::wait_until_stopped;
+use crate::subvolume_dependents::find_all_subvolume_dependents;
+
+const VM_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+const VM_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Roll a subvolume back to a snapshot, quiescing and resuming its
+/// dependents around the storage-layer swap. Returns the recreated
+/// subvolume plus the safety-snapshot name (the undo point).
+pub async fn rollback_with_dependents(
+    state: &AppState,
+    req: RollbackSnapshotRequest,
+    owner_filter: Option<&str>,
+) -> Result<RollbackResult, String> {
+    let sv = state
+        .subvolumes
+        .get(&req.filesystem, &req.subvolume, owner_filter)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Block subvolumes need loop-detach + target quiesce — not yet handled.
+    // Refuse early (clearer than failing mid-cascade), before touching anything.
+    if sv.subvolume_type == SubvolumeType::Block || sv.block_device.is_some() {
+        return Err(
+            "rollback is not yet supported for block subvolumes (iSCSI / NVMe-oF / VM disks)"
+                .to_string(),
+        );
+    }
+
+    let subvol_path = sv.path.clone();
+    let deps = find_all_subvolume_dependents(state)
+        .await
+        .into_iter()
+        .find(|d| d.filesystem == req.filesystem && d.name == req.subvolume)
+        .unwrap_or_default();
+
+    // ── Quiesce: apps ──
+    // docker stop is blocking (Docker's own stop-then-kill). A failure here
+    // means something is wrong; abort before any storage change, with
+    // nothing yet stopped to restart.
+    for app in &deps.apps {
+        info!("Rollback cascade: stopping app '{app}'");
+        if let Err(e) = state.apps.stop(app).await {
+            return Err(format!(
+                "rollback aborted before any change: app '{app}' failed to stop ({e})"
+            ));
+        }
+    }
+
+    // ── Quiesce: VMs ──
+    // Dependents carry VM *names*; stop/start take the VM *id* — resolve.
+    let vm_ids = resolve_vm_ids(state, &deps.vms).await;
+    for (id, name) in &vm_ids {
+        if !is_vm_running(state, id).await {
+            continue;
+        }
+        info!("Rollback cascade: graceful shutdown of VM '{name}'");
+        if let Err(e) = state.vms.stop(id).await {
+            warn!("Rollback: VM '{name}' stop request failed: {e}; force-killing");
+        } else if wait_until_stopped(
+            || async { !is_vm_running(state, id).await },
+            VM_SHUTDOWN_TIMEOUT,
+            VM_POLL_INTERVAL,
+        )
+        .await
+        {
+            continue;
+        }
+        if let Err(e) = state.vms.kill(id).await {
+            // Restart the apps we already stopped before bailing out.
+            resume_apps(state, &deps.apps).await;
+            return Err(format!(
+                "rollback aborted: VM '{name}' wouldn't shut down and force-kill failed ({e}). \
+                 Stopped apps were restarted; manually stop the VM and retry."
+            ));
+        }
+    }
+
+    // ── Quiesce: shares ── disable SMB/NFS exports on this subvolume so
+    // clients drop their handles during the swap. (Daemons stay up.)
+    let smb_ids = set_smb_shares_enabled(state, &subvol_path, false).await;
+    let nfs_ids = set_nfs_shares_enabled(state, &subvol_path, false).await;
+
+    // ── Swap ──
+    let result = state
+        .subvolumes
+        .rollback(req, owner_filter)
+        .await
+        .map_err(|e| e.to_string());
+
+    // ── Resume (best-effort, regardless of swap outcome — log, don't abort) ──
+    reenable_nfs_shares(state, &nfs_ids).await;
+    reenable_smb_shares(state, &smb_ids).await;
+    for (id, name) in &vm_ids {
+        if let Err(e) = state.vms.start(id).await {
+            warn!("Rollback: restart of VM '{name}' failed: {e}");
+        }
+    }
+    resume_apps(state, &deps.apps).await;
+
+    result
+}
+
+async fn resolve_vm_ids(state: &AppState, names: &[String]) -> Vec<(String, String)> {
+    let Ok(vms) = state.vms.list().await else {
+        return Vec::new();
+    };
+    names
+        .iter()
+        .filter_map(|n| {
+            vms.iter()
+                .find(|v| &v.config.name == n)
+                .map(|v| (v.config.id.clone(), n.clone()))
+        })
+        .collect()
+}
+
+async fn is_vm_running(state: &AppState, id: &str) -> bool {
+    state
+        .vms
+        .list()
+        .await
+        .ok()
+        .and_then(|vms| vms.into_iter().find(|v| v.config.id == id))
+        .is_some_and(|v| v.running)
+}
+
+async fn resume_apps(state: &AppState, apps: &[String]) {
+    for app in apps {
+        if let Err(e) = state.apps.start(app).await {
+            warn!("Rollback: restart of app '{app}' failed: {e}");
+        }
+    }
+}
+
+fn path_in_subvol(path: &str, subvol_path: &str) -> bool {
+    path == subvol_path || path.starts_with(&format!("{subvol_path}/"))
+}
+
+/// Disable (enabled=false) every SMB share whose path is under
+/// `subvol_path`, returning the ids touched so they can be re-enabled.
+async fn set_smb_shares_enabled(state: &AppState, subvol_path: &str, enabled: bool) -> Vec<String> {
+    let mut touched = Vec::new();
+    let Ok(shares) = state.smb.list().await else {
+        return touched;
+    };
+    for s in shares {
+        if s.enabled != enabled && path_in_subvol(&s.path, subvol_path) {
+            info!(
+                "Rollback cascade: {} SMB share '{}'",
+                if enabled { "re-enabling" } else { "disabling" },
+                s.name
+            );
+            if let Err(e) = state.smb.update(smb_enabled_req(&s.id, enabled)).await {
+                warn!("Rollback: toggling SMB share '{}' failed: {e}", s.name);
+            } else {
+                touched.push(s.id);
+            }
+        }
+    }
+    touched
+}
+
+async fn reenable_smb_shares(state: &AppState, ids: &[String]) {
+    for id in ids {
+        if let Err(e) = state.smb.update(smb_enabled_req(id, true)).await {
+            warn!("Rollback: re-enabling SMB share '{id}' failed: {e}");
+        }
+    }
+}
+
+async fn set_nfs_shares_enabled(state: &AppState, subvol_path: &str, enabled: bool) -> Vec<String> {
+    let mut touched = Vec::new();
+    let Ok(shares) = state.nfs.list().await else {
+        return touched;
+    };
+    for s in shares {
+        if s.enabled != enabled && path_in_subvol(&s.path, subvol_path) {
+            info!(
+                "Rollback cascade: {} NFS share ({})",
+                if enabled { "re-enabling" } else { "disabling" },
+                s.path
+            );
+            if let Err(e) = state.nfs.update(nfs_enabled_req(&s.id, enabled)).await {
+                warn!("Rollback: toggling NFS share '{}' failed: {e}", s.id);
+            } else {
+                touched.push(s.id);
+            }
+        }
+    }
+    touched
+}
+
+async fn reenable_nfs_shares(state: &AppState, ids: &[String]) {
+    for id in ids {
+        if let Err(e) = state.nfs.update(nfs_enabled_req(id, true)).await {
+            warn!("Rollback: re-enabling NFS share '{id}' failed: {e}");
+        }
+    }
+}
+
+fn smb_enabled_req(id: &str, enabled: bool) -> UpdateSmbShareRequest {
+    UpdateSmbShareRequest {
+        id: id.to_string(),
+        name: None,
+        comment: None,
+        read_only: None,
+        browseable: None,
+        guest_ok: None,
+        valid_users: None,
+        extra_params: None,
+        time_machine: None,
+        time_machine_max_size_gib: None,
+        enabled: Some(enabled),
+    }
+}
+
+fn nfs_enabled_req(id: &str, enabled: bool) -> UpdateNfsShareRequest {
+    UpdateNfsShareRequest {
+        id: id.to_string(),
+        comment: None,
+        clients: None,
+        enabled: Some(enabled),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_in_subvol;
+
+    #[test]
+    fn path_in_subvol_matches_subtree_only() {
+        let base = "/fs/tank/photos";
+        // The subvolume root and anything under it count.
+        assert!(path_in_subvol(base, base));
+        assert!(path_in_subvol("/fs/tank/photos/2024/img.jpg", base));
+        // A sibling that merely shares the prefix must NOT match.
+        assert!(!path_in_subvol("/fs/tank/photos-backup", base));
+        // An unrelated path doesn't match.
+        assert!(!path_in_subvol("/fs/tank/docs", base));
+    }
+}

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -458,6 +458,25 @@ pub struct CloneSnapshotRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct RollbackSnapshotRequest {
+    /// Name of the filesystem containing the snapshot.
+    pub filesystem: String,
+    /// Name of the parent subvolume to roll back.
+    pub subvolume: String,
+    /// Name of the snapshot to roll the subvolume back to.
+    pub snapshot: String,
+}
+
+/// Outcome of a rollback: the recreated subvolume plus the name of the
+/// read-only safety snapshot taken of the pre-rollback state (the undo
+/// point — roll back to it to get the prior state back).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RollbackResult {
+    pub subvolume: Subvolume,
+    pub safety_snapshot: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CloneSubvolumeRequest {
     /// Name of the filesystem containing the source subvolume.
     pub filesystem: String,
@@ -1581,44 +1600,120 @@ impl SubvolumeService {
             "Cloning snapshot '{}/{}@{}' to new subvolume '{}'",
             req.filesystem, req.subvolume, req.snapshot, req.new_name
         );
-        // bcachefs subvolume snapshot without -r creates a writable subvolume from snapshot
-        cmd::run_ok(
-            "bcachefs",
-            &["subvolume", "snapshot", &snap_path, &new_subvol_path],
-        )
-        .await
-        .map_err(SubvolumeError::CommandFailed)?;
-
-        // Read metadata from the snapshot itself — it inherits xattrs from the source.
-        // This works even when the parent subvolume has been deleted (DR scenario).
-        let snap_meta = read_meta_xattrs(Path::new(&snap_path));
-
-        // The new subvolume already has the correct xattrs (copied by bcachefs snapshot).
-        // Only update owner if an owner filter is set.
-        if let Some(owner) = owner_filter {
-            let _ = xattr::set(&new_subvol_path, XATTR_NASTY_OWNER, owner.as_bytes());
-        }
-
-        // For block subvolumes, attach a loop device to the restored clone's sparse image
-        if snap_meta.subvolume_type == SubvolumeType::Block {
-            let img_path = format!("{new_subvol_path}/{BLOCK_FILE_NAME}");
-            if Path::new(&img_path).exists() {
-                info!(
-                    "Attaching loop device for restored block subvolume '{}'",
-                    req.new_name
-                );
-                let mut args = vec!["--find", "--show"];
-                if snap_meta.direct_io {
-                    args.push("--direct-io=on");
-                }
-                args.push(&img_path);
-                cmd::run_ok("losetup", &args)
-                    .await
-                    .map_err(SubvolumeError::CommandFailed)?;
-            }
-        }
+        materialize_subvol_from_snapshot(&snap_path, &new_subvol_path, owner_filter).await?;
 
         self.get(&req.filesystem, &req.new_name, None).await
+    }
+
+    /// Roll a filesystem subvolume back to a snapshot's state. Assumes the
+    /// engine layer has already quiesced everything using the subvolume.
+    ///
+    /// Takes a read-only safety snapshot of the current state first (the
+    /// undo point — it survives the delete), then deletes the live
+    /// subvolume and recreates it writable from the target snapshot at the
+    /// same path, re-applying the project quota. Name/path/owner/quota are
+    /// preserved, so path-based consumers keep working.
+    ///
+    /// v1 scope: filesystem subvolumes with no nested children; block
+    /// subvolumes (loop/iSCSI/NVMe-oF/VM-disk) are refused.
+    pub async fn rollback(
+        &self,
+        req: RollbackSnapshotRequest,
+        owner_filter: Option<&str>,
+    ) -> Result<RollbackResult, SubvolumeError> {
+        let subvol = self
+            .get(&req.filesystem, &req.subvolume, owner_filter)
+            .await?;
+
+        if subvol.subvolume_type == SubvolumeType::Block {
+            return Err(SubvolumeError::CommandFailed(
+                "rollback is not yet supported for block subvolumes (iSCSI / NVMe-oF / VM disks)"
+                    .into(),
+            ));
+        }
+
+        let mount_point = self.fs_mount_point(&req.filesystem).await?;
+        let subvol_path = subvol_path(&mount_point, &req.subvolume);
+        let snap_path = snap_path(&mount_point, &req.subvolume, &req.snapshot);
+
+        if !Path::new(&snap_path).exists() {
+            return Err(SubvolumeError::NotFound(format!(
+                "snapshot {}@{}",
+                req.subvolume, req.snapshot
+            )));
+        }
+        let children = find_child_subvolumes(&mount_point, &req.subvolume).await;
+        if !children.is_empty() {
+            return Err(SubvolumeError::CommandFailed(format!(
+                "rollback refused: '{}' has nested subvolumes ({}). Roll those back individually.",
+                req.subvolume,
+                children.join(", ")
+            )));
+        }
+
+        // 1. Safety snapshot of the current state — the undo point. It's an
+        //    independent subvolume, so it survives the delete below.
+        let safety_name = format!(
+            "pre-rollback-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        );
+        self.create_snapshot(
+            CreateSnapshotRequest {
+                filesystem: req.filesystem.clone(),
+                subvolume: req.subvolume.clone(),
+                name: safety_name.clone(),
+                read_only: Some(true),
+            },
+            owner_filter,
+        )
+        .await?;
+
+        // 2. Delete the live subvolume.
+        info!(
+            "Rollback: deleting live subvolume '{}/{}' before recreating from @{}",
+            req.filesystem, req.subvolume, req.snapshot
+        );
+        cmd::run_ok("bcachefs", &["subvolume", "delete", &subvol_path])
+            .await
+            .map_err(|e| {
+                SubvolumeError::CommandFailed(format!(
+                    "rollback: deleting live subvolume failed ({e}). Your data is intact in \
+                     safety snapshot '{}@{safety_name}'.",
+                    req.subvolume
+                ))
+            })?;
+
+        // 3. Recreate writable from the target snapshot at the same path.
+        materialize_subvol_from_snapshot(&snap_path, &subvol_path, owner_filter)
+            .await
+            .map_err(|e| {
+                SubvolumeError::CommandFailed(format!(
+                    "rollback: recreating from snapshot failed ({e}). Recover from safety \
+                     snapshot '{}@{safety_name}' or the target '@{}'.",
+                    req.subvolume, req.snapshot
+                ))
+            })?;
+
+        // 4. Re-apply the project quota — project id is deterministic from
+        //    (fs, name), so the recreated subvolume reuses it; re-stamp the
+        //    original limit (0 = tracked-unlimited).
+        let projid = project_id_for(&req.filesystem, &req.subvolume);
+        set_project_quota(
+            &mount_point,
+            &subvol_path,
+            projid,
+            subvol.quota_bytes.unwrap_or(0),
+        )
+        .await;
+
+        let recreated = self.get(&req.filesystem, &req.subvolume, None).await?;
+        Ok(RollbackResult {
+            subvolume: recreated,
+            safety_snapshot: safety_name,
+        })
     }
 
     /// Clone a subvolume into a new writable subvolume (COW).
@@ -2086,6 +2181,43 @@ async fn find_child_subvolumes(mount_point: &str, parent_name: &str) -> Vec<Stri
     // Sort so deeper paths come later — reverse for depth-first deletion
     children.sort();
     children
+}
+
+/// Recreate a writable subvolume at `dest_path` from a snapshot at
+/// `snap_path` (`bcachefs subvolume snapshot` without `-r`), re-stamping
+/// the owner xattr when a scope filter is active and re-attaching a loop
+/// device for block subvolumes. bcachefs copies the source's other xattrs
+/// into the new subvolume automatically. Shared by `clone_snapshot` and
+/// `rollback`.
+async fn materialize_subvol_from_snapshot(
+    snap_path: &str,
+    dest_path: &str,
+    owner_filter: Option<&str>,
+) -> Result<(), SubvolumeError> {
+    cmd::run_ok("bcachefs", &["subvolume", "snapshot", snap_path, dest_path])
+        .await
+        .map_err(SubvolumeError::CommandFailed)?;
+
+    let snap_meta = read_meta_xattrs(Path::new(snap_path));
+    if let Some(owner) = owner_filter {
+        let _ = xattr::set(dest_path, XATTR_NASTY_OWNER, owner.as_bytes());
+    }
+
+    if snap_meta.subvolume_type == SubvolumeType::Block {
+        let img_path = format!("{dest_path}/{BLOCK_FILE_NAME}");
+        if Path::new(&img_path).exists() {
+            info!("Attaching loop device for block subvolume at '{dest_path}'");
+            let mut args = vec!["--find", "--show"];
+            if snap_meta.direct_io {
+                args.push("--direct-io=on");
+            }
+            args.push(&img_path);
+            cmd::run_ok("losetup", &args)
+                .await
+                .map_err(SubvolumeError::CommandFailed)?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -14,7 +14,7 @@
 	import { Label } from '$lib/components/ui/label';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import SortTh from '$lib/components/SortTh.svelte';
-	import { Camera, Copy, Trash2, Pencil, Check, X, AlertTriangle, RotateCcw } from '@lucide/svelte';
+	import { Camera, Copy, Trash2, Pencil, Check, X, AlertTriangle, RotateCcw, History } from '@lucide/svelte';
 
 	let pageTab = $state<'subvolumes' | 'snapshots'>(
 		typeof window !== 'undefined' && window.location.hash === '#snapshots' ? 'snapshots' : 'subvolumes'
@@ -663,6 +663,28 @@
 			}),
 			`Snapshot "${snap}" deleted`
 		);
+		await refresh();
+		if (detailSv) {
+			const updated = subvolumes.find(s => s.filesystem === detailSv!.filesystem && s.name === detailSv!.name);
+			if (updated) detailSv = updated;
+		}
+	}
+
+	async function rollbackSnapshot(sv: Subvolume, snap: string) {
+		if (!await confirm(
+			`Roll back "${sv.name}" to snapshot "${snap}"?`,
+			`This replaces the whole subvolume with the snapshot — all changes since "${snap}" was taken are discarded. Apps, VMs and shares using it are paused and resumed automatically. A read-only safety snapshot (pre-rollback-…) is created first so you can undo. This can't be interrupted.`
+		)) return;
+		await withToast(
+			// Long timeout — quiescing a VM can take up to ~60s.
+			() => client.call('snapshot.rollback', {
+				filesystem: sv.filesystem,
+				subvolume: sv.name,
+				snapshot: snap,
+			}, 300_000),
+			`"${sv.name}" rolled back — a safety snapshot was created so you can undo`
+		);
+		await loadSnapshots();
 		await refresh();
 		if (detailSv) {
 			const updated = subvolumes.find(s => s.filesystem === detailSv!.filesystem && s.name === detailSv!.name);
@@ -1384,7 +1406,8 @@
 															<Button variant="secondary" size="xs" onclick={() => { showClone = { filesystem: detailSv!.filesystem, name: detailSv!.name, snapshot: snap.name }; cloneName = ''; }}>
 															<Copy class="mr-1 h-3 w-3" />Clone
 														</Button>
-														<Button variant="destructive" size="xs" onclick={() => deleteSnapshot(detailSv!, snap.name)}>
+														<Button variant="destructive" size="xs" onclick={() => rollbackSnapshot(detailSv!, snap.name)} title="Roll the whole subvolume back to this snapshot (pauses apps/VMs/shares; creates a safety snapshot first)"><History class="mr-1 h-3 w-3" />Roll back</Button>
+															<Button variant="destructive" size="xs" onclick={() => deleteSnapshot(detailSv!, snap.name)}>
 															<Trash2 class="h-3 w-3" />
 														</Button>
 													</div>


### PR DESCRIPTION
## What

**Roll an entire subvolume back to a snapshot** in one action (feature B, the heavier sibling of file-level restore #576). bcachefs makes the swap O(1) — delete the live subvolume and recreate it writable from the snapshot at the same path — but the subvolume is usually *in use*, so the real work is safely **quiescing its dependents, swapping, and resuming**, with a built-in undo.

## How

**Storage** (`nasty-storage/subvolume.rs`): `rollback(RollbackSnapshotRequest) → RollbackResult`:
1. Take a read-only **safety snapshot** of the current state (`pre-rollback-<epoch>`) — the undo point; it survives the delete.
2. Delete the live subvolume.
3. Recreate it from the target snapshot at the same path (name/path/owner/quota preserved, so path-based consumers keep working).
4. Re-apply the project quota.

Refuses block subvolumes and nested-child subvolumes (v1). The `clone_snapshot` recreate tail (snapshot + owner re-stamp + loop attach) is factored into a shared `materialize_subvol_from_snapshot`, reused by both.

**Engine orchestration** (`subvol_rollback.rs`, NEW) — mirrors `fs_lock::lock_with_dependents`:
stop apps (abort on failure) → graceful-stop VMs (QMP powerdown, poll, kill on 60s timeout) → disable SMB/NFS exports → **swap** → resume in reverse (best-effort, log-don't-abort). Block subvols refused early; backup jobs left alone (idempotent). `find_all_subvolume_dependents` enumerates the consumers; VM names are resolved to ids for stop/start; `wait_until_stopped` is shared from `fs_lock`.

**Wiring**: `snapshot.rollback` Operator-gated RPC (router arm + `is_operator_allowed` + registry), filesystem-scoped. **WebUI**: a destructive **"Roll back"** button on the per-snapshot row with a strong confirm (discards changes since the snapshot, pauses/resumes apps/VMs/shares, notes the safety snapshot) and a 300s timeout.

## Safety properties

- **Undo**: always snapshots the current state first; if anything fails after the delete, the error names the safety snapshot to recover from.
- **Identity preserved**: same name/path/owner/quota → shares/apps/iSCSI that reference the path keep working after resume.
- **Quiesce/resume** with restart-on-failure; apps that won't stop abort the op *before* any storage change.

## Scope / non-goals (v1)

- **Filesystem subvolumes only** — block subvolumes (iSCSI/NVMe-oF/VM-disk via loop) are refused with a clear message (loop-detach + target quiesce is a riskier follow-up).
- No nested-child subvolumes.
- Synchronous RPC (long timeout), no progress UI.

## Tests

- `path_in_subvol` unit test; shared `fs_lock::wait_until_stopped` tests still green. `cargo fmt`, `cargo clippy -p nasty-storage -p nasty-engine --all-targets` clean, `cargo test -p nasty-storage -p nasty-engine` (217 pass).
- WebUI `npm run check` (0 errors) + `npm run build` clean.

**Not yet live-verified** end-to-end (box needs this build). Happy to deploy + run the round-trip (create subvol + SMB share → snapshot → diverge → roll back → verify reverted + share resumed + safety snapshot; confirm undo; confirm block-subvol refusal) once merged.
