### PR TITLE
docs: drop k8s/lego from third-party licenses, add caddy + docker

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -67,7 +67,9 @@ All dependencies use licenses compatible with GPL-3.0.
 | avahi | LGPL-2.1-or-later |
 | bcachefs-tools | GPL-2.0 |
 | btop | Apache-2.0 |
+| caddy | Apache-2.0 |
 | croc | MIT |
+| docker | Apache-2.0 |
 | ethtool | GPL-2.0 |
 | fwupd | LGPL-2.1-or-later |
 | hdparm | BSD-2-Clause |
@@ -76,10 +78,6 @@ All dependencies use licenses compatible with GPL-3.0.
 | iotop-c | GPL-2.0 |
 | iproute2 | GPL-2.0 |
 | jq | MIT |
-| k3s | Apache-2.0 |
-| kubectl | Apache-2.0 |
-| kubernetes-helm | Apache-2.0 |
-| lego | MIT |
 | lm-sensors | GPL-2.0 |
 | lsof | Zlib |
 | nfs-utils | GPL-2.0 |

--- a/webui/static/THIRD-PARTY-LICENSES.md
+++ b/webui/static/THIRD-PARTY-LICENSES.md
@@ -67,7 +67,9 @@ All dependencies use licenses compatible with GPL-3.0.
 | avahi | LGPL-2.1-or-later |
 | bcachefs-tools | GPL-2.0 |
 | btop | Apache-2.0 |
+| caddy | Apache-2.0 |
 | croc | MIT |
+| docker | Apache-2.0 |
 | ethtool | GPL-2.0 |
 | fwupd | LGPL-2.1-or-later |
 | hdparm | BSD-2-Clause |
@@ -76,10 +78,6 @@ All dependencies use licenses compatible with GPL-3.0.
 | iotop-c | GPL-2.0 |
 | iproute2 | GPL-2.0 |
 | jq | MIT |
-| k3s | Apache-2.0 |
-| kubectl | Apache-2.0 |
-| kubernetes-helm | Apache-2.0 |
-| lego | MIT |
 | lm-sensors | GPL-2.0 |
 | lsof | Zlib |
 | nfs-utils | GPL-2.0 |


### PR DESCRIPTION
Follow-up to the nginx→Caddy artifact hunt (#594).

The **System Components** table in `THIRD-PARTY-LICENSES.md` still listed
four packages from the pre-v0.0.8 architecture:

- `k3s`, `kubectl`, `kubernetes-helm` — from when apps ran on k3s + Helm
- `lego` — the ACME client, dropped for Caddy's built-in ACME (#307)

None of these are in the appliance closure anymore (verified: no `.nix`
in the repo references them, and the file is hand-maintained, not
generated). Meanwhile the list was **missing** the packages that
replaced them — `caddy` (reverse proxy / TLS) and `docker` (app
orchestration).

This removes the four dead entries and adds `caddy` + `docker`, keeping
`webui/static/THIRD-PARTY-LICENSES.md` (a byte-identical copy) in sync.

### Not touched (evaluated, deliberately left)
- `nixos/modules/nasty.nix` "k8s CNI" comment — a generic example of
  externally-managed interfaces; a NASty box can still meet k8s CNI veths
  as an *external* CSI storage provider.
- `nginx` in `nasty-apps`/`app_deploy` tests — generic `ss`-output and
  docker-compose example data, not a claim that NASty ships nginx.