### PR TITLE
net: SR-IOV virtual function management

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -65,6 +65,13 @@ pub struct InterfaceConfig {
     pub ipv6: IpConfig,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u16>,
+    /// SR-IOV: number of virtual functions to create on this physical
+    /// function. `None` = leave the device alone (default; also what
+    /// every pre-SR-IOV config deserializes to). `Some(0)` explicitly
+    /// removes previously-created VFs. Only meaningful on SR-IOV-capable
+    /// devices — `update()` validates against live `sriov_totalvfs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
 }
 
 fn default_true() -> bool {
@@ -233,6 +240,21 @@ pub struct LiveInterface {
     pub mtu: u32,
     /// "physical", "infiniband", "bond", "vlan", "bridge", "tunnel"
     pub kind: String,
+    /// SR-IOV PF: maximum VFs the device supports (`sriov_totalvfs`).
+    /// `None` for non-SR-IOV devices and for VFs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_total_vfs: Option<u32>,
+    /// SR-IOV PF: currently-created VF count (`sriov_numvfs`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
+    /// SR-IOV VF: netdev name of the parent physical function, when
+    /// resolvable through `device/physfn/net/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vf_of: Option<String>,
+    /// SR-IOV VF: index within the parent (which `virtfn<N>` symlink
+    /// points at this device).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vf_index: Option<u32>,
 }
 
 /// Full network state returned by `system.network.get`.
@@ -411,6 +433,39 @@ fn reject_infiniband_refs(
                  parent",
                 mv.parent
             ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate SR-IOV VF-count requests against live capability. Pure —
+/// `live_caps` maps live interface name → `sriov_totalvfs` (None when
+/// the device exists but isn't SR-IOV-capable). A configured-but-absent
+/// device passes (intent is kept; the presence filter withholds its
+/// profile until it exists).
+fn validate_sriov(
+    cfg: &NetworkConfig,
+    live_caps: &std::collections::HashMap<String, Option<u32>>,
+) -> Result<(), String> {
+    for iface in &cfg.interfaces {
+        let Some(n) = iface.sriov_num_vfs else {
+            continue;
+        };
+        match live_caps.get(&iface.name) {
+            Some(Some(total)) if n > *total => {
+                return Err(format!(
+                    "'{}' supports at most {total} virtual functions (requested {n})",
+                    iface.name
+                ));
+            }
+            Some(None) => {
+                return Err(format!(
+                    "'{}' is not SR-IOV capable — it exposes no sriov_totalvfs; \
+                     VF count cannot be configured on it",
+                    iface.name
+                ));
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -678,6 +733,13 @@ impl NetworkService {
         // (Plain L3 on an IB port is fine: it renders as IPoIB.)
         reject_infiniband_refs(&config, &live_kinds)?;
 
+        // SR-IOV VF counts must fit the device's capability.
+        let live_sriov_caps: std::collections::HashMap<String, Option<u32>> = live_ifaces
+            .iter()
+            .map(|i| (i.name.clone(), i.sriov_total_vfs))
+            .collect();
+        validate_sriov(&config, &live_sriov_caps)?;
+
         // A virtual device may take over the name of a stale
         // `interfaces[]` entry whose physical device is gone (kernel
         // rename left it behind). Drop such entries as part of this
@@ -721,7 +783,7 @@ impl NetworkService {
                 .map_err(|e| format!("write {PENDING_REVERT_PATH}: {e}"))?;
 
             persist_config(&config).await?;
-            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_with_vf_settle(&config, mgmt_iface.as_deref(), &live_names).await?;
 
             let txn_id = new_txn_id();
             let revert_at_unix = unix_now() + secs;
@@ -745,7 +807,7 @@ impl NetworkService {
             })
         } else {
             persist_config(&config).await?;
-            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_with_vf_settle(&config, mgmt_iface.as_deref(), &live_names).await?;
 
             info!(
                 "Network config updated ({} interfaces, {} bonds, {} bridges, {} VLANs)",
@@ -1330,6 +1392,7 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
 
         let ipv4_addresses = get_addresses(&name, false).await;
         let ipv6_addresses = get_addresses(&name, true).await;
+        let sriov = sriov_metadata(&path);
 
         result.push(LiveInterface {
             name,
@@ -1341,6 +1404,10 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
             ipv6_addresses,
             mtu,
             kind: kind.to_string(),
+            sriov_total_vfs: sriov.total_vfs,
+            sriov_num_vfs: sriov.num_vfs,
+            vf_of: sriov.vf_of,
+            vf_index: sriov.vf_index,
         });
     }
 
@@ -1357,6 +1424,60 @@ fn infiniband_names(live: &[LiveInterface]) -> std::collections::HashSet<String>
         .filter(|i| i.kind == "infiniband")
         .map(|i| i.name.clone())
         .collect()
+}
+
+#[derive(Default)]
+struct SriovMetadata {
+    total_vfs: Option<u32>,
+    num_vfs: Option<u32>,
+    vf_of: Option<String>,
+    vf_index: Option<u32>,
+}
+
+/// Read the SR-IOV family facts for one netdev from sysfs.
+/// `path` is `/sys/class/net/<name>`. PFs expose
+/// `device/sriov_totalvfs` + `device/sriov_numvfs`; VFs expose a
+/// `device/physfn` symlink to the parent PCI function, whose
+/// `virtfn<N>` symlinks give the VF its index and whose `net/` dir
+/// names the parent netdev.
+fn sriov_metadata(path: &std::path::Path) -> SriovMetadata {
+    let dev = path.join("device");
+    let read_u32 = |f: &str| -> Option<u32> {
+        std::fs::read_to_string(dev.join(f))
+            .ok()?
+            .trim()
+            .parse()
+            .ok()
+    };
+
+    let mut out = SriovMetadata {
+        total_vfs: read_u32("sriov_totalvfs"),
+        num_vfs: read_u32("sriov_numvfs"),
+        ..Default::default()
+    };
+
+    let physfn = dev.join("physfn");
+    if let Ok(pf_dir) = std::fs::canonicalize(&physfn) {
+        // Parent netdev name (first entry of the PF's net/ dir).
+        out.vf_of = std::fs::read_dir(pf_dir.join("net"))
+            .ok()
+            .and_then(|mut d| d.next()?.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string());
+        // Our index: which virtfn<N> the PF points back at us with.
+        if let (Ok(me), Ok(entries)) = (std::fs::canonicalize(&dev), std::fs::read_dir(&pf_dir)) {
+            for entry in entries.flatten() {
+                let fname = entry.file_name().to_string_lossy().to_string();
+                if let Some(n) = fname.strip_prefix("virtfn")
+                    && let Ok(idx) = n.parse::<u32>()
+                    && std::fs::canonicalize(entry.path()).is_ok_and(|t| t == me)
+                {
+                    out.vf_index = Some(idx);
+                    break;
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Classify an interface from its sysfs shape. Pure so the
@@ -1865,6 +1986,36 @@ fn outcome_to_apply_errors(outcome: &nm::dbus::NmApplyOutcome) -> Vec<NetworkApp
         .collect()
 }
 
+/// Apply, and when the update both creates VFs (a PF has a VF count)
+/// and configures interfaces that don't exist yet (the VFs
+/// themselves), give NM a moment to materialize the VFs and apply
+/// once more — otherwise the presence filter withholds the VF
+/// profiles until the *next* apply and "set count + configure VF" in
+/// one update needs two clicks. One retry only; the second outcome
+/// wins (it saw the fuller device set).
+async fn apply_with_vf_settle(
+    config: &NetworkConfig,
+    mgmt_iface: Option<&str>,
+    live_names_at_validate: &std::collections::HashSet<String>,
+) -> Result<nm::dbus::NmApplyOutcome, String> {
+    let outcome = apply_config(config, mgmt_iface).await?;
+
+    let creates_vfs = config
+        .interfaces
+        .iter()
+        .any(|i| i.sriov_num_vfs.unwrap_or(0) > 0);
+    let has_absent_config = config
+        .interfaces
+        .iter()
+        .any(|i| !live_names_at_validate.contains(&i.name));
+    if creates_vfs && has_absent_config {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        info!("network apply: re-applying after SR-IOV VF settle");
+        return apply_config(config, mgmt_iface).await;
+    }
+    Ok(outcome)
+}
+
 async fn apply_config(
     config: &NetworkConfig,
     mgmt_iface: Option<&str>,
@@ -2014,6 +2165,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            sriov_num_vfs: None,
         }
     }
 
@@ -2931,6 +3083,82 @@ mod tests {
             retain_live_physical_profiles(profiles, &live_set(&["ib0"])).len(),
             1
         );
+    }
+
+    #[test]
+    fn sriov_validation_rules() {
+        let caps: std::collections::HashMap<String, Option<u32>> = [
+            ("enp6s0f0".to_string(), Some(Some(8))),
+            ("eth0".to_string(), Some(None)),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k, v.unwrap()))
+        .collect();
+
+        let mut pf = iface("enp6s0f0");
+        pf.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![pf],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "within capability");
+
+        let mut too_many = iface("enp6s0f0");
+        too_many.sriov_num_vfs = Some(16);
+        let cfg = NetworkConfig {
+            interfaces: vec![too_many],
+            ..Default::default()
+        };
+        assert!(
+            validate_sriov(&cfg, &caps)
+                .unwrap_err()
+                .contains("at most 8"),
+            "over capability"
+        );
+
+        let mut not_capable = iface("eth0");
+        not_capable.sriov_num_vfs = Some(2);
+        let cfg = NetworkConfig {
+            interfaces: vec![not_capable],
+            ..Default::default()
+        };
+        assert!(
+            validate_sriov(&cfg, &caps)
+                .unwrap_err()
+                .contains("not SR-IOV capable"),
+            "non-capable device"
+        );
+
+        // Absent device: intent kept, validation passes (presence
+        // filter withholds the profile until it exists).
+        let mut ghost = iface("enp99s0");
+        ghost.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![ghost],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "absent device");
+
+        // Explicit zero (remove VFs) is always fine on a capable PF.
+        let mut zero = iface("enp6s0f0");
+        zero.sriov_num_vfs = Some(0);
+        let cfg = NetworkConfig {
+            interfaces: vec![zero],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "zero VFs");
+    }
+
+    #[test]
+    fn sriov_round_trips_through_layered() {
+        let mut pf = iface("enp6s0f0");
+        pf.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![pf],
+            ..Default::default()
+        };
+        let layered = layered::to_layered(&cfg);
+        assert_eq!(layered.links[0].sriov_num_vfs, Some(4));
     }
 
     #[test]

--- a/engine/nasty-system/src/network/layered.rs
+++ b/engine/nasty-system/src/network/layered.rs
@@ -51,6 +51,10 @@ pub struct Link {
     /// member MAC for bridges, hardware MAC for physical).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
+    /// SR-IOV VF count for physical functions. Meaningless (and never
+    /// set) on virtual link kinds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
     #[serde(flatten)]
     pub kind: LinkKind,
 }
@@ -177,6 +181,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: iface.enabled,
             mtu: iface.mtu,
             mac: None,
+            sriov_num_vfs: iface.sriov_num_vfs,
             kind: LinkKind::Physical,
         });
         push_addresses(&mut addresses, &iface.name, &iface.ipv4, &iface.ipv6);
@@ -187,6 +192,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: bond.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: bond.members.clone(),
                 mode: bond.mode.clone(),
@@ -201,6 +207,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: bridge.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: bridge.members.clone(),
                 stp: bridge.stp,
@@ -217,6 +224,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: vlan.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: vlan.parent.clone(),
                 id: vlan.vlan_id,
@@ -230,6 +238,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: mv.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Macvlan {
                 parent: mv.parent.clone(),
                 mode: mv.mode.clone(),
@@ -285,6 +294,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Physical,
             });
         }
