### PR TITLE
caddy: refresh withPlugins source hash after nixpkgs bump

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2035,7 +2035,7 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-IHsh+QoPbsp9HIl9WBDBO03YmSNt6A6VYt/hmAnwPJo=";
+        hash = "sha256-7qWw/wj0v0QCGpuoKpsybx6u6EuTw7pOCJKNj46F3Hg=";
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
The weekly nixpkgs bump (#597) changed the composed `caddy-with-plugins` source, invalidating the pinned fixed-output hash. Regular CI stayed green because x86_64 substituted the old source from Cachix, but the **aarch64 ISO build** had a cache miss, rebuilt from source, and surfaced the drift while building `nixos-system-nasty-v0.0.13`:

```
specified: sha256-IHsh+QoPbsp9HIl9WBDBO03YmSNt6A6VYt/hmAnwPJo=
got:       sha256-7qWw/wj0v0QCGpuoKpsybx6u6EuTw7pOCJKNj46F3Hg=
```

Updated to the `got` value, per the procedure documented directly above the pin in `nasty.nix`.

### Scope — covers the installer too
This is the **only** `caddy.withPlugins` pin in the repo. Every nixosConfiguration (appliance, VM, cloud image, and the installer's target system) imports `nixos/modules/nasty.nix`, so the fix applies everywhere. Critically, a **fresh install and any in-place update fetch `nasty` at the release tag and rebuild caddy from this hash** — so this must ship in the tagged commit or every cache-miss install/update would fail identically.

Verified by the ISO re-dispatch after merge (the definitive check, since it forces a from-source caddy rebuild on the aarch64 runner).