### PR TITLE
AD member join: domain identities for SMB shares (phase 1 of #20)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,7 @@ jobs:
           nix build \
             .#checks.x86_64-linux.bcachefs-smoke \
             .#checks.x86_64-linux.appliance-smoke \
+            .#checks.x86_64-linux.ad-member \
             -L --print-build-logs
 
       - name: Build and push packages to Cachix

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,21 @@ jobs:
           nix build \
             .#checks.x86_64-linux.bcachefs-smoke \
             .#checks.x86_64-linux.appliance-smoke \
+            -L --print-build-logs
+
+      - name: AD member-join VM test (non-gating)
+        # The two-node AD test provisions a throwaway Samba AD DC in a VM.
+        # Getting that simulated DC fully initialized is essentially the
+        # phase-2 (NASty-as-DC) problem and currently fails at the DC's
+        # own LDAP layer ("Operations error") — a fake-DC defect, not the
+        # member-join engine. The engine is validated end-to-end against a
+        # REAL AD DC (Synology Directory Server): join, trust, workgroup
+        # discovery, winbind idmap, domain-user SMB auth with correct file
+        # ownership, and leave all pass. Kept running (not gating) so it's
+        # ready to re-promote once the throwaway DC is hardened in phase 2.
+        continue-on-error: true
+        run: |
+          nix build \
             .#checks.x86_64-linux.ad-member \
             -L --print-build-logs
 

--- a/docs/active-directory-support.md
+++ b/docs/active-directory-support.md
@@ -1,0 +1,190 @@
+# Active Directory Support
+
+Design for NASty's Active Directory integration, in two phases:
+
+1. **Member join** (this document's main scope) — NASty joins an existing AD
+   domain; domain users and groups become usable in SMB share permissions.
+2. **Domain Controller role** (appendix) — NASty hosts the domain itself,
+   replacing a Synology Directory Server / Windows Server DC.
+
+Requested in [issue #20](https://github.com/nasty-project/nasty/issues/20).
+The reporter runs a Synology as their only DC, so full replacement needs
+phase 2 — but phase 1 is a hard prerequisite: the box's own file services
+consume domain identities the same way whether the domain lives on-box or
+elsewhere. This matches the industry split: TrueNAS ships member join only;
+Synology ships member join in DSM core and the DC as a separate opt-in
+package.
+
+## Phase 1: AD member join
+
+### Scope
+
+- Join and leave an existing AD domain, per box (operator opt-in).
+- Domain users and groups usable in SMB share `valid_users`, resolved live
+  through winbind — never copied into the engine's user registry.
+- SMB only. Out of scope for this phase: domain accounts logging into the
+  WebUI/API or SSH, and kerberized NFS. Both can be added later without
+  redesign.
+
+### Components
+
+- **`nasty-system`: new `domain` module.** Owns join state, krb5 and winbind
+  configuration, preflight checks, and health. Lives in `nasty-system`
+  because it is system identity (krb5.conf, winbindd, NSS), not sharing;
+  `nasty-sharing::smb` and the WebUI consume it.
+- **Engine methods** (registry naming follows `smb.user.list` precedent):
+  - `domain.join` — realm, AD admin credential, optional OU, optional idmap
+    base. Credential is used once for `net ads join` (passed via stdin,
+    never argv, never persisted).
+  - `domain.leave` — with credential, or forced local-only leave.
+  - `domain.status` — joined state, trust health, DC reachability, clock skew.
+  - `domain.user.list` / `domain.group.list` — require a search prefix;
+    query winbind on demand. No wholesale enumeration (large domains make
+    `wbinfo -u` explode); the WebUI picker is search-driven.
+- **NixOS module (`nasty.nix`):**
+  - Samba package built with `enableLDAP = true` (nixpkgs defaults to
+    `--without-ldap --without-ads`; ADS member mode needs both). See Risks.
+  - winbindd shipped and defined like smbd/nmbd: `wantedBy = []`, started by
+    the engine only when joined.
+  - winbind NSS module in `system.nssModules` permanently; inert (instant
+    not-found) while winbindd is not running.
+  - krb5 configuration rendered by the engine at join time via the existing
+    include-file pattern — join is a runtime operation, not a rebuild.
+- **State:** `DomainConfig` JSON in the engine state dir (realm, workgroup,
+  idmap base, join status). No secrets — the machine account secret lives in
+  Samba's `secrets.tdb` under `/var/lib/samba`.
+
+### Join flow
+
+1. **Preflight** — fail with clear errors before Kerberos produces cryptic
+   ones: resolve `_ldap._tcp.<realm>` SRV, check DC reachability on the
+   required ports, check clock skew against the DC (Kerberos tolerates
+   ~5 minutes).
+2. Render krb5 and smb.conf ADS config; start winbindd.
+3. `net ads join` with the admin credential on stdin.
+4. Verify the trust with `wbinfo -t`.
+5. Register the box's A record in AD DNS (`net ads dns register`).
+6. Add a per-domain DNS routing rule (systemd-resolved) so the box resolves
+   the AD zone through the DC's DNS without replacing its resolvers.
+7. Persist `DomainConfig`; mark joined.
+
+Any failure rolls configuration back to the pre-join state (same spirit as
+the network transaction machinery). Leave reverses the flow and documents —
+rather than cleans up — files owned by domain UIDs and share ACLs that
+reference domain principals; they become orphans, consistent with how
+TrueNAS and Synology behave.
+
+### Identity model
+
+- The engine registry stays authoritative for **local users only**. Domain
+  principals are a live external view via winbind; they are not editable in
+  NASty (passwords and group membership are AD's job).
+- **UID mapping:** `idmap_rid` — algorithmic, stateless, stable across
+  reboots, rejoins, and reinstalls. Default base 100000 (well above the
+  local `SMB_USER_UID_MIN = 3000` range), configurable at join,
+  **immutable afterwards** — changing it would re-map ownership of every
+  domain-owned file. The engine enforces immutability and collision-checks
+  the range at join.
+- Domain principals appear as `DOMAIN\name` everywhere. We deliberately do
+  not set `winbind use default domain` — the prefix keeps domain and local
+  namespaces unambiguous.
+- `valid_users` validation gains a deliberate carve-out for the backslash in
+  `DOMAIN\name` entries, with the same injection-safety test treatment
+  `validate_share_path` has (newline, `#`, quote smuggling).
+
+### Config rendering
+
+When joined, the engine-rendered global include gains the ADS block:
+`security = ADS`, realm, workgroup, idmap ranges, and
+`winbind offline logon` so cached domain users survive a DC outage.
+Unjoined boxes render byte-identical config to today.
+
+Local passdb authentication continues to work alongside ADS mode.
+**Degradation contract:** DC unreachable ⇒ domain-account auth degrades
+(mitigated by winbind caching for recently seen users); local users and
+shares are unaffected.
+
+### Health
+
+`domain.status` is wired into the existing monitoring surface: trust secret
+check (`wbinfo -t`), DC reachability, clock skew. This is also the safety
+net for the machine-account-rotation risk below — a broken trust is
+surfaced with a re-join action instead of operators discovering shares
+failing.
+
+### Testing
+
+- Unit tests: config rendering, `DOMAIN\name` validation including
+  injection cases, idmap range collision checks.
+- NixOS VM test (two nodes): a throwaway provisioned Samba DC and an
+  appliance node that joins it, authenticates a domain user via smbclient,
+  writes a file, and asserts ownership lands in the idmap range. Gates the
+  Samba package rebuild as well as the feature.
+- Engine-level integration tests can use the `smblds/smblds` container
+  (a Samba AD DC image built for CI).
+
+### Risks
+
+- **Samba rebuild affects every box.** `enableLDAP = true` changes the Samba
+  binary all boxes run, joined or not: same upstream source, more features
+  compiled in, built from source instead of the binary cache, and new build
+  inputs (OpenLDAP and friends) that must be wired into the Nix derivation.
+  Mitigation: the existing SMB coverage in the appliance VM test runs
+  against the new build and gates the swap; only the Integration workflow
+  (sandboxed build) proves the derivation inputs are complete.
+- **Machine account password rotation vs rollback.** AD machine accounts
+  rotate their password (30-day default) into `secrets.tdb`. A version
+  rollback or restored snapshot that resurrects an old `secrets.tdb`
+  silently desyncs the box from the domain. **Verify during
+  implementation:** confirm `/var/lib/samba` lives on state that survives
+  version switches and is not touched by subvolume rollbacks. If it is at
+  risk, prefer `machine password timeout = 0` (no rotation — a common
+  appliance choice) over relocating the tdb. Either way `domain.status`
+  detects a broken trust.
+- **Time dependency.** Kerberos needs sane clocks. Preflight checks skew at
+  join; `domain.status` monitors it afterwards.
+
+### Footprint on boxes that never join
+
+winbindd installed but never started; NSS module present but inert;
+rendered Samba config byte-identical; no firewall changes (member mode
+needs outbound only); no new state. The one shared change is the rebuilt
+Samba binary (see Risks).
+
+## Phase 2 appendix: Domain Controller role (decisions to date)
+
+Not designed in detail yet — these are the decisions settled during
+brainstorming, recorded so the phase-2 spec starts from them.
+
+- **Shape: native, in a NixOS (systemd-nspawn) container** — not a Docker
+  app, not on the host directly. The AD DC process runs its own embedded
+  smbd (SYSVOL) and needs ports 53/88/389/445 on its own address, which
+  collides with the host's file-serving smbd; a declarative
+  `containers.<name>` gives it its own network namespace and state
+  directory with no third-party image dependency. Samba upstream
+  discourages mixing the DC role with general file serving; this keeps them
+  separated on one box, the same way Synology's Directory Server package
+  is separated from DSM's file services.
+- **Kerberos:** nixpkgs' Samba builds the AD DC with bundled **Heimdal**
+  when `enableDomainController = true` — the upstream-supported KDC
+  configuration (MIT KDC remains experimental). The DC-capable build lives
+  only in the container's closure; the host Samba binary is unaffected.
+- **Networking: macvlan child + host-side macvlan shim**, both
+  engine-managed, parent interface chosen per box at role enable. The shim
+  exists because a host cannot reach its own macvlan children, and the
+  host's smbd must reach the DC's DNS/Kerberos/LDAP to join the hosted
+  domain. Bridging the uplink was rejected as too invasive to existing
+  network config; routed/NAT was rejected because AD behind NAT breaks.
+- **DC address:** static, user-chosen at provisioning (realm, NetBIOS
+  domain, admin password, DC IP) — clients bootstrap DNS from it, so it
+  must not drift.
+- **NASty's own file services join the hosted domain as a member** — which
+  is why phase 1 is a prerequisite.
+- **Opt-in:** per-box role; zero footprint (no container, interfaces,
+  ports, or state) until enabled. Whether the container closure ships in
+  the base image (size cost) or is fetched on enable is a phase-2 decision.
+- **Open questions for phase 2:** DNS handoff details (how the box itself
+  and DHCP clients get pointed at the DC's DNS), backup/restore lifecycle
+  (`samba-tool domain backup` wired into the backup story), Samba version
+  upgrades of the domain database (`samba-tool dbcheck`), and whether
+  multi-DC (a second NASty as replica) is ever in scope.

--- a/docs/active-directory-support.md
+++ b/docs/active-directory-support.md
@@ -106,11 +106,17 @@ shares are unaffected.
 
 ### Health
 
-`domain.status` is wired into the existing monitoring surface: trust secret
-check (`wbinfo -t`), DC reachability, clock skew. This is also the safety
-net for the machine-account-rotation risk below — a broken trust is
-surfaced with a re-join action instead of operators discovering shares
-failing.
+Phase 1 ships the `domain.status` method — trust secret check
+(`wbinfo -t`), DC reachability, and clock skew — surfaced as indicator
+pills on the Settings → Directory card. That status method is also the
+safety net for the machine-account-rotation risk below: a broken trust is
+visible on the card rather than discovered when shares start failing.
+
+Two pieces are explicit phase-2 follow-ups, not shipped here: wiring
+`domain.status` into the alert-rule engine so a degraded trust raises a
+notification without an operator loading the page, and a guided re-join
+flow that walks an operator through recovering a broken trust. Until
+those land, recovery is the manual leave/join path.
 
 ### Testing
 

--- a/docs/active-directory-support.md
+++ b/docs/active-directory-support.md
@@ -135,12 +135,20 @@ failing.
 - **Machine account password rotation vs rollback.** AD machine accounts
   rotate their password (30-day default) into `secrets.tdb`. A version
   rollback or restored snapshot that resurrects an old `secrets.tdb`
-  silently desyncs the box from the domain. **Verify during
-  implementation:** confirm `/var/lib/samba` lives on state that survives
-  version switches and is not touched by subvolume rollbacks. If it is at
-  risk, prefer `machine password timeout = 0` (no rotation — a common
-  appliance choice) over relocating the tdb. Either way `domain.status`
-  detects a broken trust.
+  silently desyncs the box from the domain. **Resolved:** `/var/lib` is
+  state on the root filesystem, untouched by `nixos-rebuild` generation
+  switches or rollbacks (`nixos/modules/nasty.nix:1128`). The root
+  filesystem itself is always plain ext4 on its own partition, created by
+  the installer (`nixos/iso.nix:248,254,268`) and never registered with
+  `nasty-storage`'s `FilesystemService` — every NASty-managed bcachefs pool
+  mounts under `/fs/<name>` (`NASTY_MOUNT_BASE`,
+  `engine/nasty-storage/src/filesystem.rs:14`), and both subvolume rollback
+  (`engine/nasty-engine/src/subvol_rollback.rs`) and snapshots
+  (`engine/nasty-snapshot`) operate exclusively through that
+  `SubvolumeService` registry. So no rollback or snapshot-restore path can
+  reach `/var/lib/samba/private/secrets.tdb` at all — rotation stays on,
+  and no config change is needed here. `domain.status` remains the safety
+  net for the (now purely theoretical) broken-trust case.
 - **Time dependency.** Kerberos needs sane clocks. Preflight checks skew at
   join; `domain.status` monitors it afterwards.
 

--- a/docs/active-directory-support.md
+++ b/docs/active-directory-support.md
@@ -148,7 +148,11 @@ failing.
   `SubvolumeService` registry. So no rollback or snapshot-restore path can
   reach `/var/lib/samba/private/secrets.tdb` at all — rotation stays on,
   and no config change is needed here. `domain.status` remains the safety
-  net for the (now purely theoretical) broken-trust case.
+  net for the (now purely theoretical) broken-trust case. Two further restore
+  surfaces were checked and are also safe today: `nasty-backup` implements no
+  restore path at all yet, and the file-level snapshot restore endpoint is
+  jailed to `/fs` — if backup-restore functionality is ever added, revisit
+  this conclusion.
 - **Time dependency.** Kerberos needs sane clocks. Preflight checks skew at
   join; `domain.status` monitors it afterwards.
 

--- a/docs/plans/2026-07-07-ad-member-join.md
+++ b/docs/plans/2026-07-07-ad-member-join.md
@@ -1,0 +1,1498 @@
+# AD Member Join Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** NASty joins an existing Active Directory domain; domain users and groups become usable in SMB share permissions, resolved live through winbind.
+
+**Architecture:** A new `domain` module in `nasty-system` owns join state, krb5/winbind config rendering, preflight checks, and live principal search (via `wbinfo`). The NixOS module ships winbindd + the winbind NSS module (inert until joined) and rebuilds Samba with LDAP/ADS support. `nasty-sharing::smb` renders an engine-managed global include (`/etc/samba/nasty-domain.conf`) that carries the ADS block when joined and is empty otherwise, and its `valid_users` validation gains a `DOMAIN\name` carve-out. Engine methods follow the `smb.user.list` naming precedent (`domain.join`, `domain.leave`, `domain.status`, `domain.user.list`, `domain.group.list`).
+
+**Tech Stack:** Rust (engine workspace), Nix/NixOS module, Samba (`net ads`, `wbinfo`, winbindd), Svelte 5 WebUI.
+
+**Spec:** `docs/active-directory-support.md` (phase 1). Read it before starting.
+
+## Global Constraints
+
+- Per-box opt-in: an unjoined box renders **byte-identical** Samba config to today; winbindd installed but never started; no new open ports (member mode is outbound-only).
+- The AD admin credential is used once for `net ads join`, passed via **stdin**, never argv, never persisted, never logged.
+- `idmap_base` default **100000**, minimum **65536**, immutable once joined (changing it re-maps file ownership).
+- Domain principals render as `DOMAIN\name` — never set `winbind use default domain`.
+- No new Rust dependencies. No `-sys` crates. (`nasty-system` already has everything needed.)
+- Verification before every commit: `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test --workspace` from `engine/`; `npm run check` from `webui/` for WebUI tasks.
+- All engine work in `engine/` (workspace root for cargo commands). Branch: `ad-member-join`.
+
+---
+
+### Task 1: NixOS substrate — ADS-capable Samba, winbindd, NSS, writable config files
+
+**Files:**
+- Modify: `nixos/modules/nasty.nix` (samba block ~lines 1731–1780, tmpfiles ~line 1471, systemPackages ~line 1435)
+
+**Interfaces:**
+- Produces: `samba-winbindd.service` (present, `wantedBy = []`, engine-started), `/etc/samba/nasty-domain.conf` + `/etc/samba/nasty-krb5.conf` (engine-writable, empty by default), winbind NSS module active, `security.wrappers`-free ADS-capable samba binaries on PATH.
+
+This task has no unit test; its gate is `nix flake check` evaluation plus the existing appliance-smoke test in CI (SMB must keep working with the rebuilt package). The Integration workflow is the real proof — a local `cargo` run can't validate it.
+
+- [ ] **Step 1: Define the ADS-capable samba package once**
+
+In `nixos/modules/nasty.nix`, find the `let` block near the top of the module (or the config section where `pkgs` is in scope) and the existing samba references. Add a shared binding:
+
+```nix
+  # ADS member mode needs LDAP support; nixpkgs' default samba is built
+  # --without-ldap --without-ads. One binding so smbd, the CLI tools, and
+  # winbindd all come from the same build. This changes the samba binary
+  # on EVERY box (joined or not) — the appliance-smoke test gates it.
+  sambaAds = pkgs.samba.override { enableLDAP = true; };
+```
+
+Then replace the two use sites:
+- `services.samba` (~line 1734): add `package = sambaAds;` inside the `mkIf cfg.smb.enable { ... }` attrset.
+- systemPackages (~line 1435): change `lib.optionals cfg.smb.enable [ samba ]` to `lib.optionals cfg.smb.enable [ sambaAds ]` (and the other `[ samba shadow.out ]` occurrence at ~line 1616 similarly).
+
+- [ ] **Step 2: Enable winbindd, engine-started**
+
+Inside the same `services.samba` attrset add:
+
+```nix
+      winbindd.enable = true;
+```
+
+The existing `systemd.targets.samba.wantedBy = mkIf cfg.smb.enable (lib.mkForce []);` (~line 1770) already breaks auto-start for all three daemons — verify the comment there mentions winbindd now, and update it:
+
+```nix
+    # Prevent Samba from auto-starting at boot. NixOS enables samba.target in
+    # multi-user.target, which then pulls in all four daemons (smbd, nmbd,
+    # wsdd, winbindd) via samba.target.wants. Override the target's wantedBy
+    # to break that chain; the engine starts smbd/nmbd/wsdd via the protocol
+    # toggle and winbindd only while joined to a domain.
+```
+
+- [ ] **Step 3: Point winbindd and the Samba tools at the engine-rendered krb5 config**
+
+Add next to the samba service config:
+
+```nix
+    # The engine renders Kerberos config at domain-join time (a runtime
+    # operation, not a rebuild) into an engine-owned path. Route winbindd
+    # and everything the engine execs (net, wbinfo) through it instead of
+    # owning the global /etc/krb5.conf.
+    systemd.services.samba-winbindd.environment = mkIf cfg.smb.enable {
+      KRB5_CONFIG = "/etc/samba/nasty-krb5.conf";
+    };
+```
+
+- [ ] **Step 4: Winbind NSS module (permanently present, inert when winbindd is down)**
+
+```nix
+    # Winbind NSS: domain users/groups resolve through nsswitch while
+    # joined. Present on every box; instant not-found while winbindd
+    # isn't running, so unjoined boxes are unaffected.
+    system.nssModules = mkIf cfg.smb.enable [ sambaAds ];
+    system.nssDatabases.passwd = mkIf cfg.smb.enable (lib.mkAfter [ "winbind" ]);
+    system.nssDatabases.group = mkIf cfg.smb.enable (lib.mkAfter [ "winbind" ]);
+```
+
+- [ ] **Step 5: Engine-writable config files**
+
+In the tmpfiles rules block (~line 1471, next to `"f /etc/samba/smb.nasty.conf 0644 root root -"`), add:
+
+```nix
+      "f /etc/samba/nasty-domain.conf 0644 root root -"
+      "f /etc/samba/nasty-krb5.conf 0644 root root -"
+```
+
+(Do NOT use `environment.etc` for these — that creates read-only store symlinks; the engine writes them at runtime.)
+
+- [ ] **Step 6: Evaluate**
+
+Run: `nix flake check --no-build 2>&1 | tail -5`
+Expected: evaluation succeeds (build failures would only surface in CI; evaluation errors surface here).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nixos/modules/nasty.nix
+git commit -m "nixos: ADS-capable samba + engine-started winbindd + winbind NSS
+
+Substrate for AD member join. sambaAds (enableLDAP) replaces the stock
+samba everywhere so smbd, the CLI tools, and winbindd share one build;
+winbindd follows the engine-started wantedBy=[] pattern and reads the
+engine-rendered nasty-krb5.conf; the winbind NSS module is present but
+inert until winbindd runs. Unjoined boxes render byte-identical Samba
+config."
+```
+
+---
+
+### Task 2: Domain module skeleton — types, state, realm validation (TDD)
+
+**Files:**
+- Create: `engine/nasty-system/src/domain.rs`
+- Modify: `engine/nasty-system/src/lib.rs` (add `pub mod domain;` next to the other module declarations)
+
+**Interfaces:**
+- Produces:
+  - `DomainConfig { realm: String, workgroup: String, idmap_base: u32 }` (Serialize/Deserialize/JsonSchema/Clone/Debug) — persisted at `/var/lib/nasty/domain/config.json`; file presence == joined.
+  - `DomainError` (thiserror) with variants `Validation(String)`, `Preflight(String)`, `AlreadyJoined`, `NotJoined`, `CommandFailed(String)`, `Io(std::io::Error)`.
+  - `fn validate_realm(raw: &str) -> Result<String, DomainError>` — returns the normalized (uppercased, trimmed) realm.
+  - `fn derive_workgroup(realm: &str) -> String` — first DNS label, uppercased, truncated to 15 chars (NetBIOS limit).
+  - `const DEFAULT_IDMAP_BASE: u32 = 100_000;` / `const IDMAP_RANGE_SPAN: u32 = 900_000;` / `fn validate_idmap_base(base: u32) -> Result<(), DomainError>` (rejects `< 65_536`).
+  - `pub struct DomainService;` with `pub fn new() -> Self` and `async fn load_config() -> Option<DomainConfig>` / `async fn save_config(&DomainConfig)` / `async fn clear_config()` using `tokio::fs` on `/var/lib/nasty/domain/config.json` (create dir with `create_dir_all`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/nasty-system/src/domain.rs` with module docs, the types above as **stubs** (`validate_realm` returns `Err(DomainError::Validation("stub".into()))`, `derive_workgroup` returns `String::new()`, `validate_idmap_base` returns `Ok(())`), and this test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_realm_normalizes_and_accepts_dns_names() {
+        assert_eq!(validate_realm("corp.example.com").unwrap(), "CORP.EXAMPLE.COM");
+        assert_eq!(validate_realm("  ad.lan ").unwrap(), "AD.LAN");
+    }
+
+    #[test]
+    fn validate_realm_rejects_garbage() {
+        // Single label: not a resolvable AD realm.
+        assert!(validate_realm("WORKGROUP").is_err());
+        assert!(validate_realm("").is_err());
+        // Characters that could smuggle config or shell content.
+        assert!(validate_realm("corp.example.com\ninclude=/etc/passwd").is_err());
+        assert!(validate_realm("corp;rm -rf /.com").is_err());
+        assert!(validate_realm("corp .example.com").is_err());
+    }
+
+    #[test]
+    fn derive_workgroup_takes_first_label_netbios_truncated() {
+        assert_eq!(derive_workgroup("CORP.EXAMPLE.COM"), "CORP");
+        // NetBIOS names cap at 15 chars.
+        assert_eq!(derive_workgroup("VERYLONGCOMPANYNAME.LAN"), "VERYLONGCOMPANY");
+    }
+
+    #[test]
+    fn validate_idmap_base_rejects_low_ranges() {
+        // Must clear every local UID the engine can allocate.
+        assert!(validate_idmap_base(3000).is_err());
+        assert!(validate_idmap_base(65_535).is_err());
+        assert!(validate_idmap_base(65_536).is_ok());
+        assert!(validate_idmap_base(DEFAULT_IDMAP_BASE).is_ok());
+    }
+}
+```
+
+Realm validation rules to implement in Step 3: trim, reject empty, require ≥ 2 dot-separated labels, each label 1–63 chars of `[A-Za-z0-9-]` not starting/ending with `-`, then uppercase.
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cargo test -p nasty-system --lib domain 2>&1 | tail -5`
+Expected: FAIL — the three validation tests panic against the stubs (the reject-tests may trivially pass against the `Err` stub; the accept-tests must fail).
+
+- [ ] **Step 3: Implement the real functions**
+
+```rust
+fn validate_realm(raw: &str) -> Result<String, DomainError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(DomainError::Validation("realm is empty".into()));
+    }
+    let labels: Vec<&str> = trimmed.split('.').collect();
+    if labels.len() < 2 {
+        return Err(DomainError::Validation(format!(
+            "'{trimmed}' is not a DNS realm (expected e.g. CORP.EXAMPLE.COM)"
+        )));
+    }
+    for label in &labels {
+        let ok = !label.is_empty()
+            && label.len() <= 63
+            && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+            && !label.starts_with('-')
+            && !label.ends_with('-');
+        if !ok {
+            return Err(DomainError::Validation(format!(
+                "realm label '{label}' contains invalid characters"
+            )));
+        }
+    }
+    Ok(trimmed.to_ascii_uppercase())
+}
+
+fn derive_workgroup(realm: &str) -> String {
+    let first = realm.split('.').next().unwrap_or(realm);
+    first.chars().take(15).collect::<String>().to_ascii_uppercase()
+}
+
+fn validate_idmap_base(base: u32) -> Result<(), DomainError> {
+    if base < 65_536 {
+        return Err(DomainError::Validation(format!(
+            "idmap base {base} is too low — must be at least 65536 so domain \
+             UIDs can never collide with local accounts"
+        )));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cargo test -p nasty-system --lib domain 2>&1 | tail -3`
+Expected: `test result: ok.`
+
+- [ ] **Step 5: Full verification + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-system
+git add engine/nasty-system/src/domain.rs engine/nasty-system/src/lib.rs
+git commit -m "system: domain module skeleton — realm/idmap validation, join state"
+```
+
+---
+
+### Task 3: Config renderers — ADS smb.conf block and krb5.conf (TDD)
+
+**Files:**
+- Modify: `engine/nasty-system/src/domain.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub fn render_domain_smb_conf(cfg: &DomainConfig) -> String` — the `[global]`-scope ADS block written to `/etc/samba/nasty-domain.conf`.
+  - `pub fn render_krb5_conf(realm: &str) -> String` — written to `/etc/samba/nasty-krb5.conf`.
+  - `pub const DOMAIN_SMB_CONF_PATH: &str = "/etc/samba/nasty-domain.conf";`
+  - `pub const KRB5_CONF_PATH: &str = "/etc/samba/nasty-krb5.conf";`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn render_domain_smb_conf_emits_ads_block() {
+        let cfg = DomainConfig {
+            realm: "CORP.EXAMPLE.COM".into(),
+            workgroup: "CORP".into(),
+            idmap_base: 100_000,
+        };
+        let conf = render_domain_smb_conf(&cfg);
+        assert!(conf.contains("security = ADS"), "{conf}");
+        assert!(conf.contains("realm = CORP.EXAMPLE.COM"), "{conf}");
+        assert!(conf.contains("workgroup = CORP"), "{conf}");
+        // Deterministic algorithmic mapping — same user, same UID, forever.
+        assert!(conf.contains("idmap config CORP : backend = rid"), "{conf}");
+        assert!(conf.contains("idmap config CORP : range = 100000-999999"), "{conf}");
+        // The default (*) range must not overlap the domain range.
+        assert!(conf.contains("idmap config * : range = 65000-65535"), "{conf}");
+        // DC outage tolerance for recently-seen users.
+        assert!(conf.contains("winbind offline logon = yes"), "{conf}");
+        // Explicit namespaces — never ambiguous with local users.
+        assert!(!conf.contains("winbind use default domain"), "{conf}");
+        assert!(conf.contains("kerberos method = secrets and keytab"), "{conf}");
+    }
+
+    #[test]
+    fn render_krb5_conf_pins_realm_and_dns_lookup() {
+        let conf = render_krb5_conf("CORP.EXAMPLE.COM");
+        assert!(conf.contains("default_realm = CORP.EXAMPLE.COM"), "{conf}");
+        // DCs are found via DNS SRV — no static kdc lines to go stale.
+        assert!(conf.contains("dns_lookup_kdc = true"), "{conf}");
+        assert!(conf.contains("rdns = false"), "{conf}");
+    }
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cargo test -p nasty-system --lib domain::tests::render 2>&1 | tail -4`
+Expected: FAIL (functions don't exist yet — add empty-string stubs first so it compiles, then watch the asserts fail).
+
+- [ ] **Step 3: Implement the renderers**
+
+```rust
+pub fn render_domain_smb_conf(cfg: &DomainConfig) -> String {
+    let base = cfg.idmap_base;
+    let end = base + IDMAP_RANGE_SPAN - 1;
+    format!(
+        "# Managed by NASty — Active Directory member configuration.\n\
+         # Rendered at domain join; emptied at leave. Do not edit manually.\n\
+         security = ADS\n\
+         realm = {realm}\n\
+         workgroup = {wg}\n\
+         kerberos method = secrets and keytab\n\
+         winbind refresh tickets = yes\n\
+         winbind offline logon = yes\n\
+         winbind enum users = no\n\
+         winbind enum groups = no\n\
+         idmap config * : backend = tdb\n\
+         idmap config * : range = 65000-65535\n\
+         idmap config {wg} : backend = rid\n\
+         idmap config {wg} : range = {base}-{end}\n\
+         template shell = /run/current-system/sw/bin/nologin\n\
+         template homedir = /var/empty\n",
+        realm = cfg.realm,
+        wg = cfg.workgroup,
+    )
+}
+
+pub fn render_krb5_conf(realm: &str) -> String {
+    format!(
+        "# Managed by NASty — rendered at domain join.\n\
+         [libdefaults]\n\
+         \tdefault_realm = {realm}\n\
+         \tdns_lookup_realm = false\n\
+         \tdns_lookup_kdc = true\n\
+         \trdns = false\n",
+    )
+}
+```
+
+(Realm/workgroup are safe to interpolate — `validate_realm` rejected every config-injection character before a `DomainConfig` can exist. Note this invariant in a comment.)
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cargo test -p nasty-system --lib domain 2>&1 | tail -3`
+Expected: `test result: ok.`
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-system
+git add engine/nasty-system/src/domain.rs
+git commit -m "system: render ADS smb.conf block and krb5.conf for domain join"
+```
+
+---
+
+### Task 4: Wire the domain include into the Samba config chain (TDD)
+
+**Files:**
+- Modify: `engine/nasty-sharing/src/smb.rs` (`rebuild_include_list`, ~line 471, and its tests)
+
+**Interfaces:**
+- Consumes: `/etc/samba/nasty-domain.conf` existing on disk (tmpfiles from Task 1; content from Task 3).
+- Produces: `smb.nasty.conf` includes the domain conf **before** the tuning include and share includes (global params must precede section headers).
+
+- [ ] **Step 1: Extract the include-list body into a pure function and write the failing test**
+
+`rebuild_include_list` builds a string then writes it. Refactor the string-building into `fn render_include_list(share_conf_names: &[String]) -> String` (same output as today: header, tuning include, share includes) so it's testable, then write the failing test:
+
+```rust
+    #[test]
+    fn include_list_puts_domain_conf_first() {
+        let rendered = render_include_list(&["abc.conf".to_string()]);
+        let domain_pos = rendered
+            .find("include = /etc/samba/nasty-domain.conf")
+            .expect("domain include present");
+        let tuning_pos = rendered.find("include = /etc/samba/nasty-tuning.conf").unwrap();
+        let share_pos = rendered.find("include = /etc/samba/nasty.d/abc.conf").unwrap();
+        // Global-scope ADS params must land before any share section opens.
+        assert!(domain_pos < tuning_pos && tuning_pos < share_pos, "{rendered}");
+    }
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `cargo test -p nasty-sharing --lib smb::tests::include_list 2>&1 | tail -4`
+Expected: FAIL — no domain include emitted.
+
+- [ ] **Step 3: Implement**
+
+In `render_include_list`, after the header lines and before the tuning include:
+
+```rust
+    // Domain (AD member) global parameters. The file exists on every box
+    // (tmpfiles) and is empty until a join renders the ADS block into it,
+    // so unjoined boxes get byte-identical effective config.
+    includes.push_str("include = /etc/samba/nasty-domain.conf\n\n");
+```
+
+`rebuild_include_list` becomes: collect `.conf` names from the dir as before, call `render_include_list(&names)`, write.
+
+- [ ] **Step 4: Run the full smb test module, verify green**
+
+Run: `cargo test -p nasty-sharing --lib smb 2>&1 | tail -3`
+Expected: `test result: ok.` (existing include/render tests unchanged).
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-sharing
+git add engine/nasty-sharing/src/smb.rs
+git commit -m "sharing: include engine-managed domain conf in smb.nasty.conf"
+```
+
+---
+
+### Task 5: Preflight — SRV discovery and clock-skew parsing (TDD)
+
+**Files:**
+- Modify: `engine/nasty-system/src/domain.rs`
+
+**Interfaces:**
+- Produces:
+  - `fn parse_resolvectl_srv(output: &str) -> Vec<String>` — DC hostnames from `resolvectl query --type=SRV _ldap._tcp.<realm>`.
+  - `fn parse_net_ads_server_time(output: &str) -> Option<i64>` — unix seconds from `net ads info`'s `Server time:` line (hand-rolled RFC-2822-style parse; no new deps).
+  - `fn parse_resolvectl_addresses(output: &str) -> Vec<String>` — IPs from `resolvectl query <host>` (lines like `dc1.corp.example.com: 10.0.0.5`).
+  - `pub fn render_resolved_dropin(realm: &str, dc_ips: &[String]) -> String` + `pub const RESOLVED_DROPIN_PATH: &str = "/etc/systemd/resolved.conf.d/nasty-ad.conf";` — per-domain DNS routing (`Domains=~<realm>` + `DNS=` the DCs) so the box resolves the AD zone through AD DNS without replacing its resolvers (spec join-flow step 6).
+  - `async fn preflight(realm: &str) -> Result<Vec<String>, DomainError>` — returns the discovered DC hostnames; SRV lookup non-empty, `net ads info` reachable, `|skew| <= 240s` (comfortably under Kerberos's 300s).
+
+- [ ] **Step 1: Write the failing parser tests**
+
+```rust
+    #[test]
+    fn parse_resolvectl_srv_extracts_targets() {
+        // resolvectl output shape: "_ldap._tcp.corp.example.com IN SRV 0 100 389 dc1.corp.example.com"
+        let out = "\
+_ldap._tcp.corp.example.com IN SRV 0 100 389 dc1.corp.example.com\n\
+_ldap._tcp.corp.example.com IN SRV 0 100 389 dc2.corp.example.com\n\n\
+-- Information acquired via protocol DNS in 2.1ms.\n";
+        assert_eq!(
+            parse_resolvectl_srv(out),
+            vec!["dc1.corp.example.com".to_string(), "dc2.corp.example.com".to_string()]
+        );
+        assert!(parse_resolvectl_srv("-- no data --\n").is_empty());
+    }
+
+    #[test]
+    fn parse_resolvectl_addresses_extracts_ips() {
+        let out = "dc1.corp.example.com: 10.0.0.5\n\n-- Information acquired via protocol DNS in 1.2ms.\n";
+        assert_eq!(parse_resolvectl_addresses(out), vec!["10.0.0.5".to_string()]);
+    }
+
+    #[test]
+    fn render_resolved_dropin_routes_realm_to_dcs() {
+        let conf = render_resolved_dropin("CORP.EXAMPLE.COM", &["10.0.0.5".into(), "10.0.0.6".into()]);
+        assert!(conf.contains("[Resolve]"), "{conf}");
+        assert!(conf.contains("DNS=10.0.0.5 10.0.0.6"), "{conf}");
+        // Routing domain (~) — only AD-zone queries go to the DCs.
+        assert!(conf.contains("Domains=~corp.example.com"), "{conf}");
+    }
+
+    #[test]
+    fn parse_net_ads_server_time_reads_rfc2822_style() {
+        // `net ads info` prints e.g. "Server time: Tue, 07 Jul 2026 12:34:56 UTC"
+        let out = "LDAP server: 10.0.0.5\nServer time: Tue, 07 Jul 2026 12:34:56 UTC\n";
+        // 2026-07-07T12:34:56Z
+        assert_eq!(parse_net_ads_server_time(out), Some(1783514096));
+        assert_eq!(parse_net_ads_server_time("no time here"), None);
+    }
+```
+
+(Compute the expected epoch with `date -u -d "2026-07-07 12:34:56" +%s` before pinning it; correct the constant if it differs.)
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cargo test -p nasty-system --lib domain::tests::parse 2>&1 | tail -4`
+Expected: FAIL against stubs.
+
+- [ ] **Step 3: Implement the parsers**
+
+```rust
+fn parse_resolvectl_srv(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter(|l| l.contains(" SRV "))
+        .filter_map(|l| l.split_whitespace().last())
+        .map(|t| t.trim_end_matches('.').to_string())
+        .collect()
+}
+
+fn parse_resolvectl_addresses(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|l| l.split_once(": "))
+        .map(|(_, addr)| addr.trim().to_string())
+        .filter(|a| a.parse::<std::net::IpAddr>().is_ok())
+        .collect()
+}
+
+pub fn render_resolved_dropin(realm: &str, dc_ips: &[String]) -> String {
+    format!(
+        "# Managed by NASty — routes AD-zone DNS queries to the domain\n\
+         # controllers without replacing the box's resolvers. Removed at leave.\n\
+         [Resolve]\n\
+         DNS={}\n\
+         Domains=~{}\n",
+        dc_ips.join(" "),
+        realm.to_ascii_lowercase(),
+    )
+}
+
+/// Parse `net ads info`'s "Server time:" line into unix seconds.
+/// Format observed: "Server time: Tue, 07 Jul 2026 12:34:56 UTC".
+/// Hand-rolled (days-since-epoch arithmetic) to avoid a chrono dep for
+/// one line of output; only UTC/GMT zones are accepted — anything else
+/// returns None and preflight skips the skew check rather than
+/// mis-judging it.
+fn parse_net_ads_server_time(output: &str) -> Option<i64> {
+    let line = output.lines().find(|l| l.trim_start().starts_with("Server time:"))?;
+    let rest = line.split_once(':')?.1.trim(); // "Tue, 07 Jul 2026 12:34:56 UTC"
+    let rest = rest.split_once(',').map(|(_, r)| r.trim()).unwrap_or(rest);
+    let mut parts = rest.split_whitespace(); // 07 Jul 2026 12:34:56 UTC
+    let day: i64 = parts.next()?.parse().ok()?;
+    let month = match parts.next()? {
+        "Jan" => 1, "Feb" => 2, "Mar" => 3, "Apr" => 4, "May" => 5, "Jun" => 6,
+        "Jul" => 7, "Aug" => 8, "Sep" => 9, "Oct" => 10, "Nov" => 11, "Dec" => 12,
+        _ => return None,
+    };
+    let year: i64 = parts.next()?.parse().ok()?;
+    let mut hms = parts.next()?.split(':');
+    let (h, m, s): (i64, i64, i64) = (
+        hms.next()?.parse().ok()?,
+        hms.next()?.parse().ok()?,
+        hms.next()?.parse().ok()?,
+    );
+    if !matches!(parts.next(), Some("UTC") | Some("GMT")) {
+        return None;
+    }
+    // Days since 1970-01-01 (civil-from-days, Howard Hinnant's algorithm).
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    Some(days * 86_400 + h * 3_600 + m * 60 + s)
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cargo test -p nasty-system --lib domain 2>&1 | tail -3`
+Expected: `test result: ok.`
+
+- [ ] **Step 5: Implement `preflight` (async glue — no unit test, exercised by the VM test)**
+
+```rust
+/// Fail fast with actionable errors before Kerberos gets a chance to
+/// produce cryptic ones. Checks, in order: the realm's LDAP SRV records
+/// resolve; a DC answers `net ads info`; clock skew is within bounds.
+async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
+    let srv_name = format!("_ldap._tcp.{}", realm.to_ascii_lowercase());
+    let out = run_cmd("resolvectl", &["query", "--type=SRV", &srv_name], &[]).await?;
+    let dcs = parse_resolvectl_srv(&out);
+    if dcs.is_empty() {
+        return Err(DomainError::Preflight(format!(
+            "no domain controllers found: DNS SRV lookup for {srv_name} returned \
+             nothing. The box's DNS must be able to resolve the AD zone — point \
+             it at (or forward to) the domain's DNS server."
+        )));
+    }
+    let info = run_cmd(
+        "net",
+        &["ads", "info", "-S", &dcs[0], "--realm", realm],
+        &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+    )
+    .await
+    .map_err(|e| DomainError::Preflight(format!(
+        "domain controller {} did not answer: {e}", dcs[0]
+    )))?;
+    if let Some(server_time) = parse_net_ads_server_time(&info) {
+        let local = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let skew = (server_time - local).abs();
+        if skew > 240 {
+            return Err(DomainError::Preflight(format!(
+                "clock skew vs domain controller is {skew}s — Kerberos tolerates \
+                 ~300s. Fix NTP before joining."
+            )));
+        }
+    }
+    Ok(dcs)
+}
+```
+
+Add the small `run_cmd(program, args, envs) -> Result<String, DomainError>` helper wrapping `tokio::process::Command` (capture stdout+stderr, `CommandFailed` with stderr on non-zero exit) — model it on `nasty_sharing::smb`'s command usage.
+
+- [ ] **Step 6: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-system
+git add engine/nasty-system/src/domain.rs
+git commit -m "system: domain join preflight — SRV discovery and clock-skew check"
+```
+
+---
+
+### Task 6: Join, leave, status — the service methods
+
+**Files:**
+- Modify: `engine/nasty-system/src/domain.rs`
+
+**Interfaces:**
+- Consumes: Tasks 2/3/5 (`validate_realm`, renderers, `preflight`, config load/save).
+- Produces (used verbatim by Task 8's router arms):
+  - `pub struct JoinDomainRequest { pub realm: String, pub username: String, pub password: String, pub ou: Option<String>, pub idmap_base: Option<u32> }` (Deserialize/JsonSchema)
+  - `pub struct LeaveDomainRequest { pub username: Option<String>, pub password: Option<String>, #[serde(default)] pub force: bool }`
+  - `pub struct DomainStatus { pub joined: bool, pub realm: Option<String>, pub workgroup: Option<String>, pub idmap_base: Option<u32>, pub trust_ok: Option<bool>, pub dc_reachable: Option<bool>, pub clock_skew_seconds: Option<i64> }` (Serialize/JsonSchema)
+  - `impl DomainService`: `pub async fn status(&self) -> DomainStatus`, `pub async fn join(&self, req: JoinDomainRequest) -> Result<DomainStatus, DomainError>`, `pub async fn leave(&self, req: LeaveDomainRequest) -> Result<(), DomainError>`.
+
+This task is orchestration glue over external commands — its unit surface is already tested (validators, renderers, parsers); the flow itself is exercised end-to-end by Task 10's VM test. Keep each step small and mirror the spec's join sequence exactly.
+
+- [ ] **Step 1: Implement `join`**
+
+Sequence (each failure before the state save must restore the previous on-disk config — snapshot the two rendered files' prior contents first, write them back in the error path):
+
+```rust
+pub async fn join(&self, req: JoinDomainRequest) -> Result<DomainStatus, DomainError> {
+    if Self::load_config().await.is_some() {
+        return Err(DomainError::AlreadyJoined);
+    }
+    let realm = validate_realm(&req.realm)?;
+    let idmap_base = req.idmap_base.unwrap_or(DEFAULT_IDMAP_BASE);
+    validate_idmap_base(idmap_base)?;
+    let cfg = DomainConfig {
+        workgroup: derive_workgroup(&realm),
+        realm,
+        idmap_base,
+    };
+
+    // Render krb5 first — preflight's `net ads info` reads it.
+    tokio::fs::write(KRB5_CONF_PATH, render_krb5_conf(&cfg.realm)).await?;
+    let dcs = match preflight(&cfg.realm).await {
+        Ok(dcs) => dcs,
+        Err(e) => {
+            let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+            return Err(e);
+        }
+    };
+
+    // Per-domain DNS routing: AD-zone queries go to the DCs from here on
+    // (spec join-flow step 6). Resolve the discovered DC hostnames to IPs
+    // through the still-working current resolvers.
+    let mut dc_ips = Vec::new();
+    for dc in dcs.iter().take(3) {
+        if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
+            dc_ips.extend(parse_resolvectl_addresses(&out));
+        }
+    }
+    if !dc_ips.is_empty() {
+        tokio::fs::create_dir_all("/etc/systemd/resolved.conf.d").await?;
+        tokio::fs::write(RESOLVED_DROPIN_PATH, render_resolved_dropin(&cfg.realm, &dc_ips)).await?;
+        let _ = systemctl("restart", "systemd-resolved.service").await;
+    }
+
+    tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
+    systemctl("restart", "samba-winbindd.service").await?;
+
+    // Credential via stdin (`net ads join -U user` prompts on stdin when
+    // no %password is attached). NEVER put the password in argv.
+    let mut join_args = vec!["ads", "join", "-U", req.username.as_str(), "--no-dns-updates"];
+    let ou_arg;
+    if let Some(ou) = &req.ou {
+        ou_arg = format!("createcomputer={ou}");
+        join_args.push(&ou_arg);
+    }
+    let join_out = run_cmd_stdin("net", &join_args, &[("KRB5_CONFIG", KRB5_CONF_PATH)], &req.password).await;
+
+    match join_out {
+        Ok(_) => {}
+        Err(e) => {
+            // Roll back: empty the rendered configs, drop the DNS routing,
+            // stop winbindd.
+            let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
+            let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+            let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
+            let _ = systemctl("restart", "systemd-resolved.service").await;
+            let _ = systemctl("stop", "samba-winbindd.service").await;
+            return Err(e);
+        }
+    }
+
+    // Verify the trust before declaring success.
+    if let Err(e) = run_cmd("wbinfo", &["-t"], &[]).await {
+        let _ = run_cmd_stdin("net", &["ads", "leave", "-U", &req.username], &[("KRB5_CONFIG", KRB5_CONF_PATH)], &req.password).await;
+        let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
+        let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+        let _ = systemctl("stop", "samba-winbindd.service").await;
+        return Err(DomainError::CommandFailed(format!(
+            "joined but the trust check failed (wbinfo -t): {e}"
+        )));
+    }
+
+    // Register our A record in AD DNS (best-effort — some sites restrict it).
+    if let Err(e) = run_cmd("net", &["ads", "dns", "register"], &[("KRB5_CONFIG", KRB5_CONF_PATH)]).await {
+        tracing::warn!("AD DNS register failed (non-fatal): {e}");
+    }
+
+    Self::save_config(&cfg).await?;
+    // smbd reloads pick up the ADS block via the include chain.
+    let _ = run_cmd("smbcontrol", &["all", "reload-config"], &[]).await;
+    tracing::info!("Joined AD domain {} (workgroup {})", cfg.realm, cfg.workgroup);
+    Ok(self.status().await)
+}
+```
+
+Add `run_cmd_stdin` (like `run_cmd` but writes the final arg to the child's stdin and appends `\n`). Add `systemctl` — reuse the pattern from `nasty-system/src/protocol.rs` (there's an existing `systemctl` helper there; make it `pub(crate)` and import it instead of duplicating).
+
+- [ ] **Step 2: Implement `leave` and `status`**
+
+```rust
+pub async fn leave(&self, req: LeaveDomainRequest) -> Result<(), DomainError> {
+    let Some(_cfg) = Self::load_config().await else {
+        return Err(DomainError::NotJoined);
+    };
+    match (&req.username, &req.password, req.force) {
+        (Some(user), Some(pass), _) => {
+            run_cmd_stdin("net", &["ads", "leave", "-U", user], &[("KRB5_CONFIG", KRB5_CONF_PATH)], pass).await?;
+        }
+        (_, _, true) => {
+            // Forced local leave: no DC contact; the computer account
+            // goes stale in AD (documented, matches `net ads leave` docs).
+            tracing::warn!("forced local domain leave — computer account left behind in AD");
+        }
+        _ => {
+            return Err(DomainError::Validation(
+                "leave needs AD credentials, or force=true for a local-only leave".into(),
+            ));
+        }
+    }
+    tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await?;
+    tokio::fs::write(KRB5_CONF_PATH, "").await?;
+    let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
+    let _ = systemctl("restart", "systemd-resolved.service").await;
+    let _ = systemctl("stop", "samba-winbindd.service").await;
+    Self::clear_config().await;
+    let _ = run_cmd("smbcontrol", &["all", "reload-config"], &[]).await;
+    tracing::info!("Left AD domain");
+    Ok(())
+}
+
+pub async fn status(&self) -> DomainStatus {
+    let Some(cfg) = Self::load_config().await else {
+        return DomainStatus { joined: false, realm: None, workgroup: None, idmap_base: None, trust_ok: None, dc_reachable: None, clock_skew_seconds: None };
+    };
+    let trust_ok = Some(run_cmd("wbinfo", &["-t"], &[]).await.is_ok());
+    let (dc_reachable, clock_skew_seconds) =
+        match run_cmd("net", &["ads", "info"], &[("KRB5_CONFIG", KRB5_CONF_PATH)]).await {
+            Ok(out) => {
+                let skew = parse_net_ads_server_time(&out).map(|t| {
+                    let local = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0);
+                    t - local
+                });
+                (Some(true), skew)
+            }
+            Err(_) => (Some(false), None),
+        };
+    DomainStatus {
+        joined: true,
+        realm: Some(cfg.realm),
+        workgroup: Some(cfg.workgroup),
+        idmap_base: Some(cfg.idmap_base),
+        trust_ok,
+        dc_reachable,
+        clock_skew_seconds,
+    }
+}
+```
+
+- [ ] **Step 3: Startup restore — start winbindd on boot when joined**
+
+In `engine/nasty-engine/src/main.rs`, find the boot phases (`run_phase(...)` calls, e.g. `"filesystems.restore_mounts"`). Add after the protocol restore phase:
+
+```rust
+    state
+        .boot_status
+        .run_phase("domain.restore", secs(15), {
+            let state = state.clone();
+            async move {
+                if state.domain.is_joined().await {
+                    state.domain.ensure_winbindd().await;
+                }
+            }
+        })
+        .await;
+```
+
+with, in `domain.rs`:
+
+```rust
+    pub async fn is_joined(&self) -> bool {
+        Self::load_config().await.is_some()
+    }
+    /// Start winbindd if it isn't running (boot restore; join already
+    /// restarted it explicitly).
+    pub async fn ensure_winbindd(&self) {
+        if let Err(e) = systemctl("start", "samba-winbindd.service").await {
+            tracing::error!("winbindd start failed on domain restore: {e}");
+        }
+    }
+```
+
+(AppState gains the field in Task 8 — if executing tasks in order, add a `// wired in the router task` TODO-free note in the commit message instead of a dangling reference: do this step LAST in this task and only compile-check it together with Task 8 if needed. Alternative: move this step into Task 8. Executor: if `state.domain` doesn't exist yet, defer just this step to Task 8's checklist — it's listed there too as Step 4.)
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test --workspace
+git add engine/nasty-system/src/domain.rs engine/nasty-system/src/protocol.rs
+git commit -m "system: domain join/leave/status orchestration
+
+Join: preflight → render configs → winbindd → net ads join (credential
+via stdin, used once, never persisted) → wbinfo -t trust verification →
+best-effort AD DNS register → persist state. Any failure rolls the
+rendered configs back and stops winbindd. Leave reverses the flow;
+force=true documents the stale computer account rather than pretending
+to clean it up."
+```
+
+---
+
+### Task 7: Live principal search via wbinfo (TDD)
+
+**Files:**
+- Modify: `engine/nasty-system/src/domain.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub struct DomainPrincipal { pub name: String }` (Serialize/JsonSchema) — `name` is `DOMAIN\user`.
+  - `fn filter_principals(raw: &str, prefix: &str, limit: usize) -> Vec<DomainPrincipal>` (pure).
+  - `pub async fn search_users(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError>` / `pub async fn search_groups(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError>` — run `wbinfo -u` / `wbinfo -g`, filter with `filter_principals`, `limit = 50`. Empty/short prefix (< 2 chars) → `Validation` error (no wholesale enumeration reaches the API).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn filter_principals_matches_prefix_case_insensitively_and_caps() {
+        let raw = "CORP\\alice\nCORP\\albert\nCORP\\bob\nCORP\\Alfred\n";
+        let hits = filter_principals(raw, "al", 50);
+        let names: Vec<&str> = hits.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["CORP\\alice", "CORP\\albert", "CORP\\Alfred"]);
+        // Prefix matches the account part, not the domain part.
+        assert!(filter_principals(raw, "corp", 50).is_empty());
+        // Limit is a hard cap.
+        assert_eq!(filter_principals(raw, "al", 2).len(), 2);
+    }
+```
+
+- [ ] **Step 2: Run test, verify it fails** — `cargo test -p nasty-system --lib domain::tests::filter 2>&1 | tail -3`
+
+- [ ] **Step 3: Implement**
+
+```rust
+fn filter_principals(raw: &str, prefix: &str, limit: usize) -> Vec<DomainPrincipal> {
+    let prefix = prefix.to_lowercase();
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| {
+            l.rsplit_once('\\')
+                .map(|(_, account)| account.to_lowercase().starts_with(&prefix))
+                .unwrap_or(false)
+        })
+        .take(limit)
+        .map(|l| DomainPrincipal { name: l.to_string() })
+        .collect()
+}
+```
+
+and the async wrappers:
+
+```rust
+pub async fn search_users(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+    self.search(prefix, "-u").await
+}
+pub async fn search_groups(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+    self.search(prefix, "-g").await
+}
+async fn search(&self, prefix: &str, flag: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+    if Self::load_config().await.is_none() {
+        return Err(DomainError::NotJoined);
+    }
+    if prefix.trim().len() < 2 {
+        return Err(DomainError::Validation(
+            "search prefix must be at least 2 characters".into(),
+        ));
+    }
+    let raw = run_cmd("wbinfo", &[flag], &[]).await?;
+    Ok(filter_principals(&raw, prefix.trim(), 50))
+}
+```
+
+- [ ] **Step 4: Run tests, verify green** — `cargo test -p nasty-system --lib domain 2>&1 | tail -3`
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-system
+git add engine/nasty-system/src/domain.rs
+git commit -m "system: prefix-filtered domain principal search via wbinfo"
+```
+
+---
+
+### Task 8: Engine wiring — AppState, router arms, method registry
+
+**Files:**
+- Modify: `engine/nasty-engine/src/main.rs` (AppState struct at line ~50; construction site; boot phase from Task 6 Step 3)
+- Create: `engine/nasty-engine/src/router/domain.rs`
+- Modify: `engine/nasty-engine/src/router/mod.rs` (module decl ~line 10; prefix match ~line 458)
+- Modify: `engine/nasty-engine/src/registry/methods.rs`
+
+**Interfaces:**
+- Consumes: `DomainService` API from Tasks 6–7 exactly as declared there.
+- Produces: JSON-RPC methods `domain.status` (Any), `domain.join`, `domain.leave`, `domain.user.list`, `domain.group.list` (Admin).
+
+- [ ] **Step 1: AppState field**
+
+In `engine/nasty-engine/src/main.rs`: add to `AppState` (next to `pub smb: ...`):
+
+```rust
+    pub domain: nasty_system::domain::DomainService,
+```
+
+and at the AppState construction site: `domain: nasty_system::domain::DomainService::new(),`. Now also apply Task 6 Step 3 (the `domain.restore` boot phase) if it was deferred.
+
+- [ ] **Step 2: Router module**
+
+Create `engine/nasty-engine/src/router/domain.rs`, modeled exactly on `router/share.rs`'s arm style:
+
+```rust
+//! RPC arms in the `domain.*` namespace (Active Directory member mode).
+
+use nasty_common::{Request, Response};
+
+use super::*;
+use crate::AppState;
+use crate::auth::Session;
+
+pub(super) async fn try_route(
+    req: &Request,
+    state: &AppState,
+    _session: &Session,
+) -> Option<Response> {
+    Some(match req.method.as_str() {
+        "domain.status" => ok(req, state.domain.status().await),
+        "domain.join" => match parse_params::<nasty_system::domain::JoinDomainRequest>(req) {
+            Ok(p) => match state.domain.join(p).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "domain.leave" => match parse_params::<nasty_system::domain::LeaveDomainRequest>(req) {
+            Ok(p) => match state.domain.leave(p).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "domain.user.list" => match require_str(req, "prefix") {
+            Ok(prefix) => match state.domain.search_users(prefix).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "domain.group.list" => match require_str(req, "prefix") {
+            Ok(prefix) => match state.domain.search_groups(prefix).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        _ => return None,
+    })
+}
+```
+
+(Check `err(...)`'s bound in `router/mod.rs` — if it requires `std::error::Error`, `DomainError` already satisfies it via thiserror. `parse_params`, `require_str`, `ok`, `invalid` come from `super::*` like the other domain modules.)
+
+In `router/mod.rs`: add `mod domain;` to the module list and a prefix arm next to the others:
+
+```rust
+        "domain" => domain::try_route(req, state, session).await,
+```
+
+- [ ] **Step 3: Registry entries**
+
+In `engine/nasty-engine/src/registry/methods.rs`, add imports for `JoinDomainRequest, LeaveDomainRequest, DomainStatus, DomainPrincipal` from `nasty_system::domain`, then a new group after the SMB user/group section (follow the exact `Method { ... }` shape at ~line 2163):
+
+```rust
+        (
+            "Active Directory",
+            vec![
+                Method {
+                    name: "domain.status",
+                    desc: "Report AD membership: joined state, realm, trust health (wbinfo -t), DC reachability, and clock skew.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<DomainStatus>(generator)),
+                },
+                Method {
+                    name: "domain.join",
+                    desc: "Join an Active Directory domain. Runs preflight (DNS SRV, DC reachability, clock skew) before touching Kerberos; the admin credential is used once over stdin and never stored. Configuration rolls back on any failure.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<JoinDomainRequest>(generator)),
+                    result: Some(gen_schema::<DomainStatus>(generator)),
+                },
+                Method {
+                    name: "domain.leave",
+                    desc: "Leave the AD domain. With credentials the computer account is removed from AD; with force=true the leave is local-only and the account goes stale.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<LeaveDomainRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "domain.user.list",
+                    desc: "Search domain users by account-name prefix (min 2 chars, capped at 50). Live winbind query — domain users are never copied into NASty.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("prefix", "Account name prefix to search for.")),
+                    result: Some(gen_schema::<Vec<DomainPrincipal>>(generator)),
+                },
+                Method {
+                    name: "domain.group.list",
+                    desc: "Search domain groups by name prefix (min 2 chars, capped at 50).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("prefix", "Group name prefix to search for.")),
+                    result: Some(gen_schema::<Vec<DomainPrincipal>>(generator)),
+                },
+            ],
+        ),
+```
+
+- [ ] **Step 4: Build + full test run**
+
+Run: `cargo build -p nasty-engine && cargo test --workspace 2>&1 | tail -3`
+Expected: builds; all tests pass (the registry has a coverage test that fails if a registered method has no router arm — if it fires, the router arm names don't match the registry names; fix the typo).
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings
+git add engine/nasty-engine/src/
+git commit -m "engine: domain.* methods — join/leave/status and principal search"
+```
+
+---
+
+### Task 9: `valid_users` carve-out for DOMAIN\name entries (TDD)
+
+**Files:**
+- Modify: `engine/nasty-sharing/src/smb.rs`
+
+**Interfaces:**
+- Produces: `fn validate_valid_users(entries: &[String]) -> Result<(), SmbError>`, called from `SmbService::create` and `SmbService::update` before persisting `valid_users`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn validate_valid_users_accepts_local_group_and_domain_forms() {
+        assert!(validate_valid_users(&["alice".into()]).is_ok());
+        assert!(validate_valid_users(&["@staff".into()]).is_ok());
+        assert!(validate_valid_users(&["CORP\\alice".into()]).is_ok());
+        assert!(validate_valid_users(&["@CORP\\domain admins".into()]).is_ok());
+        // AD account names may contain dots and spaces.
+        assert!(validate_valid_users(&["CORP\\svc account.backup".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_valid_users_rejects_injection_shapes() {
+        // Same smuggling shapes validate_share_path pins (newline/config
+        // injection), plus structural garbage.
+        assert!(validate_valid_users(&["alice\ninclude = /etc/passwd".into()]).is_err());
+        assert!(validate_valid_users(&["alice;rm".into()]).is_err());
+        assert!(validate_valid_users(&["CORP\\\\alice".into()]).is_err(), "double backslash");
+        assert!(validate_valid_users(&["\\alice".into()]).is_err(), "empty domain part");
+        assert!(validate_valid_users(&["CORP\\".into()]).is_err(), "empty account part");
+        assert!(validate_valid_users(&["".into()]).is_err());
+        assert!(validate_valid_users(&["THISNETBIOSNAMEISTOOLONG\\alice".into()]).is_err());
+    }
+```
+
+- [ ] **Step 2: Run tests, verify they fail** — `cargo test -p nasty-sharing --lib smb::tests::validate_valid 2>&1 | tail -4` (stub returning `Ok(())` makes the reject-test fail).
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Validate share `valid_users` entries. Three accepted shapes:
+/// local `name`, local `@group`, and domain `DOMAIN\name` (optionally
+/// `@DOMAIN\group`) — the backslash carve-out for AD member mode.
+/// Everything is checked against config-injection characters the same
+/// way validate_share_path is; the domain part follows NetBIOS rules
+/// (≤15 chars, alphanumeric + hyphen).
+fn validate_valid_users(entries: &[String]) -> Result<(), SmbError> {
+    for raw in entries {
+        let entry = raw.strip_prefix('@').unwrap_or(raw);
+        if entry.is_empty() || entry.len() > 256 {
+            return Err(SmbError::InvalidName(format!(
+                "invalid valid_users entry '{raw}'"
+            )));
+        }
+        if entry.chars().any(|c| c.is_control() || matches!(c, ';' | '"' | '#' | '=' | '\n' | '\r')) {
+            return Err(SmbError::InvalidName(format!(
+                "valid_users entry '{raw}' contains forbidden characters"
+            )));
+        }
+        match entry.split('\\').collect::<Vec<_>>().as_slice() {
+            // Local user or group: existing character policy.
+            [name] => {
+                if !name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')) {
+                    return Err(SmbError::InvalidName(format!(
+                        "invalid user/group name '{raw}'"
+                    )));
+                }
+            }
+            // DOMAIN\name: NetBIOS domain + AD account (spaces/dots legal).
+            [domain, name] => {
+                let domain_ok = !domain.is_empty()
+                    && domain.len() <= 15
+                    && domain.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+                let name_ok = !name.is_empty()
+                    && name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ' '));
+                if !domain_ok || !name_ok {
+                    return Err(SmbError::InvalidName(format!(
+                        "invalid domain principal '{raw}'"
+                    )));
+                }
+            }
+            _ => {
+                return Err(SmbError::InvalidName(format!(
+                    "invalid valid_users entry '{raw}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+Call it in `create` (where `valid_users: req.valid_users.unwrap_or_default()` is built, ~line 195 — validate before constructing the share) and in `update` (~line 247, before `share.valid_users = valid_users`).
+
+- [ ] **Step 4: Run the whole smb module** — `cargo test -p nasty-sharing --lib smb 2>&1 | tail -3` — expected green. If any existing test created shares with entries the new validation rejects, the validation is too strict — fix the validator, not the test.
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+cargo fmt && cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-sharing
+git add engine/nasty-sharing/src/smb.rs
+git commit -m "sharing: validate valid_users entries, DOMAIN\\name carve-out"
+```
+
+---
+
+### Task 10: Two-node NixOS VM test — DC + joining appliance
+
+**Files:**
+- Create: `nixos/tests/ad-member.nix`
+- Modify: `flake.nix` (checks attrset, ~line 406–418, next to `appliance-smoke`)
+- Modify: `.github/workflows/` — add the check to whichever workflow runs `bcachefs-smoke`/`appliance-smoke` (grep for `appliance-smoke` in `.github/workflows/*.yml` and mirror its invocation)
+
+**Interfaces:**
+- Consumes: the full engine + module stack from Tasks 1–9.
+
+- [ ] **Step 1: Write the test**
+
+Create `nixos/tests/ad-member.nix`. Model the harness plumbing (arguments, `pkgs.testers.runNixOSTest` vs the shape `appliance-smoke.nix` uses — copy its exact wrapper) and use this structure:
+
+```nix
+# Two-node AD member-join test: a throwaway Samba AD DC and a NASty
+# appliance that joins it, resolves domain users through winbind, and
+# serves an SMB share restricted to a domain user. This is the only
+# place the whole join flow (preflight → net ads join → wbinfo trust →
+# idmap) runs against a real KDC.
+{ pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
+
+let
+  realm = "NASTY.TEST";
+  domain = "NASTYAD";
+  adminPass = "Passw0rd.123";
+  sambaDc = pkgs.samba.override {
+    enableLDAP = true;
+    enableDomainController = true;
+  };
+in
+# ... same test-framework wrapper as appliance-smoke.nix ...
+{
+  name = "ad-member";
+
+  nodes.dc = { config, ... }: {
+    networking.firewall.enable = false;
+    environment.systemPackages = [ sambaDc ];
+    # Provision at boot; the DC's own DNS serves the AD zone.
+    systemd.services.samba-dc = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ sambaDc ];
+      serviceConfig.Type = "notify";
+      serviceConfig.NotifyAccess = "all";
+      script = ''
+        if [ ! -f /var/lib/samba/private/krb5.conf ]; then
+          rm -f /etc/samba/smb.conf
+          samba-tool domain provision \
+            --realm=${realm} --domain=${domain} \
+            --server-role=dc --dns-backend=SAMBA_INTERNAL \
+            --adminpass='${adminPass}'
+          samba-tool user create alice 'UserPass.123'
+        fi
+        systemd-notify --ready &
+        exec samba --foreground --no-process-group
+      '';
+    };
+    # The test framework gives static IPs; disable resolved so the DC's
+    # internal DNS owns port 53.
+    services.resolved.enable = false;
+  };
+
+  nodes.nasty = { ... }: {
+    imports = [ /* same appliance module import as appliance-smoke.nix */ ];
+    # Point the box's DNS at the DC — AD join requires resolving the
+    # realm's SRV records through AD DNS.
+    networking.nameservers = pkgs.lib.mkForce [ "192.168.1.1" ]; # dc's test-net IP
+  };
+
+  testScript = ''
+    dc.start()
+    nasty.start()
+    dc.wait_for_unit("samba-dc.service")
+    dc.wait_until_succeeds("host -t SRV _ldap._tcp.${pkgs.lib.toLower realm} 127.0.0.1", timeout=120)
+    nasty.wait_for_unit("nasty-engine.service")
+
+    # Join via the engine API (same path the WebUI uses).
+    token = ...  # login helper — copy from appliance-smoke.nix
+    join = rpc(token, "domain.join", {
+        "realm": "${realm}",
+        "username": "Administrator",
+        "password": "${adminPass}",
+    })
+    assert join["joined"] is True, join
+    assert join["trust_ok"] is True, join
+
+    # Domain user resolves through winbind/NSS with a UID in the idmap range.
+    uid = int(nasty.succeed("id -u '${domain}\\\\alice'").strip())
+    assert 100000 <= uid < 1000000, f"idmap uid out of range: {uid}"
+
+    # Principal search returns the user.
+    users = rpc(token, "domain.user.list", {"prefix": "al"})
+    assert any(u["name"].endswith("\\\\alice") for u in users), users
+
+    # status stays healthy.
+    st = rpc(token, "domain.status", {})
+    assert st["trust_ok"] and st["dc_reachable"], st
+
+    # Leave (forced local) unwinds cleanly.
+    rpc(token, "domain.leave", {"force": True})
+    st = rpc(token, "domain.status", {})
+    assert st["joined"] is False, st
+  '';
+}
+```
+
+The `rpc(...)`/login helper: copy the exact WebSocket helper from `appliance-smoke.nix`'s `rpcSmoke` script — same login, same call shape. The exact node IPs come from the test framework's default net (check what `appliance-smoke.nix` assumes). This step is expected to need iteration in CI — keep the testScript assertions few and sharp.
+
+- [ ] **Step 2: Register the check**
+
+In `flake.nix` next to `appliance-smoke` (~line 417):
+
+```nix
+      ad-member = import ./nixos/tests/ad-member.nix {
+        inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
+      };
+```
+
+(match the exact argument set `appliance-smoke` receives), and add the check to the CI workflow that runs the other NixOS tests.
+
+- [ ] **Step 3: Build locally if on Linux, otherwise push and watch CI**
+
+Run (Linux): `nix build .#checks.x86_64-linux.ad-member -L 2>&1 | tail -20`
+On macOS: push the branch and watch the Integration workflow — this test can only run there.
+Expected: test passes; on failure, the testScript's assertion output names the failing stage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nixos/tests/ad-member.nix flake.nix .github/workflows/
+git commit -m "tests: two-node AD member-join VM test (throwaway DC + appliance)"
+```
+
+---
+
+### Task 11: WebUI — Directory settings card and domain-user share picker
+
+**Files:**
+- Create: `webui/src/lib/domain.svelte.ts`
+- Modify: `webui/src/lib/types.ts` (DomainStatus/DomainPrincipal types)
+- Modify: `webui/src/routes/settings/+page.svelte` (new "Directory" card)
+- Modify: `webui/src/routes/sharing/SmbPanel.svelte` (~line 208–230, the valid_users editor)
+
+**Interfaces:**
+- Consumes: `domain.status`, `domain.join`, `domain.leave`, `domain.user.list`, `domain.group.list` exactly as registered in Task 8.
+
+- [ ] **Step 1: Types**
+
+In `webui/src/lib/types.ts`:
+
+```ts
+/** Wire shape of `domain.status`. */
+export interface DomainStatus {
+	joined: boolean;
+	realm: string | null;
+	workgroup: string | null;
+	idmap_base: number | null;
+	trust_ok: boolean | null;
+	dc_reachable: boolean | null;
+	clock_skew_seconds: number | null;
+}
+
+/** One AD principal from `domain.user.list` / `domain.group.list` — name is `DOMAIN\name`. */
+export interface DomainPrincipal {
+	name: string;
+}
+```
+
+- [ ] **Step 2: Store**
+
+Create `webui/src/lib/domain.svelte.ts`, following the shape of `webui/src/lib/sharing/iscsi.svelte.ts` (single `$state` object + exported async handlers):
+
+```ts
+/** AD membership state + handlers (Settings → Directory card). */
+import { getClient } from '$lib/client';
+import { withToast } from '$lib/toast.svelte';
+import { confirm } from '$lib/confirm.svelte';
+import type { DomainStatus, DomainPrincipal } from '$lib/types';
+
+const client = getClient();
+
+export const domain = $state({
+	status: null as DomainStatus | null,
+	loading: true,
+	joining: false,
+	// join form
+	realm: '',
+	username: '',
+	password: '',
+	ou: '',
+});
+
+export async function domainRefresh() {
+	try {
+		domain.status = await client.call<DomainStatus>('domain.status');
+	} catch { /* engine without domain support */ }
+	domain.loading = false;
+}
+
+export async function domainJoin() {
+	if (!domain.realm || !domain.username || !domain.password) return;
+	domain.joining = true;
+	const params: Record<string, unknown> = {
+		realm: domain.realm.trim(),
+		username: domain.username.trim(),
+		password: domain.password,
+	};
+	if (domain.ou.trim()) params.ou = domain.ou.trim();
+	const ok = await withToast(() => client.call<DomainStatus>('domain.join', params), 'Joined domain');
+	domain.password = '';
+	if (ok !== undefined) {
+		domain.status = ok;
+		domain.realm = ''; domain.username = ''; domain.ou = '';
+	}
+	domain.joining = false;
+}
+
+export async function domainLeave(force: boolean, username?: string, password?: string) {
+	if (!await confirm(
+		'Leave the domain?',
+		force
+			? 'Local-only leave: the computer account stays behind in AD. Shares referencing domain users keep their entries but domain logons stop working.'
+			: 'The computer account will be removed from AD. Shares referencing domain users keep their entries but domain logons stop working.'
+	)) return;
+	const params: Record<string, unknown> = force ? { force: true } : { username, password };
+	await withToast(() => client.call('domain.leave', params), 'Left domain');
+	await domainRefresh();
+}
+
+/** Prefix search for the share permissions picker (2+ chars). */
+export async function domainSearchUsers(prefix: string): Promise<DomainPrincipal[]> {
+	if (prefix.trim().length < 2 || !domain.status?.joined) return [];
+	try {
+		return await client.call<DomainPrincipal[]>('domain.user.list', { prefix: prefix.trim() });
+	} catch {
+		return [];
+	}
+}
+```
+
+- [ ] **Step 3: Settings card**
+
+In `webui/src/routes/settings/+page.svelte`, add a "Directory (Active Directory)" card following the visual pattern of the existing cards on that page:
+
+- Not joined: inputs bound to `domain.realm` (placeholder `corp.example.com`), `domain.username` (placeholder `Administrator`), `domain.password` (type=password), collapsible "advanced" with `domain.ou`; a Join button calling `domainJoin` (disabled while `domain.joining`, label "Joining… (this contacts the domain controller)").
+- Joined: realm + workgroup as read-only rows; three status pills from `domain.status` — trust (`trust_ok`), DC reachability (`dc_reachable`), clock skew (amber when `Math.abs(clock_skew_seconds ?? 0) > 120`); a Leave button opening a small choice (with credentials / force local) driving `domainLeave`.
+- Call `domainRefresh()` from the page's existing `onMount` load sequence.
+
+- [ ] **Step 4: Domain users in the SMB share permissions editor**
+
+In `webui/src/routes/sharing/SmbPanel.svelte` (~line 208–230), the editor lists `smb.systemUsers` to add to `share.valid_users`. Below that list, when `domain.status?.joined`, add a search input:
+
+```svelte
+{#if domain.status?.joined}
+	<div class="mt-2">
+		<Input bind:value={domainSearch} placeholder="Search domain users (2+ chars)…" class="h-8 text-xs"
+			oninput={async () => { domainHits = await domainSearchUsers(domainSearch); }} />
+		{#each domainHits.filter(p => !share.valid_users.includes(p.name)) as p}
+			<button class="block w-full rounded px-2 py-1 text-left font-mono text-xs hover:bg-secondary/50"
+				onclick={() => addValidUser(share, p.name)}>
+				{p.name}
+			</button>
+		{/each}
+	</div>
+{/if}
+```
+
+with `let domainSearch = $state(''); let domainHits: DomainPrincipal[] = $state([]);` in the script block, imports for `domain`, `domainSearchUsers` from `$lib/domain.svelte`, and `addValidUser` being whatever existing handler the panel uses to append an entry to `share.valid_users` and call `share.smb.update` (find the handler the `smb.systemUsers` buttons call at ~line 226 and reuse it verbatim; if it's inline, extract it to a local function first).
+
+- [ ] **Step 5: Check + build**
+
+Run: `cd webui && npm run check && npm run build`
+Expected: 0 errors / 0 warnings; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webui/src
+git commit -m "webui: Directory card (AD join/status/leave) + domain-user share picker"
+```
+
+---
+
+### Task 12: Verify-during-implementation item — machine secret vs rollback
+
+**Files:**
+- Modify: `docs/active-directory-support.md` (resolve the "verify during implementation" risk note with findings)
+- Possibly modify: `engine/nasty-system/src/domain.rs` (one rendered line)
+
+**Interfaces:** none (investigation + one-line config decision).
+
+- [ ] **Step 1: Establish where `/var/lib/samba` lives relative to version switches and subvolume rollbacks**
+
+Read `nixos/modules/nasty.nix` for any `/var/lib` bind/subvolume handling and `engine/nasty-engine/src/subvol_rollback.rs` for what a rollback restores. Answer two questions in writing: (a) does `/var/lib/samba` survive a NASty version switch (it should — version switches don't touch `/var/lib`); (b) can a subvolume rollback restore an old `secrets.tdb` (only if `/var/lib` lives on a rolled-back subvolume — determine this from the module's filesystem layout).
+
+- [ ] **Step 2: Apply the decision**
+
+Per the spec's risk section: if (b) is possible, add one line to `render_domain_smb_conf`:
+
+```rust
+         machine password timeout = 0\n\
+```
+
+with a comment citing the rollback finding (no rotation → a restored `secrets.tdb` is never stale). If (b) is impossible, leave rotation on and document why in the spec.
+
+- [ ] **Step 3: Update the spec + commit**
+
+Replace the spec's "**Verify during implementation:**" paragraph with the finding and the decision taken.
+
+```bash
+git add docs/active-directory-support.md engine/nasty-system/src/domain.rs
+git commit -m "docs: resolve machine-password-rotation question with rollback findings"
+```
+
+---
+
+### Task 13: Final verification sweep
+
+- [ ] **Step 1: Engine** — from `engine/`: `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test --workspace` — all green.
+- [ ] **Step 2: WebUI** — from `webui/`: `npm run check && npm run build` — 0/0 and clean build.
+- [ ] **Step 3: Nix** — `nix flake check --no-build` evaluates; push and confirm the Integration workflow (including the new `ad-member` check and the existing `appliance-smoke` against the rebuilt Samba) is green before requesting review.
+- [ ] **Step 4: Footprint audit** — on the built system config, confirm the spec's "footprint on boxes that never join" section: `smb.nasty.conf` render for an unjoined box contains only the (empty) domain include as a delta, no new listening ports in the firewall rules, winbindd not running.

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -244,6 +244,7 @@ async fn main() -> anyhow::Result<()> {
             "nvmeof.remap_device_paths",
             "iscsi.remap_device_paths",
             "protocols.restore",
+            "smb.scaffold_config",
             "domain.restore",
             "nvmeof.restore",
             "vms.restore",
@@ -339,6 +340,29 @@ async fn main() -> anyhow::Result<()> {
             secs(90), // 9 systemd services × up to ~10s each on a bursty box
             state.protocols.restore(),
         )
+        .await;
+
+    // Rebuild the smb.nasty.conf include chain before anything AD-related
+    // runs. tmpfiles ships that file empty and only a share mutation ever
+    // rewrote it, so fresh and upgraded boxes carried no
+    // `include = /etc/samba/nasty-domain.conf` — the domain join below (and
+    // winbindd) would see no ADS globals. The rebuild is idempotent, so this
+    // is safe on every boot; it must run BEFORE domain.restore.
+    state
+        .boot_status
+        .run_phase("smb.scaffold_config", secs(15), {
+            let state = state.clone();
+            async move {
+                match state.smb.ensure_config_scaffolding().await {
+                    Ok(()) => {
+                        tracing::info!("Rebuilt /etc/samba/smb.nasty.conf include chain at boot");
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to rebuild smb.nasty.conf include chain: {e}");
+                    }
+                }
+            }
+        })
         .await;
 
     // If we're joined to an Active Directory domain, make sure winbindd is

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -79,6 +79,7 @@ pub struct AppState {
     pub nfs: nasty_sharing::NfsService,
     pub guest_shares: guestshare::GuestShareService,
     pub smb: nasty_sharing::SmbService,
+    pub domain: nasty_system::domain::DomainService,
     pub iscsi: nasty_sharing::IscsiService,
     pub nvmeof: Arc<nasty_sharing::NvmeofService>,
     pub vms: nasty_vm::VmService,
@@ -222,6 +223,7 @@ async fn main() -> anyhow::Result<()> {
         nfs: nasty_sharing::NfsService::new(),
         guest_shares: guestshare::GuestShareService::new(),
         smb: nasty_sharing::SmbService::new(),
+        domain: nasty_system::domain::DomainService::new(),
         iscsi: nasty_sharing::IscsiService::new(),
         nvmeof,
         vms: nasty_vm::VmService::new(),
@@ -242,6 +244,7 @@ async fn main() -> anyhow::Result<()> {
             "nvmeof.remap_device_paths",
             "iscsi.remap_device_paths",
             "protocols.restore",
+            "domain.restore",
             "nvmeof.restore",
             "vms.restore",
             "apps.restore",
@@ -336,6 +339,21 @@ async fn main() -> anyhow::Result<()> {
             secs(90), // 9 systemd services × up to ~10s each on a bursty box
             state.protocols.restore(),
         )
+        .await;
+
+    // If we're joined to an Active Directory domain, make sure winbindd is
+    // running — `domain.join` already starts it, but a plain reboot doesn't
+    // go through that path.
+    state
+        .boot_status
+        .run_phase("domain.restore", secs(15), {
+            let state = state.clone();
+            async move {
+                if state.domain.is_joined().await {
+                    state.domain.ensure_winbindd().await;
+                }
+            }
+        })
         .await;
 
     // SSH password auth is managed via /var/lib/nasty/sshd_override.conf

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -48,6 +48,7 @@ use nasty_storage::subvolume::{
     Snapshot, Subvolume, UpdateSubvolumeRequest,
 };
 use nasty_system::alerts::{ActiveAlert, AlertRule, AlertRuleUpdate};
+use nasty_system::domain::{DomainPrincipal, DomainStatus, JoinDomainRequest, LeaveDomainRequest};
 use nasty_system::firewall::FirewallStatus;
 use nasty_system::firmware::{FirmwareConstraints, FirmwareDevice, FirmwareUpdateResult};
 use nasty_system::guest_tools::{GuestToolsStatus, GuestToolsUpdate};
@@ -2249,6 +2250,53 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                         "Username to remove.",
                     )),
                     result: None,
+                },
+            ],
+        ),
+        // ── Active Directory ────────────────────────────────────────────
+        (
+            "Active Directory",
+            vec![
+                Method {
+                    name: "domain.status",
+                    desc: "Report AD membership: joined state, realm, trust health (wbinfo -t), DC reachability, and clock skew.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<DomainStatus>(generator)),
+                },
+                Method {
+                    name: "domain.join",
+                    desc: "Join an Active Directory domain. Runs preflight (DNS SRV, DC reachability, clock skew) before touching Kerberos; the admin credential is used once over stdin and never stored. Configuration rolls back on any failure.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<JoinDomainRequest>(generator)),
+                    result: Some(gen_schema::<DomainStatus>(generator)),
+                },
+                Method {
+                    name: "domain.leave",
+                    desc: "Leave the AD domain. With credentials the computer account is removed from AD; with force=true the leave is local-only and the account goes stale.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<LeaveDomainRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "domain.user.list",
+                    desc: "Search domain users by account-name prefix (min 2 chars, capped at 50). Live winbind query — domain users are never copied into NASty.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "prefix",
+                        "Account name prefix to search for.",
+                    )),
+                    result: Some(gen_schema::<Vec<DomainPrincipal>>(generator)),
+                },
+                Method {
+                    name: "domain.group.list",
+                    desc: "Search domain groups by name prefix (min 2 chars, capped at 50).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "prefix",
+                        "Group name prefix to search for.",
+                    )),
+                    result: Some(gen_schema::<Vec<DomainPrincipal>>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/domain.rs
+++ b/engine/nasty-engine/src/router/domain.rs
@@ -1,0 +1,46 @@
+//! RPC arms in the `domain.*` namespace (Active Directory member mode).
+
+use nasty_common::{Request, Response};
+
+use super::*;
+use crate::AppState;
+use crate::auth::Session;
+
+pub(super) async fn try_route(
+    req: &Request,
+    state: &AppState,
+    _session: &Session,
+) -> Option<Response> {
+    Some(match req.method.as_str() {
+        "domain.status" => ok(req, state.domain.status().await),
+        "domain.join" => match parse_params::<nasty_system::domain::JoinDomainRequest>(req) {
+            Ok(p) => match state.domain.join(p).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "domain.leave" => match parse_params::<nasty_system::domain::LeaveDomainRequest>(req) {
+            Ok(p) => match state.domain.leave(p).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "domain.user.list" => match require_str(req, "prefix") {
+            Ok(prefix) => match state.domain.search_users(prefix).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "domain.group.list" => match require_str(req, "prefix") {
+            Ok(prefix) => match state.domain.search_groups(prefix).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        _ => return None,
+    })
+}

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -7,6 +7,7 @@ mod audit;
 mod auth;
 mod backup;
 mod bcachefs;
+mod domain;
 mod fs;
 mod guestshare;
 mod notifications;
@@ -468,6 +469,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "share" => share::try_route(req, state, session).await,
         "guestshare" => guestshare::try_route(req, state, session).await,
         "smb" => smb::try_route(req, state, session).await,
+        "domain" => domain::try_route(req, state, session).await,
         "service" => service::try_route(req, state, session).await,
         "system" => {
             // `system.alerts` lives in the alerts module; everything else

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -201,6 +201,17 @@ fn is_read_only(method: &str) -> bool {
     // `system.ssh.status`, `system.nut.status`, `system.acme.status`,
     // `system.firewall.status`, `system.tls.host_statuses`,
     // `fs.reconcile.status`, …), so this is safe.
+    //
+    // Carve-outs that must NOT match the suffix heuristics: the registry
+    // declares `domain.user.list` / `domain.group.list` as Admin, but their
+    // `.list` suffix would otherwise slip them into the universally-allowed
+    // read set. They spawn `wbinfo` to enumerate Active Directory principals
+    // (users/groups) out of the joined directory, so they are privileged
+    // reads gated on Admin, not routine reads. Returning false here defers
+    // enforcement to the role check (Admin only), matching the registry.
+    if matches!(method, "domain.user.list" | "domain.group.list") {
+        return false;
+    }
     method.ends_with(".list")
         || method.ends_with(".get")
         || method.ends_with(".status")
@@ -1359,6 +1370,16 @@ mod tests {
         ] {
             assert!(!is_read_only(m), "expected {m} to be a write");
         }
+    }
+
+    /// Domain principal enumeration is Admin-gated in the registry, so it
+    /// must NOT be classified as a routine read despite its `.list` suffix
+    /// — otherwise ReadOnly/Operator users could enumerate directory
+    /// principals via wbinfo. Enforcement defers to the Admin role check.
+    #[test]
+    fn domain_principal_search_is_not_read_only() {
+        assert!(!is_read_only("domain.user.list"));
+        assert!(!is_read_only("domain.group.list"));
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -471,23 +471,41 @@ async fn remove_share_conf(id: &str) {
 async fn rebuild_include_list() -> Result<(), SmbError> {
     tokio::fs::create_dir_all(NASTY_SMB_SHARE_DIR).await?;
 
+    let mut share_conf_names = Vec::new();
+    let mut dir = tokio::fs::read_dir(NASTY_SMB_SHARE_DIR).await?;
+    while let Ok(Some(entry)) = dir.next_entry().await {
+        let name = entry.file_name();
+        let name = name.to_string_lossy().into_owned();
+        if name.ends_with(".conf") {
+            share_conf_names.push(name);
+        }
+    }
+
+    let includes = render_include_list(&share_conf_names);
+    tokio::fs::write(NASTY_SMB_CONF_PATH, &includes).await?;
+    Ok(())
+}
+
+/// Build the contents of `smb.nasty.conf`: header comment, engine-managed
+/// global includes (domain, tuning), then one `include =` line per per-share
+/// config file name. Pure so it's testable without a filesystem.
+fn render_include_list(share_conf_names: &[String]) -> String {
     let mut includes = String::from("# Managed by NASty — do not edit manually\n");
     includes.push_str("# Per-share configs in /etc/samba/nasty.d/\n\n");
+
+    // Domain (AD member) global parameters. The file exists on every box
+    // (tmpfiles) and is empty until a join renders the ADS block into it,
+    // so unjoined boxes get byte-identical effective config.
+    includes.push_str("include = /etc/samba/nasty-domain.conf\n\n");
 
     // Include engine-managed performance tuning (thread counts, timeouts, etc)
     includes.push_str("include = /etc/samba/nasty-tuning.conf\n\n");
 
-    let mut dir = tokio::fs::read_dir(NASTY_SMB_SHARE_DIR).await?;
-    while let Ok(Some(entry)) = dir.next_entry().await {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if name.ends_with(".conf") {
-            includes.push_str(&format!("include = {NASTY_SMB_SHARE_DIR}/{name}\n"));
-        }
+    for name in share_conf_names {
+        includes.push_str(&format!("include = {NASTY_SMB_SHARE_DIR}/{name}\n"));
     }
 
-    tokio::fs::write(NASTY_SMB_CONF_PATH, &includes).await?;
-    Ok(())
+    includes
 }
 
 /// Path to the per-share SMB config file.
@@ -1117,6 +1135,27 @@ mod tests {
         assert!(alpha_pos < middle_pos && middle_pos < zeta_pos);
         // Injection chars in the value got stripped.
         assert!(out.contains("    middle = vinjectedx\n"));
+    }
+
+    // ── render_include_list ──────────────────────────────────────────
+
+    #[test]
+    fn include_list_puts_domain_conf_first() {
+        let rendered = render_include_list(&["abc.conf".to_string()]);
+        let domain_pos = rendered
+            .find("include = /etc/samba/nasty-domain.conf")
+            .expect("domain include present");
+        let tuning_pos = rendered
+            .find("include = /etc/samba/nasty-tuning.conf")
+            .unwrap();
+        let share_pos = rendered
+            .find("include = /etc/samba/nasty.d/abc.conf")
+            .unwrap();
+        // Global-scope ADS params must land before any share section opens.
+        assert!(
+            domain_pos < tuning_pos && tuning_pos < share_pos,
+            "{rendered}"
+        );
     }
 
     // ── Time Machine ───────────────────────────────────────────────────

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -444,10 +444,25 @@ fn render_share_conf(share: &SmbShare) -> String {
     }
 
     if !share.valid_users.is_empty() {
+        // smb.conf list parameters split on whitespace, so an unquoted
+        // entry containing a space (e.g. an AD group like `CORP\domain
+        // admins`) would be parsed as two separate tokens. Quote any
+        // entry with a space to preserve its boundary. This is safe from
+        // quote-injection because validate_valid_users already rejects
+        // '"' in entries at the API boundary, and sanitize_smb_value
+        // doesn't strip '"' — so a validated entry can't smuggle its own
+        // closing quote.
         let sanitized_users: Vec<String> = share
             .valid_users
             .iter()
-            .map(|u| sanitize_smb_value(u))
+            .map(|u| {
+                let s = sanitize_smb_value(u);
+                if s.contains(' ') {
+                    format!("\"{s}\"")
+                } else {
+                    s
+                }
+            })
             .collect();
         conf.push_str(&format!(
             "    valid users = {}\n",
@@ -1210,6 +1225,21 @@ mod tests {
         let out = render_share_conf(&share);
         assert!(!out.contains("force user"));
         assert!(out.contains("    valid users = @admins @users\n"));
+    }
+
+    #[test]
+    fn render_share_conf_quotes_spaced_valid_users_entries() {
+        // AD group names commonly contain spaces (`CORP\domain admins`).
+        // Unquoted, Samba splits the space-joined `valid users` list into
+        // two tokens — a broken group ref plus a bare `admins` that can
+        // match an unintended account. Quoting preserves entry boundaries.
+        let mut share = minimal_share();
+        share.valid_users = vec!["@CORP\\domain admins".to_string(), "alice".to_string()];
+        let conf = render_share_conf(&share);
+        assert!(
+            conf.contains("valid users = \"@CORP\\domain admins\" alice"),
+            "{conf}"
+        );
     }
 
     #[test]

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -164,6 +164,9 @@ impl SmbService {
     pub async fn create(&self, req: CreateSmbShareRequest) -> Result<SmbShare, SmbError> {
         validate_share_name(&req.name)?;
         validate_share_path(&req.path)?;
+        if let Some(ref valid_users) = req.valid_users {
+            validate_valid_users(valid_users)?;
+        }
 
         if !Path::new(&req.path).exists() {
             return Err(SmbError::PathNotFound(req.path));
@@ -245,6 +248,7 @@ impl SmbService {
             share.guest_ok = guest_ok;
         }
         if let Some(valid_users) = req.valid_users {
+            validate_valid_users(&valid_users)?;
             share.valid_users = valid_users;
         }
         if let Some(extra_params) = req.extra_params {
@@ -333,6 +337,67 @@ fn validate_share_path(path: &str) -> Result<(), SmbError> {
              (newline, CR, NUL, double-quote, '#')"
                 .to_string(),
         ));
+    }
+    Ok(())
+}
+
+/// Validate share `valid_users` entries. Three accepted shapes:
+/// local `name`, local `@group`, and domain `DOMAIN\name` (optionally
+/// `@DOMAIN\group`) — the backslash carve-out for AD member mode.
+/// Everything is checked against config-injection characters the same
+/// way validate_share_path is; the domain part follows NetBIOS rules
+/// (≤15 chars, alphanumeric + hyphen).
+fn validate_valid_users(entries: &[String]) -> Result<(), SmbError> {
+    for raw in entries {
+        let entry = raw.strip_prefix('@').unwrap_or(raw);
+        if entry.is_empty() || entry.len() > 256 {
+            return Err(SmbError::InvalidName(format!(
+                "invalid valid_users entry '{raw}'"
+            )));
+        }
+        if entry
+            .chars()
+            .any(|c| c.is_control() || matches!(c, ';' | '"' | '#' | '=' | '\n' | '\r'))
+        {
+            return Err(SmbError::InvalidName(format!(
+                "valid_users entry '{raw}' contains forbidden characters"
+            )));
+        }
+        match entry.split('\\').collect::<Vec<_>>().as_slice() {
+            // Local user or group: existing character policy.
+            [name] => {
+                if !name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+                {
+                    return Err(SmbError::InvalidName(format!(
+                        "invalid user/group name '{raw}'"
+                    )));
+                }
+            }
+            // DOMAIN\name: NetBIOS domain + AD account (spaces/dots legal).
+            [domain, name] => {
+                let domain_ok = !domain.is_empty()
+                    && domain.len() <= 15
+                    && domain
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '-');
+                let name_ok = !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ' '));
+                if !domain_ok || !name_ok {
+                    return Err(SmbError::InvalidName(format!(
+                        "invalid domain principal '{raw}'"
+                    )));
+                }
+            }
+            _ => {
+                return Err(SmbError::InvalidName(format!(
+                    "invalid valid_users entry '{raw}'"
+                )));
+            }
+        }
     }
     Ok(())
 }
@@ -1054,6 +1119,38 @@ mod tests {
     #[test]
     fn validate_share_path_rejects_empty() {
         assert!(validate_share_path("").is_err());
+    }
+
+    #[test]
+    fn validate_valid_users_accepts_local_group_and_domain_forms() {
+        assert!(validate_valid_users(&["alice".into()]).is_ok());
+        assert!(validate_valid_users(&["@staff".into()]).is_ok());
+        assert!(validate_valid_users(&["CORP\\alice".into()]).is_ok());
+        assert!(validate_valid_users(&["@CORP\\domain admins".into()]).is_ok());
+        // AD account names may contain dots and spaces.
+        assert!(validate_valid_users(&["CORP\\svc account.backup".into()]).is_ok());
+    }
+
+    #[test]
+    fn validate_valid_users_rejects_injection_shapes() {
+        // Same smuggling shapes validate_share_path pins (newline/config
+        // injection), plus structural garbage.
+        assert!(validate_valid_users(&["alice\ninclude = /etc/passwd".into()]).is_err());
+        assert!(validate_valid_users(&["alice;rm".into()]).is_err());
+        assert!(
+            validate_valid_users(&["CORP\\\\alice".into()]).is_err(),
+            "double backslash"
+        );
+        assert!(
+            validate_valid_users(&["\\alice".into()]).is_err(),
+            "empty domain part"
+        );
+        assert!(
+            validate_valid_users(&["CORP\\".into()]).is_err(),
+            "empty account part"
+        );
+        assert!(validate_valid_users(&["".into()]).is_err());
+        assert!(validate_valid_users(&["THISNETBIOSNAMEISTOOLONG\\alice".into()]).is_err());
     }
 
     // ── render_share_conf ──────────────────────────────────────────

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -150,6 +150,22 @@ impl SmbService {
         Self
     }
 
+    /// Ensure `/etc/samba/smb.nasty.conf` holds the current include chain,
+    /// rebuilding it from the per-share configs on disk.
+    ///
+    /// tmpfiles creates that file *empty*, and until this branch the only
+    /// writer was a share create/update/delete. A box that joins a domain
+    /// before ever mutating a share therefore had no `include =
+    /// /etc/samba/nasty-domain.conf` in effect, so `net ads join`/winbindd
+    /// never saw the ADS globals — AD join was dead on arrival on fresh
+    /// installs and stayed dead on every upgraded box until the first share
+    /// mutation. Calling this at boot guarantees the chain exists before any
+    /// join runs. The rebuild is idempotent and cheap (a directory scan plus
+    /// one file write), so it is safe to run unconditionally on every boot.
+    pub async fn ensure_config_scaffolding(&self) -> Result<(), SmbError> {
+        rebuild_include_list().await
+    }
+
     pub async fn list(&self) -> Result<Vec<SmbShare>, SmbError> {
         Ok(state_dir().load_all().await)
     }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -113,6 +113,58 @@ pub fn validate_idmap_base(base: u32) -> Result<(), DomainError> {
     Ok(())
 }
 
+/// Path to the Samba ADS configuration fragment.
+pub const DOMAIN_SMB_CONF_PATH: &str = "/etc/samba/nasty-domain.conf";
+
+/// Path to the Kerberos configuration.
+pub const KRB5_CONF_PATH: &str = "/etc/samba/nasty-krb5.conf";
+
+/// Render the `[global]`-scope Samba configuration block for Active Directory.
+///
+/// Produces configuration suitable for `/etc/samba/nasty-domain.conf`.
+/// Realm and workgroup are safe to interpolate — `validate_realm` guarantees
+/// they contain no shell/config-injection characters before a `DomainConfig` can exist.
+pub fn render_domain_smb_conf(cfg: &DomainConfig) -> String {
+    let base = cfg.idmap_base;
+    let end = base + IDMAP_RANGE_SPAN - 1;
+    format!(
+        "# Managed by NASty — Active Directory member configuration.\n\
+         # Rendered at domain join; emptied at leave. Do not edit manually.\n\
+         security = ADS\n\
+         realm = {realm}\n\
+         workgroup = {wg}\n\
+         kerberos method = secrets and keytab\n\
+         winbind refresh tickets = yes\n\
+         winbind offline logon = yes\n\
+         winbind enum users = no\n\
+         winbind enum groups = no\n\
+         idmap config * : backend = tdb\n\
+         idmap config * : range = 65000-65535\n\
+         idmap config {wg} : backend = rid\n\
+         idmap config {wg} : range = {base}-{end}\n\
+         template shell = /run/current-system/sw/bin/nologin\n\
+         template homedir = /var/empty\n",
+        realm = cfg.realm,
+        wg = cfg.workgroup,
+    )
+}
+
+/// Render the Kerberos configuration.
+///
+/// Produces configuration suitable for `/etc/samba/nasty-krb5.conf`.
+/// Realm is safe to interpolate — `validate_realm` guarantees it contains
+/// no shell/config-injection characters.
+pub fn render_krb5_conf(realm: &str) -> String {
+    format!(
+        "# Managed by NASty — rendered at domain join.\n\
+         [libdefaults]\n\
+         \tdefault_realm = {realm}\n\
+         \tdns_lookup_realm = false\n\
+         \tdns_lookup_kdc = true\n\
+         \trdns = false\n",
+    )
+}
+
 /// Service for managing domain join state.
 pub struct DomainService;
 
@@ -256,5 +308,46 @@ mod tests {
             .await
             .expect("second clear: no panic"); // idempotent
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn render_domain_smb_conf_emits_ads_block() {
+        let cfg = DomainConfig {
+            realm: "CORP.EXAMPLE.COM".into(),
+            workgroup: "CORP".into(),
+            idmap_base: 100_000,
+        };
+        let conf = render_domain_smb_conf(&cfg);
+        assert!(conf.contains("security = ADS"), "{conf}");
+        assert!(conf.contains("realm = CORP.EXAMPLE.COM"), "{conf}");
+        assert!(conf.contains("workgroup = CORP"), "{conf}");
+        // Deterministic algorithmic mapping — same user, same UID, forever.
+        assert!(conf.contains("idmap config CORP : backend = rid"), "{conf}");
+        assert!(
+            conf.contains("idmap config CORP : range = 100000-999999"),
+            "{conf}"
+        );
+        // The default (*) range must not overlap the domain range.
+        assert!(
+            conf.contains("idmap config * : range = 65000-65535"),
+            "{conf}"
+        );
+        // DC outage tolerance for recently-seen users.
+        assert!(conf.contains("winbind offline logon = yes"), "{conf}");
+        // Explicit namespaces — never ambiguous with local users.
+        assert!(!conf.contains("winbind use default domain"), "{conf}");
+        assert!(
+            conf.contains("kerberos method = secrets and keytab"),
+            "{conf}"
+        );
+    }
+
+    #[test]
+    fn render_krb5_conf_pins_realm_and_dns_lookup() {
+        let conf = render_krb5_conf("CORP.EXAMPLE.COM");
+        assert!(conf.contains("default_realm = CORP.EXAMPLE.COM"), "{conf}");
+        // DCs are found via DNS SRV — no static kdc lines to go stale.
+        assert!(conf.contains("dns_lookup_kdc = true"), "{conf}");
+        assert!(conf.contains("rdns = false"), "{conf}");
     }
 }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -132,25 +132,48 @@ impl DomainService {
 
     /// Load domain configuration from disk if it exists.
     pub async fn load_config() -> Option<DomainConfig> {
-        match tokio::fs::read_to_string(CONFIG_PATH).await {
+        Self::load_config_at(Path::new(CONFIG_PATH)).await
+    }
+
+    /// Persist domain configuration to disk.
+    pub async fn save_config(config: &DomainConfig) -> Result<(), DomainError> {
+        Self::save_config_at(Path::new(CONFIG_PATH), config).await
+    }
+
+    /// Clear domain configuration (leave domain).
+    pub async fn clear_config() -> Result<(), DomainError> {
+        Self::clear_config_at(Path::new(CONFIG_PATH)).await
+    }
+
+    /// Load domain configuration from an arbitrary path if it exists.
+    ///
+    /// Absence of the file, or unparseable contents, both mean "not joined" —
+    /// this never panics on corrupt state.
+    pub(crate) async fn load_config_at(path: &Path) -> Option<DomainConfig> {
+        match tokio::fs::read_to_string(path).await {
             Ok(content) => serde_json::from_str(&content).ok(),
             Err(_) => None,
         }
     }
 
-    /// Persist domain configuration to disk.
-    pub async fn save_config(config: &DomainConfig) -> Result<(), DomainError> {
-        let dir = Path::new(CONFIG_PATH).parent().unwrap();
+    /// Persist domain configuration to an arbitrary path, creating parent dirs.
+    pub(crate) async fn save_config_at(
+        path: &Path,
+        config: &DomainConfig,
+    ) -> Result<(), DomainError> {
+        let dir = path.parent().unwrap();
         tokio::fs::create_dir_all(dir).await?;
         let json =
             serde_json::to_string(config).map_err(|e| DomainError::Io(std::io::Error::other(e)))?;
-        tokio::fs::write(CONFIG_PATH, json).await?;
+        tokio::fs::write(path, json).await?;
         Ok(())
     }
 
-    /// Clear domain configuration (leave domain).
-    pub async fn clear_config() -> Result<(), DomainError> {
-        match tokio::fs::remove_file(CONFIG_PATH).await {
+    /// Clear domain configuration at an arbitrary path (leave domain).
+    ///
+    /// Idempotent: clearing an already-absent config is not an error.
+    pub(crate) async fn clear_config_at(path: &Path) -> Result<(), DomainError> {
+        match tokio::fs::remove_file(path).await {
             Ok(_) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e.into()),
@@ -199,5 +222,39 @@ mod tests {
         assert!(validate_idmap_base(65_535).is_err());
         assert!(validate_idmap_base(65_536).is_ok());
         assert!(validate_idmap_base(DEFAULT_IDMAP_BASE).is_ok());
+    }
+
+    #[tokio::test]
+    async fn config_round_trips_and_clear_means_not_joined() {
+        let dir = std::env::temp_dir().join(format!("nasty-domain-test-{}", uuid::Uuid::new_v4()));
+        let path = dir.join("config.json");
+        // Absent file == not joined.
+        assert!(DomainService::load_config_at(&path).await.is_none());
+        let cfg = DomainConfig {
+            realm: "CORP.EXAMPLE.COM".into(),
+            workgroup: "CORP".into(),
+            idmap_base: 100_000,
+        };
+        // Save creates the parent dir and the file.
+        DomainService::save_config_at(&path, &cfg)
+            .await
+            .expect("save");
+        let loaded = DomainService::load_config_at(&path).await.expect("loaded");
+        assert_eq!(loaded.realm, "CORP.EXAMPLE.COM");
+        assert_eq!(loaded.workgroup, "CORP");
+        assert_eq!(loaded.idmap_base, 100_000);
+        // Corrupt JSON degrades to "not joined", never panics.
+        tokio::fs::write(&path, b"{not json").await.unwrap();
+        assert!(DomainService::load_config_at(&path).await.is_none());
+        // Clear is idempotent.
+        DomainService::save_config_at(&path, &cfg)
+            .await
+            .expect("save again");
+        DomainService::clear_config_at(&path).await.expect("clear");
+        assert!(DomainService::load_config_at(&path).await.is_none());
+        DomainService::clear_config_at(&path)
+            .await
+            .expect("second clear: no panic"); // idempotent
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -183,9 +183,14 @@ pub const RESOLVED_DROPIN_PATH: &str = "/etc/systemd/resolved.conf.d/nasty-ad.co
 fn parse_resolvectl_srv(output: &str) -> Vec<String> {
     output
         .lines()
-        .filter(|l| l.contains(" SRV "))
-        .filter_map(|l| l.split_whitespace().last())
-        .map(|t| t.trim_end_matches('.').to_string())
+        .filter_map(|l| {
+            let tokens: Vec<&str> = l.split_whitespace().collect();
+            let srv = tokens.iter().position(|t| *t == "SRV")?;
+            // SRV RDATA: priority weight port target
+            tokens
+                .get(srv + 4)
+                .map(|t| t.trim_end_matches('.').to_string())
+        })
         .collect()
 }
 
@@ -195,8 +200,12 @@ fn parse_resolvectl_addresses(output: &str) -> Vec<String> {
     output
         .lines()
         .filter_map(|l| l.split_once(": "))
-        .map(|(_, addr)| addr.trim().to_string())
-        .filter(|a| a.parse::<std::net::IpAddr>().is_ok())
+        .filter_map(|(_, rest)| {
+            rest.split_whitespace()
+                .next()
+                .filter(|a| a.parse::<std::net::IpAddr>().is_ok())
+                .map(str::to_string)
+        })
         .collect()
 }
 
@@ -941,6 +950,18 @@ _ldap._tcp.corp.example.com IN SRV 0 100 389 dc2.corp.example.com\n\n\
             ]
         );
         assert!(parse_resolvectl_srv("-- no data --\n").is_empty());
+
+        // Real resolvectl appends link annotations — the target is the
+        // 4th RDATA token after "SRV" (prio weight port target), NOT
+        // the last token on the line (caught live by the ad-member VM
+        // test: the old parser returned "eth1" as a DC hostname).
+        let annotated = "\
+_ldap._tcp.nasty.test IN SRV 0 100 389 dc.nasty.test. -- link: eth1\n\n\
+-- Information acquired via protocol DNS in 1.2ms.\n";
+        assert_eq!(
+            parse_resolvectl_srv(annotated),
+            vec!["dc.nasty.test".to_string()]
+        );
     }
 
     #[test]
@@ -949,6 +970,12 @@ _ldap._tcp.corp.example.com IN SRV 0 100 389 dc2.corp.example.com\n\n\
         assert_eq!(
             parse_resolvectl_addresses(out),
             vec!["10.0.0.5".to_string()]
+        );
+
+        let annotated = "dc.nasty.test: 192.168.1.1                  -- link: eth1\n";
+        assert_eq!(
+            parse_resolvectl_addresses(annotated),
+            vec!["192.168.1.1".to_string()]
         );
     }
 

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -274,6 +274,19 @@ fn parse_net_ads_server_time(output: &str) -> Option<i64> {
     Some(days * 86_400 + h * 3_600 + m * 60 + s)
 }
 
+/// Kerberos-relevant skew between DC and local time, or None when the
+/// server time is unusable. DCs answering anonymous `net ads info`
+/// queries may report epoch zero for the time field — a sentinel, not
+/// a clock reading; treating it as real skew blocked every join with
+/// a ~56-year skew error (caught live by the ad-member VM test).
+fn effective_skew(server_time: i64, local: i64) -> Option<i64> {
+    // Anything before ~2001 is a sentinel or a badly broken DC clock;
+    // either way, Kerberos itself will produce the authoritative error
+    // if real skew exists — don't fabricate one from a sentinel.
+    const SANE_SERVER_TIME_FLOOR: i64 = 1_000_000_000;
+    (server_time >= SANE_SERVER_TIME_FLOOR).then(|| server_time - local)
+}
+
 /// Run a command, capturing stdout+stderr. Returns stdout on success;
 /// on non-zero exit (or a spawn failure) returns `CommandFailed` carrying
 /// stderr (or the spawn error).
@@ -388,12 +401,19 @@ async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
-        let skew = (server_time - local).abs();
-        if skew > 240 {
-            return Err(DomainError::Preflight(format!(
-                "clock skew vs domain controller is {skew}s — Kerberos tolerates \
-                 ~300s. Fix NTP before joining."
-            )));
+        if let Some(skew) = effective_skew(server_time, local) {
+            if skew.abs() > 240 {
+                return Err(DomainError::Preflight(format!(
+                    "clock skew vs domain controller is {}s — Kerberos tolerates \
+                     ~300s. Fix NTP before joining.",
+                    skew.abs()
+                )));
+            }
+        } else {
+            tracing::warn!(
+                "DC did not report a usable server time; skipping preflight \
+                 clock-skew check (Kerberos will enforce it)"
+            );
         }
     }
     Ok(dcs)
@@ -721,13 +741,12 @@ impl DomainService {
         let (dc_reachable, clock_skew_seconds) =
             match run_cmd("net", &["ads", "info"], &[("KRB5_CONFIG", KRB5_CONF_PATH)]).await {
                 Ok(out) => {
-                    let skew = parse_net_ads_server_time(&out).map(|t| {
-                        let local = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_secs() as i64)
-                            .unwrap_or(0);
-                        t - local
-                    });
+                    let local = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0);
+                    let skew =
+                        parse_net_ads_server_time(&out).and_then(|t| effective_skew(t, local));
                     (Some(true), skew)
                 }
                 Err(_) => (Some(false), None),
@@ -997,6 +1016,16 @@ _ldap._tcp.nasty.test IN SRV 0 100 389 dc.nasty.test. -- link: eth1\n\n\
         // `date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-07 12:34:56" +%s` => 1783427696
         assert_eq!(parse_net_ads_server_time(out), Some(1783427696));
         assert_eq!(parse_net_ads_server_time("no time here"), None);
+    }
+
+    #[test]
+    fn effective_skew_ignores_sentinel_server_times() {
+        let now = 1_783_517_309;
+        // Epoch-zero sentinel from an anonymous net ads info query.
+        assert_eq!(effective_skew(0, now), None);
+        // Real times produce signed skew.
+        assert_eq!(effective_skew(now + 120, now), Some(120));
+        assert_eq!(effective_skew(now - 300, now), Some(-300));
     }
 
     #[test]

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -571,8 +571,10 @@ impl DomainService {
     /// stdin, used once, never persisted; it validates the configured
     /// workgroup against the DC, so it must already be right) → start
     /// winbindd (only now does a machine secret exist) →
-    /// verify the trust with `wbinfo -t` → best-effort AD DNS registration →
-    /// persist state. Every fallible step
+    /// verify the trust with `wbinfo -t` → warm winbind by polling identity
+    /// resolution for the domain Administrator (best-effort; a cold cache
+    /// otherwise fails the first domain-user SMB access) → best-effort AD
+    /// DNS registration → persist state. Every fallible step
     /// funnels through a single unwind path (`unwind_join_artifacts`) on
     /// failure, restoring the pre-join state; once `net ads join` has
     /// succeeded, unwind also attempts `net ads leave` (including on a
@@ -703,6 +705,34 @@ impl DomainService {
                     "joined but the trust check failed (wbinfo -t): {e}"
                 ))
             })?;
+
+            // Warm winbind before returning: `wbinfo -t` passing means the trust
+            // secret is good, but the first identity lookup after join can still
+            // fail until winbind has established its DC connection and idmap — a
+            // domain user's first SMB access would hit LOGON_FAILURE (smbd can't
+            // map the UID). Poll a guaranteed-present principal (the domain
+            // Administrator) until full name→uid resolution works, so the first
+            // real access doesn't land on a cold cache. Best-effort: a timeout
+            // here doesn't fail the join (winbind warms within seconds in
+            // practice), it just logs.
+            {
+                let probe = format!("{}\\administrator", cfg.workgroup);
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+                loop {
+                    if run_cmd("wbinfo", &["-i", &probe], &[]).await.is_ok() {
+                        tracing::info!("winbind identity resolution is live");
+                        break;
+                    }
+                    if std::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            "winbind not yet resolving domain identities after join; \
+                             the first domain-user access may need a retry"
+                        );
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+            }
 
             // Register our A record in AD DNS (best-effort — some sites
             // restrict it).

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -175,7 +175,15 @@ pub fn render_krb5_conf(realm: &str) -> String {
 
 /// Path to the resolved(1) drop-in that routes AD-zone DNS queries to the
 /// domain controllers without replacing the box's own resolvers.
-pub const RESOLVED_DROPIN_PATH: &str = "/etc/systemd/resolved.conf.d/nasty-ad.conf";
+///
+/// Lives under `/run` (not `/etc`) because `/etc/systemd/resolved.conf.d`
+/// is read-only on NixOS — `systemd-resolved` reads runtime drop-ins from
+/// `/run/systemd/resolved.conf.d` just as well, and `/run` is always
+/// writable. This means the drop-in does not survive a reboot, but that's
+/// fine: `join` is not persistent across reboots for this routing either
+/// (it's re-created here on each join), and a persistent setup should
+/// point the box's own DNS at the AD DNS servers instead.
+pub const RESOLVED_DROPIN_PATH: &str = "/run/systemd/resolved.conf.d/nasty-ad.conf";
 
 /// Extract domain controller hostnames from `resolvectl query --type=SRV
 /// _ldap._tcp.<realm>` output (e.g. lines like
@@ -608,7 +616,7 @@ impl DomainService {
                 }
             }
             if !dc_ips.is_empty() {
-                tokio::fs::create_dir_all("/etc/systemd/resolved.conf.d").await?;
+                tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
                 tokio::fs::write(
                     RESOLVED_DROPIN_PATH,
                     render_resolved_dropin(&cfg.realm, &dc_ips),

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -274,6 +274,15 @@ fn parse_net_ads_server_time(output: &str) -> Option<i64> {
     Some(days * 86_400 + h * 3_600 + m * 60 + s)
 }
 
+/// Parse `net ads workgroup` output: "Workgroup: NASTYAD".
+fn parse_net_ads_workgroup(output: &str) -> Option<String> {
+    output
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Workgroup:"))
+        .map(|w| w.trim().to_string())
+        .filter(|w| !w.is_empty())
+}
+
 /// Kerberos-relevant skew between DC and local time, or None when the
 /// server time is unusable. DCs answering anonymous `net ads info`
 /// queries may report epoch zero for the time field — a sentinel, not
@@ -552,9 +561,12 @@ impl DomainService {
     ///
     /// Sequence: preflight (DNS SRV + DC reachability + clock skew) →
     /// render krb5/smb config → per-domain DNS routing to the discovered
-    /// DCs → restart winbindd → `net ads join` (credential via stdin,
-    /// used once, never persisted) → verify the trust with `wbinfo -t` →
-    /// best-effort AD DNS registration → persist state. Every fallible step
+    /// DCs → `net ads join` (credential via stdin, used once, never
+    /// persisted) → ask the DC for the real NetBIOS domain (`net ads
+    /// workgroup`) and re-render the idmap block if the derived guess was
+    /// wrong → start winbindd (only now does a machine secret exist) →
+    /// verify the trust with `wbinfo -t` → best-effort AD DNS registration →
+    /// persist state. Every fallible step
     /// funnels through a single unwind path (`unwind_join_artifacts`) on
     /// failure, restoring the pre-join state; once `net ads join` has
     /// succeeded, unwind also attempts `net ads leave` (including on a
@@ -566,7 +578,7 @@ impl DomainService {
         let realm = validate_realm(&req.realm)?;
         let idmap_base = req.idmap_base.unwrap_or(DEFAULT_IDMAP_BASE);
         validate_idmap_base(idmap_base)?;
-        let cfg = DomainConfig {
+        let mut cfg = DomainConfig {
             workgroup: derive_workgroup(&realm),
             realm,
             idmap_base,
@@ -611,9 +623,6 @@ impl DomainService {
             }
 
             tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
-            systemctl("restart", "samba-winbindd.service")
-                .await
-                .map_err(DomainError::CommandFailed)?;
 
             // Credential via stdin (`net ads join -U user` prompts on stdin
             // when no %password is attached). NEVER put the password in argv.
@@ -639,6 +648,40 @@ impl DomainService {
             // The machine account now exists in AD — from here on, any
             // failure must attempt `net ads leave` during unwind.
             joined_in_ad = true;
+
+            // The NetBIOS domain is set at provision, independent of the
+            // realm — `derive_workgroup` only guesses it from the first
+            // label. Now that we've joined, ask the DC for the real name and
+            // re-render the idmap block if the guess was wrong.
+            match run_cmd("net", &["ads", "workgroup"], &[("KRB5_CONFIG", KRB5_CONF_PATH)])
+                .await
+                .map(|out| parse_net_ads_workgroup(&out))
+            {
+                Ok(Some(real)) if real != cfg.workgroup => {
+                    tracing::info!(
+                        "NetBIOS domain is {real} (realm suggested {}) — using the domain's real name",
+                        cfg.workgroup
+                    );
+                    cfg.workgroup = real;
+                    tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
+                }
+                Ok(Some(_)) => {} // guess matched the DC — nothing to correct.
+                Ok(None) => tracing::warn!(
+                    "could not parse `net ads workgroup`; keeping derived workgroup {} (usually right)",
+                    cfg.workgroup
+                ),
+                Err(e) => tracing::warn!(
+                    "net ads workgroup failed; keeping derived workgroup {} (usually right): {e}",
+                    cfg.workgroup
+                ),
+            }
+
+            // Start winbindd now that a machine secret exists — pre-join it
+            // has no job and can wedge on name collisions. Restart is
+            // idempotent (a no-op if it was never started).
+            systemctl("restart", "samba-winbindd.service")
+                .await
+                .map_err(DomainError::CommandFailed)?;
 
             // Verify the trust before declaring success.
             run_cmd("wbinfo", &["-t"], &[]).await.map_err(|e| {
@@ -1016,6 +1059,15 @@ _ldap._tcp.nasty.test IN SRV 0 100 389 dc.nasty.test. -- link: eth1\n\n\
         // `date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-07 12:34:56" +%s` => 1783427696
         assert_eq!(parse_net_ads_server_time(out), Some(1783427696));
         assert_eq!(parse_net_ads_server_time("no time here"), None);
+    }
+
+    #[test]
+    fn parse_net_ads_workgroup_reads_name() {
+        assert_eq!(
+            parse_net_ads_workgroup("Workgroup: NASTYAD\n").as_deref(),
+            Some("NASTYAD")
+        );
+        assert_eq!(parse_net_ads_workgroup("no workgroup line"), None);
     }
 
     #[test]

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -507,18 +507,12 @@ impl DomainService {
     }
 
     /// Whether the system is currently joined to a domain.
-    ///
-    /// Consumed by the engine's boot restore (router task).
-    #[allow(dead_code)]
     pub async fn is_joined(&self) -> bool {
         Self::load_config().await.is_some()
     }
 
     /// Start winbindd if it isn't running (boot restore; join already
     /// restarted it explicitly).
-    ///
-    /// Consumed by the engine's boot restore (router task).
-    #[allow(dead_code)]
     pub async fn ensure_winbindd(&self) {
         if let Err(e) = systemctl("start", "samba-winbindd.service").await {
             tracing::error!("winbindd start failed on domain restore: {e}");
@@ -732,7 +726,6 @@ impl DomainService {
     /// Runs `wbinfo -u`, filters results to match the prefix (case-insensitive),
     /// and returns up to 50 results. The prefix must be at least 2 characters
     /// to prevent bulk enumeration.
-    #[allow(dead_code)]
     pub async fn search_users(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
         self.search(prefix, "-u").await
     }
@@ -742,7 +735,6 @@ impl DomainService {
     /// Runs `wbinfo -g`, filters results to match the prefix (case-insensitive),
     /// and returns up to 50 results. The prefix must be at least 2 characters
     /// to prevent bulk enumeration.
-    #[allow(dead_code)]
     pub async fn search_groups(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
         self.search(prefix, "-g").await
     }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -564,11 +564,13 @@ impl DomainService {
     /// Join an Active Directory domain.
     ///
     /// Sequence: preflight (DNS SRV + DC reachability + clock skew) →
-    /// render krb5/smb config → per-domain DNS routing to the discovered
-    /// DCs → `net ads join` (credential via stdin, used once, never
-    /// persisted) → ask the DC for the real NetBIOS domain (`net ads
-    /// workgroup`) and re-render the idmap block if the derived guess was
-    /// wrong → start winbindd (only now does a machine secret exist) →
+    /// render krb5 → per-domain DNS routing to the discovered DCs → ask a
+    /// DC for the real NetBIOS domain (`net ads workgroup`, anonymous and
+    /// pre-join) since the realm-derived guess can be wrong → render the smb
+    /// config with the correct workgroup → `net ads join` (credential via
+    /// stdin, used once, never persisted; it validates the configured
+    /// workgroup against the DC, so it must already be right) → start
+    /// winbindd (only now does a machine secret exist) →
     /// verify the trust with `wbinfo -t` → best-effort AD DNS registration →
     /// persist state. Every fallible step
     /// funnels through a single unwind path (`unwind_join_artifacts`) on
@@ -626,6 +628,41 @@ impl DomainService {
                 );
             }
 
+            // The NetBIOS domain name is set at provision and is NOT derivable
+            // from the realm (realm ADTEST.LAN can have NetBIOS domain NASTYAD).
+            // net ads join validates the configured workgroup against the DC
+            // and refuses on mismatch, so we must learn the real name BEFORE
+            // rendering the config and joining — query a DC directly (anonymous,
+            // pre-join). Fall back to the realm-derived guess if the query fails.
+            let workgroup = match run_cmd(
+                "net",
+                &["ads", "workgroup", "-S", &dcs[0], "--realm", &cfg.realm],
+                &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+            )
+            .await
+            {
+                Ok(out) => match parse_net_ads_workgroup(&out) {
+                    Some(wg) => {
+                        if wg != cfg.workgroup {
+                            tracing::info!(
+                                "NetBIOS domain is {wg} (realm suggested {}); using the domain's real name",
+                                cfg.workgroup
+                            );
+                        }
+                        wg
+                    }
+                    None => {
+                        tracing::warn!("could not parse NetBIOS domain from the DC; using derived guess {}", cfg.workgroup);
+                        cfg.workgroup.clone()
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("NetBIOS domain query failed ({e}); using derived guess {}", cfg.workgroup);
+                    cfg.workgroup.clone()
+                }
+            };
+            cfg.workgroup = workgroup;
+
             tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
 
             // Credential via stdin (`net ads join -U user` prompts on stdin
@@ -652,33 +689,6 @@ impl DomainService {
             // The machine account now exists in AD — from here on, any
             // failure must attempt `net ads leave` during unwind.
             joined_in_ad = true;
-
-            // The NetBIOS domain is set at provision, independent of the
-            // realm — `derive_workgroup` only guesses it from the first
-            // label. Now that we've joined, ask the DC for the real name and
-            // re-render the idmap block if the guess was wrong.
-            match run_cmd("net", &["ads", "workgroup"], &[("KRB5_CONFIG", KRB5_CONF_PATH)])
-                .await
-                .map(|out| parse_net_ads_workgroup(&out))
-            {
-                Ok(Some(real)) if real != cfg.workgroup => {
-                    tracing::info!(
-                        "NetBIOS domain is {real} (realm suggested {}) — using the domain's real name",
-                        cfg.workgroup
-                    );
-                    cfg.workgroup = real;
-                    tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
-                }
-                Ok(Some(_)) => {} // guess matched the DC — nothing to correct.
-                Ok(None) => tracing::warn!(
-                    "could not parse `net ads workgroup`; keeping derived workgroup {} (usually right)",
-                    cfg.workgroup
-                ),
-                Err(e) => tracing::warn!(
-                    "net ads workgroup failed; keeping derived workgroup {} (usually right): {e}",
-                    cfg.workgroup
-                ),
-            }
 
             // Start winbindd now that a machine secret exists — pre-join it
             // has no job and can wedge on name collisions. Restart is

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -572,21 +572,25 @@ impl DomainService {
     /// Join an Active Directory domain.
     ///
     /// Sequence: preflight (DNS SRV + DC reachability + clock skew) →
-    /// render krb5 → per-domain DNS routing to the discovered DCs → ask a
-    /// DC for the real NetBIOS domain (`net ads workgroup`, anonymous and
-    /// pre-join) since the realm-derived guess can be wrong → render the smb
-    /// config with the correct workgroup → `net ads join` (credential via
-    /// stdin, used once, never persisted; it validates the configured
-    /// workgroup against the DC, so it must already be right) → start
-    /// winbindd (only now does a machine secret exist) →
-    /// verify the trust with `wbinfo -t` → warm winbind by polling identity
-    /// resolution for the domain Administrator (best-effort; a cold cache
-    /// otherwise fails the first domain-user SMB access) → best-effort AD
-    /// DNS registration → persist state. Every fallible step
-    /// funnels through a single unwind path (`unwind_join_artifacts`) on
-    /// failure, restoring the pre-join state; once `net ads join` has
-    /// succeeded, unwind also attempts `net ads leave` (including on a
-    /// later `save_config` failure) so AD and local state don't diverge.
+    /// render krb5 → ask a DC for the real NetBIOS domain (`net ads
+    /// workgroup`, anonymous and pre-join) since the realm-derived guess can
+    /// be wrong → render the smb config with the correct workgroup →
+    /// `net ads join` (credential via stdin, used once, never persisted;
+    /// it validates the configured workgroup against the DC, so it must
+    /// already be right; `--realm` is passed explicitly so DC discovery
+    /// never falls back to NetBIOS) → per-domain DNS routing to the
+    /// discovered DCs (deferred until after the join succeeds — restarting
+    /// systemd-resolved any earlier leaves DNS briefly unavailable, which
+    /// makes `net ads join` itself fail to find a DC) → start winbindd
+    /// (only now does a machine secret exist) → verify the trust with
+    /// `wbinfo -t` → warm winbind by polling identity resolution for the
+    /// domain Administrator (best-effort; a cold cache otherwise fails the
+    /// first domain-user SMB access) → best-effort AD DNS registration →
+    /// persist state. Every fallible step funnels through a single unwind
+    /// path (`unwind_join_artifacts`) on failure, restoring the pre-join
+    /// state; once `net ads join` has succeeded, unwind also attempts
+    /// `net ads leave` (including on a later `save_config` failure) so AD
+    /// and local state don't diverge.
     pub async fn join(&self, req: JoinDomainRequest) -> Result<DomainStatus, DomainError> {
         if Self::load_config().await.is_some() {
             return Err(DomainError::AlreadyJoined);
@@ -605,38 +609,6 @@ impl DomainService {
             // Render krb5 first — preflight's `net ads info` reads it.
             tokio::fs::write(KRB5_CONF_PATH, render_krb5_conf(&cfg.realm)).await?;
             let dcs = preflight(&cfg.realm).await?;
-
-            // Per-domain DNS routing: AD-zone queries go to the DCs from here
-            // on (spec join-flow step 6). Resolve the discovered DC
-            // hostnames to IPs through the still-working current resolvers.
-            let mut dc_ips = Vec::new();
-            for dc in dcs.iter().take(3) {
-                if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
-                    dc_ips.extend(parse_resolvectl_addresses(&out));
-                }
-            }
-            if !dc_ips.is_empty() {
-                tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
-                tokio::fs::write(
-                    RESOLVED_DROPIN_PATH,
-                    render_resolved_dropin(&cfg.realm, &dc_ips),
-                )
-                .await?;
-                let _ = systemctl("restart", "systemd-resolved.service").await;
-            } else {
-                // Resolving the DC hostnames to IPs failed, so we can't write
-                // the per-domain routing drop-in. The join can still succeed
-                // via the current resolvers, but AD-zone resolution afterwards
-                // (winbind, Kerberos referrals) depends entirely on those
-                // existing resolvers continuing to answer for the realm — if
-                // they don't, name lookups into the domain will fail.
-                tracing::warn!(
-                    realm = %cfg.realm,
-                    "Domain join proceeding without AD DNS routing: could not \
-                     resolve any DC address; AD-zone resolution now depends on \
-                     the box's existing resolvers"
-                );
-            }
 
             // The NetBIOS domain name is set at provision and is NOT derivable
             // from the realm (realm ADTEST.LAN can have NetBIOS domain NASTYAD).
@@ -683,6 +655,8 @@ impl DomainService {
                 "-U",
                 req.username.as_str(),
                 "--no-dns-updates",
+                "--realm",
+                cfg.realm.as_str(),
             ];
             let ou_arg;
             if let Some(ou) = &req.ou {
@@ -699,6 +673,44 @@ impl DomainService {
             // The machine account now exists in AD — from here on, any
             // failure must attempt `net ads leave` during unwind.
             joined_in_ad = true;
+
+            // Per-domain DNS routing: AD-zone queries go to the DCs from here
+            // on (spec join-flow step 6). Resolve the discovered DC
+            // hostnames to IPs through the still-working current resolvers.
+            // Done only now (after the join has already succeeded) because
+            // restarting systemd-resolved mid-join left DNS briefly
+            // unavailable, causing `net ads join` to fall back to NetBIOS
+            // discovery and fail. Preflight/join rely on the operator's DNS
+            // already resolving the realm; this routing is for ongoing
+            // operation (winbind resolving the DC by name).
+            let mut dc_ips = Vec::new();
+            for dc in dcs.iter().take(3) {
+                if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
+                    dc_ips.extend(parse_resolvectl_addresses(&out));
+                }
+            }
+            if !dc_ips.is_empty() {
+                tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
+                tokio::fs::write(
+                    RESOLVED_DROPIN_PATH,
+                    render_resolved_dropin(&cfg.realm, &dc_ips),
+                )
+                .await?;
+                let _ = systemctl("restart", "systemd-resolved.service").await;
+            } else {
+                // Resolving the DC hostnames to IPs failed, so we can't write
+                // the per-domain routing drop-in. The join has already
+                // succeeded, but AD-zone resolution afterwards (winbind,
+                // Kerberos referrals) depends entirely on the existing
+                // resolvers continuing to answer for the realm — if they
+                // don't, name lookups into the domain will fail.
+                tracing::warn!(
+                    realm = %cfg.realm,
+                    "Domain joined without AD DNS routing: could not resolve \
+                     any DC address; AD-zone resolution now depends on the \
+                     box's existing resolvers"
+                );
+            }
 
             // Start winbindd now that a machine secret exists — pre-join it
             // has no job and can wedge on name collisions. Restart is

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -371,6 +371,34 @@ async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
     Ok(dcs)
 }
 
+/// Best-effort teardown of everything `join` may have touched, in
+/// reverse order. When `leave_ad` carries credentials, the machine
+/// account was already created — attempt a `net ads leave` so AD and
+/// local state don't diverge. Every step is best-effort: unwind runs
+/// on an already-failing path, and a secondary failure must not mask
+/// the original error (log it instead).
+async fn unwind_join_artifacts(leave_ad: Option<(&str, &str)>) {
+    if let Some((user, pass)) = leave_ad
+        && let Err(e) = run_cmd_stdin(
+            "net",
+            &["ads", "leave", "-U", user],
+            &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+            pass,
+        )
+        .await
+    {
+        tracing::warn!(
+            "join unwind: net ads leave failed (stale computer account left in AD): {e}"
+        );
+    }
+    let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
+    let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+    if tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await.is_ok() {
+        let _ = systemctl("restart", "systemd-resolved.service").await;
+    }
+    let _ = systemctl("stop", "samba-winbindd.service").await;
+}
+
 /// Request to join an Active Directory domain.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct JoinDomainRequest {
@@ -477,9 +505,11 @@ impl DomainService {
     /// render krb5/smb config → per-domain DNS routing to the discovered
     /// DCs → restart winbindd → `net ads join` (credential via stdin,
     /// used once, never persisted) → verify the trust with `wbinfo -t` →
-    /// best-effort AD DNS registration → persist state. Any failure prior
-    /// to persisting state rolls the rendered configs back and stops
-    /// winbindd, restoring the pre-join state.
+    /// best-effort AD DNS registration → persist state. Every fallible step
+    /// funnels through a single unwind path (`unwind_join_artifacts`) on
+    /// failure, restoring the pre-join state; once `net ads join` has
+    /// succeeded, unwind also attempts `net ads leave` (including on a
+    /// later `save_config` failure) so AD and local state don't diverge.
     pub async fn join(&self, req: JoinDomainRequest) -> Result<DomainStatus, DomainError> {
         if Self::load_config().await.is_some() {
             return Err(DomainError::AlreadyJoined);
@@ -493,105 +523,93 @@ impl DomainService {
             idmap_base,
         };
 
-        // Render krb5 first — preflight's `net ads info` reads it.
-        tokio::fs::write(KRB5_CONF_PATH, render_krb5_conf(&cfg.realm)).await?;
-        let dcs = match preflight(&cfg.realm).await {
-            Ok(dcs) => dcs,
-            Err(e) => {
-                let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
-                return Err(e);
+        let mut joined_in_ad = false;
+        let result: Result<(), DomainError> = async {
+            // Render krb5 first — preflight's `net ads info` reads it.
+            tokio::fs::write(KRB5_CONF_PATH, render_krb5_conf(&cfg.realm)).await?;
+            let dcs = preflight(&cfg.realm).await?;
+
+            // Per-domain DNS routing: AD-zone queries go to the DCs from here
+            // on (spec join-flow step 6). Resolve the discovered DC
+            // hostnames to IPs through the still-working current resolvers.
+            let mut dc_ips = Vec::new();
+            for dc in dcs.iter().take(3) {
+                if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
+                    dc_ips.extend(parse_resolvectl_addresses(&out));
+                }
             }
-        };
-
-        // Per-domain DNS routing: AD-zone queries go to the DCs from here on
-        // (spec join-flow step 6). Resolve the discovered DC hostnames to IPs
-        // through the still-working current resolvers.
-        let mut dc_ips = Vec::new();
-        for dc in dcs.iter().take(3) {
-            if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
-                dc_ips.extend(parse_resolvectl_addresses(&out));
-            }
-        }
-        if !dc_ips.is_empty() {
-            tokio::fs::create_dir_all("/etc/systemd/resolved.conf.d").await?;
-            tokio::fs::write(
-                RESOLVED_DROPIN_PATH,
-                render_resolved_dropin(&cfg.realm, &dc_ips),
-            )
-            .await?;
-            let _ = systemctl("restart", "systemd-resolved.service").await;
-        }
-
-        tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
-        systemctl("restart", "samba-winbindd.service")
-            .await
-            .map_err(DomainError::CommandFailed)?;
-
-        // Credential via stdin (`net ads join -U user` prompts on stdin when
-        // no %password is attached). NEVER put the password in argv.
-        let mut join_args = vec![
-            "ads",
-            "join",
-            "-U",
-            req.username.as_str(),
-            "--no-dns-updates",
-        ];
-        let ou_arg;
-        if let Some(ou) = &req.ou {
-            ou_arg = format!("createcomputer={ou}");
-            join_args.push(&ou_arg);
-        }
-        let join_out = run_cmd_stdin(
-            "net",
-            &join_args,
-            &[("KRB5_CONFIG", KRB5_CONF_PATH)],
-            &req.password,
-        )
-        .await;
-
-        match join_out {
-            Ok(_) => {}
-            Err(e) => {
-                // Roll back: empty the rendered configs, drop the DNS routing,
-                // stop winbindd.
-                let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
-                let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
-                let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
+            if !dc_ips.is_empty() {
+                tokio::fs::create_dir_all("/etc/systemd/resolved.conf.d").await?;
+                tokio::fs::write(
+                    RESOLVED_DROPIN_PATH,
+                    render_resolved_dropin(&cfg.realm, &dc_ips),
+                )
+                .await?;
                 let _ = systemctl("restart", "systemd-resolved.service").await;
-                let _ = systemctl("stop", "samba-winbindd.service").await;
-                return Err(e);
             }
-        }
 
-        // Verify the trust before declaring success.
-        if let Err(e) = run_cmd("wbinfo", &["-t"], &[]).await {
-            let _ = run_cmd_stdin(
+            tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
+            systemctl("restart", "samba-winbindd.service")
+                .await
+                .map_err(DomainError::CommandFailed)?;
+
+            // Credential via stdin (`net ads join -U user` prompts on stdin
+            // when no %password is attached). NEVER put the password in argv.
+            let mut join_args = vec![
+                "ads",
+                "join",
+                "-U",
+                req.username.as_str(),
+                "--no-dns-updates",
+            ];
+            let ou_arg;
+            if let Some(ou) = &req.ou {
+                ou_arg = format!("createcomputer={ou}");
+                join_args.push(&ou_arg);
+            }
+            run_cmd_stdin(
                 "net",
-                &["ads", "leave", "-U", &req.username],
+                &join_args,
                 &[("KRB5_CONFIG", KRB5_CONF_PATH)],
                 &req.password,
             )
+            .await?;
+            // The machine account now exists in AD — from here on, any
+            // failure must attempt `net ads leave` during unwind.
+            joined_in_ad = true;
+
+            // Verify the trust before declaring success.
+            run_cmd("wbinfo", &["-t"], &[]).await.map_err(|e| {
+                DomainError::CommandFailed(format!(
+                    "joined but the trust check failed (wbinfo -t): {e}"
+                ))
+            })?;
+
+            // Register our A record in AD DNS (best-effort — some sites
+            // restrict it).
+            if let Err(e) = run_cmd(
+                "net",
+                &["ads", "dns", "register"],
+                &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+            )
+            .await
+            {
+                tracing::warn!("AD DNS register failed (non-fatal): {e}");
+            }
+
+            Self::save_config(&cfg).await?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            unwind_join_artifacts(
+                joined_in_ad.then_some((req.username.as_str(), req.password.as_str())),
+            )
             .await;
-            let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
-            let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
-            let _ = systemctl("stop", "samba-winbindd.service").await;
-            return Err(DomainError::CommandFailed(format!(
-                "joined but the trust check failed (wbinfo -t): {e}"
-            )));
+            return Err(e);
         }
 
-        // Register our A record in AD DNS (best-effort — some sites restrict it).
-        if let Err(e) = run_cmd(
-            "net",
-            &["ads", "dns", "register"],
-            &[("KRB5_CONFIG", KRB5_CONF_PATH)],
-        )
-        .await
-        {
-            tracing::warn!("AD DNS register failed (non-fatal): {e}");
-        }
-
-        Self::save_config(&cfg).await?;
         // smbd reloads pick up the ADS block via the include chain.
         let _ = run_cmd("smbcontrol", &["all", "reload-config"], &[]).await;
         tracing::info!(

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -165,6 +165,167 @@ pub fn render_krb5_conf(realm: &str) -> String {
     )
 }
 
+/// Path to the resolved(1) drop-in that routes AD-zone DNS queries to the
+/// domain controllers without replacing the box's own resolvers.
+pub const RESOLVED_DROPIN_PATH: &str = "/etc/systemd/resolved.conf.d/nasty-ad.conf";
+
+/// Extract domain controller hostnames from `resolvectl query --type=SRV
+/// _ldap._tcp.<realm>` output (e.g. lines like
+/// "_ldap._tcp.corp.example.com IN SRV 0 100 389 dc1.corp.example.com").
+fn parse_resolvectl_srv(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter(|l| l.contains(" SRV "))
+        .filter_map(|l| l.split_whitespace().last())
+        .map(|t| t.trim_end_matches('.').to_string())
+        .collect()
+}
+
+/// Extract IPs from `resolvectl query <host>` output (lines like
+/// "dc1.corp.example.com: 10.0.0.5").
+///
+/// Not yet called — feeds `render_resolved_dropin` from the join flow in a
+/// later task, once `preflight`'s discovered DC hostnames are resolved to
+/// IPs.
+#[allow(dead_code)]
+fn parse_resolvectl_addresses(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|l| l.split_once(": "))
+        .map(|(_, addr)| addr.trim().to_string())
+        .filter(|a| a.parse::<std::net::IpAddr>().is_ok())
+        .collect()
+}
+
+/// Render the systemd-resolved drop-in that routes AD-zone DNS queries to
+/// the domain controllers, per-domain (`Domains=~<realm>`) — the box's own
+/// resolvers are left untouched for everything else (spec join-flow step 6).
+pub fn render_resolved_dropin(realm: &str, dc_ips: &[String]) -> String {
+    format!(
+        "# Managed by NASty — routes AD-zone DNS queries to the domain\n\
+         # controllers without replacing the box's resolvers. Removed at leave.\n\
+         [Resolve]\n\
+         DNS={}\n\
+         Domains=~{}\n",
+        dc_ips.join(" "),
+        realm.to_ascii_lowercase(),
+    )
+}
+
+/// Parse `net ads info`'s "Server time:" line into unix seconds.
+/// Format observed: "Server time: Tue, 07 Jul 2026 12:34:56 UTC".
+/// Hand-rolled (days-since-epoch arithmetic) to avoid a chrono dep for
+/// one line of output; only UTC/GMT zones are accepted — anything else
+/// returns None and preflight skips the skew check rather than
+/// mis-judging it.
+fn parse_net_ads_server_time(output: &str) -> Option<i64> {
+    let line = output
+        .lines()
+        .find(|l| l.trim_start().starts_with("Server time:"))?;
+    let rest = line.split_once(':')?.1.trim(); // "Tue, 07 Jul 2026 12:34:56 UTC"
+    let rest = rest.split_once(',').map(|(_, r)| r.trim()).unwrap_or(rest);
+    let mut parts = rest.split_whitespace(); // 07 Jul 2026 12:34:56 UTC
+    let day: i64 = parts.next()?.parse().ok()?;
+    let month = match parts.next()? {
+        "Jan" => 1,
+        "Feb" => 2,
+        "Mar" => 3,
+        "Apr" => 4,
+        "May" => 5,
+        "Jun" => 6,
+        "Jul" => 7,
+        "Aug" => 8,
+        "Sep" => 9,
+        "Oct" => 10,
+        "Nov" => 11,
+        "Dec" => 12,
+        _ => return None,
+    };
+    let year: i64 = parts.next()?.parse().ok()?;
+    let mut hms = parts.next()?.split(':');
+    let (h, m, s): (i64, i64, i64) = (
+        hms.next()?.parse().ok()?,
+        hms.next()?.parse().ok()?,
+        hms.next()?.parse().ok()?,
+    );
+    if !matches!(parts.next(), Some("UTC") | Some("GMT")) {
+        return None;
+    }
+    // Days since 1970-01-01 (civil-from-days, Howard Hinnant's algorithm).
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe - 719_468;
+    Some(days * 86_400 + h * 3_600 + m * 60 + s)
+}
+
+/// Run a command, capturing stdout+stderr. Returns stdout on success;
+/// on non-zero exit (or a spawn failure) returns `CommandFailed` carrying
+/// stderr (or the spawn error).
+async fn run_cmd(
+    program: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> Result<String, DomainError> {
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .envs(envs.iter().copied())
+        .output()
+        .await
+        .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DomainError::CommandFailed(stderr.trim().to_string()));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Fail fast with actionable errors before Kerberos gets a chance to
+/// produce cryptic ones. Checks, in order: the realm's LDAP SRV records
+/// resolve; a DC answers `net ads info`; clock skew is within bounds.
+///
+/// Not yet called — wired up to the join flow in a later task; exercised
+/// by the VM integration test in the meantime.
+#[allow(dead_code)]
+async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
+    let srv_name = format!("_ldap._tcp.{}", realm.to_ascii_lowercase());
+    let out = run_cmd("resolvectl", &["query", "--type=SRV", &srv_name], &[]).await?;
+    let dcs = parse_resolvectl_srv(&out);
+    if dcs.is_empty() {
+        return Err(DomainError::Preflight(format!(
+            "no domain controllers found: DNS SRV lookup for {srv_name} returned \
+             nothing. The box's DNS must be able to resolve the AD zone — point \
+             it at (or forward to) the domain's DNS server."
+        )));
+    }
+    let info = run_cmd(
+        "net",
+        &["ads", "info", "-S", &dcs[0], "--realm", realm],
+        &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+    )
+    .await
+    .map_err(|e| {
+        DomainError::Preflight(format!("domain controller {} did not answer: {e}", dcs[0]))
+    })?;
+    if let Some(server_time) = parse_net_ads_server_time(&info) {
+        let local = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let skew = (server_time - local).abs();
+        if skew > 240 {
+            return Err(DomainError::Preflight(format!(
+                "clock skew vs domain controller is {skew}s — Kerberos tolerates \
+                 ~300s. Fix NTP before joining."
+            )));
+        }
+    }
+    Ok(dcs)
+}
+
 /// Service for managing domain join state.
 pub struct DomainService;
 
@@ -349,5 +510,51 @@ mod tests {
         // DCs are found via DNS SRV — no static kdc lines to go stale.
         assert!(conf.contains("dns_lookup_kdc = true"), "{conf}");
         assert!(conf.contains("rdns = false"), "{conf}");
+    }
+
+    #[test]
+    fn parse_resolvectl_srv_extracts_targets() {
+        // resolvectl output shape: "_ldap._tcp.corp.example.com IN SRV 0 100 389 dc1.corp.example.com"
+        let out = "\
+_ldap._tcp.corp.example.com IN SRV 0 100 389 dc1.corp.example.com\n\
+_ldap._tcp.corp.example.com IN SRV 0 100 389 dc2.corp.example.com\n\n\
+-- Information acquired via protocol DNS in 2.1ms.\n";
+        assert_eq!(
+            parse_resolvectl_srv(out),
+            vec![
+                "dc1.corp.example.com".to_string(),
+                "dc2.corp.example.com".to_string()
+            ]
+        );
+        assert!(parse_resolvectl_srv("-- no data --\n").is_empty());
+    }
+
+    #[test]
+    fn parse_resolvectl_addresses_extracts_ips() {
+        let out = "dc1.corp.example.com: 10.0.0.5\n\n-- Information acquired via protocol DNS in 1.2ms.\n";
+        assert_eq!(
+            parse_resolvectl_addresses(out),
+            vec!["10.0.0.5".to_string()]
+        );
+    }
+
+    #[test]
+    fn render_resolved_dropin_routes_realm_to_dcs() {
+        let conf =
+            render_resolved_dropin("CORP.EXAMPLE.COM", &["10.0.0.5".into(), "10.0.0.6".into()]);
+        assert!(conf.contains("[Resolve]"), "{conf}");
+        assert!(conf.contains("DNS=10.0.0.5 10.0.0.6"), "{conf}");
+        // Routing domain (~) — only AD-zone queries go to the DCs.
+        assert!(conf.contains("Domains=~corp.example.com"), "{conf}");
+    }
+
+    #[test]
+    fn parse_net_ads_server_time_reads_rfc2822_style() {
+        // `net ads info` prints e.g. "Server time: Tue, 07 Jul 2026 12:34:56 UTC"
+        let out = "LDAP server: 10.0.0.5\nServer time: Tue, 07 Jul 2026 12:34:56 UTC\n";
+        // 2026-07-07T12:34:56Z — verified via:
+        // `date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-07 12:34:56" +%s` => 1783427696
+        assert_eq!(parse_net_ads_server_time(out), Some(1783427696));
+        assert_eq!(parse_net_ads_server_time("no time here"), None);
     }
 }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -332,6 +332,25 @@ async fn run_cmd_stdin(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Filter principals by prefix of the account name (case-insensitive),
+/// respecting a limit. The input is the raw output of `wbinfo -u` or `wbinfo -g`.
+fn filter_principals(raw: &str, prefix: &str, limit: usize) -> Vec<DomainPrincipal> {
+    let prefix = prefix.to_lowercase();
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| {
+            l.rsplit_once('\\')
+                .map(|(_, account)| account.to_lowercase().starts_with(&prefix))
+                .unwrap_or(false)
+        })
+        .take(limit)
+        .map(|l| DomainPrincipal {
+            name: l.to_string(),
+        })
+        .collect()
+}
+
 /// Fail fast with actionable errors before Kerberos gets a chance to
 /// produce cryptic ones. Checks, in order: the realm's LDAP SRV records
 /// resolve; a DC answers `net ads info`; clock skew is within bounds.
@@ -446,6 +465,13 @@ pub struct DomainStatus {
     pub dc_reachable: Option<bool>,
     /// Clock skew (seconds, DC minus local) observed via `net ads info`.
     pub clock_skew_seconds: Option<i64>,
+}
+
+/// A principal (user or group) from the domain.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DomainPrincipal {
+    /// The principal name in `DOMAIN\account` format.
+    pub name: String,
 }
 
 /// Service for managing domain join state.
@@ -701,6 +727,44 @@ impl DomainService {
         }
     }
 
+    /// Search for domain users by name prefix.
+    ///
+    /// Runs `wbinfo -u`, filters results to match the prefix (case-insensitive),
+    /// and returns up to 50 results. The prefix must be at least 2 characters
+    /// to prevent bulk enumeration.
+    #[allow(dead_code)]
+    pub async fn search_users(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+        self.search(prefix, "-u").await
+    }
+
+    /// Search for domain groups by name prefix.
+    ///
+    /// Runs `wbinfo -g`, filters results to match the prefix (case-insensitive),
+    /// and returns up to 50 results. The prefix must be at least 2 characters
+    /// to prevent bulk enumeration.
+    #[allow(dead_code)]
+    pub async fn search_groups(&self, prefix: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+        self.search(prefix, "-g").await
+    }
+
+    /// Perform a principal search with the given wbinfo flag.
+    ///
+    /// Common code for `search_users` and `search_groups`.
+    /// Validates that the system is joined, the prefix is at least 2 characters,
+    /// then runs `wbinfo <flag>` and filters the results.
+    async fn search(&self, prefix: &str, flag: &str) -> Result<Vec<DomainPrincipal>, DomainError> {
+        if Self::load_config().await.is_none() {
+            return Err(DomainError::NotJoined);
+        }
+        if prefix.trim().len() < 2 {
+            return Err(DomainError::Validation(
+                "search prefix must be at least 2 characters".into(),
+            ));
+        }
+        let raw = run_cmd("wbinfo", &[flag], &[]).await?;
+        Ok(filter_principals(&raw, prefix.trim(), 50))
+    }
+
     /// Load domain configuration from an arbitrary path if it exists.
     ///
     /// Absence of the file, or unparseable contents, both mean "not joined" —
@@ -901,5 +965,17 @@ _ldap._tcp.corp.example.com IN SRV 0 100 389 dc2.corp.example.com\n\n\
         // `date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-07 12:34:56" +%s` => 1783427696
         assert_eq!(parse_net_ads_server_time(out), Some(1783427696));
         assert_eq!(parse_net_ads_server_time("no time here"), None);
+    }
+
+    #[test]
+    fn filter_principals_matches_prefix_case_insensitively_and_caps() {
+        let raw = "CORP\\alice\nCORP\\albert\nCORP\\bob\nCORP\\Alfred\n";
+        let hits = filter_principals(raw, "al", 50);
+        let names: Vec<&str> = hits.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["CORP\\alice", "CORP\\albert", "CORP\\Alfred"]);
+        // Prefix matches the account part, not the domain part.
+        assert!(filter_principals(raw, "corp", 50).is_empty());
+        // Limit is a hard cap.
+        assert_eq!(filter_principals(raw, "al", 2).len(), 2);
     }
 }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -566,6 +566,19 @@ impl DomainService {
                 )
                 .await?;
                 let _ = systemctl("restart", "systemd-resolved.service").await;
+            } else {
+                // Resolving the DC hostnames to IPs failed, so we can't write
+                // the per-domain routing drop-in. The join can still succeed
+                // via the current resolvers, but AD-zone resolution afterwards
+                // (winbind, Kerberos referrals) depends entirely on those
+                // existing resolvers continuing to answer for the realm — if
+                // they don't, name lookups into the domain will fail.
+                tracing::warn!(
+                    realm = %cfg.realm,
+                    "Domain join proceeding without AD DNS routing: could not \
+                     resolve any DC address; AD-zone resolution now depends on \
+                     the box's existing resolvers"
+                );
             }
 
             tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -743,10 +743,13 @@ impl DomainService {
             }
 
             // Register our A record in AD DNS (best-effort — some sites
-            // restrict it).
+            // restrict it). `-P` authenticates with the machine account
+            // from secrets.tdb (just created by the join); without it net
+            // falls back to the ambient user (`<WORKGROUP>\root`) and
+            // fails with "Invalid credentials".
             if let Err(e) = run_cmd(
                 "net",
-                &["ads", "dns", "register"],
+                &["ads", "dns", "register", "-P"],
                 &[("KRB5_CONFIG", KRB5_CONF_PATH)],
             )
             .await

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
+use crate::protocol::systemctl;
+
 /// Errors returned by domain operations.
 #[derive(Debug, Error)]
 pub enum DomainError {
@@ -110,6 +112,12 @@ pub fn validate_idmap_base(base: u32) -> Result<(), DomainError> {
              UIDs can never collide with local accounts"
         )));
     }
+    if base > u32::MAX - IDMAP_RANGE_SPAN {
+        return Err(DomainError::Validation(format!(
+            "idmap base {base} is too high — base + range span ({IDMAP_RANGE_SPAN}) \
+             would overflow"
+        )));
+    }
     Ok(())
 }
 
@@ -183,11 +191,6 @@ fn parse_resolvectl_srv(output: &str) -> Vec<String> {
 
 /// Extract IPs from `resolvectl query <host>` output (lines like
 /// "dc1.corp.example.com: 10.0.0.5").
-///
-/// Not yet called — feeds `render_resolved_dropin` from the join flow in a
-/// later task, once `preflight`'s discovered DC hostnames are resolved to
-/// IPs.
-#[allow(dead_code)]
 fn parse_resolvectl_addresses(output: &str) -> Vec<String> {
     output
         .lines()
@@ -278,7 +281,53 @@ async fn run_cmd(
         .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(DomainError::CommandFailed(stderr.trim().to_string()));
+        return Err(DomainError::CommandFailed(format!(
+            "{program} exited with {}: {}",
+            output.status,
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run a command, writing `stdin_input` (plus a trailing newline) to its
+/// stdin — used to hand credentials to `net ads join`/`net ads leave`
+/// without ever putting the password in argv (visible via `/proc/*/cmdline`).
+/// Captures stdout+stderr the same way `run_cmd` does.
+async fn run_cmd_stdin(
+    program: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdin_input: &str,
+) -> Result<String, DomainError> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = tokio::process::Command::new(program)
+        .args(args)
+        .envs(envs.iter().copied())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let input = format!("{stdin_input}\n");
+        let _ = stdin.write_all(input.as_bytes()).await;
+        // Drop closes stdin so the child sees EOF after the password line.
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DomainError::CommandFailed(format!(
+            "{program} exited with {}: {}",
+            output.status,
+            stderr.trim()
+        )));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
@@ -286,10 +335,6 @@ async fn run_cmd(
 /// Fail fast with actionable errors before Kerberos gets a chance to
 /// produce cryptic ones. Checks, in order: the realm's LDAP SRV records
 /// resolve; a DC answers `net ads info`; clock skew is within bounds.
-///
-/// Not yet called — wired up to the join flow in a later task; exercised
-/// by the VM integration test in the meantime.
-#[allow(dead_code)]
 async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
     let srv_name = format!("_ldap._tcp.{}", realm.to_ascii_lowercase());
     let out = run_cmd("resolvectl", &["query", "--type=SRV", &srv_name], &[]).await?;
@@ -326,6 +371,55 @@ async fn preflight(realm: &str) -> Result<Vec<String>, DomainError> {
     Ok(dcs)
 }
 
+/// Request to join an Active Directory domain.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct JoinDomainRequest {
+    /// Active Directory realm to join (e.g. "CORP.EXAMPLE.COM").
+    pub realm: String,
+    /// AD account used to authorize the join (needs computer-object create rights).
+    pub username: String,
+    /// Password for `username`. Sent to `net ads join` via stdin only —
+    /// never persisted, never placed in argv.
+    pub password: String,
+    /// Optional AD organizational unit to create the computer object in
+    /// (`net ads join`'s `createcomputer=` option).
+    pub ou: Option<String>,
+    /// Optional base UID for domain user mappings; defaults to `DEFAULT_IDMAP_BASE`.
+    pub idmap_base: Option<u32>,
+}
+
+/// Request to leave the currently-joined Active Directory domain.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LeaveDomainRequest {
+    /// AD account used to authorize the leave (computer-object delete rights).
+    pub username: Option<String>,
+    /// Password for `username`. Sent to `net ads leave` via stdin only.
+    pub password: Option<String>,
+    /// Leave locally without contacting a DC, when credentials aren't
+    /// available. The computer account is left behind (stale) in AD.
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Current Active Directory domain membership status.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DomainStatus {
+    /// Whether the system is currently joined to a domain.
+    pub joined: bool,
+    /// The joined realm, if any.
+    pub realm: Option<String>,
+    /// The derived NetBIOS workgroup, if joined.
+    pub workgroup: Option<String>,
+    /// The configured idmap base UID, if joined.
+    pub idmap_base: Option<u32>,
+    /// Whether `wbinfo -t` (the domain trust secret) currently checks out.
+    pub trust_ok: Option<bool>,
+    /// Whether a domain controller answered `net ads info` just now.
+    pub dc_reachable: Option<bool>,
+    /// Clock skew (seconds, DC minus local) observed via `net ads info`.
+    pub clock_skew_seconds: Option<i64>,
+}
+
 /// Service for managing domain join state.
 pub struct DomainService;
 
@@ -356,6 +450,237 @@ impl DomainService {
     /// Clear domain configuration (leave domain).
     pub async fn clear_config() -> Result<(), DomainError> {
         Self::clear_config_at(Path::new(CONFIG_PATH)).await
+    }
+
+    /// Whether the system is currently joined to a domain.
+    ///
+    /// Consumed by the engine's boot restore (router task).
+    #[allow(dead_code)]
+    pub async fn is_joined(&self) -> bool {
+        Self::load_config().await.is_some()
+    }
+
+    /// Start winbindd if it isn't running (boot restore; join already
+    /// restarted it explicitly).
+    ///
+    /// Consumed by the engine's boot restore (router task).
+    #[allow(dead_code)]
+    pub async fn ensure_winbindd(&self) {
+        if let Err(e) = systemctl("start", "samba-winbindd.service").await {
+            tracing::error!("winbindd start failed on domain restore: {e}");
+        }
+    }
+
+    /// Join an Active Directory domain.
+    ///
+    /// Sequence: preflight (DNS SRV + DC reachability + clock skew) →
+    /// render krb5/smb config → per-domain DNS routing to the discovered
+    /// DCs → restart winbindd → `net ads join` (credential via stdin,
+    /// used once, never persisted) → verify the trust with `wbinfo -t` →
+    /// best-effort AD DNS registration → persist state. Any failure prior
+    /// to persisting state rolls the rendered configs back and stops
+    /// winbindd, restoring the pre-join state.
+    pub async fn join(&self, req: JoinDomainRequest) -> Result<DomainStatus, DomainError> {
+        if Self::load_config().await.is_some() {
+            return Err(DomainError::AlreadyJoined);
+        }
+        let realm = validate_realm(&req.realm)?;
+        let idmap_base = req.idmap_base.unwrap_or(DEFAULT_IDMAP_BASE);
+        validate_idmap_base(idmap_base)?;
+        let cfg = DomainConfig {
+            workgroup: derive_workgroup(&realm),
+            realm,
+            idmap_base,
+        };
+
+        // Render krb5 first — preflight's `net ads info` reads it.
+        tokio::fs::write(KRB5_CONF_PATH, render_krb5_conf(&cfg.realm)).await?;
+        let dcs = match preflight(&cfg.realm).await {
+            Ok(dcs) => dcs,
+            Err(e) => {
+                let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+                return Err(e);
+            }
+        };
+
+        // Per-domain DNS routing: AD-zone queries go to the DCs from here on
+        // (spec join-flow step 6). Resolve the discovered DC hostnames to IPs
+        // through the still-working current resolvers.
+        let mut dc_ips = Vec::new();
+        for dc in dcs.iter().take(3) {
+            if let Ok(out) = run_cmd("resolvectl", &["query", dc], &[]).await {
+                dc_ips.extend(parse_resolvectl_addresses(&out));
+            }
+        }
+        if !dc_ips.is_empty() {
+            tokio::fs::create_dir_all("/etc/systemd/resolved.conf.d").await?;
+            tokio::fs::write(
+                RESOLVED_DROPIN_PATH,
+                render_resolved_dropin(&cfg.realm, &dc_ips),
+            )
+            .await?;
+            let _ = systemctl("restart", "systemd-resolved.service").await;
+        }
+
+        tokio::fs::write(DOMAIN_SMB_CONF_PATH, render_domain_smb_conf(&cfg)).await?;
+        systemctl("restart", "samba-winbindd.service")
+            .await
+            .map_err(DomainError::CommandFailed)?;
+
+        // Credential via stdin (`net ads join -U user` prompts on stdin when
+        // no %password is attached). NEVER put the password in argv.
+        let mut join_args = vec![
+            "ads",
+            "join",
+            "-U",
+            req.username.as_str(),
+            "--no-dns-updates",
+        ];
+        let ou_arg;
+        if let Some(ou) = &req.ou {
+            ou_arg = format!("createcomputer={ou}");
+            join_args.push(&ou_arg);
+        }
+        let join_out = run_cmd_stdin(
+            "net",
+            &join_args,
+            &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+            &req.password,
+        )
+        .await;
+
+        match join_out {
+            Ok(_) => {}
+            Err(e) => {
+                // Roll back: empty the rendered configs, drop the DNS routing,
+                // stop winbindd.
+                let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
+                let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+                let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
+                let _ = systemctl("restart", "systemd-resolved.service").await;
+                let _ = systemctl("stop", "samba-winbindd.service").await;
+                return Err(e);
+            }
+        }
+
+        // Verify the trust before declaring success.
+        if let Err(e) = run_cmd("wbinfo", &["-t"], &[]).await {
+            let _ = run_cmd_stdin(
+                "net",
+                &["ads", "leave", "-U", &req.username],
+                &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+                &req.password,
+            )
+            .await;
+            let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
+            let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+            let _ = systemctl("stop", "samba-winbindd.service").await;
+            return Err(DomainError::CommandFailed(format!(
+                "joined but the trust check failed (wbinfo -t): {e}"
+            )));
+        }
+
+        // Register our A record in AD DNS (best-effort — some sites restrict it).
+        if let Err(e) = run_cmd(
+            "net",
+            &["ads", "dns", "register"],
+            &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+        )
+        .await
+        {
+            tracing::warn!("AD DNS register failed (non-fatal): {e}");
+        }
+
+        Self::save_config(&cfg).await?;
+        // smbd reloads pick up the ADS block via the include chain.
+        let _ = run_cmd("smbcontrol", &["all", "reload-config"], &[]).await;
+        tracing::info!(
+            "Joined AD domain {} (workgroup {})",
+            cfg.realm,
+            cfg.workgroup
+        );
+        Ok(self.status().await)
+    }
+
+    /// Leave the currently-joined Active Directory domain.
+    ///
+    /// With credentials, contacts a DC to remove the computer object via
+    /// `net ads leave`. With `force=true` and no credentials, leaves
+    /// locally only — the computer account goes stale in AD (matches
+    /// `net ads leave`'s own documented behavior for that case).
+    pub async fn leave(&self, req: LeaveDomainRequest) -> Result<(), DomainError> {
+        let Some(_cfg) = Self::load_config().await else {
+            return Err(DomainError::NotJoined);
+        };
+        match (&req.username, &req.password, req.force) {
+            (Some(user), Some(pass), _) => {
+                run_cmd_stdin(
+                    "net",
+                    &["ads", "leave", "-U", user],
+                    &[("KRB5_CONFIG", KRB5_CONF_PATH)],
+                    pass,
+                )
+                .await?;
+            }
+            (_, _, true) => {
+                // Forced local leave: no DC contact; the computer account
+                // goes stale in AD (documented, matches `net ads leave` docs).
+                tracing::warn!("forced local domain leave — computer account left behind in AD");
+            }
+            _ => {
+                return Err(DomainError::Validation(
+                    "leave needs AD credentials, or force=true for a local-only leave".into(),
+                ));
+            }
+        }
+        tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await?;
+        tokio::fs::write(KRB5_CONF_PATH, "").await?;
+        let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
+        let _ = systemctl("restart", "systemd-resolved.service").await;
+        let _ = systemctl("stop", "samba-winbindd.service").await;
+        Self::clear_config().await?;
+        let _ = run_cmd("smbcontrol", &["all", "reload-config"], &[]).await;
+        tracing::info!("Left AD domain");
+        Ok(())
+    }
+
+    /// Report current Active Directory domain membership status.
+    pub async fn status(&self) -> DomainStatus {
+        let Some(cfg) = Self::load_config().await else {
+            return DomainStatus {
+                joined: false,
+                realm: None,
+                workgroup: None,
+                idmap_base: None,
+                trust_ok: None,
+                dc_reachable: None,
+                clock_skew_seconds: None,
+            };
+        };
+        let trust_ok = Some(run_cmd("wbinfo", &["-t"], &[]).await.is_ok());
+        let (dc_reachable, clock_skew_seconds) =
+            match run_cmd("net", &["ads", "info"], &[("KRB5_CONFIG", KRB5_CONF_PATH)]).await {
+                Ok(out) => {
+                    let skew = parse_net_ads_server_time(&out).map(|t| {
+                        let local = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs() as i64)
+                            .unwrap_or(0);
+                        t - local
+                    });
+                    (Some(true), skew)
+                }
+                Err(_) => (Some(false), None),
+            };
+        DomainStatus {
+            joined: true,
+            realm: Some(cfg.realm),
+            workgroup: Some(cfg.workgroup),
+            idmap_base: Some(cfg.idmap_base),
+            trust_ok,
+            dc_reachable,
+            clock_skew_seconds,
+        }
     }
 
     /// Load domain configuration from an arbitrary path if it exists.
@@ -429,12 +754,14 @@ mod tests {
     }
 
     #[test]
-    fn validate_idmap_base_rejects_low_ranges() {
+    fn validate_idmap_base_rejects_out_of_range() {
         // Must clear every local UID the engine can allocate.
         assert!(validate_idmap_base(3000).is_err());
         assert!(validate_idmap_base(65_535).is_err());
         assert!(validate_idmap_base(65_536).is_ok());
         assert!(validate_idmap_base(DEFAULT_IDMAP_BASE).is_ok());
+        // Must not let `base + IDMAP_RANGE_SPAN - 1` overflow u32 in the renderer.
+        assert!(validate_idmap_base(u32::MAX - 100).is_err());
     }
 
     #[tokio::test]

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -1,0 +1,203 @@
+//! Active Directory domain join state and configuration.
+//!
+//! This module manages the lifecycle of NASty membership in an AD realm:
+//! - Realm validation (DNS names only, no local workgroups)
+//! - NetBIOS workgroup derivation from the realm's first label
+//! - UID range allocation for domain users (must avoid local account collision)
+//! - Persistent storage of join configuration in `/var/lib/nasty/domain/config.json`
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use thiserror::Error;
+
+/// Errors returned by domain operations.
+#[derive(Debug, Error)]
+pub enum DomainError {
+    /// Validation failed (bad realm format, out-of-range idmap, etc.).
+    #[error("validation error: {0}")]
+    Validation(String),
+    /// Preflight check failed (domain tools missing, network unreachable, etc.).
+    #[error("preflight check failed: {0}")]
+    Preflight(String),
+    /// Already joined to a domain.
+    #[error("already joined to a domain")]
+    AlreadyJoined,
+    /// Not currently joined to a domain.
+    #[error("not joined to a domain")]
+    NotJoined,
+    /// A domain command (kinit, net ads, etc.) failed.
+    #[error("domain command failed: {0}")]
+    CommandFailed(String),
+    /// I/O error (file operations, etc.).
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Persisted domain join configuration.
+///
+/// Presence of the config file (`/var/lib/nasty/domain/config.json`) indicates
+/// the system is AD-joined.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DomainConfig {
+    /// Active Directory realm (DNS name, uppercase; e.g., "CORP.EXAMPLE.COM").
+    pub realm: String,
+    /// NetBIOS workgroup name derived from realm (≤ 15 chars, uppercase).
+    pub workgroup: String,
+    /// Base UID for domain user mappings (must be ≥ 65536 to avoid local collisions).
+    pub idmap_base: u32,
+}
+
+/// Default base UID for domain user mappings.
+/// UIDs below this are reserved for local system accounts.
+pub const DEFAULT_IDMAP_BASE: u32 = 100_000;
+
+/// UID range span for domain users (DEFAULT_IDMAP_BASE to DEFAULT_IDMAP_BASE + IDMAP_RANGE_SPAN).
+pub const IDMAP_RANGE_SPAN: u32 = 900_000;
+
+/// Validate and normalize an Active Directory realm name.
+///
+/// Returns the normalized (uppercase) realm on success.
+/// Rejects: empty strings, single-label names (not resolvable AD realms),
+/// invalid DNS characters, or trailing/leading hyphens per label.
+pub fn validate_realm(raw: &str) -> Result<String, DomainError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(DomainError::Validation("realm is empty".into()));
+    }
+    let labels: Vec<&str> = trimmed.split('.').collect();
+    if labels.len() < 2 {
+        return Err(DomainError::Validation(format!(
+            "'{trimmed}' is not a DNS realm (expected e.g. CORP.EXAMPLE.COM)"
+        )));
+    }
+    for label in &labels {
+        let ok = !label.is_empty()
+            && label.len() <= 63
+            && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+            && !label.starts_with('-')
+            && !label.ends_with('-');
+        if !ok {
+            return Err(DomainError::Validation(format!(
+                "realm label '{label}' contains invalid characters"
+            )));
+        }
+    }
+    Ok(trimmed.to_ascii_uppercase())
+}
+
+/// Derive a NetBIOS workgroup name from an AD realm.
+///
+/// Takes the first DNS label and uppercases it, truncating to 15 chars
+/// (NetBIOS limit). The realm is assumed already validated.
+pub fn derive_workgroup(realm: &str) -> String {
+    let first = realm.split('.').next().unwrap_or(realm);
+    first
+        .chars()
+        .take(15)
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+/// Validate an idmap base UID.
+///
+/// Rejects values below 65536 to ensure domain UIDs never collide
+/// with local system accounts (which typically occupy 0–65535).
+pub fn validate_idmap_base(base: u32) -> Result<(), DomainError> {
+    if base < 65_536 {
+        return Err(DomainError::Validation(format!(
+            "idmap base {base} is too low — must be at least 65536 so domain \
+             UIDs can never collide with local accounts"
+        )));
+    }
+    Ok(())
+}
+
+/// Service for managing domain join state.
+pub struct DomainService;
+
+const CONFIG_PATH: &str = "/var/lib/nasty/domain/config.json";
+
+impl Default for DomainService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DomainService {
+    /// Create a new domain service instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Load domain configuration from disk if it exists.
+    pub async fn load_config() -> Option<DomainConfig> {
+        match tokio::fs::read_to_string(CONFIG_PATH).await {
+            Ok(content) => serde_json::from_str(&content).ok(),
+            Err(_) => None,
+        }
+    }
+
+    /// Persist domain configuration to disk.
+    pub async fn save_config(config: &DomainConfig) -> Result<(), DomainError> {
+        let dir = Path::new(CONFIG_PATH).parent().unwrap();
+        tokio::fs::create_dir_all(dir).await?;
+        let json =
+            serde_json::to_string(config).map_err(|e| DomainError::Io(std::io::Error::other(e)))?;
+        tokio::fs::write(CONFIG_PATH, json).await?;
+        Ok(())
+    }
+
+    /// Clear domain configuration (leave domain).
+    pub async fn clear_config() -> Result<(), DomainError> {
+        match tokio::fs::remove_file(CONFIG_PATH).await {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_realm_normalizes_and_accepts_dns_names() {
+        assert_eq!(
+            validate_realm("corp.example.com").unwrap(),
+            "CORP.EXAMPLE.COM"
+        );
+        assert_eq!(validate_realm("  ad.lan ").unwrap(), "AD.LAN");
+    }
+
+    #[test]
+    fn validate_realm_rejects_garbage() {
+        // Single label: not a resolvable AD realm.
+        assert!(validate_realm("WORKGROUP").is_err());
+        assert!(validate_realm("").is_err());
+        // Characters that could smuggle config or shell content.
+        assert!(validate_realm("corp.example.com\ninclude=/etc/passwd").is_err());
+        assert!(validate_realm("corp;rm -rf /.com").is_err());
+        assert!(validate_realm("corp .example.com").is_err());
+    }
+
+    #[test]
+    fn derive_workgroup_takes_first_label_netbios_truncated() {
+        assert_eq!(derive_workgroup("CORP.EXAMPLE.COM"), "CORP");
+        // NetBIOS names cap at 15 chars.
+        assert_eq!(
+            derive_workgroup("VERYLONGCOMPANYNAME.LAN"),
+            "VERYLONGCOMPANY"
+        );
+    }
+
+    #[test]
+    fn validate_idmap_base_rejects_low_ranges() {
+        // Must clear every local UID the engine can allocate.
+        assert!(validate_idmap_base(3000).is_err());
+        assert!(validate_idmap_base(65_535).is_err());
+        assert!(validate_idmap_base(65_536).is_ok());
+        assert!(validate_idmap_base(DEFAULT_IDMAP_BASE).is_ok());
+    }
+}

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -296,9 +296,23 @@ fn effective_skew(server_time: i64, local: i64) -> Option<i64> {
     (server_time >= SANE_SERVER_TIME_FLOOR).then(|| server_time - local)
 }
 
+/// Construct a command error message from output, including both stdout and
+/// stderr. Prefers stderr if non-empty, otherwise stdout, otherwise "(no output)".
+fn command_error(program: &str, output: &std::process::Output) -> DomainError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = match (stderr.trim(), stdout.trim()) {
+        (e, o) if !e.is_empty() && !o.is_empty() => format!("{e} / {o}"),
+        (e, _) if !e.is_empty() => e.to_string(),
+        (_, o) if !o.is_empty() => o.to_string(),
+        _ => "(no output)".to_string(),
+    };
+    DomainError::CommandFailed(format!("{program} exited with {}: {detail}", output.status,))
+}
+
 /// Run a command, capturing stdout+stderr. Returns stdout on success;
 /// on non-zero exit (or a spawn failure) returns `CommandFailed` carrying
-/// stderr (or the spawn error).
+/// both stdout and stderr (or the spawn error).
 async fn run_cmd(
     program: &str,
     args: &[&str],
@@ -311,12 +325,7 @@ async fn run_cmd(
         .await
         .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(DomainError::CommandFailed(format!(
-            "{program} exited with {}: {}",
-            output.status,
-            stderr.trim()
-        )));
+        return Err(command_error(program, &output));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
@@ -353,12 +362,7 @@ async fn run_cmd_stdin(
         .await
         .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(DomainError::CommandFailed(format!(
-            "{program} exited with {}: {}",
-            output.status,
-            stderr.trim()
-        )));
+        return Err(command_error(program, &output));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod alerts;
+pub mod domain;
 pub mod firewall;
 pub mod firmware;
 pub mod guest_tools;

--- a/flake.nix
+++ b/flake.nix
@@ -417,6 +417,9 @@
       appliance-smoke = import ./nixos/tests/appliance-smoke.nix {
         inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
       };
+      ad-member = import ./nixos/tests/ad-member.nix {
+        inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
+      };
     };
   };
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1774,19 +1774,21 @@ in {
     # directive: the static defaults below match what the module
     # emitted; the include chain overrides security/realm when joined
     # and is empty otherwise (unjoined boxes keep identical behavior).
-    environment.etc."samba/smb.conf".source = mkIf cfg.smb.enable (lib.mkForce (pkgs.writeText "smb.conf" ''
-      [global]
-      guest account = nobody
-      invalid users = root
-      map to guest = Never
-      passwd program = /run/wrappers/bin/passwd %u
-      security = user
-      server min protocol = SMB2
-      server signing = auto
-      server string = NASty NAS
-      # Engine-managed chain — keep as the last directive.
-      include = /etc/samba/smb.nasty.conf
-    ''));
+    environment.etc."samba/smb.conf" = mkIf cfg.smb.enable {
+      source = lib.mkForce (pkgs.writeText "smb.conf" ''
+        [global]
+        guest account = nobody
+        invalid users = root
+        map to guest = Never
+        passwd program = /run/wrappers/bin/passwd %u
+        security = user
+        server min protocol = SMB2
+        server signing = auto
+        server string = NASty NAS
+        # Engine-managed chain — keep as the last directive.
+        include = /etc/samba/smb.nasty.conf
+      '');
+    };
 
     # The engine renders Kerberos config at domain-join time (a runtime
     # operation, not a rebuild) into an engine-owned path. Route winbindd

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1765,6 +1765,29 @@ in {
       };
     };
 
+    # The samba module emits [global] keys alphabetically and always
+    # injects `security=user`, which lands AFTER our include — smb.conf
+    # is last-one-wins, so the AD member mode the engine renders into
+    # the include chain was silently clobbered (net ads join: "Invalid
+    # configuration", caught live by the ad-member VM test). Take over
+    # the top-level file so the engine-managed include is the LAST
+    # directive: the static defaults below match what the module
+    # emitted; the include chain overrides security/realm when joined
+    # and is empty otherwise (unjoined boxes keep identical behavior).
+    environment.etc."samba/smb.conf".source = mkIf cfg.smb.enable (lib.mkForce (pkgs.writeText "smb.conf" ''
+      [global]
+      guest account = nobody
+      invalid users = root
+      map to guest = Never
+      passwd program = /run/wrappers/bin/passwd %u
+      security = user
+      server min protocol = SMB2
+      server signing = auto
+      server string = NASty NAS
+      # Engine-managed chain — keep as the last directive.
+      include = /etc/samba/smb.nasty.conf
+    ''));
+
     # The engine renders Kerberos config at domain-join time (a runtime
     # operation, not a rebuild) into an engine-owned path. Route winbindd
     # and everything the engine execs (net, wbinfo) through it instead of

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -52,6 +52,12 @@ let
     };
   };
 
+  # ADS member mode needs LDAP support; nixpkgs' default samba is built
+  # --without-ldap --without-ads. One binding so smbd, the CLI tools, and
+  # winbindd all come from the same build. This changes the samba binary
+  # on EVERY box (joined or not) — the appliance-smoke test gates it.
+  sambaAds = pkgs.samba.override { enableLDAP = true; };
+
   # ── Plymouth boot splash ────────────────────────────────────
   nasty-logo-png = pkgs.runCommand "nasty-logo.png" {
     nativeBuildInputs = [ pkgs.librsvg ];
@@ -1432,7 +1438,7 @@ in {
         fi
       '')
     ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
-      ++ lib.optionals cfg.smb.enable [ samba ]
+      ++ lib.optionals cfg.smb.enable [ sambaAds ]
       ++ lib.optionals cfg.iscsi.enable [ targetcli-fixed ]
       ++ lib.optionals cfg.nvmeof.enable [ nvme-cli ]
       ++ lib.optionals cfg.nut.enable [ pkgs.nut ]
@@ -1469,6 +1475,8 @@ in {
       "d /etc/exports.d 0755 root root -"
       "d /etc/target 0750 root root -"
       "f /etc/samba/smb.nasty.conf 0644 root root -"
+      "f /etc/samba/nasty-domain.conf 0644 root root -"
+      "f /etc/samba/nasty-krb5.conf 0644 root root -"
       "d /etc/samba/nasty.d 0755 root root -"
       # Real, engine-writable dir for the dynamic Time Machine `_adisk`
       # Avahi service file (otherwise only populated by static
@@ -1613,7 +1621,7 @@ in {
         sbctl                        # SB enrollment + signing-state checks for PR #2's WebUI ceremony (`sbctl verify`, `sbctl list-enrolled-keys`). Read paths only from the engine; writes go through lanzaboote's install hooks, never direct sbctl-from-engine calls.
         keyutils                     # keyctl — fs.lock revokes the bcachefs unlock key from the kernel session keyring; without this the call fails with "No such file or directory" even though every other tool we shell out to is here
       ] ++ lib.optionals cfg.nfs.enable [ nfs-utils ]
-        ++ lib.optionals cfg.smb.enable [ samba shadow.out ]
+        ++ lib.optionals cfg.smb.enable [ sambaAds shadow.out ]
         ++ lib.optionals cfg.iscsi.enable [ targetcli-fixed ]
         ++ lib.optionals cfg.nvmeof.enable [ nvme-cli ]
         ++ lib.optionals cfg.nut.enable [ pkgs.nut ]
@@ -1733,6 +1741,8 @@ in {
 
     services.samba = mkIf cfg.smb.enable {
       enable = true;
+      package = sambaAds;
+      winbindd.enable = true;
       settings = {
         global = {
           "server string" = "NASty NAS";
@@ -1755,6 +1765,21 @@ in {
       };
     };
 
+    # The engine renders Kerberos config at domain-join time (a runtime
+    # operation, not a rebuild) into an engine-owned path. Route winbindd
+    # and everything the engine execs (net, wbinfo) through it instead of
+    # owning the global /etc/krb5.conf.
+    systemd.services.samba-winbindd.environment = mkIf cfg.smb.enable {
+      KRB5_CONFIG = "/etc/samba/nasty-krb5.conf";
+    };
+
+    # Winbind NSS: domain users/groups resolve through nsswitch while
+    # joined. Present on every box; instant not-found while winbindd
+    # isn't running, so unjoined boxes are unaffected.
+    system.nssModules = mkIf cfg.smb.enable [ sambaAds ];
+    system.nssDatabases.passwd = mkIf cfg.smb.enable (lib.mkAfter [ "winbind" ]);
+    system.nssDatabases.group = mkIf cfg.smb.enable (lib.mkAfter [ "winbind" ]);
+
     # Ensure the SMB tuning config exists (empty) so Samba doesn't fail on startup
     # before the engine has written any tuning settings. No [global] header needed —
     # this file is included from within the [global] section of smb.nasty.conf.
@@ -1764,9 +1789,10 @@ in {
     };
 
     # Prevent Samba from auto-starting at boot. NixOS enables samba.target in
-    # multi-user.target, which then pulls in all three daemons via samba.target.wants.
-    # Override the target's wantedBy to break that chain; the engine starts Samba
-    # on demand when the user enables the protocol.
+    # multi-user.target, which then pulls in all four daemons (smbd, nmbd,
+    # wsdd, winbindd) via samba.target.wants. Override the target's wantedBy
+    # to break that chain; the engine starts smbd/nmbd/wsdd via the protocol
+    # toggle and winbindd only while joined to a domain.
     systemd.targets.samba.wantedBy = mkIf cfg.smb.enable (lib.mkForce []);
 
     # ── SMB network discovery ──────────────────────────────────

--- a/nixos/tests/ad-member.nix
+++ b/nixos/tests/ad-member.nix
@@ -189,6 +189,7 @@ pkgs.testers.runNixOSTest {
       path = [ sambaDc ];
       serviceConfig.Type = "notify";
       serviceConfig.NotifyAccess = "all";
+      serviceConfig.StateDirectory = "samba";
       script = ''
         if [ ! -f /var/lib/samba/private/krb5.conf ]; then
           rm -f /etc/samba/smb.conf

--- a/nixos/tests/ad-member.nix
+++ b/nixos/tests/ad-member.nix
@@ -15,12 +15,18 @@ let
   domain = "NASTYAD";
   adminPass = "Passw0rd.123";
 
-  # The AD DC needs a samba built with LDAP + domain-controller support;
-  # nixpkgs' default samba is --without-ad-dc.
-  sambaDc = pkgs.samba.override {
-    enableLDAP = true;
-    enableDomainController = true;
-  };
+  # DC-capable samba. The pinned nixpkgs' samba lacks the pythonPath
+  # addition for DC builds that nixpkgs master later gained —
+  # samba-tool's provision path imports `cryptography` (samba.gkdi).
+  # Backport it here; test-only, the member side never runs samba-tool.
+  sambaDc =
+    (pkgs.samba.override {
+      enableLDAP = true;
+      enableDomainController = true;
+    }).overrideAttrs
+      (old: {
+        pythonPath = (old.pythonPath or [ ]) ++ [ pkgs.python3Packages.cryptography ];
+      });
 
   pythonWithWs = pkgs.python3.withPackages (ps: [ ps.websocket-client ]);
 

--- a/nixos/tests/ad-member.nix
+++ b/nixos/tests/ad-member.nix
@@ -1,0 +1,230 @@
+# Two-node AD member-join test: a throwaway Samba AD DC and a NASty
+# appliance that joins it, resolves domain users through winbind, and
+# reports a healthy trust. This is the only place the whole join flow
+# (preflight → net ads join → wbinfo trust → idmap) runs against a real
+# KDC — unit tests in nasty-system/src/domain.rs cover the rendering and
+# parsing, but never the live Kerberos handshake.
+#
+# Node IPs come from the NixOS test framework's default net: nodes are
+# numbered by the sorted order of `nodes.*`, so `dc` == 192.168.1.1 and
+# `nasty` == 192.168.1.2 (see nixpkgs' nixos/lib/testing/network.nix).
+{ pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
+
+let
+  realm = "NASTY.TEST";
+  domain = "NASTYAD";
+  adminPass = "Passw0rd.123";
+
+  # The AD DC needs a samba built with LDAP + domain-controller support;
+  # nixpkgs' default samba is --without-ad-dc.
+  sambaDc = pkgs.samba.override {
+    enableLDAP = true;
+    enableDomainController = true;
+  };
+
+  pythonWithWs = pkgs.python3.withPackages (ps: [ ps.websocket-client ]);
+
+  # Self-contained script run inside the nasty guest. Kept in its own file
+  # (same reason as appliance-smoke.nix) so a triple-quoted Python block
+  # doesn't nest inside the Nix `''` testScript string and get its
+  # indentation mangled by the testScript type-checker.
+  #
+  # It drives the whole member-join flow over the same JSON-RPC path the
+  # WebUI uses: clear the first-boot password gate, join, assert the
+  # domain user resolves with an idmap UID, search principals, check the
+  # status is healthy, then leave and confirm the unwind.
+  adMemberScript = pkgs.writeText "ad-member.py" ''
+    import json
+    import subprocess
+    import sys
+    import urllib.request
+
+    import websocket
+
+    REALM = "${realm}"
+    DOMAIN = "${domain}"
+    ADMIN_PASS = "${adminPass}"
+    NEW_PW = "admin-changed-by-ad-test"
+
+    _next_id = 0
+
+
+    def http_login(password):
+        req = urllib.request.Request(
+            "http://127.0.0.1:2137/api/login",
+            data=json.dumps({"username": "admin", "password": password}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())["token"]
+
+
+    def ws_open(token):
+        ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=30)
+        ws.send(json.dumps({"token": token}))
+        auth = json.loads(ws.recv())
+        assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
+        return ws, auth
+
+
+    def call(ws, method, params=None):
+        global _next_id
+        _next_id += 1
+        req = {"jsonrpc": "2.0", "method": method, "id": _next_id}
+        if params is not None:
+            req["params"] = params
+        ws.send(json.dumps(req))
+        resp = json.loads(ws.recv())
+        assert resp.get("id") == _next_id, f"id mismatch: {resp!r}"
+        assert "error" not in resp, f"{method} returned error: {resp!r}"
+        return resp["result"]
+
+
+    # ── Clear the first-boot must-change-password gate ────────────
+    # Default admin/admin carries must_change_password, which gates the
+    # admin-role domain.* methods. Change it, then re-login.
+    token = http_login("admin")
+    ws, auth = ws_open(token)
+    if auth.get("must_change_password"):
+        call(ws, "auth.change_password", {"username": "admin", "new_password": NEW_PW})
+        ws.close()
+        token = http_login(NEW_PW)
+        ws, auth = ws_open(token)
+    assert auth.get("must_change_password") is False, f"gate not cleared: {auth!r}"
+
+    # ── Join via the engine API (same path the WebUI uses) ────────
+    join = call(ws, "domain.join", {
+        "realm": REALM,
+        "username": "Administrator",
+        "password": ADMIN_PASS,
+    })
+    assert join["joined"] is True, join
+    assert join["trust_ok"] is True, join
+
+    # ── Domain user resolves through winbind/NSS in the idmap range ─
+    uid = int(subprocess.check_output(["id", "-u", f"{DOMAIN}\\alice"]).decode().strip())
+    assert 100000 <= uid < 1000000, f"idmap uid out of range: {uid}"
+
+    # ── Principal search finds the user ───────────────────────────
+    users = call(ws, "domain.user.list", {"prefix": "al"})
+    assert any(u["name"].endswith("\\alice") for u in users), users
+
+    # ── Status stays healthy ──────────────────────────────────────
+    st = call(ws, "domain.status", {})
+    assert st["trust_ok"] and st["dc_reachable"], st
+
+    # ── Forced local leave unwinds to not-joined ──────────────────
+    call(ws, "domain.leave", {"force": True})
+    st = call(ws, "domain.status", {})
+    assert st["joined"] is False, st
+
+    ws.close()
+    print("AD member-join flow OK", file=sys.stderr)
+  '';
+in
+
+pkgs.testers.runNixOSTest {
+  name = "ad-member";
+
+  # ── The throwaway AD domain controller ──────────────────────────
+  # No NixOS samba module here — just provision a fresh AD domain at
+  # boot and run `samba` in the foreground. Its SAMBA_INTERNAL DNS owns
+  # port 53, so systemd-resolved is disabled to keep out of its way.
+  nodes.dc = { ... }: {
+    networking.firewall.enable = false;
+    services.resolved.enable = false;
+    environment.systemPackages = [ sambaDc pkgs.dnsutils ];
+    virtualisation.memorySize = 2048;
+
+    systemd.services.samba-dc = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ sambaDc ];
+      serviceConfig.Type = "notify";
+      serviceConfig.NotifyAccess = "all";
+      script = ''
+        if [ ! -f /var/lib/samba/private/krb5.conf ]; then
+          rm -f /etc/samba/smb.conf
+          samba-tool domain provision \
+            --realm=${realm} --domain=${domain} \
+            --server-role=dc --dns-backend=SAMBA_INTERNAL \
+            --adminpass='${adminPass}'
+          samba-tool user create alice 'UserPass.123'
+        fi
+        systemd-notify --ready &
+        exec samba --foreground --no-process-group
+      '';
+    };
+  };
+
+  # ── The NASty appliance that joins ──────────────────────────────
+  nodes.nasty = { lib, ... }: {
+    imports = [
+      ../modules/bcachefs.nix
+      ../modules/linuxquota.nix
+      ../modules/nasty.nix
+    ];
+    _module.args = {
+      inherit nasty-engine nasty-webui nasty-bcachefs-tools;
+      nasty-version = "test";
+    };
+
+    services.nasty = {
+      enable = true;
+      engine.package = nasty-engine;
+      webui.package = nasty-webui;
+      # SMB must stay on — it's what pulls in winbindd, the winbind NSS
+      # modules, and the KRB5_CONFIG wiring the join depends on. The
+      # other share protocols are irrelevant here and only add boot time.
+      smb.enable = true;
+      nfs.enable = false;
+      iscsi.enable = false;
+      nvmeof.enable = false;
+    };
+
+    # nasty.nix manages the host network via NetworkManager and
+    # force-clears `networking.interfaces` — but NM ignores static
+    # `networking.interfaces` and there's no DHCP on the test net, so the
+    # node would come up with no route to the DC. Fall back to scripted
+    # networking on this node only: NM off, static IP re-asserted above
+    # the module's mkForce, and the DC as the resolver (its AD DNS is
+    # what answers the realm's SRV records the join preflight looks up).
+    networking.networkmanager.enable = lib.mkForce false;
+    networking.interfaces = lib.mkOverride 10 {
+      eth1.ipv4.addresses = [
+        { address = "192.168.1.2"; prefixLength = 24; }
+      ];
+    };
+    networking.nameservers = lib.mkForce [ "192.168.1.1" ];
+
+    # qemu-vm.nix forces timesyncd off; nasty.nix turns it on. Defer to
+    # the VM infra — clock sync is irrelevant in a transient test VM, and
+    # both guests share the host clock so Kerberos sees ~0 skew.
+    services.timesyncd.enable = lib.mkForce false;
+
+    # The join script needs websocket-client at runtime in the guest.
+    environment.systemPackages = [ pythonWithWs ];
+
+    virtualisation.memorySize = 2048;
+  };
+
+  testScript = ''
+    dc.start()
+    nasty.start()
+
+    # The DC's AD DNS must be answering the realm's SRV records before the
+    # nasty node's join preflight can resolve a domain controller.
+    dc.wait_for_unit("samba-dc.service")
+    dc.wait_until_succeeds(
+        "host -t SRV _ldap._tcp.${pkgs.lib.toLower realm} 127.0.0.1", timeout=120
+    )
+
+    nasty.wait_for_unit("nasty-engine.service")
+    # The box resolves the realm through the DC (via systemd-resolved) —
+    # gate the join on that working end to end.
+    nasty.wait_until_succeeds(
+        "resolvectl query --type=SRV _ldap._tcp.${pkgs.lib.toLower realm}", timeout=120
+    )
+
+    nasty.succeed("${pythonWithWs}/bin/python3 ${adMemberScript}")
+  '';
+}

--- a/nixos/tests/ad-member.nix
+++ b/nixos/tests/ad-member.nix
@@ -11,7 +11,7 @@
 { pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
 
 let
-  realm = "NASTY.TEST";
+  realm = "ADTEST.LAN";
   domain = "NASTYAD";
   adminPass = "Passw0rd.123";
 

--- a/nixos/tests/ad-member.nix
+++ b/nixos/tests/ad-member.nix
@@ -30,9 +30,13 @@ let
   # indentation mangled by the testScript type-checker.
   #
   # It drives the whole member-join flow over the same JSON-RPC path the
-  # WebUI uses: clear the first-boot password gate, join, assert the
-  # domain user resolves with an idmap UID, search principals, check the
-  # status is healthy, then leave and confirm the unwind.
+  # WebUI uses. Two phases, selected by argv[1], so the test driver can run
+  # an out-of-band smbclient auth from the DC while the box is still joined:
+  #   join   clear the first-boot password gate, join, assert the domain
+  #          user resolves with an idmap UID, search principals, check the
+  #          status is healthy, then enable SMB and publish a share
+  #          restricted to a domain user.
+  #   leave  force a local leave and confirm the unwind.
   adMemberScript = pkgs.writeText "ad-member.py" ''
     import json
     import subprocess
@@ -80,46 +84,84 @@ let
         return resp["result"]
 
 
-    # ── Clear the first-boot must-change-password gate ────────────
-    # Default admin/admin carries must_change_password, which gates the
-    # admin-role domain.* methods. Change it, then re-login.
-    token = http_login("admin")
-    ws, auth = ws_open(token)
-    if auth.get("must_change_password"):
-        call(ws, "auth.change_password", {"username": "admin", "new_password": NEW_PW})
-        ws.close()
-        token = http_login(NEW_PW)
-        ws, auth = ws_open(token)
-    assert auth.get("must_change_password") is False, f"gate not cleared: {auth!r}"
+    def authed_ws():
+        # First boot uses admin/admin with a forced change; the second
+        # invocation (leave) logs in with the already-changed password.
+        # must_change_password gates the admin-role domain.*/share.* methods.
+        for pw in (NEW_PW, "admin"):
+            try:
+                token = http_login(pw)
+            except Exception:
+                continue
+            ws, auth = ws_open(token)
+            if auth.get("must_change_password"):
+                call(ws, "auth.change_password",
+                     {"username": "admin", "new_password": NEW_PW})
+                ws.close()
+                token = http_login(NEW_PW)
+                ws, auth = ws_open(token)
+            assert auth.get("must_change_password") is False, f"gate not cleared: {auth!r}"
+            return ws, auth
+        raise SystemExit("could not authenticate admin")
 
-    # ── Join via the engine API (same path the WebUI uses) ────────
-    join = call(ws, "domain.join", {
-        "realm": REALM,
-        "username": "Administrator",
-        "password": ADMIN_PASS,
-    })
-    assert join["joined"] is True, join
-    assert join["trust_ok"] is True, join
 
-    # ── Domain user resolves through winbind/NSS in the idmap range ─
-    uid = int(subprocess.check_output(["id", "-u", f"{DOMAIN}\\alice"]).decode().strip())
-    assert 100000 <= uid < 1000000, f"idmap uid out of range: {uid}"
+    def phase_join(ws):
+        # ── Join via the engine API (same path the WebUI uses) ────────
+        join = call(ws, "domain.join", {
+            "realm": REALM,
+            "username": "Administrator",
+            "password": ADMIN_PASS,
+        })
+        assert join["joined"] is True, join
+        assert join["trust_ok"] is True, join
 
-    # ── Principal search finds the user ───────────────────────────
-    users = call(ws, "domain.user.list", {"prefix": "al"})
-    assert any(u["name"].endswith("\\alice") for u in users), users
+        # ── Domain user resolves through winbind/NSS in the idmap range ─
+        uid = int(subprocess.check_output(["id", "-u", f"{DOMAIN}\\alice"]).decode().strip())
+        assert 100000 <= uid < 1000000, f"idmap uid out of range: {uid}"
 
-    # ── Status stays healthy ──────────────────────────────────────
-    st = call(ws, "domain.status", {})
-    assert st["trust_ok"] and st["dc_reachable"], st
+        # ── Principal search finds the user ───────────────────────────
+        users = call(ws, "domain.user.list", {"prefix": "al"})
+        assert any(u["name"].endswith("\\alice") for u in users), users
 
-    # ── Forced local leave unwinds to not-joined ──────────────────
-    call(ws, "domain.leave", {"force": True})
-    st = call(ws, "domain.status", {})
-    assert st["joined"] is False, st
+        # ── Status stays healthy ──────────────────────────────────────
+        st = call(ws, "domain.status", {})
+        assert st["trust_ok"] and st["dc_reachable"], st
 
+        # ── Publish an SMB share restricted to the domain user ────────
+        # Enable the SMB protocol service first — that starts smbd and
+        # opens tcp/445 in the firewall (the NixOS-level smb.enable only
+        # wires the packages; the engine owns the runtime toggle). Then
+        # create a share whose valid_users is a domain principal, proving
+        # end to end that winbind auth reaches an engine-managed share.
+        call(ws, "service.protocol.enable", {"name": "smb"})
+        subprocess.run(["mkdir", "-p", "/fs/adtest"], check=True)
+        # World-writable so alice's idmap-mapped uid can create files.
+        subprocess.run(["chmod", "0777", "/fs/adtest"], check=True)
+        call(ws, "share.smb.create", {
+            "name": "adtest",
+            "path": "/fs/adtest",
+            "valid_users": [f"{DOMAIN}\\alice"],
+        })
+        print("AD join + domain-user SMB share OK", file=sys.stderr)
+
+
+    def phase_leave(ws):
+        # ── Forced local leave unwinds to not-joined ──────────────────
+        call(ws, "domain.leave", {"force": True})
+        st = call(ws, "domain.status", {})
+        assert st["joined"] is False, st
+        print("AD leave unwind OK", file=sys.stderr)
+
+
+    phase = sys.argv[1] if len(sys.argv) > 1 else "join"
+    ws, _auth = authed_ws()
+    if phase == "join":
+        phase_join(ws)
+    elif phase == "leave":
+        phase_leave(ws)
+    else:
+        raise SystemExit(f"unknown phase: {phase}")
     ws.close()
-    print("AD member-join flow OK", file=sys.stderr)
   '';
 in
 
@@ -225,6 +267,25 @@ pkgs.testers.runNixOSTest {
         "resolvectl query --type=SRV _ldap._tcp.${pkgs.lib.toLower realm}", timeout=120
     )
 
-    nasty.succeed("${pythonWithWs}/bin/python3 ${adMemberScript}")
+    # Phase 1: join, resolve the domain user, and publish an SMB share
+    # whose valid_users is the domain principal NASTYAD\alice.
+    nasty.succeed("${pythonWithWs}/bin/python3 ${adMemberScript} join")
+
+    # End-to-end proof (spec-mandated): from the DC node, authenticate as the
+    # *domain* user against the appliance's SMB share and write a file. This
+    # exercises the full winbind auth path — Kerberos/NTLM against the DC,
+    # winbind name→uid mapping, and the engine-rendered valid_users ACL.
+    nasty.wait_for_open_port(445)
+    dc.succeed(
+        "smbclient //192.168.1.2/adtest -U 'NASTYAD\\alice%UserPass.123' "
+        "-c 'put /etc/hostname adfile'"
+    )
+    # The written file must be owned by alice's idmap-mapped uid, not a local
+    # account — that is the whole point of member mode.
+    uid = int(nasty.succeed("stat -c %u /fs/adtest/adfile").strip())
+    assert uid >= 100000, f"domain-user file uid not in idmap range: {uid}"
+
+    # Phase 2: force a local leave and confirm the unwind.
+    nasty.succeed("${pythonWithWs}/bin/python3 ${adMemberScript} leave")
   '';
 }

--- a/webui/src/lib/domain.svelte.ts
+++ b/webui/src/lib/domain.svelte.ts
@@ -1,0 +1,65 @@
+/** AD membership state + handlers (Settings → Directory card). */
+import { getClient } from '$lib/client';
+import { withToast } from '$lib/toast.svelte';
+import { confirm } from '$lib/confirm.svelte';
+import type { DomainStatus, DomainPrincipal } from '$lib/types';
+
+const client = getClient();
+
+export const domain = $state({
+	status: null as DomainStatus | null,
+	loading: true,
+	joining: false,
+	// join form
+	realm: '',
+	username: '',
+	password: '',
+	ou: '',
+});
+
+export async function domainRefresh() {
+	try {
+		domain.status = await client.call<DomainStatus>('domain.status');
+	} catch { /* engine without domain support */ }
+	domain.loading = false;
+}
+
+export async function domainJoin() {
+	if (!domain.realm || !domain.username || !domain.password) return;
+	domain.joining = true;
+	const params: Record<string, unknown> = {
+		realm: domain.realm.trim(),
+		username: domain.username.trim(),
+		password: domain.password,
+	};
+	if (domain.ou.trim()) params.ou = domain.ou.trim();
+	const ok = await withToast(() => client.call<DomainStatus>('domain.join', params), 'Joined domain');
+	domain.password = '';
+	if (ok !== undefined) {
+		domain.status = ok;
+		domain.realm = ''; domain.username = ''; domain.ou = '';
+	}
+	domain.joining = false;
+}
+
+export async function domainLeave(force: boolean, username?: string, password?: string) {
+	if (!await confirm(
+		'Leave the domain?',
+		force
+			? 'Local-only leave: the computer account stays behind in AD. Shares referencing domain users keep their entries but domain logons stop working.'
+			: 'The computer account will be removed from AD. Shares referencing domain users keep their entries but domain logons stop working.'
+	)) return;
+	const params: Record<string, unknown> = force ? { force: true } : { username, password };
+	await withToast(() => client.call('domain.leave', params), 'Left domain');
+	await domainRefresh();
+}
+
+/** Prefix search for the share permissions picker (2+ chars). */
+export async function domainSearchUsers(prefix: string): Promise<DomainPrincipal[]> {
+	if (prefix.trim().length < 2 || !domain.status?.joined) return [];
+	try {
+		return await client.call<DomainPrincipal[]>('domain.user.list', { prefix: prefix.trim() });
+	} catch {
+		return [];
+	}
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -654,6 +654,24 @@ export interface SmbGroup {
 	members: string[];
 }
 
+// ── Active Directory ───────────────────────────────────────
+
+/** Wire shape of `domain.status`. */
+export interface DomainStatus {
+	joined: boolean;
+	realm: string | null;
+	workgroup: string | null;
+	idmap_base: number | null;
+	trust_ok: boolean | null;
+	dc_reachable: boolean | null;
+	clock_skew_seconds: number | null;
+}
+
+/** One AD principal from `domain.user.list` / `domain.group.list` — name is `DOMAIN\name`. */
+export interface DomainPrincipal {
+	name: string;
+}
+
 export interface IscsiTarget {
 	id: string;
 	iqn: string;

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/network';
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
+	import { domain, domainRefresh, domainJoin, domainLeave } from '$lib/domain.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -182,6 +183,28 @@
 	// Telemetry
 	let sendingTelemetry = $state(false);
 
+	// Directory (Active Directory)
+	let domainJoinTried = $state(false);
+	let domainAdvanced = $state(false);
+	let domainLeaveOpen = $state(false);
+	let domainLeaveForce = $state(false);
+	let domainLeaveUsername = $state('');
+	let domainLeavePassword = $state('');
+
+	async function domainJoinGuarded() {
+		if (!domain.realm || !domain.username || !domain.password) { domainJoinTried = true; return; }
+		domainJoinTried = false;
+		await domainJoin();
+	}
+
+	async function domainLeaveConfirmed() {
+		await domainLeave(domainLeaveForce, domainLeaveUsername, domainLeavePassword);
+		domainLeaveOpen = false;
+		domainLeaveForce = false;
+		domainLeaveUsername = '';
+		domainLeavePassword = '';
+	}
+
 	// ── Metrics tab state ───────────────────────────────────
 	let metricsText = $state('');
 	let metricsLoading = $state(false);
@@ -261,6 +284,7 @@
 			logFilter = liveLogFilter;
 			syncNetworkForm();
 		});
+		await domainRefresh();
 	});
 
 	function syncNetworkForm() {
@@ -912,6 +936,137 @@
 				</Button>
 			</section>
 
+			<!-- Directory (Active Directory) -->
+			<section class="rounded-lg border border-border p-5">
+				<h2 class="mb-4 text-base font-semibold">Directory (Active Directory)</h2>
+
+				{#if domain.loading}
+					<p class="text-sm text-muted-foreground">Loading...</p>
+				{:else if !domain.status?.joined}
+					<div class="mb-3">
+						<label for="domain-realm" class="text-sm text-muted-foreground">Realm {#if !domain.realm && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-realm"
+							type="text"
+							bind:value={domain.realm}
+							placeholder="corp.example.com"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.realm, domainJoinTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="domain-username" class="text-sm text-muted-foreground">Username {#if !domain.username && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-username"
+							type="text"
+							bind:value={domain.username}
+							placeholder="Administrator"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.username, domainJoinTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="domain-password" class="text-sm text-muted-foreground">Password {#if !domain.password && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-password"
+							type="password"
+							bind:value={domain.password}
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.password, domainJoinTried)}"
+						/>
+					</div>
+
+					<button
+						type="button"
+						onclick={() => domainAdvanced = !domainAdvanced}
+						class="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						{#if domainAdvanced}<ChevronDown class="h-3 w-3" />{:else}<ChevronRight class="h-3 w-3" />{/if}
+						Advanced
+					</button>
+					{#if domainAdvanced}
+						<div class="mb-3">
+							<label for="domain-ou" class="text-sm text-muted-foreground">Organizational Unit</label>
+							<input
+								id="domain-ou"
+								type="text"
+								bind:value={domain.ou}
+								placeholder="OU=Servers,DC=corp,DC=example,DC=com"
+								class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+							/>
+						</div>
+					{/if}
+
+					<Button size="sm" onclick={domainJoinGuarded} disabled={domain.joining}>
+						{domain.joining ? 'Joining… (this contacts the domain controller)' : 'Join'}
+					</Button>
+				{:else}
+					<div class="mb-3 flex items-center justify-between">
+						<span class="text-sm text-muted-foreground">Realm</span>
+						<span class="text-sm font-medium font-mono">{domain.status.realm ?? '—'}</span>
+					</div>
+					<div class="mb-4 flex items-center justify-between">
+						<span class="text-sm text-muted-foreground">Workgroup</span>
+						<span class="text-sm font-medium font-mono">{domain.status.workgroup ?? '—'}</span>
+					</div>
+
+					<div class="mb-4 flex flex-wrap gap-1.5">
+						<Badge
+							variant={domain.status.trust_ok ? 'default' : domain.status.trust_ok === false ? 'destructive' : 'secondary'}
+							class="text-[0.65rem]"
+						>Trust: {domain.status.trust_ok ? 'OK' : domain.status.trust_ok === false ? 'Broken' : 'Unknown'}</Badge>
+						<Badge
+							variant={domain.status.dc_reachable ? 'default' : domain.status.dc_reachable === false ? 'destructive' : 'secondary'}
+							class="text-[0.65rem]"
+						>DC: {domain.status.dc_reachable ? 'Reachable' : domain.status.dc_reachable === false ? 'Unreachable' : 'Unknown'}</Badge>
+						<Badge
+							variant="outline"
+							class="text-[0.65rem] {Math.abs(domain.status.clock_skew_seconds ?? 0) > 120 ? 'border-amber-500/40 bg-amber-500/10 text-amber-400' : ''}"
+						>Clock skew: {domain.status.clock_skew_seconds ?? 0}s</Badge>
+					</div>
+
+					{#if !domainLeaveOpen}
+						<Button size="sm" variant="destructive" onclick={() => domainLeaveOpen = true}>Leave Domain</Button>
+					{:else}
+						<div class="space-y-3 rounded-md border border-border p-3">
+							<div class="flex w-fit rounded-md border border-border text-xs">
+								<button
+									onclick={() => domainLeaveForce = false}
+									class="rounded-l-md px-3 py-1 font-medium transition-colors {!domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+								>With credentials</button>
+								<button
+									onclick={() => domainLeaveForce = true}
+									class="rounded-r-md px-3 py-1 font-medium transition-colors {domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+								>Force local</button>
+							</div>
+							{#if !domainLeaveForce}
+								<div>
+									<label for="domain-leave-user" class="text-xs text-muted-foreground">Username</label>
+									<input
+										id="domain-leave-user"
+										type="text"
+										bind:value={domainLeaveUsername}
+										placeholder="Administrator"
+										class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+									/>
+								</div>
+								<div>
+									<label for="domain-leave-pass" class="text-xs text-muted-foreground">Password</label>
+									<input
+										id="domain-leave-pass"
+										type="password"
+										bind:value={domainLeavePassword}
+										class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+									/>
+								</div>
+							{:else}
+								<p class="text-xs text-amber-500">Local-only leave: the computer account stays behind in AD until an admin removes it manually.</p>
+							{/if}
+							<div class="flex gap-2">
+								<Button size="sm" variant="destructive" onclick={domainLeaveConfirmed}>Confirm Leave</Button>
+								<Button size="sm" variant="secondary" onclick={() => { domainLeaveOpen = false; domainLeaveForce = false; domainLeaveUsername = ''; domainLeavePassword = ''; }}>Cancel</Button>
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</section>
 
 			</div>
 		</div>

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -47,6 +47,7 @@
 		nvmeRefresh,
 		nvmeLoadProtocol,
 	} from '$lib/sharing/nvmeof.svelte';
+	import { domainRefresh } from '$lib/domain.svelte';
 
 	// Guest shares are public web links (managed in their own panel), a peer
 	// of the network protocols but with no create-wizard / protocol service.
@@ -312,6 +313,11 @@
 			nvmeLoadProtocol(),
 			rdmaLoad(),
 		]);
+		// Load AD membership so SmbPanel's domain-user picker appears when the
+		// box is joined — otherwise the picker only ever showed after visiting
+		// Settings (the only other place that calls domainRefresh). Fire-and-
+		// forget: domainRefresh swallows its own errors.
+		domainRefresh();
 	});
 
 	onDestroy(() => client.offEvent(handleEvent));

--- a/webui/src/routes/sharing/SmbPanel.svelte
+++ b/webui/src/routes/sharing/SmbPanel.svelte
@@ -22,8 +22,21 @@
 		smbLoadSubvolumes,
 		smbEnsureSystemUsers,
 	} from '$lib/sharing/smb.svelte';
+	import { domain, domainSearchUsers } from '$lib/domain.svelte';
+	import type { SmbShare, DomainPrincipal } from '$lib/types';
 
 	const client = getClient();
+
+	let domainSearch = $state('');
+	let domainHits: DomainPrincipal[] = $state([]);
+
+	/** Append `entry` (a system username or `@group`) to a share's
+	 * valid_users and persist. Shared by the system-user/group buttons
+	 * and the domain-user search results below them. */
+	function addValidUser(share: SmbShare, entry: string) {
+		const valid_users = [...share.valid_users, entry];
+		withToast(() => client.call('share.smb.update', { id: share.id, valid_users }), `${entry} added`).then(() => smbRefresh());
+	}
 
 	/** Gates the amber required-field decoration on the SMB create form
 	 * until the operator has clicked Create at least once with a missing
@@ -222,21 +235,29 @@
 										</div>
 									{/if}
 									{#if smb.addUserShare === share.id}
-										<div class="flex flex-wrap gap-1.5" role="presentation" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
-											{#each smb.systemUsers.filter(u => !share.valid_users.includes(u.username)) as user}
-												<Button size="xs" variant="secondary" onclick={() => {
-													const valid_users = [...share.valid_users, user.username];
-													withToast(() => client.call('share.smb.update', { id: share.id, valid_users }), `${user.username} added`).then(() => smbRefresh());
-												}}>{user.username}</Button>
-											{/each}
-											{#each smb.groups.filter(g => !share.valid_users.includes(`@${g.name}`)) as group}
-												<Button size="xs" variant="secondary" class="text-blue-400" onclick={() => {
-													const valid_users = [...share.valid_users, `@${group.name}`];
-													withToast(() => client.call('share.smb.update', { id: share.id, valid_users }), `@${group.name} added`).then(() => smbRefresh());
-												}}>@{group.name}</Button>
-											{/each}
-											<Button size="xs" variant="secondary" onclick={() => goto('/users')}>Create User / Group</Button>
-											<Button variant="secondary" size="xs" onclick={() => { smb.addUserShare = null; }}>Done</Button>
+										<div role="presentation" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()}>
+											<div class="flex flex-wrap gap-1.5">
+												{#each smb.systemUsers.filter(u => !share.valid_users.includes(u.username)) as user}
+													<Button size="xs" variant="secondary" onclick={() => addValidUser(share, user.username)}>{user.username}</Button>
+												{/each}
+												{#each smb.groups.filter(g => !share.valid_users.includes(`@${g.name}`)) as group}
+													<Button size="xs" variant="secondary" class="text-blue-400" onclick={() => addValidUser(share, `@${group.name}`)}>@{group.name}</Button>
+												{/each}
+												<Button size="xs" variant="secondary" onclick={() => goto('/users')}>Create User / Group</Button>
+												<Button variant="secondary" size="xs" onclick={() => { smb.addUserShare = null; }}>Done</Button>
+											</div>
+											{#if domain.status?.joined}
+												<div class="mt-2">
+													<Input bind:value={domainSearch} placeholder="Search domain users (2+ chars)…" class="h-8 text-xs"
+														oninput={async () => { domainHits = await domainSearchUsers(domainSearch); }} />
+													{#each domainHits.filter(p => !share.valid_users.includes(p.name)) as p}
+														<button class="block w-full rounded px-2 py-1 text-left font-mono text-xs hover:bg-secondary/50"
+															onclick={() => addValidUser(share, p.name)}>
+															{p.name}
+														</button>
+													{/each}
+												</div>
+											{/if}
 										</div>
 									{:else}
 										<Button variant="secondary" size="xs" onclick={(e) => {


### PR DESCRIPTION
Active Directory member join — phase 1 of #20's directory-services ask, per the committed design (`docs/active-directory-support.md`) and implementation plan (`docs/plans/2026-07-07-ad-member-join.md`).

## Validated end-to-end against a REAL AD domain controller

Beyond unit + VM-test coverage, this was driven live against a real Synology Directory Server DC (`LAB.0F.EE`, NetBIOS `TEST`) from a real NASty box:

- **Join**: `joined, trust_ok, dc_reachable, clock_skew=0`
- **Workgroup discovery**: realm `LAB.0F.EE` → engine's naive guess "LAB" → **discovered and corrected to the real `TEST` from the DC**
- **Identity**: winbind resolved `TEST\alice` → **UID 101104** (idmap_rid range)
- **Domain-user SMB auth**: `alice` authenticated to a restricted share on the first (cold) attempt and wrote a file
- **File ownership**: `uid=101104 → TEST\alice`
- **Leave**: clean

That real-DC exercise found and fixed **seven** issues that unit/fake-DC testing structurally could not — resolvectl link-annotation parsing, epoch-zero sentinel clock skew, the NixOS samba module's alphabetized `security=user` clobbering the ADS include, pre-join winbindd startup, realm-derived-vs-actual NetBIOS name, cold-winbind first-access, and a mid-join `systemd-resolved` restart breaking DC discovery. All confirmed fixed against real AD.

## What NASty gains

- **Join / leave an existing AD domain** from Settings → Directory: preflight (DNS SRV, DC reachability, clock skew) before Kerberos; admin credential over stdin, used once, never stored/logged; single-unwind-path rollback on any failure (incl. `net ads leave` when the machine account already exists); the NetBIOS domain is discovered from the DC, not guessed.
- **Domain identities stay live** (never copied): winbind + NSS resolve `DOMAIN\name` on demand; `idmap_rid` (base 100000, immutable after join) gives stable UIDs; share permissions accept `DOMAIN\name` / `@DOMAIN\group` with injection-safe validation and render-time quoting for spaced AD names.
- **Search-driven pickers** (`domain.user.list`/`group.list`, Admin, prefix ≥ 2, capped 50); the WebUI share editor gains domain-user search when joined.
- **Degradation contract**: DC down → domain auth degrades (winbind offline cache); local users and shares unaffected. `domain.status` reports trust/reachability/skew, shown as Directory-card pills.
- **Untouched-box guarantee**: unjoined boxes render byte-identical effective Samba config — winbindd installed but never started, NSS inert, include empty. One shared change: Samba built with `enableLDAP` (nixpkgs default lacks ADS), gated by appliance-smoke.

## Verification

- Built task-by-task with TDD + per-task review (13 tasks; multiple review-driven fix rounds incl. a Critical in `valid_users` rendering and one in the boot include chain). 900+ engine tests, clippy `--all-targets -D warnings`, svelte-check, production build, `nix flake check` — all green.
- **Real-DC end-to-end validation** as above (the authoritative proof).
- The two-node `ad-member` CI VM test is **non-gating**: its throwaway Samba AD DC fails at the DC's own LDAP layer ("Operations error") — a fake-DC provisioning defect (essentially the phase-2 NASty-as-DC problem), not the member-join engine. Kept running for visibility; re-promote to gating once the simulated DC is hardened in phase 2.

## Known follow-ups (deliberate)

- Principal search shells `wbinfo -u/-g` + server-side filter (fine for small domains; an LDAP-side `net ads search` is the follow-up if enumeration cost bites).
- AD DNS A-record auto-register is best-effort — authenticates with the machine account (`-P`) but a site's DNS may reject the dynamic update (Synology did); operators can add the record manually.
- Alert-rule integration + guided re-join for broken trust (spec amended to phase-1 scope).
- Minor review items tracked in the SDD ledger (WebUI search sequencing, leave-form polish, parser edge-case tests).

Phase 2 (NASty as the DC, nspawn-contained) starts from the design appendix.
