### PR TITLE
sharing: one-call iSCSI portal replacement, firewall follows portal ports

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -540,6 +540,10 @@ async fn main() -> anyhow::Result<()> {
                 if nasty_system::rdma::enabled().await {
                     state.firewall.open_rdma().await;
                 }
+                // iSCSI/NVMe-oF rules follow configured portal ports
+                // (#602); replace the static defaults with the real
+                // port sets from restored targets.
+                router::share::sync_portal_firewall_ports(&state).await;
             }
         })
         .await;

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -21,7 +21,7 @@ use nasty_apps::{
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
     AddAclRequest, AddLunRequest, AddPortalRequest, CreateTargetRequest, DeleteTargetRequest,
-    IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest,
+    IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest, SetPortalsRequest,
 };
 use nasty_sharing::nfs::{
     CreateNfsShareRequest, DeleteNfsShareRequest, NfsShare, UpdateNfsShareRequest,
@@ -977,6 +977,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     desc: "Remove a listening portal from an iSCSI target. The last portal cannot be removed; add a replacement first.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<RemovePortalRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
+                    name: "share.iscsi.set_portals",
+                    desc: "Replace an iSCSI target's portal set in one call. The engine orders the transition (adds before removes where possible, conflicting adds after), so swapping the wildcard portal for a specific address on the same port works directly — no temporary portal needed.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<SetPortalsRequest>(generator)),
                     result: Some(gen_schema::<IscsiTarget>(generator)),
                 },
             ],

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -11,7 +11,7 @@ mod fs;
 mod guestshare;
 mod notifications;
 mod service;
