### PR TITLE
installer: rewrite the stock hardware-config header that points at a missing file (#575)

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -320,6 +320,31 @@ in
       ' /tmp/hw-config/hardware-configuration.nix > /tmp/hw-clean.nix \
         && mv /tmp/hw-clean.nix /tmp/hw-config/hardware-configuration.nix
 
+      # nixos-generate-config writes a 3-line header telling the user to edit
+      # /etc/nixos/configuration.nix — a file the NASty appliance has no copy of
+      # (the system config lives in the `nasty` flake input; the only local
+      # hand-editable file is /etc/nixos/flake.nix). Left as-is it sends
+      # NixOS-literate operators chasing a missing file (issue #575). Replace it
+      # with a header that describes the actual flake-based layout.
+      if head -n1 /tmp/hw-config/hardware-configuration.nix | grep -q 'Do not modify this file'; then
+        {
+          printf '%s\n' \
+            '# Auto-generated hardware detection for THIS machine (disks, kernel' \
+            '# modules, CPU). Do not hand-edit — the NASty installer regenerates it.' \
+            '#' \
+            '# NASty is a flake-based appliance: there is NO /etc/nixos/configuration.nix,' \
+            '# so NixOS guides that say "edit configuration.nix" do not map here.' \
+            '#   * System config lives in the `nasty` flake input' \
+            '#     (github:nasty-project/nasty), imported by /etc/nixos/flake.nix.' \
+            '#   * Network, TLS, shares, apps and the upstream ref are managed by the' \
+            '#     NASty engine / WebUI — not by hand-editing .nix files.' \
+            '#   * To track a different nasty/bcachefs ref or add overlays, edit the' \
+            '#     wrapper flake /etc/nixos/flake.nix (also in the WebUI Upstream section).'
+          tail -n +4 /tmp/hw-config/hardware-configuration.nix
+        } > /tmp/hw-config/hardware-configuration.nix.nasty \
+          && mv /tmp/hw-config/hardware-configuration.nix.nasty /tmp/hw-config/hardware-configuration.nix
+      fi
+
       cp /tmp/hw-config/hardware-configuration.nix /mnt/etc/nixos/hardware-configuration.nix
 
       echo "==> Writing network configuration..."


### PR DESCRIPTION
Closes #575

## Issue (#575)

> There are some .nix files that document being auto-generated from /etc/configuration.nix but that file seems to not exist which makes it hard to follow nixos articles that tell you to make changes there?

## Root cause

`/etc/nixos/hardware-configuration.nix` carries the stock `nixos-generate-config` header:

```
# Do not modify this file!  It was generated by ‘nixos-generate-config’
# and may be overwritten by future invocations.  Please make changes
# to /etc/nixos/configuration.nix instead.
```

But a NASty appliance has **no `/etc/nixos/configuration.nix`**. Confirmed on a live box — `/etc/nixos/` contains only:

```
flake.nix  flake.lock  hardware-configuration.nix  networking.nix
```

The system config (`./nixos/configuration.nix` + modules) is baked into the **`nasty` flake input** (`github:nasty-project/nasty`) that the wrapper `/etc/nixos/flake.nix` pulls in. So NixOS guides that say "edit configuration.nix" send operators chasing a file that isn't there.

## Fix

In `nasty-install` (`nixos/iso.nix`), right after the existing hardware-config post-processing, replace the stock 3-line header with one that describes the actual layout:
- there is **no** `configuration.nix`; system config comes from the `nasty` flake input;
- network/TLS/shares/apps/upstream-ref are managed by the **engine/WebUI**, not by editing `.nix` files;
- the wrapper `/etc/nixos/flake.nix` is where you pin a different nasty/bcachefs ref or add overlays (also exposed in the WebUI Upstream section).

Guarded on the stock header being present (no-op if upstream ever rewords it) and **idempotent**. The manual `INSTALL.md` path is unaffected — it clones the full repo into `/etc/nixos`, so `configuration.nix` genuinely exists there.

## Testing

Validated the rewrite shell logic against a realistic `nixos-generate-config` file: stock pointer removed, Nix body (imports/fileSystems/etc.) preserved byte-for-byte after the header, and a second run is a no-op. `nix-instantiate --parse nixos/iso.nix` passes.
