### PR TITLE
apps: .env file support for compose apps (#629)

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1504,6 +1504,43 @@ async fn remove_startup_override(app_name: &str) {
     }
 }
 
+/// Marks where NASty's managed `.env` header ends and the operator's
+/// pasted dotenv begins, so the two can be recombined on write and split
+/// apart on read without the operator ever seeing NASty's bookkeeping.
+const ENV_USER_MARKER: &str = "# >>> NASty: user-provided .env >>>";
+
+/// Render the project `.env`: NASty's managed `COMPOSE_PROJECT_NAME`
+/// header, followed by the operator's pasted dotenv (Immich/Nextcloud
+/// style config) when present. Compose reads this file from the project
+/// directory automatically — that's how the existing project-name line
+/// already reaches it — so no invocation change is needed.
+///
+/// Public so the streaming deploy handler — which writes the compose
+/// files itself rather than via `compose_install` — produces byte-
+/// identical `.env` layout to what `compose_get`/[`extract_user_env`]
+/// read back.
+pub fn render_env_file(app_name: &str, user_env: Option<&str>) -> String {
+    let mut out = format!("COMPOSE_PROJECT_NAME={app_name}\n");
+    if let Some(user) = user_env {
+        let user = user.trim();
+        if !user.is_empty() {
+            out.push_str(ENV_USER_MARKER);
+            out.push('\n');
+            out.push_str(user);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Recover just the operator's pasted dotenv from a rendered `.env`,
+/// dropping NASty's managed header. `None` when no user content was
+/// stored (the marker is absent).
+fn extract_user_env(env_file: &str) -> Option<String> {
+    let user = env_file.split_once(ENV_USER_MARKER)?.1.trim_matches('\n');
+    (!user.is_empty()).then(|| user.to_string())
+}
+
 /// The `-f` args for a `docker compose` invocation: always the user's
 /// compose file, plus the startup override when it exists (managed stacks).
 /// Single source of truth so install/update/restore/set_startup agree.
@@ -1910,6 +1947,23 @@ pub struct InstallComposeRequest {
     pub name: String,
     /// Contents of docker-compose.yml.
     pub compose_file: String,
+    /// Optional `.env` file contents. Compose reads it from the project
+    /// directory for `${VAR}` substitution and defaults — the deployment
+    /// method Immich/Nextcloud and similar expect. Absent or empty means
+    /// no operator env. NASty's `COMPOSE_PROJECT_NAME` is managed
+    /// separately and prepended automatically.
+    #[serde(default)]
+    pub env_file: Option<String>,
+}
+
+/// Compose app source returned by `apps.compose.get` for the editor.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ComposeContent {
+    /// docker-compose.yml text.
+    pub compose_file: String,
+    /// Operator-provided `.env` text, or null when none was stored.
+    /// NASty's managed `COMPOSE_PROJECT_NAME` header is stripped.
+    pub env_file: Option<String>,
 }
 
 /// Set NASty-managed startup ordering for a compose stack (#437).
@@ -4053,9 +4107,14 @@ impl AppsService {
         )
         .await?;
 
-        // Write a .env file with project name
-        let env_content = format!("COMPOSE_PROJECT_NAME={name}\n", name = req.name,);
-        tokio::fs::write(format!("{}/.env", project_dir), &env_content).await?;
+        // Write the project .env: managed COMPOSE_PROJECT_NAME plus the
+        // operator's pasted dotenv (if any). Compose reads it from the
+        // project directory automatically.
+        tokio::fs::write(
+            format!("{}/.env", project_dir),
+            render_env_file(&req.name, req.env_file.as_deref()),
+        )
+        .await?;
 
         // Validate compose file before deploying
         let compose_path = format!("{}/docker-compose.yml", project_dir);
@@ -4166,6 +4225,14 @@ impl AppsService {
         tokio::fs::write(
             format!("{}/docker-compose.yml", project_dir),
             &req.compose_file,
+        )
+        .await?;
+
+        // Re-render the .env so edits to the operator's dotenv take effect
+        // (and clearing it drops back to the managed project-name only).
+        tokio::fs::write(
+            format!("{}/.env", project_dir),
+            render_env_file(&req.name, req.env_file.as_deref()),
         )
         .await?;
 
@@ -4355,11 +4422,21 @@ impl AppsService {
         Ok(())
     }
 
-    pub async fn compose_get(&self, name: &str) -> Result<String, AppsError> {
-        let path = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
-        tokio::fs::read_to_string(&path)
+    pub async fn compose_get(&self, name: &str) -> Result<ComposeContent, AppsError> {
+        let dir = format!("{}/{}", COMPOSE_DIR, name);
+        let compose_file = tokio::fs::read_to_string(format!("{dir}/docker-compose.yml"))
             .await
-            .map_err(|_| AppsError::AppNotFound(name.to_string()))
+            .map_err(|_| AppsError::AppNotFound(name.to_string()))?;
+        // The .env may not exist on very old stacks; its absence just means
+        // no operator env. Strip NASty's managed header before returning.
+        let env_file = tokio::fs::read_to_string(format!("{dir}/.env"))
+            .await
+            .ok()
+            .and_then(|e| extract_user_env(&e));
+        Ok(ComposeContent {
+            compose_file,
+            env_file,
+        })
     }
 
     pub async fn compose_logs(&self, name: &str, tail: Option<u32>) -> Result<String, AppsError> {
@@ -6460,10 +6537,50 @@ async fn fetch_manifest_json(
 #[cfg(test)]
 mod tests {
     use super::{
-        AppVolume, StartupConfig, compose_file_args, docker_data_root_status,
-        render_startup_override, validate_simple_volumes,
+        AppVolume, StartupConfig, compose_file_args, docker_data_root_status, extract_user_env,
+        render_env_file, render_startup_override, validate_simple_volumes,
     };
     use std::path::PathBuf;
+
+    #[test]
+    fn env_file_project_name_only_when_no_user_env() {
+        assert_eq!(
+            render_env_file("immich", None),
+            "COMPOSE_PROJECT_NAME=immich\n"
+        );
+        // Whitespace-only user env is treated as none.
+        assert_eq!(
+            render_env_file("immich", Some("  \n \n")),
+            "COMPOSE_PROJECT_NAME=immich\n"
+        );
+    }
+
+    #[test]
+    fn env_file_appends_user_env_after_marker() {
+        let rendered = render_env_file("immich", Some("DB_PASSWORD=secret\nUPLOAD_LOCATION=/fs/x"));
+        assert!(rendered.starts_with("COMPOSE_PROJECT_NAME=immich\n"));
+        assert!(rendered.contains("DB_PASSWORD=secret\nUPLOAD_LOCATION=/fs/x\n"));
+        // The project name comes before the user block.
+        assert!(
+            rendered.find("COMPOSE_PROJECT_NAME").unwrap() < rendered.find("DB_PASSWORD").unwrap()
+        );
+    }
+
+    #[test]
+    fn user_env_round_trips_and_hides_managed_header() {
+        let user = "DB_PASSWORD=secret\n# a comment\nUPLOAD_LOCATION=/fs/x";
+        let extracted = extract_user_env(&render_env_file("immich", Some(user)));
+        assert_eq!(extracted.as_deref(), Some(user));
+        // No user env → nothing to extract, and the managed line never leaks.
+        assert_eq!(extract_user_env(&render_env_file("immich", None)), None);
+        assert!(!render_env_file("immich", Some(user)).is_empty());
+    }
+
+    #[test]
+    fn extract_user_env_none_for_legacy_env_without_marker() {
+        // A .env written before this feature (project name only) has no marker.
+        assert_eq!(extract_user_env("COMPOSE_PROJECT_NAME=old\n"), None);
+    }
 
     #[test]
     fn startup_override_pins_each_service_to_no() {

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -47,6 +47,10 @@ struct DeployRequest {
     image: Option<String>,
     /// For compose: docker-compose.yml content
     compose_file: Option<String>,
+    /// For compose: optional `.env` file contents (Immich/Nextcloud-style
+    /// config). Written to the project directory for `${VAR}` substitution.
+    #[serde(default)]
+    env_file: Option<String>,
     /// For simple: JSON-encoded InstallAppRequest params (ports, env, volumes, etc.)
     install_params: Option<serde_json::Value>,
     /// Compose only: opt out of the strict sandbox so containers can request
@@ -431,13 +435,19 @@ async fn deploy_compose(
         return;
     }
 
-    // Write .env. Failure here is non-fatal for `docker compose` (it
-    // falls back to the project name from --project-name) but it can
-    // mask why a `${COMPOSE_PROJECT_NAME}` interpolation came back
-    // empty in user-supplied YAML — log so it's debuggable.
-    let env_content = format!("COMPOSE_PROJECT_NAME={}\n", req.name);
+    // Write .env: NASty's managed COMPOSE_PROJECT_NAME plus the operator's
+    // pasted dotenv (Immich/Nextcloud-style config). Compose reads it from
+    // the project directory for `${VAR}` substitution and defaults. Shared
+    // renderer so `compose_get` can split the operator's part back out.
+    // Failure is non-fatal for the project name (--project-name covers it)
+    // but a missing user env would leave `${VAR}` empty — log it.
     let env_path = format!("{}/.env", compose_dir);
-    if let Err(e) = tokio::fs::write(&env_path, &env_content).await {
+    if let Err(e) = tokio::fs::write(
+        &env_path,
+        nasty_apps::render_env_file(&req.name, req.env_file.as_deref()),
+    )
+    .await
+    {
         tracing::warn!("compose .env write to {env_path} failed: {e}");
     }
 

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -289,6 +289,9 @@
 	// Compose mode state
 	let composeName = $state('');
 	let composeContent = $state('');
+	// Optional .env pasted alongside the compose file (Immich/Nextcloud
+	// style). Written to the project dir for ${VAR} substitution.
+	let composeEnv = $state('');
 	let showCompose = $state(false);
 	let editingCompose: string | null = $state(null);
 
@@ -1521,13 +1524,14 @@
 			kind: 'compose',
 			name,
 			compose_file: composeContent,
+			env_file: composeEnv.trim() ? composeEnv : null,
 			allow_unsafe: composeAllowUnsafe,
 			ingress_host_port: newIngressPort,
 		});
 		if (ok) {
 			showCompose = false;
 			editingCompose = null;
-			composeName = ''; composeContent = ''; composeTried = false;
+			composeName = ''; composeContent = ''; composeEnv = ''; composeTried = false;
 			composeAllowUnsafe = false;
 		}
 		await refresh();
@@ -1535,13 +1539,14 @@
 
 	async function editCompose(name: string) {
 		const content = await withToast(
-			() => client.call<string>('apps.compose.get', { name }),
+			() => client.call<{ compose_file: string; env_file: string | null }>('apps.compose.get', { name }),
 			''
 		);
 		if (content === undefined) return;
 		editingCompose = name;
 		composeName = name;
-		composeContent = content;
+		composeContent = content.compose_file;
+		composeEnv = content.env_file ?? '';
 		// Pre-fill the unsafe flag from the live apps list — compose apps store
 		// it in .nasty-meta.json next to the yaml; the engine surfaces it on App.
 		composeAllowUnsafe = apps.find(a => a.name === name)?.unsafe_mode ?? false;
@@ -1563,7 +1568,7 @@
 		if (composeLintTimer) { clearTimeout(composeLintTimer); composeLintTimer = null; }
 		composeTcpPorts = [];
 		newIngressPort = null;
-		composeName = ''; composeContent = ''; composeTried = false;
+		composeName = ''; composeContent = ''; composeEnv = ''; composeTried = false;
 		composeAllowUnsafe = false;
 	}
 
@@ -2232,6 +2237,21 @@
 							{:else if composeLint?.valid && composeLint.schema_checked && composeContent.trim()}
 								<p class="mt-1 text-xs text-green-600">✓ Valid compose file</p>
 							{/if}
+						</div>
+						<!-- Optional .env — Compose reads it for ${VAR} substitution -->
+						<div class="mb-4">
+							<Label for="compose-env">.env file <span class="text-xs font-normal text-muted-foreground">(optional)</span></Label>
+							<textarea
+								id="compose-env"
+								bind:value={composeEnv}
+								spellcheck="false"
+								autocomplete="off"
+								placeholder="DB_PASSWORD=changeme&#10;UPLOAD_LOCATION=/fs/tank/immich"
+								class="mt-1 h-40 w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+							></textarea>
+							<p class="mt-1 text-xs text-muted-foreground">
+								For stacks configured via a dotenv file (Immich, Nextcloud, …). Paste it here and Compose uses it for <code>${'{'}VAR{'}'}</code> substitution. NASty manages <code>COMPOSE_PROJECT_NAME</code> itself.
+							</p>
 						</div>
 						<!-- Allow unsafe — opt out of strict compose sandbox -->
 						<div class="mb-4 rounded-md border border-border p-3">


### PR DESCRIPTION
Fixes #629 (pashadia).

Several self-hostable apps — Immich, Nextcloud, and many others — are configured entirely through a `.env` file that the compose YAML references with `${VAR}`. NASty had no way to supply one, so those stacks couldn't be deployed as-published.

## What's added

- The compose editor gains an optional **.env** textarea below the YAML. Paste the dotenv and Compose uses it for `${VAR}` substitution and defaults.
- It **round-trips**: editing an app repopulates both the YAML and the `.env`.

## How it works (small change by design)

Compose already reads `.env` from the project directory — that's how NASty's managed `COMPOSE_PROJECT_NAME` line already reaches it — so **no compose-invocation change was needed**. The work is just writing the file and round-tripping it:

- A shared `render_env_file()` writes NASty's managed `COMPOSE_PROJECT_NAME` header plus the operator's pasted dotenv, separated by a marker; `extract_user_env()` splits the operator's part back out for `compose_get`. Both writers (the streaming deploy path the WebUI uses, and the `compose_install`/`update` RPCs) go through the same renderer, so the layout is byte-identical and the round-trip is lossless.
- `COMPOSE_PROJECT_NAME` stays NASty-managed and is never shown to or editable by the operator.

## Notes

- **Secrets**: a real `.env` holds DB passwords / API keys. It lands on disk root-owned under the app dir — the same trust model as the compose file itself (which can also embed secrets); its contents are never logged.
- **Validation**: dotenv is lenient (`KEY=VALUE`, `#` comments); passed through as-is and Compose reports any errors on deploy.

## Tests

TDD on the pure render/extract logic: project-name-only when empty, user env appended after the marker, lossless round-trip, and legacy `.env` (no marker) → None. 919 workspace tests green; svelte-check 0/0; fmt + clippy `--all-targets -D warnings` clean; webui build OK.