### PR TITLE
webui: clear the bcachefs top-bar chip when a watched switch completes

### DIFF
--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -524,6 +524,17 @@
 						checkInfo = null; // clear stale "available" after upgrade
 						await loadVersionPage();
 						writeVersionPageAction(null);
+						// Nudge the layout's cached sysInfo so the top-bar
+						// bcachefs chip clears without a manual reload. The
+						// same nudge exists in loadStatus() for the
+						// came-back-to-the-page case, but when the operator
+						// sits here watching the rebuild, THIS branch detects
+						// completion — and a bcachefs-tools-only switch never
+						// restarts the engine, so the reconnect-driven refresh
+						// doesn't fire either. Reconcile (spaced retries), not
+						// a single trigger: the fetch can race the settling
+						// rebuild.
+						sysInfoRefresh.triggerReconcile();
 						if (status.state === 'success') {
 						if (status.webui_changed) refreshState.set();
 						if (status.reboot_required) rebootState.set();


### PR DESCRIPTION
Reported after the .41/.59 upgrades: click the top-bar chip's one-click bcachefs sync, watch the rebuild finish — the chip stays lit until cmd+R.

Two completion detectors exist on the update page; only `loadStatus()` (page mount — the *came-back-later* case) nudged the layout's cached `sysInfo` via `sysInfoRefresh.triggerReconcile()`. The 3-second poll — the path that fires when the operator **stays on the page watching the rebuild** — refreshed the page's own rows and cleared the `version-switch` action marker (disarming the mount path too), but never triggered the layout refresh. And since a bcachefs-tools-only switch doesn't restart the engine, the WS reconnect refresh never fires either. Net effect: stale chip until manual reload, exactly as observed.

Fix: the poll's completion branch now fires the same spaced-retry reconcile. svelte-check 0/0, production build clean.

Residual (not addressed here): if the operator kicks off a switch and navigates away from /update *without returning*, nothing watches for completion — the marker survives so returning to /update fixes it, but the chip stays stale on other pages until then. If we care, the clean shape is an engine-side completion event the layout subscribes to; flagging rather than gold-plating.