### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.38.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781720951,
-        "narHash": "sha256-VNY9kURuXky504utCZ0Ye76mDG2TFAdzrgYI2iup/PI=",
+        "lastModified": 1783100339,
+        "narHash": "sha256-9sDE7ua3WMCfV9ZbwQdAbpatv2IhvcwHzzPr+/l2au0=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "a0527526f098ff833faf9199278938ea1d5e48f6",
+        "rev": "dde5ecf6ad8b40c3285a6194f5a2642d0e9c6310",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.38.6",
+        "ref": "v1.38.8",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -191,6 +191,11 @@
         # Nixpkgs' base derivation hasn't picked this up yet, so we add it
         # to buildInputs here so the override builds against the new release.
         buildInputs = (old.buildInputs or []) ++ [ pkgs.libunwind ];
+        # v1.38.8 drives the `bindgen` CLI from fs/build.rs (codegen.rs
+        # execs $BINDGEN, default "bindgen") instead of using bindgen as
+        # a build-dependency library. rust-bindgen is the wrapped binary
+        # with its libclang plumbing included.
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ pkgs.rust-bindgen ];
       });
     in base.overrideAttrs (old: {
       passthru = old.passthru // {

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.38.6 release tag.
+    # Pinned to v1.38.8 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.6";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────
@@ -199,12 +199,13 @@
         kernelModule = { lib, stdenv, kernelModuleMakeFlags, kernel }:
           (old.passthru.kernelModule { inherit lib stdenv kernelModuleMakeFlags kernel; }).overrideAttrs (kOld: {
             postPatch = (kOld.postPatch or "") + ''
-              # ccflags-y in the top-level Makefile only covers objects built
-              # there.  The actual compilation happens in src/fs/bcachefs/,
-              # so we patch that subdir's Makefile, inside the BCACHEFS_DKMS
-              # block where CONFIG_BCACHEFS_FS is already set.
-              sed -i 's|# Enable other features here?|# Enable other features here?\n\tCONFIG_BCACHEFS_QUOTA := y\n\tccflags-y += -DCONFIG_BCACHEFS_QUOTA|' \
-                src/fs/bcachefs/Makefile
+              # Quota needs no patching since v1.38.8: fs/Makefile enables
+              # CONFIG_BCACHEFS_QUOTA for DKMS builds whenever the host
+              # kernel has CONFIG_QUOTA (NixOS kernels do), routed through
+              # bcachefs-config-cppflags so the C compile and bindgen agree
+              # on struct layout. Any future config injection here must use
+              # that variable too — a bare `ccflags-y +=` diverges from
+              # bindgen and corrupts memory silently (see fs/Makefile).
               # @NASTY_DEBUG_CHECKS_LINE@
             '';
           });

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.6";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
 
     # NOTE: lanzaboote is intentionally NOT declared as a top-level
     # input here. Secure Boot is per-box opt-in: when the operator


### PR DESCRIPTION
Tracks upstream v1.38.8 (from v1.38.6). Unlike previous bumps this one carries a real change alongside the ref/lock/template updates:

## Quota postPatch deleted — upstream now does it, better

Between 1.38.6 and 1.38.8 upstream restructured the kernel-module tree (`src/fs/bcachefs/` → `fs/`, 207 commits). Our DKMS `postPatch` sed'ed `src/fs/bcachefs/Makefile` to force `CONFIG_BCACHEFS_QUOTA` — that file no longer exists, and more importantly the patch is obsolete: `fs/Makefile` now enables quota for DKMS builds automatically whenever the host kernel has `CONFIG_QUOTA` (NixOS kernels do), routed through `bcachefs-config-cppflags` so the C compile and **bindgen** agree on struct layout. The new Makefile explicitly warns that bare `ccflags-y +=` config injection (our old sed's mechanism) makes bindgen and C disagree on struct sizes — silent memory corruption. Deleting the patch is the correct move, not just cleanup.

The `@NASTY_DEBUG_CHECKS_LINE@` marker is preserved, with a comment that future config injection must use `bcachefs-config-cppflags`.

## Validation notes

- Verified locally: v1.38.8 tag fetches, `Cargo.toml` version parse (the derivation's `version` read) yields `1.38.8`, `fs/Makefile` + `dkms/Makefile` present.
- What only CI/the Integration workflow can prove: the nixpkgs `passthru.kernelModule` derivation building against the restructured tree (it now contains vendored Rust under `fs/vendor/` and new shim crates), and the appliance VM test exercising the module. If the module build trips on the new layout, that's expected fallout to investigate here — please don't merge on green engine checks alone; the Integration/appliance run is the real gate for this one.
- Runtime check worth doing on a test box after the switch: `setquota`/`repquota` still work (quota now comes from the upstream auto-enable rather than our patch), and `bcachefs version` reports 1.38.8.