@@ -362,6 +372,7 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 ipv4,
                 ipv6,
                 mtu: link.mtu,
+                sriov_num_vfs: link.sriov_num_vfs,
             }),
             LinkKind::Bond {
                 members,
@@ -591,6 +602,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            sriov_num_vfs: None,
         }
     }
 
@@ -853,6 +865,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Physical,
         }
     }
@@ -863,6 +876,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -878,6 +892,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -892,6 +907,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: parent.into(),
                 id,
@@ -985,6 +1001,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Macvlan {
                 parent: parent.into(),
                 mode: "bridge".into(),

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -49,6 +49,12 @@ pub struct NmConnection {
     pub port_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u16>,
+    /// SR-IOV VF count to create on this PF at activation
+    /// (`sriov.total-vfs`). NM owns VF lifecycle: it writes the
+    /// device's `sriov_numvfs` when the profile activates, which also
+    /// recreates VFs automatically at boot with no engine involvement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
     /// Explicit MAC override (NM `cloned-mac-address`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
@@ -440,6 +446,7 @@ fn profile_for_link(
         controller,
         port_type,
         mtu: link.mtu,
+        sriov_num_vfs: link.sriov_num_vfs,
         mac: link.mac.clone(),
         autoconnect: link.enabled,
         ipv4,
@@ -610,6 +617,15 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
             out.push_str(&format!("cloned-mac-address={mac}\n"));
         }
         out.push('\n');
+    }
+
+    // [sriov] — VF count on an SR-IOV PF. NM creates/destroys the VFs
+    // at activation time; autoprobe is left at the global default so
+    // VF host drivers bind normally (passthrough VFs get claimed
+    // per-device via passthrough.nix udev rules instead).
+    if let Some(n) = p.sriov_num_vfs {
+        out.push_str("[sriov]\n");
+        out.push_str(&format!("total-vfs={n}\n\n"));
     }
 
     // [ipv4]
@@ -816,6 +832,13 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
         }
     }
 
