### PR TITLE
Firewall: user-managed custom port rules (#620)

### DIFF
--- a/docs/firewall-custom-rules.md
+++ b/docs/firewall-custom-rules.md
@@ -161,12 +161,15 @@ read-only `published_app_ports`).
   apply and surface the apply error). The rule stays in JSON and takes effect
   on the next successful apply or reboot; there is no bespoke rollback —
   consistency with the existing code beats a one-off transaction.
-- **Interface disappearance.** Today `strip_iface_refs` *drops* a vanished
-  interface from service restrictions. For a custom rule that would *widen* it
-  to all interfaces — the wrong direction for an explicitly opened port. So a
-  custom rule pinned to a now-removed interface is **disabled (fail-closed)**,
-  not widened, and the UI shows it disabled with a hint. This extends the
-  existing interface-sync logic rather than reusing it verbatim.
+- **Interface disappearance needs no special handling.** The renderer emits
+  `iifname "<iface>"` (a per-packet string match), not `iif <index>`.
+  `iifname` tolerates an absent interface: the rule simply matches no traffic
+  and the `nft -f` load still succeeds. So a custom rule pinned to a
+  since-removed interface is **naturally inert — fail-closed by construction**
+  — with no widening and no ruleset breakage, and therefore no disable/strip
+  logic. (`strip_iface_refs`, the analogous helper for service restrictions,
+  is defined but not wired to any live interface-removal event; custom rules
+  deliberately do not depend on it.)
 
 ## WebUI
 
@@ -190,8 +193,8 @@ read-only `published_app_ports`).
 - **Unit** (`firewall.rs`): the validation matrix (range sanity; collision
   refuse against a disabled protocol port, a portal port, and transport-
   sensitivity; exact-duplicate refuse; overlapping-range allow); nft rendering
-  (range vs single port; `enabled=false` omitted from the ruleset);
-  interface-disappearance disables the rule fail-closed.
+  (range vs single port; `enabled=false` omitted from the ruleset; a rule with
+  an `iface` renders `iifname "<iface>"` so an absent interface is inert).
 - **Router layer:** the Docker-overlap warning, tested with a stubbed
   published-ports list (or noted as integration if the harness makes it
   awkward).

