### PR TITLE
ci: watch caddy, not nginx, in the nixpkgs-bump curated diff

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -113,7 +113,7 @@ jobs:
                 pkgs = (builtins.getFlake \"github:NixOS/nixpkgs/$rev\").legacyPackages.x86_64-linux;
                 names = [
                   \"qemu\" \"docker\" \"openssl\" \"openssh\" \"networkmanager\"
-                  \"samba\" \"nfs-utils\" \"nginx\" \"targetcli-fb\" \"lvm2\"
+                  \"samba\" \"nfs-utils\" \"caddy\" \"targetcli-fb\" \"lvm2\"
                   \"util-linux\" \"glibc\"
                 ];
                 versionOf = name:


### PR DESCRIPTION
The weekly `nixpkgs-bump` workflow's curated package watch-list still
contained `"nginx"` — a leftover from before the v0.0.8 nginx → Caddy
migration. NASty no longer ships nginx (the reverse proxy / TLS
terminator is `services.caddy`).

The list is evaluated directly against nixpkgs (`nixpkgs.<name>.version`),
not against NASty's actual closure, so every bump PR reported phantom
`nginx: x → y` changes for a package we don't use — e.g. #586.

Swap `"nginx"` → `"caddy"` so the curated diff tracks the component that
actually gates the WebUI/TLS path.

No behavior change beyond the reported package set.