### PR TITLE
nixos: bump diskwatch to 0.1.2

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -745,12 +745,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.1.1";
-          hash = "sha256-pveHyT3ljQQ9GdOMhZhcY7QD/pMvL3fLrbM6D5fO+h4=";
+          rev = "v0.1.2";
+          hash = "sha256-8tQXcbY/sguw42vE0p5Q8/psmwfYQihWcSIsApI4OmE=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.1.1";
+        version = "0.1.2";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";


### PR DESCRIPTION
Updates the pinned diskwatch package from v0.1.1 to v0.1.2.

The headline upstream change is corrected per-device usage attribution: mount usage is now attributed to the devices that actually back it (upstream matthart1983/diskwatch#4), which improves accuracy on multi-device setups like our bcachefs mounts. Upstream also added a Nix flake and package derivation of its own — our inline `cargoLock.lockFile` packaging keeps working as-is, so no derivation changes were needed here.

Dependency check: the only new crate in the lockfile is `fnv` (pure Rust, no `-sys` crates), so no new Nix build inputs are required.