### PR TITLE
appliance: bundle diskwatch disk-diagnostics TUI on the CLI

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -473,6 +473,7 @@ in {
          iostat -x 1
          dool -dny 1
          btop                                       interactive CPU/mem/disk/net dashboard
+         diskwatch                                  read-only disk diagnostics TUI (devices, SMART, IO, hot files)
          # → type 'debug' for perf profiling and kernel oops symbolization
          # → type 'benchmark' for fio storage tests
 
@@ -732,6 +733,27 @@ in {
         # what nasty-top's own flake does after nasty-top#17.
         cargoLock.lockFile = "${nastyTopSrc}/Cargo.lock";
         meta.mainProgram = "nasty-top";
+      })
+
+      # diskwatch — third-party read-only disk-diagnostics TUI (MIT,
+      # github:matthart1983/diskwatch). Consolidates lsblk/smartctl/
+      # iostat/df/SMART/hot-files into one console view and understands
+      # bcachefs multi-device mounts, so it complements nasty-top on the
+      # storage side. Packaged inline the same way as nasty-top above:
+      # pinned tag + cargoLock.lockFile, no cargoHash to maintain.
+      (let
+        diskwatchSrc = pkgs.fetchFromGitHub {
+          owner = "matthart1983";
+          repo = "diskwatch";
+          rev = "v0.1.1";
+          hash = "sha256-pveHyT3ljQQ9GdOMhZhcY7QD/pMvL3fLrbM6D5fO+h4=";
+        };
+      in pkgs.rustPlatform.buildRustPackage {
+        pname = "diskwatch";
+        version = "0.1.1";
+        src = diskwatchSrc;
+        cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
+        meta.mainProgram = "diskwatch";
       })
 
       (writeShellScriptBin "nasty-cleanup" ''


### PR DESCRIPTION
Adds [diskwatch](https://github.com/matthart1983/diskwatch) (MIT) to the
appliance PATH — a read-only disk-diagnostics TUI that consolidates
`lsblk`/`smartctl`/`iostat`/`df`/SMART/hot-files into one console view.
It's a storage-side complement to `nasty-top` for triage over SSH or the
built-in terminal.

Packaged **inline exactly like `nasty-top`**: pinned tag `v0.1.1` +
`cargoLock.lockFile` (no `cargoHash` to recompute on bumps), with
`meta.mainProgram`. Also listed in the terminal I/O-monitoring command
reference next to `btop`. **CLI only — no WebUI surface.**

### Verified on the test VM
Deployed this branch via `nixos-rebuild switch` on the NASty test VM:
- Builds cleanly (`diskwatch 0.1.1`), lands on `/run/current-system/sw/bin/diskwatch`.
- `diskwatch --diag` correctly reads the box's disks **and the bcachefs
  multi-device pool** (`/dev/sdb:/dev/sdd:/dev/sdc -> /fs/first`), plus
  ext4/vfat filesystems and usage.

### Note
diskwatch is an individual-authored project at v0.1.1 — worth a glance at
the maintenance/supply-chain trade-off before merge, same as any pinned
third-party input.