### PR TITLE
flake: nixpkgs bump (Linux 6.18.38) — supersedes #631

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847225,
-        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -199,10 +199,16 @@
       });
     in base.overrideAttrs (old: {
       passthru = old.passthru // {
-        # kernelModule must keep the same named-attr signature that callPackage
-        # expects: { lib, stdenv, kernelModuleMakeFlags, kernel } -> drv.
-        kernelModule = { lib, stdenv, kernelModuleMakeFlags, kernel }:
-          (old.passthru.kernelModule { inherit lib stdenv kernelModuleMakeFlags kernel; }).overrideAttrs (kOld: {
+        # kernelModule must mirror nixpkgs' kernel-module.nix argument set so
+        # `callPackage` fills them and we can forward them to the wrapped
+        # derivation. nixpkgs added `rustPlatform` here (bcachefs's kernel
+        # module is gaining Rust) — forward it too, or eval fails with
+        # "called without required argument 'rustPlatform'". Keep this in
+        # sync with pkgs/by-name/bc/bcachefs-tools/kernel-module.nix.
+        kernelModule = { lib, stdenv, kernelModuleMakeFlags, kernel, rustPlatform }:
+          (old.passthru.kernelModule {
+            inherit lib stdenv kernelModuleMakeFlags kernel rustPlatform;
+          }).overrideAttrs (kOld: {
             postPatch = (kOld.postPatch or "") + ''
               # Quota needs no patching since v1.38.8: fs/Makefile enables
               # CONFIG_BCACHEFS_QUOTA for DKMS builds whenever the host


### PR DESCRIPTION
Replaces the automated bump in #631, which was generated from a **stale main**: that branch's `flake.nix` still pins bcachefs-tools **v1.38.6** with the old quota patch (it predates #621's 1.38.8 bump and ~30 other merged commits), so merging it risked reverting that work, and its CI validated the wrong tree.

This is the same nixpkgs bump done cleanly off current main, **plus** the flake fix the newer nixpkgs requires.

## Changes

- **nixpkgs** `95ca1e2` → `0ad6f47` (Linux **6.18.37 → 6.18.38**) — same rev #631 targeted.
- **Forward `rustPlatform` to the bcachefs kernel module.** The new nixpkgs added a required `rustPlatform` argument to `bcachefs-tools/kernel-module.nix` (bcachefs's kernel module is gaining Rust). Our `passthru.kernelModule` wrapper forwarded only `{ lib, stdenv, kernelModuleMakeFlags, kernel }`, so evaluation failed:

  ```
  error: function 'anonymous lambda' called without required argument 'rustPlatform'
  ```

  This is exactly why #631's `bcachefs smoke` job failed — the wrapper is the same on both branches, so the incompatibility is real for current main too. Fixed by threading `rustPlatform` through.

## Verification

- `nix flake check --no-build` evaluates clean on darwin (linux checks omitted there). The kernel-module eval is linux-only, so the `bcachefs smoke` VM job is the real gate for the `rustPlatform` fix — that's what to watch here.

**Please close #631 in favour of this.**