### PR TITLE
net: SR-IOV per-VF properties — VLAN, MAC, trust, spoof checking

### DIFF
--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -72,6 +72,37 @@ pub struct InterfaceConfig {
     /// devices — `update()` validates against live `sriov_totalvfs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sriov_num_vfs: Option<u32>,
+    /// SR-IOV: per-VF properties (VLAN, MAC, trust, spoof checking),
+    /// applied by NM via `sriov.vfs` when the PF profile activates —
+    /// the declarative form of `ip link set <pf> vf <n> ...` (#614
+    /// follow-up). Only meaningful alongside `sriov_num_vfs`; indices
+    /// are validated against it. Empty = no per-VF configuration
+    /// (default; also what every pre-existing config deserializes to).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vfs: Vec<VfConfig>,
+}
+
+/// Properties for one SR-IOV virtual function on a PF.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct VfConfig {
+    /// VF index (0-based; must be below the configured VF count).
+    pub index: u32,
+    /// 802.1Q VLAN (1–4094) the VF's traffic is tagged with on the
+    /// PF, like `ip link set <pf> vf <n> vlan <id>`. Absent = untagged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vlan: Option<u16>,
+    /// Administrative MAC. Fixed by the PF driver; a guest consuming
+    /// the VF can't change it unless the VF is trusted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mac: Option<String>,
+    /// VF trust — required by some guests for promiscuous mode or
+    /// MAC changes. Off unless set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust: Option<bool>,
+    /// Spoof checking — the NIC drops frames whose source MAC doesn't
+    /// match the VF's. Driver default unless set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spoof_check: Option<bool>,
 }
 
 fn default_true() -> bool {
@@ -448,6 +479,7 @@ fn validate_sriov(
     live_caps: &std::collections::HashMap<String, Option<u32>>,
 ) -> Result<(), String> {
     for iface in &cfg.interfaces {
+        validate_vf_properties(iface)?;
         let Some(n) = iface.sriov_num_vfs else {
             continue;
         };
@@ -469,6 +501,68 @@ fn validate_sriov(
         }
     }
     Ok(())
+}
+
+/// Validate per-VF properties against the interface's own VF count.
+/// Purely config-internal (no live state needed): NM only applies
+/// `sriov.vfs` on a profile that also creates the VFs, so dangling or
+/// out-of-range entries would silently do nothing — refuse them with
+/// a real error instead.
+fn validate_vf_properties(iface: &InterfaceConfig) -> Result<(), String> {
+    if iface.vfs.is_empty() {
+        return Ok(());
+    }
+    let Some(count) = iface.sriov_num_vfs else {
+        return Err(format!(
+            "'{}' has per-VF properties but no VF count — set the VF count on the \
+             interface first",
+            iface.name
+        ));
+    };
+    let mut seen = std::collections::HashSet::new();
+    for vf in &iface.vfs {
+        if vf.index >= count {
+            return Err(format!(
+                "'{}' creates {count} VFs — VF index {} is out of range (0–{})",
+                iface.name,
+                vf.index,
+                count.saturating_sub(1)
+            ));
+        }
+        if !seen.insert(vf.index) {
+            return Err(format!(
+                "'{}' has duplicate configuration for VF index {}",
+                iface.name, vf.index
+            ));
+        }
+        if let Some(vlan) = vf.vlan
+            && !(1..=4094).contains(&vlan)
+        {
+            return Err(format!(
+                "VF {} on '{}': VLAN {vlan} is not a valid 802.1Q id (1–4094)",
+                vf.index, iface.name
+            ));
+        }
+        if let Some(mac) = &vf.mac
+            && !is_valid_mac(mac)
+        {
+            return Err(format!(
+                "VF {} on '{}': '{mac}' is not a valid MAC address \
+                 (expected six colon-separated hex octets)",
+                vf.index, iface.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Six colon-separated hex octets, e.g. `00:11:22:aa:bb:cc`.
+fn is_valid_mac(mac: &str) -> bool {
+    let parts: Vec<&str> = mac.split(':').collect();
+    parts.len() == 6
+        && parts
+            .iter()
+            .all(|p| p.len() == 2 && p.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 /// Path of the NM conf.d drop-in that scopes NM's ownership of
@@ -2163,6 +2257,7 @@ mod tests {
             enabled: true,
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
+            vfs: Vec::new(),
             mtu: None,
             sriov_num_vfs: None,
         }
@@ -3146,6 +3241,110 @@ mod tests {
             ..Default::default()
         };
         assert!(validate_sriov(&cfg, &caps).is_ok(), "zero VFs");
+    }
+
+    #[test]
+    fn sriov_vf_property_validation_rules() {
+        let caps: std::collections::HashMap<String, Option<u32>> =
+            [("enp6s0f0".to_string(), Some(8u32))].into_iter().collect();
+        let vf = |index: u32| VfConfig {
+            index,
+            vlan: None,
+            mac: None,
+            trust: None,
+            spoof_check: None,
+        };
+        let cfg_with = |i: InterfaceConfig| NetworkConfig {
+            interfaces: vec![i],
+            ..Default::default()
+        };
+
+        // Full property set on VFs within the configured count: fine.
+        let mut pf = iface("enp6s0f0");
+        pf.sriov_num_vfs = Some(4);
+        pf.vfs = vec![
+            VfConfig {
+                index: 0,
+                vlan: Some(100),
+                mac: Some("00:11:22:33:44:55".into()),
+                trust: Some(true),
+                spoof_check: Some(false),
+            },
+            vf(3),
+        ];
+        assert!(validate_sriov(&cfg_with(pf), &caps).is_ok(), "valid vfs");
+
+        // Per-VF properties without a VF count are dangling config —
+        // NM only applies sriov.vfs on a profile that creates VFs.
+        let mut no_count = iface("enp6s0f0");
+        no_count.vfs = vec![vf(0)];
+        assert!(
+            validate_sriov(&cfg_with(no_count), &caps)
+                .unwrap_err()
+                .contains("VF count"),
+            "vfs without count"
+        );
+
+        // Index must stay below the configured count.
+        let mut oob = iface("enp6s0f0");
+        oob.sriov_num_vfs = Some(4);
+        oob.vfs = vec![vf(4)];
+        assert!(
+            validate_sriov(&cfg_with(oob), &caps)
+                .unwrap_err()
+                .contains("index"),
+            "index beyond count"
+        );
+
+        // One entry per VF.
+        let mut dup = iface("enp6s0f0");
+        dup.sriov_num_vfs = Some(4);
+        dup.vfs = vec![vf(1), vf(1)];
+        assert!(
+            validate_sriov(&cfg_with(dup), &caps)
+                .unwrap_err()
+                .contains("duplicate"),
+            "duplicate index"
+        );
+
+        // VLAN must be a valid 802.1Q id (1–4094).
+        for bad_vlan in [0u16, 4095] {
+            let mut v = iface("enp6s0f0");
+            v.sriov_num_vfs = Some(4);
+            v.vfs = vec![VfConfig {
+                vlan: Some(bad_vlan),
+                ..vf(0)
+            }];
+            assert!(
+                validate_sriov(&cfg_with(v), &caps)
+                    .unwrap_err()
+                    .contains("VLAN"),
+                "vlan {bad_vlan} rejected"
+            );
+        }
+
+        // MAC must be six colon-separated hex octets.
+        let mut bad_mac = iface("enp6s0f0");
+        bad_mac.sriov_num_vfs = Some(4);
+        bad_mac.vfs = vec![VfConfig {
+            mac: Some("00:11:22:33:44".into()),
+            ..vf(0)
+        }];
+        assert!(
+            validate_sriov(&cfg_with(bad_mac), &caps)
+                .unwrap_err()
+                .contains("MAC"),
+            "malformed mac"
+        );
+
+        // Absent device: intent kept, same as the VF-count rule.
+        let mut ghost = iface("enp99s0");
+        ghost.sriov_num_vfs = Some(4);
+        ghost.vfs = vec![vf(0)];
+        assert!(
+            validate_sriov(&cfg_with(ghost), &caps).is_ok(),
+            "absent device with vfs"
+        );
     }
 
     #[test]

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -65,6 +65,13 @@ pub struct InterfaceConfig {
     pub ipv6: IpConfig,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u16>,
+    /// SR-IOV: number of virtual functions to create on this physical
+    /// function. `None` = leave the device alone (default; also what
+    /// every pre-SR-IOV config deserializes to). `Some(0)` explicitly
+    /// removes previously-created VFs. Only meaningful on SR-IOV-capable
+    /// devices — `update()` validates against live `sriov_totalvfs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
 }
 
 fn default_true() -> bool {
@@ -233,6 +240,21 @@ pub struct LiveInterface {
     pub mtu: u32,
     /// "physical", "infiniband", "bond", "vlan", "bridge", "tunnel"
     pub kind: String,
+    /// SR-IOV PF: maximum VFs the device supports (`sriov_totalvfs`).
+    /// `None` for non-SR-IOV devices and for VFs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_total_vfs: Option<u32>,
+    /// SR-IOV PF: currently-created VF count (`sriov_numvfs`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
+    /// SR-IOV VF: netdev name of the parent physical function, when
+    /// resolvable through `device/physfn/net/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vf_of: Option<String>,
+    /// SR-IOV VF: index within the parent (which `virtfn<N>` symlink
+    /// points at this device).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vf_index: Option<u32>,
 }
 
 /// Full network state returned by `system.network.get`.
@@ -411,6 +433,39 @@ fn reject_infiniband_refs(
                  parent",
                 mv.parent
             ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate SR-IOV VF-count requests against live capability. Pure —
+/// `live_caps` maps live interface name → `sriov_totalvfs` (None when
+/// the device exists but isn't SR-IOV-capable). A configured-but-absent
+/// device passes (intent is kept; the presence filter withholds its
+/// profile until it exists).
+fn validate_sriov(
+    cfg: &NetworkConfig,
+    live_caps: &std::collections::HashMap<String, Option<u32>>,
+) -> Result<(), String> {
+    for iface in &cfg.interfaces {
+        let Some(n) = iface.sriov_num_vfs else {
+            continue;
+        };
+        match live_caps.get(&iface.name) {
+            Some(Some(total)) if n > *total => {
+                return Err(format!(
+                    "'{}' supports at most {total} virtual functions (requested {n})",
+                    iface.name
+                ));
+            }
+            Some(None) => {
+                return Err(format!(
+                    "'{}' is not SR-IOV capable — it exposes no sriov_totalvfs; \
+                     VF count cannot be configured on it",
+                    iface.name
+                ));
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -678,6 +733,13 @@ impl NetworkService {
         // (Plain L3 on an IB port is fine: it renders as IPoIB.)
         reject_infiniband_refs(&config, &live_kinds)?;
 
+        // SR-IOV VF counts must fit the device's capability.
+        let live_sriov_caps: std::collections::HashMap<String, Option<u32>> = live_ifaces
+            .iter()
+            .map(|i| (i.name.clone(), i.sriov_total_vfs))
+            .collect();
+        validate_sriov(&config, &live_sriov_caps)?;
+
         // A virtual device may take over the name of a stale
         // `interfaces[]` entry whose physical device is gone (kernel
         // rename left it behind). Drop such entries as part of this
@@ -721,7 +783,7 @@ impl NetworkService {
                 .map_err(|e| format!("write {PENDING_REVERT_PATH}: {e}"))?;
 
             persist_config(&config).await?;
-            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_with_vf_settle(&config, mgmt_iface.as_deref(), &live_names).await?;
 
             let txn_id = new_txn_id();
             let revert_at_unix = unix_now() + secs;
@@ -745,7 +807,7 @@ impl NetworkService {
             })
         } else {
             persist_config(&config).await?;
-            let outcome = apply_config(&config, mgmt_iface.as_deref()).await?;
+            let outcome = apply_with_vf_settle(&config, mgmt_iface.as_deref(), &live_names).await?;
 
             info!(
                 "Network config updated ({} interfaces, {} bonds, {} bridges, {} VLANs)",
@@ -1330,6 +1392,7 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
 
         let ipv4_addresses = get_addresses(&name, false).await;
         let ipv6_addresses = get_addresses(&name, true).await;
+        let sriov = sriov_metadata(&path);
 
         result.push(LiveInterface {
             name,
@@ -1341,6 +1404,10 @@ async fn enumerate_interfaces() -> Vec<LiveInterface> {
             ipv6_addresses,
             mtu,
             kind: kind.to_string(),
+            sriov_total_vfs: sriov.total_vfs,
+            sriov_num_vfs: sriov.num_vfs,
+            vf_of: sriov.vf_of,
+            vf_index: sriov.vf_index,
         });
     }
 
@@ -1357,6 +1424,60 @@ fn infiniband_names(live: &[LiveInterface]) -> std::collections::HashSet<String>
         .filter(|i| i.kind == "infiniband")
         .map(|i| i.name.clone())
         .collect()
+}
+
+#[derive(Default)]
+struct SriovMetadata {
+    total_vfs: Option<u32>,
+    num_vfs: Option<u32>,
+    vf_of: Option<String>,
+    vf_index: Option<u32>,
+}
+
+/// Read the SR-IOV family facts for one netdev from sysfs.
+/// `path` is `/sys/class/net/<name>`. PFs expose
+/// `device/sriov_totalvfs` + `device/sriov_numvfs`; VFs expose a
+/// `device/physfn` symlink to the parent PCI function, whose
+/// `virtfn<N>` symlinks give the VF its index and whose `net/` dir
+/// names the parent netdev.
+fn sriov_metadata(path: &std::path::Path) -> SriovMetadata {
+    let dev = path.join("device");
+    let read_u32 = |f: &str| -> Option<u32> {
+        std::fs::read_to_string(dev.join(f))
+            .ok()?
+            .trim()
+            .parse()
+            .ok()
+    };
+
+    let mut out = SriovMetadata {
+        total_vfs: read_u32("sriov_totalvfs"),
+        num_vfs: read_u32("sriov_numvfs"),
+        ..Default::default()
+    };
+
+    let physfn = dev.join("physfn");
+    if let Ok(pf_dir) = std::fs::canonicalize(&physfn) {
+        // Parent netdev name (first entry of the PF's net/ dir).
+        out.vf_of = std::fs::read_dir(pf_dir.join("net"))
+            .ok()
+            .and_then(|mut d| d.next()?.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string());
+        // Our index: which virtfn<N> the PF points back at us with.
+        if let (Ok(me), Ok(entries)) = (std::fs::canonicalize(&dev), std::fs::read_dir(&pf_dir)) {
+            for entry in entries.flatten() {
+                let fname = entry.file_name().to_string_lossy().to_string();
+                if let Some(n) = fname.strip_prefix("virtfn")
+                    && let Ok(idx) = n.parse::<u32>()
+                    && std::fs::canonicalize(entry.path()).is_ok_and(|t| t == me)
+                {
+                    out.vf_index = Some(idx);
+                    break;
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Classify an interface from its sysfs shape. Pure so the
@@ -1865,6 +1986,36 @@ fn outcome_to_apply_errors(outcome: &nm::dbus::NmApplyOutcome) -> Vec<NetworkApp
         .collect()
 }
 
+/// Apply, and when the update both creates VFs (a PF has a VF count)
+/// and configures interfaces that don't exist yet (the VFs
+/// themselves), give NM a moment to materialize the VFs and apply
+/// once more — otherwise the presence filter withholds the VF
+/// profiles until the *next* apply and "set count + configure VF" in
+/// one update needs two clicks. One retry only; the second outcome
+/// wins (it saw the fuller device set).
+async fn apply_with_vf_settle(
+    config: &NetworkConfig,
+    mgmt_iface: Option<&str>,
+    live_names_at_validate: &std::collections::HashSet<String>,
+) -> Result<nm::dbus::NmApplyOutcome, String> {
+    let outcome = apply_config(config, mgmt_iface).await?;
+
+    let creates_vfs = config
+        .interfaces
+        .iter()
+        .any(|i| i.sriov_num_vfs.unwrap_or(0) > 0);
+    let has_absent_config = config
+        .interfaces
+        .iter()
+        .any(|i| !live_names_at_validate.contains(&i.name));
+    if creates_vfs && has_absent_config {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        info!("network apply: re-applying after SR-IOV VF settle");
+        return apply_config(config, mgmt_iface).await;
+    }
+    Ok(outcome)
+}
+
 async fn apply_config(
     config: &NetworkConfig,
     mgmt_iface: Option<&str>,
@@ -2014,6 +2165,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            sriov_num_vfs: None,
         }
     }
 
@@ -2931,6 +3083,82 @@ mod tests {
             retain_live_physical_profiles(profiles, &live_set(&["ib0"])).len(),
             1
         );
+    }
+
+    #[test]
+    fn sriov_validation_rules() {
+        let caps: std::collections::HashMap<String, Option<u32>> = [
+            ("enp6s0f0".to_string(), Some(Some(8))),
+            ("eth0".to_string(), Some(None)),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k, v.unwrap()))
+        .collect();
+
+        let mut pf = iface("enp6s0f0");
+        pf.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![pf],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "within capability");
+
+        let mut too_many = iface("enp6s0f0");
+        too_many.sriov_num_vfs = Some(16);
+        let cfg = NetworkConfig {
+            interfaces: vec![too_many],
+            ..Default::default()
+        };
+        assert!(
+            validate_sriov(&cfg, &caps)
+                .unwrap_err()
+                .contains("at most 8"),
+            "over capability"
+        );
+
+        let mut not_capable = iface("eth0");
+        not_capable.sriov_num_vfs = Some(2);
+        let cfg = NetworkConfig {
+            interfaces: vec![not_capable],
+            ..Default::default()
+        };
+        assert!(
+            validate_sriov(&cfg, &caps)
+                .unwrap_err()
+                .contains("not SR-IOV capable"),
+            "non-capable device"
+        );
+
+        // Absent device: intent kept, validation passes (presence
+        // filter withholds the profile until it exists).
+        let mut ghost = iface("enp99s0");
+        ghost.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![ghost],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "absent device");
+
+        // Explicit zero (remove VFs) is always fine on a capable PF.
+        let mut zero = iface("enp6s0f0");
+        zero.sriov_num_vfs = Some(0);
+        let cfg = NetworkConfig {
+            interfaces: vec![zero],
+            ..Default::default()
+        };
+        assert!(validate_sriov(&cfg, &caps).is_ok(), "zero VFs");
+    }
+
+    #[test]
+    fn sriov_round_trips_through_layered() {
+        let mut pf = iface("enp6s0f0");
+        pf.sriov_num_vfs = Some(4);
+        let cfg = NetworkConfig {
+            interfaces: vec![pf],
+            ..Default::default()
+        };
+        let layered = layered::to_layered(&cfg);
+        assert_eq!(layered.links[0].sriov_num_vfs, Some(4));
     }
 
     #[test]

--- a/engine/nasty-system/src/network/layered.rs
+++ b/engine/nasty-system/src/network/layered.rs
@@ -55,6 +55,10 @@ pub struct Link {
     /// set) on virtual link kinds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sriov_num_vfs: Option<u32>,
+    /// SR-IOV per-VF properties (VLAN/MAC/trust/spoof-check). Like the
+    /// VF count, physical-function-only.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vfs: Vec<super::VfConfig>,
     #[serde(flatten)]
     pub kind: LinkKind,
 }
@@ -182,6 +186,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             mtu: iface.mtu,
             mac: None,
             sriov_num_vfs: iface.sriov_num_vfs,
+            vfs: iface.vfs.clone(),
             kind: LinkKind::Physical,
         });
         push_addresses(&mut addresses, &iface.name, &iface.ipv4, &iface.ipv6);
@@ -193,6 +198,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             mtu: bond.mtu,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bond {
                 members: bond.members.clone(),
                 mode: bond.mode.clone(),
@@ -208,6 +214,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             mtu: bridge.mtu,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bridge {
                 members: bridge.members.clone(),
                 stp: bridge.stp,
@@ -225,6 +232,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             mtu: vlan.mtu,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Vlan {
                 parent: vlan.parent.clone(),
                 id: vlan.vlan_id,
@@ -239,6 +247,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             mtu: mv.mtu,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Macvlan {
                 parent: mv.parent.clone(),
                 mode: mv.mode.clone(),
@@ -295,6 +304,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Physical,
             });
         }
@@ -373,6 +383,7 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 ipv6,
                 mtu: link.mtu,
                 sriov_num_vfs: link.sriov_num_vfs,
+                vfs: link.vfs.clone(),
             }),
             LinkKind::Bond {
                 members,
@@ -602,6 +613,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            vfs: Vec::new(),
             sriov_num_vfs: None,
         }
     }
@@ -726,6 +738,30 @@ mod tests {
     }
 
     // ── Layered shape spot-checks ──────────────────────────────
+
+    #[test]
+    fn vf_properties_survive_layered_round_trip() {
+        // The per-VF config rides the same legacy↔layered path as the
+        // VF count; a dropped clone in either converter would silently
+        // wipe operator VF settings on the next apply.
+        use crate::network::VfConfig;
+        let mut iface = legacy_iface("enp6s0f0");
+        iface.sriov_num_vfs = Some(4);
+        iface.vfs = vec![VfConfig {
+            index: 1,
+            vlan: Some(7),
+            mac: None,
+            trust: Some(true),
+            spoof_check: None,
+        }];
+        let expected = iface.vfs.clone();
+        let cfg = NetworkConfig {
+            interfaces: vec![iface],
+            ..Default::default()
+        };
+        let back = from_layered(&to_layered(&cfg));
+        assert_eq!(back.interfaces[0].vfs, expected);
+    }
 
     #[test]
     fn to_layered_emits_no_address_for_default_disabled_iface() {
@@ -866,6 +902,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Physical,
         }
     }
@@ -877,6 +914,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -893,6 +931,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -908,6 +947,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Vlan {
                 parent: parent.into(),
                 id,
@@ -1002,6 +1042,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Macvlan {
                 parent: parent.into(),
                 mode: "bridge".into(),

--- a/engine/nasty-system/src/network/layered.rs
+++ b/engine/nasty-system/src/network/layered.rs
@@ -51,6 +51,10 @@ pub struct Link {
     /// member MAC for bridges, hardware MAC for physical).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
+    /// SR-IOV VF count for physical functions. Meaningless (and never
+    /// set) on virtual link kinds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
     #[serde(flatten)]
     pub kind: LinkKind,
 }
@@ -177,6 +181,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: iface.enabled,
             mtu: iface.mtu,
             mac: None,
+            sriov_num_vfs: iface.sriov_num_vfs,
             kind: LinkKind::Physical,
         });
         push_addresses(&mut addresses, &iface.name, &iface.ipv4, &iface.ipv6);
@@ -187,6 +192,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: bond.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: bond.members.clone(),
                 mode: bond.mode.clone(),
@@ -201,6 +207,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: bridge.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: bridge.members.clone(),
                 stp: bridge.stp,
@@ -217,6 +224,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: vlan.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: vlan.parent.clone(),
                 id: vlan.vlan_id,
@@ -230,6 +238,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
             enabled: true,
             mtu: mv.mtu,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Macvlan {
                 parent: mv.parent.clone(),
                 mode: mv.mode.clone(),
@@ -285,6 +294,7 @@ pub fn to_layered(legacy: &NetworkConfig) -> LayeredConfig {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Physical,
             });
         }
@@ -362,6 +372,7 @@ pub fn from_layered(layered: &LayeredConfig) -> NetworkConfig {
                 ipv4,
                 ipv6,
                 mtu: link.mtu,
+                sriov_num_vfs: link.sriov_num_vfs,
             }),
             LinkKind::Bond {
                 members,
@@ -591,6 +602,7 @@ mod tests {
             ipv4: IpConfig::default(),
             ipv6: IpConfig::default(),
             mtu: None,
+            sriov_num_vfs: None,
         }
     }
 
@@ -853,6 +865,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Physical,
         }
     }
@@ -863,6 +876,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -878,6 +892,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -892,6 +907,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: parent.into(),
                 id,
@@ -985,6 +1001,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Macvlan {
                 parent: parent.into(),
                 mode: "bridge".into(),

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -49,6 +49,12 @@ pub struct NmConnection {
     pub port_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u16>,
+    /// SR-IOV VF count to create on this PF at activation
+    /// (`sriov.total-vfs`). NM owns VF lifecycle: it writes the
+    /// device's `sriov_numvfs` when the profile activates, which also
+    /// recreates VFs automatically at boot with no engine involvement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sriov_num_vfs: Option<u32>,
     /// Explicit MAC override (NM `cloned-mac-address`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
@@ -440,6 +446,7 @@ fn profile_for_link(
         controller,
         port_type,
         mtu: link.mtu,
+        sriov_num_vfs: link.sriov_num_vfs,
         mac: link.mac.clone(),
         autoconnect: link.enabled,
         ipv4,
@@ -610,6 +617,15 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
             out.push_str(&format!("cloned-mac-address={mac}\n"));
         }
         out.push('\n');
+    }
+
+    // [sriov] — VF count on an SR-IOV PF. NM creates/destroys the VFs
+    // at activation time; autoprobe is left at the global default so
+    // VF host drivers bind normally (passthrough VFs get claimed
+    // per-device via passthrough.nix udev rules instead).
+    if let Some(n) = p.sriov_num_vfs {
+        out.push_str("[sriov]\n");
+        out.push_str(&format!("total-vfs={n}\n\n"));
     }
 
     // [ipv4]
@@ -816,6 +832,13 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
         }
     }
 
+    // [sriov] — see the keyfile serializer note.
+    if let Some(n) = p.sriov_num_vfs {
+        let mut sriov = HashMap::new();
+        sriov.insert("total-vfs".into(), into_value(n));
+        out.insert("sriov".into(), sriov);
+    }
+
     // [ipv4]
     out.insert("ipv4".into(), ip_section_dict(&p.ipv4, Family::V4));
     // [ipv6]
@@ -967,6 +990,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Physical,
         }
     }
@@ -977,6 +1001,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -992,6 +1017,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -1056,6 +1082,29 @@ mod tests {
         // The sibling ethernet port is unaffected by the IB context.
         let eth = find(&profiles, "eth0");
         assert_eq!(eth.conn_type, NmConnectionType::Ethernet);
+    }
+
+    #[test]
+    fn sriov_pf_emits_total_vfs_in_both_serializers() {
+        let mut link = link_phys("enp6s0f0");
+        link.sriov_num_vfs = Some(8);
+        let layered = LayeredConfig {
+            links: vec![link, link_phys("eth0")],
+            ..Default::default()
+        };
+        let profiles = to_nm_profiles(&layered);
+
+        let pf = find(&profiles, "enp6s0f0");
+        let keyfile = serialize_keyfile(pf);
+        assert!(keyfile.contains("[sriov]"), "{keyfile}");
+        assert!(keyfile.contains("total-vfs=8"), "{keyfile}");
+        let dict = to_settings_dict(pf);
+        assert!(dict.contains_key("sriov"));
+
+        // Plain NIC: no [sriov] anywhere.
+        let eth = find(&profiles, "eth0");
+        assert!(!serialize_keyfile(eth).contains("[sriov]"));
+        assert!(!to_settings_dict(eth).contains_key("sriov"));
     }
 
     #[test]
@@ -1186,6 +1235,7 @@ mod tests {
                     enabled: true,
                     mtu: None,
                     mac: None,
+                    sriov_num_vfs: None,
                     kind: LinkKind::Macvlan {
                         parent: "eth1".into(),
                         mode: "bridge".into(),
@@ -1243,6 +1293,7 @@ mod tests {
                     enabled: true,
                     mtu: None,
                     mac: None,
+                    sriov_num_vfs: None,
                     kind: LinkKind::Vlan {
                         parent: "eth0".into(),
                         id: 100,
@@ -1271,6 +1322,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1444,6 +1496,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1469,6 +1522,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1586,6 +1640,7 @@ mod tests {
             enabled: true,
             mtu: Some(1400),
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -1734,6 +1789,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1770,6 +1826,7 @@ mod tests {
                 enabled: true,
                 mtu: None,
                 mac: None,
+                sriov_num_vfs: None,
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1916,6 +1973,7 @@ mod tests {
             enabled: true,
             mtu: Some(1400),
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -2116,6 +2174,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -2131,6 +2190,7 @@ mod tests {
             enabled: true,
             mtu: None,
             mac: None,
+            sriov_num_vfs: None,
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,

--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -55,6 +55,9 @@ pub struct NmConnection {
     /// recreates VFs automatically at boot with no engine involvement.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sriov_num_vfs: Option<u32>,
+    /// SR-IOV per-VF properties, emitted as `sriov.vfs` entries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vfs: Vec<super::VfConfig>,
     /// Explicit MAC override (NM `cloned-mac-address`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
@@ -447,6 +450,7 @@ fn profile_for_link(
         port_type,
         mtu: link.mtu,
         sriov_num_vfs: link.sriov_num_vfs,
+        vfs: link.vfs.clone(),
         mac: link.mac.clone(),
         autoconnect: link.enabled,
         ipv4,
@@ -506,6 +510,27 @@ fn deterministic_uuid_for(name: &str) -> String {
 /// Render an `NmConnection` to NM `.nmconnection` keyfile text. The
 /// output is what NM would consume from
 /// `/etc/NetworkManager/system-connections/<id>.nmconnection`.
+/// VF attribute string in NM's `nm_utils_sriov_vf_to_str` shape with
+/// the index omitted: space-separated `attr=val` pairs in attribute
+/// name order, `vlans=ID[.QOS[.PROTO]]` appended last. This is exactly
+/// what NM's keyfile writer puts after `vf.<index>=`.
+fn vf_attr_string(vf: &super::VfConfig) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(mac) = &vf.mac {
+        parts.push(format!("mac={mac}"));
+    }
+    if let Some(sc) = vf.spoof_check {
+        parts.push(format!("spoof-check={sc}"));
+    }
+    if let Some(t) = vf.trust {
+        parts.push(format!("trust={t}"));
+    }
+    if let Some(vlan) = vf.vlan {
+        parts.push(format!("vlans={vlan}"));
+    }
+    parts.join(" ")
+}
+
 pub fn serialize_keyfile(p: &NmConnection) -> String {
     let mut out = String::new();
 
@@ -625,7 +650,13 @@ pub fn serialize_keyfile(p: &NmConnection) -> String {
     // per-device via passthrough.nix udev rules instead).
     if let Some(n) = p.sriov_num_vfs {
         out.push_str("[sriov]\n");
-        out.push_str(&format!("total-vfs={n}\n\n"));
+        out.push_str(&format!("total-vfs={n}\n"));
+        // One `vf.<index>` key per configured VF — the shape NM's own
+        // keyfile writer produces (nm-keyfile.c, sriov_vfs_writer).
+        for vf in &p.vfs {
+            out.push_str(&format!("vf.{}={}\n", vf.index, vf_attr_string(vf)));
+        }
+        out.push('\n');
     }
 
     // [ipv4]
@@ -836,6 +867,34 @@ pub fn to_settings_dict(p: &NmConnection) -> HashMap<String, HashMap<String, Own
     if let Some(n) = p.sriov_num_vfs {
         let mut sriov = HashMap::new();
         sriov.insert("total-vfs".into(), into_value(n));
+        // `vfs` is aa{sv} with `vlans` nested as aa{sv} of
+        // {id, qos, protocol} — NM's vfs_to_dbus shape
+        // (nm-setting-sriov.c). protocol 0 = 802.1Q.
+        if !p.vfs.is_empty() {
+            let mut vfs: Vec<HashMap<String, OwnedValue>> = Vec::new();
+            for vf in &p.vfs {
+                let mut e = HashMap::new();
+                e.insert("index".into(), into_value(vf.index));
+                if let Some(mac) = &vf.mac {
+                    e.insert("mac".into(), into_value(mac.clone()));
+                }
+                if let Some(sc) = vf.spoof_check {
+                    e.insert("spoof-check".into(), into_value(sc));
+                }
+                if let Some(t) = vf.trust {
+                    e.insert("trust".into(), into_value(t));
+                }
+                if let Some(vlan) = vf.vlan {
+                    let mut v: HashMap<String, OwnedValue> = HashMap::new();
+                    v.insert("id".into(), into_value(u32::from(vlan)));
+                    v.insert("qos".into(), into_value(0u32));
+                    v.insert("protocol".into(), into_value(0u32));
+                    e.insert("vlans".into(), into_value(vec![v]));
+                }
+                vfs.push(e);
+            }
+            sriov.insert("vfs".into(), into_value(vfs));
+        }
         out.insert("sriov".into(), sriov);
     }
 
@@ -991,6 +1050,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Physical,
         }
     }
@@ -1002,6 +1062,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -1018,6 +1079,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,
@@ -1105,6 +1167,88 @@ mod tests {
         let eth = find(&profiles, "eth0");
         assert!(!serialize_keyfile(eth).contains("[sriov]"));
         assert!(!to_settings_dict(eth).contains_key("sriov"));
+
+        // Count-only PF: no per-VF keys.
+        assert!(!keyfile.contains("vf."), "{keyfile}");
+    }
+
+    fn pf_with_vf_properties() -> LayeredConfig {
+        let mut link = link_phys("enp6s0f0");
+        link.sriov_num_vfs = Some(8);
+        link.vfs = vec![
+            crate::network::VfConfig {
+                index: 0,
+                vlan: Some(100),
+                mac: Some("00:11:22:33:44:55".into()),
+                trust: Some(true),
+                spoof_check: Some(false),
+            },
+            crate::network::VfConfig {
+                index: 3,
+                vlan: Some(200),
+                mac: None,
+                trust: None,
+                spoof_check: None,
+            },
+        ];
+        LayeredConfig {
+            links: vec![link],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sriov_vf_properties_emit_as_keyfile_vf_keys() {
+        // NM's keyfile writer (nm-keyfile.c, sriov_vfs_writer) stores
+        // one `vf.<index>` key per VF whose value is the attribute
+        // string without the index: space-separated `attr=val` pairs
+        // in name order, `vlans=ID[.QOS[.PROTO]]` last. Pin the exact
+        // shape so NM parses what we write.
+        let profiles = to_nm_profiles(&pf_with_vf_properties());
+        let keyfile = serialize_keyfile(find(&profiles, "enp6s0f0"));
+        assert!(
+            keyfile.contains("vf.0=mac=00:11:22:33:44:55 spoof-check=false trust=true vlans=100"),
+            "{keyfile}"
+        );
+        assert!(keyfile.contains("vf.3=vlans=200"), "{keyfile}");
+    }
+
+    #[test]
+    fn sriov_vf_properties_emit_as_dbus_vardicts() {
+        // NM's D-Bus shape (nm-setting-sriov.c, vfs_to_dbus): `vfs` is
+        // aa{sv}, each VF vardict carrying `index` (u) plus attributes,
+        // with `vlans` nested as aa{sv} of {id, qos, protocol}.
+        let profiles = to_nm_profiles(&pf_with_vf_properties());
+        let dict = to_settings_dict(find(&profiles, "enp6s0f0"));
+        let sriov = dict.get("sriov").expect("sriov section");
+
+        let outer = sriov.get("vfs").expect("vfs key").try_clone().unwrap();
+        let arr: zbus::zvariant::Array = outer.try_into().expect("vfs is an array");
+        let first: zbus::zvariant::Value = arr.iter().next().unwrap().try_clone().unwrap();
+        let entry: zbus::zvariant::Dict = first.try_into().expect("vf entry is a dict");
+        let vf: HashMap<String, OwnedValue> = entry.try_into().unwrap();
+
+        let index: u32 = vf["index"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(index, 0);
+        let mac: String = vf["mac"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(mac, "00:11:22:33:44:55");
+        let trust: bool = vf["trust"].try_clone().unwrap().try_into().unwrap();
+        assert!(trust);
+        let spoof: bool = vf["spoof-check"].try_clone().unwrap().try_into().unwrap();
+        assert!(!spoof);
+
+        let vlans = vf["vlans"].try_clone().unwrap();
+        let vlans_arr: zbus::zvariant::Array = vlans.try_into().expect("vlans is an array");
+        let vlan_entry: zbus::zvariant::Value =
+            vlans_arr.iter().next().unwrap().try_clone().unwrap();
+        let vlan_dict: zbus::zvariant::Dict = vlan_entry.try_into().unwrap();
+        let vlan: HashMap<String, OwnedValue> = vlan_dict.try_into().unwrap();
+        let id: u32 = vlan["id"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(id, 100);
+        let qos: u32 = vlan["qos"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(qos, 0);
+        let protocol: u32 = vlan["protocol"].try_clone().unwrap().try_into().unwrap();
+        assert_eq!(protocol, 0, "0 = 802.1Q");
     }
 
     #[test]
@@ -1236,6 +1380,7 @@ mod tests {
                     mtu: None,
                     mac: None,
                     sriov_num_vfs: None,
+                    vfs: Vec::new(),
                     kind: LinkKind::Macvlan {
                         parent: "eth1".into(),
                         mode: "bridge".into(),
@@ -1294,6 +1439,7 @@ mod tests {
                     mtu: None,
                     mac: None,
                     sriov_num_vfs: None,
+                    vfs: Vec::new(),
                     kind: LinkKind::Vlan {
                         parent: "eth0".into(),
                         id: 100,
@@ -1323,6 +1469,7 @@ mod tests {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1497,6 +1644,7 @@ mod tests {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1523,6 +1671,7 @@ mod tests {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1641,6 +1790,7 @@ mod tests {
             mtu: Some(1400),
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -1790,6 +1940,7 @@ mod tests {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Bridge {
                     members: vec![],
                     stp: true,
@@ -1827,6 +1978,7 @@ mod tests {
                 mtu: None,
                 mac: None,
                 sriov_num_vfs: None,
+                vfs: Vec::new(),
                 kind: LinkKind::Vlan {
                     parent: "eth0".into(),
                     id: 10,
@@ -1974,6 +2126,7 @@ mod tests {
             mtu: Some(1400),
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Vlan {
                 parent: "eth0".into(),
                 id: 100,
@@ -2175,6 +2328,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bridge {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 stp: false,
@@ -2191,6 +2345,7 @@ mod tests {
             mtu: None,
             mac: None,
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             kind: LinkKind::Bond {
                 members: members.iter().map(|s| (*s).to_string()).collect(),
                 mode: BondMode::Lacp,

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -569,6 +569,7 @@ mod tests {
     fn ethernet_profile(id: &str) -> NmConnection {
         NmConnection {
             sriov_num_vfs: None,
+            vfs: Vec::new(),
             id: id.into(),
             uuid: format!("uuid-for-{id}"),
             conn_type: NmConnectionType::Ethernet,

--- a/engine/nasty-system/src/network/nm/dbus.rs
+++ b/engine/nasty-system/src/network/nm/dbus.rs
@@ -568,6 +568,7 @@ mod tests {
 
     fn ethernet_profile(id: &str) -> NmConnection {
         NmConnection {
+            sriov_num_vfs: None,
             id: id.into(),
             uuid: format!("uuid-for-{id}"),
             conn_type: NmConnectionType::Ethernet,

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -396,6 +396,11 @@ pub struct PciDevice {
     pub iommu_group: u32,
     /// Whether the device is currently bound to vfio-pci.
     pub bound_to_vfio: bool,
+    /// Whether this is an SR-IOV virtual function (has a physfn
+    /// parent). VFs are prime passthrough candidates — the host keeps
+    /// the PF and siblings while one VF goes to the VM.
+    #[serde(default)]
+    pub virtual_function: bool,
 }
 
 // ── Service ─────────────────────────────────────────────────────
@@ -1426,6 +1431,8 @@ async fn list_pci_devices() -> Vec<PciDevice> {
                 .and_then(|p| p.file_name()?.to_str()?.parse::<u32>().ok())
                 .unwrap_or(0);
 
+        let virtual_function =
+            std::path::Path::new(&format!("/sys/bus/pci/devices/{address}/physfn")).exists();
         let bound_to_vfio = tokio::fs::read_link(format!("/sys/bus/pci/devices/{address}/driver"))
             .await
             .ok()
@@ -1438,6 +1445,7 @@ async fn list_pci_devices() -> Vec<PciDevice> {
             description,
             iommu_group,
             bound_to_vfio,
+            virtual_function,
         });
     }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1177,6 +1177,21 @@ export interface InterfaceConfig {
 	mtu: number | null;
 	/** SR-IOV: VFs to create on this PF (absent = leave alone). */
 	sriov_num_vfs?: number | null;
+	/** SR-IOV: per-VF properties, applied alongside the VF count. */
+	vfs?: VfConfig[];
+}
+
+/** Per-VF properties on an SR-IOV PF (`ip link set <pf> vf <n> ...`). */
+export interface VfConfig {
+	index: number;
+	/** 802.1Q VLAN (1–4094); absent = untagged. */
+	vlan?: number | null;
+	/** Administrative MAC. */
+	mac?: string | null;
+	/** VF trust (promiscuous mode / MAC changes from the guest). */
+	trust?: boolean | null;
+	/** Spoof checking. */
+	spoof_check?: boolean | null;
 }
 
 export type BondMode = 'lacp' | 'active_backup' | 'balance_rr' | 'balance_xor';

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1143,6 +1143,8 @@ export interface InterfaceConfig {
 	ipv4: IpConfig;
 	ipv6: IpConfig;
 	mtu: number | null;
+	/** SR-IOV: VFs to create on this PF (absent = leave alone). */
+	sriov_num_vfs?: number | null;
 }
 
 export type BondMode = 'lacp' | 'active_backup' | 'balance_rr' | 'balance_xor';
@@ -1202,6 +1204,14 @@ export interface LiveInterface {
 	ipv6_addresses: string[];
 	mtu: number;
 	kind: string;
+	/** SR-IOV PF: maximum VFs the device supports. */
+	sriov_total_vfs?: number | null;
+	/** SR-IOV PF: currently-created VF count. */
+	sriov_num_vfs?: number | null;
+	/** SR-IOV VF: parent PF's interface name. */
+	vf_of?: string | null;
+	/** SR-IOV VF: index within the parent. */
+	vf_index?: number | null;
 }
 
 export interface NetworkState {
@@ -1549,6 +1559,8 @@ export interface PciDevice {
 	description: string;
 	iommu_group: number;
 	bound_to_vfio: boolean;
+	/** SR-IOV virtual function (has a physfn parent). */
+	virtual_function?: boolean;
 }
 
 // ── Apps ────────────────────────────────────────────────────

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -53,6 +53,7 @@
 	let netIpv6Gateway = $state('');
 	// MTU on inline interface form (string so an empty value means "unset")
 	let netMtu = $state('');
+	let netSriovVfs = $state('');
 	// Bond form
 	let showBondForm = $state(false);
 	let bondName = $state('bond0');
@@ -408,10 +409,12 @@
 			netIpv6Addrs = cfg.ipv6.addresses.length > 0 ? [...cfg.ipv6.addresses] : [''];
 			netIpv6Gateway = cfg.ipv6.gateway ?? '';
 			netMtu = cfg.mtu != null ? String(cfg.mtu) : '';
+			netSriovVfs = (cfg as InterfaceConfig).sriov_num_vfs != null ? String((cfg as InterfaceConfig).sriov_num_vfs) : '';
 		} else {
 			netDhcp = true; netIpv4Addrs = ['']; netGateway = '';
 			netIpv6Method = 'slaac'; netIpv6Addrs = ['']; netIpv6Gateway = '';
 			netMtu = '';
+			netSriovVfs = '';
 		}
 		netChanged = false;
 	}
@@ -460,7 +463,13 @@
 			if (idx >= 0) payload.vlans[idx] = { ...payload.vlans[idx], ipv4, ipv6, mtu };
 		} else {
 			const idx = payload.interfaces.findIndex(i => i.name === selectedIface);
+			const sriovNum = parseMtu(netSriovVfs); // same "number or null" coercion
 			const entry: InterfaceConfig = { name: selectedIface, enabled: true, ipv4, ipv6, mtu };
+			// Distinguish "leave alone" (absent) from explicit 0 (remove VFs):
+			// parseMtu treats 0 as null, so read the raw field for zero.
+			if (netSriovVfs !== '' && netSriovVfs != null) {
+				entry.sriov_num_vfs = sriovNum ?? 0;
+			}
 			if (idx >= 0) payload.interfaces[idx] = entry; else payload.interfaces.push(entry);
 		}
 
@@ -909,6 +918,8 @@
 										<span class="font-mono text-sm font-medium">{iface.name}</span>
 										<Badge variant={iface.up ? 'default' : 'secondary'} class="text-[0.6rem]">{iface.up ? 'Up' : 'Down'}</Badge>
 										<Badge variant="outline" class="text-[0.6rem]">{iface.kind}</Badge>
+										{#if iface.vf_of != null}<Badge variant="secondary" class="text-[0.6rem]">VF {iface.vf_index} of {iface.vf_of}</Badge>{/if}
+										{#if (iface.sriov_num_vfs ?? 0) > 0}<Badge variant="secondary" class="text-[0.6rem]">{iface.sriov_num_vfs} VFs</Badge>{/if}
 										{#if isConfigured}<Badge variant="outline" class="text-[0.6rem]">Configured</Badge>{/if}
 									</div>
 									{#if iface.ipv4_addresses.length > 0 || iface.ipv6_addresses.length > 0}
@@ -1030,6 +1041,20 @@
 										<input id="net-mtu" type="number" min="68" max="65535" bind:value={netMtu} placeholder="default (1500)" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
 										<p class="mt-1 text-[0.65rem] text-muted-foreground">Leave empty for default. 9000 enables jumbo frames (requires switch support end-to-end).</p>
 									</div>
+
+									<!-- SR-IOV (shown only on capable PFs) -->
+									{#if (networkState?.interfaces.find(i => i.name === selectedIface)?.sriov_total_vfs ?? 0) > 0}
+										{@const sriovMax = networkState?.interfaces.find(i => i.name === selectedIface)?.sriov_total_vfs}
+										<div>
+											<label for="net-sriov" class="text-xs text-muted-foreground">SR-IOV virtual functions (0–{sriovMax})</label>
+											<input id="net-sriov" type="number" min="0" max={sriovMax} bind:value={netSriovVfs} placeholder="leave empty to not manage" oninput={() => netChanged = true} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm" />
+											<p class="mt-1 text-[0.65rem] text-muted-foreground">
+												VFs are created when this profile activates and reappear automatically at boot.
+												Each VF shows up as its own interface below — usable for host networking or VM passthrough (Hardware page).
+												Empty = NASty doesn't touch the VF count; 0 = remove all VFs.
+											</p>
+										</div>
+									{/if}
 
 									<!-- DNS -->
 									<div>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -15,7 +15,7 @@
 	} from '$lib/network';
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
-	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig } from '$lib/types';
+	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
@@ -54,6 +54,10 @@
 	// MTU on inline interface form (string so an empty value means "unset")
 	let netMtu = $state('');
 	let netSriovVfs = $state('');
+	// Per-VF property rows (VLAN/MAC as strings so empty means "unset";
+	// trust/spoof-check tri-state: '' = driver default, 'true'/'false' explicit)
+	type VfRow = { index: number; vlan: string; mac: string; trust: '' | 'true' | 'false'; spoofCheck: '' | 'true' | 'false' };
+	let netVfRows: VfRow[] = $state([]);
 	// Bond form
 	let showBondForm = $state(false);
 	let bondName = $state('bond0');
@@ -410,11 +414,19 @@
 			netIpv6Gateway = cfg.ipv6.gateway ?? '';
 			netMtu = cfg.mtu != null ? String(cfg.mtu) : '';
 			netSriovVfs = (cfg as InterfaceConfig).sriov_num_vfs != null ? String((cfg as InterfaceConfig).sriov_num_vfs) : '';
+			netVfRows = ((cfg as InterfaceConfig).vfs ?? []).map(v => ({
+				index: v.index,
+				vlan: v.vlan != null ? String(v.vlan) : '',
+				mac: v.mac ?? '',
+				trust: v.trust == null ? '' as const : v.trust ? 'true' as const : 'false' as const,
+				spoofCheck: v.spoof_check == null ? '' as const : v.spoof_check ? 'true' as const : 'false' as const,
+			}));
 		} else {
 			netDhcp = true; netIpv4Addrs = ['']; netGateway = '';
 			netIpv6Method = 'slaac'; netIpv6Addrs = ['']; netIpv6Gateway = '';
 			netMtu = '';
 			netSriovVfs = '';
+			netVfRows = [];
 		}
 		netChanged = false;
 	}
@@ -469,6 +481,21 @@
 			// parseMtu treats 0 as null, so read the raw field for zero.
 			if (netSriovVfs !== '' && netSriovVfs != null) {
 				entry.sriov_num_vfs = sriovNum ?? 0;
+			}
+			// Per-VF properties ride along only when VFs are managed;
+			// rows with nothing set are dropped rather than sent empty.
+			if (entry.sriov_num_vfs != null && entry.sriov_num_vfs > 0 && netVfRows.length > 0) {
+				const vfs: VfConfig[] = [];
+				for (const r of netVfRows) {
+					const vf: VfConfig = { index: r.index };
+					const vlan = parseMtu(r.vlan);
+					if (vlan != null) vf.vlan = vlan;
+					if (r.mac.trim()) vf.mac = r.mac.trim();
+					if (r.trust !== '') vf.trust = r.trust === 'true';
+					if (r.spoofCheck !== '') vf.spoof_check = r.spoofCheck === 'true';
+					if (vf.vlan != null || vf.mac != null || vf.trust != null || vf.spoof_check != null) vfs.push(vf);
+				}
+				if (vfs.length > 0) entry.vfs = vfs;
 			}
 			if (idx >= 0) payload.interfaces[idx] = entry; else payload.interfaces.push(entry);
 		}
@@ -1053,6 +1080,48 @@
 												Each VF shows up as its own interface below — usable for host networking or VM passthrough (Hardware page).
 												Empty = NASty doesn't touch the VF count; 0 = remove all VFs.
 											</p>
+
+											<!-- Per-VF properties (#614 follow-up): VLAN / MAC / trust / spoof checking -->
+											{#if parseMtu(netSriovVfs) != null && parseMtu(netSriovVfs)! > 0}
+												{@const vfCount = parseMtu(netSriovVfs)!}
+												<div class="mt-3">
+													<span class="text-xs text-muted-foreground">Per-VF properties</span>
+													{#each netVfRows as row, ri}
+														<div class="mt-1 flex flex-wrap items-center gap-2 rounded bg-secondary/40 px-2 py-1.5 text-xs">
+															<span class="font-mono">VF</span>
+															<input type="number" min="0" max={vfCount - 1} bind:value={row.index} oninput={() => netChanged = true} class="w-14 rounded-md border border-input bg-background px-1 py-0.5 font-mono" />
+															<input type="number" min="1" max="4094" bind:value={row.vlan} placeholder="VLAN" oninput={() => netChanged = true} class="w-20 rounded-md border border-input bg-background px-1 py-0.5 font-mono" />
+															<input bind:value={row.mac} placeholder="MAC (optional)" oninput={() => netChanged = true} class="w-40 rounded-md border border-input bg-background px-1 py-0.5 font-mono" />
+															<label class="flex items-center gap-1">trust
+																<select bind:value={row.trust} onchange={() => netChanged = true} class="rounded-md border border-input bg-background px-1 py-0.5">
+																	<option value="">default</option>
+																	<option value="true">on</option>
+																	<option value="false">off</option>
+																</select>
+															</label>
+															<label class="flex items-center gap-1">spoof check
+																<select bind:value={row.spoofCheck} onchange={() => netChanged = true} class="rounded-md border border-input bg-background px-1 py-0.5">
+																	<option value="">default</option>
+																	<option value="true">on</option>
+																	<option value="false">off</option>
+																</select>
+															</label>
+															<Button variant="ghost" size="xs" onclick={() => { netVfRows.splice(ri, 1); netChanged = true; }}>✕</Button>
+														</div>
+													{/each}
+													<Button variant="outline" size="xs" class="mt-2" onclick={() => {
+														const used = new Set(netVfRows.map(r => r.index));
+														let next = 0;
+														while (used.has(next) && next < vfCount) next++;
+														netVfRows.push({ index: next, vlan: '', mac: '', trust: '', spoofCheck: '' });
+														netChanged = true;
+													}} disabled={netVfRows.length >= vfCount}>+ VF settings</Button>
+													<p class="mt-1 text-[0.65rem] text-muted-foreground">
+														Like <code>ip link set {selectedIface} vf N vlan/mac/trust/spoofchk</code>, but persistent — applied by NetworkManager with the profile.
+														VFs without a row keep driver defaults.
+													</p>
+												</div>
+											{/if}
 										</div>
 									{/if}
 

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -1381,6 +1381,7 @@
 								/>
 								<div>
 									<span class="font-mono">{dev.address}</span>
+									{#if dev.virtual_function}<Badge variant="secondary" class="ml-1 text-[0.6rem]">VF</Badge>{/if}
 									<span class="text-muted-foreground ml-1">{dev.description}</span>
 									<span class="text-muted-foreground ml-1">(IOMMU group {dev.iommu_group})</span>
 								</div>


### PR DESCRIPTION
Adds the per-VF properties deferred from #614 and concretely requested by dsevost there: VLAN, MAC, trust, and spoof checking per virtual function — the declarative equivalent of `ip link set <pf> vf <n> vlan/mac/trust/spoofchk`, applied by NetworkManager with the PF profile so it persists and reapplies at boot.

> **Note:** this branch also carries the #614 merge itself. #614 was merged into its stacked base branch `infiniband-foundation` after #611 had already landed in main, so the SR-IOV VF-count feature never reached main — this PR brings both across (the `infiniband-foundation` merge was conflict-free against current main; full suite green on the result).

## What's new

- **`vfs` on the PF's interface config** — a list of `{index, vlan, mac, trust, spoof_check}` entries next to `sriov_num_vfs`, carried through the legacy↔layered conversion (round-trip pinned by test).
- **Wire formats verified against NM source, not guessed**: the keyfile serializer emits one `vf.<index>` key per VF exactly as NM's own `sriov_vfs_writer` does (attribute string, `vlans=ID` last); the D-Bus dict emits `sriov.vfs` as `aa{sv}` with VLANs nested as `{id, qos, protocol}` vardicts per `vfs_to_dbus`.
- **Validation with real errors** (same philosophy as #614): per-VF entries require a VF count on the interface, indices must be unique and below the count, VLAN must be a valid 802.1Q id (1–4094), MAC must be six hex octets. Configured-but-absent devices still pass — intent is kept.
- **WebUI**: per-VF rows under the VF count field (shown only when VFs are managed), with tri-state trust/spoof-check (driver default / on / off) so "explicitly off" — needed e.g. to disable spoof checking on a trusted VF — is expressible.

## Validation

- TDD: validation, both serializer emissions, and the layered round-trip written as failing tests first; 872 workspace tests green.
- `cargo fmt --check` clean (lesson from #617 applied), clippy `--workspace --all-targets` clean, svelte-check 0/0, webui production build OK.
- Like #614, the positive path needs real SR-IOV hardware — the ask for dsevost is a VLAN-tagged VF (`vf.N=... vlans=X` visible in the NM keyfile, traffic tagged on the wire).
