### PR TITLE
deps: bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
A new advisory **RUSTSEC-2026-0190** flags unsoundness in `anyhow`'s `Error::downcast_mut()` — adding context via `Error::context` and then calling `downcast_mut` on the result violates borrow rules, resulting in UB. Fixed upstream in **1.0.103**; we were pinned at 1.0.102.

Pure `Cargo.lock` bump (`cargo update -p anyhow --precise 1.0.103`); `cargo build --workspace` is clean.

This clears the `cargo-deny` failure the advisory-DB update introduced on `main` and on every open PR (e.g. #589) — it's not anything those PRs changed.