-mod share;
+pub(crate) mod share;
 mod smb;
 mod snapshot;
 mod subvolume;

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -16,6 +16,82 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    let resp = route_inner(req, state, session).await?;
+    // iSCSI/NVMe-oF firewall rules follow the configured portal ports
+    // (#602). Resync after any mutation that can change them; gate
+    // refusals and errors return early above or carry `error`, so only
+    // real changes pay the recompute.
+    if resp.error.is_none()
+        && matches!(
+            req.method.as_str(),
+            "share.iscsi.create"
+                | "share.iscsi.delete"
+                | "share.iscsi.add_portal"
+                | "share.iscsi.remove_portal"
+                | "share.iscsi.set_portals"
+                | "share.nvmeof.create"
+                | "share.nvmeof.delete"
+                | "share.nvmeof.add_port"
+                | "share.nvmeof.remove_port"
+        )
+    {
+        sync_portal_firewall_ports(state).await;
+    }
+    Some(resp)
+}
+
+/// Recompute the iSCSI and NVMe-oF firewall port sets from the
+/// configured portals. Defaults to the protocol's standard port while
+/// no targets exist, so enabling the protocol opens what the next
+/// `create` will bind. NVMe-oF RDMA listeners are excluded — RoCE
+/// rides udp/4791 under the separate `rdma` rule, and native IB never
+/// traverses netfilter.
+pub(crate) async fn sync_portal_firewall_ports(state: &AppState) {
+    use nasty_system::firewall::{PortSpec, Transport};
+    use nasty_system::protocol::Protocol;
+    use std::collections::BTreeSet;
+
+    let tcp = |port: u16| PortSpec {
+        port,
+        transport: Transport::Tcp,
+        source: None,
+        iface: None,
+    };
+
+    let mut iscsi_ports: BTreeSet<u16> = BTreeSet::new();
+    if let Ok(targets) = state.iscsi.list().await {
+        iscsi_ports.extend(targets.iter().flat_map(|t| t.portals.iter().map(|p| p.port)));
+    }
+    if iscsi_ports.is_empty() {
+        iscsi_ports.insert(3260);
+    }
+    state
+        .firewall
+        .set_service_ports(Protocol::Iscsi, iscsi_ports.into_iter().map(tcp).collect())
+        .await;
+
+    let mut nvmeof_ports: BTreeSet<u16> = BTreeSet::new();
+    if let Ok(subsystems) = state.nvmeof.list().await {
+        nvmeof_ports.extend(subsystems.iter().flat_map(|s| {
+            s.ports
+                .iter()
+                .filter(|p| p.transport == "tcp")
+                .filter_map(|p| p.service_id.parse::<u16>().ok())
+        }));
+    }
+    if nvmeof_ports.is_empty() {
+        nvmeof_ports.insert(4420);
+    }
+    state
+        .firewall
+        .set_service_ports(
+            Protocol::Nvmeof,
+            nvmeof_ports.into_iter().map(tcp).collect(),
+        )
+        .await;
+}
+
+async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Option<Response> {
     Some(match req.method.as_str() {
         "share.nfs.list" => match state.nfs.list().await {
             Ok(v) => ok(req, v),
@@ -255,6 +331,27 @@ pub(super) async fn try_route(
                         return Some(r);
                     }
                     match state.iscsi.add_portal(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
+                Err(e) => invalid(req, e),
+            }
+        }
+        "share.iscsi.set_portals" => {
+            if let Some(r) =
+                require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
+            {
+                return Some(r);
+            }
+            match parse_params::<nasty_sharing::iscsi::SetPortalsRequest>(req) {
+                Ok(p) => {
+                    if p.portals.iter().any(|portal| portal.iser)
+                        && let Some(r) = require_rdma(req, "ib_isert").await
+                    {
+                        return Some(r);
+                    }
+                    match state.iscsi.set_portals(p).await {
                         Ok(v) => ok(req, v),
                         Err(e) => err(req, e),
                     }

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -60,7 +60,11 @@ pub(crate) async fn sync_portal_firewall_ports(state: &AppState) {
 
     let mut iscsi_ports: BTreeSet<u16> = BTreeSet::new();
     if let Ok(targets) = state.iscsi.list().await {
-        iscsi_ports.extend(targets.iter().flat_map(|t| t.portals.iter().map(|p| p.port)));
+        iscsi_ports.extend(
+            targets
+                .iter()
+                .flat_map(|t| t.portals.iter().map(|p| p.port)),
+        );
     }
     if iscsi_ports.is_empty() {
         iscsi_ports.insert(3260);

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -1581,11 +1581,9 @@ mod tests {
         // The create path relies on 0.0.0.0:3260 and [::]:3260
         // coexisting — a v6 wildcard must not be deferred behind a v4
         // wildcard removal that isn't happening.
-        let steps = plan_portal_transition(
-            &[p("0.0.0.0", 3260)],
-            &[p("0.0.0.0", 3260), p("::", 3260)],
-        )
-        .unwrap();
+        let steps =
+            plan_portal_transition(&[p("0.0.0.0", 3260)], &[p("0.0.0.0", 3260), p("::", 3260)])
+                .unwrap();
         assert_eq!(steps, vec![PortalStep::Add(p("::", 3260))]);
     }
 
@@ -1625,9 +1623,11 @@ mod tests {
 
     #[test]
     fn planner_normalizes_bracketed_v6_addresses() {
-        let steps =
-            plan_portal_transition(&[p("0.0.0.0", 3260)], &[p("0.0.0.0", 3260), p("[fd00::1]", 3261)])
-                .unwrap();
+        let steps = plan_portal_transition(
+            &[p("0.0.0.0", 3260)],
+            &[p("0.0.0.0", 3260), p("[fd00::1]", 3261)],
+        )
+        .unwrap();
         assert_eq!(steps, vec![PortalStep::Add(p("fd00::1", 3261))]);
     }
 

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -49,7 +49,7 @@ pub struct IscsiTarget {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Portal {
     /// IP address the portal listens on (use `0.0.0.0` for all interfaces).
     pub ip: String,
@@ -243,6 +243,17 @@ pub struct AddPortalRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetPortalsRequest {
+    /// ID of the target whose portal set is being replaced.
+    pub target_id: String,
+    /// Desired complete portal set. Entries missing from this list are
+    /// removed, new ones are added; the engine orders the transition so
+    /// same-port wildcard↔specific swaps work in one call. Must not be
+    /// empty — a target with zero portals is unreachable.
+    pub portals: Vec<Portal>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct RemovePortalRequest {
     /// ID of the target from which to remove the portal.
     pub target_id: String,
@@ -395,20 +406,10 @@ impl IscsiService {
         // so cleanup is just rmdir'ing the TPG and the target dir.
         let mut created_portals = Vec::with_capacity(mandatory_portals.len() + 1);
         for portal in &mandatory_portals {
-            let np_path = np_path_for(&tpg_path, &portal.ip, portal.port);
-            let created = match configfs_mkdir(&np_path).await {
-                Ok(()) if portal.iser => {
-                    // See add_portal: the iser attr switches the portal's
-                    // transport; captured by saveconfig for boot restore.
-                    configfs_write(&format!("{np_path}/iser"), "1").await
-                }
-                other => other,
-            };
-            if let Err(e) = created {
+            if let Err(e) = create_np(&tpg_path, portal).await {
                 // Best-effort cleanup of what we created so far so the
                 // next attempt doesn't trip the idempotency check with
                 // a stale half-target.
-                let _ = configfs_rmdir(&np_path).await;
                 let _ = configfs_rmdir(&tpg_path).await;
                 let _ = configfs_rmdir(&format!("{ISCSI_BASE}/{iqn}")).await;
                 return Err(e);
@@ -798,28 +799,13 @@ impl IscsiService {
         }
 
         let tpg_path = format!("{ISCSI_BASE}/{}/tpgt_1", target.iqn);
-        let np_path = np_path_for(&tpg_path, &ip, req.port);
-        configfs_mkdir(&np_path).await?;
-
-        // iSER rides on a normal network portal: LIO switches the
-        // transport when `1` is written to the portal's iser attr
-        // (requires ib_isert, loaded by the router gate). The flag is
-        // captured by `save_lio_config` below, so targetcli's boot
-        // restore replays it — no engine-side replay needed.
-        if req.iser
-            && let Err(e) = configfs_write(&format!("{np_path}/iser"), "1").await
-        {
-            // Roll the portal back so a failed iSER enable doesn't
-            // leave a silent TCP portal where RDMA was requested.
-            let _ = configfs_rmdir(&np_path).await;
-            return Err(e);
-        }
-
-        target.portals.push(Portal {
+        let portal = Portal {
             ip: ip.clone(),
             port: req.port,
             iser: req.iser,
-        });
+        };
+        create_np(&tpg_path, &portal).await?;
+        target.portals.push(portal);
 
         state_dir().save(&target.id, &target).await?;
         save_lio_config().await;
@@ -872,9 +858,99 @@ impl IscsiService {
         );
         Ok(target.redacted())
     }
+
+    /// Replace a target's portal set in one call. The planner orders
+    /// the add/remove steps so a same-port wildcard↔specific swap (or
+    /// an iser toggle) works directly — no temporary portal on a third
+    /// port, which is the dance operators were forced into before
+    /// (#602). Non-conflicting additions run before removals so a
+    /// replacement portal is reachable before the old one goes away.
+    pub async fn set_portals(&self, req: SetPortalsRequest) -> Result<IscsiTarget, IscsiError> {
+        let mut target: IscsiTarget = state_dir()
+            .load(&req.target_id)
+            .await
+            .ok_or_else(|| IscsiError::NotFound(req.target_id.clone()))?;
+
+        let steps = plan_portal_transition(&target.portals, &req.portals)?;
+        if steps.is_empty() {
+            return Ok(target.redacted());
+        }
+
+        let tpg_path = format!("{ISCSI_BASE}/{}/tpgt_1", target.iqn);
+        let mut applied: Vec<&PortalStep> = Vec::with_capacity(steps.len());
+        for step in &steps {
+            let result = match step {
+                PortalStep::Add(p) => create_np(&tpg_path, p).await,
+                PortalStep::Remove(p) => {
+                    configfs_rmdir(&np_path_for(&tpg_path, &p.ip, p.port)).await
+                }
+            };
+            if let Err(e) = result {
+                // Unwind in reverse so configfs matches the stored
+                // state we are about to NOT overwrite. Best effort — a
+                // portal that fails to restore is logged, and the next
+                // set_portals attempt re-plans from stored state.
+                for done in applied.into_iter().rev() {
+                    match done {
+                        PortalStep::Add(p) => {
+                            let _ = configfs_rmdir(&np_path_for(&tpg_path, &p.ip, p.port)).await;
+                        }
+                        PortalStep::Remove(p) => {
+                            if create_np(&tpg_path, p).await.is_err() {
+                                tracing::warn!(
+                                    "portal set rollback: failed to restore {}:{} on '{}'",
+                                    p.ip,
+                                    p.port,
+                                    target.iqn
+                                );
+                            }
+                        }
+                    }
+                }
+                return Err(e);
+            }
+            match step {
+                PortalStep::Add(p) => target.portals.push(p.clone()),
+                PortalStep::Remove(p) => target
+                    .portals
+                    .retain(|q| !(q.ip == p.ip && q.port == p.port)),
+            }
+            applied.push(step);
+        }
+
+        state_dir().save(&target.id, &target).await?;
+        save_lio_config().await;
+
+        info!(
+            "Replaced portal set on target '{}' ({} steps, {} portals)",
+            target.iqn,
+            steps.len(),
+            target.portals.len()
+        );
+        Ok(target.redacted())
+    }
 }
 
 // ── configfs helpers ────────────────────────────────────────────
+
+/// Create a network portal (np) directory, flipping it to iSER when
+/// requested. iSER rides on a normal network portal: LIO switches the
+/// transport when `1` is written to the portal's iser attr (requires
+/// ib_isert, loaded by the router gate). The flag is captured by
+/// `save_lio_config`, so targetcli's boot restore replays it — no
+/// engine-side replay needed. A failed iSER flip rolls the np back so
+/// RDMA-requested portals never silently degrade to TCP.
+async fn create_np(tpg_path: &str, portal: &Portal) -> Result<(), IscsiError> {
+    let np_path = np_path_for(tpg_path, &portal.ip, portal.port);
+    configfs_mkdir(&np_path).await?;
+    if portal.iser
+        && let Err(e) = configfs_write(&format!("{np_path}/iser"), "1").await
+    {
+        let _ = configfs_rmdir(&np_path).await;
+        return Err(e);
+    }
+    Ok(())
+}
 
 async fn configfs_mkdir(path: &str) -> Result<(), IscsiError> {
     tokio::fs::create_dir_all(path)
@@ -1075,6 +1151,83 @@ async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
 /// Build the configfs `np/<addr>` path for a portal. LIO's configfs
 /// expects IPv6 addresses bracketed (`[::]:3260`) so the `:` between
 /// address and port stays unambiguous; IPv4 stays bare.
+/// One step of a portal-set transition. Steps are applied in order;
+/// see `plan_portal_transition` for the ordering contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortalStep {
+    Add(Portal),
+    Remove(Portal),
+}
+
+/// Compute the ordered configfs steps that turn `current` into
+/// `desired`.
+///
+/// Ordering contract (the reason this planner exists, #602): the
+/// kernel refuses an np on a port that a same-family wildcard already
+/// binds (and the reverse), and an iser toggle reuses the same np
+/// directory — so adds that collide with a pending remove are deferred
+/// until after the removes. Everything else is added first, so a
+/// replacement portal is reachable before the old one goes away.
+fn plan_portal_transition(
+    current: &[Portal],
+    desired: &[Portal],
+) -> Result<Vec<PortalStep>, IscsiError> {
+    if desired.is_empty() {
+        return Err(IscsiError::CommandFailed(
+            "portal set cannot be empty — target would become unreachable".to_string(),
+        ));
+    }
+
+    let mut normalized: Vec<Portal> = Vec::with_capacity(desired.len());
+    for p in desired {
+        let ip = validate_portal_ip(&p.ip)?;
+        if p.port == 0 {
+            return Err(IscsiError::CommandFailed(
+                "portal port must be non-zero".to_string(),
+            ));
+        }
+        if normalized.iter().any(|q| q.ip == ip && q.port == p.port) {
+            return Err(IscsiError::CommandFailed(format!(
+                "duplicate portal {ip}:{} in requested set",
+                p.port
+            )));
+        }
+        normalized.push(Portal {
+            ip,
+            port: p.port,
+            iser: p.iser,
+        });
+    }
+
+    let removes: Vec<Portal> = current
+        .iter()
+        .filter(|c| !normalized.contains(c))
+        .cloned()
+        .collect();
+    let adds: Vec<Portal> = normalized
+        .into_iter()
+        .filter(|d| !current.contains(d))
+        .collect();
+
+    let is_v6 = |ip: &str| ip.contains(':');
+    let is_wildcard = |ip: &str| ip == "0.0.0.0" || ip == "::";
+    let conflicts = |a: &Portal, r: &Portal| {
+        a.port == r.port
+            && is_v6(&a.ip) == is_v6(&r.ip)
+            && (a.ip == r.ip || is_wildcard(&a.ip) || is_wildcard(&r.ip))
+    };
+
+    let (deferred, immediate): (Vec<_>, Vec<_>) = adds
+        .into_iter()
+        .partition(|a| removes.iter().any(|r| conflicts(a, r)));
+
+    let mut steps: Vec<PortalStep> = Vec::new();
+    steps.extend(immediate.into_iter().map(PortalStep::Add));
+    steps.extend(removes.into_iter().map(PortalStep::Remove));
+    steps.extend(deferred.into_iter().map(PortalStep::Add));
+    Ok(steps)
+}
+
 fn np_path_for(tpg_path: &str, ip: &str, port: u16) -> String {
     if ip.contains(':') {
         format!("{tpg_path}/np/[{ip}]:{port}")
@@ -1327,5 +1480,164 @@ mod tests {
             msg.contains(non_secret_value),
             "non-secret values must surface in errors for diagnostics: {msg}"
         );
+    }
+
+    // ── plan_portal_transition ────────────────────────────────────
+    //
+    // The planner exists because of the dance dsevost hit on #602:
+    // swapping the default wildcard 0.0.0.0:3260 for a specific-IP
+    // portal on the same port required a temporary portal on a third
+    // port. The kernel refuses a specific-IP np while a same-family
+    // wildcard binds that port (and vice versa), so ordering is the
+    // whole point: conflicting adds must run after the removes.
+
+    fn p(ip: &str, port: u16) -> Portal {
+        Portal {
+            ip: ip.into(),
+            port,
+            iser: false,
+        }
+    }
+
+    fn p_iser(ip: &str, port: u16) -> Portal {
+        Portal {
+            ip: ip.into(),
+            port,
+            iser: true,
+        }
+    }
+
+    #[test]
+    fn planner_swaps_wildcard_for_specific_on_same_port_remove_first() {
+        let steps =
+            plan_portal_transition(&[p("0.0.0.0", 3260)], &[p("192.168.255.248", 3260)]).unwrap();
+        assert_eq!(
+            steps,
+            vec![
+                PortalStep::Remove(p("0.0.0.0", 3260)),
+                PortalStep::Add(p("192.168.255.248", 3260)),
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_swaps_specific_for_wildcard_on_same_port_remove_first() {
+        let steps =
+            plan_portal_transition(&[p("192.168.255.248", 3260)], &[p("0.0.0.0", 3260)]).unwrap();
+        assert_eq!(
+            steps,
+            vec![
+                PortalStep::Remove(p("192.168.255.248", 3260)),
+                PortalStep::Add(p("0.0.0.0", 3260)),
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_adds_nonconflicting_portals_before_removes() {
+        // Availability: the new portal on a free port comes up before
+        // the old one goes away.
+        let steps = plan_portal_transition(&[p("0.0.0.0", 3260)], &[p("10.0.0.1", 3261)]).unwrap();
+        assert_eq!(
+            steps,
+            vec![
+                PortalStep::Add(p("10.0.0.1", 3261)),
+                PortalStep::Remove(p("0.0.0.0", 3260)),
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_emits_nothing_for_unchanged_set() {
+        let current = [p("0.0.0.0", 3260), p_iser("10.0.0.1", 3260)];
+        let steps = plan_portal_transition(&current, &current).unwrap();
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn planner_removes_only_the_dropped_portal() {
+        let steps = plan_portal_transition(
+            &[p("10.0.0.1", 3260), p("10.0.0.2", 3260)],
+            &[p("10.0.0.1", 3260)],
+        )
+        .unwrap();
+        assert_eq!(steps, vec![PortalStep::Remove(p("10.0.0.2", 3260))]);
+    }
+
+    #[test]
+    fn planner_allows_same_port_on_different_specific_ips() {
+        // Two specific IPs sharing a port is a legal LIO config — no
+        // conflict, plain add.
+        let steps = plan_portal_transition(
+            &[p("10.0.0.1", 3260)],
+            &[p("10.0.0.1", 3260), p("10.0.0.2", 3260)],
+        )
+        .unwrap();
+        assert_eq!(steps, vec![PortalStep::Add(p("10.0.0.2", 3260))]);
+    }
+
+    #[test]
+    fn planner_scopes_wildcard_conflicts_to_address_family() {
+        // The create path relies on 0.0.0.0:3260 and [::]:3260
+        // coexisting — a v6 wildcard must not be deferred behind a v4
+        // wildcard removal that isn't happening.
+        let steps = plan_portal_transition(
+            &[p("0.0.0.0", 3260)],
+            &[p("0.0.0.0", 3260), p("::", 3260)],
+        )
+        .unwrap();
+        assert_eq!(steps, vec![PortalStep::Add(p("::", 3260))]);
+    }
+
+    #[test]
+    fn planner_treats_iser_toggle_as_remove_then_add() {
+        // Same np directory — the remove must precede the re-add.
+        let steps =
+            plan_portal_transition(&[p("10.0.0.1", 3260)], &[p_iser("10.0.0.1", 3260)]).unwrap();
+        assert_eq!(
+            steps,
+            vec![
+                PortalStep::Remove(p("10.0.0.1", 3260)),
+                PortalStep::Add(p_iser("10.0.0.1", 3260)),
+            ]
+        );
+    }
+
+    #[test]
+    fn planner_rejects_empty_desired_set() {
+        // A target with zero portals is unreachable — same invariant
+        // remove_portal enforces.
+        assert!(plan_portal_transition(&[p("0.0.0.0", 3260)], &[]).is_err());
+    }
+
+    #[test]
+    fn planner_rejects_duplicate_ip_port_pairs() {
+        // Two entries for the same np (even if the iser flag differs)
+        // are contradictory intent, not a valid set.
+        assert!(
+            plan_portal_transition(
+                &[p("0.0.0.0", 3260)],
+                &[p("10.0.0.1", 3260), p_iser("10.0.0.1", 3260)],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn planner_normalizes_bracketed_v6_addresses() {
+        let steps =
+            plan_portal_transition(&[p("0.0.0.0", 3260)], &[p("0.0.0.0", 3260), p("[fd00::1]", 3261)])
+                .unwrap();
+        assert_eq!(steps, vec![PortalStep::Add(p("fd00::1", 3261))]);
+    }
+
+    #[test]
+    fn planner_rejects_invalid_ip() {
+        assert!(plan_portal_transition(&[], &[p("not-an-ip", 3260)]).is_err());
+    }
+
+    #[test]
+    fn planner_rejects_port_zero() {
+        assert!(plan_portal_transition(&[], &[p("10.0.0.1", 0)]).is_err());
     }
 }

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -752,10 +752,7 @@ mod tests {
     fn replace_rule_ports_applies_service_restrictions_to_new_ports() {
         let mut state = state_with_rule("iscsi", vec![tcp(3260)], true);
         let restrictions = FirewallRestrictions {
-            services: HashMap::from([(
-                "iscsi".to_string(),
-                vec!["192.168.1.0/24".to_string()],
-            )]),
+            services: HashMap::from([("iscsi".to_string(), vec!["192.168.1.0/24".to_string()])]),
             interfaces: HashMap::new(),
         };
         replace_rule_ports(&mut state, &restrictions, "iscsi", vec![tcp(3261)]);
@@ -774,8 +771,7 @@ mod tests {
         // rule must exist (so a later `open` keeps the right ports)
         // but stay closed.
         let mut state = FirewallState::default();
-        let changed =
-            replace_rule_ports(&mut state, &no_restrictions(), "nvmeof", vec![tcp(4421)]);
+        let changed = replace_rule_ports(&mut state, &no_restrictions(), "nvmeof", vec![tcp(4421)]);
         assert!(changed);
         assert_eq!(state.rules.len(), 1);
         assert_eq!(state.rules[0].service, "nvmeof");

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -77,7 +77,7 @@ pub enum Transport {
     Udp,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PortSpec {
     pub port: u16,
     pub transport: Transport,
@@ -414,6 +414,62 @@ impl FirewallService {
     pub async fn get_restrictions(&self) -> HashMap<String, Vec<String>> {
         self.restrictions.lock().await.services.clone()
     }
+
+    /// Point a service's firewall rule at a new port set. iSCSI and
+    /// NVMe-oF listen on operator-chosen portal ports, so their rules
+    /// follow the configured portals instead of the protocol default
+    /// (#602: a portal on a custom port was silently unreachable).
+    /// Preserves the rule's open/closed state; no-op (and no nft
+    /// apply) when the effective set is unchanged.
+    pub async fn set_service_ports(&self, proto: Protocol, ports: Vec<PortSpec>) {
+        let mut state = self.state.lock().await;
+        let restrictions = self.restrictions.lock().await;
+        if !replace_rule_ports(&mut state, &restrictions, proto.name(), ports) {
+            return;
+        }
+        if let Err(e) = apply_nftables(&state).await {
+            error!("Failed to update firewall ports for {}: {e}", proto.name());
+        } else {
+            info!("Firewall: updated ports for {}", proto.name());
+        }
+    }
+}
+
+/// Replace `service`'s port set in `state`, re-applying that service's
+/// source/interface restrictions. Creates the rule (closed) when the
+/// service has none yet, so a later `open` keeps the right ports.
+/// Returns whether anything changed, so callers can skip the nft apply.
+fn replace_rule_ports(
+    state: &mut FirewallState,
+    restrictions: &FirewallRestrictions,
+    service: &str,
+    ports: Vec<PortSpec>,
+) -> bool {
+    let sources = restrictions
+        .services
+        .get(service)
+        .cloned()
+        .unwrap_or_default();
+    let ifaces = restrictions
+        .interfaces
+        .get(service)
+        .cloned()
+        .unwrap_or_default();
+    let ports = apply_restrictions(ports, &sources, &ifaces);
+
+    if let Some(rule) = state.rules.iter_mut().find(|r| r.service == service) {
+        if rule.ports == ports {
+            return false;
+        }
+        rule.ports = ports;
+    } else {
+        state.rules.push(FirewallRule {
+            service: service.to_string(),
+            ports,
+            active: false,
+        });
+    }
+    true
 }
 
 /// Apply source and interface restrictions to a set of ports.
@@ -640,5 +696,97 @@ mod tests {
 
         let mut populated = restrictions_with(&[("nfs", &["enp4s0"])]);
         assert!(!populated.strip_iface_refs(&[]));
+    }
+
+    // ── replace_rule_ports ────────────────────────────────────────
+    //
+    // iSCSI/NVMe-oF listen ports follow their configured portals
+    // (#602: a portal on a custom port was unreachable because the
+    // service rule was pinned to the default port). These pin the
+    // port-replacement semantics the engine relies on after every
+    // portal mutation.
+
+    fn state_with_rule(service: &str, ports: Vec<PortSpec>, active: bool) -> FirewallState {
+        FirewallState {
+            rules: vec![FirewallRule {
+                service: service.to_string(),
+                ports,
+                active,
+            }],
+        }
+    }
+
+    fn no_restrictions() -> FirewallRestrictions {
+        FirewallRestrictions {
+            services: HashMap::new(),
+            interfaces: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn replace_rule_ports_swaps_ports_and_keeps_active_flag() {
+        let mut state = state_with_rule("iscsi", vec![tcp(3260)], true);
+        let changed = replace_rule_ports(
+            &mut state,
+            &no_restrictions(),
+            "iscsi",
+            vec![tcp(3260), tcp(3261)],
+        );
+        assert!(changed);
+        assert_eq!(state.rules[0].ports, vec![tcp(3260), tcp(3261)]);
+        assert!(state.rules[0].active, "active flag must survive the swap");
+    }
+
+    #[test]
+    fn replace_rule_ports_preserves_inactive_flag() {
+        let mut state = state_with_rule("iscsi", vec![tcp(3260)], false);
+        replace_rule_ports(&mut state, &no_restrictions(), "iscsi", vec![tcp(3999)]);
+        assert!(
+            !state.rules[0].active,
+            "a disabled service must not be opened by a port resync"
+        );
+        assert_eq!(state.rules[0].ports, vec![tcp(3999)]);
+    }
+
+    #[test]
+    fn replace_rule_ports_applies_service_restrictions_to_new_ports() {
+        let mut state = state_with_rule("iscsi", vec![tcp(3260)], true);
+        let restrictions = FirewallRestrictions {
+            services: HashMap::from([(
+                "iscsi".to_string(),
+                vec!["192.168.1.0/24".to_string()],
+            )]),
+            interfaces: HashMap::new(),
+        };
+        replace_rule_ports(&mut state, &restrictions, "iscsi", vec![tcp(3261)]);
+        assert_eq!(state.rules[0].ports.len(), 1);
+        assert_eq!(state.rules[0].ports[0].port, 3261);
+        assert_eq!(
+            state.rules[0].ports[0].source.as_deref(),
+            Some("192.168.1.0/24"),
+            "restrictions must be re-applied to the replacement ports"
+        );
+    }
+
+    #[test]
+    fn replace_rule_ports_creates_inactive_rule_for_unknown_service() {
+        // A resync can land before the service was ever opened; the
+        // rule must exist (so a later `open` keeps the right ports)
+        // but stay closed.
+        let mut state = FirewallState::default();
+        let changed =
+            replace_rule_ports(&mut state, &no_restrictions(), "nvmeof", vec![tcp(4421)]);
+        assert!(changed);
+        assert_eq!(state.rules.len(), 1);
+        assert_eq!(state.rules[0].service, "nvmeof");
+        assert_eq!(state.rules[0].ports, vec![tcp(4421)]);
+        assert!(!state.rules[0].active);
+    }
+
+    #[test]
+    fn replace_rule_ports_reports_unchanged_for_identical_set() {
+        let mut state = state_with_rule("iscsi", vec![tcp(3260)], true);
+        let changed = replace_rule_ports(&mut state, &no_restrictions(), "iscsi", vec![tcp(3260)]);
+        assert!(!changed, "identical port set must not trigger an nft apply");
     }
 }

--- a/webui/src/lib/sharing/iscsi.svelte.ts
+++ b/webui/src/lib/sharing/iscsi.svelte.ts
@@ -34,6 +34,12 @@ export const iscsi = $state({
 	addPortalPort: 3260,
 	addPortalFamily: 'ipv4' as 'ipv4' | 'ipv6',
 	addPortalIser: false,
+	// Edit mode reuses the addPortal* form fields; these remember which
+	// portal is being replaced so set_portals can swap it in one call
+	// (same-port wildcard→specific swaps included).
+	editPortalTarget: '',
+	editPortalOrigIp: '',
+	editPortalOrigPort: 0,
 	search: '',
 	sortDir: 'asc' as 'asc' | 'desc',
 });
@@ -139,6 +145,35 @@ export async function iscsiAddPortal() {
 	);
 	if (ok !== undefined) {
 		iscsi.addPortalTarget = '';
+		iscsi.addPortalIp = '';
+		iscsi.addPortalIser = false;
+		iscsi.addPortalPort = 3260;
+		iscsi.addPortalFamily = 'ipv4';
+		await iscsiRefresh();
+	}
+}
+
+/** Replace the portal being edited with the form values via
+ *  share.iscsi.set_portals. The engine plans the transition, so
+ *  swapping the wildcard portal for a specific address on the same
+ *  port works directly — the old add-then-remove dance through a
+ *  temporary port is gone (#602). */
+export async function iscsiReplacePortal() {
+	const target = iscsi.targets.find(t => t.id === iscsi.editPortalTarget);
+	if (!target || !iscsi.addPortalIp) return;
+	const portals = target.portals.map(p =>
+		p.ip === iscsi.editPortalOrigIp && p.port === iscsi.editPortalOrigPort
+			? { ip: iscsi.addPortalIp.trim(), port: iscsi.addPortalPort, iser: iscsi.addPortalIser }
+			: { ip: p.ip, port: p.port, iser: p.iser ?? false }
+	);
+	const ok = await withToast(
+		() => client.call('share.iscsi.set_portals', { target_id: iscsi.editPortalTarget, portals }),
+		'Portal updated',
+	);
+	if (ok !== undefined) {
+		iscsi.editPortalTarget = '';
+		iscsi.editPortalOrigIp = '';
+		iscsi.editPortalOrigPort = 0;
 		iscsi.addPortalIp = '';
 		iscsi.addPortalIser = false;
 		iscsi.addPortalPort = 3260;

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -20,6 +20,7 @@
 		iscsiAddAcl,
 		iscsiRemoveAcl,
 		iscsiAddPortal,
+		iscsiReplacePortal,
 		iscsiRemovePortal,
 		iscsiLoadSubvolumes,
 	} from '$lib/sharing/iscsi.svelte';
@@ -56,6 +57,27 @@
 		if (!iscsi.addPortalIp || addPortalIpError) { addPortalTried = true; return; }
 		addPortalTried = false;
 		await iscsiAddPortal();
+	}
+	async function iscsiReplacePortalGuarded() {
+		if (!iscsi.addPortalIp || addPortalIpError) { addPortalTried = true; return; }
+		addPortalTried = false;
+		await iscsiReplacePortal();
+	}
+	function startEditPortal(targetId: string, p: { ip: string; port: number; iser?: boolean }) {
+		iscsi.addPortalTarget = '';
+		iscsi.editPortalTarget = targetId;
+		iscsi.editPortalOrigIp = p.ip;
+		iscsi.editPortalOrigPort = p.port;
+		iscsi.addPortalIp = p.ip;
+		iscsi.addPortalPort = p.port;
+		iscsi.addPortalIser = p.iser ?? false;
+		iscsi.addPortalFamily = p.ip.includes(':') ? 'ipv6' : 'ipv4';
+		addPortalTried = false;
+	}
+	function cancelPortalForm() {
+		iscsi.addPortalTarget = '';
+		iscsi.editPortalTarget = '';
+		addPortalTried = false;
 	}
 
 	const iscsiFiltered = $derived(
@@ -153,6 +175,7 @@
 												<div class="flex items-center gap-3 rounded bg-secondary/50 px-2 py-1.5">
 													<span class="font-mono text-xs">{p.ip.includes(':') && p.ip !== '0.0.0.0' ? `[${p.ip}]` : p.ip}:{p.port}</span>
 													{#if p.iser}<Badge variant="secondary" class="text-[0.6rem]">iSER</Badge>{/if}
+													<Button variant="outline" size="xs" onclick={() => startEditPortal(target.id, p)}>Edit</Button>
 													{#if target.portals.length > 1}
 														<Button variant="destructive" size="xs" onclick={() => iscsiRemovePortal(target.id, p.ip, p.port)}>Remove</Button>
 													{/if}
@@ -160,7 +183,7 @@
 											{/each}
 										</div>
 									{/if}
-									{#if iscsi.addPortalTarget === target.id}
+									{#if iscsi.addPortalTarget === target.id || iscsi.editPortalTarget === target.id}
 										<div class="mt-3 rounded border p-3">
 											<ListenAddressPicker
 												bind:address={iscsi.addPortalIp}
@@ -182,15 +205,19 @@
 													<Label class="text-xs">Port</Label>
 													<Input type="number" bind:value={iscsi.addPortalPort} class="mt-1 h-8 w-24 text-xs" />
 												</div>
-												<Button size="xs" onclick={iscsiAddPortalGuarded}>Add</Button>
-												<Button size="xs" variant="ghost" onclick={() => { iscsi.addPortalTarget = ''; addPortalTried = false; }}>Cancel</Button>
+												{#if iscsi.editPortalTarget === target.id}
+													<Button size="xs" onclick={iscsiReplacePortalGuarded}>Save</Button>
+												{:else}
+													<Button size="xs" onclick={iscsiAddPortalGuarded}>Add</Button>
+												{/if}
+												<Button size="xs" variant="ghost" onclick={cancelPortalForm}>Cancel</Button>
 											</div>
 											{#if !iscsi.addPortalIp && addPortalTried}
 												<p class="mt-1 text-[0.7rem] text-amber-500">Listen address is required.</p>
 											{/if}
 										</div>
 									{:else}
-										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; iscsi.addPortalIser = false; }}>+ Add Portal</Button>
+										<Button size="xs" variant="outline" class="mt-2" onclick={() => { iscsi.editPortalTarget = ''; iscsi.addPortalTarget = target.id; iscsi.addPortalIp = ''; iscsi.addPortalPort = 3260; iscsi.addPortalFamily = 'ipv4'; iscsi.addPortalIser = false; }}>+ Add Portal</Button>
 									{/if}
 								</div>
 


### PR DESCRIPTION
Fixes the portal-management friction dsevost hit while validating #616 on real fabric, plus the firewall gap behind it.

## What's new

- **`share.iscsi.set_portals`** — replace a target's portal set in one call. A pure planner diffs current vs. desired portals and orders the configfs steps: non-conflicting additions come up before removals (a replacement portal is reachable before the old one goes away), while adds that collide with a pending remove — same-port wildcard↔specific swaps, iSER toggles — run after it. Failures unwind in reverse, best-effort, and stored state is only written on success. `add_portal`/`remove_portal` are unchanged for API compatibility; the router applies the same iSER RDMA gating as `create`.
- **Firewall follows portal ports** — the iSCSI and NVMe-oF rules now derive their port sets from configured portals (per-service source/interface restrictions re-applied, no nft churn when unchanged), resynced after every portal-affecting mutation and at boot from restored targets. Portals on custom ports are reachable without hand-written nftables rules; defaults (3260/4420) apply while no targets exist. NVMe-oF RDMA listeners stay under the `rdma` rule (udp/4791).
- **WebUI** — portal rows gain an **Edit** action: changing `0.0.0.0:3260` to a specific address is one save. No more add-temp → delete-default → re-add → delete-temp dance.

## Validation

- TDD: 12 planner tests + 5 firewall port-replacement tests written first and watched fail; 883 workspace tests green.
- clippy `--workspace --all-targets` clean, svelte-check 0/0, webui production build OK.