--- a/docs/firewall-custom-rules.md
+++ b/docs/firewall-custom-rules.md
@@ -1,0 +1,206 @@
+# Firewall: User-Managed Port Rules
+
+Design for user-managed custom port rules on the Firewall page. Requested in
+[issue #620](https://github.com/nasty-project/nasty/issues/620) (from
+discussion #591): an operator was reduced to `nft add rule inet nasty input
+tcp dport <port> accept` by hand — lost on every reboot, because the engine
+owns `table inet nasty` and rebuilds it atomically — since there was no
+supported way to open a port that isn't tied to a NASty service.
+
+## Scope
+
+**In scope (v1):**
+- Open a **single TCP/UDP port or a contiguous range** on the host firewall,
+  persisted in engine state, rendered into `table inet nasty` alongside the
+  service rules, surviving reboots and rule rebuilds.
+- Same optional **source-CIDR and interface restrictions** the service rules
+  already support.
+- A per-rule **enable/disable toggle** and a required human **label**.
+- Validation that **refuses** ports a NASty service owns and **warns** on
+  ports a Docker app already publishes.
+
+**Out of scope (deferred):**
+- Arbitrary port *sets* / lists in one rule (`{80, 443, 8000-8010}`). A rule
+  is one port or one contiguous range; several disjoint ranges are several
+  rules.
+- Outbound/egress or forward-chain rules. This is the `input` chain only.
+- Protocols other than TCP/UDP.
+
+## Where it matters (and where it doesn't)
+
+- **`network_mode: host` apps** and anything an operator runs directly on the
+  host outside NASty's service model — their ports bind on the host and land
+  on the default-deny `input` chain, with no UI path to open them today.
+- **Bridge-networked apps do NOT need this.** Docker DNATs published ports in
+  `prerouting` straight to the container, bypassing the `inet nasty` input
+  chain — the Firewall page already lists those read-only. The UI copy must
+  say so, or first-time users add redundant rules for apps that were reachable
+  all along (that is effectively what happened in #591).
+
+## Principle: the engine owns the ruleset
+
+Custom rules are just another persisted input to the same atomic rebuild that
+already renders service rules. They never escape `table inet nasty`, are never
+hand-edited, and survive reboots because the engine re-materializes them on
+init — the exact property the hand-rolled `nft add rule` lacked.
+
+## Data model
+
+A new `CustomRule` type in `engine/nasty-system/src/firewall.rs`:
+
+| field | type | meaning |
+|-------|------|---------|
+| `id` | `String` | Engine-generated opaque UUID — the stable key; survives label edits. |
+| `label` | `String` | Required, short, human ("Plex (host mode)"). |
+| `transport` | `Transport` | Reuses the existing `Tcp`/`Udp` enum. |
+| `from` | `u16` | Low port, `1 ≤ from`. |
+| `to` | `u16` | High port, `from ≤ to ≤ 65535`; equals `from` for a single port. |
+| `source` | `Option<String>` | Optional source CIDR, same semantics as service rules. |
+| `iface` | `Option<String>` | Optional interface restriction, same semantics as service rules. |
+| `enabled` | `bool` | The toggle. Disabled rules keep their config but are not rendered. |
+
+`PortSpec` (the single-port type used by service rules) and the derived
+service rules are left untouched — custom rules carry their own range and
+concerns, so `PortSpec` does not grow a range field that 99% of rules would
+never use.
+
+## Persistence
+
+A new `/var/lib/nasty/firewall-custom.json` holding the `Vec<CustomRule>`,
+loaded at engine init and held in `FirewallService` in a mutex alongside the
+existing `restrictions` mutex, saved on every mutation. Same load/save shape
+as the existing `firewall-restrictions.json`. No secrets in the file.
+
+## Validation (on add / update)
+
+1. **Range sanity.** `1 ≤ from ≤ to ≤ 65535`; `label` non-empty; `transport`
+   valid.
+2. **Service-owned collision → hard refuse.** The custom `[from,to]` interval,
+   matched by transport, is checked against every service rule currently in
+   `state.rules`. That set already includes *disabled* protocols (init pushes
+   a rule per protocol with `active=false`) and the live iSCSI/NVMe-oF portal
+   ports, so it is the full "what a NASty service owns" picture. Any
+   intersection is rejected with a message naming the owner — e.g. "tcp/445 is
+   managed by SMB — enable SMB to open it." This check lives in the firewall
+   module, which owns `state.rules`.
+3. **Exact-duplicate custom rule → refuse.** Same transport + from + to +
+   source + iface as an existing rule. Overlapping (non-identical) custom
+   ranges are allowed — they are additive and harmless.
+4. **Docker-published overlap → allow + warn.** If the range intersects a host
+   port a Docker app publishes, the rule is still created, but the response
+   carries a warning ("port already reachable via `<app>`; bridge apps publish
+   past the firewall"). Because the firewall module is deliberately
+   Docker-agnostic — only the router joins `apps.list` for published ports —
+   this warning is computed at the router layer, the same place `status()`
+   already attaches `published_app_ports`. It never blocks.
+
+## Engine surface
+
+`FirewallService` gains a `custom` mutex beside `state`/`restrictions` and
+three methods:
+
+- `add_custom_rule(input) -> Result<CustomRule, String>` — generate the UUID,
+  run validations 1–3, push to the store, save JSON, re-apply nft, return the
+  created rule.
+- `update_custom_rule(id, input) -> Result<CustomRule, String>` — find by id,
+  re-validate (the duplicate check excludes the rule itself), replace, save,
+  apply. The row toggle is an `update` with `enabled` flipped — there is no
+  separate toggle method.
+- `remove_custom_rule(id) -> Result<(), String>` — drop by id, save, apply.
+
+RPC arms in `engine/nasty-engine/src/router/system.rs`, registered in
+`registry/methods.rs`:
+
+- `system.firewall.custom.add` — params `{ label, transport, from, to,
+  source?, iface?, enabled? }` (`enabled` defaults to `true` when omitted);
+  returns `{ rule: CustomRule, warnings: [String] }`.
+- `system.firewall.custom.update` — params `{ id, label, transport, from, to,
+  source?, iface?, enabled }`; returns `{ rule, warnings }`.
+- `system.firewall.custom.remove` — params `{ id }`.
+
+All three are **Admin**-role, matching the existing `system.firewall.restrict`
+(firewall management is admin territory in a NAS appliance). Admin methods are
+accepted by the Admin branch of the authorization gate and are not listed in
+`is_operator_allowed`, so the registry-role↔allowlist guard test (which checks
+`MethodRole::Operator` methods) does not apply to them.
+
+The `add`/`update` arms compute the Docker-overlap warning at the router layer
+(fetching published ports exactly as `system.firewall.status` does) and attach
+it to the response; the firewall module never learns about Docker.
+
+## Rendering
+
+`apply_nftables` takes a new `custom: &[CustomRule]` parameter and, after the
+service-rule loop, emits one line per **enabled** rule, reusing the same
+condition builder as service ports:
+
+```
+[iifname "<iface>"] [ip saddr <cidr>] <tcp|udp> dport <from>[-<to>] accept # custom:<label>
+```
+
+A single port (`from == to`) renders as a bare `dport <from>`; a range renders
+as `dport <from>-<to>` (nft supports ranges natively, so a range stays one
+rule / one line). The signature change touches the existing callers
+(`set_service_ports`, the restrict path, `open_rdma`/`close_rdma`) — each
+passes the service's current custom slice. Lock acquisition order is fixed as
+**state → restrictions → custom** everywhere to avoid deadlock.
+
+## Status
+
+`FirewallStatus` gains `custom_rules: Vec<CustomRule>`, filled by `status()`.
+The `system.firewall.status` arm is otherwise unchanged (it still joins the
+read-only `published_app_ports`).
+
+## Error handling
+
+- **Validation failure** (range, collision, duplicate) → method error
+  (`InvalidParams`) with the pointed message; nothing is persisted, and the UI
+  shows it inline.
+- **nft apply failure after a successful persist** → mirror the existing
+  module convention (`restrict` / `set_service_ports` already persist-then-
+  apply and surface the apply error). The rule stays in JSON and takes effect
+  on the next successful apply or reboot; there is no bespoke rollback —
+  consistency with the existing code beats a one-off transaction.
+- **Interface disappearance.** Today `strip_iface_refs` *drops* a vanished
+  interface from service restrictions. For a custom rule that would *widen* it
+  to all interfaces — the wrong direction for an explicitly opened port. So a
+  custom rule pinned to a now-removed interface is **disabled (fail-closed)**,
+  not widened, and the UI shows it disabled with a hint. This extends the
+  existing interface-sync logic rather than reusing it verbatim.
+
+## WebUI
+
+`webui/src/routes/firewall/+page.svelte` and `webui/src/lib/types.ts`:
+
+- A new **"Custom port rules"** section listing rows — label, transport,
+  port/range, source/interface, an enable toggle, edit, and delete.
+- An **add form**: label, transport select, a port field with an optional "to"
+  for a range, an optional source CIDR, and an optional interface picker
+  (reusing the same interface dropdown source the restrict editor uses).
+- **Copy** stating that bridge/published app ports are already open and listed
+  read-only above — no custom rule needed — heading off the #591 redundant-
+  rule trap directly.
+- **Docker-overlap warnings** surface as a non-blocking notice; validation
+  refusals as inline errors.
+- `types.ts`: add the `CustomRule` interface and extend `FirewallStatus` with
+  `custom_rules`.
+
+## Testing
+
+- **Unit** (`firewall.rs`): the validation matrix (range sanity; collision
+  refuse against a disabled protocol port, a portal port, and transport-
+  sensitivity; exact-duplicate refuse; overlapping-range allow); nft rendering
+  (range vs single port; `enabled=false` omitted from the ruleset);
+  interface-disappearance disables the rule fail-closed.
+- **Router layer:** the Docker-overlap warning, tested with a stubbed
+  published-ports list (or noted as integration if the harness makes it
+  awkward).
+- The registry-role↔allowlist guard test already covers the new Admin methods
+  implicitly (they are not Operator-role, so it is a correct no-op).
+
+## Follow-ups (not v1)
+
+- Arbitrary port sets / multiple disjoint ranges per rule.
+- Egress / forward-chain rules.
+- A "clone from published app port" shortcut for the rare host-mode app that
+  genuinely needs a matching rule.

--- a/docs/superpowers/plans/2026-07-10-firewall-custom-rules.md
+++ b/docs/superpowers/plans/2026-07-10-firewall-custom-rules.md
@@ -1,0 +1,1206 @@
+# Firewall Custom Port Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator open a TCP/UDP port or contiguous range on the host firewall from the Firewall page — persisted, rendered into `table inet nasty` alongside the service rules, surviving reboots.
+
+**Architecture:** A new persisted `CustomRule` type in `nasty-system`'s firewall module, materialized into the existing atomic nftables rebuild via its own render block; Admin-role `system.firewall.custom.{add,update,remove}` RPCs with server-side validation (refuse service-owned ports, warn on Docker-published overlap, sanitize all interpolated input); a Custom-rules section on the WebUI Firewall page.
+
+**Tech Stack:** Rust (`nasty-system`, `nasty-engine`), nftables (`nft`), tokio, `uuid`, Svelte 5 (`webui`).
+
+## Global Constraints
+
+- A custom rule is **one port or one contiguous range** (`from ≤ to`, `1 ≤ from`, `to ≤ 65535`), single transport (TCP or UDP). No port sets / disjoint ranges in v1.
+- **Refuse** a custom rule whose `[from,to]` interval intersects (same transport) any port a NASty service owns — checked against live `state.rules`, which already contains disabled protocols and iSCSI/NVMe-oF portal ports. Error names the owner.
+- **Refuse** an exact-duplicate custom rule (same transport + from + to + source + iface); **allow** overlapping (non-identical) custom ranges.
+- **Allow + warn** when a custom rule overlaps a Docker-published host port — computed at the router layer (which has `apps.list`); the firewall module stays Docker-agnostic.
+- All interpolated fields are sanitized before reaching the nft ruleset: `source` must be a valid IP or CIDR, `iface` must match `^[A-Za-z0-9._@-]+$` (≤ 15 chars, Linux `IFNAMSIZ`), `label` must be non-empty, ≤ 64 chars, and free of control characters. The nft comment uses the opaque `id`, never the free-text label.
+- Custom-rule methods are **Admin**-role (matching `system.firewall.restrict`); they are not added to `is_operator_allowed`.
+- A custom rule pinned to a since-removed interface needs no special handling: the renderer emits `iifname "<iface>"` (string match), which matches nothing when the interface is absent and does not break the `nft -f` load — naturally fail-closed.
+- Lock acquisition order in `FirewallService` is fixed **state → restrictions → custom** everywhere, to avoid deadlock.
+- Verification before every Rust commit (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`. For WebUI: `npm run check` and `npm test` (from `webui/`).
+- `webui/src/lib/types.ts` is hand-maintained ("Mirrors engine Rust types") — update by hand.
+
+---
+
+## File Structure
+
+- `engine/nasty-system/src/firewall.rs` — **modify**: add `CustomRule` + `CustomRuleInput`, persistence (`firewall-custom.json`), a `custom` mutex on `FirewallService`, extract a pure `render_ruleset`, add the custom render block, thread `custom` through `apply_nftables` and every caller, add validation helpers and the three CRUD methods, extend `FirewallStatus`.
+- `engine/nasty-engine/src/router/system.rs` — **modify**: `system.firewall.custom.{add,update,remove}` arms + the Docker-overlap warning helper.
+- `engine/nasty-engine/src/registry/methods.rs` — **modify**: register the three methods (Admin).
+- `webui/src/lib/types.ts` — **modify**: `CustomRule` interface + `FirewallStatus.custom_rules`.
+- `webui/src/routes/firewall/+page.svelte` — **modify**: Custom port rules section (list, add form, toggle, delete, warnings, guidance copy).
+
+---
+
+## Task 1: CustomRule type, persistence, and nft rendering
+
+**Files:**
+- Modify: `engine/nasty-system/src/firewall.rs`
+- Test: `engine/nasty-system/src/firewall.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces:
+  - `pub struct CustomRule { pub id: String, pub label: String, pub transport: Transport, pub from: u16, pub to: u16, pub source: Option<String>, pub iface: Option<String>, pub enabled: bool }` (derives `Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema`).
+  - `pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String` — the pure nft-ruleset string (extracted from `apply_nftables`), including the custom block.
+  - `apply_nftables(state: &FirewallState, custom: &[CustomRule])` — signature gains `custom`.
+  - `FirewallStatus.custom_rules: Vec<CustomRule>`.
+  - `FirewallService.custom: tokio::sync::Mutex<Vec<CustomRule>>`.
+
+- [ ] **Step 1: Write failing tests for rendering**
+
+Add to the `tests` module in `engine/nasty-system/src/firewall.rs`:
+
+```rust
+#[test]
+fn render_includes_enabled_custom_single_port() {
+    let state = FirewallState::default();
+    let custom = vec![CustomRule {
+        id: "id1".into(),
+        label: "plex".into(),
+        transport: Transport::Tcp,
+        from: 32400,
+        to: 32400,
+        source: None,
+        iface: None,
+        enabled: true,
+    }];
+    let out = render_ruleset(&state, &custom);
+    assert!(out.contains("tcp dport 32400 accept # custom:id1"), "got:\n{out}");
+}
+
+#[test]
+fn render_includes_range_and_conditions() {
+    let state = FirewallState::default();
+    let custom = vec![CustomRule {
+        id: "id2".into(),
+        label: "games".into(),
+        transport: Transport::Udp,
+        from: 8000,
+        to: 8010,
+        source: Some("10.0.0.0/8".into()),
+        iface: Some("eth0".into()),
+        enabled: true,
+    }];
+    let out = render_ruleset(&state, &custom);
+    assert!(
+        out.contains("iifname \"eth0\" ip saddr 10.0.0.0/8 udp dport 8000-8010 accept # custom:id2"),
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn render_omits_disabled_custom() {
+    let state = FirewallState::default();
+    let custom = vec![CustomRule {
+        id: "id3".into(),
+        label: "off".into(),
+        transport: Transport::Tcp,
+        from: 9999,
+        to: 9999,
+        source: None,
+        iface: None,
+        enabled: false,
+    }];
+    let out = render_ruleset(&state, &custom);
+    assert!(!out.contains("9999"), "disabled rule must not render; got:\n{out}");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `engine/`): `cargo test -p nasty-system firewall::tests::render`
+Expected: FAIL — `CustomRule` and `render_ruleset` don't exist.
+
+- [ ] **Step 3: Add the `CustomRule` type and persistence**
+
+After the `FirewallRule` struct, add:
+
+```rust
+/// A user-managed firewall port rule (issue #620). Opens a single TCP/UDP
+/// port or a contiguous range on the host `input` chain, independent of
+/// NASty's service model. Persisted to `firewall-custom.json` and rendered
+/// into `table inet nasty` alongside the service rules.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomRule {
+    /// Engine-generated opaque id (UUID). Stable across label edits; used as
+    /// the nft comment so free-text never enters the ruleset.
+    pub id: String,
+    /// Required human label ("Plex (host mode)"). UI only.
+    pub label: String,
+    pub transport: Transport,
+    /// Low port of the range (== `to` for a single port).
+    pub from: u16,
+    /// High port of the range.
+    pub to: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iface: Option<String>,
+    pub enabled: bool,
+}
+
+const CUSTOM_PATH: &str = "/var/lib/nasty/firewall-custom.json";
+
+/// Load persisted custom rules; empty on missing/corrupt file (same
+/// tolerance as `FirewallRestrictions::load`).
+fn load_custom_rules() -> Vec<CustomRule> {
+    std::fs::read_to_string(CUSTOM_PATH)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+async fn save_custom_rules(rules: &[CustomRule]) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(rules).map_err(|e| format!("serialize: {e}"))?;
+    tokio::fs::write(CUSTOM_PATH, json)
+        .await
+        .map_err(|e| format!("write {CUSTOM_PATH}: {e}"))
+}
+```
+
+- [ ] **Step 4: Add the `custom` mutex to `FirewallService` and load it in `init`**
+
+In `struct FirewallService`, add the field:
+
+```rust
+pub struct FirewallService {
+    state: tokio::sync::Mutex<FirewallState>,
+    restrictions: tokio::sync::Mutex<FirewallRestrictions>,
+    custom: tokio::sync::Mutex<Vec<CustomRule>>,
+}
+```
+
+In `FirewallService::new()`, initialize it:
+
+```rust
+        Self {
+            state: tokio::sync::Mutex::new(FirewallState::default()),
+            restrictions: tokio::sync::Mutex::new(FirewallRestrictions::default()),
+            custom: tokio::sync::Mutex::new(Vec::new()),
+        }
+```
+
+In `init()`, after `*restrictions = FirewallRestrictions::load();`, load custom rules (respecting lock order state → restrictions → custom):
+
+```rust
+        let mut custom = self.custom.lock().await;
+        *custom = load_custom_rules();
+```
+
+- [ ] **Step 5: Extract `render_ruleset` and add the custom block; thread `custom` through `apply_nftables`**
+
+Replace the body of `apply_nftables` so the string-building becomes a pure function. Change the signature and split:
+
+```rust
+/// Generate and apply the full nftables ruleset atomically.
+async fn apply_nftables(state: &FirewallState, custom: &[CustomRule]) -> Result<(), String> {
+    let rules = render_ruleset(state, custom);
+
+    // Apply atomically: flush + load  (unchanged below)
+    let flush = Command::new("nft")
+        .args(["delete", "table", "inet", "nasty"])
+        .output()
+        .await;
+    if let Ok(o) = &flush
+        && !o.status.success()
+    {
+        let stderr = String::from_utf8_lossy(&o.stderr);
+        if !stderr.contains("No such file") && !stderr.contains("does not exist") {
+            warn!("nft delete table warning: {stderr}");
+        }
+    }
+
+    let tmp = "/tmp/nasty-firewall.nft";
+    tokio::fs::write(tmp, &rules)
+        .await
+        .map_err(|e| format!("write {tmp}: {e}"))?;
+
+    let output = Command::new("nft")
+        .args(["-f", tmp])
+        .output()
+        .await
+        .map_err(|e| format!("nft -f: {e}"))?;
+
+    let _ = tokio::fs::remove_file(tmp).await;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("nft apply failed: {stderr}"));
+    }
+    Ok(())
+}
+
+/// Build the full `table inet nasty` ruleset text from the service rules and
+/// the custom rules. Pure — no I/O — so it can be unit-tested.
+pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
+    let mut rules = String::new();
+    rules.push_str("table inet nasty {\n");
+    rules.push_str("    chain input {\n");
+    rules.push_str("        type filter hook input priority 0; policy drop;\n");
+    rules.push_str("        ct state established,related accept\n");
+    rules.push_str("        ct state invalid drop\n");
+    rules.push_str("        iif lo accept\n");
+    rules.push_str("        # ICMP/ICMPv6 — always allow\n");
+    rules.push_str("        ip protocol icmp accept\n");
+    rules.push_str("        ip6 nexthdr icmpv6 accept\n");
+    rules.push_str("        # DHCPv6 client\n");
+    rules.push_str("        udp dport 546 accept\n");
+
+    for rule in &state.rules {
+        if !rule.active {
+            continue;
+        }
+        for port in &rule.ports {
+            let proto = match port.transport {
+                Transport::Tcp => "tcp",
+                Transport::Udp => "udp",
+            };
+            let mut conditions = Vec::new();
+            if let Some(ref iface) = port.iface {
+                conditions.push(format!("iifname \"{iface}\""));
+            }
+            if let Some(ref src) = port.source {
+                conditions.push(format!("ip saddr {src}"));
+            }
+            conditions.push(format!("{proto} dport {}", port.port));
+            rules.push_str(&format!(
+                "        {} accept # {}\n",
+                conditions.join(" "),
+                rule.service
+            ));
+        }
+    }
+
+    for rule in custom {
+        if !rule.enabled {
+            continue;
+        }
+        let proto = match rule.transport {
+            Transport::Tcp => "tcp",
+            Transport::Udp => "udp",
+        };
+        let mut conditions = Vec::new();
+        if let Some(ref iface) = rule.iface {
+            conditions.push(format!("iifname \"{iface}\""));
+        }
+        if let Some(ref src) = rule.source {
+            conditions.push(format!("ip saddr {src}"));
+        }
+        if rule.from == rule.to {
+            conditions.push(format!("{proto} dport {}", rule.from));
+        } else {
+            conditions.push(format!("{proto} dport {}-{}", rule.from, rule.to));
+        }
+        rules.push_str(&format!(
+            "        {} accept # custom:{}\n",
+            conditions.join(" "),
+            rule.id
+        ));
+    }
+
+    rules.push_str("    }\n");
+    rules.push_str("}\n");
+    rules
+}
+```
+
+- [ ] **Step 6: Update every `apply_nftables` caller to pass the custom slice**
+
+Each existing caller currently locks `state` (and some `restrictions`). Add a `custom` lock (acquired last) and pass `&custom`. The seven call sites and how to fix each:
+
+- `init` (near line 262): it already holds `state` and `restrictions` and (from Step 4) `custom`. Change the call to `apply_nftables(&state, &custom).await`.
+- `open` (near line 289), `close` (near 306), `open_rdma` (near 328), `close_rdma` (near 344): each holds only `state`. Before the `apply_nftables` call add `let custom = self.custom.lock().await;` and change the call to `apply_nftables(&state, &custom).await`.
+- `set_restriction` (near line 408): holds `state` (and earlier `restrictions`, already dropped via its own block). Add `let custom = self.custom.lock().await;` before the call and change it to `apply_nftables(&state, &custom).await?`.
+- `set_service_ports` (near line 430): holds `state` and `restrictions`. Add `let custom = self.custom.lock().await;` before the call and change it to `apply_nftables(&state, &custom).await`.
+
+In every case acquire `custom` only after `state` (and `restrictions` where held) to preserve the state → restrictions → custom order.
+
+- [ ] **Step 7: Extend `FirewallStatus` and `status()`**
+
+Add the field to `FirewallStatus` (after `published_app_ports`):
+
+```rust
+    /// User-managed custom port rules (issue #620). Rendered into the
+    /// firewall alongside service rules; editable on the Firewall page.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_rules: Vec<CustomRule>,
+```
+
+In `status()`, lock `custom` (after `state` and `restrictions`) and fill it:
+
+```rust
+    pub async fn status(&self) -> FirewallStatus {
+        let state = self.state.lock().await;
+        let restrictions = self.restrictions.lock().await;
+        let custom = self.custom.lock().await;
+        FirewallStatus {
+            active: true,
+            rules: state.rules.clone(),
+            restrictions: restrictions.services.clone(),
+            interface_restrictions: restrictions.interfaces.clone(),
+            published_app_ports: Vec::new(),
+            custom_rules: custom.clone(),
+        }
+    }
+```
+
+- [ ] **Step 8: Run the render tests + full crate suite**
+
+Run (from `engine/`):
+```
+cargo test -p nasty-system firewall::tests::render
+cargo test -p nasty-system
+```
+Expected: the three new render tests pass; all existing `nasty-system` tests still pass (the `apply_nftables` signature change compiles across callers).
+
+- [ ] **Step 9: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+Expected: clean.
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/firewall.rs
+git commit -m "firewall: CustomRule type, persistence, and nft rendering"
+```
+
+---
+
+## Task 2: Validation + CRUD methods
+
+**Files:**
+- Modify: `engine/nasty-system/src/firewall.rs`
+- Test: `engine/nasty-system/src/firewall.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `CustomRule`, `FirewallState`, `Transport`, `render_ruleset`/`apply_nftables` (Task 1).
+- Produces:
+  - `pub struct CustomRuleInput { pub label: String, pub transport: Transport, pub from: u16, pub to: u16, pub source: Option<String>, pub iface: Option<String>, pub enabled: bool }` (derives `Debug, Clone, Deserialize, JsonSchema`; `enabled` uses `#[serde(default = "default_true")]`).
+  - `pub fn validate_custom_input(input: &CustomRuleInput) -> Result<(), String>` — range + label + source + iface sanitization (no state needed).
+  - `pub fn service_port_conflict(state: &FirewallState, transport: Transport, from: u16, to: u16) -> Option<String>` — returns the owning service name if the interval collides.
+  - `pub async fn add_custom_rule(&self, input: CustomRuleInput) -> Result<CustomRule, String>`
+  - `pub async fn update_custom_rule(&self, id: &str, input: CustomRuleInput) -> Result<CustomRule, String>`
+  - `pub async fn remove_custom_rule(&self, id: &str) -> Result<(), String>`
+
+- [ ] **Step 1: Write failing tests for the pure validators**
+
+Add to the `tests` module:
+
+```rust
+fn input(from: u16, to: u16, transport: Transport) -> CustomRuleInput {
+    CustomRuleInput {
+        label: "test".into(),
+        transport,
+        from,
+        to,
+        source: None,
+        iface: None,
+        enabled: true,
+    }
+}
+
+#[test]
+fn validate_rejects_bad_range_and_input() {
+    // from > to
+    assert!(validate_custom_input(&input(100, 50, Transport::Tcp)).is_err());
+    // from == 0
+    assert!(validate_custom_input(&input(0, 10, Transport::Tcp)).is_err());
+    // empty label
+    let mut i = input(80, 80, Transport::Tcp);
+    i.label = "".into();
+    assert!(validate_custom_input(&i).is_err());
+    // control char in label
+    let mut i = input(80, 80, Transport::Tcp);
+    i.label = "a\nb".into();
+    assert!(validate_custom_input(&i).is_err());
+    // bad source
+    let mut i = input(80, 80, Transport::Tcp);
+    i.source = Some("1.2.3.4 accept".into());
+    assert!(validate_custom_input(&i).is_err());
+    // bad iface
+    let mut i = input(80, 80, Transport::Tcp);
+    i.iface = Some("eth0; drop".into());
+    assert!(validate_custom_input(&i).is_err());
+    // valid: single port, valid CIDR, valid iface
+    let mut i = input(8000, 8010, Transport::Udp);
+    i.source = Some("192.168.1.0/24".into());
+    i.iface = Some("tailscale0".into());
+    assert!(validate_custom_input(&i).is_ok());
+    // valid: bare IP source
+    let mut i = input(8000, 8000, Transport::Tcp);
+    i.source = Some("10.0.0.5".into());
+    assert!(validate_custom_input(&i).is_ok());
+}
+
+#[test]
+fn service_conflict_detects_owned_ports() {
+    let mut state = FirewallState::default();
+    // SMB owns tcp/445 (active), a disabled service owns tcp/2049,
+    // transport matters.
+    state.rules.push(FirewallRule {
+        service: "smb".into(),
+        ports: vec![PortSpec { port: 445, transport: Transport::Tcp, source: None, iface: None }],
+        active: true,
+    });
+    state.rules.push(FirewallRule {
+        service: "nfs".into(),
+        ports: vec![PortSpec { port: 2049, transport: Transport::Tcp, source: None, iface: None }],
+        active: false, // disabled service still owns its port
+    });
+
+    assert_eq!(service_port_conflict(&state, Transport::Tcp, 445, 445).as_deref(), Some("smb"));
+    // range spanning the port
+    assert_eq!(service_port_conflict(&state, Transport::Tcp, 440, 450).as_deref(), Some("smb"));
+    // disabled service still conflicts
+    assert_eq!(service_port_conflict(&state, Transport::Tcp, 2049, 2049).as_deref(), Some("nfs"));
+    // transport mismatch → no conflict
+    assert_eq!(service_port_conflict(&state, Transport::Udp, 445, 445), None);
+    // free port → no conflict
+    assert_eq!(service_port_conflict(&state, Transport::Tcp, 32400, 32400), None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (from `engine/`): `cargo test -p nasty-system firewall::tests::validate firewall::tests::service_conflict`
+Expected: FAIL — `CustomRuleInput`, `validate_custom_input`, `service_port_conflict` don't exist.
+
+- [ ] **Step 3: Add `CustomRuleInput`, `default_true`, and the pure validators**
+
+```rust
+fn default_true() -> bool {
+    true
+}
+
+/// Fields a client sends to create/update a custom rule (no `id` — the
+/// engine assigns it on create and preserves it on update).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct CustomRuleInput {
+    pub label: String,
+    pub transport: Transport,
+    pub from: u16,
+    pub to: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iface: Option<String>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+/// Reject a bare IP or CIDR that isn't parseable, so nothing unsafe reaches
+/// the `ip saddr <...>` interpolation. Accepts "10.0.0.5", "10.0.0.0/8",
+/// "2001:db8::/32".
+fn valid_source(s: &str) -> bool {
+    use std::net::IpAddr;
+    let (addr, prefix) = match s.split_once('/') {
+        Some((a, p)) => (a, Some(p)),
+        None => (s, None),
+    };
+    let ip: IpAddr = match addr.parse() {
+        Ok(ip) => ip,
+        Err(_) => return false,
+    };
+    match prefix {
+        None => true,
+        Some(p) => match p.parse::<u8>() {
+            Ok(bits) => match ip {
+                IpAddr::V4(_) => bits <= 32,
+                IpAddr::V6(_) => bits <= 128,
+            },
+            Err(_) => false,
+        },
+    }
+}
+
+/// Interface names: Linux IFNAMSIZ is 16 (15 usable chars). Restrict to a
+/// safe charset so nothing breaks out of the `iifname "<...>"` string.
+fn valid_iface(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 15
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '@'))
+}
+
+/// Validate a custom-rule input independent of current firewall state:
+/// range sanity, label hygiene, and source/iface sanitization.
+pub fn validate_custom_input(input: &CustomRuleInput) -> Result<(), String> {
+    if input.from == 0 {
+        return Err("port must be ≥ 1".into());
+    }
+    if input.from > input.to {
+        return Err("range start must be ≤ range end".into());
+    }
+    let label = input.label.trim();
+    if label.is_empty() {
+        return Err("label is required".into());
+    }
+    if label.len() > 64 {
+        return Err("label must be ≤ 64 characters".into());
+    }
+    if input.label.chars().any(|c| c.is_control()) {
+        return Err("label must not contain control characters".into());
+    }
+    if let Some(src) = &input.source
+        && !valid_source(src)
+    {
+        return Err(format!("invalid source (expected an IP or CIDR): {src}"));
+    }
+    if let Some(iface) = &input.iface
+        && !valid_iface(iface)
+    {
+        return Err(format!("invalid interface name: {iface}"));
+    }
+    Ok(())
+}
+
+/// If `[from,to]` (of `transport`) intersects any port a service rule owns,
+/// return that service's name. Covers active AND inactive service rules —
+/// a disabled service still owns its port.
+pub fn service_port_conflict(
+    state: &FirewallState,
+    transport: Transport,
+    from: u16,
+    to: u16,
+) -> Option<String> {
+    for rule in &state.rules {
+        for port in &rule.ports {
+            if port.transport == transport && port.port >= from && port.port <= to {
+                return Some(rule.service.clone());
+            }
+        }
+    }
+    None
+}
+```
+
+Note: `Transport` needs `PartialEq` (it already derives `PartialEq, Eq`). `FirewallRule`/`PortSpec` fields are used directly in the test — they are already `pub`.
+
+- [ ] **Step 4: Run the validator tests to verify they pass**
+
+Run (from `engine/`): `cargo test -p nasty-system firewall::tests::validate firewall::tests::service_conflict`
+Expected: PASS.
+
+- [ ] **Step 5: Add the three CRUD methods to `FirewallService`**
+
+Add inside `impl FirewallService` (e.g. after `set_service_ports`):
+
+```rust
+    /// Create a custom port rule. Validates input + service-port collision +
+    /// exact-duplicate, persists, and rebuilds the firewall. Returns the
+    /// created rule (with its assigned id). Duplicate/collision/validation
+    /// failures return an `Err` and change nothing.
+    pub async fn add_custom_rule(&self, input: CustomRuleInput) -> Result<CustomRule, String> {
+        validate_custom_input(&input)?;
+
+        let state = self.state.lock().await;
+        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+            return Err(format!(
+                "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
+                transport_str(input.transport),
+                input.from,
+                input.to,
+            ));
+        }
+        let mut custom = self.custom.lock().await;
+        if custom.iter().any(|r| same_rule(r, &input)) {
+            return Err("an identical custom rule already exists".into());
+        }
+
+        let rule = CustomRule {
+            id: uuid::Uuid::new_v4().to_string(),
+            label: input.label.trim().to_string(),
+            transport: input.transport,
+            from: input.from,
+            to: input.to,
+            source: input.source.clone(),
+            iface: input.iface.clone(),
+            enabled: input.enabled,
+        };
+        custom.push(rule.clone());
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: added custom rule {} ({})", rule.id, rule.label);
+        Ok(rule)
+    }
+
+    /// Update an existing custom rule by id (full replace of the mutable
+    /// fields). Re-validates; the duplicate check ignores the rule itself.
+    pub async fn update_custom_rule(
+        &self,
+        id: &str,
+        input: CustomRuleInput,
+    ) -> Result<CustomRule, String> {
+        validate_custom_input(&input)?;
+
+        let state = self.state.lock().await;
+        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+            return Err(format!(
+                "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
+                transport_str(input.transport),
+                input.from,
+                input.to,
+            ));
+        }
+        let mut custom = self.custom.lock().await;
+        if custom.iter().any(|r| r.id != id && same_rule(r, &input)) {
+            return Err("an identical custom rule already exists".into());
+        }
+        let Some(rule) = custom.iter_mut().find(|r| r.id == id) else {
+            return Err(format!("custom rule not found: {id}"));
+        };
+        rule.label = input.label.trim().to_string();
+        rule.transport = input.transport;
+        rule.from = input.from;
+        rule.to = input.to;
+        rule.source = input.source.clone();
+        rule.iface = input.iface.clone();
+        rule.enabled = input.enabled;
+        let updated = rule.clone();
+
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: updated custom rule {id}");
+        Ok(updated)
+    }
+
+    /// Remove a custom rule by id and rebuild the firewall. No-op error if the
+    /// id is unknown.
+    pub async fn remove_custom_rule(&self, id: &str) -> Result<(), String> {
+        let state = self.state.lock().await;
+        let mut custom = self.custom.lock().await;
+        let before = custom.len();
+        custom.retain(|r| r.id != id);
+        if custom.len() == before {
+            return Err(format!("custom rule not found: {id}"));
+        }
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: removed custom rule {id}");
+        Ok(())
+    }
+```
+
+Add the two small helpers near the other free functions:
+
+```rust
+fn transport_str(t: Transport) -> &'static str {
+    match t {
+        Transport::Tcp => "tcp",
+        Transport::Udp => "udp",
+    }
+}
+
+/// True when an existing rule is an exact duplicate of the input
+/// (transport + range + source + iface). Label and enabled are ignored.
+fn same_rule(r: &CustomRule, input: &CustomRuleInput) -> bool {
+    r.transport == input.transport
+        && r.from == input.from
+        && r.to == input.to
+        && r.source == input.source
+        && r.iface == input.iface
+}
+```
+
+- [ ] **Step 6: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test -p nasty-system`
+Expected: clean; all validator tests pass.
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/firewall.rs
+git commit -m "firewall: custom-rule validation and add/update/remove"
+```
+
+---
+
+## Task 3: Router arms + registry + Docker-overlap warning
+
+**Files:**
+- Modify: `engine/nasty-engine/src/router/system.rs`
+- Modify: `engine/nasty-engine/src/registry/methods.rs`
+- Test: `engine/nasty-engine/src/router/system.rs` (`#[cfg(test)] mod tests`) — for the pure warning helper.
+
+**Interfaces:**
+- Consumes: `FirewallService::{add_custom_rule, update_custom_rule, remove_custom_rule}` and `CustomRuleInput`/`CustomRule` (Task 2); `PublishedAppPort` (existing); router helpers `parse_params`, `ok`, `err`, `require_str`.
+- Produces: `system.firewall.custom.{add,update,remove}` RPCs; `fn docker_overlap_warnings(rule: &CustomRule, published: &[PublishedAppPort]) -> Vec<String>`.
+
+- [ ] **Step 1: Write a failing test for the warning helper**
+
+Add to a `#[cfg(test)] mod tests` at the bottom of `engine/nasty-engine/src/router/system.rs` (create the module if absent):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::docker_overlap_warnings;
+    use nasty_system::firewall::{CustomRule, PublishedAppPort, Transport};
+
+    fn rule(from: u16, to: u16, transport: Transport) -> CustomRule {
+        CustomRule {
+            id: "id".into(),
+            label: "l".into(),
+            transport,
+            from,
+            to,
+            source: None,
+            iface: None,
+            enabled: true,
+        }
+    }
+
+    fn pub_port(host: u16, transport: &str, app: &str) -> PublishedAppPort {
+        PublishedAppPort {
+            app: app.into(),
+            host_port: host,
+            container_port: host,
+            transport: transport.into(),
+        }
+    }
+
+    #[test]
+    fn warns_on_tcp_overlap() {
+        let w = docker_overlap_warnings(&rule(8080, 8080, Transport::Tcp), &[pub_port(8080, "tcp", "nginx")]);
+        assert_eq!(w.len(), 1);
+        assert!(w[0].contains("nginx"), "got: {:?}", w);
+    }
+
+    #[test]
+    fn no_warn_on_transport_or_port_mismatch() {
+        assert!(docker_overlap_warnings(&rule(8080, 8080, Transport::Tcp), &[pub_port(8080, "udp", "x")]).is_empty());
+        assert!(docker_overlap_warnings(&rule(8080, 8080, Transport::Tcp), &[pub_port(9090, "tcp", "x")]).is_empty());
+    }
+
+    #[test]
+    fn warns_for_each_app_in_range() {
+        let w = docker_overlap_warnings(
+            &rule(8000, 8100, Transport::Tcp),
+            &[pub_port(8080, "tcp", "a"), pub_port(8090, "tcp", "b")],
+        );
+        assert_eq!(w.len(), 2);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (from `engine/`): `cargo test -p nasty-engine docker_overlap`
+Expected: FAIL — `docker_overlap_warnings` doesn't exist.
+
+- [ ] **Step 3: Add the warning helper**
+
+Add near the other helpers in `engine/nasty-engine/src/router/system.rs` (module-level `pub(crate) fn` so the test can reach it):
+
+```rust
+/// Warnings (never errors) for a custom rule that overlaps a Docker-published
+/// host port. Bridge apps publish past the firewall, so the rule is redundant
+/// — surfaced so the operator doesn't think the port was closed.
+pub(crate) fn docker_overlap_warnings(
+    rule: &nasty_system::firewall::CustomRule,
+    published: &[nasty_system::firewall::PublishedAppPort],
+) -> Vec<String> {
+    use nasty_system::firewall::Transport;
+    let proto = match rule.transport {
+        Transport::Tcp => "tcp",
+        Transport::Udp => "udp",
+    };
+    published
+        .iter()
+        .filter(|p| p.transport == proto && p.host_port >= rule.from && p.host_port <= rule.to)
+        .map(|p| {
+            format!(
+                "{}/{} is already reachable via app '{}' (bridge apps publish past the firewall)",
+                proto, p.host_port, p.app
+            )
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run to verify the helper tests pass**
+
+Run (from `engine/`): `cargo test -p nasty-engine docker_overlap`
+Expected: PASS.
+
+- [ ] **Step 5: Add the router arms**
+
+First add a params struct near the top of `system.rs` (next to other `Deserialize` param structs):
+
+```rust
+#[derive(serde::Deserialize)]
+struct CustomRuleUpdateParams {
+    id: String,
+    #[serde(flatten)]
+    input: nasty_system::firewall::CustomRuleInput,
+}
+```
+
+Add a small helper to gather current published ports (mirrors the `system.firewall.status` arm) so `add`/`update` can compute warnings:
+
+```rust
+async fn published_ports(state: &AppState) -> Vec<nasty_system::firewall::PublishedAppPort> {
+    match state.apps.list().await {
+        Ok(apps) => apps
+            .iter()
+            .flat_map(|app| {
+                app.ports.iter().map(move |p| nasty_system::firewall::PublishedAppPort {
+                    app: app.name.clone(),
+                    host_port: p.host_port,
+                    container_port: p.container_port,
+                    transport: p.protocol.clone(),
+                })
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+```
+
+Add the three arms alongside `system.firewall.restrict`:
+
+```rust
+        "system.firewall.custom.add" => {
+            match parse_params::<nasty_system::firewall::CustomRuleInput>(req) {
+                Ok(input) => match state.firewall.add_custom_rule(input).await {
+                    Ok(rule) => {
+                        let warnings = docker_overlap_warnings(&rule, &published_ports(state).await);
+                        ok(req, serde_json::json!({ "rule": rule, "warnings": warnings }))
+                    }
+                    Err(e) => err(req, e),
+                },
+                Err(e) => err(req, e),
+            }
+        }
+        "system.firewall.custom.update" => match parse_params::<CustomRuleUpdateParams>(req) {
+            Ok(p) => match state.firewall.update_custom_rule(&p.id, p.input).await {
+                Ok(rule) => {
+                    let warnings = docker_overlap_warnings(&rule, &published_ports(state).await);
+                    ok(req, serde_json::json!({ "rule": rule, "warnings": warnings }))
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => err(req, e),
+        },
+        "system.firewall.custom.remove" => match require_str(req, "id") {
+            Ok(id) => match state.firewall.remove_custom_rule(id).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+```
+
+Note: confirm `parse_params`, `ok`, `err`, `require_str` are in scope in `system.rs` (they are used by the existing `system.firewall.*` arms — reuse the same imports).
+
+- [ ] **Step 6: Register the three methods (Admin)**
+
+In `engine/nasty-engine/src/registry/methods.rs`, after the `system.firewall.restrict` entry, add:
+
+```rust
+                Method {
+                    name: "system.firewall.custom.add",
+                    desc: "Open a user-managed TCP/UDP port or contiguous range on the host firewall (issue #620). Rejects ports a NASty service owns; returns { rule, warnings } where warnings flag overlap with a Docker-published port (allowed but redundant).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<nasty_system::firewall::CustomRuleInput>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "system.firewall.custom.update",
+                    desc: "Update a custom firewall port rule by id (full replace of its fields, including the enable/disable toggle). Same validation and { rule, warnings } response as add.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "required": ["id", "label", "transport", "from", "to"],
+                        "properties": {
+                            "id": { "type": "string", "description": "Custom rule id." },
+                            "label": { "type": "string", "description": "Required human label." },
+                            "transport": { "type": "string", "enum": ["tcp", "udp"] },
+                            "from": { "type": "integer", "description": "Low port (1–65535)." },
+                            "to": { "type": "integer", "description": "High port; equals from for a single port." },
+                            "source": { "type": "string", "description": "Optional source IP/CIDR." },
+                            "iface": { "type": "string", "description": "Optional interface name." },
+                            "enabled": { "type": "boolean", "description": "Whether the rule is rendered into nft." }
+                        }
+                    })),
+                    result: None,
+                },
+                Method {
+                    name: "system.firewall.custom.remove",
+                    desc: "Remove a user-managed custom firewall port rule by id and rebuild the nftables ruleset.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("id", "Custom rule id.")),
+                    result: None,
+                },
+```
+
+Confirm `ad_hoc_one` and `gen_schema` are already used in this file (they are, by neighboring entries).
+
+- [ ] **Step 7: Build + registry tests**
+
+Run (from `engine/`):
+```
+cargo build -p nasty-engine
+cargo test -p nasty-engine
+```
+Expected: builds; registry tests (translation/no-collision, builds-without-panic) pass. `system.firewall.custom.*` default to POST verb via the suffix translator (no `.get`/`.list` suffix) — no paths.rs change needed. The registry-role↔allowlist guard test (`operator_role_methods_are_operator_allowed`) is unaffected: these are Admin-role.
+
+- [ ] **Step 8: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+Expected: clean.
+
+```bash
+cd engine && cargo fmt
+git add nasty-engine/src/router/system.rs nasty-engine/src/registry/methods.rs
+git commit -m "firewall: wire system.firewall.custom.* RPCs with Docker-overlap warnings"
+```
+
+---
+
+## Task 4: WebUI — custom port rules section
+
+**Files:**
+- Modify: `webui/src/lib/types.ts`
+- Modify: `webui/src/routes/firewall/+page.svelte`
+
+**Interfaces:**
+- Consumes: `system.firewall.status` (now returns `custom_rules`); `system.firewall.custom.{add,update,remove}` (`{ rule, warnings }` for add/update); `networkState.interfaces` (existing iface source).
+- Produces: the Custom port rules UI.
+
+- [ ] **Step 1: Update the TypeScript types**
+
+In `webui/src/lib/types.ts`, add the `CustomRule` interface near `FirewallStatus`:
+
+```ts
+export interface CustomRule {
+	id: string;
+	label: string;
+	transport: 'tcp' | 'udp';
+	from: number;
+	to: number;
+	source?: string | null;
+	iface?: string | null;
+	enabled: boolean;
+}
+```
+
+Add the field to `FirewallStatus` (after `published_app_ports`):
+
+```ts
+	custom_rules?: CustomRule[];
+```
+
+- [ ] **Step 2: Type-check the WebUI (types compile before UI wiring)**
+
+Run (from `webui/`): `npm run check`
+Expected: no new type errors.
+
+- [ ] **Step 3: Add the custom-rules script state + handlers**
+
+In `webui/src/routes/firewall/+page.svelte`'s `<script>`, extend the import and add state + functions:
+
+```ts
+	import type { FirewallStatus, NetworkState, PublishedAppPort, CustomRule } from '$lib/types';
+```
+
+```ts
+	// Custom port rules (#620)
+	let showAddCustom = $state(false);
+	let editCustomId: string | null = $state(null);
+	let cLabel = $state('');
+	let cTransport: 'tcp' | 'udp' = $state('tcp');
+	let cFrom = $state('');
+	let cTo = $state('');
+	let cSource = $state('');
+	let cIface = $state('');
+	let cEnabled = $state(true);
+
+	function resetCustomForm() {
+		showAddCustom = false;
+		editCustomId = null;
+		cLabel = ''; cTransport = 'tcp'; cFrom = ''; cTo = '';
+		cSource = ''; cIface = ''; cEnabled = true;
+	}
+
+	function startAddCustom() {
+		resetCustomForm();
+		showAddCustom = true;
+	}
+
+	function startEditCustom(r: CustomRule) {
+		editCustomId = r.id;
+		showAddCustom = true;
+		cLabel = r.label;
+		cTransport = r.transport;
+		cFrom = String(r.from);
+		cTo = r.to === r.from ? '' : String(r.to);
+		cSource = r.source ?? '';
+		cIface = r.iface ?? '';
+		cEnabled = r.enabled;
+	}
+
+	async function saveCustom() {
+		const from = parseInt(cFrom, 10);
+		const to = cTo.trim() ? parseInt(cTo, 10) : from;
+		const params: Record<string, unknown> = {
+			label: cLabel.trim(),
+			transport: cTransport,
+			from,
+			to,
+			enabled: cEnabled,
+		};
+		if (cSource.trim()) params.source = cSource.trim();
+		if (cIface.trim()) params.iface = cIface.trim();
+		if (editCustomId) params.id = editCustomId;
+
+		const method = editCustomId ? 'system.firewall.custom.update' : 'system.firewall.custom.add';
+		const res = await withToast(
+			() => client.call<{ rule: CustomRule; warnings: string[] }>(method, params),
+			editCustomId ? 'Custom rule updated' : 'Custom rule added',
+		);
+		if (!res) return;
+		for (const w of res.warnings ?? []) {
+			await withToast(() => Promise.resolve(null), w);
+		}
+		resetCustomForm();
+		await loadFirewall();
+	}
+
+	async function toggleCustom(r: CustomRule) {
+		await withToast(
+			() => client.call('system.firewall.custom.update', {
+				id: r.id, label: r.label, transport: r.transport,
+				from: r.from, to: r.to,
+				...(r.source ? { source: r.source } : {}),
+				...(r.iface ? { iface: r.iface } : {}),
+				enabled: !r.enabled,
+			}),
+			r.enabled ? 'Rule disabled' : 'Rule enabled',
+		);
+		await loadFirewall();
+	}
+
+	async function removeCustom(r: CustomRule) {
+		await withToast(
+			() => client.call('system.firewall.custom.remove', { id: r.id }),
+			'Custom rule removed',
+		);
+		await loadFirewall();
+	}
+```
+
+Note: match the page's actual `withToast` usage for surfacing warnings — if the codebase has a dedicated non-error notice/toast API, use that instead of the `Promise.resolve` shim above; the requirement is only that each warning string is shown non-blocking. Confirm the exact `withToast` signature in this file before finalizing.
+
+- [ ] **Step 4: Add the Custom port rules section markup**
+
+After the existing service-rules `<section>` (and any published-app-ports section) in `webui/src/routes/firewall/+page.svelte`, add a section. Match the page's existing styling/classes (border/section pattern seen in the service-rules block):
+
+```svelte
+	<section class="mt-4 rounded-lg border border-border p-5">
+		<div class="flex items-center justify-between">
+			<div>
+				<h2 class="text-sm font-semibold">Custom port rules</h2>
+				<p class="text-xs text-muted-foreground mt-0.5">
+					Open a port for something running directly on the host (e.g. a
+					<code>network_mode: host</code> app). Bridge-networked apps don't need a rule —
+					their published ports (listed above) already bypass the firewall.
+				</p>
+			</div>
+			<Button size="xs" onclick={startAddCustom}>Add rule</Button>
+		</div>
+
+		{#if firewallStatus?.custom_rules?.length}
+			<div class="mt-3 space-y-1">
+				{#each firewallStatus.custom_rules as r}
+					<div class="flex items-center gap-3 rounded px-3 py-2 text-sm hover:bg-muted/30 {r.enabled ? '' : 'opacity-40'}">
+						<span class="h-2 w-2 rounded-full shrink-0 {r.enabled ? 'bg-green-400' : 'bg-muted-foreground'}"></span>
+						<span class="font-medium w-40 truncate">{r.label}</span>
+						<span class="font-mono text-xs text-muted-foreground">
+							{r.from === r.to ? r.from : `${r.from}-${r.to}`}/{r.transport}
+						</span>
+						{#if r.source}<span class="text-xs text-amber-400">{r.source}</span>{/if}
+						{#if r.iface}<span class="text-xs text-blue-400">{r.iface}</span>{/if}
+						<div class="ml-auto flex items-center gap-2">
+							<Button size="xs" variant="secondary" onclick={() => toggleCustom(r)}>{r.enabled ? 'Disable' : 'Enable'}</Button>
+							<Button size="xs" variant="secondary" onclick={() => startEditCustom(r)}>Edit</Button>
+							<Button size="xs" variant="secondary" onclick={() => removeCustom(r)}>Delete</Button>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{:else}
+			<p class="mt-3 text-xs text-muted-foreground">No custom rules.</p>
+		{/if}
+
+		{#if showAddCustom}
+			<div class="mt-3 rounded-lg border border-border bg-secondary/20 p-3 space-y-3">
+				<div class="text-xs font-medium">{editCustomId ? 'Edit rule' : 'New rule'}</div>
+				<input class="w-full rounded border border-border bg-background px-2 py-1 text-sm" placeholder="Label (e.g. Plex host mode)" bind:value={cLabel} />
+				<div class="flex gap-2">
+					<select class="rounded border border-border bg-background px-2 py-1 text-sm" bind:value={cTransport}>
+						<option value="tcp">TCP</option>
+						<option value="udp">UDP</option>
+					</select>
+					<input class="w-24 rounded border border-border bg-background px-2 py-1 text-sm" placeholder="Port" bind:value={cFrom} />
+					<input class="w-24 rounded border border-border bg-background px-2 py-1 text-sm" placeholder="to (opt)" bind:value={cTo} />
+				</div>
+				<input class="w-full rounded border border-border bg-background px-2 py-1 text-sm" placeholder="Source IP/CIDR (optional)" bind:value={cSource} />
+				{#if networkState}
+					<select class="w-full rounded border border-border bg-background px-2 py-1 text-sm" bind:value={cIface}>
+						<option value="">Any interface</option>
+						{#each networkState.interfaces as iface}
+							<option value={iface.name}>{iface.name}</option>
+						{/each}
+					</select>
+				{/if}
+				<label class="flex items-center gap-2 text-sm">
+					<input type="checkbox" bind:checked={cEnabled} /> Enabled
+				</label>
+				<div class="flex justify-end gap-2">
+					<Button size="sm" variant="secondary" onclick={resetCustomForm}>Cancel</Button>
+					<Button size="sm" onclick={saveCustom}>{editCustomId ? 'Save' : 'Add'}</Button>
+				</div>
+			</div>
+		{/if}
+	</section>
+```
+
+(Match the actual component imports/classes the page already uses — if `Button` variants/sizes differ, mirror the service-rules block. Use the same interface list source `networkState.interfaces` the restrict editor uses.)
+
+- [ ] **Step 5: Type-check and test the WebUI**
+
+Run (from `webui/`):
+```
+npm run check
+npm test
+```
+Expected: no type errors; existing tests pass. (No new WebUI unit test is required — the Firewall page has no component-test harness for these sections; the flow is validated end-to-end against a real engine.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add webui/src/lib/types.ts webui/src/routes/firewall/+page.svelte
+git commit -m "webui: custom port rules section on the Firewall page"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (checked against `docs/firewall-custom-rules.md`):
+- Single port or contiguous range, persisted, rendered into `table inet nasty` → Task 1.
+- Source/interface restrictions → carried on `CustomRule`, rendered in Task 1, validated in Task 2.
+- Enable/disable toggle + required label → `enabled`/`label` fields (Task 1), toggle via update (Tasks 2–4).
+- Refuse service-owned ports (active + inactive + portal, transport-matched) → `service_port_conflict` (Task 2).
+- Refuse exact duplicate, allow overlapping custom ranges → `same_rule` (Task 2).
+- Allow + warn on Docker overlap, computed at router → `docker_overlap_warnings` (Task 3).
+- Input sanitization (CIDR/IP, iface charset, control-char-free label; id in nft comment) → Task 2 validators + Task 1 render uses `id`.
+- Admin role, no allowlist entry, guard test unaffected → Task 3.
+- Interface disappearance naturally fail-closed via `iifname` → no task needed; the render test asserts `iifname "<iface>"` is emitted (Task 1 range test).
+- Status exposes `custom_rules` → Task 1.
+- WebUI section + guidance copy heading off the #591 redundant-rule trap → Task 4.
+- Lock order state → restrictions → custom → Tasks 1–2.
+
+**Placeholder scan:** No TBD/TODO. Two "confirm the exact signature/classes in this file" notes (Task 3 Step 5 helper imports; Task 4 `withToast`/`Button` conventions) are guardrails against drift from real code, each with the concrete thing to check — not deferred work.
+
+**Type consistency:** `CustomRule`, `CustomRuleInput`, `render_ruleset`, `service_port_conflict`, `validate_custom_input`, `same_rule`, `transport_str`, `add_custom_rule`/`update_custom_rule`/`remove_custom_rule`, `docker_overlap_warnings` are named identically across defining and consuming tasks. `{ rule, warnings }` response shape matches between Task 3 (engine) and Task 4 (WebUI call sites). `CustomRule` fields match between Rust (Task 1) and TS (Task 4): `id, label, transport('tcp'|'udp'), from, to, source?, iface?, enabled`. The `enabled` default (`true`) is in `CustomRuleInput` (Rust) and defaulted by the WebUI form state.

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1753,6 +1753,42 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     })),
                     result: None,
                 },
+                Method {
+                    name: "system.firewall.custom.add",
+                    desc: "Open a user-managed TCP/UDP port or contiguous range on the host firewall (issue #620). Rejects ports a NASty service owns; returns { rule, warnings } where warnings flag overlap with a Docker-published port (allowed but redundant).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<
+                        nasty_system::firewall::CustomRuleInput,
+                    >(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "system.firewall.custom.update",
+                    desc: "Update a custom firewall port rule by id (full replace of its fields, including the enable/disable toggle). Same validation and { rule, warnings } response as add.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "required": ["id", "label", "transport", "from", "to"],
+                        "properties": {
+                            "id": { "type": "string", "description": "Custom rule id." },
+                            "label": { "type": "string", "description": "Required human label." },
+                            "transport": { "type": "string", "enum": ["tcp", "udp"] },
+                            "from": { "type": "integer", "description": "Low port (1–65535)." },
+                            "to": { "type": "integer", "description": "High port; equals from for a single port." },
+                            "source": { "type": "string", "description": "Optional source IP/CIDR." },
+                            "iface": { "type": "string", "description": "Optional interface name." },
+                            "enabled": { "type": "boolean", "description": "Whether the rule is rendered into nft." }
+                        }
+                    })),
+                    result: None,
+                },
+                Method {
+                    name: "system.firewall.custom.remove",
+                    desc: "Remove a user-managed custom firewall port rule by id and rebuild the nftables ruleset.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("id", "Custom rule id.")),
+                    result: None,
+                },
             ],
         ),
         // ── System Update (release channel) ──────────────────────────────

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1768,7 +1768,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Admin,
                     params: MethodParams::AdHoc(serde_json::json!({
                         "type": "object",
-                        "required": ["id", "label", "transport", "from", "to"],
+                        "required": ["id", "label", "transport", "from", "to", "enabled"],
                         "properties": {
                             "id": { "type": "string", "description": "Custom rule id." },
                             "label": { "type": "string", "description": "Required human label." },

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -11,6 +11,59 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+#[derive(serde::Deserialize)]
+struct CustomRuleUpdateParams {
+    id: String,
+    #[serde(flatten)]
+    input: nasty_system::firewall::CustomRuleInput,
+}
+
+/// Warnings (never errors) for a custom rule that overlaps a Docker-published
+/// host port. Bridge apps publish past the firewall, so the rule is redundant
+/// — surfaced so the operator doesn't think the port was closed.
+pub(crate) fn docker_overlap_warnings(
+    rule: &nasty_system::firewall::CustomRule,
+    published: &[nasty_system::firewall::PublishedAppPort],
+) -> Vec<String> {
+    use nasty_system::firewall::Transport;
+    let proto = match rule.transport {
+        Transport::Tcp => "tcp",
+        Transport::Udp => "udp",
+    };
+    published
+        .iter()
+        .filter(|p| p.transport == proto && p.host_port >= rule.from && p.host_port <= rule.to)
+        .map(|p| {
+            format!(
+                "{}/{} is already reachable via app '{}' (bridge apps publish past the firewall)",
+                proto, p.host_port, p.app
+            )
+        })
+        .collect()
+}
+
+/// Gather the host ports currently published by Docker apps (mirrors
+/// `system.firewall.status`) so `custom.add`/`custom.update` can compute
+/// overlap warnings.
+async fn published_ports(state: &AppState) -> Vec<nasty_system::firewall::PublishedAppPort> {
+    match state.apps.list().await {
+        Ok(apps) => apps
+            .iter()
+            .flat_map(|app| {
+                app.ports
+                    .iter()
+                    .map(move |p| nasty_system::firewall::PublishedAppPort {
+                        app: app.name.clone(),
+                        host_port: p.host_port,
+                        container_port: p.container_port,
+                        transport: p.protocol.clone(),
+                    })
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
@@ -816,6 +869,42 @@ pub(super) async fn try_route(
                 Err(e) => err(req, e),
             }
         }
+        "system.firewall.custom.add" => {
+            match parse_params::<nasty_system::firewall::CustomRuleInput>(req) {
+                Ok(input) => match state.firewall.add_custom_rule(input).await {
+                    Ok(rule) => {
+                        let warnings =
+                            docker_overlap_warnings(&rule, &published_ports(state).await);
+                        ok(
+                            req,
+                            serde_json::json!({ "rule": rule, "warnings": warnings }),
+                        )
+                    }
+                    Err(e) => err(req, e),
+                },
+                Err(e) => err(req, e),
+            }
+        }
+        "system.firewall.custom.update" => match parse_params::<CustomRuleUpdateParams>(req) {
+            Ok(p) => match state.firewall.update_custom_rule(&p.id, p.input).await {
+                Ok(rule) => {
+                    let warnings = docker_overlap_warnings(&rule, &published_ports(state).await);
+                    ok(
+                        req,
+                        serde_json::json!({ "rule": rule, "warnings": warnings }),
+                    )
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => err(req, e),
+        },
+        "system.firewall.custom.remove" => match require_str(req, "id") {
+            Ok(id) => match state.firewall.remove_custom_rule(id).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
         _ => return None,
     })
 }
@@ -1043,5 +1132,70 @@ fn human_bytes(b: u64) -> String {
         format!("{b} B")
     } else {
         format!("{v:.1} {}", U[i])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::docker_overlap_warnings;
+    use nasty_system::firewall::{CustomRule, PublishedAppPort, Transport};
+
+    fn rule(from: u16, to: u16, transport: Transport) -> CustomRule {
+        CustomRule {
+            id: "id".into(),
+            label: "l".into(),
+            transport,
+            from,
+            to,
+            source: None,
+            iface: None,
+            enabled: true,
+        }
+    }
+
+    fn pub_port(host: u16, transport: &str, app: &str) -> PublishedAppPort {
+        PublishedAppPort {
+            app: app.into(),
+            host_port: host,
+            container_port: host,
+            transport: transport.into(),
+        }
+    }
+
+    #[test]
+    fn warns_on_tcp_overlap() {
+        let w = docker_overlap_warnings(
+            &rule(8080, 8080, Transport::Tcp),
+            &[pub_port(8080, "tcp", "nginx")],
+        );
+        assert_eq!(w.len(), 1);
+        assert!(w[0].contains("nginx"), "got: {:?}", w);
+    }
+
+    #[test]
+    fn no_warn_on_transport_or_port_mismatch() {
+        assert!(
+            docker_overlap_warnings(
+                &rule(8080, 8080, Transport::Tcp),
+                &[pub_port(8080, "udp", "x")]
+            )
+            .is_empty()
+        );
+        assert!(
+            docker_overlap_warnings(
+                &rule(8080, 8080, Transport::Tcp),
+                &[pub_port(9090, "tcp", "x")]
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn warns_for_each_app_in_range() {
+        let w = docker_overlap_warnings(
+            &rule(8000, 8100, Transport::Tcp),
+            &[pub_port(8080, "tcp", "a"), pub_port(8090, "tcp", "b")],
+        );
+        assert_eq!(w.len(), 2);
     }
 }

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -837,6 +837,18 @@ async fn apply_nftables(state: &FirewallState, custom: &[CustomRule]) -> Result<
     Ok(())
 }
 
+/// nft source-address clause with the correct family: `ip6 saddr` for an
+/// IPv6 source, `ip saddr` for IPv4. `src` may be a bare address or CIDR;
+/// the family is decided by the address part. Defaults to `ip saddr` if the
+/// address part doesn't parse (renderer is downstream of validation).
+fn saddr_clause(src: &str) -> String {
+    let addr = src.split('/').next().unwrap_or(src);
+    match addr.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V6(_)) => format!("ip6 saddr {src}"),
+        _ => format!("ip saddr {src}"),
+    }
+}
+
 /// Build the full `table inet nasty` ruleset text from the service rules and
 /// the custom rules. Pure — no I/O — so it can be unit-tested.
 pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
@@ -867,7 +879,7 @@ pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
                 conditions.push(format!("iifname \"{iface}\""));
             }
             if let Some(ref src) = port.source {
-                conditions.push(format!("ip saddr {src}"));
+                conditions.push(saddr_clause(src));
             }
             conditions.push(format!("{proto} dport {}", port.port));
             rules.push_str(&format!(
@@ -891,7 +903,7 @@ pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
             conditions.push(format!("iifname \"{iface}\""));
         }
         if let Some(ref src) = rule.source {
-            conditions.push(format!("ip saddr {src}"));
+            conditions.push(saddr_clause(src));
         }
         if rule.from == rule.to {
             conditions.push(format!("{proto} dport {}", rule.from));
@@ -1134,6 +1146,36 @@ mod tests {
                 "iifname \"eth0\" ip saddr 10.0.0.0/8 udp dport 8000-8010 accept # custom:id2"
             ),
             "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn render_uses_ip6_saddr_for_ipv6_custom_source() {
+        // Regression for the fail-open bug: `ip saddr <ipv6>` is a family
+        // mismatch that fails `nft -f` at load time. Because apply_nftables
+        // deletes `table inet nasty` before reloading, a failed load leaves
+        // the host with NO firewall table at all — policy-drop and every
+        // service rule gone, fail-open. The renderer must pick `ip6 saddr`
+        // for IPv6 sources.
+        let state = FirewallState::default();
+        let custom = vec![CustomRule {
+            id: "id4".into(),
+            label: "v6-restricted".into(),
+            transport: Transport::Tcp,
+            from: 51820,
+            to: 51820,
+            source: Some("2001:db8::/32".into()),
+            iface: None,
+            enabled: true,
+        }];
+        let out = render_ruleset(&state, &custom);
+        assert!(
+            out.contains("ip6 saddr 2001:db8::/32 tcp dport 51820 accept # custom:id4"),
+            "got:\n{out}"
+        );
+        assert!(
+            !out.contains("ip saddr 2001"),
+            "must not emit the IPv4 family clause for an IPv6 source; got:\n{out}"
         );
     }
 

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -136,14 +136,116 @@ fn load_custom_rules() -> Vec<CustomRule> {
         .unwrap_or_default()
 }
 
-// Unused until a later task (#620) adds the API surface that mutates
-// custom rules (add/edit/delete/enable/disable) and persists them.
-#[allow(dead_code)]
 async fn save_custom_rules(rules: &[CustomRule]) -> Result<(), String> {
     let json = serde_json::to_string_pretty(rules).map_err(|e| format!("serialize: {e}"))?;
     tokio::fs::write(CUSTOM_PATH, json)
         .await
         .map_err(|e| format!("write {CUSTOM_PATH}: {e}"))
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Fields a client sends to create/update a custom rule (no `id` — the
+/// engine assigns it on create and preserves it on update).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct CustomRuleInput {
+    pub label: String,
+    pub transport: Transport,
+    pub from: u16,
+    pub to: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iface: Option<String>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+/// Reject a bare IP or CIDR that isn't parseable, so nothing unsafe reaches
+/// the `ip saddr <...>` interpolation. Accepts "10.0.0.5", "10.0.0.0/8",
+/// "2001:db8::/32".
+fn valid_source(s: &str) -> bool {
+    use std::net::IpAddr;
+    let (addr, prefix) = match s.split_once('/') {
+        Some((a, p)) => (a, Some(p)),
+        None => (s, None),
+    };
+    let ip: IpAddr = match addr.parse() {
+        Ok(ip) => ip,
+        Err(_) => return false,
+    };
+    match prefix {
+        None => true,
+        Some(p) => match p.parse::<u8>() {
+            Ok(bits) => match ip {
+                IpAddr::V4(_) => bits <= 32,
+                IpAddr::V6(_) => bits <= 128,
+            },
+            Err(_) => false,
+        },
+    }
+}
+
+/// Interface names: Linux IFNAMSIZ is 16 (15 usable chars). Restrict to a
+/// safe charset so nothing breaks out of the `iifname "<...>"` string.
+fn valid_iface(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 15
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '@'))
+}
+
+/// Validate a custom-rule input independent of current firewall state:
+/// range sanity, label hygiene, and source/iface sanitization.
+pub fn validate_custom_input(input: &CustomRuleInput) -> Result<(), String> {
+    if input.from == 0 {
+        return Err("port must be ≥ 1".into());
+    }
+    if input.from > input.to {
+        return Err("range start must be ≤ range end".into());
+    }
+    let label = input.label.trim();
+    if label.is_empty() {
+        return Err("label is required".into());
+    }
+    if label.len() > 64 {
+        return Err("label must be ≤ 64 characters".into());
+    }
+    if input.label.chars().any(|c| c.is_control()) {
+        return Err("label must not contain control characters".into());
+    }
+    if let Some(src) = &input.source
+        && !valid_source(src)
+    {
+        return Err(format!("invalid source (expected an IP or CIDR): {src}"));
+    }
+    if let Some(iface) = &input.iface
+        && !valid_iface(iface)
+    {
+        return Err(format!("invalid interface name: {iface}"));
+    }
+    Ok(())
+}
+
+/// If `[from,to]` (of `transport`) intersects any port a service rule owns,
+/// return that service's name. Covers active AND inactive service rules —
+/// a disabled service still owns its port.
+pub fn service_port_conflict(
+    state: &FirewallState,
+    transport: Transport,
+    from: u16,
+    to: u16,
+) -> Option<String> {
+    for rule in &state.rules {
+        for port in &rule.ports {
+            if port.transport == transport && port.port >= from && port.port <= to {
+                return Some(rule.service.clone());
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -493,6 +595,100 @@ impl FirewallService {
             info!("Firewall: updated ports for {}", proto.name());
         }
     }
+
+    /// Create a custom port rule. Validates input + service-port collision +
+    /// exact-duplicate, persists, and rebuilds the firewall. Returns the
+    /// created rule (with its assigned id). Duplicate/collision/validation
+    /// failures return an `Err` and change nothing.
+    pub async fn add_custom_rule(&self, input: CustomRuleInput) -> Result<CustomRule, String> {
+        validate_custom_input(&input)?;
+
+        let state = self.state.lock().await;
+        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+            return Err(format!(
+                "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
+                transport_str(input.transport),
+                input.from,
+                input.to,
+            ));
+        }
+        let mut custom = self.custom.lock().await;
+        if custom.iter().any(|r| same_rule(r, &input)) {
+            return Err("an identical custom rule already exists".into());
+        }
+
+        let rule = CustomRule {
+            id: uuid::Uuid::new_v4().to_string(),
+            label: input.label.trim().to_string(),
+            transport: input.transport,
+            from: input.from,
+            to: input.to,
+            source: input.source.clone(),
+            iface: input.iface.clone(),
+            enabled: input.enabled,
+        };
+        custom.push(rule.clone());
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: added custom rule {} ({})", rule.id, rule.label);
+        Ok(rule)
+    }
+
+    /// Update an existing custom rule by id (full replace of the mutable
+    /// fields). Re-validates; the duplicate check ignores the rule itself.
+    pub async fn update_custom_rule(
+        &self,
+        id: &str,
+        input: CustomRuleInput,
+    ) -> Result<CustomRule, String> {
+        validate_custom_input(&input)?;
+
+        let state = self.state.lock().await;
+        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+            return Err(format!(
+                "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
+                transport_str(input.transport),
+                input.from,
+                input.to,
+            ));
+        }
+        let mut custom = self.custom.lock().await;
+        if custom.iter().any(|r| r.id != id && same_rule(r, &input)) {
+            return Err("an identical custom rule already exists".into());
+        }
+        let Some(rule) = custom.iter_mut().find(|r| r.id == id) else {
+            return Err(format!("custom rule not found: {id}"));
+        };
+        rule.label = input.label.trim().to_string();
+        rule.transport = input.transport;
+        rule.from = input.from;
+        rule.to = input.to;
+        rule.source = input.source.clone();
+        rule.iface = input.iface.clone();
+        rule.enabled = input.enabled;
+        let updated = rule.clone();
+
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: updated custom rule {id}");
+        Ok(updated)
+    }
+
+    /// Remove a custom rule by id and rebuild the firewall. No-op error if the
+    /// id is unknown.
+    pub async fn remove_custom_rule(&self, id: &str) -> Result<(), String> {
+        let state = self.state.lock().await;
+        let mut custom = self.custom.lock().await;
+        let before = custom.len();
+        custom.retain(|r| r.id != id);
+        if custom.len() == before {
+            return Err(format!("custom rule not found: {id}"));
+        }
+        save_custom_rules(&custom).await?;
+        apply_nftables(&state, &custom).await?;
+        info!("Firewall: removed custom rule {id}");
+        Ok(())
+    }
 }
 
 /// Replace `service`'s port set in `state`, re-applying that service's
@@ -577,6 +773,23 @@ fn apply_restrictions(
         }
     }
     result
+}
+
+fn transport_str(t: Transport) -> &'static str {
+    match t {
+        Transport::Tcp => "tcp",
+        Transport::Udp => "udp",
+    }
+}
+
+/// True when an existing rule is an exact duplicate of the input
+/// (transport + range + source + iface). Label and enabled are ignored.
+fn same_rule(r: &CustomRule, input: &CustomRuleInput) -> bool {
+    r.transport == input.transport
+        && r.from == input.from
+        && r.to == input.to
+        && r.source == input.source
+        && r.iface == input.iface
 }
 
 // ── nftables application ───────────────────────────────────────
@@ -941,6 +1154,105 @@ mod tests {
         assert!(
             !out.contains("9999"),
             "disabled rule must not render; got:\n{out}"
+        );
+    }
+
+    // ── validate_custom_input / service_port_conflict (#620) ────────
+
+    fn input(from: u16, to: u16, transport: Transport) -> CustomRuleInput {
+        CustomRuleInput {
+            label: "test".into(),
+            transport,
+            from,
+            to,
+            source: None,
+            iface: None,
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_bad_range_and_input() {
+        // from > to
+        assert!(validate_custom_input(&input(100, 50, Transport::Tcp)).is_err());
+        // from == 0
+        assert!(validate_custom_input(&input(0, 10, Transport::Tcp)).is_err());
+        // empty label
+        let mut i = input(80, 80, Transport::Tcp);
+        i.label = "".into();
+        assert!(validate_custom_input(&i).is_err());
+        // control char in label
+        let mut i = input(80, 80, Transport::Tcp);
+        i.label = "a\nb".into();
+        assert!(validate_custom_input(&i).is_err());
+        // bad source
+        let mut i = input(80, 80, Transport::Tcp);
+        i.source = Some("1.2.3.4 accept".into());
+        assert!(validate_custom_input(&i).is_err());
+        // bad iface
+        let mut i = input(80, 80, Transport::Tcp);
+        i.iface = Some("eth0; drop".into());
+        assert!(validate_custom_input(&i).is_err());
+        // valid: single port, valid CIDR, valid iface
+        let mut i = input(8000, 8010, Transport::Udp);
+        i.source = Some("192.168.1.0/24".into());
+        i.iface = Some("tailscale0".into());
+        assert!(validate_custom_input(&i).is_ok());
+        // valid: bare IP source
+        let mut i = input(8000, 8000, Transport::Tcp);
+        i.source = Some("10.0.0.5".into());
+        assert!(validate_custom_input(&i).is_ok());
+    }
+
+    #[test]
+    fn service_conflict_detects_owned_ports() {
+        let mut state = FirewallState::default();
+        // SMB owns tcp/445 (active), a disabled service owns tcp/2049,
+        // transport matters.
+        state.rules.push(FirewallRule {
+            service: "smb".into(),
+            ports: vec![PortSpec {
+                port: 445,
+                transport: Transport::Tcp,
+                source: None,
+                iface: None,
+            }],
+            active: true,
+        });
+        state.rules.push(FirewallRule {
+            service: "nfs".into(),
+            ports: vec![PortSpec {
+                port: 2049,
+                transport: Transport::Tcp,
+                source: None,
+                iface: None,
+            }],
+            active: false, // disabled service still owns its port
+        });
+
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 445, 445).as_deref(),
+            Some("smb")
+        );
+        // range spanning the port
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 440, 450).as_deref(),
+            Some("smb")
+        );
+        // disabled service still conflicts
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 2049, 2049).as_deref(),
+            Some("nfs")
+        );
+        // transport mismatch → no conflict
+        assert_eq!(
+            service_port_conflict(&state, Transport::Udp, 445, 445),
+            None
+        );
+        // free port → no conflict
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 32400, 32400),
+            None
         );
     }
 }

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -102,6 +102,50 @@ pub struct FirewallState {
     pub rules: Vec<FirewallRule>,
 }
 
+/// A user-managed firewall port rule (issue #620). Opens a single TCP/UDP
+/// port or a contiguous range on the host `input` chain, independent of
+/// NASty's service model. Persisted to `firewall-custom.json` and rendered
+/// into `table inet nasty` alongside the service rules.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct CustomRule {
+    /// Engine-generated opaque id (UUID). Stable across label edits; used as
+    /// the nft comment so free-text never enters the ruleset.
+    pub id: String,
+    /// Required human label ("Plex (host mode)"). UI only.
+    pub label: String,
+    pub transport: Transport,
+    /// Low port of the range (== `to` for a single port).
+    pub from: u16,
+    /// High port of the range.
+    pub to: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iface: Option<String>,
+    pub enabled: bool,
+}
+
+const CUSTOM_PATH: &str = "/var/lib/nasty/firewall-custom.json";
+
+/// Load persisted custom rules; empty on missing/corrupt file (same
+/// tolerance as `FirewallRestrictions::load`).
+fn load_custom_rules() -> Vec<CustomRule> {
+    std::fs::read_to_string(CUSTOM_PATH)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+// Unused until a later task (#620) adds the API surface that mutates
+// custom rules (add/edit/delete/enable/disable) and persists them.
+#[allow(dead_code)]
+async fn save_custom_rules(rules: &[CustomRule]) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(rules).map_err(|e| format!("serialize: {e}"))?;
+    tokio::fs::write(CUSTOM_PATH, json)
+        .await
+        .map_err(|e| format!("write {CUSTOM_PATH}: {e}"))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FirewallStatus {
     pub active: bool,
@@ -120,6 +164,10 @@ pub struct FirewallStatus {
     /// itself has no knowledge of Docker.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub published_app_ports: Vec<PublishedAppPort>,
+    /// User-managed custom port rules (issue #620). Rendered into the
+    /// firewall alongside service rules; editable on the Firewall page.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_rules: Vec<CustomRule>,
 }
 
 /// One host port published by a Docker-managed app. Read-only; surfaced
@@ -195,6 +243,7 @@ pub fn rdma_ports() -> Vec<PortSpec> {
 pub struct FirewallService {
     state: tokio::sync::Mutex<FirewallState>,
     restrictions: tokio::sync::Mutex<FirewallRestrictions>,
+    custom: tokio::sync::Mutex<Vec<CustomRule>>,
 }
 
 impl Default for FirewallService {
@@ -208,6 +257,7 @@ impl FirewallService {
         Self {
             state: tokio::sync::Mutex::new(FirewallState::default()),
             restrictions: tokio::sync::Mutex::new(FirewallRestrictions::default()),
+            custom: tokio::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -217,6 +267,8 @@ impl FirewallService {
         let mut state = self.state.lock().await;
         let mut restrictions = self.restrictions.lock().await;
         *restrictions = FirewallRestrictions::load();
+        let mut custom = self.custom.lock().await;
+        *custom = load_custom_rules();
 
         // WebUI is always open
         let webui_sources = restrictions
@@ -259,7 +311,7 @@ impl FirewallService {
             });
         }
 
-        if let Err(e) = apply_nftables(&state).await {
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to apply initial firewall rules: {e}");
         } else {
             info!("Firewall initialized with {} rules", state.rules.len());
@@ -286,7 +338,8 @@ impl FirewallService {
                 active: true,
             });
         }
-        if let Err(e) = apply_nftables(&state).await {
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to open firewall for {name}: {e}");
         } else {
             info!("Firewall: opened ports for {name}");
@@ -303,7 +356,8 @@ impl FirewallService {
             }
             rule.active = false;
         }
-        if let Err(e) = apply_nftables(&state).await {
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to close firewall for {name}: {e}");
         } else {
             info!("Firewall: closed ports for {name}");
@@ -325,7 +379,8 @@ impl FirewallService {
                 active: true,
             });
         }
-        if let Err(e) = apply_nftables(&state).await {
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to open firewall for rdma: {e}");
         } else {
             info!("Firewall: opened ports for rdma");
@@ -341,7 +396,8 @@ impl FirewallService {
             }
             rule.active = false;
         }
-        if let Err(e) = apply_nftables(&state).await {
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to close firewall for rdma: {e}");
         } else {
             info!("Firewall: closed ports for rdma");
@@ -352,6 +408,7 @@ impl FirewallService {
     pub async fn status(&self) -> FirewallStatus {
         let state = self.state.lock().await;
         let restrictions = self.restrictions.lock().await;
+        let custom = self.custom.lock().await;
         FirewallStatus {
             active: true,
             rules: state.rules.clone(),
@@ -360,6 +417,7 @@ impl FirewallService {
             // Populated by the engine layer (router) which has the apps
             // handle; the firewall module has no Docker knowledge.
             published_app_ports: Vec::new(),
+            custom_rules: custom.clone(),
         }
     }
 
@@ -405,7 +463,8 @@ impl FirewallService {
             rule.ports = apply_restrictions(base_ports, &sources, &ifaces);
         }
 
-        apply_nftables(&state).await?;
+        let custom = self.custom.lock().await;
+        apply_nftables(&state, &custom).await?;
         info!("Firewall: updated restrictions for {service}");
         Ok(())
     }
@@ -427,7 +486,8 @@ impl FirewallService {
         if !replace_rule_ports(&mut state, &restrictions, proto.name(), ports) {
             return;
         }
-        if let Err(e) = apply_nftables(&state).await {
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
             error!("Failed to update firewall ports for {}: {e}", proto.name());
         } else {
             info!("Firewall: updated ports for {}", proto.name());
@@ -522,47 +582,8 @@ fn apply_restrictions(
 // ── nftables application ───────────────────────────────────────
 
 /// Generate and apply the full nftables ruleset atomically.
-async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
-    let mut rules = String::new();
-    rules.push_str("table inet nasty {\n");
-    rules.push_str("    chain input {\n");
-    rules.push_str("        type filter hook input priority 0; policy drop;\n");
-    rules.push_str("        ct state established,related accept\n");
-    rules.push_str("        ct state invalid drop\n");
-    rules.push_str("        iif lo accept\n");
-    rules.push_str("        # ICMP/ICMPv6 — always allow\n");
-    rules.push_str("        ip protocol icmp accept\n");
-    rules.push_str("        ip6 nexthdr icmpv6 accept\n");
-    rules.push_str("        # DHCPv6 client\n");
-    rules.push_str("        udp dport 546 accept\n");
-
-    for rule in &state.rules {
-        if !rule.active {
-            continue;
-        }
-        for port in &rule.ports {
-            let proto = match port.transport {
-                Transport::Tcp => "tcp",
-                Transport::Udp => "udp",
-            };
-            let mut conditions = Vec::new();
-            if let Some(ref iface) = port.iface {
-                conditions.push(format!("iifname \"{iface}\""));
-            }
-            if let Some(ref src) = port.source {
-                conditions.push(format!("ip saddr {src}"));
-            }
-            conditions.push(format!("{proto} dport {}", port.port));
-            rules.push_str(&format!(
-                "        {} accept # {}\n",
-                conditions.join(" "),
-                rule.service
-            ));
-        }
-    }
-
-    rules.push_str("    }\n");
-    rules.push_str("}\n");
+async fn apply_nftables(state: &FirewallState, custom: &[CustomRule]) -> Result<(), String> {
+    let rules = render_ruleset(state, custom);
 
     // Apply atomically: flush + load
     let flush = Command::new("nft")
@@ -601,6 +622,79 @@ async fn apply_nftables(state: &FirewallState) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Build the full `table inet nasty` ruleset text from the service rules and
+/// the custom rules. Pure — no I/O — so it can be unit-tested.
+pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
+    let mut rules = String::new();
+    rules.push_str("table inet nasty {\n");
+    rules.push_str("    chain input {\n");
+    rules.push_str("        type filter hook input priority 0; policy drop;\n");
+    rules.push_str("        ct state established,related accept\n");
+    rules.push_str("        ct state invalid drop\n");
+    rules.push_str("        iif lo accept\n");
+    rules.push_str("        # ICMP/ICMPv6 — always allow\n");
+    rules.push_str("        ip protocol icmp accept\n");
+    rules.push_str("        ip6 nexthdr icmpv6 accept\n");
+    rules.push_str("        # DHCPv6 client\n");
+    rules.push_str("        udp dport 546 accept\n");
+
+    for rule in &state.rules {
+        if !rule.active {
+            continue;
+        }
+        for port in &rule.ports {
+            let proto = match port.transport {
+                Transport::Tcp => "tcp",
+                Transport::Udp => "udp",
+            };
+            let mut conditions = Vec::new();
+            if let Some(ref iface) = port.iface {
+                conditions.push(format!("iifname \"{iface}\""));
+            }
+            if let Some(ref src) = port.source {
+                conditions.push(format!("ip saddr {src}"));
+            }
+            conditions.push(format!("{proto} dport {}", port.port));
+            rules.push_str(&format!(
+                "        {} accept # {}\n",
+                conditions.join(" "),
+                rule.service
+            ));
+        }
+    }
+
+    for rule in custom {
+        if !rule.enabled {
+            continue;
+        }
+        let proto = match rule.transport {
+            Transport::Tcp => "tcp",
+            Transport::Udp => "udp",
+        };
+        let mut conditions = Vec::new();
+        if let Some(ref iface) = rule.iface {
+            conditions.push(format!("iifname \"{iface}\""));
+        }
+        if let Some(ref src) = rule.source {
+            conditions.push(format!("ip saddr {src}"));
+        }
+        if rule.from == rule.to {
+            conditions.push(format!("{proto} dport {}", rule.from));
+        } else {
+            conditions.push(format!("{proto} dport {}-{}", rule.from, rule.to));
+        }
+        rules.push_str(&format!(
+            "        {} accept # custom:{}\n",
+            conditions.join(" "),
+            rule.id
+        ));
+    }
+
+    rules.push_str("    }\n");
+    rules.push_str("}\n");
+    rules
 }
 
 #[cfg(test)]
@@ -784,5 +878,69 @@ mod tests {
         let mut state = state_with_rule("iscsi", vec![tcp(3260)], true);
         let changed = replace_rule_ports(&mut state, &no_restrictions(), "iscsi", vec![tcp(3260)]);
         assert!(!changed, "identical port set must not trigger an nft apply");
+    }
+
+    // ── render_ruleset custom rules (#620) ──────────────────────────
+
+    #[test]
+    fn render_includes_enabled_custom_single_port() {
+        let state = FirewallState::default();
+        let custom = vec![CustomRule {
+            id: "id1".into(),
+            label: "plex".into(),
+            transport: Transport::Tcp,
+            from: 32400,
+            to: 32400,
+            source: None,
+            iface: None,
+            enabled: true,
+        }];
+        let out = render_ruleset(&state, &custom);
+        assert!(
+            out.contains("tcp dport 32400 accept # custom:id1"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn render_includes_range_and_conditions() {
+        let state = FirewallState::default();
+        let custom = vec![CustomRule {
+            id: "id2".into(),
+            label: "games".into(),
+            transport: Transport::Udp,
+            from: 8000,
+            to: 8010,
+            source: Some("10.0.0.0/8".into()),
+            iface: Some("eth0".into()),
+            enabled: true,
+        }];
+        let out = render_ruleset(&state, &custom);
+        assert!(
+            out.contains(
+                "iifname \"eth0\" ip saddr 10.0.0.0/8 udp dport 8000-8010 accept # custom:id2"
+            ),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn render_omits_disabled_custom() {
+        let state = FirewallState::default();
+        let custom = vec![CustomRule {
+            id: "id3".into(),
+            label: "off".into(),
+            transport: Transport::Tcp,
+            from: 9999,
+            to: 9999,
+            source: None,
+            iface: None,
+            enabled: false,
+        }];
+        let out = render_ruleset(&state, &custom);
+        assert!(
+            !out.contains("9999"),
+            "disabled rule must not render; got:\n{out}"
+        );
     }
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1337,6 +1337,20 @@ export interface PublishedAppPort {
 	transport: string;
 }
 
+/** Operator-defined port rule (#620), for opening ports on the host that
+ * aren't already covered by a service or Docker's published-port DNAT
+ * (e.g. `network_mode: host` apps). Managed via `system.firewall.custom.*`. */
+export interface CustomRule {
+	id: string;
+	label: string;
+	transport: 'tcp' | 'udp';
+	from: number;
+	to: number;
+	source?: string | null;
+	iface?: string | null;
+	enabled: boolean;
+}
+
 export interface FirewallStatus {
 	active: boolean;
 	rules: FirewallRule[];
@@ -1345,6 +1359,8 @@ export interface FirewallStatus {
 	/** Host ports Docker apps publish. NOT governed by this firewall (Docker
 	 * DNATs them past the input chain) — shown read-only for visibility. */
 	published_app_ports?: PublishedAppPort[];
+	/** Operator-defined custom port rules (#620). */
+	custom_rules?: CustomRule[];
 }
 
 export interface AlertRule {

--- a/webui/src/routes/firewall/+page.svelte
+++ b/webui/src/routes/firewall/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getClient } from '$lib/client';
-	import { withToast } from '$lib/toast.svelte';
-	import type { FirewallStatus, NetworkState, PublishedAppPort } from '$lib/types';
+	import { withToast, info } from '$lib/toast.svelte';
+	import type { FirewallStatus, NetworkState, PublishedAppPort, CustomRule } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 
 	const client = getClient();
@@ -12,6 +12,17 @@
 	let fwEditService: string | null = $state(null);
 	let fwEditSources = $state('');
 	let fwEditIfaces: string[] = $state([]);
+
+	// Custom port rules (#620)
+	let showAddCustom = $state(false);
+	let editCustomId: string | null = $state(null);
+	let cLabel = $state('');
+	let cTransport: 'tcp' | 'udp' = $state('tcp');
+	let cFrom = $state('');
+	let cTo = $state('');
+	let cSource = $state('');
+	let cIface = $state('');
+	let cEnabled = $state(true);
 
 	/** A published app port, or a collapsed contiguous 1:1 range of them. */
 	type AppPortRow = PublishedAppPort & { host_port_end?: number };
@@ -68,6 +79,85 @@
 		fwEditService = null;
 		fwEditSources = '';
 		fwEditIfaces = [];
+		await loadFirewall();
+	}
+
+	function resetCustomForm() {
+		showAddCustom = false;
+		editCustomId = null;
+		cLabel = '';
+		cTransport = 'tcp';
+		cFrom = '';
+		cTo = '';
+		cSource = '';
+		cIface = '';
+		cEnabled = true;
+	}
+
+	function startAddCustom() {
+		resetCustomForm();
+		showAddCustom = true;
+	}
+
+	function startEditCustom(r: CustomRule) {
+		editCustomId = r.id;
+		showAddCustom = true;
+		cLabel = r.label;
+		cTransport = r.transport;
+		cFrom = String(r.from);
+		cTo = r.to === r.from ? '' : String(r.to);
+		cSource = r.source ?? '';
+		cIface = r.iface ?? '';
+		cEnabled = r.enabled;
+	}
+
+	async function saveCustom() {
+		const from = parseInt(cFrom, 10);
+		const to = cTo.trim() ? parseInt(cTo, 10) : from;
+		const params: Record<string, unknown> = {
+			label: cLabel.trim(),
+			transport: cTransport,
+			from,
+			to,
+			enabled: cEnabled,
+		};
+		if (cSource.trim()) params.source = cSource.trim();
+		if (cIface.trim()) params.iface = cIface.trim();
+		if (editCustomId) params.id = editCustomId;
+
+		const method = editCustomId ? 'system.firewall.custom.update' : 'system.firewall.custom.add';
+		const res = await withToast(
+			() => client.call<{ rule: CustomRule; warnings: string[] }>(method, params),
+			editCustomId ? 'Custom rule updated' : 'Custom rule added'
+		);
+		if (!res) return;
+		for (const w of res.warnings ?? []) {
+			info(w);
+		}
+		resetCustomForm();
+		await loadFirewall();
+	}
+
+	async function toggleCustom(r: CustomRule) {
+		await withToast(
+			() =>
+				client.call('system.firewall.custom.update', {
+					id: r.id,
+					label: r.label,
+					transport: r.transport,
+					from: r.from,
+					to: r.to,
+					...(r.source ? { source: r.source } : {}),
+					...(r.iface ? { iface: r.iface } : {}),
+					enabled: !r.enabled,
+				}),
+			r.enabled ? 'Rule disabled' : 'Rule enabled'
+		);
+		await loadFirewall();
+	}
+
+	async function removeCustom(r: CustomRule) {
+		await withToast(() => client.call('system.firewall.custom.remove', { id: r.id }), 'Custom rule removed');
 		await loadFirewall();
 	}
 </script>
@@ -189,5 +279,118 @@
 				</div>
 			</section>
 		{/if}
+
+		<section class="mt-6 rounded-lg border border-border p-5">
+			<div class="flex items-center justify-between gap-4">
+				<div>
+					<h2 class="text-sm font-semibold">Custom port rules</h2>
+					<p class="mt-1 text-xs text-muted-foreground">
+						Open a port for something running directly on the host (e.g. a <code>network_mode: host</code> app).
+						Bridge-networked apps don't need a rule — their published ports (listed above, if any) already bypass
+						this firewall.
+					</p>
+				</div>
+				<Button size="xs" onclick={startAddCustom}>Add rule</Button>
+			</div>
+
+			{#if firewallStatus.custom_rules?.length}
+				<div class="mt-3 space-y-1">
+					{#each firewallStatus.custom_rules as r}
+						<div class="flex items-center gap-3 rounded px-3 py-2 text-sm {r.enabled ? '' : 'opacity-40'}">
+							<span class="h-2 w-2 rounded-full shrink-0 {r.enabled ? 'bg-green-400' : 'bg-muted-foreground'}"></span>
+							<span class="font-medium w-32 truncate">{r.label}</span>
+							<span class="font-mono text-xs text-muted-foreground">
+								{r.from === r.to ? r.from : `${r.from}-${r.to}`}/{r.transport}
+							</span>
+							{#if r.source}
+								<span class="text-xs text-amber-400">{r.source}</span>
+							{/if}
+							{#if r.iface}
+								<span class="text-xs text-blue-400">{r.iface}</span>
+							{/if}
+							<div class="ml-auto flex items-center gap-2">
+								<Button size="xs" variant="secondary" onclick={() => toggleCustom(r)}>{r.enabled ? 'Disable' : 'Enable'}</Button>
+								<Button size="xs" variant="secondary" onclick={() => startEditCustom(r)}>Edit</Button>
+								<Button size="xs" variant="destructive" onclick={() => removeCustom(r)}>Delete</Button>
+							</div>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<p class="mt-3 text-xs text-muted-foreground">No custom rules.</p>
+			{/if}
+
+			{#if showAddCustom}
+				<div class="mt-3 rounded-lg border border-border bg-secondary/20 p-3 space-y-3">
+					<div class="text-xs font-medium">{editCustomId ? 'Edit rule' : 'New rule'}</div>
+
+					<div>
+						<div class="text-xs text-muted-foreground mb-1">Label</div>
+						<input
+							bind:value={cLabel}
+							placeholder="e.g. Plex host mode"
+							class="w-full rounded-md border border-input bg-background px-2 py-1 text-sm"
+						/>
+					</div>
+
+					<div class="flex gap-2">
+						<div>
+							<div class="text-xs text-muted-foreground mb-1">Transport</div>
+							<select bind:value={cTransport} class="rounded-md border border-input bg-background px-2 py-1 text-sm h-[30px]">
+								<option value="tcp">TCP</option>
+								<option value="udp">UDP</option>
+							</select>
+						</div>
+						<div>
+							<div class="text-xs text-muted-foreground mb-1">Port</div>
+							<input
+								bind:value={cFrom}
+								placeholder="e.g. 32400"
+								class="w-24 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
+							/>
+						</div>
+						<div>
+							<div class="text-xs text-muted-foreground mb-1">to (optional, range)</div>
+							<input
+								bind:value={cTo}
+								placeholder="e.g. 32410"
+								class="w-24 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
+							/>
+						</div>
+					</div>
+
+					<div>
+						<div class="text-xs text-muted-foreground mb-1">Allowed source IP/CIDR (optional, empty = all)</div>
+						<input
+							bind:value={cSource}
+							placeholder="e.g. 192.168.1.0/24"
+							class="w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
+						/>
+					</div>
+
+					<div>
+						<div class="text-xs text-muted-foreground mb-1">Interface (optional, empty = any)</div>
+						{#if networkState}
+							<select bind:value={cIface} class="w-full rounded-md border border-input bg-background px-2 py-1 text-sm h-[30px]">
+								<option value="">Any interface</option>
+								{#each networkState.interfaces as iface}
+									<option value={iface.name}>{iface.name}</option>
+								{/each}
+							</select>
+						{/if}
+					</div>
+
+					<label class="flex items-center gap-1.5 text-xs">
+						<input type="checkbox" bind:checked={cEnabled} />
+						Enabled
+					</label>
+
+					<div class="flex gap-2">
+						<Button size="xs" onclick={saveCustom}>{editCustomId ? 'Save' : 'Add'}</Button>
+						<Button size="xs" variant="secondary" onclick={resetCustomForm}>Cancel</Button>
+					</div>
+				</div>
+			{/if}
+		</section>
 	{/if}
 </div>


### PR DESCRIPTION
Closes #620. Lets an operator open a host port from the Firewall page — for a `network_mode: host` app, or anything running on the box outside NASty's service model. Requested in discussion #591, where an operator was reduced to `nft add rule inet nasty input tcp dport <port> accept` by hand, lost on every reboot because the engine owns and rebuilds `table inet nasty`.

## What you can do now
- **Add a custom rule** on the Firewall page: a single TCP/UDP port or a contiguous range, with the same optional source-CIDR / interface restrictions the service rules already support, and an enable/disable toggle. It's persisted and rendered into `table inet nasty` alongside the service rules — surviving reboots and rule rebuilds.
- **Not for bridge apps.** Docker publishes bridge-app ports past the firewall (already listed read-only on the page), so those never need a rule — the section says so, and if you try, you get a non-blocking warning naming the app instead of a redundant rule. That's the exact confusion #591 hit.

## How it works
- New persisted `CustomRule` in `nasty-system`'s firewall module, materialized into the existing atomic nftables rebuild via its own render block. `PortSpec` and the derived service rules are untouched.
- `system.firewall.custom.{add,update,remove}` RPCs, **Admin**-role (matching `system.firewall.restrict`).
- **Validation refuses ports a NASty service owns** — active *or* disabled protocols, WebUI, RDMA, and the live iSCSI/NVMe-oF portal ports — with a message pointing you at enabling that service instead. Exact-duplicate rules are refused; overlapping custom ranges are fine.
- **Input is sanitized before it reaches nft**: source must be a valid IP/CIDR, interface must match a safe charset, label is control-char-free — and the nft comment uses the rule's opaque id, never the free-text label. Interface handling is naturally fail-closed: `iifname "<x>"` matches nothing when the interface is absent and never breaks the ruleset load.

## Also in here
A whole-branch review caught a fail-open that the per-task reviews couldn't see: the validator accepted IPv6 sources, but the renderer emitted `ip saddr` (the IPv4 family) unconditionally — an IPv6-sourced rule would fail the entire `nft -f` load, and since the table is deleted before reload, that drops *all* host firewalling until fixed. Now the renderer is family-aware (`ip6 saddr` for IPv6), applied to both the custom and the pre-existing service-restrict paths, with a regression test.

## Testing
- Unit: rendering (single port, range, disabled omitted, IPv6 → `ip6 saddr`), the validation matrix (range, service-collision incl. disabled + portal + transport-sensitivity, duplicate, source/iface/label sanitizers), and the Docker-overlap warning helper.
- `nasty-system` + `nasty-engine` suites and WebUI 144/144 green; fmt + clippy `--all-targets` clean.
- The nftables apply path is exercised on real boxes; worth a quick host-mode-app smoke test before relying on it.

## Follow-ups (deliberately out of scope)
- Arbitrary port sets / multiple disjoint ranges per rule; egress/forward-chain rules; a "clone from published app port" shortcut.

Design: `docs/firewall-custom-rules.md` · Plan: `docs/superpowers/plans/2026-07-10-firewall-custom-rules.md`


