### PR TITLE
deps: crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Clears the freshly published [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl), which cargo-deny now flags on **every** PR — it's what failed #621's advisories check, unrelated to the bcachefs bump itself.

Transitive dependency via `rustic_core`/`opendal` in `nasty-backup`. Lock-only change (`cargo update -p crossbeam-epoch`). 890 workspace tests, `cargo fmt --check`, and clippy `--all-targets` green.

Once merged, I'll update #621 from main so its advisories check passes.