### PR TITLE
net: saved interface config now survives renames and absent devices

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -310,55 +310,88 @@ pub struct ConfirmRequest {
     pub txn_id: String,
 }
 
-// ── Orphan-interface detection ────────────────────────────────
+// ── Absent-device handling ────────────────────────────────────
 //
-// An entry in `interfaces[]` is "orphan" when its name doesn't
-// correspond to any real device on the system AND isn't a name the
-// user has reserved for a configured-but-not-yet-applied virtual
-// interface (bond/bridge/vlan).  Mostly happens when the kernel
-// renames a device (Mellanox short→suffix names) or when the user
-// deletes a bond from the UI but its underlying-physical entries
-// linger.  Without cleanup the layered model still emits a
-// `Physical` link for these, and the next legitimate bond create
-// fails validation with a duplicate-name conflict.
+// Persisted config is operator intent; a device being absent from
+// sysfs *right now* is an observation.  The two get out of sync
+// constantly and legitimately: the kernel renames a NIC across a
+// reboot (Mellanox short→suffix names), an SR-IOV VF hasn't been
+// created yet when the engine starts, a card is temporarily
+// reseated.  We therefore NEVER auto-delete `interfaces[]` entries
+// on liveness (an earlier engine did, and permanently destroyed
+// operator config on every rename or transient absence — #602).
+//
+// The two problems that pruning used to solve are handled without
+// destroying intent:
+//
+// - **NM must not see profiles for absent physical devices** —
+//   otherwise NM keeps trying to activate them at boot, `nm-online`
+//   never reaches `startup-complete`, and
+//   `NetworkManager-wait-online` fails upgrades (exit 4, discussion
+//   #159).  Solved by filtering the *desired profile set* through
+//   `retain_live_physical_profiles` at every point it's computed
+//   (apply, preview, startup reconcile).  The config keeps the
+//   entry; NM only ever sees profiles for devices that exist.
+//
+// - **A stale entry must not block re-using its name for a new
+//   bond/bridge/VLAN** (the layered validator's duplicate-name
+//   check).  Solved by `supersede_absent_physical_entries` inside
+//   `update()`: when an explicit user action introduces a virtual
+//   device whose name collides with a config entry whose device is
+//   absent, the stale entry is dropped as part of that update —
+//   newer intent replaces older intent.  Entries whose device is
+//   LIVE are kept, so the duplicate-name error still protects
+//   against clobbering a real NIC's config.
 
