### PR TITLE
storage: handle bcachefs 1.38.8 by-uuid mount sources (fixes "filesystem missing" after upgrade)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3013,6 +3013,7 @@ dependencies = [
 name = "nasty-storage"
 version = "0.0.13"
 dependencies = [
+ "libc",
  "nasty-common",
  "schemars 1.2.1",
  "serde",

--- a/engine/nasty-storage/Cargo.toml
+++ b/engine/nasty-storage/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
+libc.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 xattr = "1.6.1"

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -2220,16 +2220,21 @@ impl FilesystemService {
 
             // Read /proc/mounts to know which devices are *actually* mounted.
             // lsblk's mountpoint field can be stale after bcachefs device removal/wipe.
+            // bcachefs sources come in three shapes across module versions:
+            // a plain device, a colon-joined member list (< 1.38.8), or a
+            // single /dev/disk/by-uuid/<fs-uuid> (≥ 1.38.8 multi-device) that
+            // must be expanded to real members via sysfs.
             let mounted_devices: std::collections::HashSet<String> =
                 tokio::fs::read_to_string("/proc/mounts")
                     .await
                     .unwrap_or_default()
                     .lines()
                     .flat_map(|line| {
-                        // Each line: "device mountpoint fstype options ..."
-                        // bcachefs uses colon-separated multi-device: "/dev/sdb:/dev/sdc /fs/first ..."
                         let dev_field = line.split_whitespace().next().unwrap_or("");
-                        dev_field.split(':').map(String::from).collect::<Vec<_>>()
+                        resolve_mount_devices(
+                            dev_field.split(':').map(String::from).collect::<Vec<_>>(),
+                            std::path::Path::new(SYSFS_BCACHEFS),
+                        )
                     })
                     .collect();
 
@@ -4372,6 +4377,65 @@ fn parse_bcachefs_mount_line(line: &str) -> Option<ProcMountsBcachefs> {
     })
 }
 
+/// If the parsed mount source is the bcachefs ≥1.38.8 multi-device
+/// form — a single `/dev/disk/by-uuid/<fs-uuid>` entry — return the
+/// UUID. Older modules report the colon-joined member list instead,
+/// and single-device mounts a plain device path; both return None.
+fn by_uuid_source(devices: &[String]) -> Option<&str> {
+    match devices {
+        [only] => only.strip_prefix("/dev/disk/by-uuid/"),
+        _ => None,
+    }
+}
+
+/// Resolve a mounted filesystem's member devices from sysfs:
+/// `<base>/<uuid>/dev-N/block` symlinks point at the members' block
+/// device sysfs nodes, whose basename is the kernel device name.
+/// Returns None when the filesystem has no sysfs presence (not
+/// mounted, or gone by the time we look). Ordered by member index so
+/// output is stable across udev enumeration order.
+fn sysfs_fs_members(base: &std::path::Path, uuid: &str) -> Option<Vec<String>> {
+    let fs_dir = base.join(uuid);
+    let entries = std::fs::read_dir(&fs_dir).ok()?;
+    let mut members: Vec<(u32, String)> = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(idx) = name
+            .to_str()
+            .and_then(|n| n.strip_prefix("dev-"))
+            .and_then(|n| n.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(target) = std::fs::read_link(entry.path().join("block")) else {
+            continue;
+        };
+        if let Some(dev_name) = target.file_name().and_then(|n| n.to_str()) {
+            members.push((idx, format!("/dev/{dev_name}")));
+        }
+    }
+    if members.is_empty() {
+        return None;
+    }
+    members.sort_by_key(|(idx, _)| *idx);
+    Some(members.into_iter().map(|(_, path)| path).collect())
+}
+
+/// Replace a by-uuid mount source with the real member list from
+/// sysfs. Colon-list and plain-device sources pass through untouched;
+/// a by-uuid source whose sysfs entry is missing (unmount race) also
+/// passes through — a stale-looking path beats claiming the
+/// filesystem has no mounted devices at all.
+fn resolve_mount_devices(devices: Vec<String>, sysfs_base: &std::path::Path) -> Vec<String> {
+    match by_uuid_source(&devices).and_then(|uuid| sysfs_fs_members(sysfs_base, uuid)) {
+        Some(members) => members,
+        None => devices,
+    }
+}
+
+/// Where the kernel exposes mounted bcachefs filesystems.
+const SYSFS_BCACHEFS: &str = "/sys/fs/bcachefs";
+
 /// Parse /proc/mounts for bcachefs entries.
 /// Returns map of mount_point -> list of devices.
 async fn read_bcachefs_mounts() -> Result<HashMap<String, Vec<String>>, FilesystemError> {
@@ -4381,7 +4445,12 @@ async fn read_bcachefs_mounts() -> Result<HashMap<String, Vec<String>>, Filesyst
     let mounts = content
         .lines()
         .filter_map(parse_bcachefs_mount_line)
-        .map(|m| (m.mount_point, m.devices))
+        .map(|m| {
+            (
+                m.mount_point,
+                resolve_mount_devices(m.devices, std::path::Path::new(SYSFS_BCACHEFS)),
+            )
+        })
         .collect();
     Ok(mounts)
 }
@@ -5989,6 +6058,89 @@ weird_future_op: ...
         assert!(parse_bcachefs_mount_line("").is_none());
         assert!(parse_bcachefs_mount_line("/dev/sda").is_none());
         assert!(parse_bcachefs_mount_line("/dev/sda /mnt").is_none());
+    }
+
+    // ── by-uuid mount source resolution (bcachefs ≥ 1.38.8) ───────
+    //
+    // The 1.38.8 kernel module's show_devname reports multi-device
+    // filesystems as `/dev/disk/by-uuid/<fs-uuid>` in /proc/mounts
+    // instead of the colon-joined member list. Splitting that on ':'
+    // yields a path that matches no member device, so the engine
+    // believed the filesystem wasn't mounted at all (the ".41 says
+    // filesystem is missing" report). Members must come from sysfs.
+
+    #[test]
+    fn by_uuid_source_detected_only_for_single_by_uuid_entry() {
+        assert_eq!(
+            by_uuid_source(&["/dev/disk/by-uuid/cf4eabd3-14a5-4bbb-87a6-d6f217cdfb47".into()]),
+            Some("cf4eabd3-14a5-4bbb-87a6-d6f217cdfb47")
+        );
+        assert_eq!(by_uuid_source(&["/dev/sda".into()]), None);
+        assert_eq!(
+            by_uuid_source(&["/dev/sdb".into(), "/dev/sdd".into()]),
+            None
+        );
+        assert_eq!(by_uuid_source(&[]), None);
+    }
+
+    /// Build a fake `/sys/fs/bcachefs/<uuid>/dev-N/block` tree under a
+    /// unique temp dir. Returns (base, uuid); caller removes base.
+    fn sysfs_fixture(members: &[(&str, &str)]) -> (std::path::PathBuf, String) {
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let base = std::env::temp_dir().join(format!("nasty-sysfs-{}", uuid::Uuid::new_v4()));
+        let fs_dir = base.join(&uuid);
+        for (devdir, target) in members {
+            let d = fs_dir.join(devdir);
+            std::fs::create_dir_all(&d).unwrap();
+            std::os::unix::fs::symlink(target, d.join("block")).unwrap();
+        }
+        (base, uuid)
+    }
+
+    #[test]
+    fn sysfs_members_resolve_block_symlink_basenames_in_index_order() {
+        let (base, uuid) = sysfs_fixture(&[
+            ("dev-1", "../../../devices/pci0000:00/host1/block/sdd"),
+            ("dev-0", "../../../devices/pci0000:00/host0/block/sdb"),
+            ("dev-10", "../../../devices/pci0000:00/host2/block/sde"),
+        ]);
+        let members = sysfs_fs_members(&base, &uuid).expect("members resolve");
+        assert_eq!(
+            members,
+            vec![
+                "/dev/sdb".to_string(),
+                "/dev/sdd".to_string(),
+                "/dev/sde".to_string()
+            ],
+            "sorted by member index, numerically (dev-10 after dev-1)"
+        );
+        assert!(
+            sysfs_fs_members(&base, "00000000-0000-0000-0000-000000000000").is_none(),
+            "unknown uuid (unmounted fs) yields None"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn resolve_mount_devices_swaps_by_uuid_source_for_sysfs_members() {
+        let (base, uuid) = sysfs_fixture(&[("dev-0", "../sdb"), ("dev-1", "../sdd")]);
+
+        let resolved = resolve_mount_devices(vec![format!("/dev/disk/by-uuid/{uuid}")], &base);
+        assert_eq!(
+            resolved,
+            vec!["/dev/sdb".to_string(), "/dev/sdd".to_string()]
+        );
+
+        // Old-format colon lists pass through untouched.
+        let raw = vec!["/dev/sdb".to_string(), "/dev/sdd".to_string()];
+        assert_eq!(resolve_mount_devices(raw.clone(), &base), raw);
+
+        // A by-uuid source whose sysfs entry is gone (fs racing an
+        // unmount) keeps the raw source rather than reporting nothing.
+        let ghost = vec!["/dev/disk/by-uuid/dead-beef".to_string()];
+        assert_eq!(resolve_mount_devices(ghost.clone(), &base), ghost);
+
+        std::fs::remove_dir_all(&base).ok();
     }
 
     // ── parse_bcachefs_opt ─────────────────────────────────────────

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -2050,51 +2050,142 @@ pub(crate) struct ProjectQuotaInfo {
     pub hard_bytes: u64,
 }
 
+/// Split a Linux `dev_t` into (major, minor) — glibc's bit layout:
+/// 12-bit major at bits 8–19 (high part at 32+), 8-bit minor low with
+/// the high part at bits 20+.
+fn split_dev_t(dev: u64) -> (u32, u32) {
+    let major = ((dev >> 8) & 0xfff) | ((dev >> 32) & !0xfff_u64);
+    let minor = (dev & 0xff) | ((dev >> 12) & !0xff_u64);
+    (major as u32, minor as u32)
+}
+
+/// Resolve a `dev_t` to its `/dev/<name>` block device via the
+/// kernel's `<base>/<major>:<minor>` symlinks (base is
+/// `/sys/dev/block` in production). The symlink target's basename is
+/// the kernel device name.
+fn block_device_for_dev(base: &std::path::Path, dev: u64) -> Option<String> {
+    let (major, minor) = split_dev_t(dev);
+    let target = std::fs::read_link(base.join(format!("{major}:{minor}"))).ok()?;
+    let name = target.file_name()?.to_str()?;
+    Some(format!("/dev/{name}"))
+}
+
+/// Convert quotactl block-quota fields to [`ProjectQuotaInfo`]:
+/// `dqb_curspace` is in bytes, `dqb_bhardlimit` in 1KiB blocks
+/// (QIF_DQBLKSIZE). `0` stays `0` — the "no limit" convention shared
+/// with the old repquota parser.
+// Only the linux-gated quotactl path calls this in production code.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn project_quota_info(curspace_bytes: u64, bhardlimit_blocks: u64) -> ProjectQuotaInfo {
+    ProjectQuotaInfo {
+        used_bytes: curspace_bytes,
+        hard_bytes: bhardlimit_blocks.saturating_mul(1024),
+    }
+}
+
+/// Enumerate all project quotas on `device` via Q_GETNEXTQUOTA.
+///
+/// Direct quotactl instead of shelling to repquota: quota-tools
+/// resolves the /proc/mounts *source string* to pick its quotactl
+/// device, and bcachefs ≥ 1.38.8 reports multi-device filesystems as
+/// a by-uuid symlink that can resolve to a member whose dev_t is not
+/// the superblock's — every repquota invocation then fails with
+/// ENODEV. The caller hands us the device that actually matches the
+/// mountpoint's st_dev, so the kernel lookup always succeeds.
+#[cfg(target_os = "linux")]
+fn read_project_quotas(device: &str) -> std::io::Result<HashMap<u32, ProjectQuotaInfo>> {
+    // struct if_nextdqblk from linux/quota.h.
+    #[repr(C)]
+    #[derive(Default, Clone, Copy)]
+    struct IfNextDqblk {
+        dqb_bhardlimit: u64,
+        dqb_bsoftlimit: u64,
+        dqb_curspace: u64,
+        dqb_ihardlimit: u64,
+        dqb_isoftlimit: u64,
+        dqb_curinodes: u64,
+        dqb_btime: u64,
+        dqb_itime: u64,
+        dqb_valid: u32,
+        dqb_id: u32,
+    }
+    const Q_GETNEXTQUOTA: libc::c_int = 0x800009;
+    const PRJQUOTA: libc::c_int = 2;
+    let cmd = (Q_GETNEXTQUOTA << 8) | PRJQUOTA;
+
+    let cdev = std::ffi::CString::new(device)
+        .map_err(|_| std::io::Error::other("device path contains NUL"))?;
+    let mut out = HashMap::new();
+    let mut id: u32 = 0;
+    // Bounded: each iteration returns the next *allocated* quota entry,
+    // so this only loops once per project that actually exists. The cap
+    // is a runaway guard, far above any real subvolume count.
+    for _ in 0..100_000 {
+        let mut blk = IfNextDqblk::default();
+        let rc = unsafe {
+            libc::quotactl(
+                cmd,
+                cdev.as_ptr(),
+                id as libc::c_int,
+                &mut blk as *mut IfNextDqblk as *mut libc::c_char,
+            )
+        };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            // ENOENT/ESRCH: no further entries — normal loop end (also
+            // the "no quotas at all" case on the first call).
+            match err.raw_os_error() {
+                Some(libc::ENOENT) | Some(libc::ESRCH) => break,
+                _ => return Err(err),
+            }
+        }
+        if blk.dqb_id > 0 {
+            out.insert(
+                blk.dqb_id,
+                project_quota_info(blk.dqb_curspace, blk.dqb_bhardlimit),
+            );
+        }
+        id = match blk.dqb_id.checked_add(1) {
+            Some(next) => next,
+            None => break,
+        };
+    }
+    Ok(out)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_project_quotas(_device: &str) -> std::io::Result<HashMap<u32, ProjectQuotaInfo>> {
+    Ok(HashMap::new())
+}
+
 /// Query project quota usage for all projects on a filesystem in one shot.
 /// Returns a map of project_id → (used, hard limit).
-/// Falls back to empty map if repquota is unavailable or fails.
+/// Falls back to empty map if quota information is unavailable.
 async fn query_project_usages(mount_point: &str) -> HashMap<u32, ProjectQuotaInfo> {
-    let mut usages = HashMap::new();
+    use std::os::unix::fs::MetadataExt;
 
-    // repquota -P --raw-grace outputs KB values with numeric project IDs when using -n
-    let output = match cmd::run_ok("repquota", &["-P", "--raw-grace", "-n", mount_point]).await {
-        Ok(o) => o,
+    // The device quotactl needs is the one backing the mountpoint's
+    // st_dev — NOT the /proc/mounts source string (see
+    // read_project_quotas). /sys/dev/block maps dev_t → kernel name.
+    let dev = match tokio::fs::metadata(mount_point).await {
+        Ok(m) => m.dev(),
         Err(e) => {
-            warn!("repquota failed on {mount_point}: {e}");
-            return usages;
+            warn!("quota query: stat {mount_point} failed: {e}");
+            return HashMap::new();
         }
     };
+    let Some(device) = block_device_for_dev(std::path::Path::new("/sys/dev/block"), dev) else {
+        warn!("quota query: no block device found for {mount_point} (dev_t {dev})");
+        return HashMap::new();
+    };
 
-    // Parse lines like: "#1689127545 -- 125486988 1073741824000 1073741824000 0 78 0 0 0"
-    // Fields: project_name status used_kb soft_kb hard_kb grace files_used files_soft files_hard files_grace
-    for line in output.lines() {
-        let line = line.trim();
-        if !line.starts_with('#') {
-            continue;
+    match read_project_quotas(&device) {
+        Ok(usages) => usages,
+        Err(e) => {
+            warn!("quota query via quotactl failed on {mount_point} ({device}): {e}");
+            HashMap::new()
         }
-        let id_str = &line[1..]; // strip '#'
-        let mut parts = id_str.split_whitespace();
-        let projid: u32 = match parts.next().and_then(|s| s.parse().ok()) {
-            Some(id) if id > 0 => id,
-            _ => continue,
-        };
-        let _status = parts.next(); // "--" or "+-" etc
-        let used_kb: u64 = match parts.next().and_then(|s| s.parse().ok()) {
-            Some(v) => v,
-            None => continue,
-        };
-        let _soft_kb = parts.next();
-        let hard_kb: u64 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-        usages.insert(
-            projid,
-            ProjectQuotaInfo {
-                used_bytes: used_kb * 1024,
-                hard_bytes: hard_kb * 1024,
-            },
-        );
     }
-
-    usages
 }
 
 /// Build a map of canonical backing-file path → loop device name.
@@ -2223,6 +2314,57 @@ async fn materialize_subvol_from_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── project quota via quotactl (bcachefs ≥ 1.38.8, #623) ──────
+    //
+    // repquota resolves the /proc/mounts source string, which for
+    // 1.38.8 multi-device filesystems is a by-uuid symlink that can
+    // point at a member whose dev_t differs from the superblock's —
+    // quotactl(ENODEV) with no repquota invocation that works. The
+    // engine now calls quotactl directly against the device that
+    // matches the mountpoint's st_dev; these pin the pure pieces.
+
+    #[test]
+    fn split_dev_t_matches_linux_encoding() {
+        // 8:16 (/dev/sdb) — the classic low-bits layout.
+        assert_eq!(split_dev_t(0x810), (8, 16));
+        // 259:5 — nvme partition majors live in the 12-bit field.
+        assert_eq!(split_dev_t(0x10305), (259, 5));
+        // minor > 255 spills into the high minor bits (bits 20+).
+        assert_eq!(split_dev_t((0x100 << 12) | (8 << 8)), (8, 256));
+    }
+
+    #[test]
+    fn block_device_resolves_via_sys_dev_block_symlink() {
+        let base = std::env::temp_dir().join(format!("nasty-devblk-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        std::os::unix::fs::symlink(
+            "../../devices/pci0000:00/0000:00:1f.2/host1/block/sdb",
+            base.join("8:16"),
+        )
+        .unwrap();
+        assert_eq!(
+            block_device_for_dev(&base, 0x810).as_deref(),
+            Some("/dev/sdb")
+        );
+        assert_eq!(
+            block_device_for_dev(&base, 0x830),
+            None,
+            "unknown dev_t yields None"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn project_quota_info_uses_bytes_for_usage_and_1k_blocks_for_limit() {
+        // quotactl reports curspace in bytes but limits in 1KiB blocks
+        // (QIF_DQBLKSIZE) — the same split repquota's KB output had.
+        let info = project_quota_info(125_486_988 * 1024, 1_048_576_000);
+        assert_eq!(info.used_bytes, 125_486_988 * 1024);
+        assert_eq!(info.hard_bytes, 1_048_576_000 * 1024);
+        // 0 = "no limit", preserved as 0 (existing convention).
+        assert_eq!(project_quota_info(42, 0).hard_bytes, 0);
+    }
 
     #[test]
     fn validate_subvolume_name_accepts_typical_names() {


### PR DESCRIPTION
After the #621 upgrade, a multi-device box reported its mounted filesystem as missing, with repquota failures alongside. Root cause: the 1.38.8 kernel module changed `show_devname` — multi-device filesystems now appear in `/proc/mounts` as `/dev/disk/by-uuid/<fs-uuid>` instead of `/dev/sdb:/dev/sdd`.

## Fixes

- **Mounted-member detection** (the "filesystem is missing" symptom): by-uuid sources are resolved to real member devices via `/sys/fs/bcachefs/<uuid>/dev-N/block`. Colon lists and plain paths pass through byte-identical — **compatibility with < 1.38.8 modules is pinned by tests** (passthrough cases + all pre-existing colon-list tests unchanged).
- **Project quotas**: replaced the repquota shell-out with direct `quotactl(Q_GETNEXTQUOTA)` against the device backing the mountpoint's `st_dev`. With the by-uuid source, *no* repquota invocation can work (quota-tools canonicalizes the source to an arbitrary member whose dev_t may differ from the superblock's → ENODEV); the direct syscall sidesteps the tool entirely and works on both old and new modules.

## Evidence & validation

- Root-caused live on the .41 (1.38.8, broken) / .59 (1.38.6, working) pair: raw `quotactl` probes ENODEV against the by-uuid target and succeed against the superblock's member; journald shows both symptoms starting exactly at the upgrade.
- Syscall loop replicated in Python on both boxes: struct layout and loop termination verified live; **output cross-validated byte-for-byte against repquota** on .59's real project quotas (usage bytes and 1K-block limits identical).
- TDD: 6 new tests (by-uuid detection, sysfs member resolution incl. numeric dev-N ordering, passthrough compatibility, dev_t split, /sys/dev/block resolution, quota unit conversion) written failing-first. 896 workspace tests, fmt, clippy `--all-targets -D warnings` green.

Once merged: .41 should show the filesystem again after an engine restart, no reboot needed. An upstream report about the by-uuid/dev_t mismatch breaking quota-tools may be worth filing separately.