+    // [sriov] — see the keyfile serializer note.
+    if let Some(n) = p.sriov_num_vfs {
+        let mut sriov = HashMap::new();
+        sriov.insert("total-vfs".into(), into_value(n));
+        out.insert("sriov".into(), sriov);
+    }
+
     // [ipv4]
     out.insert("ipv4".into(), ip_section_dict(&p.ipv4, Family::V4));
     // [ipv6]
@@ -967,6 +990,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Physical,
         }
     }
@@ -977,6 +1001,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -992,6 +1017,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -1056,6 +1082,29 @@ mod tests {
         // The sibling ethernet port is unaffected by the IB context.
         let eth = find(&profiles, "eth0");
         assert_eq!(eth.conn_type, NmConnectionType::Ethernet);
+    }
+
+    #[test]
+    fn sriov_pf_emits_total_vfs_in_both_serializers() {
+        let mut link = link_phys("enp6s0f0");
+        link.sriov_num_vfs = Some(8);
+        let layered = LayeredConfig {
+            links: vec![link, link_phys("eth0")],
+            ..Default::default()
+        };
+        let profiles = to_nm_profiles(&layered);
+
+        let pf = find(&profiles, "enp6s0f0");
+        let keyfile = serialize_keyfile(pf);
+        assert!(keyfile.contains("[sriov]"), "{keyfile}");
+        assert!(keyfile.contains("total-vfs=8"), "{keyfile}");
+        let dict = to_settings_dict(pf);
+        assert!(dict.contains_key("sriov"));
+
+        // Plain NIC: no [sriov] anywhere.
+        let eth = find(&profiles, "eth0");
+        assert!(!serialize_keyfile(eth).contains("[sriov]"));
+        assert!(!to_settings_dict(eth).contains_key("sriov"));
     }
 
     #[test]
