### PR TITLE
release: bump workspace version to 0.0.13

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-apps"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-backup"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "chrono",
  "cron",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-common"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "base64 0.22.1",
  "schemars 1.2.1",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-engine"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-metrics"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-sharing"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",
@@ -3004,14 +3004,14 @@ dependencies = [
 
 [[package]]
 name = "nasty-snapshot"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "nasty-storage",
 ]
 
 [[package]]
 name = "nasty-storage"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-system"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-vm"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 license = "GPL-3.0-only"
 


### PR DESCRIPTION
Bumps `engine/Cargo.toml` `[workspace.package]` version **0.0.12 → 0.0.13** and refreshes `Cargo.lock` (the ten `nasty-*` workspace crates re-pin at 0.0.13, no external dep changes).

### Why this matters for the release
`flake.nix` reads this value as `nasty-version`, which is the single source of truth for:
- the installer wrapper's pinned ref — `nasty.url = github:nasty-project/nasty/v${nasty-version}` → a fresh install pins **`v0.0.13`**;
- `system.nixos.label`;
- the version shown in the WebUI.

Landing this **before tagging** means the release ISO pins the new `v0.0.13` tag (and reports itself as 0.0.13) rather than the stale `v0.0.12`. A fresh install then resolves check-update to the same commit the tag points at, i.e. reports "up to date" out of the box.

Version metadata only — no functional change.

### Release ordering (for reference, not part of this PR)
1. this bump
2. merge #597 (kernel 6.18.36 → 6.18.37) — so the release carries the newest kernel
3. tag `v0.0.13` on the resulting `main`
4. build the ISO from the tag