### PR TITLE
sharing: RDMA transports — iSER, NFS-over-RDMA, NVMe-oF RDMA

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -535,6 +535,11 @@ async fn main() -> anyhow::Result<()> {
                     proto_states.push((*p, enabled));
                 }
                 state.firewall.init(&proto_states).await;
+                // RDMA transports are a per-box opt-in orthogonal to the
+                // protocol list; restore its firewall rule when enabled.
+                if nasty_system::rdma::enabled().await {
+                    state.firewall.open_rdma().await;
+                }
             }
         })
         .await;

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -58,6 +58,7 @@ use nasty_system::notifications::{ChannelType, NotificationConfig};
 use nasty_system::nut::{NutConfig, NutConfigUpdate, UpsStatus};
 use nasty_system::passthrough::{PassthroughConfig, PassthroughUpdate};
 use nasty_system::protocol::ProtocolStatus;
+use nasty_system::rdma::{RdmaSetRequest, RdmaStatus};
 use nasty_system::secure_boot::ReadinessReport;
 use nasty_system::secure_boot_enrollment::{EnrollmentState, EnrollmentStatusResponse};
 use nasty_system::settings::{AcmeStatus, HostTlsStatus, OidcSettings, Settings, SettingsUpdate};
@@ -1497,6 +1498,26 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<UpsStatus>(generator)),
+                },
+            ],
+        ),
+        // ── System: RDMA transports ──────────────────────────────────────
+        (
+            "System RDMA",
+            vec![
+                Method {
+                    name: "system.rdma.status",
+                    desc: "Return RDMA capability and opt-in state: detected RDMA devices (InfiniBand/RoCE), transport-module availability, and whether nfsd has an RDMA listener.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<RdmaStatus>(generator)),
+                },
+                Method {
+                    name: "system.rdma.set",
+                    desc: "Enable or disable RDMA share transports on this box (per-box opt-in; enabling requires an RDMA-capable device, disabling requires no remaining RDMA ports/portals).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<RdmaSetRequest>(generator)),
+                    result: Some(gen_schema::<RdmaStatus>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -212,6 +212,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.secure_boot.enrollment.status"
                 | "system.secure_boot.readiness"
                 | "system.passthrough.get"
+                | "system.rdma.status"
                 | "system.stats"
                 | "system.disks"
                 | "system.network.get"
@@ -527,6 +528,23 @@ pub(super) async fn require_protocol(
     } else {
         None
     }
+}
+
+/// Gate an RDMA-transport request (iSER portal, NVMe-oF rdma port) on
+/// the per-box RDMA opt-in, and load the transport's kernel module on
+/// the way through so a stale unload can't fail the configfs write.
+pub(super) async fn require_rdma(req: &Request, module: &str) -> Option<Response> {
+    if !nasty_system::rdma::enabled().await {
+        return Some(Response::error(
+            req.id.clone(),
+            ErrorCode::InternalError,
+            "RDMA transport is disabled on this box — enable RDMA on the Sharing page              first (requires an RDMA-capable NIC)",
+        ));
+    }
+    if let Err(e) = nasty_system::rdma::ensure_module(module).await {
+        return Some(Response::error(req.id.clone(), ErrorCode::InternalError, e));
+    }
+    None
 }
 
 #[allow(clippy::result_large_err)]

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -538,7 +538,7 @@ pub(super) async fn require_rdma(req: &Request, module: &str) -> Option<Response
         return Some(Response::error(
             req.id.clone(),
             ErrorCode::InternalError,
-            "RDMA transport is disabled on this box — enable RDMA on the Sharing page              first (requires an RDMA-capable NIC)",
+            "RDMA transport is disabled on this box — enable RDMA on the Sharing page first (requires an RDMA-capable NIC)",
         ));
     }
     if let Err(e) = nasty_system::rdma::ensure_module(module).await {

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -249,10 +249,10 @@ pub(super) async fn try_route(
             }
             match parse_params::<nasty_sharing::iscsi::AddPortalRequest>(req) {
                 Ok(p) => {
-                    if p.iser {
-                        if let Some(r) = require_rdma(req, "ib_isert").await {
-                            return Some(r);
-                        }
+                    if p.iser
+                        && let Some(r) = require_rdma(req, "ib_isert").await
+                    {
+                        return Some(r);
                     }
                     match state.iscsi.add_portal(p).await {
                         Ok(v) => ok(req, v),
@@ -397,10 +397,10 @@ pub(super) async fn try_route(
             }
             match parse_params::<nasty_sharing::nvmeof::AddPortRequest>(req) {
                 Ok(p) => {
-                    if p.transport.as_deref() == Some("rdma") {
-                        if let Some(r) = require_rdma(req, "nvmet-rdma").await {
-                            return Some(r);
-                        }
+                    if p.transport.as_deref() == Some("rdma")
+                        && let Some(r) = require_rdma(req, "nvmet-rdma").await
+                    {
+                        return Some(r);
                     }
                     match state.nvmeof.add_port(p).await {
                         Ok(v) => ok(req, v),

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -142,6 +142,13 @@ pub(super) async fn try_route(
             }
             match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
                 Ok(p) => {
+                    if p.portals
+                        .as_deref()
+                        .is_some_and(|ps| ps.iter().any(|portal| portal.iser))
+                        && let Some(r) = require_rdma(req, "ib_isert").await
+                    {
+                        return Some(r);
+                    }
                     if let Some(ref dp) = p.device_path
                         && let Some(conflict) =
                             check_block_device_conflict(state, dp, "iscsi").await
@@ -240,11 +247,18 @@ pub(super) async fn try_route(
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.add_portal(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::AddPortalRequest>(req) {
+                Ok(p) => {
+                    if p.iser {
+                        if let Some(r) = require_rdma(req, "ib_isert").await {
+                            return Some(r);
+                        }
+                    }
+                    match state.iscsi.add_portal(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -381,11 +395,18 @@ pub(super) async fn try_route(
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.add_port(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::AddPortRequest>(req) {
+                Ok(p) => {
+                    if p.transport.as_deref() == Some("rdma") {
+                        if let Some(r) = require_rdma(req, "nvmet-rdma").await {
+                            return Some(r);
+                        }
+                    }
+                    match state.nvmeof.add_port(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -114,7 +114,7 @@ pub(super) async fn try_route(
                         return Some(err(
                             req,
                             format!(
-                                "cannot disable RDMA while these still use it: {} — remove                                  the RDMA ports/portals first",
+                                "cannot disable RDMA while these still use it: {} — remove the RDMA ports/portals first",
                                 consumers.join(", ")
                             ),
                         ));

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -88,6 +88,52 @@ pub(super) async fn try_route(
                 Err(e) => err(req, e.to_string()),
             }
         }
+        "system.rdma.status" => ok(req, nasty_system::rdma::status().await),
+        "system.rdma.set" => match parse_params::<nasty_system::rdma::RdmaSetRequest>(req) {
+            Ok(p) => {
+                if !p.enabled {
+                    // Refuse while share config still expects RDMA —
+                    // disabling under live consumers would strand them
+                    // (nvmet-rdma port writes fail, iSER portals die).
+                    let mut consumers: Vec<String> = Vec::new();
+                    if let Ok(subsystems) = state.nvmeof.list().await {
+                        for s in subsystems {
+                            if s.ports.iter().any(|port| port.transport == "rdma") {
+                                consumers.push(format!("NVMe-oF subsystem '{}'", s.nqn));
+                            }
+                        }
+                    }
+                    if let Ok(targets) = state.iscsi.list().await {
+                        for t in targets {
+                            if t.portals.iter().any(|portal| portal.iser) {
+                                consumers.push(format!("iSCSI target '{}' (iSER portal)", t.iqn));
+                            }
+                        }
+                    }
+                    if !consumers.is_empty() {
+                        return Some(err(
+                            req,
+                            format!(
+                                "cannot disable RDMA while these still use it: {} — remove                                  the RDMA ports/portals first",
+                                consumers.join(", ")
+                            ),
+                        ));
+                    }
+                }
+                match nasty_system::rdma::set_enabled(p.enabled).await {
+                    Ok(status) => {
+                        if p.enabled {
+                            state.firewall.open_rdma().await;
+                        } else {
+                            state.firewall.close_rdma().await;
+                        }
+                        ok(req, status)
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
+            Err(e) => err(req, e.to_string()),
+        },
         "system.passthrough.get" => ok(req, nasty_system::passthrough::load().await),
         "system.passthrough.update" => {
             match parse_params::<nasty_system::passthrough::PassthroughUpdate>(req) {

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -55,6 +55,12 @@ pub struct Portal {
     pub ip: String,
     /// TCP port number (default iSCSI port is 3260).
     pub port: u16,
+    /// iSER (iSCSI over RDMA) enabled on this portal. Requires the
+    /// per-box RDMA opt-in and an RDMA-capable NIC on the portal's
+    /// address; the router arm gates on both. Defaults false so every
+    /// pre-iSER state file loads unchanged (#602).
+    #[serde(default)]
+    pub iser: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -230,6 +236,10 @@ pub struct AddPortalRequest {
     pub ip: String,
     /// TCP port to listen on. Standard iSCSI port is 3260.
     pub port: u16,
+    /// Enable iSER (iSCSI over RDMA) on this portal. Requires the
+    /// per-box RDMA opt-in (gated in the router).
+    #[serde(default)]
+    pub iser: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -369,6 +379,7 @@ impl IscsiService {
                 let defaults = vec![Portal {
                     ip: "0.0.0.0".to_string(),
                     port: 3260,
+                    iser: false,
                 }];
                 let try_v6 = crate::v6::host_has_global_ipv6().await;
                 (defaults, try_v6)
@@ -385,10 +396,19 @@ impl IscsiService {
         let mut created_portals = Vec::with_capacity(mandatory_portals.len() + 1);
         for portal in &mandatory_portals {
             let np_path = np_path_for(&tpg_path, &portal.ip, portal.port);
-            if let Err(e) = configfs_mkdir(&np_path).await {
+            let created = match configfs_mkdir(&np_path).await {
+                Ok(()) if portal.iser => {
+                    // See add_portal: the iser attr switches the portal's
+                    // transport; captured by saveconfig for boot restore.
+                    configfs_write(&format!("{np_path}/iser"), "1").await
+                }
+                other => other,
+            };
+            if let Err(e) = created {
                 // Best-effort cleanup of what we created so far so the
                 // next attempt doesn't trip the idempotency check with
                 // a stale half-target.
+                let _ = configfs_rmdir(&np_path).await;
                 let _ = configfs_rmdir(&tpg_path).await;
                 let _ = configfs_rmdir(&format!("{ISCSI_BASE}/{iqn}")).await;
                 return Err(e);
@@ -405,6 +425,7 @@ impl IscsiService {
             let v6_portal = Portal {
                 ip: "::".to_string(),
                 port: 3260,
+                iser: false,
             };
             let np_path = np_path_for(&tpg_path, &v6_portal.ip, v6_portal.port);
             match configfs_mkdir(&np_path).await {
@@ -780,15 +801,35 @@ impl IscsiService {
         let np_path = np_path_for(&tpg_path, &ip, req.port);
         configfs_mkdir(&np_path).await?;
 
+        // iSER rides on a normal network portal: LIO switches the
+        // transport when `1` is written to the portal's iser attr
+        // (requires ib_isert, loaded by the router gate). The flag is
+        // captured by `save_lio_config` below, so targetcli's boot
+        // restore replays it — no engine-side replay needed.
+        if req.iser
+            && let Err(e) = configfs_write(&format!("{np_path}/iser"), "1").await
+        {
+            // Roll the portal back so a failed iSER enable doesn't
+            // leave a silent TCP portal where RDMA was requested.
+            let _ = configfs_rmdir(&np_path).await;
+            return Err(e);
+        }
+
         target.portals.push(Portal {
             ip: ip.clone(),
             port: req.port,
+            iser: req.iser,
         });
 
         state_dir().save(&target.id, &target).await?;
         save_lio_config().await;
 
-        info!("Added portal {ip}:{} to target '{}'", req.port, target.iqn);
+        info!(
+            "Added {} portal {ip}:{} to target '{}'",
+            if req.iser { "iSER" } else { "TCP" },
+            req.port,
+            target.iqn
+        );
         Ok(target.redacted())
     }
 

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -27,6 +27,8 @@ pub enum NvmeofError {
     ConfigFs(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("unsupported transport '{0}' (expected \"tcp\" or \"rdma\")")]
+    InvalidTransport(String),
 }
 
 // ── Data types ──────────────────────────────────────────────────
@@ -404,6 +406,9 @@ impl NvmeofService {
                 subsystem = self
                     .add_port(AddPortRequest {
                         subsystem_id: subsystem.id.clone(),
+                        // Auto-created ports are deliberately TCP: RDMA ports are an
+                        // explicit per-port choice via add_port (and Tailscale is an
+                        // overlay — RDMA over it is meaningless).
                         transport: Some("tcp".to_string()),
                         addr: Some(req.addr.unwrap_or_else(|| "0.0.0.0".to_string())),
                         service_id: Some(svc_port),
@@ -627,6 +632,7 @@ impl NvmeofService {
             .ok_or_else(|| NvmeofError::NotFound(req.subsystem_id.clone()))?;
 
         let transport = req.transport.unwrap_or_else(|| "tcp".to_string());
+        validate_transport(&transport)?;
         let addr = match req.addr {
             Some(a) if !a.is_empty() && a != "0.0.0.0" => a,
             _ => {
@@ -1047,6 +1053,16 @@ fn validate_host_nqn(nqn: &str) -> Result<(), NvmeofError> {
         )));
     }
     Ok(())
+}
+
+/// The two transports nvmet supports on NASty. Lowercase only —
+/// that's what configfs `addr_trtype` accepts; anything else used to
+/// be written through verbatim and die as an opaque configfs EINVAL.
+fn validate_transport(t: &str) -> Result<(), NvmeofError> {
+    match t {
+        "tcp" | "rdma" => Ok(()),
+        other => Err(NvmeofError::InvalidTransport(other.to_string())),
+    }
 }
 
 #[cfg(test)]

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -179,6 +179,17 @@ pub fn webui_ports() -> Vec<PortSpec> {
     vec![tcp(80), tcp(443)]
 }
 
+/// Ports for the RDMA share transports (per-box opt-in, #602).
+/// udp/4791 is RoCEv2's encapsulation port — ALL RoCE traffic
+/// (NVMe/RDMA "4420", NFS-RDMA "20049", iSER) rides inside it; those
+/// numbers are RDMA-CM service ids, not IP ports. tcp/20049 covers
+/// iWARP NFS-RDMA. Native InfiniBand never traverses netfilter — no
+/// rule is needed or possible. Consequence for operators: per-service
+/// source restrictions on RoCE can only filter at 4791 granularity.
+pub fn rdma_ports() -> Vec<PortSpec> {
+    vec![udp(4791), tcp(20049)]
+}
+
 // ── Firewall service ───────────────────────────────────────────
 
 pub struct FirewallService {
@@ -299,6 +310,44 @@ impl FirewallService {
         }
     }
 
+    /// Open the named RDMA transport rule (per-box opt-in, #602).
+    pub async fn open_rdma(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "rdma") {
+            if rule.active {
+                return;
+            }
+            rule.active = true;
+        } else {
+            state.rules.push(FirewallRule {
+                service: "rdma".to_string(),
+                ports: rdma_ports(),
+                active: true,
+            });
+        }
+        if let Err(e) = apply_nftables(&state).await {
+            error!("Failed to open firewall for rdma: {e}");
+        } else {
+            info!("Firewall: opened ports for rdma");
+        }
+    }
+
+    /// Close the named RDMA transport rule.
+    pub async fn close_rdma(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "rdma") {
+            if !rule.active {
+                return;
+            }
+            rule.active = false;
+        }
+        if let Err(e) = apply_nftables(&state).await {
+            error!("Failed to close firewall for rdma: {e}");
+        } else {
+            info!("Firewall: closed ports for rdma");
+        }
+    }
+
     /// Get current firewall status including restrictions.
     pub async fn status(&self) -> FirewallStatus {
         let state = self.state.lock().await;
@@ -346,6 +395,8 @@ impl FirewallService {
         if let Some(rule) = state.rules.iter_mut().find(|r| r.service == service) {
             let base_ports = if service == "webui" {
                 webui_ports()
+            } else if service == "rdma" {
+                rdma_ports()
             } else if let Some(proto) = Protocol::from_name(service) {
                 ports_for_protocol(proto)
             } else {

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -8,6 +8,7 @@ pub mod notifications;
 pub mod nut;
 pub mod passthrough;
 pub mod protocol;
+pub mod rdma;
 pub mod rest_server;
 pub mod secure_boot;
 pub mod secure_boot_enrollment;

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -274,10 +274,12 @@ impl ProtocolService {
             // NFS started with the RDMA toggle on: add the rdma
             // listener. Warn-only — TCP NFS must keep working even if
             // the RDMA side can't come up (#602).
-            if !failed && proto == Protocol::Nfs && crate::rdma::enabled().await {
-                if let Err(e) = crate::rdma::activate_nfs_rdma().await {
-                    warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
-                }
+            if !failed
+                && proto == Protocol::Nfs
+                && crate::rdma::enabled().await
+                && let Err(e) = crate::rdma::activate_nfs_rdma().await
+            {
+                warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
             }
         }
     }
@@ -374,10 +376,11 @@ impl ProtocolService {
         // NFS started with the RDMA toggle on: add the rdma listener.
         // Warn-only — TCP NFS must keep working even if the RDMA side
         // can't come up (#602).
-        if proto == Protocol::Nfs && crate::rdma::enabled().await {
-            if let Err(e) = crate::rdma::activate_nfs_rdma().await {
-                warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
-            }
+        if proto == Protocol::Nfs
+            && crate::rdma::enabled().await
+            && let Err(e) = crate::rdma::activate_nfs_rdma().await
+        {
+            warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
         }
 
         let running = is_protocol_running(proto).await;

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -236,18 +236,9 @@ impl ProtocolService {
 
             // Load kernel modules before starting services (iSCSI/NVMe-oF
             // services require the LIO/nvmet modules to already be present)
-            if proto == Protocol::Iscsi {
-                for module in &["target_core_mod", "iscsi_target_mod"] {
-                    if let Err(e) = modprobe(module).await {
-                        warn!("{e}");
-                    }
-                }
-            }
-            if proto == Protocol::Nvmeof {
-                for module in &["nvmet", "nvmet-tcp"] {
-                    if let Err(e) = modprobe(module).await {
-                        warn!("{e}");
-                    }
+            for module in protocol_modules(proto).await {
+                if let Err(e) = modprobe(module).await {
+                    warn!("{e}");
                 }
             }
 
@@ -277,6 +268,15 @@ impl ProtocolService {
                         "auto-disable persistence for {} failed: {e}",
                         proto.display_name()
                     );
+                }
+            }
+
+            // NFS started with the RDMA toggle on: add the rdma
+            // listener. Warn-only — TCP NFS must keep working even if
+            // the RDMA side can't come up (#602).
+            if !failed && proto == Protocol::Nfs && crate::rdma::enabled().await {
+                if let Err(e) = crate::rdma::activate_nfs_rdma().await {
+                    warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
                 }
             }
         }
@@ -316,18 +316,9 @@ impl ProtocolService {
         prepare_protocol(proto).await;
 
         // Load kernel modules before starting services
-        if proto == Protocol::Iscsi {
-            for module in &["target_core_mod", "iscsi_target_mod"] {
-                if let Err(e) = modprobe(module).await {
-                    warn!("{e}");
-                }
-            }
-        }
-        if proto == Protocol::Nvmeof {
-            for module in &["nvmet", "nvmet-tcp"] {
-                if let Err(e) = modprobe(module).await {
-                    warn!("{e}");
-                }
+        for module in protocol_modules(proto).await {
+            if let Err(e) = modprobe(module).await {
+                warn!("{e}");
             }
         }
 
@@ -378,6 +369,15 @@ impl ProtocolService {
         // daemons already active.
         if proto == Protocol::Smb {
             crate::network::rebind_discovery_daemons().await;
+        }
+
+        // NFS started with the RDMA toggle on: add the rdma listener.
+        // Warn-only — TCP NFS must keep working even if the RDMA side
+        // can't come up (#602).
+        if proto == Protocol::Nfs && crate::rdma::enabled().await {
+            if let Err(e) = crate::rdma::activate_nfs_rdma().await {
+                warn!("NFS-over-RDMA activation failed (TCP NFS unaffected): {e}");
+            }
         }
 
         let running = is_protocol_running(proto).await;
@@ -476,7 +476,31 @@ async fn prepare_protocol(proto: Protocol) {
     }
 }
 
-async fn systemctl(action: &str, service: &str) -> Result<(), String> {
+/// Kernel modules a protocol needs before its services start. The
+/// RDMA additions are gated on the per-box toggle so an unopted box
+/// never loads transport modules it can't use (#602).
+async fn protocol_modules(proto: Protocol) -> Vec<&'static str> {
+    let rdma = crate::rdma::enabled().await;
+    match proto {
+        Protocol::Iscsi => {
+            let mut m = vec!["target_core_mod", "iscsi_target_mod"];
+            if rdma {
+                m.push("ib_isert");
+            }
+            m
+        }
+        Protocol::Nvmeof => {
+            let mut m = vec!["nvmet", "nvmet-tcp"];
+            if rdma {
+                m.push("nvmet-rdma");
+            }
+            m
+        }
+        _ => vec![],
+    }
+}
+
+pub(crate) async fn systemctl(action: &str, service: &str) -> Result<(), String> {
     let output = tokio::process::Command::new("systemctl")
         .args([action, service])
         .output()
@@ -491,7 +515,7 @@ async fn systemctl(action: &str, service: &str) -> Result<(), String> {
     }
 }
 
-async fn systemctl_is_active(service: &str) -> bool {
+pub(crate) async fn systemctl_is_active(service: &str) -> bool {
     tokio::process::Command::new("systemctl")
         .args(["is-active", "--quiet", service])
         .status()
@@ -500,7 +524,7 @@ async fn systemctl_is_active(service: &str) -> bool {
         .unwrap_or(false)
 }
 
-async fn modprobe(module: &str) -> Result<(), String> {
+pub(crate) async fn modprobe(module: &str) -> Result<(), String> {
     let output = tokio::process::Command::new("modprobe")
         .arg(module)
         .output()

--- a/engine/nasty-system/src/rdma.rs
+++ b/engine/nasty-system/src/rdma.rs
@@ -1,0 +1,272 @@
+//! Per-box RDMA opt-in for storage share transports (#602).
+//!
+//! RDMA is a transport *modifier* on existing share protocols (iSER on
+//! iSCSI portals, NFS-over-RDMA listeners, NVMe-oF `trtype=rdma`
+//! ports), not a protocol of its own — so it lives beside
+//! `protocol.rs` rather than inside it. The per-box toggle follows the
+//! house pattern: capability detection informs the WebUI, the explicit
+//! toggle enables the feature (the toggle IS the validation).
+//!
+//! Capability signal: `/sys/class/infiniband` non-empty — one probe
+//! covers native InfiniBand, RoCE NICs, and `rdma_rxe` soft-RoCE
+//! identically (all register an RDMA device there; the directory name
+//! is historical).
+//!
+//! State: `/var/lib/nasty/rdma.json`, default disabled — upgraded
+//! boxes behave exactly as before until the operator opts in, and a
+//! rolled-back engine simply ignores the file.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::protocol::{modprobe, systemctl, systemctl_is_active};
+
+const STATE_PATH: &str = "/var/lib/nasty/rdma.json";
+const IB_CLASS_DIR: &str = "/sys/class/infiniband";
+const NFSD_PORTLIST: &str = "/proc/fs/nfsd/portlist";
+
+/// nfsd's RDMA listener service id. Like NVMe-oF's 4420, this is an
+/// RDMA-CM service id, not an IP port — the only wire-level port RDMA
+/// traffic occupies is RoCEv2's UDP 4791 (native IB bypasses the IP
+/// stack entirely).
+pub const NFS_RDMA_PORT: u16 = 20049;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct RdmaConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// One RDMA device from `/sys/class/infiniband`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RdmaDevice {
+    /// Device name, e.g. `mlx5_0`, `rxe0`.
+    pub name: String,
+    /// `InfiniBand` or `Ethernet` (RoCE / soft-RoCE), from the first
+    /// port's `link_layer`.
+    pub link_layer: String,
+    /// Associated network interfaces, when resolvable.
+    pub netdevs: Vec<String>,
+}
+
+/// Live RDMA state for the WebUI checklist.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RdmaStatus {
+    pub enabled: bool,
+    /// An RDMA device exists — the gate for flipping the toggle on.
+    pub capable: bool,
+    pub devices: Vec<RdmaDevice>,
+    /// `modprobe -n` dry-run results — informational (the checklist
+    /// shows them); real errors surface at activation time.
+    pub ib_isert_available: bool,
+    pub nvmet_rdma_available: bool,
+    pub nfs_rdma_available: bool,
+    /// nfsd currently has an `rdma` listener in its portlist.
+    pub nfs_rdma_active: bool,
+    /// One-line reason the toggle is disabled, when it is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocker: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct RdmaSetRequest {
+    pub enabled: bool,
+}
+
+static STATE_LOCK: Mutex<()> = Mutex::const_new(());
+
+pub async fn load() -> RdmaConfig {
+    let _guard = STATE_LOCK.lock().await;
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
+}
+
+/// Quick boolean for gate checks in the routers.
+pub async fn enabled() -> bool {
+    load().await.enabled
+}
+
+pub async fn status() -> RdmaStatus {
+    let devices = scan_devices().await;
+    let capable = !devices.is_empty();
+    let enabled = load().await.enabled;
+    let blocker = (!capable).then(|| {
+        "no RDMA-capable device found (/sys/class/infiniband is empty) — install an \
+         RDMA NIC (InfiniBand or RoCE) or load a soft-RoCE device (rdma_rxe) first"
+            .to_string()
+    });
+    RdmaStatus {
+        enabled,
+        capable,
+        devices,
+        ib_isert_available: modprobe_dry_run("ib_isert").await,
+        nvmet_rdma_available: modprobe_dry_run("nvmet-rdma").await,
+        nfs_rdma_available: modprobe_dry_run("rpcrdma").await,
+        nfs_rdma_active: portlist_has_rdma(
+            &tokio::fs::read_to_string(NFSD_PORTLIST)
+                .await
+                .unwrap_or_default(),
+        ),
+        blocker,
+    }
+}
+
+/// Flip the toggle. Enabling requires a capable box and live-activates
+/// the transports for already-running protocols; disabling restarts
+/// nfs-server if needed (the portlist has no listener-removal API).
+///
+/// Precondition checks that need nasty-sharing state (no RDMA NVMe-oF
+/// ports / iSER portals left when disabling) live in the router arm —
+/// this crate can't see the sharing crate.
+pub async fn set_enabled(enable: bool) -> Result<RdmaStatus, String> {
+    if enable {
+        let devices = scan_devices().await;
+        if devices.is_empty() {
+            return Err(
+                "cannot enable RDMA: no RDMA-capable device found (/sys/class/infiniband \
+                 is empty). Install an RDMA NIC (InfiniBand or RoCE) or load a soft-RoCE \
+                 device (rdma_rxe) first."
+                    .to_string(),
+            );
+        }
+    }
+
+    {
+        let _guard = STATE_LOCK.lock().await;
+        let cfg = RdmaConfig { enabled: enable };
+        let json = serde_json::to_string_pretty(&cfg).map_err(|e| format!("serialize: {e}"))?;
+        tokio::fs::write(STATE_PATH, json)
+            .await
+            .map_err(|e| format!("write {STATE_PATH}: {e}"))?;
+    }
+
+    if enable {
+        // Live-activate for protocols that are already running; the
+        // protocol enable/restore paths handle the rest from now on.
+        if systemctl_is_active("nfs-server.service").await
+            && let Err(e) = activate_nfs_rdma().await
+        {
+            warn!("RDMA enabled but NFS-RDMA activation failed: {e}");
+        }
+        if std::path::Path::new("/sys/kernel/config/nvmet").exists()
+            && let Err(e) = ensure_module("nvmet-rdma").await
+        {
+            warn!("RDMA enabled but nvmet-rdma load failed: {e}");
+        }
+        if std::path::Path::new("/sys/module/iscsi_target_mod").exists()
+            && let Err(e) = ensure_module("ib_isert").await
+        {
+            warn!("RDMA enabled but ib_isert load failed: {e}");
+        }
+        info!("RDMA transports enabled");
+    } else {
+        if systemctl_is_active("nfs-server.service").await {
+            // Only a restart drops the rdma listener; the start path
+            // sees enabled=false and won't re-add it.
+            if let Err(e) = systemctl("restart", "nfs-server.service").await {
+                warn!("RDMA disable: nfs-server restart failed: {e}");
+            }
+        }
+        info!("RDMA transports disabled");
+    }
+
+    Ok(status().await)
+}
+
+/// Load a kernel module for an RDMA transport on demand — used by the
+/// share routers right before creating an RDMA port/portal, so the
+/// module is present even if it was unloaded since enable.
+pub async fn ensure_module(module: &str) -> Result<(), String> {
+    modprobe(module).await
+}
+
+/// Add nfsd's RDMA listener (idempotent). Called after every
+/// engine-initiated nfs-server start while the toggle is on; the
+/// engine is the only thing that starts nfs-server on NASty, so this
+/// covers every start path. (A manual `systemctl restart nfs-server`
+/// over SSH drops the listener until the next engine-driven start —
+/// documented operator caveat, not a supported flow.)
+pub async fn activate_nfs_rdma() -> Result<(), String> {
+    let portlist = tokio::fs::read_to_string(NFSD_PORTLIST)
+        .await
+        .map_err(|e| format!("read {NFSD_PORTLIST}: {e} (is nfsd running?)"))?;
+    if portlist_has_rdma(&portlist) {
+        return Ok(());
+    }
+    // The kernel would auto-load svcrdma via the write below, but the
+    // explicit modprobe turns a missing module into a readable error
+    // instead of a bare EPROTONOSUPPORT.
+    modprobe("rpcrdma").await?;
+    tokio::fs::write(NFSD_PORTLIST, format!("rdma {NFS_RDMA_PORT}\n"))
+        .await
+        .map_err(|e| format!("add rdma listener to {NFSD_PORTLIST}: {e}"))?;
+    info!("NFS-over-RDMA listener active (service id {NFS_RDMA_PORT})");
+    Ok(())
+}
+
+/// `rdma <port>` line present in an nfsd portlist dump. Pure for
+/// testing.
+pub fn portlist_has_rdma(portlist: &str) -> bool {
+    portlist.lines().any(|l| l.trim_start().starts_with("rdma"))
+}
+
+async fn modprobe_dry_run(module: &str) -> bool {
+    nasty_common::cmd::run("modprobe", &["-n", "-q", module])
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+async fn scan_devices() -> Vec<RdmaDevice> {
+    let mut out = Vec::new();
+    let Ok(mut dir) = tokio::fs::read_dir(IB_CLASS_DIR).await else {
+        return out;
+    };
+    while let Ok(Some(entry)) = dir.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let base = entry.path();
+        // First port's link layer identifies the fabric. Ports are
+        // numbered from 1.
+        let link_layer = tokio::fs::read_to_string(base.join("ports/1/link_layer"))
+            .await
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+        // Associated netdevs: real hardware exposes device/net/<if>;
+        // rxe devices expose a `parent` attribute naming the netdev.
+        let mut netdevs = Vec::new();
+        if let Ok(mut net) = tokio::fs::read_dir(base.join("device/net")).await {
+            while let Ok(Some(e)) = net.next_entry().await {
+                netdevs.push(e.file_name().to_string_lossy().to_string());
+            }
+        } else if let Ok(parent) = tokio::fs::read_to_string(base.join("parent")).await {
+            let parent = parent.trim().to_string();
+            if !parent.is_empty() {
+                netdevs.push(parent);
+            }
+        }
+        netdevs.sort();
+        out.push(RdmaDevice {
+            name,
+            link_layer,
+            netdevs,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portlist_rdma_detection() {
+        assert!(portlist_has_rdma("tcp 2049\nrdma 20049\n"));
+        assert!(portlist_has_rdma("rdma 20049"));
+        // Indented variants and missing entries.
+        assert!(portlist_has_rdma("  rdma 20049\n"));
+        assert!(!portlist_has_rdma("tcp 2049\nudp 2049\n"));
+        assert!(!portlist_has_rdma(""));
+    }
+}

--- a/webui/src/lib/sharing/iscsi.svelte.ts
+++ b/webui/src/lib/sharing/iscsi.svelte.ts
@@ -33,6 +33,7 @@ export const iscsi = $state({
 	addPortalIp: '',
 	addPortalPort: 3260,
 	addPortalFamily: 'ipv4' as 'ipv4' | 'ipv6',
+	addPortalIser: false,
 	search: '',
 	sortDir: 'asc' as 'asc' | 'desc',
 });
@@ -132,12 +133,14 @@ export async function iscsiAddPortal() {
 			target_id: iscsi.addPortalTarget,
 			ip: iscsi.addPortalIp.trim(),
 			port: iscsi.addPortalPort,
+			iser: iscsi.addPortalIser,
 		}),
 		'Portal added',
 	);
 	if (ok !== undefined) {
 		iscsi.addPortalTarget = '';
 		iscsi.addPortalIp = '';
+		iscsi.addPortalIser = false;
 		iscsi.addPortalPort = 3260;
 		iscsi.addPortalFamily = 'ipv4';
 		await iscsiRefresh();

--- a/webui/src/lib/sharing/rdma.svelte.ts
+++ b/webui/src/lib/sharing/rdma.svelte.ts
@@ -1,0 +1,30 @@
+import { getClient } from '$lib/client';
+import { withToast } from '$lib/toast.svelte';
+import type { RdmaStatus } from '$lib/types';
+
+const client = getClient();
+
+export const rdma = $state({
+	status: null as RdmaStatus | null,
+	loading: false,
+});
+
+export async function rdmaLoad() {
+	rdma.loading = true;
+	try {
+		rdma.status = await client.call<RdmaStatus>('system.rdma.status');
+	} catch {
+		// Older engine without the RPC: hide the card instead of failing
+		// the sharing page.
+		rdma.status = null;
+	}
+	rdma.loading = false;
+}
+
+export async function rdmaSet(enabled: boolean) {
+	const res = await withToast(
+		() => client.call<RdmaStatus>('system.rdma.set', { enabled }),
+		enabled ? 'RDMA transports enabled' : 'RDMA transports disabled',
+	);
+	if (res) rdma.status = res;
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -278,6 +278,26 @@ export interface UsbDevice {
  * Granularity: vendor:device, not BDF, so the binding survives slot
  * moves. Caveat: marking a (vendor, device) pair claims **all**
  * matching devices. */
+/** One RDMA device from /sys/class/infiniband (`system.rdma.status`). */
+export interface RdmaDevice {
+	name: string;
+	/** "InfiniBand" | "Ethernet" (RoCE / soft-RoCE). */
+	link_layer: string;
+	netdevs: string[];
+}
+
+/** RDMA capability + opt-in state from `system.rdma.status`. */
+export interface RdmaStatus {
+	enabled: boolean;
+	capable: boolean;
+	devices: RdmaDevice[];
+	ib_isert_available: boolean;
+	nvmet_rdma_available: boolean;
+	nfs_rdma_available: boolean;
+	nfs_rdma_active: boolean;
+	blocker?: string | null;
+}
+
 export interface PassthroughDeviceId {
 	vendor: string;
 	device: string;
@@ -647,6 +667,8 @@ export interface IscsiTarget {
 export interface Portal {
 	ip: string;
 	port: number;
+	/** iSER (iSCSI over RDMA) portal. */
+	iser?: boolean;
 }
 
 export interface Lun {

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -7,6 +7,7 @@
 	import type { Subvolume, ProtocolStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
+	import { rdma, rdmaLoad, rdmaSet } from '$lib/sharing/rdma.svelte';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -309,6 +310,7 @@
 			smbLoadProtocol(),
 			iscsiLoadProtocol(),
 			nvmeLoadProtocol(),
+			rdmaLoad(),
 		]);
 	});
 
@@ -497,6 +499,42 @@
 			{/if}
 		</CardContent>
 	</Card>
+{/if}
+
+<!-- RDMA transports (per-box opt-in) — hidden when the engine predates the RPC -->
+{#if rdma.status}
+	<div class="mb-4 rounded-lg border border-border p-4">
+		<div class="flex items-center gap-3">
+			<div class="flex-1">
+				<div class="flex items-center gap-2">
+					<span class="text-sm font-semibold">RDMA transports</span>
+					{#each rdma.status.devices as d (d.name)}
+						<Badge variant="outline" class="text-[0.65rem]">{d.name} · {d.link_layer}{d.netdevs.length ? ` · ${d.netdevs.join(', ')}` : ''}</Badge>
+					{/each}
+					{#if rdma.status.enabled && rdma.status.nfs_rdma_active}
+						<Badge variant="secondary" class="text-[0.65rem]">NFS listener active</Badge>
+					{/if}
+				</div>
+				<p class="mt-1 text-xs text-muted-foreground">
+					{#if !rdma.status.capable}
+						{rdma.status.blocker}
+					{:else if rdma.status.enabled}
+						iSER portals, NFS-over-RDMA (mount with <code class="font-mono">-o rdma,port=20049,vers=4.2</code>) and NVMe-oF RDMA ports are available.
+					{:else}
+						RDMA-capable hardware detected. Enable to offer iSER, NFS-over-RDMA and NVMe-oF RDMA transports on this box.
+					{/if}
+				</p>
+			</div>
+			<Button
+				size="sm"
+				variant={rdma.status.enabled ? 'secondary' : 'default'}
+				disabled={!rdma.status.capable}
+				onclick={() => rdmaSet(!rdma.status!.enabled)}
+			>
+				{rdma.status.enabled ? 'Disable' : 'Enable'}
+			</Button>
+		</div>
+	</div>
 {/if}
 
 <!-- Tab bar with inline status -->

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -7,6 +8,7 @@
 	import { requiredFieldCls } from '$lib/utils';
 	import { validateAddressForFamily } from '$lib/network';
 	import ListenAddressPicker from '$lib/components/ListenAddressPicker.svelte';
+	import { rdma } from '$lib/sharing/rdma.svelte';
 	import {
 		iscsi,
 		iscsiToggleSort,
@@ -150,6 +152,7 @@
 											{#each target.portals as p}
 												<div class="flex items-center gap-3 rounded bg-secondary/50 px-2 py-1.5">
 													<span class="font-mono text-xs">{p.ip.includes(':') && p.ip !== '0.0.0.0' ? `[${p.ip}]` : p.ip}:{p.port}</span>
+													{#if p.iser}<Badge variant="secondary" class="text-[0.6rem]">iSER</Badge>{/if}
 													{#if target.portals.length > 1}
 														<Button variant="destructive" size="xs" onclick={() => iscsiRemovePortal(target.id, p.ip, p.port)}>Remove</Button>
 													{/if}
@@ -167,6 +170,13 @@
 												placeholderV4="0.0.0.0 or 192.168.1.10"
 												placeholderV6=":: or fd00::1"
 											/>
+											<label class="mt-3 flex items-center gap-2 text-xs {rdma.status?.enabled ? '' : 'opacity-50'}">
+												<input type="checkbox" bind:checked={iscsi.addPortalIser} disabled={!rdma.status?.enabled} class="h-3.5 w-3.5" />
+												iSER (iSCSI over RDMA)
+												{#if !rdma.status?.enabled}
+													<span class="text-muted-foreground">— {rdma.status?.capable ? 'enable RDMA in the transports card above' : 'requires an RDMA-capable NIC'}</span>
+												{/if}
+											</label>
 											<div class="mt-3 flex items-end gap-2">
 												<div>
 													<Label class="text-xs">Port</Label>
@@ -180,7 +190,7 @@
 											{/if}
 										</div>
 									{:else}
-										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; }}>+ Add Portal</Button>
+										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; iscsi.addPortalIser = false; }}>+ Add Portal</Button>
 									{/if}
 								</div>
 

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -8,6 +8,7 @@
 	import { requiredFieldCls } from '$lib/utils';
 	import { validateAddressForFamily } from '$lib/network';
 	import ListenAddressPicker from '$lib/components/ListenAddressPicker.svelte';
+	import { rdma } from '$lib/sharing/rdma.svelte';
 	import {
 		nvme,
 		nvmeToggleSort,
@@ -217,7 +218,7 @@
 												<Label class="text-xs">Transport</Label>
 												<select bind:value={nvme.addPortTransport} class="mt-1 h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs">
 													<option value="tcp">TCP</option>
-													<option value="rdma">RDMA</option>
+													<option value="rdma" disabled={!rdma.status?.enabled}>RDMA{rdma.status?.enabled ? '' : rdma.status?.capable ? ' (enable RDMA in the transports card above)' : ' (requires an RDMA-capable NIC)'}</option>
 												</select>
 											</div>
 											<ListenAddressPicker


### PR DESCRIPTION
Storage shares can now serve RDMA clients. Final stage of #602, building on the merged network foundation (#611 IPoIB, #612 per-device claims, #614 SR-IOV, #615 reconcile converge).

## What's new

- **Per-box RDMA opt-in** (`system.rdma.status`/`set`, card on the Sharing page): capability detection via `/sys/class/infiniband` (one signal for native IB, RoCE, and soft-RoCE), device checklist with link-layer badges, and an explicit toggle. Enabling requires a capable device; disabling refuses while any RDMA port/portal still exists (offenders named).
- **iSER** (the reporter's primary protocol): iSCSI portals take an `iser` flag — one configfs attribute write switches the portal's transport, and targetcli's saveconfig captures it so boot restore replays it with no engine-side machinery. WebUI checkbox in the add-portal form, gated on the toggle; iSER badge on portal rows.
- **NFS-over-RDMA**: an `rdma 20049` listener joins nfsd's portlist after every engine-initiated nfs-server start while the toggle is on (warn-only — TCP NFS is never hostage to the RDMA side). Disabling restarts nfs-server to drop the listener. Client mount hint shown on the card.
- **NVMe-oF**: the `transport` field is validated (`tcp`|`rdma` instead of an opaque configfs EINVAL), the previously-shipped-but-ungated RDMA dropdown option is gated on the toggle, and `nvmet-rdma` loads with the protocol when opted in.
- **Firewall**: a named `rdma` rule opens `udp/4791` (RoCEv2's wire port — the 4420/20049 "ports" are RDMA-CM service ids riding inside it) and `tcp/20049` (iWARP NFS). Native IB and RoCE v1 don't traverse netfilter. Restrictions work on the rule like any service; the RoCE caveat (everything shares 4791) is documented in the code.
- Kernel modules (`ib_isert`, `nvmet-rdma`, `rpcrdma`) load on demand — with the protocol when opted in, and again at port/portal creation.

State compatibility: `rdma.json` defaults to disabled (upgraded boxes unchanged; rolled-back engines ignore it); `Portal.iser` serde-defaults false so all pre-iSER state loads unchanged.

## Validation (live, soft-RoCE on the dev box)

- Toggle lifecycle: capable=false + blocker without a device, enable refused; `rxe0` detected with link-layer and netdev; enable opens the firewall rule (verified in nftables); disable with consumers refused naming both the NVMe-oF subsystem and the iSER target; after removing them, disable restarts nfs-server (portlist rdma line gone) and closes the rule.
- **NVMe-oF over RDMA end-to-end**: rdma port created (`addr_trtype=rdma`, `nvmet_rdma` loaded, `enabling port 2` in dmesg), `nvme discover -t rdma` finds the subsystem, `nvme connect -t rdma` + 50MiB read at 388 MB/s + clean disconnect.
- **NFS**: `rdma 20049` appears in the portlist via the protocol-enable hook.
- **iSER**: portal created with `iser=1` in LIO configfs, sibling TCP portal untouched (`iser=0`).
- Negative gates: rdma port with toggle off → clear error; bogus transport → `unsupported transport 'bogus' (expected "tcp" or "rdma")`.
- 865 workspace tests green; clippy `--all-targets`, fmt, svelte-check clean.

**iSER data-path on real fabric** (rxe loopback only exercises portal setup here) is part of the dsevost validation ask on #602 — it's his production protocol on RoCEv2/ConnectX.