-/// Find names of orphan `interfaces[]` entries.  Pure — live state
-/// passed in explicitly so this is testable without sysfs.
-///
-/// Both signals required to flag a name (no live device AND not
-/// claimed by any virtual master), so:
-///
-/// - a down-but-still-in-sysfs NIC stays (it's in `live`),
-/// - a freshly-added bond that hasn't been applied yet stays
-///   (it's in `bonds[]` / `bridges[]` / `vlans[]`),
-/// - only true leftovers are returned.
-fn find_orphan_interfaces(cfg: &NetworkConfig, live: &[LiveInterface]) -> Vec<String> {
-    use std::collections::HashSet;
-    let live_names: HashSet<&str> = live.iter().map(|i| i.name.as_str()).collect();
-    let bond_names: HashSet<&str> = cfg.bonds.iter().map(|b| b.name.as_str()).collect();
-    let bridge_names: HashSet<&str> = cfg.bridges.iter().map(|b| b.name.as_str()).collect();
-    let vlan_names: HashSet<String> = cfg
-        .vlans
-        .iter()
-        .map(|v| format!("{}.{}", v.parent, v.vlan_id))
-        .collect();
-    cfg.interfaces
-        .iter()
-        .filter(|i| {
-            !live_names.contains(i.name.as_str())
-                && !bond_names.contains(i.name.as_str())
-                && !bridge_names.contains(i.name.as_str())
-                && !vlan_names.contains(&i.name)
+/// Drop desired NM profiles that target an absent physical device.
+/// Virtual links (bond/bridge/vlan/macvlan) are always kept — NM is
+/// the one who *creates* those devices, so "absent" is their normal
+/// pre-apply state.  Pure — live names passed in explicitly so this
+/// is testable without sysfs.
+fn retain_live_physical_profiles(
+    profiles: Vec<nm::NmConnection>,
+    live_names: &std::collections::HashSet<String>,
+) -> Vec<nm::NmConnection> {
+    profiles
+        .into_iter()
+        .filter(|p| {
+            !matches!(p.conn_type, nm::NmConnectionType::Ethernet)
+                || live_names.contains(&p.interface_name)
         })
-        .map(|i| i.name.clone())
         .collect()
 }
 
-/// Strip the named entries from `cfg.interfaces[]`.  Touches
-/// nothing else — bonds, bridges, VLANs, DNS, etc. stay as-is.
-fn prune_orphan_interfaces(cfg: &mut NetworkConfig, names: &[String]) {
-    let drop: std::collections::HashSet<&str> = names.iter().map(|s| s.as_str()).collect();
-    cfg.interfaces.retain(|i| !drop.contains(i.name.as_str()));
+/// Drop `interfaces[]` entries whose name is being taken over by a
+/// bond/bridge/VLAN/macvlan in the same config AND whose device is
+/// absent.  Returns the superseded names (for logging).  Entries
+/// with a live device are left alone — the layered validator's
+/// duplicate-name check will then reject the update, which is the
+/// right outcome for a name collision with real hardware.
+fn supersede_absent_physical_entries(
+    cfg: &mut NetworkConfig,
+    live_names: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut virtual_names: HashSet<String> = cfg.bonds.iter().map(|b| b.name.clone()).collect();
+    virtual_names.extend(cfg.bridges.iter().map(|b| b.name.clone()));
+    virtual_names.extend(cfg.macvlans.iter().map(|m| m.name.clone()));
+    virtual_names.extend(
+        cfg.vlans
+            .iter()
+            .map(|v| format!("{}.{}", v.parent, v.vlan_id)),
+    );
+
+    let superseded: Vec<String> = cfg
+        .interfaces
+        .iter()
+        .filter(|i| virtual_names.contains(&i.name) && !live_names.contains(&i.name))
+        .map(|i| i.name.clone())
+        .collect();
+    if !superseded.is_empty() {
+        let drop: HashSet<&str> = superseded.iter().map(|s| s.as_str()).collect();
+        cfg.interfaces.retain(|i| !drop.contains(i.name.as_str()));
+    }
+    superseded
 }
 
 // ── Service ────────────────────────────────────────────────────
@@ -476,7 +509,29 @@ impl NetworkService {
         // form, so reboot reapplies the same L3 we just applied at runtime.
         let prev = load_config().await;
         let live = LiveTopology::snapshot().await;
-        let config = resolve_inherit(config, &prev, &live);
+        let mut config = resolve_inherit(config, &prev, &live);
+
+        // A virtual device may take over the name of a stale
+        // `interfaces[]` entry whose physical device is gone (kernel
+        // rename left it behind). Drop such entries as part of this
+        // explicit update so the layered validator's duplicate-name
+        // check doesn't refuse the create; live-device collisions
+        // still fail validation as before.
+        let live_names: std::collections::HashSet<String> = enumerate_interfaces()
+            .await
+            .into_iter()
+            .map(|i| i.name)
+            .collect();
+        let superseded = supersede_absent_physical_entries(&mut config, &live_names);
+        if !superseded.is_empty() {
+            info!(
+                "network update: superseded stale absent-device entr{} {:?} \
+                 (name taken over by a new virtual interface)",
+                if superseded.len() == 1 { "y" } else { "ies" },
+                superseded
+            );
+        }
+        let config = config;
 
         // Decide whether this change needs a rollback timer. The classifier
         // looks for changes that touch the management iface — anything that
@@ -665,80 +720,34 @@ impl NetworkService {
         enumerate_interfaces().await
     }
 
-    /// Idempotent startup pass: drop `interfaces[]` entries with no
-    /// corresponding live device or virtual master claim, then
-    /// delete `nasty-*` NM connection profiles that no longer
-    /// correspond to anything our config emits.
+    /// Idempotent startup pass: delete `nasty-*` NM connection
+    /// profiles that no longer correspond to anything our config
+    /// emits *for the devices that exist right now*.
     ///
-    /// Two distinct shapes of orphan, both real:
-    ///
-    /// - **networking.json orphans** — a user deletes a bond from
-    ///   the WebUI but the bond's underlying physical interfaces
-    ///   stay in `interfaces[]` even after the master goes.  Or
-    ///   the kernel renames an interface across reboots (Mellanox
-    ///   `eth0` → `enp6s0f0np0`) but the old name stayed cached
-    ///   in `interfaces[]` from a previous boot.  Either way the
-    ///   layered model emits a stray `Physical` link, NM gets a
-    ///   profile for an interface that doesn't exist, and the
-    ///   next bond create on a real interface name fails the
-    ///   validator's duplicate-name check.
-    ///
-    /// - **NM profile orphans** — same root cause from NM's side:
-    ///   `nasty-<name>` profiles persisted to
-    ///   `/etc/NetworkManager/system-connections/` for interfaces
-    ///   that are gone.  Without cleanup NM keeps trying to
-    ///   activate them at every boot; `nm-online` can never reach
-    ///   `startup-complete` and `NetworkManager-wait-online`
-    ///   fails the upgrade (exit 4, the symptom in discussion
-    ///   #159).
+    /// Persisted config is deliberately NOT touched here — see the
+    /// "Absent-device handling" section above.  A `nasty-<name>`
+    /// profile is orphan when it isn't in the desired set, which
+    /// covers both real orphans (config entry deleted) and profiles
+    /// for currently-absent devices (kernel rename, SR-IOV VF not
+    /// created yet).  The latter come back automatically on the
+    /// next apply once the device exists; meanwhile keeping them
+    /// out of NM is what keeps `NetworkManager-wait-online` green
+    /// during upgrades (exit 4, the symptom in discussion #159).
     ///
     /// Best-effort: warnings on every failed sub-step, no error
     /// propagation upward.  Engine startup must not block on this.
     pub async fn reconcile_orphans(&self) {
-        let mut cfg = load_config().await;
+        let cfg = load_config().await;
         let live = enumerate_interfaces().await;
+        let live_names: std::collections::HashSet<String> =
+            live.into_iter().map(|i| i.name).collect();
 
-        // Step 1: prune stale interfaces[] entries.
-        let orphans = find_orphan_interfaces(&cfg, &live);
-        if !orphans.is_empty() {
-            warn!(
-                "reconcile_orphans: pruning {} stale interfaces[] entr{}: {:?}",
-                orphans.len(),
-                if orphans.len() == 1 { "y" } else { "ies" },
-                orphans
-            );
-            prune_orphan_interfaces(&mut cfg, &orphans);
-            if let Err(e) = persist_config(&cfg).await {
-                warn!(
-                    "reconcile_orphans: persist after prune failed: {e}; \
-                     continuing with in-memory cleaned config"
-                );
-            }
-            // Strip dangling firewall references too — same shape:
-            // user restricted a protocol to bond0, deleted bond0
-            // from the network UI, the firewall rule kept the ref
-            // and the dropdown source no longer offers it so the
-            // user can't unselect it manually.
-            let mut restrictions = crate::firewall::FirewallRestrictions::load();
-            if restrictions.strip_iface_refs(&orphans) {
-                if let Err(e) = restrictions.save().await {
-                    warn!(
-                        "reconcile_orphans: persist firewall restrictions \
-                         after iface strip failed: {e}"
-                    );
-                } else {
-                    info!(
-                        "reconcile_orphans: stripped firewall references \
-                         to pruned interface(s)"
-                    );
-                }
-            }
-        }
-
-        // Step 2: delete `nasty-*` NM profiles not in the desired
-        // set.  Compute the desired set from the (now-pruned)
-        // layered config; anything else with our prefix is orphan.
-        let desired = nm::to_nm_profiles(&layered::to_layered(&cfg));
+        // Delete `nasty-*` NM profiles not in the (presence-filtered)
+        // desired set; anything else with our prefix is orphan.
+        let desired = retain_live_physical_profiles(
+            nm::to_nm_profiles(&layered::to_layered(&cfg)),
+            &live_names,
+        );
         let desired_ids: std::collections::HashSet<&str> =
             desired.iter().map(|p| p.id.as_str()).collect();
 
@@ -788,7 +797,14 @@ impl NetworkService {
     pub async fn nm_preview(&self) -> Result<nm::dbus::NmDiff, String> {
         let cfg = load_config().await;
         let layered_cfg = layered::to_layered(&cfg);
-        let desired = nm::to_nm_profiles(&layered_cfg);
+        let live_names: std::collections::HashSet<String> = enumerate_interfaces()
+            .await
+            .into_iter()
+            .map(|i| i.name)
+            .collect();
+        // Same presence filter as apply_config, so the preview
+        // reflects what an apply would actually push.
+        let desired = retain_live_physical_profiles(nm::to_nm_profiles(&layered_cfg), &live_names);
 
         let client = nm::dbus::NmDbusClient::new().await?;
         let existing = client.list_nasty_connections().await?;
@@ -806,7 +822,12 @@ impl NetworkService {
     pub async fn nm_apply(&self) -> Result<nm::dbus::NmApplyOutcome, String> {
         let cfg = load_config().await;
         let layered_cfg = layered::to_layered(&cfg);
-        let desired = nm::to_nm_profiles(&layered_cfg);
+        let live_names: std::collections::HashSet<String> = enumerate_interfaces()
+            .await
+            .into_iter()
+            .map(|i| i.name)
+            .collect();
+        let desired = retain_live_physical_profiles(nm::to_nm_profiles(&layered_cfg), &live_names);
 
         let client = nm::dbus::NmDbusClient::new().await?;
         nm::dbus::apply_profiles(&client, &desired).await
@@ -1638,17 +1659,21 @@ async fn apply_config(
     // member's MAC. Without this, NM creates the master with a
     // random MAC and DHCP gives it a new lease — which yanks the
     // user's session if they're enslaving the management iface.
-    let live_macs = enumerate_interfaces()
-        .await
-        .into_iter()
-        .map(|i| (i.name, i.mac))
-        .collect();
+    let live = enumerate_interfaces().await;
+    let live_names: std::collections::HashSet<String> =
+        live.iter().map(|i| i.name.clone()).collect();
+    let live_macs = live.into_iter().map(|i| (i.name, i.mac)).collect();
     let mac_ctx = nm::MacContext {
         live_macs,
         mgmt_iface: mgmt_iface.map(|s| s.to_string()),
     };
     let layered_cfg = layered::to_layered(config);
-    let profiles = nm::to_nm_profiles_with_macs(&layered_cfg, &mac_ctx);
+    // Presence filter: profiles for configured-but-absent physical
+    // devices are withheld from NM (see "Absent-device handling").
+    let profiles = retain_live_physical_profiles(
+        nm::to_nm_profiles_with_macs(&layered_cfg, &mac_ctx),
+        &live_names,
+    );
     let client = nm::dbus::NmDbusClient::new()
         .await
         .map_err(|e| format!("connect to NetworkManager: {e}"))?;
@@ -2397,76 +2422,45 @@ mod tests {
         }
     }
 
-    // ── orphan-interface detection ────────────────────────────
+    // ── absent-device handling ─────────────────────────────────
 
-    fn live(name: &str) -> LiveInterface {
-        LiveInterface {
-            name: name.to_string(),
-            mac: "00:00:00:00:00:00".to_string(),
-            up: true,
-            speed_mbps: None,
-            carrier: true,
-            ipv4_addresses: Vec::new(),
-            ipv6_addresses: Vec::new(),
-            mtu: 1500,
-            kind: "physical".to_string(),
-        }
+    fn live_set(names: &[&str]) -> std::collections::HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Project a config to desired profiles the same way the apply
+    /// path does — keeps these tests honest against the real
+    /// layered→NM pipeline instead of hand-built profiles.
+    fn profiles_of(cfg: &NetworkConfig) -> Vec<nm::NmConnection> {
+        nm::to_nm_profiles(&layered::to_layered(cfg))
     }
 
     #[test]
-    fn find_orphan_flags_interfaces_with_no_live_or_virtual_match() {
-        // The Mellanox case: networking.json carries enp6s0f0
-        // (the kernel-renamed-away short name) plus the current
-        // enp6s0f0np0.  Only the latter exists in `live`.  The
-        // orphan check must flag the short name so the next bond
-        // create doesn't fail validation.
+    fn presence_filter_withholds_absent_physical_profiles() {
+        // The Mellanox-rename / SR-IOV-VF case: config carries
+        // enp6s0f0 (absent) and enp6s0f0np0 (live).  The desired NM
+        // set must include only the live one — an absent-device
+        // profile would stall NetworkManager-wait-online at the
+        // next upgrade (discussion #159).  Crucially the CONFIG
+        // keeps both entries: intent is never auto-deleted.
         let cfg = NetworkConfig {
-            interfaces: vec![iface("enp4s0"), iface("enp6s0f0"), iface("enp6s0f0np0")],
+            interfaces: vec![iface("enp6s0f0"), iface("enp6s0f0np0")],
             ..Default::default()
         };
-        let live_state = vec![live("enp4s0"), live("enp6s0f0np0")];
-        assert_eq!(find_orphan_interfaces(&cfg, &live_state), vec!["enp6s0f0"]);
+        let kept = retain_live_physical_profiles(profiles_of(&cfg), &live_set(&["enp6s0f0np0"]));
+        let ids: Vec<_> = kept.iter().map(|p| p.interface_name.as_str()).collect();
+        assert_eq!(ids, vec!["enp6s0f0np0"]);
     }
 
     #[test]
-    fn find_orphan_does_not_flag_freshly_added_bond_pre_apply() {
-        // User added bond0 to bonds[] but hasn't clicked Apply yet
-        // — no live bond0 device.  We must not flag it as orphan;
-        // the bonds[] entry is the user's documented intent.
+    fn presence_filter_keeps_virtual_links_even_when_absent() {
+        // bond0 / br0 / eth0.100 don't exist until NM creates them —
+        // absence is their normal pre-apply state, so the filter
+        // must never drop virtual-link profiles. Their live member
+        // (eth0) stays too.
         let cfg = NetworkConfig {
-            interfaces: vec![iface("eth0")],
+            interfaces: vec![],
             bonds: vec![bond("bond0", &["eth0"])],
-            ..Default::default()
-        };
-        let live_state = vec![live("eth0")];
-        assert!(find_orphan_interfaces(&cfg, &live_state).is_empty());
-    }
-
-    #[test]
-    fn find_orphan_does_not_flag_down_nic_still_in_sysfs() {
-        // A NIC that's been unplugged but is still in sysfs (cable
-        // out, USB NIC removed and re-inserted, ...) shows up in
-        // `live` with `up=false carrier=false`.  We must NOT strip
-        // its config entry — losing the saved IP/DHCP settings the
-        // user expects back when the cable is reconnected would
-        // be its own bug.
-        let cfg = NetworkConfig {
-            interfaces: vec![iface("eth0")],
-            ..Default::default()
-        };
-        let mut down = live("eth0");
-        down.up = false;
-        down.carrier = false;
-        assert!(find_orphan_interfaces(&cfg, &[down]).is_empty());
-    }
-
-    #[test]
-    fn find_orphan_respects_bridge_and_vlan_names_too() {
-        // Symmetric check: an interfaces[] entry whose name matches
-        // any virtual master (bond / bridge / vlan) is user intent,
-        // not orphan.
-        let cfg = NetworkConfig {
-            interfaces: vec![iface("br0"), iface("eth0.100")],
             bridges: vec![bridge("br0", &[])],
             vlans: vec![VlanConfig {
                 parent: "eth0".to_string(),
@@ -2477,27 +2471,109 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(find_orphan_interfaces(&cfg, &[]).is_empty());
+        let all = profiles_of(&cfg);
+        let total = all.len();
+        let kept = retain_live_physical_profiles(all, &live_set(&["eth0"]));
+        assert_eq!(kept.len(), total, "no virtual profile may be dropped");
     }
 
     #[test]
-    fn prune_orphan_interfaces_removes_only_the_named_entries() {
-        let mut cfg = NetworkConfig {
-            interfaces: vec![iface("eth0"), iface("bond0"), iface("eth1")],
+    fn presence_filter_withholds_absent_member_profiles() {
+        // A bond member whose NIC is currently missing: the member's
+        // ethernet profile is withheld (comes back on the next apply
+        // after the device reappears), the bond itself stays.
+        let cfg = NetworkConfig {
+            bonds: vec![bond("bond0", &["eth0", "eth1"])],
             ..Default::default()
         };
-        prune_orphan_interfaces(&mut cfg, &["bond0".to_string()]);
-        let names: Vec<_> = cfg.interfaces.iter().map(|i| i.name.as_str()).collect();
-        assert_eq!(names, vec!["eth0", "eth1"]);
+        let kept = retain_live_physical_profiles(profiles_of(&cfg), &live_set(&["eth0"]));
+        let names: Vec<_> = kept.iter().map(|p| p.interface_name.as_str()).collect();
+        assert!(names.contains(&"bond0"));
+        assert!(names.contains(&"eth0"));
+        assert!(!names.contains(&"eth1"));
     }
 
     #[test]
-    fn prune_orphan_interfaces_is_a_noop_when_list_empty() {
+    fn supersede_drops_absent_entry_taken_over_by_virtual_name() {
+        // A stale entry for a renamed-away NIC ("eth0") lingers; the
+        // user now creates a bond named eth0.  The explicit action
+        // wins: the stale entry is dropped so the duplicate-name
+        // check doesn't refuse the bond.
+        let mut cfg = NetworkConfig {
+            interfaces: vec![iface("eth0"), iface("enp4s0")],
+            bonds: vec![bond("eth0", &["enp4s0"])],
+            ..Default::default()
+        };
+        let superseded = supersede_absent_physical_entries(&mut cfg, &live_set(&["enp4s0"]));
+        assert_eq!(superseded, vec!["eth0"]);
+        let names: Vec<_> = cfg.interfaces.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["enp4s0"]);
+    }
+
+    #[test]
+    fn supersede_leaves_live_device_collisions_for_the_validator() {
+        // Same collision but the device actually exists: do NOT
+        // silently drop the config of real hardware — the layered
+        // validator's duplicate-name error is the right outcome.
         let mut cfg = NetworkConfig {
             interfaces: vec![iface("eth0")],
+            bonds: vec![bond("eth0", &["enp4s0"])],
             ..Default::default()
         };
-        prune_orphan_interfaces(&mut cfg, &[]);
+        let superseded =
+            supersede_absent_physical_entries(&mut cfg, &live_set(&["eth0", "enp4s0"]));
+        assert!(superseded.is_empty());
         assert_eq!(cfg.interfaces.len(), 1);
+    }
+
+    #[test]
+    fn supersede_ignores_absent_entries_without_a_name_collision() {
+        // An absent-device entry nobody is claiming stays put —
+        // that's the whole point of the fix (config survives
+        // renames and transient VF absence).
+        let mut cfg = NetworkConfig {
+            interfaces: vec![iface("enp6s0f0"), iface("eth9")],
+            bonds: vec![bond("bond0", &["enp4s0"])],
+            vlans: vec![VlanConfig {
+                parent: "eth9".to_string(),
+                vlan_id: 100,
+                ipv4: IpConfig::default(),
+                ipv6: IpConfig::default(),
+                mtu: None,
+            }],
+            ..Default::default()
+        };
+        let superseded = supersede_absent_physical_entries(&mut cfg, &live_set(&["enp4s0"]));
+        assert!(superseded.is_empty());
+        assert_eq!(cfg.interfaces.len(), 2);
+    }
+
+    #[test]
+    fn supersede_handles_vlan_and_macvlan_name_forms() {
+        // VLAN names are `{parent}.{id}`; macvlans are plain names.
+        // Both can take over a stale absent entry.
+        let mut cfg = NetworkConfig {
+            interfaces: vec![iface("eth0.100"), iface("mv0")],
+            vlans: vec![VlanConfig {
+                parent: "eth0".to_string(),
+                vlan_id: 100,
+                ipv4: IpConfig::default(),
+                ipv6: IpConfig::default(),
+                mtu: None,
+            }],
+            macvlans: vec![MacvlanConfig {
+                name: "mv0".to_string(),
+                parent: "eth0".to_string(),
+                mode: "bridge".to_string(),
+                ipv4: IpConfig::default(),
+                mtu: None,
+                routes: Vec::new(),
+            }],
+            ..Default::default()
+        };
+        let mut superseded = supersede_absent_physical_entries(&mut cfg, &live_set(&["eth0"]));
+        superseded.sort();
+        assert_eq!(superseded, vec!["eth0.100", "mv0"]);
+        assert!(cfg.interfaces.is_empty());
     }
 }

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -84,6 +84,36 @@
 	const network = $derived.by((): NetworkConfig | null => {
 		return networkState?.config ?? null;
 	});
+	// Config entries whose device is gone right now (kernel rename,
+	// SR-IOV VF not created yet, card reseated). The engine keeps them
+	// on purpose — surface them so the operator can see the saved
+	// config and remove genuinely stale entries, instead of them
+	// lingering invisibly.
+	const absentConfigured = $derived.by((): InterfaceConfig[] => {
+		if (!networkState || !network) return [];
+		const liveNames = new Set(networkState.interfaces.map(i => i.name));
+		const virtualNames = new Set([
+			...(network.bonds || []).map(b => b.name),
+			...(network.bridges || []).map(b => b.name),
+			...(network.vlans || []).map(v => `${v.parent}.${v.vlan_id}`),
+		]);
+		return (network.interfaces || []).filter(
+			c => !liveNames.has(c.name) && !virtualNames.has(c.name),
+		);
+	});
+
+	async function removeAbsentEntry(name: string) {
+		if (!network) return;
+		const payload: NetworkConfig = {
+			interfaces: (network.interfaces || []).filter(i => i.name !== name),
+			dns: network.dns || [],
+			bonds: network.bonds || [],
+			vlans: network.vlans || [],
+			bridges: network.bridges || [],
+		};
+		await applyNetworkUpdate(payload, `Removed saved config for absent device ${name}`);
+		networkState = await client.call<NetworkState>('system.network.get');
+	}
 	let savingNetwork = $state(false);
 	let netDhcp = $state(true);
 	let netGateway = $state('');
@@ -1023,6 +1053,21 @@
 									{/if}
 								</div>
 							{/if}
+						</div>
+					{/each}
+					{#each absentConfigured as entry (entry.name)}
+						<div class="flex items-center gap-4 rounded-lg border border-dashed border-border px-4 py-3 opacity-70">
+							<div class="flex-1 min-w-0">
+								<div class="flex items-center gap-2">
+									<span class="font-mono text-sm font-medium">{entry.name}</span>
+									<Badge variant="secondary" class="text-[0.6rem]">Device absent</Badge>
+									<Badge variant="outline" class="text-[0.6rem]">Configured</Badge>
+								</div>
+								<div class="mt-0.5 text-xs text-muted-foreground">
+									Saved configuration kept — the device isn't present right now (renamed, removed, or not yet created). It reapplies automatically when the device returns.
+								</div>
+							</div>
+							<Button size="xs" variant="ghost" onclick={() => removeAbsentEntry(entry.name)}>Remove</Button>
 						</div>
 					{/each}
 				</div>


### PR DESCRIPTION
Saved network configuration is now durable across kernel NIC renames, hardware changes, and devices that appear late or intermittently (SR-IOV VFs, reseated cards). Fixes #609; groundwork for #602.

## What changed

Persisted config is treated as operator intent and is never auto-deleted. Previously the startup reconcile pruned any `interfaces[]` entry whose device wasn't in sysfs at that moment — destroying saved config (plus firewall refs and NM profiles) on every rename or transient absence, as reported by @dsevost in #602.

The two problems the prune used to solve are handled without destroying intent:

- **`NetworkManager-wait-online` stays green (discussion #159) by construction:** the desired NM profile set is presence-filtered wherever it's computed (apply, preview, `nm_apply`, startup reconcile). NM only ever sees profiles for devices that exist; a withheld profile reappears automatically on the next apply once its device does.
- **Names remain reusable:** a new bond/bridge/VLAN whose name collides with a stale absent-device entry supersedes it as part of that explicit update. Collisions with live devices still fail the duplicate-name validation as before.

The WebUI now shows configured-but-absent interfaces as ghost rows — saved config visibly kept, with an explicit Remove action — instead of entries silently vanishing (or, now, silently lingering).

## Validation

Live on the dev box (v0.0.13 baseline vs this branch):

- Baseline reproduces #609 exactly: absent-device entry pruned on engine restart (`reconcile_orphans: pruning 1 stale interfaces[] entry`), NM profile pushed-then-deleted.
- With this branch: same entry **survives engine restart**; no NM profile is written for it (`system-connections` clean, no apply errors); creating a bridge that takes over the stale name logs `superseded stale absent-device entry ["enp9s99"]` and proceeds; restoring the config cleanly sweeps profiles and devices.
- 7 new hermetic unit tests (presence filter incl. virtual-link and bond-member cases; supersede incl. live-collision and vlan/macvlan name forms); all 128 network tests pass; workspace clippy `--all-targets` and svelte-check clean.

Note for reviewers: `find_orphan_interfaces` / `prune_orphan_interfaces` and the firewall `strip_iface_refs` call are gone from the reconcile path; `strip_iface_refs` itself remains (still unit-tested) in case an explicit-delete flow wants it later.