@@ -1186,6 +1235,7 @@ mod tests {
                     enabled: true,
                     mtu: None,
                     mac: None,
+                    sriov_num_vfs: None,
                     kind: LinkKind::Macvlan {
                         parent: "eth1".into(),
                         mode: "bridge".into(),
@@ -1243,6 +1293,7 @@ mod tests {
                     enabled: true,
                     mtu: None,
                     mac: None,
+                    sriov_num_vfs: None,
                     kind: LinkKind::Vlan {
                         parent: "eth0".into(),
                         id: 100,
@@ -1271,6 +1322,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1444,6 +1496,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1469,6 +1522,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1586,6 +1640,7 @@ mod tests {
             enabled: true,
             mtu: Some(1400),
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -1734,6 +1789,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1770,6 +1826,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1916,6 +1973,7 @@ mod tests {
             enabled: true,
             mtu: Some(1400),
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -2116,6 +2174,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -2131,6 +2190,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -568,6 +568,7 @@ mod tests {
 
     fn ethernet_profile(id: &str) -> NmConnection {
         NmConnection {
+            sriov_num_vfs: None,
             id: id.into(),
             uuid: format!("uuid-for-{id}"),
             conn_type: NmConnectionType::Ethernet,

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -396,6 +396,11 @@ pub struct PciDevice {
     pub iommu_group: u32,
     /// Whether the device is currently bound to vfio-pci.
     pub bound_to_vfio: bool,
+    /// Whether this is an SR-IOV virtual function (has a physfn
+    /// parent). VFs are prime passthrough candidates — the host keeps
+    /// the PF and siblings while one VF goes to the VM.
+    #[serde(default)]
+    pub virtual_function: bool,
 }
 
 // ── Service ─────────────────────────────────────────────────────
@@ -1426,6 +1431,8 @@ async fn list_pci_devices() -> Vec<PciDevice> {
                 .and_then(|p| p.file_name()?.to_str()?.parse::<u32>().ok())
                 .unwrap_or(0);
 
+        let virtual_function =
+            std::path::Path::new(&format!("/sys/bus/pci/devices/{address}/physfn")).exists();
         let bound_to_vfio = tokio::fs::read_link(format!("/sys/bus/pci/devices/{address}/driver"))
             .await
             .ok()
@@ -1438,6 +1445,7 @@ async fn list_pci_devices() -> Vec<PciDevice> {
             description,
             iommu_group,
             bound_to_vfio,
+            virtual_function,
         });
     }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1143,6 +1143,8 @@ export interface InterfaceConfig {
 	ipv4: IpConfig;
 	ipv6: IpConfig;
 	mtu: number | null;
+	/** SR-IOV: VFs to create on this PF (absent = leave alone). */
+	sriov_num_vfs?: number | null;
 }
 
 export type BondMode = 'lacp' | 'active_backup' | 'balance_rr' | 'balance_xor';
@@ -1202,6 +1204,14 @@ export interface LiveInterface {
 	ipv6_addresses: string[];
 	mtu: number;
 	kind: string;
+	/** SR-IOV PF: maximum VFs the device supports. */
+	sriov_total_vfs?: number | null;
+	/** SR-IOV PF: currently-created VF count. */
+	sriov_num_vfs?: number | null;
+	/** SR-IOV VF: parent PF's interface name. */
+	vf_of?: string | null;
+	/** SR-IOV VF: index within the parent. */
+	vf_index?: number | null;
 }
 
 export interface NetworkState {
@@ -1549,6 +1559,8 @@ export interface PciDevice {
 	description: string;
 	iommu_group: number;
 	bound_to_vfio: boolean;
+	/** SR-IOV virtual function (has a physfn parent). */
+	virtual_function?: boolean;
 }
 
 // ── Apps ────────────────────────────────────────────────────

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -53,6 +53,7 @@
 	let netIpv6Gateway = $state('');
 	// MTU on inline interface form (string so an empty value means "unset")
 	let netMtu = $state('');
+	let netSriovVfs = $state('');
 	// Bond form
 	let showBondForm = $state(false);
 	let bondName = $state('bond0');
@@ -408,10 +409,12 @@
 			netIpv6Addrs = cfg.ipv6.addresses.length > 0 ? [...cfg.ipv6.addresses] : [''];
 			netIpv6Gateway = cfg.ipv6.gateway ?? '';
 			netMtu = cfg.mtu != null ? String(cfg.mtu) : '';
+			netSriovVfs = (cfg as InterfaceConfig).sriov_num_vfs != null ? String((cfg as InterfaceConfig).sriov_num_vfs) : '';
 		} else {
 			netDhcp = true; netIpv4Addrs = ['']; netGateway = '';
 			netIpv6Method = 'slaac'; netIpv6Addrs = ['']; netIpv6Gateway = '';
 			netMtu = '';
+			netSriovVfs = '';
 		}
 		netChanged = false;
 	}
@@ -460,7 +463,13 @@
 			if (idx >= 0) payload.vlans[idx] = { ...payload.vlans[idx], ipv4, ipv6, mtu };
 		} else {
 			const idx = payload.interfaces.findIndex(i => i.name === selectedIface);
+			const sriovNum = parseMtu(netSriovVfs); // same "number or null" coercion
 			const entry: InterfaceConfig = { name: selectedIface, enabled: true, ipv4, ipv6, mtu };
+			// Distinguish "leave alone" (absent) from explicit 0 (remove VFs):
+			// parseMtu treats 0 as null, so read the raw field for zero.
+			if (netSriovVfs !== '' && netSriovVfs != null) {
+				entry.sriov_num_vfs = sriovNum ?? 0;
+			}
 			if (idx >= 0) payload.interfaces[idx] = entry; else payload.interfaces.push(entry);
 		}
 
@@ -909,6 +918,8 @@
 										<span class="font-mono text-sm font-medium">{iface.name}</span>
 										<Badge variant={iface.up ? 'default' : 'secondary'} class="text-[0.6rem]">{iface.up ? 'Up' : 'Down'}</Badge>
 										<Badge variant="outline" class="text-[0.6rem]">{iface.kind}</Badge>
+										{#if iface.vf_of != null}<Badge variant="secondary" class="text-[0.6rem]">VF {iface.vf_index} of {iface.vf_of}</Badge>{/if}
+										{#if (iface.sriov_num_vfs ?? 0) > 0}<Badge variant="secondary" class="text-[0.6rem]">{iface.sriov_num_vfs} VFs</Badge>{/if}
 										{#if isConfigured}<Badge variant="outline" class="text-[0.6rem]">Configured</Badge>{/if}
 									</div>
 									{#if iface.ipv4_addresses.length > 0 || iface.ipv6_addresses.length > 0}
@@ -1030,6 +1041,20 @@
 										<input id="net-mtu" type="number" min="68" max="65535" bind:value={netMtu} placeholder="default (1500)" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
 										<p class="mt-1 text-[0.65rem] text-muted-foreground">Leave empty for default. 9000 enables jumbo frames (requires switch support end-to-end).</p>
 									</div>
+
+									<!-- SR-IOV (shown only on capable PFs) -->
+									{#if (networkState?.interfaces.find(i => i.name === selectedIface)?.sriov_total_vfs ?? 0) > 0}
+										{@const sriovMax = networkState?.interfaces.find(i => i.name === selectedIface)?.sriov_total_vfs}
+										<div>
+											<label for="net-sriov" class="text-xs text-muted-foreground">SR-IOV virtual functions (0–{sriovMax})</label>
+											<input id="net-sriov" type="number" min="0" max={sriovMax} bind:value={netSriovVfs} placeholder="leave empty to not manage" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
+											<p class="mt-1 text-[0.65rem] text-muted-foreground">
+												VFs are created when this profile activates and reappear automatically at boot.
+												Each VF shows up as its own interface below — usable for host networking or VM passthrough (Hardware page).
+												Empty = NASty doesn't touch the VF count; 0 = remove all VFs.
+											</p>
+										</div>
+									{/if}
 
 									<!-- DNS -->
 									<div>

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -1381,6 +1381,7 @@
 								/>
 								<div>
 									<span class="font-mono">{dev.address}</span>
+									{#if dev.virtual_function}<Badge variant="secondary" class="ml-1 text-[0.6rem]">VF</Badge>{/if}
 									<span class="text-muted-foreground ml-1">{dev.description}</span>
 									<span class="text-muted-foreground ml-1">(IOMMU group {dev.iommu_group})</span>
 								</div>


### PR DESCRIPTION
SR-IOV-capable NICs can now have their VF count managed from the Network page. Third PR of the #602 series — **stacked on #611** (shares renderer/enumeration code; will retarget to main when that merges). Pairs with #612: VFs created here can be host interfaces or per-device passthrough donors.

## What's new

- **VF count on the PF's interface config** (`sriov_num_vfs`, next to MTU in the WebUI, shown only for SR-IOV-capable devices): renders as NM's `[sriov] total-vfs` on the PF profile, so NM owns the VF lifecycle — created at activation, recreated automatically at boot with no engine involvement. Absent = leave the device alone (all existing configs unchanged); explicit 0 removes VFs.
- **Family awareness in enumeration**: PFs report total/current VF counts; VFs report their parent PF and index (via `device/physfn`), shown as badges in the interface list and a VF badge in the VM passthrough picker. VFs stay kind `physical` — host networking on a VF (dsevost's VF-per-VLAN pattern) is a first-class use.
- **Validation with real errors**: over-capability and non-SR-IOV devices are refused at update time (instead of an obscure NM activation failure); configured-but-absent devices pass — intent is kept and the presence filter (#610) withholds the profile until the device exists.
- **One-click PF+VF setup**: an update that both creates VFs and configures not-yet-existing interfaces re-applies once after a short settle, so VF profiles land without a second apply.

Deferred (additive later, per the scope discussion): per-VF properties (MAC/VLAN/trust/spoof).

## Validation

- Hermetic tests: `[sriov]` emission in both serializers (and absence on plain NICs), layered round-trip, validation rules (over-capability, non-capable, absent-allowed, explicit-zero). 341 engine tests green; workspace clippy `--all-targets` + svelte-check clean.
- Live on the dev box: non-capable NIC → clean rejection; absent device with a VF count → accepted, intent persisted, profile withheld. Ethernet behavior otherwise unchanged.
- `netdevsim` was evaluated as a positive-path stand-in but its sysfs shape diverges from real PCI SR-IOV (no `sriov_totalvfs`, attrs not under the netdev's `device/` path), so the **positive path needs real SR-IOV hardware** — part of the dsevost validation ask on #602, alongside the IB branch.