### PR TITLE
Active Directory: NASty as the domain controller (#20)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,9 +77,7 @@ jobs:
             .#checks.x86_64-linux.appliance-smoke \
             -L --print-build-logs
 
-      - name: AD VM tests (non-gating)
-        # Two two-node AD tests, kept non-gating for different reasons:
-        #
+      - name: AD member-join VM test (non-gating — known throwaway-DC defect)
         # ad-member provisions a throwaway Samba AD DC in a VM. Getting
         # that simulated DC fully initialized is essentially the phase-2
         # (NASty-as-DC) problem and currently fails at the DC's own LDAP
@@ -89,19 +87,27 @@ jobs:
         # discovery, winbind idmap, domain-user SMB auth with correct file
         # ownership, and leave all pass. Kept running (not gating) so it's
         # ready to re-promote once the throwaway DC is hardened in phase 2.
-        #
-        # ad-dc (#20) is new: NASty provisions a real domain via
-        # samba-dc.service + dc.provision, and a second NASty joins it
-        # with the same shipped member flow ad-member exercises. Non-
-        # gating on landing since this is its first live CI run and a
-        # brand-new two-VM AD test is exactly the kind of thing that finds
-        # a harness or readiness-signal issue the first time it runs for
-        # real (see nixos/tests/ad-dc.nix's header for the two named
-        # fallbacks). Promote to gating once it's green for a few runs.
         continue-on-error: true
         run: |
           nix build \
             .#checks.x86_64-linux.ad-member \
+            -L --print-build-logs
+
+      - name: AD DC VM test (non-gating while stabilizing)
+        # ad-dc (#20): NASty provisions a real domain via
+        # samba-dc.service + dc.provision, and a second NASty joins it
+        # with the same shipped member flow ad-member exercises. This is
+        # the test's first live CI run, and a brand-new two-VM AD test is
+        # exactly the kind of thing that finds a harness or
+        # readiness-signal issue the first time it runs for real (see
+        # nixos/tests/ad-dc.nix's header for the two named fallbacks).
+        # Non-gating until it has built up a green track record, then
+        # promote to gating. continue-on-error masks the step's
+        # conclusion in the GitHub UI, so its logs — not the checkmark —
+        # are the source of truth while it stabilizes.
+        continue-on-error: true
+        run: |
+          nix build \
             .#checks.x86_64-linux.ad-dc \
             -L --print-build-logs
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,20 +77,32 @@ jobs:
             .#checks.x86_64-linux.appliance-smoke \
             -L --print-build-logs
 
-      - name: AD member-join VM test (non-gating)
-        # The two-node AD test provisions a throwaway Samba AD DC in a VM.
-        # Getting that simulated DC fully initialized is essentially the
-        # phase-2 (NASty-as-DC) problem and currently fails at the DC's
-        # own LDAP layer ("Operations error") — a fake-DC defect, not the
+      - name: AD VM tests (non-gating)
+        # Two two-node AD tests, kept non-gating for different reasons:
+        #
+        # ad-member provisions a throwaway Samba AD DC in a VM. Getting
+        # that simulated DC fully initialized is essentially the phase-2
+        # (NASty-as-DC) problem and currently fails at the DC's own LDAP
+        # layer ("Operations error") — a fake-DC defect, not the
         # member-join engine. The engine is validated end-to-end against a
         # REAL AD DC (Synology Directory Server): join, trust, workgroup
         # discovery, winbind idmap, domain-user SMB auth with correct file
         # ownership, and leave all pass. Kept running (not gating) so it's
         # ready to re-promote once the throwaway DC is hardened in phase 2.
+        #
+        # ad-dc (#20) is new: NASty provisions a real domain via
+        # samba-dc.service + dc.provision, and a second NASty joins it
+        # with the same shipped member flow ad-member exercises. Non-
+        # gating on landing since this is its first live CI run and a
+        # brand-new two-VM AD test is exactly the kind of thing that finds
+        # a harness or readiness-signal issue the first time it runs for
+        # real (see nixos/tests/ad-dc.nix's header for the two named
+        # fallbacks). Promote to gating once it's green for a few runs.
         continue-on-error: true
         run: |
           nix build \
             .#checks.x86_64-linux.ad-member \
+            .#checks.x86_64-linux.ad-dc \
             -L --print-build-logs
 
       - name: Build and push packages to Cachix

--- a/docs/ad-domain-controller.md
+++ b/docs/ad-domain-controller.md
@@ -1,0 +1,264 @@
+# Active Directory: NASty as the Domain Controller
+
+Design for hosting an AD domain on a NASty box — the second half of
+[issue #20](https://github.com/nasty-project/nasty/issues/20). The first
+half, member mode (NASty joins an *existing* domain), shipped in #627 and is
+documented in `docs/active-directory-support.md`. This feature is the
+inverse: NASty *is* the domain, replacing a Synology Directory Server or a
+Windows Server DC. The #20 reporter runs a Synology as his only DC today —
+that is the setup this replaces.
+
+Strategic note: TrueNAS removed its DC role years ago; Synology still ships
+Directory Server as a package. A NAS that can host the domain — and whose
+sibling boxes can join it with the member mode we already ship — is a real
+differentiator.
+
+## Scope
+
+**In scope (v1):**
+- Provision a **new** AD domain on this box (`samba-tool domain provision`,
+  Samba AD DC, SAMBA_INTERNAL DNS) from the WebUI: realm + Administrator
+  password + optional DNS forwarder.
+- **Exactly one DC per domain.** v1 never joins an existing domain as an
+  additional DC.
+- The DC **serves the box's file shares** through its own integrated smbd —
+  the existing `smb.nasty.conf` include chain rides along unchanged, and
+  share ACLs reference the AD users/groups the box hosts.
+- Domain user/group/computer management in the WebUI (the Synology-DS-sized
+  surface): users (list/create/delete/set password/enable/disable), groups
+  (list/create/delete/membership), computers (read-only list).
+- **Domain backup** as a first-class operation: `samba-tool domain backup
+  offline` into an operator-chosen path jailed under `/fs`, where the
+  existing backup profiles (rustic) can ship it offsite and #635's restore
+  can bring it back.
+- Demote (= destroy the domain, in a single-DC world) with heavy
+  confirmation and an automatic final backup.
+- Mutual exclusivity with member mode, enforced both ways.
+
+**Out of scope (explicitly deferred):**
+- Joining an existing domain as an **additional DC** (DRS replication, FSMO
+  management, SysVol replication) — the real HA answer, and its own
+  brainstorm when it comes.
+- BIND9_DLZ DNS backend (SAMBA_INTERNAL only).
+- GPO / OU / password-policy / delegation / trust management in the WebUI.
+  The sysvol and GPO infrastructure exists on the DC automatically; Windows
+  RSAT manages it natively — we do not rebuild RSAT.
+- Signed NTP for domain clients (documented limitation).
+- Automated domain **restore** in the WebUI. v1 documents the manual
+  procedure (fresh box, `samba-tool domain backup restore`, runnable from
+  the WebUI terminal); automating it is a named follow-up, not a silent gap.
+
+## Fleet story (costs nothing, worth stating)
+
+Member mode is already validated against a Samba AD DC — the CI member test
+joins one. So the moment this ships, one NASty hosts the domain and every
+other NASty joins it with existing, shipped code. A NASty-only fleet with
+centralized identity, no Windows Server anywhere. The v1 VM test proves
+exactly this pairing.
+
+## Architecture
+
+A new `engine/nasty-system/src/dc.rs` (`DcService`), sibling to member
+mode's `domain.rs` — Approach B from the brainstorm. `domain.rs` (freshly
+validated against a real DC) is not restructured; it only gains the inverse
+mutual-exclusion check. Shared logic (`validate_realm`, `derive_workgroup`,
+the resolved-drop-in pattern) is imported from `domain.rs`, which already
+exports it — not duplicated.
+
+### Packaging: one samba build
+
+nasty.nix's `sambaAds` (`enableLDAP = true`) becomes the DC-capable superset
+(`enableLDAP = true; enableDomainController = true;` plus the
+`python3Packages.cryptography` pythonPath addition the CI DC build already
+carries for samba-tool's provision path — check whether the pinned nixpkgs
+still needs the backport at implementation time). One build serves both
+roles; member boxes simply never run the DC bits. Two parallel samba store
+paths would invite version skew. `samba-tool` joins the engine service's
+PATH. This changes the samba closure on every box — the nix-sandbox /
+Integration workflow is the gate that catches packaging fallout, not local
+cargo builds.
+
+### Provision flow (`dc.provision { realm, admin_password, dns_forwarder? }`)
+
+1. **Preconditions, all checked up front with pointed errors:**
+   - not already hosting a domain;
+   - not joined to a domain as a member (probes member mode's persisted
+     config; `domain.join` gains the mirror check against `dc.json`);
+   - **static IP** — the interface carrying the box's primary address (the
+     one clients reach the DC on) must be statically configured in NASty's
+     network config; a DHCP-addressed DC is a time bomb. The error names
+     the Network page as the fix;
+   - port 53 must be freeable (resolved's stub listener is ours to move;
+     anything else squatting on :53 is an error).
+2. **Provision:** `samba-tool domain provision --realm=<REALM>
+   --domain=<WORKGROUP> --server-role=dc --dns-backend=SAMBA_INTERNAL`
+   against an **engine-owned config path** `/etc/samba/smb.dc.conf`
+   (samba-tool's `--configfile`). The nix-managed `/etc/samba/smb.conf` is
+   never touched — on NixOS it is a store symlink and must stay one. The
+   workgroup is derived from the realm (`derive_workgroup`).
+3. **Shares include:** after provision, the engine appends the existing
+   NASty include chain (`include = /etc/samba/smb.nasty.conf`) plus
+   NASty-required globals to `smb.dc.conf`, so the DC's integrated smbd
+   serves sysvol/netlogon *and* the box's shares — decision (a) from the
+   brainstorm, the pragmatic single-box pattern. Samba upstream's
+   "don't file-serve from a DC" caveat is documented, not hidden. Note:
+   the DC allocates user/group IDs from its own `idmap.ldb`, not member
+   mode's `idmap_rid` math — on-disk UIDs differ between a DC-mode box and
+   a member-mode box. Fine standalone; documented.
+4. **Credential hygiene (same rule as member join — secrets never ride
+   argv):** `--adminpass` on argv is visible in `/proc` for the life of the
+   process. Provision therefore runs with a **random throwaway password on
+   argv**, and the operator's real Administrator password is set immediately
+   after via `samba-tool user setpassword Administrator` **fed over stdin**,
+   then never logged and never persisted.
+5. **DNS:** SAMBA_INTERNAL owns :53. A `/run/systemd/resolved.conf.d/`
+   drop-in (same mechanism member mode uses) sets `DNSStubListener=no` and
+   points the box's own resolution at `127.0.0.1` (the samba DNS).
+   `dns forwarder = <upstream>` in `smb.dc.conf` keeps external resolution
+   working — operator-suppliable, defaulting to the box's current upstream
+   resolvers. Clients then use the NASty DC as their DNS for the AD zone.
+6. **Service switchover — systemd `Conflicts=`:** a new `samba-dc.service`
+   in nasty.nix (present on every box, disabled by default, engine-toggled —
+   per-box opt-in as always) runs `samba --foreground
+   --configfile=/etc/samba/smb.dc.conf` and declares `Conflicts=` +
+   `After=` against `samba-smbd`/`samba-nmbd`/`samba-winbindd`, so starting
+   the DC atomically stops the member-mode daemons and stopping it lets
+   them return. The engine records the role in `/var/lib/nasty/dc.json` and
+   its boot-restore phase re-establishes it after reboot.
+7. **Firewall:** a `dc` service-rule set in the firewall module (same shape
+   as `rdma_ports()`): tcp+udp 53, 88, 464; tcp 135, 139, 389, 445, 636,
+   3268, 3269; udp 137, 138; plus the dynamic RPC range tcp 49152–65535.
+   Opened when the role activates, closed on demote. The RPC range is the
+   firewall's first ranged *service* rule: `PortSpec` gains an optional
+   range end (`to: Option<u16>`, serde-default, additive — existing
+   persisted state unaffected) and the service render loop emits
+   `dport from-to` when set, mirroring what #637's custom rules already
+   render. No NTP port: the box does not serve time (see 8).
+8. **Time:** the box keeps timesyncd as an NTP *client*; serving signed NTP
+   to domain clients is out of scope and documented.
+
+### State & disaster recovery
+
+- **Domain state stays on the root ext4** at samba's default
+  `/var/lib/samba` — no relocation to `/fs`. The DC is auth infrastructure;
+  it must come up even when the pool has trouble, and bcachefs snapshots of
+  *live* ldb databases aren't transactionally consistent anyway.
+- **`dc.backup { dest }`** runs `samba-tool domain backup offline`
+  (the transaction-safe copy of the domain databases) with a target dir
+  **jailed under `/fs`** — same canonicalize-and-check validation shape as
+  restore (#635). The resulting tarball is ordinary `/fs` data: a rustic
+  backup profile ships it offsite; #635's restore brings it back to a new
+  box; `samba-tool domain backup restore` (documented, WebUI terminal)
+  resurrects the domain. The DR story composes entirely from parts that
+  already shipped.
+- **Demote takes a parachute:** before tearing anything down, a final
+  domain backup is written into `/fs` (when a filesystem exists; if none
+  does, the confirmation says so in red).
+
+### Demote (`dc.demote { realm_confirmation }`)
+
+Single-DC world: demote **destroys the domain** — every user, group, and
+joined machine's trust. Accordingly: the request carries the typed realm
+(exact match), the WebUI frames it as a danger-zone action, and the engine
+sequence is: final backup → stop `samba-dc` → remove `smb.dc.conf` + domain
+state → drop the resolved drop-in → close the `dc` firewall rules → delete
+`dc.json`. The box returns to standalone; SMB units come back under their
+normal protocol toggles. A provision that fails mid-flight unwinds through
+the same teardown path (minus the backup), surfacing the failing step — the
+member-join work proved unwind discipline has to be there from day one.
+
+## Engine surface
+
+`DcService` methods (all `samba-tool` invocations use the engine-owned
+config via `--configfile`; **every password travels over stdin, never
+argv**):
+
+- `provision(ProvisionRequest) -> DcStatus`
+- `demote(DemoteRequest) -> ()`
+- `status() -> DcStatus { hosting, realm, workgroup, dns_forwarder,
+  service_healthy }` — `service_healthy` = `samba-dc.service` active;
+  cheap enough for the page to poll.
+- Users: `user_list`, `user_create { name, password, given_name?,
+  surname? }`, `user_delete`, `user_set_password`, `user_enable`,
+  `user_disable`.
+- Groups: `group_list`, `group_create`, `group_delete`,
+  `group_add_member`, `group_remove_member`.
+- Computers: `computer_list` (read-only).
+- `backup { dest } -> { path }` — dest jailed under `/fs`, created if
+  missing, must be empty (samba-tool requires an empty target dir).
+
+Every samba-tool failure returns stderr verbatim in the error — the
+member-join experience showed real deployments fail in ways only the real
+message explains.
+
+## RPC / registry
+
+`dc.*` namespace in a new `engine/nasty-engine/src/router/dc.rs`:
+`dc.status` (role `Any`); **everything else `Admin`** — hosting identity
+infrastructure is above Operator's pay grade, matching
+`system.firewall.restrict`'s posture. Admin methods are enforced by
+omission from both allowlists (the #635 lesson: the registry role is
+declarative; the allowlist is the gate — Admin-only methods are correct by
+construction, and the `operator_role_methods_are_operator_allowed` guard
+test doesn't apply).
+
+## WebUI
+
+The Domain page becomes three-state:
+
+- **Standalone:** two cards — "Join an existing domain" (existing member
+  flow) and "Host a new domain," with an honest blurb: this NASty becomes
+  the domain controller; one DC per domain; back it up; clients should use
+  it as DNS.
+- **Member:** the existing member UI, untouched.
+- **DC:** a dashboard — realm, workgroup, service health; Users / Groups /
+  Computers tabs with inline create / reset-password / enable-disable /
+  membership actions; a "Back up domain" action with the `/fs` destination
+  picker; Demote in a danger zone requiring the typed realm. Copy notes
+  RSAT works against this DC for advanced administration (OUs, GPOs,
+  policies).
+
+Password fields follow the existing conventions (never echoed back;
+`domain.join`'s credential handling is the template).
+
+## Error handling
+
+- Precondition failures → `InvalidParams`-style errors before anything
+  changes, each naming the fix (static IP → Network page; joined → leave
+  first; already hosting → demote first).
+- Mid-provision failure → unwind (teardown path), error names the step.
+- Provisioned but `samba-dc` won't start → `status.service_healthy = false`;
+  the UI shows unhealthy with a journal pointer
+  (`journalctl -u samba-dc`).
+- Backup target not under `/fs` / not empty → refused up front, same jail
+  errors as #635.
+- Demote realm mismatch → refused, nothing touched.
+
+## Testing
+
+- **Unit** (`dc.rs`): precondition matrix (joined ↔ hosting exclusion,
+  static-IP check logic); config-render fragments (include-chain append,
+  dns forwarder line); the **argv-hygiene invariant** — no constructed
+  `samba-tool` command line ever contains a secret (directly testable);
+  backup-dest jail (reuse the #635 test shapes); demote confirmation
+  matching.
+- **VM test — the money shot** (`nixos/tests/ad-dc.nix`): NASty box A
+  provisions a domain via the RPC path the WebUI uses; creates a user;
+  NASty box B **joins that domain with the shipped member flow**, resolves
+  the user through winbind, authenticates over SMB against B, writes a file
+  owned by the domain user. One test proves the whole fleet story —
+  NASty DC + NASty member, no Windows anywhere. Harness cribbed from
+  `ad-member.nix` (whose throwaway DC this feature effectively
+  productizes). Wired into the Integration workflow's path filter.
+- **Real-world:** a Windows client joined to the hosted domain + RSAT
+  against it (lab); johnnyq as the Synology-Directory-Server-replacement
+  validator — the acceptance test we can't fully synthesize.
+
+## Follow-ups (explicitly not v1)
+
+- Automated domain restore in the WebUI (v1 documents the manual
+  `samba-tool domain backup restore` procedure).
+- Additional-DC join / replication / FSMO (the HA story).
+- Scheduled domain backups (v1: manual button; trivial once the scheduler
+  grows a hook).
+- Signed NTP for domain clients.

--- a/docs/superpowers/plans/2026-07-10-ad-domain-controller.md
+++ b/docs/superpowers/plans/2026-07-10-ad-domain-controller.md
@@ -1,0 +1,1852 @@
+# AD Domain Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a NASty box host an Active Directory domain (Samba AD DC, single-DC, SAMBA_INTERNAL DNS) provisioned and managed from the WebUI — the second half of issue #20.
+
+**Architecture:** A new `dc.rs` module in `nasty-system` (sibling to member mode's `domain.rs`, which stays untouched except a mutual-exclusion check and two helper visibility bumps) owns provision/demote/status, user/group/computer management, and domain backup. The DC runs as a nix-defined, engine-toggled `samba-dc.service` with an engine-owned config (`--configfile=/etc/samba/smb.dc.conf`) that includes the existing share chain, so the DC's integrated smbd serves the box's shares. systemd `Conflicts=` swaps member-mode daemons out atomically. The firewall gains a `dc` service-rule set (and its first ranged service port). WebUI: the Settings "Directory" card becomes three-state with a `DcPanel` component.
+
+**Tech Stack:** Rust (`nasty-system`, `nasty-engine`), Samba (`samba-tool`, `samba` AD DC daemon), NixOS module + VM test, Svelte 5.
+
+## Global Constraints
+
+- **Secrets never ride argv** (visible in `/proc/*/cmdline`). Provision uses a random throwaway `--adminpass`, then sets the real Administrator password via `samba-tool user setpassword` **fed over stdin**. Every user-password operation feeds stdin. There is a unit test pinning this invariant.
+- **The nix-managed `/etc/samba/smb.conf` is never touched.** All DC samba-tool/daemon invocations pass `--configfile=/etc/samba/smb.dc.conf` (engine-owned).
+- **Exactly one DC per domain** (new-domain provision only). Mutual exclusion with member mode enforced both ways (`dc.provision` refuses when joined; `domain.join` refuses when hosting).
+- **Domain state stays on root ext4** at `/var/lib/samba` — no relocation to `/fs`.
+- **`dc.backup` destination is jailed under `/fs`** (canonicalize + prefix check; must not exist or be an empty dir).
+- **Demote destroys the domain**: typed-realm confirmation required; a final backup parachute is taken into `/fs` first when a filesystem exists.
+- **Service switchover via `Conflicts=`**: `samba-dc.service` conflicts with `samba-smbd`/`samba-nmbd`/`samba-winbindd`. It is NOT `wantedBy` anything — the engine starts it (provision + boot-restore phase `dc.restore`).
+- **One samba build**: nasty.nix's `sambaAds` becomes the DC-capable superset (`enableLDAP = true; enableDomainController = true;` + `python3Packages.cryptography` on `pythonPath`).
+- **Roles:** `dc.status` = `Any`; every other `dc.*` method = `Admin`. `dc.user.list`, `dc.group.list`, `dc.computer.list` MUST be added to the `is_read_only` carve-out in `router/mod.rs` (their `.list` suffix would otherwise leak them to ReadOnly sessions — same trap `domain.user.list` already documents).
+- **Static-IP precondition (amended from spec, approved):** hard-fail only when NASty's own network config (`networking.json`) manages interfaces and none is `Static` (all-DHCP → error naming the Network page); when NASty has no opinion (no managed interfaces — externally configured box, CI VM), provision proceeds and the response carries a **warning**.
+- Firewall `dc` port set: tcp+udp 53, 88, 464; tcp 135, 139, 389, 445, 636, 3268, 3269; udp 137, 138; tcp range 49152–65535. **No NTP port** (the box does not serve time).
+- Verification before every Rust commit (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`. WebUI (from `webui/`): `npm run check && npm test`. Nix changes are gated by the Integration workflow (VM tests), not local builds.
+- No new Rust dependencies (so no nix derivation input changes for the engine build).
+
+---
+
+## File Structure
+
+- `engine/nasty-system/src/firewall.rs` — **modify**: `PortSpec.to: Option<u16>` (additive), ranged render + ranged `service_port_conflict`, `dc_ports()`, `open_dc()`/`close_dc()`.
+- `engine/nasty-system/src/domain.rs` — **modify (minimal)**: `run_cmd`/`run_cmd_stdin` become `pub(crate)`; `join()` gains the "not while hosting" check.
+- `engine/nasty-system/src/dc.rs` — **create**: everything DC — types, persistence, validation, renders, provision/demote/status/backup, users/groups/computers.
+- `engine/nasty-system/src/lib.rs` — **modify**: `pub mod dc;`.
+- `engine/nasty-engine/src/main.rs` — **modify**: `AppState.dc`, `dc.restore` boot phase.
+- `engine/nasty-engine/src/router/dc.rs` — **create**: `dc.*` arms. `router/mod.rs` — **modify**: chain the new router, extend the `is_read_only` carve-out + its test.
+- `engine/nasty-engine/src/registry/methods.rs` — **modify**: `dc.*` entries.
+- `nixos/modules/nasty.nix` — **modify**: DC-capable samba build, `samba-dc.service`.
+- `webui/src/lib/types.ts`, `webui/src/lib/dc.svelte.ts` (**create**), `webui/src/lib/directory/DcPanel.svelte` (**create**), `webui/src/routes/settings/+page.svelte`, `webui/src/routes/firewall/+page.svelte` — WebUI.
+- `nixos/tests/ad-dc.nix` — **create**; `flake.nix` + `.github/workflows/integration.yml` — **modify**: register the check.
+
+---
+
+## Task 1: Firewall — ranged PortSpec + the `dc` service rule
+
+**Files:**
+- Modify: `engine/nasty-system/src/firewall.rs`
+- Test: `engine/nasty-system/src/firewall.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: existing `PortSpec`, `render_ruleset`, `service_port_conflict`, `open_rdma`/`close_rdma` (the shape to mirror).
+- Produces:
+  - `PortSpec.to: Option<u16>` — `#[serde(default, skip_serializing_if = "Option::is_none")]`; `None` = single port (all existing behavior unchanged).
+  - `pub fn dc_ports() -> Vec<PortSpec>`
+  - `pub async fn open_dc(&self)` / `pub async fn close_dc(&self)` on `FirewallService` — the `"dc"` named rule, exact mirrors of `open_rdma`/`close_rdma`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `tests` module in `firewall.rs`:
+
+```rust
+#[test]
+fn render_emits_ranged_service_port() {
+    let mut state = FirewallState::default();
+    state.rules.push(FirewallRule {
+        service: "dc".into(),
+        ports: vec![PortSpec {
+            port: 49152,
+            to: Some(65535),
+            transport: Transport::Tcp,
+            source: None,
+            iface: None,
+        }],
+        active: true,
+    });
+    let out = render_ruleset(&state, &[]);
+    assert!(out.contains("tcp dport 49152-65535 accept # dc"), "got:\n{out}");
+}
+
+#[test]
+fn service_conflict_matches_ranged_service_ports() {
+    let mut state = FirewallState::default();
+    state.rules.push(FirewallRule {
+        service: "dc".into(),
+        ports: vec![PortSpec {
+            port: 49152,
+            to: Some(65535),
+            transport: Transport::Tcp,
+            source: None,
+            iface: None,
+        }],
+        active: false, // inactive still owns its ports
+    });
+    // custom range overlapping the service range → conflict
+    assert_eq!(
+        service_port_conflict(&state, Transport::Tcp, 50000, 50010).as_deref(),
+        Some("dc")
+    );
+    // below the range → free
+    assert_eq!(service_port_conflict(&state, Transport::Tcp, 40000, 49151), None);
+}
+
+#[test]
+fn dc_ports_cover_ad_services() {
+    let ports = dc_ports();
+    let has = |t: Transport, p: u16| ports.iter().any(|s| s.transport == t && s.port == p && s.to.is_none());
+    for p in [53u16, 88, 464] {
+        assert!(has(Transport::Tcp, p) && has(Transport::Udp, p), "missing tcp+udp {p}");
+    }
+    for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+        assert!(has(Transport::Tcp, p), "missing tcp {p}");
+    }
+    for p in [137u16, 138] {
+        assert!(has(Transport::Udp, p), "missing udp {p}");
+    }
+    assert!(
+        ports.iter().any(|s| s.transport == Transport::Tcp && s.port == 49152 && s.to == Some(65535)),
+        "missing RPC range"
+    );
+    // No NTP — the box does not serve time.
+    assert!(!ports.iter().any(|s| s.port == 123));
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run (from `engine/`): `cargo test -p nasty-system firewall::tests::render_emits_ranged firewall::tests::service_conflict_matches_ranged firewall::tests::dc_ports_cover`
+Expected: FAIL — no field `to`, no `dc_ports`.
+
+- [ ] **Step 3: Add `to` to `PortSpec` and fix every constructor**
+
+In `struct PortSpec`, after `port`:
+
+```rust
+    /// Optional end of a contiguous port range (`port`..=`to`). `None`
+    /// means a single port. First used by the DC role's dynamic-RPC range.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to: Option<u16>,
+```
+
+Every `PortSpec { ... }` literal in the file gains `to: None` **except** where propagating an existing spec. The touch points: `tcp()` and `udp()` helpers, and the three literals inside `apply_restrictions` (those propagate: `to: port.to,`). Add a ranged helper next to `tcp()`/`udp()`:
+
+```rust
+fn tcp_range(from: u16, to: u16) -> PortSpec {
+    PortSpec {
+        port: from,
+        to: Some(to),
+        transport: Transport::Tcp,
+        source: None,
+        iface: None,
+    }
+}
+```
+
+- [ ] **Step 4: Teach the service render loop and the conflict check about ranges**
+
+In `render_ruleset`'s **service** loop, replace the dport condition line:
+
+```rust
+            match port.to {
+                Some(to) => conditions.push(format!("{proto} dport {}-{to}", port.port)),
+                None => conditions.push(format!("{proto} dport {}", port.port)),
+            }
+```
+
+In `service_port_conflict`, replace the containment test with interval intersection:
+
+```rust
+            let hi = port.to.unwrap_or(port.port);
+            if port.transport == transport && port.port <= to && hi >= from {
+                return Some(rule.service.clone());
+            }
+```
+
+- [ ] **Step 5: Add `dc_ports()` and the open/close methods**
+
+Next to `rdma_ports()`:
+
+```rust
+/// Ports for the Active Directory DC role (#20): DNS, Kerberos +
+/// kpasswd, RPC endpoint mapper, NetBIOS, LDAP(S), SMB, Global Catalog,
+/// and the dynamic RPC range. Deliberately no NTP — the box does not
+/// serve time to domain clients (documented limitation).
+pub fn dc_ports() -> Vec<PortSpec> {
+    let mut ports = Vec::new();
+    for p in [53u16, 88, 464] {
+        ports.push(tcp(p));
+        ports.push(udp(p));
+    }
+    for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+        ports.push(tcp(p));
+    }
+    for p in [137u16, 138] {
+        ports.push(udp(p));
+    }
+    ports.push(tcp_range(49152, 65535));
+    ports
+}
+```
+
+In `impl FirewallService`, after `close_rdma`, add `open_dc`/`close_dc` — copy `open_rdma`/`close_rdma` verbatim, replacing `"rdma"` with `"dc"` and `rdma_ports()` with `dc_ports()` (including the custom-lock acquisition and `apply_nftables(&state, &custom)` call those methods already carry).
+
+- [ ] **Step 6: Run the tests + full crate**
+
+Run (from `engine/`): `cargo test -p nasty-system`
+Expected: new tests PASS; all existing firewall tests (renders, custom rules, validation) still pass — single-port behavior is unchanged because `to: None` renders exactly as before.
+
+- [ ] **Step 7: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/firewall.rs
+git commit -m "firewall: ranged service ports + dc rule set (#20)"
+```
+
+---
+
+## Task 2: dc.rs — types, persistence, validation, renders, command hygiene
+
+**Files:**
+- Create: `engine/nasty-system/src/dc.rs`
+- Modify: `engine/nasty-system/src/lib.rs` (add `pub mod dc;`)
+- Modify: `engine/nasty-system/src/domain.rs` (visibility: `run_cmd` and `run_cmd_stdin` become `pub(crate) async fn`; doc comments unchanged)
+- Test: `engine/nasty-system/src/dc.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `domain::{validate_realm, derive_workgroup}` (already `pub`), `domain::{run_cmd, run_cmd_stdin}` (made `pub(crate)` here), `network::NetworkConfig`/`IpMethod` (already `pub`).
+- Produces (Tasks 3–5 rely on these exact names):
+  - `pub const DC_CONF_PATH: &str = "/etc/samba/smb.dc.conf";`
+  - `pub const DC_STATE_PATH: &str = "/var/lib/nasty/dc.json";`
+  - `pub const DC_RESOLVED_DROPIN_PATH: &str = "/run/systemd/resolved.conf.d/nasty-dc.conf";`
+  - `pub enum DcError { Validation(String), Precondition(String), CommandFailed(String), NotHosting, AlreadyHosting, Io(std::io::Error) }` (thiserror, operator-facing messages).
+  - `pub struct DcConfig { pub realm: String, pub workgroup: String, pub dns_forwarder: String }` (Serialize/Deserialize/Clone/Debug/JsonSchema).
+  - `pub struct ProvisionRequest { pub realm: String, pub admin_password: String, pub dns_forwarder: Option<String> }`, `pub struct DemoteRequest { pub realm_confirmation: String }` (Deserialize/JsonSchema; passwords redacted from Debug or Debug not derived).
+  - `pub struct DcStatus { pub hosting: bool, pub realm: Option<String>, pub workgroup: Option<String>, pub dns_forwarder: Option<String>, pub service_healthy: bool }` (Serialize/JsonSchema).
+  - `pub fn render_dc_resolved_dropin() -> String`
+  - `pub fn insert_into_global(conf: &str, extra: &str) -> String`
+  - `pub fn nasty_global_additions(dns_forwarder: &str) -> String`
+  - `pub enum StaticIpCheck { Pass, Warn(String), Fail(String) }` + `pub fn static_ip_check(cfg: Option<&crate::network::NetworkConfig>) -> StaticIpCheck`
+  - `pub fn validate_backup_dest(dest: &Path, root: &Path) -> Result<PathBuf, DcError>`
+  - `fn samba_tool_args<'a>(sub: &[&'a str]) -> Vec<&'a str>` — prefixes every call with the subcommand and appends `["--configfile", DC_CONF_PATH]`.
+  - `DcService::{new, load_config, save_config, clear_config}` (assoc fns mirroring `DomainService`'s, own path).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/nasty-system/src/dc.rs` with the module doc, the constants/types above as stubs where needed, and this test module (the tests define the contracts; implement to satisfy them):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── insert_into_global ────────────────────────────────────
+    #[test]
+    fn insert_into_global_lands_inside_global_section() {
+        let conf = "# Global parameters\n[global]\n\tdns forwarder = 127.0.0.53\n\trealm = AD.EXAMPLE.COM\n\n[sysvol]\n\tpath = /var/lib/samba/sysvol\n\n[netlogon]\n\tpath = /var/lib/samba/sysvol/ad.example.com/scripts\n";
+        let out = insert_into_global(conf, "\tinclude = /etc/samba/smb.nasty.conf\n");
+        let global_pos = out.find("[global]").unwrap();
+        let include_pos = out.find("include = /etc/samba/smb.nasty.conf").unwrap();
+        let sysvol_pos = out.find("[sysvol]").unwrap();
+        assert!(global_pos < include_pos && include_pos < sysvol_pos, "got:\n{out}");
+        // Original content preserved
+        assert!(out.contains("[netlogon]"));
+    }
+
+    #[test]
+    fn nasty_global_additions_carry_include_and_forwarder() {
+        let extra = nasty_global_additions("192.168.1.1");
+        assert!(extra.contains("include = /etc/samba/smb.nasty.conf"));
+        assert!(extra.contains("dns forwarder = 192.168.1.1"));
+    }
+
+    // ── resolved drop-in ──────────────────────────────────────
+    #[test]
+    fn dc_resolved_dropin_points_box_at_samba_dns() {
+        let out = render_dc_resolved_dropin();
+        assert!(out.contains("DNSStubListener=no"));
+        assert!(out.contains("DNS=127.0.0.1"));
+    }
+
+    // ── static-IP precondition ────────────────────────────────
+    fn iface(name: &str, method: crate::network::IpMethod) -> crate::network::InterfaceConfig {
+        // Build via serde so the test doesn't chase struct-field churn:
+        serde_json::from_value(serde_json::json!({
+            "name": name,
+            "method": method,
+        }))
+        .expect("InterfaceConfig from minimal json (all other fields serde-default)")
+    }
+
+    #[test]
+    fn static_ip_check_matrix() {
+        use crate::network::{IpMethod, NetworkConfig};
+        // No config at all → externally managed → warn, not fail.
+        assert!(matches!(static_ip_check(None), StaticIpCheck::Warn(_)));
+        // Empty config → same.
+        let empty = NetworkConfig::default();
+        assert!(matches!(static_ip_check(Some(&empty)), StaticIpCheck::Warn(_)));
+        // A static interface → pass.
+        let mut ok = NetworkConfig::default();
+        ok.interfaces.push(iface("eth0", IpMethod::Static));
+        assert!(matches!(static_ip_check(Some(&ok)), StaticIpCheck::Pass));
+        // Managed but all-DHCP → fail, message names the Network page.
+        let mut bad = NetworkConfig::default();
+        bad.interfaces.push(iface("eth0", IpMethod::Dhcp));
+        match static_ip_check(Some(&bad)) {
+            StaticIpCheck::Fail(msg) => assert!(msg.contains("Network"), "msg: {msg}"),
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    // ── backup-dest jail ──────────────────────────────────────
+    #[test]
+    fn backup_dest_jail() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("tank")).unwrap();
+        // ok: not-yet-existing dir under root
+        let dest = root.path().join("tank").join("dc-backup");
+        assert!(validate_backup_dest(&dest, root.path()).is_ok());
+        // ok: existing but empty
+        std::fs::create_dir(&dest).unwrap();
+        assert!(validate_backup_dest(&dest, root.path()).is_ok());
+        // reject: non-empty
+        std::fs::write(dest.join("x"), b"x").unwrap();
+        assert!(validate_backup_dest(&dest, root.path()).is_err());
+        // reject: traversal escape
+        let esc = root.path().join("tank").join("..").join("..").join("etc");
+        assert!(validate_backup_dest(&esc, root.path()).is_err());
+        // reject: relative
+        assert!(validate_backup_dest(std::path::Path::new("x/y"), root.path()).is_err());
+    }
+
+    // ── argv hygiene: THE invariant ───────────────────────────
+    #[test]
+    fn no_secret_ever_in_samba_tool_argv() {
+        // Every argv builder used for password-carrying operations must
+        // keep the password out. The builders return the argv; the secret
+        // travels via run_cmd_stdin.
+        let secret = "Sup3r.Secret!";
+        for argv in [
+            setpassword_args("Administrator"),
+            user_create_args("alice", None, None),
+        ] {
+            assert!(
+                !argv.iter().any(|a| a.contains(secret)),
+                "secret leaked into argv: {argv:?}"
+            );
+            // and every samba-tool call pins the DC config
+            assert!(argv.windows(2).any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH));
+        }
+        // Provision's argv carries ONLY the throwaway password, never the
+        // operator's. (The throwaway is random per call; assert the real
+        // secret isn't there.)
+        let prov = provision_args("AD.EXAMPLE.COM", "ADEXAMPLE", "throwaway-x");
+        assert!(!prov.iter().any(|a| a.contains(secret)));
+        assert!(prov.iter().any(|a| a == "--dns-backend=SAMBA_INTERNAL"));
+        assert!(prov.iter().any(|a| a == "--server-role=dc"));
+    }
+}
+```
+
+Notes for the implementer: `tempfile` is already a dev-dependency of `nasty-backup`, not necessarily of `nasty-system` — check `grep tempfile engine/nasty-system/Cargo.toml` and add `tempfile = "3"` under `[dev-dependencies]` if absent. The test helper builds `InterfaceConfig` through serde on purpose — only `name` and `method` matter and every other field is `#[serde(default)]`; if deserialization fails because some field lacks a default, construct the struct literally instead and note it.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run (from `engine/`): `cargo test -p nasty-system dc::tests`
+Expected: FAIL — none of the functions exist yet.
+
+- [ ] **Step 3: Implement the module core**
+
+The full implementation (top of `dc.rs`, above the tests):
+
+```rust
+//! Active Directory Domain Controller role (#20, second half).
+//!
+//! NASty *hosts* a domain: `samba-tool domain provision` with the
+//! SAMBA_INTERNAL DNS backend, run against an engine-owned config
+//! (`smb.dc.conf`) so the nix-managed /etc/samba/smb.conf is never
+//! touched. The DC's integrated smbd serves the box's shares via the
+//! existing `smb.nasty.conf` include chain. Exactly one DC per domain;
+//! mutual exclusion with member mode (`domain.rs`) both ways.
+//!
+//! Credential rule (same as member join): secrets NEVER ride argv —
+//! provision uses a random throwaway password, the real Administrator
+//! password is set via `samba-tool user setpassword` over stdin.
+
+use std::path::{Path, PathBuf};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::domain::{run_cmd, run_cmd_stdin};
+
+pub const DC_CONF_PATH: &str = "/etc/samba/smb.dc.conf";
+pub const DC_STATE_PATH: &str = "/var/lib/nasty/dc.json";
+pub const DC_RESOLVED_DROPIN_PATH: &str = "/run/systemd/resolved.conf.d/nasty-dc.conf";
+/// Root every domain-backup destination must resolve under.
+const FS_ROOT: &str = "/fs";
+/// NASty's own network config — consulted (read-only) by the static-IP
+/// precondition. Path mirrors `network.rs`'s private `JSON_PATH`.
+const NETWORKING_JSON_PATH: &str = "/var/lib/nasty/networking.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum DcError {
+    #[error("{0}")]
+    Validation(String),
+    #[error("{0}")]
+    Precondition(String),
+    #[error("{0}")]
+    CommandFailed(String),
+    #[error("this box is not hosting a domain")]
+    NotHosting,
+    #[error("this box is already hosting a domain — demote it first")]
+    AlreadyHosting,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<crate::domain::DomainError> for DcError {
+    fn from(e: crate::domain::DomainError) -> Self {
+        DcError::CommandFailed(e.to_string())
+    }
+}
+
+/// Persisted DC role state. Presence of the file == this box hosts a domain.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DcConfig {
+    pub realm: String,
+    pub workgroup: String,
+    pub dns_forwarder: String,
+}
+
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct ProvisionRequest {
+    /// Kerberos realm / DNS zone for the new domain, e.g. "ad.example.lan".
+    pub realm: String,
+    /// Administrator password. Set via samba-tool over stdin; never argv,
+    /// never logged, never persisted.
+    pub admin_password: String,
+    /// Upstream DNS the DC forwards non-domain queries to. Defaults to the
+    /// box's current upstream resolver.
+    #[serde(default)]
+    pub dns_forwarder: Option<String>,
+}
+
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct DemoteRequest {
+    /// Must exactly match the hosted realm — demoting DESTROYS the domain.
+    pub realm_confirmation: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DcStatus {
+    pub hosting: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub realm: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workgroup: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_forwarder: Option<String>,
+    /// Whether samba-dc.service is active. Meaningful only when hosting.
+    pub service_healthy: bool,
+}
+
+// ── Pure renders / helpers ─────────────────────────────────────
+
+/// resolved drop-in for DC mode: samba's SAMBA_INTERNAL DNS owns :53,
+/// so resolved must release the stub listener and the box resolves
+/// through samba (which forwards non-domain queries upstream).
+pub fn render_dc_resolved_dropin() -> String {
+    "# Managed by NASty — this box hosts an AD domain; samba's internal\n\
+     # DNS owns port 53. Removed at demote.\n\
+     [Resolve]\n\
+     DNS=127.0.0.1\n\
+     DNSStubListener=no\n"
+        .to_string()
+}
+
+/// The [global] lines NASty adds to the provision-generated smb.dc.conf:
+/// the share include chain and the upstream DNS forwarder.
+pub fn nasty_global_additions(dns_forwarder: &str) -> String {
+    format!(
+        "\t# NASty-managed additions (share include chain + upstream DNS)\n\
+         \tinclude = /etc/samba/smb.nasty.conf\n\
+         \tdns forwarder = {dns_forwarder}\n"
+    )
+}
+
+/// Insert `extra` immediately after the `[global]` section header. A blind
+/// append would land inside the last share section ([netlogon]) instead.
+pub fn insert_into_global(conf: &str, extra: &str) -> String {
+    let mut out = String::with_capacity(conf.len() + extra.len());
+    let mut inserted = false;
+    for line in conf.lines() {
+        out.push_str(line);
+        out.push('\n');
+        if !inserted && line.trim() == "[global]" {
+            out.push_str(extra);
+            inserted = true;
+        }
+    }
+    if !inserted {
+        // No [global] header at all (unexpected) — prepend one.
+        return format!("[global]\n{extra}{out}");
+    }
+    out
+}
+
+/// Static-IP precondition (spec-amended): Fail only when NASty's own
+/// network config manages interfaces and none is Static; Warn when NASty
+/// has no opinion (externally managed box / fresh VM); Pass when at least
+/// one managed interface is Static.
+#[derive(Debug)]
+pub enum StaticIpCheck {
+    Pass,
+    Warn(String),
+    Fail(String),
+}
+
+pub fn static_ip_check(cfg: Option<&crate::network::NetworkConfig>) -> StaticIpCheck {
+    let Some(cfg) = cfg else {
+        return StaticIpCheck::Warn(
+            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
+        );
+    };
+    if cfg.interfaces.is_empty() {
+        return StaticIpCheck::Warn(
+            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
+        );
+    }
+    if cfg
+        .interfaces
+        .iter()
+        .any(|i| i.method == crate::network::IpMethod::Static)
+    {
+        return StaticIpCheck::Pass;
+    }
+    StaticIpCheck::Fail(
+        "a domain controller needs a static IP address, but every NASty-managed interface uses DHCP — set a static address on the Network page first".into(),
+    )
+}
+
+/// Jail a domain-backup destination under `/fs` (root parameterized for
+/// tests). Must be absolute, resolve under root after canonicalizing the
+/// existing prefix, and be either absent or an empty directory —
+/// `samba-tool domain backup` requires an empty target dir. Local sibling
+/// of nasty-backup's restore jail; duplicated across the crate boundary
+/// on purpose (nasty-system must not depend on nasty-backup).
+pub fn validate_backup_dest(dest: &Path, root: &Path) -> Result<PathBuf, DcError> {
+    if !dest.is_absolute() {
+        return Err(DcError::Validation("destination must be an absolute path".into()));
+    }
+    let mut existing = dest;
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let canonical_prefix = loop {
+        match existing.canonicalize() {
+            Ok(p) => break p,
+            Err(_) => {
+                let file = existing
+                    .file_name()
+                    .ok_or_else(|| DcError::Validation("destination escapes /fs".into()))?;
+                tail.push(file);
+                existing = existing
+                    .parent()
+                    .ok_or_else(|| DcError::Validation("destination escapes /fs".into()))?;
+            }
+        }
+    };
+    let mut resolved = canonical_prefix;
+    for part in tail.iter().rev() {
+        resolved.push(part);
+    }
+    let canonical_root = root.canonicalize().map_err(DcError::Io)?;
+    if !resolved.starts_with(&canonical_root) || resolved == canonical_root {
+        return Err(DcError::Validation(
+            "destination must be inside a NASty filesystem under /fs".into(),
+        ));
+    }
+    if resolved.is_dir() {
+        let mut entries = std::fs::read_dir(&resolved)?;
+        if entries.next().is_some() {
+            return Err(DcError::Validation(
+                "destination directory is not empty — samba-tool requires an empty backup target".into(),
+            ));
+        }
+    } else if resolved.exists() {
+        return Err(DcError::Validation("destination exists and is not a directory".into()));
+    }
+    Ok(resolved)
+}
+
+// ── samba-tool argv builders (pure; unit-tested for argv hygiene) ──
+
+fn with_conf(mut argv: Vec<String>) -> Vec<String> {
+    argv.push("--configfile".into());
+    argv.push(DC_CONF_PATH.into());
+    argv
+}
+
+pub(crate) fn provision_args(realm: &str, workgroup: &str, throwaway_pass: &str) -> Vec<String> {
+    with_conf(vec![
+        "domain".into(),
+        "provision".into(),
+        format!("--realm={realm}"),
+        format!("--domain={workgroup}"),
+        "--server-role=dc".into(),
+        "--dns-backend=SAMBA_INTERNAL".into(),
+        format!("--adminpass={throwaway_pass}"),
+    ])
+}
+
+pub(crate) fn setpassword_args(user: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "setpassword".into(), user.into()])
+}
+
+pub(crate) fn user_create_args(
+    name: &str,
+    given_name: Option<&str>,
+    surname: Option<&str>,
+) -> Vec<String> {
+    let mut argv = vec!["user".into(), "create".into(), name.into()];
+    if let Some(g) = given_name {
+        argv.push(format!("--given-name={g}"));
+    }
+    if let Some(s) = surname {
+        argv.push(format!("--surname={s}"));
+    }
+    with_conf(argv)
+}
+```
+
+Then the service skeleton + persistence (the lifecycle methods land in Task 3):
+
+```rust
+// ── Service ────────────────────────────────────────────────────
+
+pub struct DcService;
+
+impl Default for DcService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DcService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn load_config() -> Option<DcConfig> {
+        let raw = tokio::fs::read_to_string(DC_STATE_PATH).await.ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    pub async fn save_config(config: &DcConfig) -> Result<(), DcError> {
+        let json = serde_json::to_string_pretty(config)
+            .map_err(|e| DcError::Validation(format!("serialize dc config: {e}")))?;
+        tokio::fs::write(DC_STATE_PATH, json).await?;
+        Ok(())
+    }
+
+    pub async fn clear_config() -> Result<(), DcError> {
+        match tokio::fs::remove_file(DC_STATE_PATH).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+/// Run samba-tool with the given argv (already carrying --configfile).
+async fn samba_tool(argv: &[String]) -> Result<String, DcError> {
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    Ok(run_cmd("samba-tool", &args, &[]).await?)
+}
+
+/// Run samba-tool feeding `stdin_input` (the only way secrets travel).
+async fn samba_tool_stdin(argv: &[String], stdin_input: &str) -> Result<String, DcError> {
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    Ok(run_cmd_stdin("samba-tool", &args, &[], stdin_input).await?)
+}
+```
+
+In `domain.rs`, change the two helper signatures (nothing else):
+
+```rust
+pub(crate) async fn run_cmd(
+pub(crate) async fn run_cmd_stdin(
+```
+
+In `lib.rs`, add `pub mod dc;` next to `pub mod domain;`.
+
+Note: `provision_args`/`setpassword_args`/`user_create_args`/`samba_tool`/`samba_tool_stdin` will be `dead_code` until Task 3 wires them — add `#[allow(dead_code)]` on `samba_tool`/`samba_tool_stdin` ONLY if clippy demands it, with a `// consumed by Task 3 lifecycle` comment, and Task 3 MUST remove it. The `pub(crate)` argv builders are exercised by the tests, so they're live already.
+
+- [ ] **Step 4: Run to verify the tests pass**
+
+Run (from `engine/`): `cargo test -p nasty-system dc::tests`
+Expected: PASS (all six).
+
+- [ ] **Step 5: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/dc.rs nasty-system/src/lib.rs nasty-system/src/domain.rs nasty-system/Cargo.toml
+git commit -m "dc: types, persistence, validation, renders, samba-tool argv hygiene (#20)"
+```
+
+---
+
+## Task 3: dc.rs — provision / demote / status / backup lifecycle
+
+**Files:**
+- Modify: `engine/nasty-system/src/dc.rs`
+- Modify: `engine/nasty-system/src/domain.rs` (join gains the hosting check)
+- Test: `engine/nasty-system/src/dc.rs` (one new pure test), plus compile/clippy/suite — the lifecycle itself is VM-test territory (Task 8), same convention as member join.
+
+**Interfaces:**
+- Consumes: everything Task 2 produced; `domain::{validate_realm, derive_workgroup}`; `DomainService::load_config`.
+- Produces (Tasks 5/8 rely on):
+  - `pub async fn provision(&self, req: ProvisionRequest) -> Result<(DcStatus, Vec<String>), DcError>` — the `Vec<String>` is warnings (static-IP warn).
+  - `pub async fn demote(&self, req: DemoteRequest) -> Result<(), DcError>`
+  - `pub async fn status(&self) -> DcStatus`
+  - `pub async fn backup(&self, dest: &str) -> Result<String, DcError>` — returns the tarball path.
+  - `pub async fn ensure_running(&self) -> bool` — boot-restore: true when hosting (caller opens the firewall).
+
+- [ ] **Step 1: Write the one new pure failing test**
+
+```rust
+    #[test]
+    fn find_backup_tarball_picks_the_tarball() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.txt"), b"x").unwrap();
+        std::fs::write(dir.path().join("samba-backup-2026-07-10.tar.bz2"), b"x").unwrap();
+        let found = find_backup_tarball(dir.path()).unwrap();
+        assert!(found.ends_with("samba-backup-2026-07-10.tar.bz2"));
+    }
+```
+
+Run (from `engine/`): `cargo test -p nasty-system dc::tests::find_backup_tarball` — Expected: FAIL (missing fn).
+
+- [ ] **Step 2: Implement the lifecycle**
+
+Add to `dc.rs` (inside `impl DcService`, plus the free helpers). Complete code:
+
+```rust
+    /// Provision a brand-new AD domain on this box. Returns the status plus
+    /// operator-facing warnings (e.g. externally-managed network config).
+    ///
+    /// Sequence: preflight → samba-tool provision (throwaway --adminpass,
+    /// engine-owned smb.dc.conf) → insert NASty [global] additions → set the
+    /// real Administrator password via stdin → resolved drop-in (release
+    /// :53) → start samba-dc.service → persist dc.json. Any failure after
+    /// provision unwinds through the demote teardown (minus the backup).
+    pub async fn provision(
+        &self,
+        req: ProvisionRequest,
+    ) -> Result<(DcStatus, Vec<String>), DcError> {
+        // ── Preflight ──────────────────────────────────────────
+        if Self::load_config().await.is_some() {
+            return Err(DcError::AlreadyHosting);
+        }
+        if crate::domain::DomainService::load_config().await.is_some() {
+            return Err(DcError::Precondition(
+                "this box is joined to a domain as a member — leave the domain before hosting one".into(),
+            ));
+        }
+        let realm = crate::domain::validate_realm(&req.realm)
+            .map_err(|e| DcError::Validation(e.to_string()))?;
+        let workgroup = crate::domain::derive_workgroup(&realm);
+
+        let mut warnings = Vec::new();
+        let net_cfg: Option<crate::network::NetworkConfig> =
+            tokio::fs::read_to_string(NETWORKING_JSON_PATH)
+                .await
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok());
+        match static_ip_check(net_cfg.as_ref()) {
+            StaticIpCheck::Pass => {}
+            StaticIpCheck::Warn(w) => warnings.push(w),
+            StaticIpCheck::Fail(msg) => return Err(DcError::Precondition(msg)),
+        }
+
+        let dns_forwarder = resolve_dns_forwarder(req.dns_forwarder.as_deref()).await?;
+
+        // A stale DC config would make samba-tool refuse to provision.
+        let _ = tokio::fs::remove_file(DC_CONF_PATH).await;
+
+        // ── Provision (throwaway password on argv, rotated below) ──
+        let throwaway = uuid::Uuid::new_v4().to_string();
+        info!("dc: provisioning domain {realm} (workgroup {workgroup})");
+        samba_tool(&provision_args(&realm, &workgroup, &throwaway)).await?;
+
+        // Everything past this point unwinds on failure.
+        let result: Result<(), DcError> = async {
+            // NASty [global] additions inside the generated config.
+            let conf = tokio::fs::read_to_string(DC_CONF_PATH).await?;
+            let conf = insert_into_global(&conf, &nasty_global_additions(&dns_forwarder));
+            tokio::fs::write(DC_CONF_PATH, conf).await?;
+
+            // Real Administrator password — over stdin, twice (prompt +
+            // confirmation). Never argv, never logged.
+            samba_tool_stdin(
+                &setpassword_args("Administrator"),
+                &format!("{}\n{}", req.admin_password, req.admin_password),
+            )
+            .await?;
+
+            // Release :53 to samba, route the box's own lookups through it.
+            tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
+            tokio::fs::write(DC_RESOLVED_DROPIN_PATH, render_dc_resolved_dropin()).await?;
+            run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await?;
+
+            // samba-dc conflicts with smbd/nmbd/winbindd — systemd swaps
+            // them atomically.
+            run_cmd("systemctl", &["start", "samba-dc.service"], &[]).await?;
+
+            Self::save_config(&DcConfig {
+                realm: realm.clone(),
+                workgroup: workgroup.clone(),
+                dns_forwarder: dns_forwarder.clone(),
+            })
+            .await?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            warn!("dc: provision failed after samba-tool provision — unwinding: {e}");
+            self.teardown().await;
+            return Err(e);
+        }
+
+        info!("dc: domain {realm} provisioned");
+        Ok((self.status().await, warnings))
+    }
+
+    /// Demote — DESTROYS the domain. Typed-realm confirmation; takes a
+    /// final backup parachute into /fs when a filesystem exists.
+    pub async fn demote(&self, req: DemoteRequest) -> Result<(), DcError> {
+        let cfg = Self::load_config().await.ok_or(DcError::NotHosting)?;
+        if req.realm_confirmation.trim() != cfg.realm {
+            return Err(DcError::Validation(format!(
+                "confirmation does not match the hosted realm ({})",
+                cfg.realm
+            )));
+        }
+        // Parachute: best-effort final backup into /fs.
+        match first_fs_dir().await {
+            Some(fs_dir) => {
+                let dest = format!(
+                    "{fs_dir}/dc-final-backup-{}",
+                    chrono::Utc::now().format("%Y%m%d-%H%M%S")
+                );
+                match self.backup(&dest).await {
+                    Ok(path) => info!("dc: final domain backup written to {path}"),
+                    Err(e) => warn!("dc: final backup failed (continuing demote): {e}"),
+                }
+            }
+            None => warn!("dc: no /fs filesystem mounted — demoting WITHOUT a final backup"),
+        }
+        info!("dc: demoting — destroying domain {}", cfg.realm);
+        self.teardown().await;
+        Ok(())
+    }
+
+    /// Shared teardown for demote and provision-unwind: stop the DC, remove
+    /// its config + domain state, restore resolved, clear dc.json. Every
+    /// step best-effort — teardown must never strand the box half-torn.
+    async fn teardown(&self) {
+        let _ = run_cmd("systemctl", &["stop", "samba-dc.service"], &[]).await;
+        let _ = tokio::fs::remove_file(DC_CONF_PATH).await;
+        // Domain databases + sysvol. Root-resident by design.
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/private").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/sysvol").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/bind-dns").await;
+        if tokio::fs::remove_file(DC_RESOLVED_DROPIN_PATH).await.is_ok() {
+            let _ = run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await;
+        }
+        let _ = Self::clear_config().await;
+    }
+
+    pub async fn status(&self) -> DcStatus {
+        match Self::load_config().await {
+            Some(cfg) => {
+                let healthy = run_cmd("systemctl", &["is-active", "samba-dc.service"], &[])
+                    .await
+                    .is_ok();
+                DcStatus {
+                    hosting: true,
+                    realm: Some(cfg.realm),
+                    workgroup: Some(cfg.workgroup),
+                    dns_forwarder: Some(cfg.dns_forwarder),
+                    service_healthy: healthy,
+                }
+            }
+            None => DcStatus {
+                hosting: false,
+                realm: None,
+                workgroup: None,
+                dns_forwarder: None,
+                service_healthy: false,
+            },
+        }
+    }
+
+    /// Domain backup: `samba-tool domain backup offline` into a /fs-jailed,
+    /// empty target dir. Returns the tarball path.
+    pub async fn backup(&self, dest: &str) -> Result<String, DcError> {
+        if Self::load_config().await.is_none() {
+            return Err(DcError::NotHosting);
+        }
+        let resolved =
+            validate_backup_dest(Path::new(dest), Path::new(FS_ROOT))?;
+        tokio::fs::create_dir_all(&resolved).await?;
+        let target = resolved.to_string_lossy().to_string();
+        samba_tool(&with_conf(vec![
+            "domain".into(),
+            "backup".into(),
+            "offline".into(),
+            format!("--targetdir={target}"),
+        ]))
+        .await?;
+        find_backup_tarball(&resolved).ok_or_else(|| {
+            DcError::CommandFailed("samba-tool reported success but no backup tarball was found".into())
+        })
+    }
+
+    /// Boot restore (`dc.restore` phase): when hosting, rewrite the /run
+    /// resolved drop-in (tmpfs — gone after reboot), restart resolved if it
+    /// changed, and start the DC. Returns whether the box hosts a domain so
+    /// the caller can open the firewall.
+    pub async fn ensure_running(&self) -> bool {
+        if Self::load_config().await.is_none() {
+            return false;
+        }
+        let dropin = render_dc_resolved_dropin();
+        let current = tokio::fs::read_to_string(DC_RESOLVED_DROPIN_PATH)
+            .await
+            .unwrap_or_default();
+        if current != dropin {
+            let _ = tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await;
+            if tokio::fs::write(DC_RESOLVED_DROPIN_PATH, dropin).await.is_ok() {
+                let _ = run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await;
+            }
+        }
+        if let Err(e) = run_cmd("systemctl", &["start", "samba-dc.service"], &[]).await {
+            warn!("dc: failed to start samba-dc at boot restore: {e}");
+        }
+        true
+    }
+```
+
+Free helpers (module level):
+
+```rust
+/// The upstream DNS forwarder: explicit wins; else the first global server
+/// from `resolvectl dns`; else an error asking the operator to supply one
+/// (once samba owns :53 there is no other upstream path).
+async fn resolve_dns_forwarder(explicit: Option<&str>) -> Result<String, DcError> {
+    if let Some(f) = explicit {
+        let f = f.trim();
+        if f.parse::<std::net::IpAddr>().is_err() {
+            return Err(DcError::Validation(format!(
+                "dns_forwarder must be an IP address, got: {f}"
+            )));
+        }
+        return Ok(f.to_string());
+    }
+    let out = run_cmd("resolvectl", &["dns"], &[]).await.unwrap_or_default();
+    for token in out.split_whitespace() {
+        if let Ok(ip) = token.parse::<std::net::IpAddr>() {
+            if !ip.is_loopback() {
+                return Ok(ip.to_string());
+            }
+        }
+    }
+    Err(DcError::Precondition(
+        "could not determine an upstream DNS forwarder — supply one in the provision form".into(),
+    ))
+}
+
+/// First mounted filesystem under /fs (for the demote parachute).
+async fn first_fs_dir() -> Option<String> {
+    let mut rd = tokio::fs::read_dir(FS_ROOT).await.ok()?;
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
+            return Some(entry.path().to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+/// The tarball samba-tool wrote into the backup target dir.
+fn find_backup_tarball(dir: &Path) -> Option<String> {
+    let rd = std::fs::read_dir(dir).ok()?;
+    for entry in rd.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.ends_with(".tar.bz2") {
+            return Some(entry.path().to_string_lossy().to_string());
+        }
+    }
+    None
+}
+```
+
+Check `nasty-system/Cargo.toml` has `uuid` and `chrono` (both confirmed present: `uuid.workspace = true`, `chrono` with `clock` feature). Remove any `#[allow(dead_code)]` Task 2 left on `samba_tool`/`samba_tool_stdin`.
+
+In `domain.rs`'s `join()`, at the top of the preflight (right after its existing validation begins), add:
+
+```rust
+        if crate::dc::DcService::load_config().await.is_some() {
+            return Err(DomainError::Validation(
+                "this box hosts an Active Directory domain — demote it before joining another domain".into(),
+            ));
+        }
+```
+
+- [ ] **Step 3: Run tests + full verification**
+
+Run (from `engine/`): `cargo test -p nasty-system dc::tests` — all pass (including `find_backup_tarball_picks_the_tarball`).
+Then: `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/dc.rs nasty-system/src/domain.rs
+git commit -m "dc: provision/demote/status/backup lifecycle with unwind (#20)"
+```
+
+---
+
+## Task 4: dc.rs — users, groups, computers
+
+**Files:**
+- Modify: `engine/nasty-system/src/dc.rs`
+- Test: `engine/nasty-system/src/dc.rs`
+
+**Interfaces:**
+- Consumes: `samba_tool`, `samba_tool_stdin`, `with_conf`, `user_create_args` (Task 2/3).
+- Produces (Task 5 relies on):
+  - `pub struct DcPrincipal { pub name: String }` (Serialize/JsonSchema)
+  - `pub async fn user_list(&self) -> Result<Vec<DcPrincipal>, DcError>`
+  - `pub async fn user_create(&self, name: &str, password: &str, given_name: Option<&str>, surname: Option<&str>) -> Result<(), DcError>`
+  - `pub async fn user_delete(&self, name: &str) -> Result<(), DcError>`
+  - `pub async fn user_set_password(&self, name: &str, password: &str) -> Result<(), DcError>`
+  - `pub async fn user_enable(&self, name: &str)` / `user_disable` — `Result<(), DcError>`
+  - `pub async fn group_list(&self) -> Result<Vec<DcPrincipal>, DcError>`
+  - `pub async fn group_create(&self, name: &str)` / `group_delete` — `Result<(), DcError>`
+  - `pub async fn group_add_member(&self, group: &str, member: &str)` / `group_remove_member` — `Result<(), DcError>`
+  - `pub async fn computer_list(&self) -> Result<Vec<DcPrincipal>, DcError>`
+
+- [ ] **Step 1: Write failing tests (parser + argv hygiene extension)**
+
+```rust
+    #[test]
+    fn parse_principal_lines_skips_noise() {
+        let raw = "Administrator\nGuest\n\nalice\n  bob  \n";
+        let out = parse_principal_lines(raw);
+        let names: Vec<&str> = out.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["Administrator", "Guest", "alice", "bob"]);
+    }
+
+    #[test]
+    fn management_argv_never_carries_secrets_and_pins_config() {
+        let secret = "Sup3r.Secret!";
+        for argv in [
+            user_delete_args("alice"),
+            user_enable_args("alice"),
+            user_disable_args("alice"),
+            group_add_args("staff"),
+            group_delete_args("staff"),
+            group_members_args("addmembers", "staff", "alice"),
+            list_args("user"),
+            list_args("group"),
+            list_args("computer"),
+        ] {
+            assert!(!argv.iter().any(|a| a.contains(secret)), "argv: {argv:?}");
+            assert!(argv.windows(2).any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH));
+        }
+    }
+```
+
+Run: `cargo test -p nasty-system dc::tests::parse_principal dc::tests::management_argv` — Expected: FAIL.
+
+- [ ] **Step 2: Implement**
+
+Argv builders + parser (module level):
+
+```rust
+fn parse_principal_lines(raw: &str) -> Vec<DcPrincipal> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|l| DcPrincipal { name: l.to_string() })
+        .collect()
+}
+
+pub(crate) fn list_args(kind: &str) -> Vec<String> {
+    with_conf(vec![kind.into(), "list".into()])
+}
+pub(crate) fn user_delete_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "delete".into(), name.into()])
+}
+pub(crate) fn user_enable_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "enable".into(), name.into()])
+}
+pub(crate) fn user_disable_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "disable".into(), name.into()])
+}
+pub(crate) fn group_add_args(name: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), "add".into(), name.into()])
+}
+pub(crate) fn group_delete_args(name: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), "delete".into(), name.into()])
+}
+pub(crate) fn group_members_args(op: &str, group: &str, member: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), op.into(), group.into(), member.into()])
+}
+```
+
+The type + methods:
+
+```rust
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DcPrincipal {
+    pub name: String,
+}
+```
+
+```rust
+    // ── Domain principal management (all samba-tool; passwords via stdin) ──
+
+    async fn require_hosting(&self) -> Result<(), DcError> {
+        if Self::load_config().await.is_none() {
+            return Err(DcError::NotHosting);
+        }
+        Ok(())
+    }
+
+    pub async fn user_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(&samba_tool(&list_args("user")).await?))
+    }
+
+    pub async fn user_create(
+        &self,
+        name: &str,
+        password: &str,
+        given_name: Option<&str>,
+        surname: Option<&str>,
+    ) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        // `samba-tool user create` prompts "New Password:" + "Retype
+        // Password:" — both fed over stdin (never argv).
+        samba_tool_stdin(
+            &user_create_args(name, given_name, surname),
+            &format!("{password}\n{password}"),
+        )
+        .await?;
+        info!("dc: created domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_delete(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_delete_args(name)).await?;
+        info!("dc: deleted domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_set_password(&self, name: &str, password: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool_stdin(&setpassword_args(name), &format!("{password}\n{password}")).await?;
+        info!("dc: reset password for domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_enable(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_enable_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn user_disable(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_disable_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(&samba_tool(&list_args("group")).await?))
+    }
+
+    pub async fn group_create(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_add_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_delete(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_delete_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_add_member(&self, group: &str, member: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_members_args("addmembers", group, member)).await?;
+        Ok(())
+    }
+
+    pub async fn group_remove_member(&self, group: &str, member: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_members_args("removemembers", group, member)).await?;
+        Ok(())
+    }
+
+    pub async fn computer_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(&samba_tool(&list_args("computer")).await?))
+    }
+```
+
+- [ ] **Step 3: Run tests + full verification, commit**
+
+`cargo test -p nasty-system dc::tests` → PASS; then the full three-step verification.
+
+```bash
+cd engine && cargo fmt
+git add nasty-system/src/dc.rs
+git commit -m "dc: domain user/group/computer management via samba-tool (#20)"
+```
+
+---
+
+## Task 5: Engine wiring — AppState, router, registry, carve-outs, boot restore
+
+**Files:**
+- Modify: `engine/nasty-engine/src/main.rs`
+- Create: `engine/nasty-engine/src/router/dc.rs`
+- Modify: `engine/nasty-engine/src/router/mod.rs` (chain router; extend `is_read_only` carve-out + test)
+- Modify: `engine/nasty-engine/src/registry/methods.rs`
+
+**Interfaces:**
+- Consumes: `DcService` + every Task 3/4 method; `FirewallService::{open_dc, close_dc}` (Task 1); router helpers (`ok`, `err`, `invalid`, `parse_params`, `require_str`).
+- Produces: RPC methods `dc.status`, `dc.provision`, `dc.demote`, `dc.backup`, `dc.user.{list,create,delete,set_password,enable,disable}`, `dc.group.{list,create,delete,add_member,remove_member}`, `dc.computer.list`.
+
+- [ ] **Step 1: Failing test — the read-only carve-out**
+
+In `router/mod.rs`'s existing tests (next to the `domain.user.list` assertions at ~line 1381):
+
+```rust
+        assert!(!is_read_only("dc.user.list"));
+        assert!(!is_read_only("dc.group.list"));
+        assert!(!is_read_only("dc.computer.list"));
+        assert!(is_read_only("dc.status")); // status is a safe read
+```
+
+Run: `cargo test -p nasty-engine read_only` — Expected: FAIL (the three `.list` methods currently match the suffix heuristic).
+
+- [ ] **Step 2: Extend the carve-out**
+
+In `is_read_only`, extend the existing `matches!`:
+
+```rust
+    if matches!(
+        method,
+        "domain.user.list"
+            | "domain.group.list"
+            // Same trap for DC mode: these enumerate the hosted directory
+            // and are Admin-gated in the registry — the `.list` suffix must
+            // not slip them into the ReadOnly set.
+            | "dc.user.list"
+            | "dc.group.list"
+            | "dc.computer.list"
+    ) {
+        return false;
+    }
+```
+
+Run the test again → PASS.
+
+- [ ] **Step 3: AppState + boot restore**
+
+In `main.rs`: add the field and constructor entry next to `domain` (lines ~82/~226):
+
+```rust
+    pub dc: nasty_system::dc::DcService,
+```
+```rust
+            dc: nasty_system::dc::DcService::new(),
+```
+
+Register the phase name next to `"domain.restore"` (~line 248): add `"dc.restore",`.
+
+Add the phase right after the existing `domain.restore` block (~line 373), same shape:
+
+```rust
+    // If this box hosts an AD domain, bring the DC back up: rewrite the
+    // /run resolved drop-in (tmpfs — empty after reboot), start samba-dc
+    // (Conflicts= swaps member-mode samba out), and open the DC firewall
+    // ports. Must run after the smb.nasty.conf reconcile above — the DC
+    // config includes it.
+    .run_phase("dc.restore", secs(30), {
+        let state = state.clone();
+        async move {
+            if state.dc.ensure_running().await {
+                state.firewall.open_dc().await;
+            }
+        }
+    })
+```
+
+(Match the surrounding `run_phase` closure style exactly — clone pattern, `secs(...)` helper.)
+
+- [ ] **Step 4: Router arms**
+
+Create `engine/nasty-engine/src/router/dc.rs`:
+
+```rust
+//! RPC arms in the `dc.*` namespace (Active Directory Domain Controller
+//! role — this box HOSTS the domain). Member mode lives in domain.rs.
+
+use nasty_common::{Request, Response};
+use serde::Deserialize;
+
+use super::*;
+use crate::AppState;
+use crate::auth::Session;
+
+#[derive(Deserialize)]
+struct UserCreateParams {
+    name: String,
+    password: String,
+    #[serde(default)]
+    given_name: Option<String>,
+    #[serde(default)]
+    surname: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SetPasswordParams {
+    name: String,
+    password: String,
+}
+
+#[derive(Deserialize)]
+struct GroupMemberParams {
+    group: String,
+    member: String,
+}
+
+pub(super) async fn try_route(
+    req: &Request,
+    state: &AppState,
+    _session: &Session,
+) -> Option<Response> {
+    Some(match req.method.as_str() {
+        "dc.status" => ok(req, state.dc.status().await),
+        "dc.provision" => match parse_params::<nasty_system::dc::ProvisionRequest>(req) {
+            Ok(p) => match state.dc.provision(p).await {
+                Ok((status, warnings)) => {
+                    // DC ports open only after a successful provision.
+                    state.firewall.open_dc().await;
+                    ok(req, serde_json::json!({ "status": status, "warnings": warnings }))
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.demote" => match parse_params::<nasty_system::dc::DemoteRequest>(req) {
+            Ok(p) => match state.dc.demote(p).await {
+                Ok(()) => {
+                    state.firewall.close_dc().await;
+                    ok(req, "ok")
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.backup" => match require_str(req, "dest") {
+            Ok(dest) => match state.dc.backup(dest).await {
+                Ok(path) => ok(req, serde_json::json!({ "path": path })),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.list" => match state.dc.user_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "dc.user.create" => match parse_params::<UserCreateParams>(req) {
+            Ok(p) => match state
+                .dc
+                .user_create(&p.name, &p.password, p.given_name.as_deref(), p.surname.as_deref())
+                .await
+            {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.user.delete" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_delete(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.set_password" => match parse_params::<SetPasswordParams>(req) {
+            Ok(p) => match state.dc.user_set_password(&p.name, &p.password).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.user.enable" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_enable(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.disable" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_disable(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.list" => match state.dc.group_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "dc.group.create" => match require_str(req, "name") {
+            Ok(name) => match state.dc.group_create(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.delete" => match require_str(req, "name") {
+            Ok(name) => match state.dc.group_delete(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.add_member" => match parse_params::<GroupMemberParams>(req) {
+            Ok(p) => match state.dc.group_add_member(&p.group, &p.member).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.group.remove_member" => match parse_params::<GroupMemberParams>(req) {
+            Ok(p) => match state.dc.group_remove_member(&p.group, &p.member).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.computer.list" => match state.dc.computer_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        _ => return None,
+    })
+}
+```
+
+Register the module and chain it in `router/mod.rs`: add `mod dc;` next to `mod domain;`, and chain `dc::try_route(...)` immediately after the `domain::try_route(...)` call site (grep `domain::try_route` for the exact chaining style — an `if let Some(r) = ... { return r; }` or `.or()` chain; mirror it).
+
+- [ ] **Step 5: Registry entries**
+
+In `registry/methods.rs`, after the `domain.*` group, add the `dc.*` methods. `dc.status` → `role: MethodRole::Any`, `result: Some(gen_schema::<nasty_system::dc::DcStatus>(generator))`, `params: MethodParams::None`. All others → `role: MethodRole::Admin`:
+
+- `dc.provision`: `MethodParams::Schema(gen_schema::<nasty_system::dc::ProvisionRequest>(generator))`; desc: "Provision a brand-new Active Directory domain on this box (Samba AD DC, internal DNS). Exactly one DC per domain; refuses when the box is domain-joined. The Administrator password is set over stdin and never logged. Returns { status, warnings }."
+- `dc.demote`: `MethodParams::Schema(gen_schema::<nasty_system::dc::DemoteRequest>(generator))`; desc: "Demote the DC — DESTROYS the hosted domain (typed-realm confirmation required). Takes a final domain backup into /fs when a filesystem exists, then tears the role down."
+- `dc.backup`: `MethodParams::AdHoc(ad_hoc_one("dest", "Backup target directory; must resolve under /fs and be empty or absent."))`; desc: "Run `samba-tool domain backup offline` into a /fs-jailed directory and return the tarball path. Ship it offsite with a backup profile."
+- `dc.user.list` / `dc.group.list` / `dc.computer.list`: `MethodParams::None`, result `Some(gen_schema::<Vec<nasty_system::dc::DcPrincipal>>(generator))`; descs: "List domain users / groups / joined computers (Admin — enumerates the hosted directory)."
+- `dc.user.create`: AdHoc schema `{ name (req), password (req), given_name?, surname? }`; desc mentions password-over-stdin.
+- `dc.user.delete` / `dc.user.enable` / `dc.user.disable` / `dc.group.create` / `dc.group.delete`: `ad_hoc_one("name", ...)`.
+- `dc.user.set_password`: AdHoc `{ name (req), password (req) }`.
+- `dc.group.add_member` / `dc.group.remove_member`: AdHoc `{ group (req), member (req) }`.
+
+Follow the exact `Method { name, desc, role, params, result }` shape of the neighboring `domain.*` entries; for AdHoc multi-field schemas copy the `backup.restore` entry's `serde_json::json!({...})` style.
+
+- [ ] **Step 6: Build + tests + verification, commit**
+
+Run (from `engine/`):
+```
+cargo build -p nasty-engine
+cargo test -p nasty-engine
+cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test
+```
+Expected: registry no-collision + builds-without-panic pass; the new carve-out assertions pass; `operator_role_methods_are_operator_allowed` passes untouched (every new mutating method is Admin, correctly absent from `is_operator_allowed`).
+
+```bash
+cd engine && cargo fmt
+git add nasty-engine/src/main.rs nasty-engine/src/router/dc.rs nasty-engine/src/router/mod.rs nasty-engine/src/registry/methods.rs
+git commit -m "dc: wire dc.* RPCs, boot restore phase, read-only carve-outs (#20)"
+```
+
+---
+
+## Task 6: nasty.nix — DC-capable samba + samba-dc.service
+
+**Files:**
+- Modify: `nixos/modules/nasty.nix`
+
+**Interfaces:**
+- Consumes: the existing `sambaAds` binding (line ~59) and the samba service wiring.
+- Produces: a DC-capable samba on every SMB-enabled box; a `samba-dc.service` the engine starts/stops.
+
+No Rust tests — the gate is the Integration workflow's VM tests (Task 8 adds `ad-dc`; the existing `appliance-smoke`/`ad-member` catch member-mode regressions from the samba build change). Locally verify nix parses: `nix --extra-experimental-features 'nix-command flakes' flake check --no-build 2>&1 | head` is acceptable if fast; otherwise rely on CI (per project convention: only the Integration workflow proves nix changes).
+
+- [ ] **Step 1: Upgrade the samba build**
+
+Replace the `sambaAds` binding (keep the name — every existing reference keeps working):
+
+```nix
+  # ADS member mode needs LDAP; the DC role (#20) needs the full domain-
+  # controller build. One superset build serves both roles — member boxes
+  # simply never run the DC bits; two parallel samba store paths would
+  # invite version skew. samba-tool's provision path imports python
+  # `cryptography` (samba.gkdi) — keep it on pythonPath (harmless when the
+  # pinned nixpkgs already carries it; required when it doesn't).
+  sambaAds =
+    (pkgs.samba.override {
+      enableLDAP = true;
+      enableDomainController = true;
+    }).overrideAttrs
+      (old: {
+        pythonPath = (old.pythonPath or [ ]) ++ [ pkgs.python3Packages.cryptography ];
+      });
+```
+
+- [ ] **Step 2: Add the samba-dc unit**
+
+Next to the samba service configuration (`services.samba = mkIf cfg.smb.enable ...`, ~line 1742), add:
+
+```nix
+    # ── AD Domain Controller role (#20) ──────────────────────────
+    # Present on every SMB-enabled box, disabled by default; the ENGINE
+    # starts it (dc.provision / the dc.restore boot phase) — per-box
+    # runtime opt-in, like every other role. Conflicts= makes systemd swap
+    # the member-mode daemons out atomically: starting samba-dc stops
+    # smbd/nmbd/winbindd, stopping it lets them return under their normal
+    # toggles. The AD DC `samba` daemon runs its own smbd internally
+    # (serving sysvol + the NASty shares via the include chain in
+    # /etc/samba/smb.dc.conf, which `dc.provision` generates — never the
+    # nix-managed smb.conf).
+    systemd.services.samba-dc = mkIf cfg.smb.enable {
+      description = "Samba Active Directory Domain Controller (NASty-managed)";
+      # Lesson from the ad-member CI DC: without network-online ordering
+      # the DC races the interface and provision-time DNS registration
+      # fails in ways that look like samba bugs.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      conflicts = [ "samba-smbd.service" "samba-nmbd.service" "samba-winbindd.service" ];
+      serviceConfig = {
+        Type = "notify";
+        NotifyAccess = "all";
+        ExecStart = "${sambaAds}/bin/samba --foreground --no-process-group --configfile=/etc/samba/smb.dc.conf";
+        LimitNOFILE = 16384;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      # NOT wantedBy multi-user.target: the engine owns the role.
+    };
+```
+
+(If the module's option style requires `systemd.services.samba-dc = mkIf ...` to live inside the module's existing `config = mkMerge [...]`/attrset structure, place it beside the other `systemd.services.*` entries the module already defines — match whatever wrapping the neighbors use.)
+
+- [ ] **Step 3: Sanity + commit**
+
+`git diff` review: only the two blocks above changed; `sambaAds` name untouched elsewhere (engine PATH at ~1625, `services.samba.package`, `system.nssModules` all keep working).
+
+```bash
+git add nixos/modules/nasty.nix
+git commit -m "nixos: DC-capable samba build + engine-managed samba-dc unit (#20)"
+```
+
+---
+
+## Task 7: WebUI — three-state Directory card + DcPanel
+
+**Files:**
+- Modify: `webui/src/lib/types.ts`
+- Create: `webui/src/lib/dc.svelte.ts`
+- Create: `webui/src/lib/directory/DcPanel.svelte`
+- Modify: `webui/src/routes/settings/+page.svelte`
+- Modify: `webui/src/routes/firewall/+page.svelte` (range-aware port chip)
+
+**Interfaces:**
+- Consumes: `dc.*` RPCs (Task 5 shapes: `dc.provision → { status, warnings }`, `dc.status → DcStatus`, lists → `DcPrincipal[]`, `dc.backup → { path }`); existing `domain.svelte.ts` (the pattern to mirror) and the Settings Directory card.
+- Produces: the three-state Directory UI.
+
+- [ ] **Step 1: Types**
+
+In `webui/src/lib/types.ts`, near `DomainStatus`:
+
+```ts
+/** Returned by `dc.status` — Active Directory Domain Controller role. */
+export interface DcStatus {
+	hosting: boolean;
+	realm?: string | null;
+	workgroup?: string | null;
+	dns_forwarder?: string | null;
+	service_healthy: boolean;
+}
+
+export interface DcPrincipal {
+	name: string;
+}
+```
+
+And in the `PortSpec`-mirroring interface used by the Firewall page (find the firewall rule/port type in `types.ts`), add:
+
+```ts
+	/** End of a contiguous port range; absent = single port. */
+	to?: number | null;
+```
+
+- [ ] **Step 2: State module**
+
+Create `webui/src/lib/dc.svelte.ts`, mirroring `domain.svelte.ts`'s conventions (same `$state` object + exported async handlers, `withToast`, password cleared after use):
+
+```ts
+/** AD Domain Controller role state + handlers (Settings → Directory card). */
+import { getClient } from '$lib/client';
+import { withToast } from '$lib/toast.svelte';
+import type { DcStatus, DcPrincipal } from '$lib/types';
+
+const client = getClient();
+
+export const dc = $state({
+	status: null as DcStatus | null,
+	loading: true,
+	provisioning: false,
+	// provision form
+	realm: '',
+	adminPassword: '',
+	dnsForwarder: '',
+	// panel data
+	users: [] as DcPrincipal[],
+	groups: [] as DcPrincipal[],
+	computers: [] as DcPrincipal[],
+});
+
+export async function dcRefresh() {
+	try {
+		dc.status = await client.call<DcStatus>('dc.status');
+	} catch { /* engine without dc support */ }
+	dc.loading = false;
+}
+
+export async function dcProvision(): Promise<boolean> {
+	if (!dc.realm || !dc.adminPassword) return false;
+	dc.provisioning = true;
+	const params: Record<string, unknown> = {
+		realm: dc.realm.trim(),
+		admin_password: dc.adminPassword,
+	};
+	if (dc.dnsForwarder.trim()) params.dns_forwarder = dc.dnsForwarder.trim();
+	const res = await withToast(
+		() => client.call<{ status: DcStatus; warnings: string[] }>('dc.provision', params),
+		'Domain provisioned',
+	);
+	dc.adminPassword = '';
+	dc.provisioning = false;
+	if (!res) return false;
+	dc.status = res.status;
+	dc.realm = '';
+	dc.dnsForwarder = '';
+	return res.warnings?.length ? (res.warnings.forEach(w => notifyWarning(w)), true) : true;
+}
+
+export async function dcDemote(realmConfirmation: string): Promise<boolean> {
+	const ok = await withToast(
+		() => client.call('dc.demote', { realm_confirmation: realmConfirmation }),
+		'Domain demoted',
+	);
+	if (ok !== undefined) await dcRefresh();
+	return ok !== undefined;
+}
+
+export async function dcLoadPrincipals() {
+	try {
+		[dc.users, dc.groups, dc.computers] = await Promise.all([
+			client.call<DcPrincipal[]>('dc.user.list'),
+			client.call<DcPrincipal[]>('dc.group.list'),
+			client.call<DcPrincipal[]>('dc.computer.list'),
+		]);
+	} catch { /* surfaced by panel */ }
+}
+```
+
+`notifyWarning`: use the toast module's non-error notice API — the Firewall page's custom-rule warnings (from #637) established the convention (`info(...)` in `toast.svelte.ts`); import and use exactly that. If the helper is named differently, match the real name and note it.
+
+- [ ] **Step 3: DcPanel component**
+
+Create `webui/src/lib/directory/DcPanel.svelte` — the hosting-state dashboard rendered inside the Directory card. Structure (match the Settings page's section/input/button classes — read neighboring markup and reuse it):
+
+- Header row: realm + workgroup, a green/amber dot for `service_healthy` ("Running" / "Not running — check `journalctl -u samba-dc`").
+- Three tabs (simple `$state` tab switch, same pattern as other in-page tabs — if none exists on the Settings page, use a small button-group): **Users**, **Groups**, **Computers**.
+  - Users tab: list rows (name + Enable/Disable + Reset password + Delete buttons); an add form (name, password, optional given/surname) calling `dc.user.create` then `dcLoadPrincipals()`. Reset password opens a small inline form (password field) → `dc.user.set_password`.
+  - Groups tab: list rows (name + Delete); add form (name); a membership row (group + member inputs with Add/Remove buttons → `dc.group.add_member`/`remove_member`).
+  - Computers tab: read-only name list.
+- **Back up domain**: destination input (placeholder `/fs/tank/dc-backups/2026-07-10`) → `dc.backup { dest }`; on success toast the returned `path`.
+- **Danger zone**: Demote — expandable section with red framing, explanatory copy ("Destroys the domain: every user, group, and joined machine's trust. A final backup is written to /fs first when a filesystem exists."), a text input for the realm, and a Demote button `disabled={typed !== dc.status?.realm}` calling `dcDemote(typed)`.
+- All mutations `await` then `dcLoadPrincipals()`; every call routes through `withToast`.
+
+- [ ] **Step 4: Three-state Directory card**
+
+In `webui/src/routes/settings/+page.svelte`'s Directory section (~line 940):
+
+- Import `dc`, `dcRefresh`, `dcProvision` from `$lib/dc.svelte` and `DcPanel` from `$lib/directory/DcPanel.svelte`; call `dcRefresh()` alongside the existing `domainRefresh()` in `onMount`.
+- Restructure the card body:
+
+```svelte
+{#if domain.loading || dc.loading}
+	<p class="text-sm text-muted-foreground">Loading...</p>
+{:else if dc.status?.hosting}
+	<DcPanel />
+{:else if domain.status?.joined}
+	<!-- existing joined-state markup, unchanged -->
+{:else}
+	<!-- standalone: two paths -->
+	<!-- (1) existing join form, unchanged, under a subheading "Join an existing domain" -->
+	<!-- (2) new subheading "Host a new domain" with copy:
+	     "This NASty becomes the Active Directory domain controller —
+	      clients and other NASty boxes join the domain it hosts. One DC
+	      per domain; back it up from this panel. Clients should use this
+	      box as their DNS server. Advanced administration (OUs, GPOs)
+	      works with Windows RSAT."
+	     Fields: Realm (placeholder ad.example.lan), Administrator password,
+	     optional DNS forwarder (placeholder "auto — current upstream").
+	     Provision button (disabled while dc.provisioning) → dcProvision(). -->
+{/if}
+```
+
+The join form and the host form are mutually exclusive paths out of standalone — after either succeeds the card re-renders into the corresponding state.
+
+- [ ] **Step 5: Firewall page range chip**
+
+In `webui/src/routes/firewall/+page.svelte`, the service-rule port chips render `` `${p.port}/${p.transport}` `` — make it range-aware:
+
+```ts
+${p.to != null ? `${p.port}-${p.to}` : p.port}/${p.transport}
+```
+
+(Adjust to the actual expression at that site — it's inside a `new Set(rule.ports.map(...))`.)
+
+- [ ] **Step 6: Check, test, commit**
+
+Run (from `webui/`): `npm run check && npm test`
+Expected: 0 errors/warnings; suite passes.
+
+```bash
+git add webui/src/lib/types.ts webui/src/lib/dc.svelte.ts webui/src/lib/directory/DcPanel.svelte webui/src/routes/settings/+page.svelte webui/src/routes/firewall/+page.svelte
+git commit -m "webui: three-state Directory card + DC panel (#20)"
+```
+
+---
+
+## Task 8: VM test — NASty DC + NASty member (the fleet money-shot)
+
+**Files:**
+- Create: `nixos/tests/ad-dc.nix`
+- Modify: `flake.nix` (register the check next to `ad-member`, ~line 426)
+- Modify: `.github/workflows/integration.yml` (add `.#checks.x86_64-linux.ad-dc \` next to the `ad-member` line, ~line 93)
+
+**Interfaces:**
+- Consumes: the full stack from Tasks 1–7; `nixos/tests/ad-member.nix` as the harness template (module imports, `_module.args`, the JSON-RPC websocket driver script pattern, login/bearer flow).
+
+**Test topology & flow (write the test to this contract):**
+
+- **Node `dcbox`** — full NASty appliance (same imports/`_module.args` as ad-member's `nasty` node). Test driver script (same websocket JSON-RPC pattern, own file like ad-member's):
+  1. login → bearer;
+  2. `dc.provision { realm: "NASTYDC.LAN", admin_password: "Passw0rd.123" }` → expect `status.hosting == true` (a static-IP *warning* is expected — the VM's network is externally managed; assert warnings array may be non-empty but provision succeeded);
+  3. poll `dc.status` until `service_healthy == true` (timeout ~60s);
+  4. `dc.user.create { name: "alice", password: "UserPass.123" }`;
+  5. `dc.user.list` → contains `alice`;
+  6. `dc.backup { dest: "/fs/<fs>/dc-backup" }` — only if the test harness sets up a filesystem (ad-member's does not; if no `/fs` in this harness, SKIP the backup step and leave a comment saying the jail is unit-tested and backup needs a pool — do not fabricate a pool just for this).
+- **Node `member`** — second full NASty appliance with `networking.nameservers` pointed at `dcbox`'s test IP (the DC owns DNS for the realm). Driver:
+  1. login → bearer;
+  2. `domain.join { realm: "NASTYDC.LAN", username: "Administrator", password: "Passw0rd.123" }` — the SHIPPED member flow, unchanged;
+  3. `domain.status` → joined + trust ok;
+  4. `wbinfo -i 'NASTYDC\alice'` resolves (uid in the idmap range);
+  5. from `dcbox`: `smbclient //member/<share-or-ipc> -U 'NASTYDC\alice%UserPass.123' -c 'exit'` succeeds (out-of-band auth exactly like ad-member's phase-2 check — crib it; IPC$ suffices if the harness creates no share).
+- Test driver ordering: `dcbox.wait_for_unit("nasty-engine")` → provision phase → `member.wait_for_unit(...)` → join phase → assertions. Reuse ad-member's timeout/retry idioms.
+
+- [ ] **Step 1: Write `nixos/tests/ad-dc.nix`** following the contract above, cribbing structure (nodes, driver script file, python test script) from `ad-member.nix`. The DC node does NOT use ad-member's throwaway `samba-dc` script-unit — it exercises the real `nasty.nix` `samba-dc.service` + engine provisioning path end to end.
+
+- [ ] **Step 2: Register the check**
+
+In `flake.nix` next to `ad-member` (~line 426):
+
+```nix
+      ad-dc = import ./nixos/tests/ad-dc.nix {
+        inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
+      };
+```
+
+(Copy the `ad-member` entry's exact argument set — pass whatever it passes.)
+
+In `.github/workflows/integration.yml` (~line 93), add to the checks list:
+
+```
+            .#checks.x86_64-linux.ad-dc \
+```
+
+- [ ] **Step 3: Local syntax gate, commit, CI**
+
+Local (macOS) can't run the VM test; gate what's gateable: `nix --extra-experimental-features 'nix-command flakes' flake show 2>&1 | grep ad-dc` (the check evaluates). The real validation is the Integration workflow on push — this task's changes touch `nixos/**` + `flake.nix`, so the path filter fires it.
+
+```bash
+git add nixos/tests/ad-dc.nix flake.nix .github/workflows/integration.yml
+git commit -m "tests: ad-dc VM test — NASty DC provisioned via RPC, NASty member joins it (#20)"
+```
+
+Expected CI: `Engine` green (no Rust change in this task), `Integration` runs `ad-dc` + `ad-member` + the smokes. Iterate on CI failures the way the ad-member work did — the first live run WILL find something (Type=notify readiness, provision-vs-config-path behavior, getpass-over-stdin); each fix lands as its own commit on this branch. Two named fallbacks if the VM run disproves an assumption: (a) if `samba` never signals readiness, switch the unit to `Type=simple` + poll `samba-tool` reachability in `dc.status`; (b) if `samba-tool domain provision -s <path>` refuses to write the config at the `-s` path, provision with `--targetdir` into a scratch dir and move the generated smb.conf to `DC_CONF_PATH`.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/ad-domain-controller.md`):
+- Provision (realm/password/forwarder, SAMBA_INTERNAL, engine-owned config, include chain, credential hygiene, resolved drop-in, Conflicts= switchover, firewall, boot restore) → Tasks 1, 2, 3, 5, 6.
+- Single-DC + mutual exclusion both ways → Task 3 (provision preflight + `domain.join` check).
+- Static-IP precondition, spec-amended softening → Tasks 2 (pure check + matrix test), 3 (wired), 8 (VM relies on the Warn path).
+- Users/groups/computers surface → Task 4 (engine), 5 (RPC), 7 (UI).
+- Backup jailed under /fs → Tasks 2 (jail + tests), 3 (op), 5 (RPC), 7 (UI); VM-test backup step conditional on a pool existing.
+- Demote destroys + typed realm + parachute + unwind-shared teardown → Task 3, UI danger zone → Task 7.
+- Roles (status Any, rest Admin) + `.list` carve-outs + guard-test posture → Task 5.
+- One samba build + samba-dc unit + network-online lesson → Task 6.
+- Fleet money-shot VM test + CI registration → Task 8.
+- Errors: preflight named-fix messages (Tasks 2/3), stderr-verbatim (inherited via `run_cmd`), unhealthy status + journal pointer (Tasks 3/7).
+- Out-of-scope items (multi-DC, GPO UI, BIND9, signed NTP, restore automation) → no task implements them; docs already state them.
+
+**Placeholder scan:** No TBD/TODO/"fill in". Deliberate bounded flexibility: Task 5 Step 5 describes registry entries by exact name/role/params-shape rather than pasting 15 near-identical `Method{}` blocks (each field is specified); Task 7 Steps 3–4 specify the DcPanel/card by contract with exact RPC calls and state fields (matching how Task 6 of the firewall plan handled Svelte markup, where the file's real conventions must win); Task 8 defines the VM test as a step-by-step contract over the named template. Two implementation risks carry named fallbacks (Type=notify; provision config path) rather than silent assumptions.
+
+**Type consistency:** `DcService`, `DcConfig`, `DcStatus`, `DcPrincipal`, `ProvisionRequest { realm, admin_password, dns_forwarder }`, `DemoteRequest { realm_confirmation }`, `provision → (DcStatus, Vec<String>)` ↔ router `{ status, warnings }` ↔ WebUI `{ status: DcStatus; warnings: string[] }`; `dc.backup { dest } → { path }` ↔ UI; `PortSpec.to: Option<u16>` ↔ TS `to?: number | null`; `open_dc`/`close_dc` used in router + boot phase; snake_case wire fields (`admin_password`, `realm_confirmation`, `given_name`) consistent across Rust serde and WebUI params. All checked.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -80,6 +80,7 @@ pub struct AppState {
     pub guest_shares: guestshare::GuestShareService,
     pub smb: nasty_sharing::SmbService,
     pub domain: nasty_system::domain::DomainService,
+    pub dc: nasty_system::dc::DcService,
     pub iscsi: nasty_sharing::IscsiService,
     pub nvmeof: Arc<nasty_sharing::NvmeofService>,
     pub vms: nasty_vm::VmService,
@@ -224,6 +225,7 @@ async fn main() -> anyhow::Result<()> {
         guest_shares: guestshare::GuestShareService::new(),
         smb: nasty_sharing::SmbService::new(),
         domain: nasty_system::domain::DomainService::new(),
+        dc: nasty_system::dc::DcService::new(),
         iscsi: nasty_sharing::IscsiService::new(),
         nvmeof,
         vms: nasty_vm::VmService::new(),
@@ -246,6 +248,7 @@ async fn main() -> anyhow::Result<()> {
             "protocols.restore",
             "smb.scaffold_config",
             "domain.restore",
+            "dc.restore",
             "nvmeof.restore",
             "vms.restore",
             "apps.restore",
@@ -375,6 +378,23 @@ async fn main() -> anyhow::Result<()> {
             async move {
                 if state.domain.is_joined().await {
                     state.domain.ensure_winbindd().await;
+                }
+            }
+        })
+        .await;
+
+    // If this box hosts an AD domain, bring the DC back up: rewrite the
+    // /run resolved drop-in (tmpfs — empty after reboot), start samba-dc
+    // (Conflicts= swaps member-mode samba out), and open the DC firewall
+    // ports. Must run after the smb.nasty.conf reconcile above — the DC
+    // config includes it.
+    state
+        .boot_status
+        .run_phase("dc.restore", secs(30), {
+            let state = state.clone();
+            async move {
+                if state.dc.ensure_running().await {
+                    state.firewall.open_dc().await;
                 }
             }
         })

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -384,18 +384,19 @@ async fn main() -> anyhow::Result<()> {
         .await;
 
     // If this box hosts an AD domain, bring the DC back up: rewrite the
-    // /run resolved drop-in (tmpfs — empty after reboot), start samba-dc
-    // (Conflicts= swaps member-mode samba out), and open the DC firewall
-    // ports. Must run after the smb.nasty.conf reconcile above — the DC
-    // config includes it.
+    // /run resolved drop-in (tmpfs — empty after reboot) and start
+    // samba-dc (Conflicts= swaps member-mode samba out). Must run after
+    // the smb.nasty.conf reconcile above — the DC config includes it.
+    // The DC firewall opens later, in firewall.init: at this point in
+    // boot `state.rules` holds nothing yet, so opening here would
+    // rebuild the nftables table before the base (webui/ssh) rules
+    // exist, locking management out until firewall.init runs.
     state
         .boot_status
         .run_phase("dc.restore", secs(30), {
             let state = state.clone();
             async move {
-                if state.dc.ensure_running().await {
-                    state.firewall.open_dc().await;
-                }
+                state.dc.ensure_running().await;
             }
         })
         .await;
@@ -605,6 +606,13 @@ async fn main() -> anyhow::Result<()> {
                 // protocol list; restore its firewall rule when enabled.
                 if nasty_system::rdma::enabled().await {
                     state.firewall.open_rdma().await;
+                }
+                // DC role (#20): open the AD service ports once the base rules exist.
+                // dc.restore (earlier) only restarts the service + DNS drop-in — opening
+                // the firewall there would rebuild the table before webui/ssh rules are
+                // in state, locking management out until this point.
+                if nasty_system::dc::DcService::load_config().await.is_some() {
+                    state.firewall.open_dc().await;
                 }
                 // iSCSI/NVMe-oF rules follow configured portal ports
                 // (#602); replace the static defaults with the real

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -48,6 +48,7 @@ use nasty_storage::subvolume::{
     Snapshot, Subvolume, UpdateSubvolumeRequest,
 };
 use nasty_system::alerts::{ActiveAlert, AlertRule, AlertRuleUpdate};
+use nasty_system::dc::{DcPrincipal, DcStatus, DemoteRequest, ProvisionRequest};
 use nasty_system::domain::{DomainPrincipal, DomainStatus, JoinDomainRequest, LeaveDomainRequest};
 use nasty_system::firewall::FirewallStatus;
 use nasty_system::firmware::{FirmwareConstraints, FirmwareDevice, FirmwareUpdateResult};
@@ -2333,6 +2334,168 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                         "Group name prefix to search for.",
                     )),
                     result: Some(gen_schema::<Vec<DomainPrincipal>>(generator)),
+                },
+            ],
+        ),
+        // ── Active Directory: Domain Controller ──────────────────────────
+        (
+            "Active Directory: Domain Controller",
+            vec![
+                Method {
+                    name: "dc.status",
+                    desc: "Report this box's Domain Controller role: hosting state, realm, workgroup, DNS forwarder, and samba-dc.service health.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<DcStatus>(generator)),
+                },
+                Method {
+                    name: "dc.provision",
+                    desc: "Provision a brand-new Active Directory domain on this box (Samba AD DC, internal DNS). Exactly one DC per domain; refuses when the box is domain-joined. The Administrator password is set over stdin and never logged. Returns { status, warnings }.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<ProvisionRequest>(generator)),
+                    result: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "status": gen_schema::<DcStatus>(generator),
+                            "warnings": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Operator-facing warnings surfaced during provisioning (e.g. externally-managed network config)."
+                            }
+                        },
+                        "required": ["status", "warnings"]
+                    })),
+                },
+                Method {
+                    name: "dc.demote",
+                    desc: "Demote the DC — DESTROYS the hosted domain (typed-realm confirmation required). Takes a final domain backup into /fs when a filesystem exists, then tears the role down.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<DemoteRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "dc.backup",
+                    desc: "Run `samba-tool domain backup offline` into a /fs-jailed directory and return the tarball path. Ship it offsite with a backup profile.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "dest",
+                        "Backup target directory; must resolve under /fs and be empty or absent.",
+                    )),
+                    result: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Path to the written backup tarball."}
+                        },
+                        "required": ["path"]
+                    })),
+                },
+                Method {
+                    name: "dc.user.list",
+                    desc: "List domain users (Admin — enumerates the hosted directory).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<DcPrincipal>>(generator)),
+                },
+                Method {
+                    name: "dc.user.create",
+                    desc: "Create a domain user via `samba-tool user create`. The password is fed over stdin (prompt + confirmation) — never argv, never logged.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "required": ["name", "password"],
+                        "properties": {
+                            "name": { "type": "string", "description": "Domain username (sAMAccountName)." },
+                            "password": { "type": "string", "description": "Initial password. Sent over stdin — never argv, never logged." },
+                            "given_name": { "type": "string", "description": "Optional given (first) name." },
+                            "surname": { "type": "string", "description": "Optional surname (last) name." }
+                        }
+                    })),
+                    result: None,
+                },
+                Method {
+                    name: "dc.user.delete",
+                    desc: "Delete a domain user via `samba-tool user delete`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Domain username to delete.")),
+                    result: None,
+                },
+                Method {
+                    name: "dc.user.set_password",
+                    desc: "Reset a domain user's password via `samba-tool user setpassword`. Sent over stdin — never argv, never logged.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_two(
+                        "name",
+                        "Domain username.",
+                        "password",
+                        "New password. Sent over stdin — never argv, never logged.",
+                    )),
+                    result: None,
+                },
+                Method {
+                    name: "dc.user.enable",
+                    desc: "Enable a previously disabled domain user account via `samba-tool user enable`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Domain username to enable.")),
+                    result: None,
+                },
+                Method {
+                    name: "dc.user.disable",
+                    desc: "Disable a domain user account via `samba-tool user disable` — the account remains but cannot authenticate.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Domain username to disable.")),
+                    result: None,
+                },
+                Method {
+                    name: "dc.group.list",
+                    desc: "List domain groups (Admin — enumerates the hosted directory).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<DcPrincipal>>(generator)),
+                },
+                Method {
+                    name: "dc.group.create",
+                    desc: "Create a domain security group via `samba-tool group add`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Domain group name to create.")),
+                    result: None,
+                },
+                Method {
+                    name: "dc.group.delete",
+                    desc: "Delete a domain group via `samba-tool group delete`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_one("name", "Domain group name to delete.")),
+                    result: None,
+                },
+                Method {
+                    name: "dc.group.add_member",
+                    desc: "Add a member to a domain group via `samba-tool group addmembers`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_two(
+                        "group",
+                        "Domain group name.",
+                        "member",
+                        "Username to add to the group.",
+                    )),
+                    result: None,
+                },
+                Method {
+                    name: "dc.group.remove_member",
+                    desc: "Remove a member from a domain group via `samba-tool group removemembers`.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::AdHoc(ad_hoc_two(
+                        "group",
+                        "Domain group name.",
+                        "member",
+                        "Username to remove from the group.",
+                    )),
+                    result: None,
+                },
+                Method {
+                    name: "dc.computer.list",
+                    desc: "List joined computers (Admin — enumerates the hosted directory).",
+                    role: MethodRole::Admin,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<DcPrincipal>>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/dc.rs
+++ b/engine/nasty-engine/src/router/dc.rs
@@ -1,0 +1,157 @@
+//! RPC arms in the `dc.*` namespace (Active Directory Domain Controller
+//! role — this box HOSTS the domain). Member mode lives in domain.rs.
+
+use nasty_common::{Request, Response};
+use serde::Deserialize;
+
+use super::*;
+use crate::AppState;
+use crate::auth::Session;
+
+#[derive(Deserialize)]
+struct UserCreateParams {
+    name: String,
+    password: String,
+    #[serde(default)]
+    given_name: Option<String>,
+    #[serde(default)]
+    surname: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SetPasswordParams {
+    name: String,
+    password: String,
+}
+
+#[derive(Deserialize)]
+struct GroupMemberParams {
+    group: String,
+    member: String,
+}
+
+pub(super) async fn try_route(
+    req: &Request,
+    state: &AppState,
+    _session: &Session,
+) -> Option<Response> {
+    Some(match req.method.as_str() {
+        "dc.status" => ok(req, state.dc.status().await),
+        "dc.provision" => match parse_params::<nasty_system::dc::ProvisionRequest>(req) {
+            Ok(p) => match state.dc.provision(p).await {
+                Ok((status, warnings)) => {
+                    // DC ports open only after a successful provision.
+                    state.firewall.open_dc().await;
+                    ok(
+                        req,
+                        serde_json::json!({ "status": status, "warnings": warnings }),
+                    )
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.demote" => match parse_params::<nasty_system::dc::DemoteRequest>(req) {
+            Ok(p) => match state.dc.demote(p).await {
+                Ok(()) => {
+                    state.firewall.close_dc().await;
+                    ok(req, "ok")
+                }
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.backup" => match require_str(req, "dest") {
+            Ok(dest) => match state.dc.backup(dest).await {
+                Ok(path) => ok(req, serde_json::json!({ "path": path })),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.list" => match state.dc.user_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "dc.user.create" => match parse_params::<UserCreateParams>(req) {
+            Ok(p) => match state
+                .dc
+                .user_create(
+                    &p.name,
+                    &p.password,
+                    p.given_name.as_deref(),
+                    p.surname.as_deref(),
+                )
+                .await
+            {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.user.delete" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_delete(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.set_password" => match parse_params::<SetPasswordParams>(req) {
+            Ok(p) => match state.dc.user_set_password(&p.name, &p.password).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.user.enable" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_enable(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.user.disable" => match require_str(req, "name") {
+            Ok(name) => match state.dc.user_disable(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.list" => match state.dc.group_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        "dc.group.create" => match require_str(req, "name") {
+            Ok(name) => match state.dc.group_create(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.delete" => match require_str(req, "name") {
+            Ok(name) => match state.dc.group_delete(name).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(r) => r,
+        },
+        "dc.group.add_member" => match parse_params::<GroupMemberParams>(req) {
+            Ok(p) => match state.dc.group_add_member(&p.group, &p.member).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.group.remove_member" => match parse_params::<GroupMemberParams>(req) {
+            Ok(p) => match state.dc.group_remove_member(&p.group, &p.member).await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            },
+            Err(e) => invalid(req, e),
+        },
+        "dc.computer.list" => match state.dc.computer_list().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
+        _ => return None,
+    })
+}

--- a/engine/nasty-engine/src/router/dc.rs
+++ b/engine/nasty-engine/src/router/dc.rs
@@ -55,6 +55,23 @@ pub(super) async fn try_route(
             Ok(p) => match state.dc.demote(p).await {
                 Ok(()) => {
                     state.firewall.close_dc().await;
+                    // Teardown (inside dc.demote) stops samba-dc.service,
+                    // but nothing else restarts the member-mode SMB units
+                    // it had Conflicts=-swapped out — bring SMB back under
+                    // its own protocol toggle, matching the spec's promise
+                    // that shares resume without a reboot. dc.demote()
+                    // clears dc.json before returning Ok, so this doesn't
+                    // trip the enable() DC-hosting guard (#20). Best-effort:
+                    // demote itself already succeeded, so a restart
+                    // failure here is logged, not surfaced as an RPC error.
+                    if state
+                        .protocols
+                        .is_enabled(nasty_system::protocol::Protocol::Smb)
+                        .await
+                        && let Err(e) = state.protocols.enable("smb").await
+                    {
+                        tracing::warn!("dc.demote: failed to restart SMB after demote: {e}");
+                    }
                     ok(req, "ok")
                 }
                 Err(e) => err(req, e),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -7,6 +7,7 @@ mod audit;
 mod auth;
 mod backup;
 mod bcachefs;
+mod dc;
 mod domain;
 mod fs;
 mod guestshare;
@@ -218,7 +219,17 @@ fn is_read_only(method: &str) -> bool {
     // (users/groups) out of the joined directory, so they are privileged
     // reads gated on Admin, not routine reads. Returning false here defers
     // enforcement to the role check (Admin only), matching the registry.
-    if matches!(method, "domain.user.list" | "domain.group.list") {
+    if matches!(
+        method,
+        "domain.user.list"
+            | "domain.group.list"
+            // Same trap for DC mode: these enumerate the hosted directory
+            // and are Admin-gated in the registry — the `.list` suffix must
+            // not slip them into the ReadOnly set.
+            | "dc.user.list"
+            | "dc.group.list"
+            | "dc.computer.list"
+    ) {
         return false;
     }
     method.ends_with(".list")
@@ -490,6 +501,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "guestshare" => guestshare::try_route(req, state, session).await,
         "smb" => smb::try_route(req, state, session).await,
         "domain" => domain::try_route(req, state, session).await,
+        "dc" => dc::try_route(req, state, session).await,
         "service" => service::try_route(req, state, session).await,
         "system" => {
             // `system.alerts` lives in the alerts module; everything else
@@ -1389,6 +1401,10 @@ mod tests {
     fn domain_principal_search_is_not_read_only() {
         assert!(!is_read_only("domain.user.list"));
         assert!(!is_read_only("domain.group.list"));
+        assert!(!is_read_only("dc.user.list"));
+        assert!(!is_read_only("dc.group.list"));
+        assert!(!is_read_only("dc.computer.list"));
+        assert!(is_read_only("dc.status")); // status is a safe read
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -53,6 +53,7 @@ pub(crate) async fn sync_portal_firewall_ports(state: &AppState) {
 
     let tcp = |port: u16| PortSpec {
         port,
+        to: None,
         transport: Transport::Tcp,
         source: None,
         iface: None,

--- a/engine/nasty-system/Cargo.toml
+++ b/engine/nasty-system/Cargo.toml
@@ -33,3 +33,4 @@ zbus.workspace = true
 # `test-util` enables tokio::time::pause/advance for transaction tests.
 # Not used at runtime, only in #[cfg(test)] code.
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = "3"

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -1,0 +1,469 @@
+//! Active Directory Domain Controller role (#20, second half).
+//!
+//! NASty *hosts* a domain: `samba-tool domain provision` with the
+//! SAMBA_INTERNAL DNS backend, run against an engine-owned config
+//! (`smb.dc.conf`) so the nix-managed /etc/samba/smb.conf is never
+//! touched. The DC's integrated smbd serves the box's shares via the
+//! existing `smb.nasty.conf` include chain. Exactly one DC per domain;
+//! mutual exclusion with member mode (`domain.rs`) both ways.
+//!
+//! Credential rule (same as member join): secrets NEVER ride argv —
+//! provision uses a random throwaway password, the real Administrator
+//! password is set via `samba-tool user setpassword` over stdin.
+
+use std::path::{Path, PathBuf};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{run_cmd, run_cmd_stdin};
+
+pub const DC_CONF_PATH: &str = "/etc/samba/smb.dc.conf";
+pub const DC_STATE_PATH: &str = "/var/lib/nasty/dc.json";
+pub const DC_RESOLVED_DROPIN_PATH: &str = "/run/systemd/resolved.conf.d/nasty-dc.conf";
+/// Root every domain-backup destination must resolve under.
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+const FS_ROOT: &str = "/fs";
+/// NASty's own network config — consulted (read-only) by the static-IP
+/// precondition. Path mirrors `network.rs`'s private `JSON_PATH`.
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+const NETWORKING_JSON_PATH: &str = "/var/lib/nasty/networking.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum DcError {
+    #[error("{0}")]
+    Validation(String),
+    #[error("{0}")]
+    Precondition(String),
+    #[error("{0}")]
+    CommandFailed(String),
+    #[error("this box is not hosting a domain")]
+    NotHosting,
+    #[error("this box is already hosting a domain — demote it first")]
+    AlreadyHosting,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<crate::domain::DomainError> for DcError {
+    fn from(e: crate::domain::DomainError) -> Self {
+        DcError::CommandFailed(e.to_string())
+    }
+}
+
+/// Persisted DC role state. Presence of the file == this box hosts a domain.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DcConfig {
+    pub realm: String,
+    pub workgroup: String,
+    pub dns_forwarder: String,
+}
+
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct ProvisionRequest {
+    /// Kerberos realm / DNS zone for the new domain, e.g. "ad.example.lan".
+    pub realm: String,
+    /// Administrator password. Set via samba-tool over stdin; never argv,
+    /// never logged, never persisted.
+    pub admin_password: String,
+    /// Upstream DNS the DC forwards non-domain queries to. Defaults to the
+    /// box's current upstream resolver.
+    #[serde(default)]
+    pub dns_forwarder: Option<String>,
+}
+
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct DemoteRequest {
+    /// Must exactly match the hosted realm — demoting DESTROYS the domain.
+    pub realm_confirmation: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DcStatus {
+    pub hosting: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub realm: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workgroup: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_forwarder: Option<String>,
+    /// Whether samba-dc.service is active. Meaningful only when hosting.
+    pub service_healthy: bool,
+}
+
+// ── Pure renders / helpers ─────────────────────────────────────
+
+/// resolved drop-in for DC mode: samba's SAMBA_INTERNAL DNS owns :53,
+/// so resolved must release the stub listener and the box resolves
+/// through samba (which forwards non-domain queries upstream).
+pub fn render_dc_resolved_dropin() -> String {
+    "# Managed by NASty — this box hosts an AD domain; samba's internal\n\
+     # DNS owns port 53. Removed at demote.\n\
+     [Resolve]\n\
+     DNS=127.0.0.1\n\
+     DNSStubListener=no\n"
+        .to_string()
+}
+
+/// The [global] lines NASty adds to the provision-generated smb.dc.conf:
+/// the share include chain and the upstream DNS forwarder.
+pub fn nasty_global_additions(dns_forwarder: &str) -> String {
+    format!(
+        "\t# NASty-managed additions (share include chain + upstream DNS)\n\
+         \tinclude = /etc/samba/smb.nasty.conf\n\
+         \tdns forwarder = {dns_forwarder}\n"
+    )
+}
+
+/// Insert `extra` immediately after the `[global]` section header. A blind
+/// append would land inside the last share section ([netlogon]) instead.
+pub fn insert_into_global(conf: &str, extra: &str) -> String {
+    let mut out = String::with_capacity(conf.len() + extra.len());
+    let mut inserted = false;
+    for line in conf.lines() {
+        out.push_str(line);
+        out.push('\n');
+        if !inserted && line.trim() == "[global]" {
+            out.push_str(extra);
+            inserted = true;
+        }
+    }
+    if !inserted {
+        // No [global] header at all (unexpected) — prepend one.
+        return format!("[global]\n{extra}{out}");
+    }
+    out
+}
+
+/// Static-IP precondition (spec-amended): Fail only when NASty's own
+/// network config manages interfaces and none is Static; Warn when NASty
+/// has no opinion (externally managed box / fresh VM); Pass when at least
+/// one managed interface is Static.
+#[derive(Debug)]
+pub enum StaticIpCheck {
+    Pass,
+    Warn(String),
+    Fail(String),
+}
+
+pub fn static_ip_check(cfg: Option<&crate::network::NetworkConfig>) -> StaticIpCheck {
+    let Some(cfg) = cfg else {
+        return StaticIpCheck::Warn(
+            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
+        );
+    };
+    if cfg.interfaces.is_empty() {
+        return StaticIpCheck::Warn(
+            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
+        );
+    }
+    // NOTE: `InterfaceConfig` has no top-level `method` — it's per-family,
+    // at `ipv4.method` / `ipv6.method`. Either family being Static counts.
+    if cfg.interfaces.iter().any(|i| {
+        i.ipv4.method == crate::network::IpMethod::Static
+            || i.ipv6.method == crate::network::IpMethod::Static
+    }) {
+        return StaticIpCheck::Pass;
+    }
+    StaticIpCheck::Fail(
+        "a domain controller needs a static IP address, but every NASty-managed interface uses DHCP — set a static address on the Network page first".into(),
+    )
+}
+
+/// Jail a domain-backup destination under `/fs` (root parameterized for
+/// tests). Must be absolute, resolve under root after canonicalizing the
+/// existing prefix, and be either absent or an empty directory —
+/// `samba-tool domain backup` requires an empty target dir. Local sibling
+/// of nasty-backup's restore jail; duplicated across the crate boundary
+/// on purpose (nasty-system must not depend on nasty-backup).
+pub fn validate_backup_dest(dest: &Path, root: &Path) -> Result<PathBuf, DcError> {
+    if !dest.is_absolute() {
+        return Err(DcError::Validation(
+            "destination must be an absolute path".into(),
+        ));
+    }
+    let mut existing = dest;
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let canonical_prefix = loop {
+        match existing.canonicalize() {
+            Ok(p) => break p,
+            Err(_) => {
+                let file = existing
+                    .file_name()
+                    .ok_or_else(|| DcError::Validation("destination escapes /fs".into()))?;
+                tail.push(file);
+                existing = existing
+                    .parent()
+                    .ok_or_else(|| DcError::Validation("destination escapes /fs".into()))?;
+            }
+        }
+    };
+    let mut resolved = canonical_prefix;
+    for part in tail.iter().rev() {
+        resolved.push(part);
+    }
+    let canonical_root = root.canonicalize().map_err(DcError::Io)?;
+    if !resolved.starts_with(&canonical_root) || resolved == canonical_root {
+        return Err(DcError::Validation(
+            "destination must be inside a NASty filesystem under /fs".into(),
+        ));
+    }
+    if resolved.is_dir() {
+        let mut entries = std::fs::read_dir(&resolved)?;
+        if entries.next().is_some() {
+            return Err(DcError::Validation(
+                "destination directory is not empty — samba-tool requires an empty backup target"
+                    .into(),
+            ));
+        }
+    } else if resolved.exists() {
+        return Err(DcError::Validation(
+            "destination exists and is not a directory".into(),
+        ));
+    }
+    Ok(resolved)
+}
+
+// ── samba-tool argv builders (pure; unit-tested for argv hygiene) ──
+//
+// These are `pub(crate)` and called from `#[cfg(test)] mod tests` below
+// (so `cargo test` sees them as live), but Task 3 hasn't wired a
+// non-test caller yet. `cargo clippy --all-targets` also builds the
+// plain `--lib` target (no `--cfg test`), where the test module doesn't
+// exist and these are genuinely unreferenced — hence the explicit
+// allows, matching `samba_tool`/`samba_tool_stdin` below.
+
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+fn with_conf(mut argv: Vec<String>) -> Vec<String> {
+    argv.push("--configfile".into());
+    argv.push(DC_CONF_PATH.into());
+    argv
+}
+
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+pub(crate) fn provision_args(realm: &str, workgroup: &str, throwaway_pass: &str) -> Vec<String> {
+    with_conf(vec![
+        "domain".into(),
+        "provision".into(),
+        format!("--realm={realm}"),
+        format!("--domain={workgroup}"),
+        "--server-role=dc".into(),
+        "--dns-backend=SAMBA_INTERNAL".into(),
+        format!("--adminpass={throwaway_pass}"),
+    ])
+}
+
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+pub(crate) fn setpassword_args(user: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "setpassword".into(), user.into()])
+}
+
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+pub(crate) fn user_create_args(
+    name: &str,
+    given_name: Option<&str>,
+    surname: Option<&str>,
+) -> Vec<String> {
+    let mut argv = vec!["user".into(), "create".into(), name.into()];
+    if let Some(g) = given_name {
+        argv.push(format!("--given-name={g}"));
+    }
+    if let Some(s) = surname {
+        argv.push(format!("--surname={s}"));
+    }
+    with_conf(argv)
+}
+
+// ── Service ────────────────────────────────────────────────────
+
+pub struct DcService;
+
+impl Default for DcService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DcService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn load_config() -> Option<DcConfig> {
+        let raw = tokio::fs::read_to_string(DC_STATE_PATH).await.ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    pub async fn save_config(config: &DcConfig) -> Result<(), DcError> {
+        let json = serde_json::to_string_pretty(config)
+            .map_err(|e| DcError::Validation(format!("serialize dc config: {e}")))?;
+        tokio::fs::write(DC_STATE_PATH, json).await?;
+        Ok(())
+    }
+
+    pub async fn clear_config() -> Result<(), DcError> {
+        match tokio::fs::remove_file(DC_STATE_PATH).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+/// Run samba-tool with the given argv (already carrying --configfile).
+///
+/// Unused until Task 3 wires the provision/demote lifecycle on top of the
+/// argv builders above.
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+async fn samba_tool(argv: &[String]) -> Result<String, DcError> {
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    Ok(run_cmd("samba-tool", &args, &[]).await?)
+}
+
+/// Run samba-tool feeding `stdin_input` (the only way secrets travel).
+///
+/// Unused until Task 3 wires the provision/demote lifecycle on top of the
+/// argv builders above.
+#[allow(dead_code)] // consumed by Task 3 lifecycle
+async fn samba_tool_stdin(argv: &[String], stdin_input: &str) -> Result<String, DcError> {
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    Ok(run_cmd_stdin("samba-tool", &args, &[], stdin_input).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── insert_into_global ────────────────────────────────────
+    #[test]
+    fn insert_into_global_lands_inside_global_section() {
+        let conf = "# Global parameters\n[global]\n\tdns forwarder = 127.0.0.53\n\trealm = AD.EXAMPLE.COM\n\n[sysvol]\n\tpath = /var/lib/samba/sysvol\n\n[netlogon]\n\tpath = /var/lib/samba/sysvol/ad.example.com/scripts\n";
+        let out = insert_into_global(conf, "\tinclude = /etc/samba/smb.nasty.conf\n");
+        let global_pos = out.find("[global]").unwrap();
+        let include_pos = out.find("include = /etc/samba/smb.nasty.conf").unwrap();
+        let sysvol_pos = out.find("[sysvol]").unwrap();
+        assert!(
+            global_pos < include_pos && include_pos < sysvol_pos,
+            "got:\n{out}"
+        );
+        // Original content preserved
+        assert!(out.contains("[netlogon]"));
+    }
+
+    #[test]
+    fn nasty_global_additions_carry_include_and_forwarder() {
+        let extra = nasty_global_additions("192.168.1.1");
+        assert!(extra.contains("include = /etc/samba/smb.nasty.conf"));
+        assert!(extra.contains("dns forwarder = 192.168.1.1"));
+    }
+
+    // ── resolved drop-in ──────────────────────────────────────
+    #[test]
+    fn dc_resolved_dropin_points_box_at_samba_dns() {
+        let out = render_dc_resolved_dropin();
+        assert!(out.contains("DNSStubListener=no"));
+        assert!(out.contains("DNS=127.0.0.1"));
+    }
+
+    // ── static-IP precondition ────────────────────────────────
+    fn iface(name: &str, method: crate::network::IpMethod) -> crate::network::InterfaceConfig {
+        // NOTE (deviation from brief): `InterfaceConfig` has no top-level
+        // `method` field — it's per-family at `ipv4.method` / `ipv6.method`
+        // (see network.rs). The brief's flat {"name","method"} JSON doesn't
+        // error on that mismatch — serde silently ignores the unmatched
+        // "method" key rather than failing loudly, since InterfaceConfig
+        // doesn't `deny_unknown_fields`, leaving ipv4.method at its
+        // `IpMethod::default()` (Disabled) regardless of the argument. That
+        // would make this helper silently useless rather than "fail to
+        // deserialize", so — per the brief's own fallback instruction —
+        // the struct is built literally instead, driving `ipv4.method`.
+        crate::network::InterfaceConfig {
+            name: name.to_string(),
+            enabled: true,
+            ipv4: crate::network::IpConfig {
+                method,
+                addresses: Vec::new(),
+                gateway: None,
+            },
+            ipv6: crate::network::IpConfig::default(),
+            mtu: None,
+            sriov_num_vfs: None,
+            vfs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn static_ip_check_matrix() {
+        use crate::network::{IpMethod, NetworkConfig};
+        // No config at all → externally managed → warn, not fail.
+        assert!(matches!(static_ip_check(None), StaticIpCheck::Warn(_)));
+        // Empty config → same.
+        let empty = NetworkConfig::default();
+        assert!(matches!(
+            static_ip_check(Some(&empty)),
+            StaticIpCheck::Warn(_)
+        ));
+        // A static interface → pass.
+        let mut ok = NetworkConfig::default();
+        ok.interfaces.push(iface("eth0", IpMethod::Static));
+        assert!(matches!(static_ip_check(Some(&ok)), StaticIpCheck::Pass));
+        // Managed but all-DHCP → fail, message names the Network page.
+        let mut bad = NetworkConfig::default();
+        bad.interfaces.push(iface("eth0", IpMethod::Dhcp));
+        match static_ip_check(Some(&bad)) {
+            StaticIpCheck::Fail(msg) => assert!(msg.contains("Network"), "msg: {msg}"),
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    // ── backup-dest jail ──────────────────────────────────────
+    #[test]
+    fn backup_dest_jail() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("tank")).unwrap();
+        // ok: not-yet-existing dir under root
+        let dest = root.path().join("tank").join("dc-backup");
+        assert!(validate_backup_dest(&dest, root.path()).is_ok());
+        // ok: existing but empty
+        std::fs::create_dir(&dest).unwrap();
+        assert!(validate_backup_dest(&dest, root.path()).is_ok());
+        // reject: non-empty
+        std::fs::write(dest.join("x"), b"x").unwrap();
+        assert!(validate_backup_dest(&dest, root.path()).is_err());
+        // reject: traversal escape
+        let esc = root.path().join("tank").join("..").join("..").join("etc");
+        assert!(validate_backup_dest(&esc, root.path()).is_err());
+        // reject: relative
+        assert!(validate_backup_dest(std::path::Path::new("x/y"), root.path()).is_err());
+    }
+
+    // ── argv hygiene: THE invariant ───────────────────────────
+    #[test]
+    fn no_secret_ever_in_samba_tool_argv() {
+        // Every argv builder used for password-carrying operations must
+        // keep the password out. The builders return the argv; the secret
+        // travels via run_cmd_stdin.
+        let secret = "Sup3r.Secret!";
+        for argv in [
+            setpassword_args("Administrator"),
+            user_create_args("alice", None, None),
+        ] {
+            assert!(
+                !argv.iter().any(|a| a.contains(secret)),
+                "secret leaked into argv: {argv:?}"
+            );
+            // and every samba-tool call pins the DC config
+            assert!(
+                argv.windows(2)
+                    .any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH)
+            );
+        }
+        // Provision's argv carries ONLY the throwaway password, never the
+        // operator's. (The throwaway is random per call; assert the real
+        // secret isn't there.)
+        let prov = provision_args("AD.EXAMPLE.COM", "ADEXAMPLE", "throwaway-x");
+        assert!(!prov.iter().any(|a| a.contains(secret)));
+        assert!(prov.iter().any(|a| a == "--dns-backend=SAMBA_INTERNAL"));
+        assert!(prov.iter().any(|a| a == "--server-role=dc"));
+    }
+}

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -135,10 +135,23 @@ pub fn insert_into_global(conf: &str, extra: &str) -> String {
     out
 }
 
-/// Static-IP precondition (spec-amended): Fail only when NASty's own
-/// network config manages interfaces and none is Static; Warn when NASty
-/// has no opinion (externally managed box / fresh VM); Pass when at least
-/// one managed interface is Static.
+/// Static-IP precondition (spec-amended). NASty fails this check only
+/// when it itself is managing this box's addressing dynamically — that's
+/// fixable by the operator on the Network page. When NASty has no L3
+/// opinion at all, the box is externally managed and we can only warn.
+///
+/// - **Pass**: any interface/bond/vlan/bridge has `ipv4` or `ipv6`
+///   `Static`.
+/// - **Fail**: no `Static` anywhere, but at least one `Dhcp`/`Slaac` —
+///   NASty itself is assigning a dynamic address.
+/// - **Warn**: no network config, or nothing but `Disabled`/`Inherit` —
+///   NASty has no opinion on this box's addressing (externally managed
+///   box / fresh VM). This covers the all-`Disabled` case, which used to
+///   Fail: a box NASty was never told to address isn't the same failure
+///   as one NASty is actively DHCP-addressing.
+///
+/// `macvlans` are excluded from all of the above: they're engine-managed
+/// app shims (#448), never the box's own address.
 #[derive(Debug)]
 pub enum StaticIpCheck {
     Pass,
@@ -146,28 +159,52 @@ pub enum StaticIpCheck {
     Fail(String),
 }
 
+/// Warn text shared by both "NASty has no L3 opinion" cases below (no
+/// persisted config at all, or one that exists but assigns nothing
+/// dynamically itself) — a single `const` so the two call sites can't
+/// drift apart.
+const STATIC_IP_EXTERNALLY_MANAGED_WARN: &str = "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)";
+
+/// True if any interface/bond/vlan/bridge has an `ipv4` or `ipv6` method
+/// matching `pred`. `macvlans` are deliberately excluded — they're
+/// engine-managed app shims (#448), never the box's own address.
+fn any_managed_ip_method(
+    cfg: &crate::network::NetworkConfig,
+    pred: impl Fn(&crate::network::IpMethod) -> bool,
+) -> bool {
+    cfg.interfaces
+        .iter()
+        .any(|i| pred(&i.ipv4.method) || pred(&i.ipv6.method))
+        || cfg
+            .bonds
+            .iter()
+            .any(|b| pred(&b.ipv4.method) || pred(&b.ipv6.method))
+        || cfg
+            .vlans
+            .iter()
+            .any(|v| pred(&v.ipv4.method) || pred(&v.ipv6.method))
+        || cfg
+            .bridges
+            .iter()
+            .any(|b| pred(&b.ipv4.method) || pred(&b.ipv6.method))
+}
+
 pub fn static_ip_check(cfg: Option<&crate::network::NetworkConfig>) -> StaticIpCheck {
+    use crate::network::IpMethod;
+
     let Some(cfg) = cfg else {
-        return StaticIpCheck::Warn(
-            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
-        );
+        return StaticIpCheck::Warn(STATIC_IP_EXTERNALLY_MANAGED_WARN.into());
     };
-    if cfg.interfaces.is_empty() {
-        return StaticIpCheck::Warn(
-            "NASty does not manage this box's network config — make sure the DC's IP address is static (a DHCP-addressed DC breaks the domain when the lease changes)".into(),
-        );
-    }
-    // NOTE: `InterfaceConfig` has no top-level `method` — it's per-family,
-    // at `ipv4.method` / `ipv6.method`. Either family being Static counts.
-    if cfg.interfaces.iter().any(|i| {
-        i.ipv4.method == crate::network::IpMethod::Static
-            || i.ipv6.method == crate::network::IpMethod::Static
-    }) {
+
+    if any_managed_ip_method(cfg, |m| matches!(m, IpMethod::Static)) {
         return StaticIpCheck::Pass;
     }
-    StaticIpCheck::Fail(
-        "a domain controller needs a static IP address, but every NASty-managed interface uses DHCP — set a static address on the Network page first".into(),
-    )
+    if any_managed_ip_method(cfg, |m| matches!(m, IpMethod::Dhcp | IpMethod::Slaac)) {
+        return StaticIpCheck::Fail(
+            "a domain controller needs a static IP address, but this box's NASty-managed addressing is dynamic (DHCP/SLAAC) — set a static address on the Network page first".into(),
+        );
+    }
+    StaticIpCheck::Warn(STATIC_IP_EXTERNALLY_MANAGED_WARN.into())
 }
 
 /// Jail a domain-backup destination under `/fs` (root parameterized for
@@ -392,28 +429,156 @@ mod tests {
         }
     }
 
+    /// Same shape as `iface`, but drives `ipv6.method` instead of
+    /// `ipv4.method` — needed for the "ipv4 disabled, ipv6 static" case
+    /// (either family counts, see `static_ip_check`).
+    fn iface_ipv6(name: &str, method: crate::network::IpMethod) -> crate::network::InterfaceConfig {
+        crate::network::InterfaceConfig {
+            name: name.to_string(),
+            enabled: true,
+            ipv4: crate::network::IpConfig::default(),
+            ipv6: crate::network::IpConfig {
+                method,
+                addresses: Vec::new(),
+                gateway: None,
+            },
+            mtu: None,
+            sriov_num_vfs: None,
+            vfs: Vec::new(),
+        }
+    }
+
+    /// Minimal `BondConfig` driving just `ipv4.method` — mirrors `iface`.
+    /// `mode` is irrelevant to the static-IP check; `ActiveBackup` is an
+    /// arbitrary valid value.
+    fn bond(name: &str, method: crate::network::IpMethod) -> crate::network::BondConfig {
+        crate::network::BondConfig {
+            name: name.to_string(),
+            members: Vec::new(),
+            mode: crate::network::BondMode::ActiveBackup,
+            ipv4: crate::network::IpConfig {
+                method,
+                addresses: Vec::new(),
+                gateway: None,
+            },
+            ipv6: crate::network::IpConfig::default(),
+            mtu: None,
+            inherit_member_mac: true,
+        }
+    }
+
+    /// Minimal `BridgeConfig` driving just `ipv4.method` — mirrors `iface`.
+    fn bridge(name: &str, method: crate::network::IpMethod) -> crate::network::BridgeConfig {
+        crate::network::BridgeConfig {
+            name: name.to_string(),
+            members: Vec::new(),
+            ipv4: crate::network::IpConfig {
+                method,
+                addresses: Vec::new(),
+                gateway: None,
+            },
+            ipv6: crate::network::IpConfig::default(),
+            mtu: None,
+            stp: false,
+            forward_delay_s: None,
+            inherit_member_mac: true,
+        }
+    }
+
     #[test]
     fn static_ip_check_matrix() {
         use crate::network::{IpMethod, NetworkConfig};
+
         // No config at all → externally managed → warn, not fail.
         assert!(matches!(static_ip_check(None), StaticIpCheck::Warn(_)));
-        // Empty config → same.
+
+        // Empty config (every Vec empty) → same.
         let empty = NetworkConfig::default();
         assert!(matches!(
             static_ip_check(Some(&empty)),
             StaticIpCheck::Warn(_)
         ));
-        // A static interface → pass.
-        let mut ok = NetworkConfig::default();
-        ok.interfaces.push(iface("eth0", IpMethod::Static));
-        assert!(matches!(static_ip_check(Some(&ok)), StaticIpCheck::Pass));
-        // Managed but all-DHCP → fail, message names the Network page.
-        let mut bad = NetworkConfig::default();
-        bad.interfaces.push(iface("eth0", IpMethod::Dhcp));
-        match static_ip_check(Some(&bad)) {
-            StaticIpCheck::Fail(msg) => assert!(msg.contains("Network"), "msg: {msg}"),
+
+        // Single interface, all-Disabled → NASty has no L3 opinion → warn,
+        // NOT fail. Changed behavior: the old predicate treated "managed
+        // but not Static" as Fail, which punished boxes NASty was never
+        // told to address at all.
+        let mut all_disabled = NetworkConfig::default();
+        all_disabled
+            .interfaces
+            .push(iface("eth0", IpMethod::Disabled));
+        assert!(matches!(
+            static_ip_check(Some(&all_disabled)),
+            StaticIpCheck::Warn(_)
+        ));
+
+        // ipv4 Dhcp → NASty itself assigns a dynamic address → fail,
+        // message points the operator at the Network page.
+        let mut dhcp = NetworkConfig::default();
+        dhcp.interfaces.push(iface("eth0", IpMethod::Dhcp));
+        match static_ip_check(Some(&dhcp)) {
+            StaticIpCheck::Fail(msg) => assert!(msg.contains("Network page"), "msg: {msg}"),
             other => panic!("expected Fail, got {other:?}"),
         }
+
+        // ipv4 Slaac → same dynamic-addressing fail.
+        let mut slaac = NetworkConfig::default();
+        slaac.interfaces.push(iface("eth0", IpMethod::Slaac));
+        assert!(matches!(
+            static_ip_check(Some(&slaac)),
+            StaticIpCheck::Fail(_)
+        ));
+
+        // ipv4 Disabled + ipv6 Static on the same interface → pass;
+        // either family counts.
+        let mut ipv6_static = NetworkConfig::default();
+        ipv6_static
+            .interfaces
+            .push(iface_ipv6("eth0", IpMethod::Static));
+        assert!(matches!(
+            static_ip_check(Some(&ipv6_static)),
+            StaticIpCheck::Pass
+        ));
+
+        // Static on a bridge only, no interfaces at all → pass; bridges
+        // are collected too, not just top-level interfaces.
+        let mut bridge_static = NetworkConfig::default();
+        bridge_static.bridges.push(bridge("br0", IpMethod::Static));
+        assert!(matches!(
+            static_ip_check(Some(&bridge_static)),
+            StaticIpCheck::Pass
+        ));
+
+        // Same, but with a Disabled interface also present → still pass.
+        let mut bridge_static_disabled_iface = NetworkConfig::default();
+        bridge_static_disabled_iface
+            .interfaces
+            .push(iface("eth0", IpMethod::Disabled));
+        bridge_static_disabled_iface
+            .bridges
+            .push(bridge("br0", IpMethod::Static));
+        assert!(matches!(
+            static_ip_check(Some(&bridge_static_disabled_iface)),
+            StaticIpCheck::Pass
+        ));
+
+        // Dhcp on a bond only → fail; bonds are collected too.
+        let mut bond_dhcp = NetworkConfig::default();
+        bond_dhcp.bonds.push(bond("bond0", IpMethod::Dhcp));
+        match static_ip_check(Some(&bond_dhcp)) {
+            StaticIpCheck::Fail(msg) => assert!(msg.contains("Network page"), "msg: {msg}"),
+            other => panic!("expected Fail, got {other:?}"),
+        }
+
+        // Inherit-only (nothing Static/Dhcp/Slaac anywhere) → warn, not
+        // fail — Inherit is NASty deferring to a member's L3, not NASty
+        // itself assigning a dynamic address.
+        let mut inherit_only = NetworkConfig::default();
+        inherit_only.bridges.push(bridge("br0", IpMethod::Inherit));
+        assert!(matches!(
+            static_ip_check(Some(&inherit_only)),
+            StaticIpCheck::Warn(_)
+        ));
     }
 
     // ── backup-dest jail ──────────────────────────────────────
@@ -465,5 +630,10 @@ mod tests {
         assert!(!prov.iter().any(|a| a.contains(secret)));
         assert!(prov.iter().any(|a| a == "--dns-backend=SAMBA_INTERNAL"));
         assert!(prov.iter().any(|a| a == "--server-role=dc"));
+        // ...and pins the DC config, same as every other samba-tool call.
+        assert!(
+            prov.windows(2)
+                .any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH)
+        );
     }
 }

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -114,6 +114,20 @@ pub fn nasty_global_additions(dns_forwarder: &str) -> String {
     )
 }
 
+/// Remove every existing `dns forwarder = ...` line (samba-tool provision
+/// writes one pointing at resolv.conf's value — typically the resolved stub
+/// we've just disabled; smb.conf is last-value-wins, so a leftover line
+/// would override the operator's forwarder).
+fn strip_dns_forwarder_lines(conf: &str) -> String {
+    conf.lines()
+        .filter(|l| {
+            let t = l.trim();
+            !(t.starts_with("dns forwarder") && t.contains('='))
+        })
+        .map(|l| format!("{l}\n"))
+        .collect()
+}
+
 /// Insert `extra` immediately after the `[global]` section header. A blind
 /// append would land inside the last share section ([netlogon]) instead.
 pub fn insert_into_global(conf: &str, extra: &str) -> String {
@@ -382,8 +396,13 @@ impl DcService {
 
         let dns_forwarder = resolve_dns_forwarder(req.dns_forwarder.as_deref()).await?;
 
-        // A stale DC config would make samba-tool refuse to provision.
+        // A stale DC config or half-written domain databases (from an
+        // earlier failed provision) would make samba-tool refuse to run.
+        // Safe here: preflight already ruled out hosting AND member mode.
         let _ = tokio::fs::remove_file(DC_CONF_PATH).await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/private").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/sysvol").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/bind-dns").await;
 
         // ── Provision (throwaway password on argv, rotated below) ──
         let throwaway = uuid::Uuid::new_v4().to_string();
@@ -392,9 +411,16 @@ impl DcService {
 
         // Everything past this point unwinds on failure.
         let result: Result<(), DcError> = async {
-            // NASty [global] additions inside the generated config.
+            // NASty [global] additions inside the generated config. Strip
+            // samba-tool's own `dns forwarder` line first — smb.conf is
+            // last-value-wins within a section, so a leftover line (pointing
+            // at the resolved stub we've just disabled) would silently win
+            // over the operator's forwarder if it came after ours.
             let conf = tokio::fs::read_to_string(DC_CONF_PATH).await?;
-            let conf = insert_into_global(&conf, &nasty_global_additions(&dns_forwarder));
+            let conf = insert_into_global(
+                &strip_dns_forwarder_lines(&conf),
+                &nasty_global_additions(&dns_forwarder),
+            );
             tokio::fs::write(DC_CONF_PATH, conf).await?;
 
             // Real Administrator password — over stdin, twice (prompt +
@@ -645,6 +671,25 @@ mod tests {
         let extra = nasty_global_additions("192.168.1.1");
         assert!(extra.contains("include = /etc/samba/smb.nasty.conf"));
         assert!(extra.contains("dns forwarder = 192.168.1.1"));
+    }
+
+    #[test]
+    fn strip_dns_forwarder_lines_removes_samba_provisioned_forwarder() {
+        // provision-shaped config: samba-tool wrote its own `dns forwarder`
+        // line (pointing at resolv.conf's value — typically the resolved
+        // stub) into [global].
+        let conf = "# Global parameters\n[global]\n\tdns forwarder = 127.0.0.53\n\trealm = AD.EXAMPLE.COM\n\n[sysvol]\n\tpath = /var/lib/samba/sysvol\n\n[netlogon]\n\tpath = /var/lib/samba/sysvol/ad.example.com/scripts\n";
+        let out = insert_into_global(
+            &strip_dns_forwarder_lines(conf),
+            &nasty_global_additions("192.168.1.1"),
+        );
+        assert!(out.contains("dns forwarder = 192.168.1.1"), "got:\n{out}");
+        assert!(!out.contains("127.0.0.53"), "got:\n{out}");
+        assert_eq!(
+            out.matches("dns forwarder").count(),
+            1,
+            "expected exactly one dns forwarder line, got:\n{out}"
+        );
     }
 
     // ── resolved drop-in ──────────────────────────────────────

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -90,6 +90,11 @@ pub struct DcStatus {
     pub service_healthy: bool,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DcPrincipal {
+    pub name: String,
+}
+
 // ── Pure renders / helpers ─────────────────────────────────────
 
 /// resolved drop-in for DC mode: samba's SAMBA_INTERNAL DNS owns :53,
@@ -298,14 +303,6 @@ pub(crate) fn setpassword_args(user: &str) -> Vec<String> {
     with_conf(vec!["user".into(), "setpassword".into(), user.into()])
 }
 
-/// Argv shape only — `DcService::user_create` (Task 4) is the runtime
-/// caller; Task 3's lifecycle (provision/demote/status/backup/
-/// ensure_running) has no create-user step. Exercised today by
-/// `no_secret_ever_in_samba_tool_argv`. `cargo clippy --all-targets` also
-/// checks the plain `--lib` target (no `--cfg test`), where that's the
-/// only caller — hence still needs the explicit allow until Task 4 wires
-/// a non-test one.
-#[allow(dead_code)]
 pub(crate) fn user_create_args(
     name: &str,
     given_name: Option<&str>,
@@ -319,6 +316,44 @@ pub(crate) fn user_create_args(
         argv.push(format!("--surname={s}"));
     }
     with_conf(argv)
+}
+
+fn parse_principal_lines(raw: &str) -> Vec<DcPrincipal> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|l| DcPrincipal {
+            name: l.to_string(),
+        })
+        .collect()
+}
+
+pub(crate) fn list_args(kind: &str) -> Vec<String> {
+    with_conf(vec![kind.into(), "list".into()])
+}
+
+pub(crate) fn user_delete_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "delete".into(), name.into()])
+}
+
+pub(crate) fn user_enable_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "enable".into(), name.into()])
+}
+
+pub(crate) fn user_disable_args(name: &str) -> Vec<String> {
+    with_conf(vec!["user".into(), "disable".into(), name.into()])
+}
+
+pub(crate) fn group_add_args(name: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), "add".into(), name.into()])
+}
+
+pub(crate) fn group_delete_args(name: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), "delete".into(), name.into()])
+}
+
+pub(crate) fn group_members_args(op: &str, group: &str, member: &str) -> Vec<String> {
+    with_conf(vec!["group".into(), op.into(), group.into(), member.into()])
 }
 
 // ── Service ────────────────────────────────────────────────────
@@ -580,6 +615,105 @@ impl DcService {
             warn!("dc: failed to start samba-dc at boot restore: {e}");
         }
         true
+    }
+
+    // ── Domain principal management (all samba-tool; passwords via stdin) ──
+
+    async fn require_hosting(&self) -> Result<(), DcError> {
+        if Self::load_config().await.is_none() {
+            return Err(DcError::NotHosting);
+        }
+        Ok(())
+    }
+
+    pub async fn user_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(
+            &samba_tool(&list_args("user")).await?,
+        ))
+    }
+
+    pub async fn user_create(
+        &self,
+        name: &str,
+        password: &str,
+        given_name: Option<&str>,
+        surname: Option<&str>,
+    ) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        // `samba-tool user create` prompts "New Password:" + "Retype
+        // Password:" — both fed over stdin (never argv).
+        samba_tool_stdin(
+            &user_create_args(name, given_name, surname),
+            &format!("{password}\n{password}"),
+        )
+        .await?;
+        info!("dc: created domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_delete(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_delete_args(name)).await?;
+        info!("dc: deleted domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_set_password(&self, name: &str, password: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool_stdin(&setpassword_args(name), &format!("{password}\n{password}")).await?;
+        info!("dc: reset password for domain user {name}");
+        Ok(())
+    }
+
+    pub async fn user_enable(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_enable_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn user_disable(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&user_disable_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(
+            &samba_tool(&list_args("group")).await?,
+        ))
+    }
+
+    pub async fn group_create(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_add_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_delete(&self, name: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_delete_args(name)).await?;
+        Ok(())
+    }
+
+    pub async fn group_add_member(&self, group: &str, member: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_members_args("addmembers", group, member)).await?;
+        Ok(())
+    }
+
+    pub async fn group_remove_member(&self, group: &str, member: &str) -> Result<(), DcError> {
+        self.require_hosting().await?;
+        samba_tool(&group_members_args("removemembers", group, member)).await?;
+        Ok(())
+    }
+
+    pub async fn computer_list(&self) -> Result<Vec<DcPrincipal>, DcError> {
+        self.require_hosting().await?;
+        Ok(parse_principal_lines(
+            &samba_tool(&list_args("computer")).await?,
+        ))
     }
 }
 
@@ -943,5 +1077,35 @@ mod tests {
             prov.windows(2)
                 .any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH)
         );
+    }
+
+    #[test]
+    fn parse_principal_lines_skips_noise() {
+        let raw = "Administrator\nGuest\n\nalice\n  bob  \n";
+        let out = parse_principal_lines(raw);
+        let names: Vec<&str> = out.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["Administrator", "Guest", "alice", "bob"]);
+    }
+
+    #[test]
+    fn management_argv_never_carries_secrets_and_pins_config() {
+        let secret = "Sup3r.Secret!";
+        for argv in [
+            user_delete_args("alice"),
+            user_enable_args("alice"),
+            user_disable_args("alice"),
+            group_add_args("staff"),
+            group_delete_args("staff"),
+            group_members_args("addmembers", "staff", "alice"),
+            list_args("user"),
+            list_args("group"),
+            list_args("computer"),
+        ] {
+            assert!(!argv.iter().any(|a| a.contains(secret)), "argv: {argv:?}");
+            assert!(
+                argv.windows(2)
+                    .any(|w| w[0] == "--configfile" && w[1] == DC_CONF_PATH)
+            );
+        }
     }
 }

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -119,6 +119,15 @@ pub fn nasty_global_additions(dns_forwarder: &str) -> String {
     )
 }
 
+/// Sanity check that samba-tool's provision actually wrote its generated
+/// configuration back to the --configfile path (rather than leaving the
+/// empty file we seeded for lp.load()). A provisioned config always
+/// carries a [global] section with the realm.
+fn looks_provisioned(conf: &str) -> bool {
+    let lower = conf.to_lowercase();
+    lower.contains("[global]") && lower.contains("realm")
+}
+
 /// Remove every existing `dns forwarder = ...` line (samba-tool provision
 /// writes one pointing at resolv.conf's value — typically the resolved stub
 /// we've just disabled; smb.conf is last-value-wins, so a leftover line
@@ -439,6 +448,12 @@ impl DcService {
         let _ = tokio::fs::remove_dir_all("/var/lib/samba/sysvol").await;
         let _ = tokio::fs::remove_dir_all("/var/lib/samba/bind-dns").await;
 
+        // samba-tool with an explicit --configfile requires the file to
+        // EXIST at load time (lp.load() errors on a missing path — first
+        // live CI run proved it); provision then writes the generated
+        // config back to the same path. Hand it an empty one to load.
+        tokio::fs::write(DC_CONF_PATH, "").await?;
+
         // ── Provision (throwaway password on argv, rotated below) ──
         let throwaway = uuid::Uuid::new_v4().to_string();
         info!("dc: provisioning domain {realm} (workgroup {workgroup})");
@@ -452,6 +467,11 @@ impl DcService {
             // at the resolved stub we've just disabled) would silently win
             // over the operator's forwarder if it came after ours.
             let conf = tokio::fs::read_to_string(DC_CONF_PATH).await?;
+            if !looks_provisioned(&conf) {
+                return Err(DcError::CommandFailed(
+                    "samba-tool provision succeeded but did not write the expected configuration to smb.dc.conf".into(),
+                ));
+            }
             let conf = insert_into_global(
                 &strip_dns_forwarder_lines(&conf),
                 &nasty_global_additions(&dns_forwarder),
@@ -824,6 +844,22 @@ mod tests {
             1,
             "expected exactly one dns forwarder line, got:\n{out}"
         );
+    }
+
+    // ── looks_provisioned ─────────────────────────────────────
+    #[test]
+    fn looks_provisioned_accepts_generated_config() {
+        // Same provision-shaped fixture used above to model samba-tool's
+        // generated smb.dc.conf.
+        let conf = "# Global parameters\n[global]\n\tdns forwarder = 127.0.0.53\n\trealm = AD.EXAMPLE.COM\n\n[sysvol]\n\tpath = /var/lib/samba/sysvol\n\n[netlogon]\n\tpath = /var/lib/samba/sysvol/ad.example.com/scripts\n";
+        assert!(looks_provisioned(conf));
+    }
+
+    #[test]
+    fn looks_provisioned_rejects_empty_seed_file() {
+        // The empty file we seed for samba-tool's lp.load() before
+        // provision runs — must not be mistaken for a provisioned config.
+        assert!(!looks_provisioned(""));
     }
 
     // ── resolved drop-in ──────────────────────────────────────

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
 use crate::domain::{run_cmd, run_cmd_stdin};
 
@@ -22,11 +23,9 @@ pub const DC_CONF_PATH: &str = "/etc/samba/smb.dc.conf";
 pub const DC_STATE_PATH: &str = "/var/lib/nasty/dc.json";
 pub const DC_RESOLVED_DROPIN_PATH: &str = "/run/systemd/resolved.conf.d/nasty-dc.conf";
 /// Root every domain-backup destination must resolve under.
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 const FS_ROOT: &str = "/fs";
 /// NASty's own network config — consulted (read-only) by the static-IP
 /// precondition. Path mirrors `network.rs`'s private `JSON_PATH`.
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 const NETWORKING_JSON_PATH: &str = "/var/lib/nasty/networking.json";
 
 #[derive(Debug, thiserror::Error)]
@@ -262,22 +261,13 @@ pub fn validate_backup_dest(dest: &Path, root: &Path) -> Result<PathBuf, DcError
 }
 
 // ── samba-tool argv builders (pure; unit-tested for argv hygiene) ──
-//
-// These are `pub(crate)` and called from `#[cfg(test)] mod tests` below
-// (so `cargo test` sees them as live), but Task 3 hasn't wired a
-// non-test caller yet. `cargo clippy --all-targets` also builds the
-// plain `--lib` target (no `--cfg test`), where the test module doesn't
-// exist and these are genuinely unreferenced — hence the explicit
-// allows, matching `samba_tool`/`samba_tool_stdin` below.
 
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 fn with_conf(mut argv: Vec<String>) -> Vec<String> {
     argv.push("--configfile".into());
     argv.push(DC_CONF_PATH.into());
     argv
 }
 
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 pub(crate) fn provision_args(realm: &str, workgroup: &str, throwaway_pass: &str) -> Vec<String> {
     with_conf(vec![
         "domain".into(),
@@ -290,12 +280,18 @@ pub(crate) fn provision_args(realm: &str, workgroup: &str, throwaway_pass: &str)
     ])
 }
 
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 pub(crate) fn setpassword_args(user: &str) -> Vec<String> {
     with_conf(vec!["user".into(), "setpassword".into(), user.into()])
 }
 
-#[allow(dead_code)] // consumed by Task 3 lifecycle
+/// Argv shape only — `DcService::user_create` (Task 4) is the runtime
+/// caller; Task 3's lifecycle (provision/demote/status/backup/
+/// ensure_running) has no create-user step. Exercised today by
+/// `no_secret_ever_in_samba_tool_argv`. `cargo clippy --all-targets` also
+/// checks the plain `--lib` target (no `--cfg test`), where that's the
+/// only caller — hence still needs the explicit allow until Task 4 wires
+/// a non-test one.
+#[allow(dead_code)]
 pub(crate) fn user_create_args(
     name: &str,
     given_name: Option<&str>,
@@ -345,26 +341,283 @@ impl DcService {
             Err(e) => Err(e.into()),
         }
     }
+
+    /// Provision a brand-new AD domain on this box. Returns the status plus
+    /// operator-facing warnings (e.g. externally-managed network config).
+    ///
+    /// Sequence: preflight → samba-tool provision (throwaway --adminpass,
+    /// engine-owned smb.dc.conf) → insert NASty [global] additions → set the
+    /// real Administrator password via stdin → resolved drop-in (release
+    /// :53) → start samba-dc.service → persist dc.json. Any failure after
+    /// provision unwinds through the demote teardown (minus the backup).
+    pub async fn provision(
+        &self,
+        req: ProvisionRequest,
+    ) -> Result<(DcStatus, Vec<String>), DcError> {
+        // ── Preflight ──────────────────────────────────────────
+        if Self::load_config().await.is_some() {
+            return Err(DcError::AlreadyHosting);
+        }
+        if crate::domain::DomainService::load_config().await.is_some() {
+            return Err(DcError::Precondition(
+                "this box is joined to a domain as a member — leave the domain before hosting one"
+                    .into(),
+            ));
+        }
+        let realm = crate::domain::validate_realm(&req.realm)
+            .map_err(|e| DcError::Validation(e.to_string()))?;
+        let workgroup = crate::domain::derive_workgroup(&realm);
+
+        let mut warnings = Vec::new();
+        let net_cfg: Option<crate::network::NetworkConfig> =
+            tokio::fs::read_to_string(NETWORKING_JSON_PATH)
+                .await
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok());
+        match static_ip_check(net_cfg.as_ref()) {
+            StaticIpCheck::Pass => {}
+            StaticIpCheck::Warn(w) => warnings.push(w),
+            StaticIpCheck::Fail(msg) => return Err(DcError::Precondition(msg)),
+        }
+
+        let dns_forwarder = resolve_dns_forwarder(req.dns_forwarder.as_deref()).await?;
+
+        // A stale DC config would make samba-tool refuse to provision.
+        let _ = tokio::fs::remove_file(DC_CONF_PATH).await;
+
+        // ── Provision (throwaway password on argv, rotated below) ──
+        let throwaway = uuid::Uuid::new_v4().to_string();
+        info!("dc: provisioning domain {realm} (workgroup {workgroup})");
+        samba_tool(&provision_args(&realm, &workgroup, &throwaway)).await?;
+
+        // Everything past this point unwinds on failure.
+        let result: Result<(), DcError> = async {
+            // NASty [global] additions inside the generated config.
+            let conf = tokio::fs::read_to_string(DC_CONF_PATH).await?;
+            let conf = insert_into_global(&conf, &nasty_global_additions(&dns_forwarder));
+            tokio::fs::write(DC_CONF_PATH, conf).await?;
+
+            // Real Administrator password — over stdin, twice (prompt +
+            // confirmation). Never argv, never logged.
+            samba_tool_stdin(
+                &setpassword_args("Administrator"),
+                &format!("{}\n{}", req.admin_password, req.admin_password),
+            )
+            .await?;
+
+            // Release :53 to samba, route the box's own lookups through it.
+            tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
+            tokio::fs::write(DC_RESOLVED_DROPIN_PATH, render_dc_resolved_dropin()).await?;
+            run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await?;
+
+            // samba-dc conflicts with smbd/nmbd/winbindd — systemd swaps
+            // them atomically.
+            run_cmd("systemctl", &["start", "samba-dc.service"], &[]).await?;
+
+            Self::save_config(&DcConfig {
+                realm: realm.clone(),
+                workgroup: workgroup.clone(),
+                dns_forwarder: dns_forwarder.clone(),
+            })
+            .await?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            warn!("dc: provision failed after samba-tool provision — unwinding: {e}");
+            self.teardown().await;
+            return Err(e);
+        }
+
+        info!("dc: domain {realm} provisioned");
+        Ok((self.status().await, warnings))
+    }
+
+    /// Demote — DESTROYS the domain. Typed-realm confirmation; takes a
+    /// final backup parachute into /fs when a filesystem exists.
+    pub async fn demote(&self, req: DemoteRequest) -> Result<(), DcError> {
+        let cfg = Self::load_config().await.ok_or(DcError::NotHosting)?;
+        if req.realm_confirmation.trim() != cfg.realm {
+            return Err(DcError::Validation(format!(
+                "confirmation does not match the hosted realm ({})",
+                cfg.realm
+            )));
+        }
+        // Parachute: best-effort final backup into /fs.
+        match first_fs_dir().await {
+            Some(fs_dir) => {
+                let dest = format!(
+                    "{fs_dir}/dc-final-backup-{}",
+                    chrono::Utc::now().format("%Y%m%d-%H%M%S")
+                );
+                match self.backup(&dest).await {
+                    Ok(path) => info!("dc: final domain backup written to {path}"),
+                    Err(e) => warn!("dc: final backup failed (continuing demote): {e}"),
+                }
+            }
+            None => warn!("dc: no /fs filesystem mounted — demoting WITHOUT a final backup"),
+        }
+        info!("dc: demoting — destroying domain {}", cfg.realm);
+        self.teardown().await;
+        Ok(())
+    }
+
+    /// Shared teardown for demote and provision-unwind: stop the DC, remove
+    /// its config + domain state, restore resolved, clear dc.json. Every
+    /// step best-effort — teardown must never strand the box half-torn.
+    async fn teardown(&self) {
+        let _ = run_cmd("systemctl", &["stop", "samba-dc.service"], &[]).await;
+        let _ = tokio::fs::remove_file(DC_CONF_PATH).await;
+        // Domain databases + sysvol. Root-resident by design.
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/private").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/sysvol").await;
+        let _ = tokio::fs::remove_dir_all("/var/lib/samba/bind-dns").await;
+        if tokio::fs::remove_file(DC_RESOLVED_DROPIN_PATH)
+            .await
+            .is_ok()
+        {
+            let _ = run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await;
+        }
+        let _ = Self::clear_config().await;
+    }
+
+    pub async fn status(&self) -> DcStatus {
+        match Self::load_config().await {
+            Some(cfg) => {
+                let healthy = run_cmd("systemctl", &["is-active", "samba-dc.service"], &[])
+                    .await
+                    .is_ok();
+                DcStatus {
+                    hosting: true,
+                    realm: Some(cfg.realm),
+                    workgroup: Some(cfg.workgroup),
+                    dns_forwarder: Some(cfg.dns_forwarder),
+                    service_healthy: healthy,
+                }
+            }
+            None => DcStatus {
+                hosting: false,
+                realm: None,
+                workgroup: None,
+                dns_forwarder: None,
+                service_healthy: false,
+            },
+        }
+    }
+
+    /// Domain backup: `samba-tool domain backup offline` into a /fs-jailed,
+    /// empty target dir. Returns the tarball path.
+    pub async fn backup(&self, dest: &str) -> Result<String, DcError> {
+        if Self::load_config().await.is_none() {
+            return Err(DcError::NotHosting);
+        }
+        let resolved = validate_backup_dest(Path::new(dest), Path::new(FS_ROOT))?;
+        tokio::fs::create_dir_all(&resolved).await?;
+        let target = resolved.to_string_lossy().to_string();
+        samba_tool(&with_conf(vec![
+            "domain".into(),
+            "backup".into(),
+            "offline".into(),
+            format!("--targetdir={target}"),
+        ]))
+        .await?;
+        find_backup_tarball(&resolved).ok_or_else(|| {
+            DcError::CommandFailed(
+                "samba-tool reported success but no backup tarball was found".into(),
+            )
+        })
+    }
+
+    /// Boot restore (`dc.restore` phase): when hosting, rewrite the /run
+    /// resolved drop-in (tmpfs — gone after reboot), restart resolved if it
+    /// changed, and start the DC. Returns whether the box hosts a domain so
+    /// the caller can open the firewall.
+    pub async fn ensure_running(&self) -> bool {
+        if Self::load_config().await.is_none() {
+            return false;
+        }
+        let dropin = render_dc_resolved_dropin();
+        let current = tokio::fs::read_to_string(DC_RESOLVED_DROPIN_PATH)
+            .await
+            .unwrap_or_default();
+        if current != dropin {
+            let _ = tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await;
+            if tokio::fs::write(DC_RESOLVED_DROPIN_PATH, dropin)
+                .await
+                .is_ok()
+            {
+                let _ = run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await;
+            }
+        }
+        if let Err(e) = run_cmd("systemctl", &["start", "samba-dc.service"], &[]).await {
+            warn!("dc: failed to start samba-dc at boot restore: {e}");
+        }
+        true
+    }
 }
 
 /// Run samba-tool with the given argv (already carrying --configfile).
-///
-/// Unused until Task 3 wires the provision/demote lifecycle on top of the
-/// argv builders above.
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 async fn samba_tool(argv: &[String]) -> Result<String, DcError> {
     let args: Vec<&str> = argv.iter().map(String::as_str).collect();
     Ok(run_cmd("samba-tool", &args, &[]).await?)
 }
 
 /// Run samba-tool feeding `stdin_input` (the only way secrets travel).
-///
-/// Unused until Task 3 wires the provision/demote lifecycle on top of the
-/// argv builders above.
-#[allow(dead_code)] // consumed by Task 3 lifecycle
 async fn samba_tool_stdin(argv: &[String], stdin_input: &str) -> Result<String, DcError> {
     let args: Vec<&str> = argv.iter().map(String::as_str).collect();
     Ok(run_cmd_stdin("samba-tool", &args, &[], stdin_input).await?)
+}
+
+/// The upstream DNS forwarder: explicit wins; else the first global server
+/// from `resolvectl dns`; else an error asking the operator to supply one
+/// (once samba owns :53 there is no other upstream path).
+async fn resolve_dns_forwarder(explicit: Option<&str>) -> Result<String, DcError> {
+    if let Some(f) = explicit {
+        let f = f.trim();
+        if f.parse::<std::net::IpAddr>().is_err() {
+            return Err(DcError::Validation(format!(
+                "dns_forwarder must be an IP address, got: {f}"
+            )));
+        }
+        return Ok(f.to_string());
+    }
+    let out = run_cmd("resolvectl", &["dns"], &[])
+        .await
+        .unwrap_or_default();
+    for token in out.split_whitespace() {
+        if let Ok(ip) = token.parse::<std::net::IpAddr>()
+            && !ip.is_loopback()
+        {
+            return Ok(ip.to_string());
+        }
+    }
+    Err(DcError::Precondition(
+        "could not determine an upstream DNS forwarder — supply one in the provision form".into(),
+    ))
+}
+
+/// First mounted filesystem under /fs (for the demote parachute).
+async fn first_fs_dir() -> Option<String> {
+    let mut rd = tokio::fs::read_dir(FS_ROOT).await.ok()?;
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
+            return Some(entry.path().to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+/// The tarball samba-tool wrote into the backup target dir.
+fn find_backup_tarball(dir: &Path) -> Option<String> {
+    let rd = std::fs::read_dir(dir).ok()?;
+    for entry in rd.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.ends_with(".tar.bz2") {
+            return Some(entry.path().to_string_lossy().to_string());
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -600,6 +853,16 @@ mod tests {
         assert!(validate_backup_dest(&esc, root.path()).is_err());
         // reject: relative
         assert!(validate_backup_dest(std::path::Path::new("x/y"), root.path()).is_err());
+    }
+
+    // ── backup tarball discovery ──────────────────────────────
+    #[test]
+    fn find_backup_tarball_picks_the_tarball() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.txt"), b"x").unwrap();
+        std::fs::write(dir.path().join("samba-backup-2026-07-10.tar.bz2"), b"x").unwrap();
+        let found = find_backup_tarball(dir.path()).unwrap();
+        assert!(found.ends_with("samba-backup-2026-07-10.tar.bz2"));
     }
 
     // ── argv hygiene: THE invariant ───────────────────────────

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -11,6 +11,7 @@
 //! provision uses a random throwaway password, the real Administrator
 //! password is set via `samba-tool user setpassword` over stdin.
 
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use schemars::JsonSchema;
@@ -365,6 +366,32 @@ pub(crate) fn group_members_args(op: &str, group: &str, member: &str) -> Vec<Str
     with_conf(vec!["group".into(), op.into(), group.into(), member.into()])
 }
 
+// ── Resolved drop-in I/O (shared by DC mode + member-mode join) ────
+
+/// Directory both DC mode (this module) and member-mode join
+/// (`domain.rs`) write systemd-resolved runtime drop-ins into.
+const RESOLVED_DROPIN_DIR: &str = "/run/systemd/resolved.conf.d";
+
+/// Write a resolved drop-in readable by the sandboxed `systemd-resolve`
+/// user. The engine service's `UMask=0077` (nixos/modules/nasty.nix)
+/// makes a plain `create_dir_all`/`write` produce root-only modes;
+/// resolved then silently IGNORES the whole directory ("Failed to chase
+/// and open directory '/run/systemd/resolved.conf.d', ignoring:
+/// Permission denied") rather than just the one drop-in it can't read —
+/// CI's first live DC run proved it end to end: `DNSStubListener=no`
+/// never took effect, resolved's stub kept :53, and samba's internal DNS
+/// failed to bind. Used by both DC mode and member-mode join — the
+/// latter had the exact same latent bug, it just never surfaced because
+/// most boxes' `/run/systemd/resolved.conf.d` happened to pre-exist with
+/// sane permissions before NASty ever wrote to it.
+pub(crate) async fn write_resolved_dropin(path: &str, contents: &str) -> std::io::Result<()> {
+    tokio::fs::create_dir_all(RESOLVED_DROPIN_DIR).await?;
+    tokio::fs::set_permissions(RESOLVED_DROPIN_DIR, std::fs::Permissions::from_mode(0o755)).await?;
+    tokio::fs::write(path, contents).await?;
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).await?;
+    Ok(())
+}
+
 // ── Service ────────────────────────────────────────────────────
 
 pub struct DcService;
@@ -487,8 +514,7 @@ impl DcService {
             .await?;
 
             // Release :53 to samba, route the box's own lookups through it.
-            tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
-            tokio::fs::write(DC_RESOLVED_DROPIN_PATH, render_dc_resolved_dropin()).await?;
+            write_resolved_dropin(DC_RESOLVED_DROPIN_PATH, &render_dc_resolved_dropin()).await?;
             run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await?;
 
             // samba-dc conflicts with smbd/nmbd/winbindd — systemd swaps
@@ -623,11 +649,10 @@ impl DcService {
             .await
             .unwrap_or_default();
         if current != dropin {
-            let _ = tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await;
-            if tokio::fs::write(DC_RESOLVED_DROPIN_PATH, dropin)
+            let wrote = write_resolved_dropin(DC_RESOLVED_DROPIN_PATH, &dropin)
                 .await
-                .is_ok()
-            {
+                .is_ok();
+            if wrote {
                 let _ = run_cmd("systemctl", &["restart", "systemd-resolved"], &[]).await;
             }
         }

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -321,7 +321,7 @@ fn command_error(program: &str, output: &std::process::Output) -> DomainError {
 /// Run a command, capturing stdout+stderr. Returns stdout on success;
 /// on non-zero exit (or a spawn failure) returns `CommandFailed` carrying
 /// both stdout and stderr (or the spawn error).
-async fn run_cmd(
+pub(crate) async fn run_cmd(
     program: &str,
     args: &[&str],
     envs: &[(&str, &str)],
@@ -342,7 +342,7 @@ async fn run_cmd(
 /// stdin — used to hand credentials to `net ads join`/`net ads leave`
 /// without ever putting the password in argv (visible via `/proc/*/cmdline`).
 /// Captures stdout+stderr the same way `run_cmd` does.
-async fn run_cmd_stdin(
+pub(crate) async fn run_cmd_stdin(
     program: &str,
     args: &[&str],
     envs: &[(&str, &str)],

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
 
+use crate::dc::write_resolved_dropin;
 use crate::protocol::systemctl;
 
 /// Errors returned by domain operations.
@@ -695,10 +696,9 @@ impl DomainService {
                 }
             }
             if !dc_ips.is_empty() {
-                tokio::fs::create_dir_all("/run/systemd/resolved.conf.d").await?;
-                tokio::fs::write(
+                write_resolved_dropin(
                     RESOLVED_DROPIN_PATH,
-                    render_resolved_dropin(&cfg.realm, &dc_ips),
+                    &render_resolved_dropin(&cfg.realm, &dc_ips),
                 )
                 .await?;
                 let _ = systemctl("restart", "systemd-resolved.service").await;

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -595,6 +595,11 @@ impl DomainService {
         if Self::load_config().await.is_some() {
             return Err(DomainError::AlreadyJoined);
         }
+        if crate::dc::DcService::load_config().await.is_some() {
+            return Err(DomainError::Validation(
+                "this box hosts an Active Directory domain — demote it before joining another domain".into(),
+            ));
+        }
         let realm = validate_realm(&req.realm)?;
         let idmap_base = req.idmap_base.unwrap_or(DEFAULT_IDMAP_BASE);
         validate_idmap_base(idmap_base)?;

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -634,6 +634,8 @@ impl FirewallService {
                 webui_ports()
             } else if service == "rdma" {
                 rdma_ports()
+            } else if service == "dc" {
+                dc_ports()
             } else if let Some(proto) = Protocol::from_name(service) {
                 ports_for_protocol(proto)
             } else {

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -358,16 +358,17 @@ pub fn rdma_ports() -> Vec<PortSpec> {
 }
 
 /// Ports for the Active Directory DC role (#20): DNS, Kerberos +
-/// kpasswd, RPC endpoint mapper, NetBIOS, LDAP(S), SMB, Global Catalog,
-/// and the dynamic RPC range. Deliberately no NTP — the box does not
-/// serve time to domain clients (documented limitation).
+/// kpasswd, RPC endpoint mapper, NetBIOS, LDAP (tcp) + CLDAP DC-locator
+/// ping (udp), LDAP(S), SMB, Global Catalog, and the dynamic RPC range.
+/// Deliberately no NTP — the box does not serve time to domain clients
+/// (documented limitation).
 pub fn dc_ports() -> Vec<PortSpec> {
     let mut ports = Vec::new();
-    for p in [53u16, 88, 464] {
+    for p in [53u16, 88, 389, 464] {
         ports.push(tcp(p));
         ports.push(udp(p));
     }
-    for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+    for p in [135u16, 139, 445, 636, 3268, 3269] {
         ports.push(tcp(p));
     }
     for p in [137u16, 138] {
@@ -1442,13 +1443,13 @@ mod tests {
                 .iter()
                 .any(|s| s.transport == t && s.port == p && s.to.is_none())
         };
-        for p in [53u16, 88, 464] {
+        for p in [53u16, 88, 389, 464] {
             assert!(
                 has(Transport::Tcp, p) && has(Transport::Udp, p),
                 "missing tcp+udp {p}"
             );
         }
-        for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+        for p in [135u16, 139, 445, 636, 3268, 3269] {
             assert!(has(Transport::Tcp, p), "missing tcp {p}");
         }
         for p in [137u16, 138] {

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -80,6 +80,10 @@ pub enum Transport {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PortSpec {
     pub port: u16,
+    /// Optional end of a contiguous port range (`port`..=`to`). `None`
+    /// means a single port. First used by the DC role's dynamic-RPC range.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to: Option<u16>,
     pub transport: Transport,
     /// Optional source IP/CIDR restriction (e.g. "192.168.1.0/24").
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -240,7 +244,8 @@ pub fn service_port_conflict(
 ) -> Option<String> {
     for rule in &state.rules {
         for port in &rule.ports {
-            if port.transport == transport && port.port >= from && port.port <= to {
+            let hi = port.to.unwrap_or(port.port);
+            if port.transport == transport && port.port <= to && hi >= from {
                 return Some(rule.service.clone());
             }
         }
@@ -292,6 +297,7 @@ pub struct PublishedAppPort {
 fn tcp(port: u16) -> PortSpec {
     PortSpec {
         port,
+        to: None,
         transport: Transport::Tcp,
         source: None,
         iface: None,
@@ -301,7 +307,18 @@ fn tcp(port: u16) -> PortSpec {
 fn udp(port: u16) -> PortSpec {
     PortSpec {
         port,
+        to: None,
         transport: Transport::Udp,
+        source: None,
+        iface: None,
+    }
+}
+
+fn tcp_range(from: u16, to: u16) -> PortSpec {
+    PortSpec {
+        port: from,
+        to: Some(to),
+        transport: Transport::Tcp,
         source: None,
         iface: None,
     }
@@ -338,6 +355,26 @@ pub fn webui_ports() -> Vec<PortSpec> {
 /// source restrictions on RoCE can only filter at 4791 granularity.
 pub fn rdma_ports() -> Vec<PortSpec> {
     vec![udp(4791), tcp(20049)]
+}
+
+/// Ports for the Active Directory DC role (#20): DNS, Kerberos +
+/// kpasswd, RPC endpoint mapper, NetBIOS, LDAP(S), SMB, Global Catalog,
+/// and the dynamic RPC range. Deliberately no NTP — the box does not
+/// serve time to domain clients (documented limitation).
+pub fn dc_ports() -> Vec<PortSpec> {
+    let mut ports = Vec::new();
+    for p in [53u16, 88, 464] {
+        ports.push(tcp(p));
+        ports.push(udp(p));
+    }
+    for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+        ports.push(tcp(p));
+    }
+    for p in [137u16, 138] {
+        ports.push(udp(p));
+    }
+    ports.push(tcp_range(49152, 65535));
+    ports
 }
 
 // ── Firewall service ───────────────────────────────────────────
@@ -503,6 +540,46 @@ impl FirewallService {
             error!("Failed to close firewall for rdma: {e}");
         } else {
             info!("Firewall: closed ports for rdma");
+        }
+    }
+
+    /// Open the named Active Directory DC rule (#20, per-box opt-in).
+    pub async fn open_dc(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "dc") {
+            if rule.active {
+                return;
+            }
+            rule.active = true;
+        } else {
+            state.rules.push(FirewallRule {
+                service: "dc".to_string(),
+                ports: dc_ports(),
+                active: true,
+            });
+        }
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
+            error!("Failed to open firewall for dc: {e}");
+        } else {
+            info!("Firewall: opened ports for dc");
+        }
+    }
+
+    /// Close the named Active Directory DC rule.
+    pub async fn close_dc(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "dc") {
+            if !rule.active {
+                return;
+            }
+            rule.active = false;
+        }
+        let custom = self.custom.lock().await;
+        if let Err(e) = apply_nftables(&state, &custom).await {
+            error!("Failed to close firewall for dc: {e}");
+        } else {
+            info!("Firewall: closed ports for dc");
         }
     }
 
@@ -746,6 +823,7 @@ fn apply_restrictions(
                 for iface in ifaces {
                     result.push(PortSpec {
                         port: port.port,
+                        to: port.to,
                         transport: port.transport,
                         source: Some(src.clone()),
                         iface: Some(iface.clone()),
@@ -756,6 +834,7 @@ fn apply_restrictions(
             for src in sources {
                 result.push(PortSpec {
                     port: port.port,
+                    to: port.to,
                     transport: port.transport,
                     source: Some(src.clone()),
                     iface: None,
@@ -765,6 +844,7 @@ fn apply_restrictions(
             for iface in ifaces {
                 result.push(PortSpec {
                     port: port.port,
+                    to: port.to,
                     transport: port.transport,
                     source: None,
                     iface: Some(iface.clone()),
@@ -881,7 +961,10 @@ pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
             if let Some(ref src) = port.source {
                 conditions.push(saddr_clause(src));
             }
-            conditions.push(format!("{proto} dport {}", port.port));
+            match port.to {
+                Some(to) => conditions.push(format!("{proto} dport {}-{to}", port.port)),
+                None => conditions.push(format!("{proto} dport {}", port.port)),
+            }
             rules.push_str(&format!(
                 "        {} accept # {}\n",
                 conditions.join(" "),
@@ -1255,6 +1338,7 @@ mod tests {
             service: "smb".into(),
             ports: vec![PortSpec {
                 port: 445,
+                to: None,
                 transport: Transport::Tcp,
                 source: None,
                 iface: None,
@@ -1265,6 +1349,7 @@ mod tests {
             service: "nfs".into(),
             ports: vec![PortSpec {
                 port: 2049,
+                to: None,
                 transport: Transport::Tcp,
                 source: None,
                 iface: None,
@@ -1296,5 +1381,84 @@ mod tests {
             service_port_conflict(&state, Transport::Tcp, 32400, 32400),
             None
         );
+    }
+
+    // ── ranged service ports + dc rule set (#20) ─────────────────────
+
+    #[test]
+    fn render_emits_ranged_service_port() {
+        let mut state = FirewallState::default();
+        state.rules.push(FirewallRule {
+            service: "dc".into(),
+            ports: vec![PortSpec {
+                port: 49152,
+                to: Some(65535),
+                transport: Transport::Tcp,
+                source: None,
+                iface: None,
+            }],
+            active: true,
+        });
+        let out = render_ruleset(&state, &[]);
+        assert!(
+            out.contains("tcp dport 49152-65535 accept # dc"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn service_conflict_matches_ranged_service_ports() {
+        let mut state = FirewallState::default();
+        state.rules.push(FirewallRule {
+            service: "dc".into(),
+            ports: vec![PortSpec {
+                port: 49152,
+                to: Some(65535),
+                transport: Transport::Tcp,
+                source: None,
+                iface: None,
+            }],
+            active: false, // inactive still owns its ports
+        });
+        // custom range overlapping the service range → conflict
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 50000, 50010).as_deref(),
+            Some("dc")
+        );
+        // below the range → free
+        assert_eq!(
+            service_port_conflict(&state, Transport::Tcp, 40000, 49151),
+            None
+        );
+    }
+
+    #[test]
+    fn dc_ports_cover_ad_services() {
+        let ports = dc_ports();
+        let has = |t: Transport, p: u16| {
+            ports
+                .iter()
+                .any(|s| s.transport == t && s.port == p && s.to.is_none())
+        };
+        for p in [53u16, 88, 464] {
+            assert!(
+                has(Transport::Tcp, p) && has(Transport::Udp, p),
+                "missing tcp+udp {p}"
+            );
+        }
+        for p in [135u16, 139, 389, 445, 636, 3268, 3269] {
+            assert!(has(Transport::Tcp, p), "missing tcp {p}");
+        }
+        for p in [137u16, 138] {
+            assert!(has(Transport::Udp, p), "missing udp {p}");
+        }
+        assert!(
+            ports
+                .iter()
+                .any(|s| s.transport == Transport::Tcp && s.port == 49152 && s.to == Some(65535)),
+            "missing RPC range"
+        );
+        // No NTP — the box does not serve time.
+        assert!(!ports.iter().any(|s| s.port == 123));
     }
 }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod alerts;
+pub mod dc;
 pub mod domain;
 pub mod firewall;
 pub mod firmware;

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -311,6 +311,20 @@ impl ProtocolService {
     pub async fn enable(&self, name: &str) -> Result<ProtocolStatus, String> {
         let proto = Protocol::from_name(name).ok_or_else(|| format!("unknown protocol: {name}"))?;
 
+        // A hosted AD domain's samba-dc.service already serves SMB (shares
+        // included) through its own smbd, and Conflicts= swaps it out for
+        // member-mode smbd/nmbd/winbindd — enabling the standalone SMB
+        // toggle here would silently stop the DC. Demoting clears dc.json
+        // and lifts this guard (disable is intentionally left unguarded).
+        if proto == Protocol::Smb && crate::dc::DcService::load_config().await.is_some() {
+            return Err(
+                "this box hosts an Active Directory domain — its domain controller \
+                         serves SMB (shares included); demote it on the Settings → Directory \
+                         panel before enabling standalone SMB"
+                    .to_string(),
+            );
+        }
+
         let mut state = load_state().await;
         state.set(proto, true);
         save_state(&state).await?;

--- a/flake.nix
+++ b/flake.nix
@@ -426,6 +426,9 @@
       ad-member = import ./nixos/tests/ad-member.nix {
         inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
       };
+      ad-dc = import ./nixos/tests/ad-dc.nix {
+        inherit pkgs nasty-engine nasty-webui nasty-bcachefs-tools;
+      };
     };
   };
 }

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -52,11 +52,20 @@ let
     };
   };
 
-  # ADS member mode needs LDAP support; nixpkgs' default samba is built
-  # --without-ldap --without-ads. One binding so smbd, the CLI tools, and
-  # winbindd all come from the same build. This changes the samba binary
-  # on EVERY box (joined or not) — the appliance-smoke test gates it.
-  sambaAds = pkgs.samba.override { enableLDAP = true; };
+  # ADS member mode needs LDAP; the DC role (#20) needs the full domain-
+  # controller build. One superset build serves both roles — member boxes
+  # simply never run the DC bits; two parallel samba store paths would
+  # invite version skew. samba-tool's provision path imports python
+  # `cryptography` (samba.gkdi) — keep it on pythonPath (harmless when the
+  # pinned nixpkgs already carries it; required when it doesn't).
+  sambaAds =
+    (pkgs.samba.override {
+      enableLDAP = true;
+      enableDomainController = true;
+    }).overrideAttrs
+      (old: {
+        pythonPath = (old.pythonPath or [ ]) ++ [ pkgs.python3Packages.cryptography ];
+      });
 
   # ── Plymouth boot splash ────────────────────────────────────
   nasty-logo-png = pkgs.runCommand "nasty-logo.png" {
@@ -1819,6 +1828,35 @@ in {
     # to break that chain; the engine starts smbd/nmbd/wsdd via the protocol
     # toggle and winbindd only while joined to a domain.
     systemd.targets.samba.wantedBy = mkIf cfg.smb.enable (lib.mkForce []);
+
+    # ── AD Domain Controller role (#20) ──────────────────────────
+    # Present on every SMB-enabled box, disabled by default; the ENGINE
+    # starts it (dc.provision / the dc.restore boot phase) — per-box
+    # runtime opt-in, like every other role. Conflicts= makes systemd swap
+    # the member-mode daemons out atomically: starting samba-dc stops
+    # smbd/nmbd/winbindd, stopping it lets them return under their normal
+    # toggles. The AD DC `samba` daemon runs its own smbd internally
+    # (serving sysvol + the NASty shares via the include chain in
+    # /etc/samba/smb.dc.conf, which `dc.provision` generates — never the
+    # nix-managed smb.conf).
+    systemd.services.samba-dc = mkIf cfg.smb.enable {
+      description = "Samba Active Directory Domain Controller (NASty-managed)";
+      # Lesson from the ad-member CI DC: without network-online ordering
+      # the DC races the interface and provision-time DNS registration
+      # fails in ways that look like samba bugs.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      conflicts = [ "samba-smbd.service" "samba-nmbd.service" "samba-winbindd.service" ];
+      serviceConfig = {
+        Type = "notify";
+        NotifyAccess = "all";
+        ExecStart = "${sambaAds}/bin/samba --foreground --no-process-group --configfile=/etc/samba/smb.dc.conf";
+        LimitNOFILE = 16384;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      # NOT wantedBy multi-user.target: the engine owns the role.
+    };
 
     # ── SMB network discovery ──────────────────────────────────
     # NASty was invisible to file-manager network browsers — TrueNAS,

--- a/nixos/tests/ad-dc.nix
+++ b/nixos/tests/ad-dc.nix
@@ -1,0 +1,388 @@
+# Two-node AD test, DC side: a NASty box provisions a brand-new Active
+# Directory domain via the engine API (real `nasty.nix` samba-dc.service,
+# real `dc.provision` RPC — not a throwaway script-unit) and a second NASty
+# box joins it with the shipped member flow (#627). This is the fleet
+# money-shot for #20: it proves the two roles this feature ships —
+# "NASty hosts a domain" and "NASty joins a domain" — actually interop,
+# end to end, over the wire.
+#
+# ad-member.nix is the harness template this file cribs from: module
+# imports, `_module.args`, the JSON-RPC-over-websocket driver-script
+# pattern (login → bearer → call), and the out-of-band smbclient check
+# from the other node. The one structural difference: ad-member's DC side
+# is a throwaway samba-tool script-unit standing in for "some AD DC";
+# here BOTH boxes are full NASty appliances, so the DC side exercises the
+# real engine-owned unit + provisioning path this feature actually ships.
+#
+# Node IPs come from the NixOS test framework's default net: nodes are
+# numbered by the sorted order of `nodes.*`, so `dcbox` == 192.168.1.1 and
+# `member` == 192.168.1.2 (see nixpkgs' nixos/lib/testing/network.nix —
+# same mechanism ad-member.nix documents for its `dc`/`nasty` nodes).
+#
+# This is samba-dc.service's first live exercise (unit tests cover the
+# argv/render/parse logic in nasty-system/src/dc.rs, but never a real
+# `samba-tool domain provision` + service start). Two named risk areas if
+# this VM run disproves an assumption the code makes:
+#   (a) Type=notify readiness — samba-dc.service's ExecStart execs `samba
+#       --foreground` directly with no wrapper script (unlike ad-member's
+#       throwaway DC, which manually fires `systemd-notify --ready`).
+#       If samba's own sd_notify support never signals READY=1,
+#       `systemctl start samba-dc.service` (called synchronously inside
+#       dc.provision) fails at its own TimeoutStartSec, well before this
+#       test's 60s service_healthy poll or 300s RPC socket timeout would
+#       matter. Fallback: switch the unit to Type=simple and poll
+#       `samba-tool` reachability from dc.status instead.
+#   (b) provision-vs-config-path — dc.rs's samba-tool invocations already
+#       pass `--configfile=/etc/samba/smb.dc.conf` (DC_CONF_PATH) directly
+#       to `domain provision`, so this should already write the config
+#       where the module's ExecStart expects it. If samba-tool refuses to
+#       write there, the fallback is `--targetdir` into a scratch dir with
+#       the generated smb.conf moved to DC_CONF_PATH afterward.
+{ pkgs, nasty-engine, nasty-webui, nasty-bcachefs-tools }:
+
+let
+  realm = "NASTYDC.LAN";
+  # derive_workgroup(realm) (nasty-system/src/domain.rs): first label,
+  # NetBIOS-truncated to 15 chars, uppercased. "NASTYDC" needs no
+  # truncation — spelling it out here (rather than deriving it in Nix)
+  # keeps this file honest about what the wbinfo domain prefix actually
+  # has to be.
+  workgroup = "NASTYDC";
+  adminPass = "Passw0rd.123";
+  alicePass = "UserPass.123";
+  # Fixed and deterministic rather than "the test net's gateway" — this
+  # isolated two-node vlan has no router/gateway node at all. dc.provision
+  # only validates that dns_forwarder parses as an IP address (it's
+  # written into smb.dc.conf, never dialled during provision), so an
+  # unreachable-but-well-formed address is fine and keeps the testparm
+  # assertion below deterministic.
+  dnsForwarder = "192.168.1.254";
+
+  pythonWithWs = pkgs.python3.withPackages (ps: [ ps.websocket-client ]);
+
+  # Self-contained script run inside each guest, same reason ad-member.nix
+  # keeps its driver in its own file (a triple-quoted Python block nested
+  # inside the Nix `''` testScript string gets its indentation mangled by
+  # the testScript type-checker). One file, two phases selected by
+  # argv[1] — `provision` runs on dcbox, `join` runs on member — sharing
+  # the login/websocket/call boilerplate the way ad-member's join/leave
+  # phases do.
+  adDcScript = pkgs.writeText "ad-dc.py" ''
+    import json
+    import subprocess
+    import sys
+    import time
+    import urllib.request
+
+    import websocket
+
+    REALM = "${realm}"
+    WORKGROUP = "${workgroup}"
+    ADMIN_PASS = "${adminPass}"
+    ALICE_PASS = "${alicePass}"
+    DNS_FORWARDER = "${dnsForwarder}"
+    NEW_PW = "admin-changed-by-ad-dc-test"
+
+    _next_id = 0
+
+
+    def http_login(password):
+        req = urllib.request.Request(
+            "http://127.0.0.1:2137/api/login",
+            data=json.dumps({"username": "admin", "password": password}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())["token"]
+
+
+    def ws_open(token):
+        # `dc.provision` runs `samba-tool domain provision` synchronously
+        # inside the RPC call — LDAP database init, Kerberos realm setup,
+        # sysvol — much heavier than a plain domain.join. Give the socket
+        # a generous read timeout so a slow CI runner doesn't trip a
+        # client-side timeout on an otherwise-successful call.
+        ws = websocket.create_connection("ws://127.0.0.1:2137/ws", timeout=300)
+        ws.send(json.dumps({"token": token}))
+        auth = json.loads(ws.recv())
+        assert auth.get("authenticated") is True, f"WS auth failed: {auth!r}"
+        return ws, auth
+
+
+    def call(ws, method, params=None):
+        global _next_id
+        _next_id += 1
+        req = {"jsonrpc": "2.0", "method": method, "id": _next_id}
+        if params is not None:
+            req["params"] = params
+        ws.send(json.dumps(req))
+        resp = json.loads(ws.recv())
+        assert resp.get("id") == _next_id, f"id mismatch: {resp!r}"
+        assert "error" not in resp, f"{method} returned error: {resp!r}"
+        return resp["result"]
+
+
+    def authed_ws():
+        # First boot uses admin/admin with a forced change, same gate
+        # ad-member.py's authed_ws() clears — every fresh NASty box starts
+        # here regardless of which role it ends up playing.
+        for pw in (NEW_PW, "admin"):
+            try:
+                token = http_login(pw)
+            except Exception:
+                continue
+            ws, auth = ws_open(token)
+            if auth.get("must_change_password"):
+                call(ws, "auth.change_password",
+                     {"username": "admin", "new_password": NEW_PW})
+                ws.close()
+                token = http_login(NEW_PW)
+                ws, auth = ws_open(token)
+            assert auth.get("must_change_password") is False, f"gate not cleared: {auth!r}"
+            return ws, auth
+        raise SystemExit("could not authenticate admin")
+
+
+    def phase_provision(ws):
+        # ── Provision a brand-new domain via the engine API ────────────
+        # Note for future readers: samba-tool domain provision wipes
+        # /var/lib/samba/private before writing the AD database there —
+        # any local SMB passdb users on this box are gone after this
+        # call. Deliberate (the DC replaces local SMB auth entirely);
+        # nothing local is configured on this fresh test box, so there's
+        # nothing to assert here beyond flagging it for the next reader.
+        prov = call(ws, "dc.provision", {
+            "realm": REALM,
+            "admin_password": ADMIN_PASS,
+            "dns_forwarder": DNS_FORWARDER,
+        })
+        assert prov["status"]["hosting"] is True, prov
+        # A static-IP *warning* is expected here — this VM's address isn't
+        # configured through NASty's own network.* RPC (networking.json
+        # never gets written), so the precondition can't confirm a static
+        # address and downgrades Fail to Warn (dc.rs::static_ip_check).
+        # Provision must still succeed with a non-empty warnings array.
+        assert isinstance(prov["warnings"], list), prov
+
+        # ── Poll until samba-dc.service reports healthy ─────────────────
+        healthy_status = None
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            st = call(ws, "dc.status")
+            if st.get("service_healthy"):
+                healthy_status = st
+                break
+            time.sleep(1)
+        assert healthy_status is not None, "samba-dc.service did not report healthy within 60s"
+        assert healthy_status["hosting"] is True, healthy_status
+        assert healthy_status["realm"] == REALM, healthy_status
+        assert healthy_status["workgroup"] == WORKGROUP, healthy_status
+        assert healthy_status["dns_forwarder"] == DNS_FORWARDER, healthy_status
+
+        # ── Create a domain user, confirm it shows up in the listing ────
+        call(ws, "dc.user.create", {"name": "alice", "password": ALICE_PASS})
+        users = call(ws, "dc.user.list")
+        assert any(u["name"] == "alice" for u in users), users
+
+        # dc.backup is intentionally not exercised here: like ad-member's
+        # harness, this one sets up no /fs pool, and dc.backup jails its
+        # target under /fs (dc.rs::validate_backup_dest). The jail and the
+        # samba-tool backup call itself are unit-tested; fabricating a
+        # pool just to exercise this one RPC isn't worth the added
+        # boot-time/complexity here.
+        print("DC provisioned + healthy + alice created", file=sys.stderr)
+
+
+    def phase_join(ws):
+        # ── Join via the engine API — the shipped member flow (#627),
+        # unchanged ────────────────────────────────────────────────────
+        join = call(ws, "domain.join", {
+            "realm": REALM,
+            "username": "Administrator",
+            "password": ADMIN_PASS,
+        })
+        assert join["joined"] is True, join
+        assert join["trust_ok"] is True, join
+
+        st = call(ws, "domain.status")
+        assert st["joined"] is True, st
+        assert st["trust_ok"] is True, st
+
+        # winbindd is started directly by domain.join (not gated behind
+        # the smb protocol toggle) — wbinfo should resolve the domain
+        # user right away. `wbinfo -i` mimics getent passwd's
+        # colon-delimited line; field index 2 is the uid.
+        out = subprocess.run(
+            ["wbinfo", "-i", f"{WORKGROUP}\\alice"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        uid = int(out.split(":")[2])
+        assert 100000 <= uid < 1000000, f"idmap uid out of range: {uid} (wbinfo said: {out!r})"
+
+        # Start smbd (port 445) — needed for the out-of-band smbclient
+        # probe from dcbox that follows. Build-time-vs-runtime split: the
+        # module's smb.enable pulled in winbind/KRB5 wiring already, but
+        # the SMB daemons themselves only start via the engine's runtime
+        # protocol toggle (same as ad-member.py's phase_join).
+        call(ws, "service.protocol.enable", {"name": "smb"})
+        print(f"domain join + wbinfo resolve OK (uid={uid})", file=sys.stderr)
+
+
+    phase = sys.argv[1] if len(sys.argv) > 1 else "provision"
+    ws, _auth = authed_ws()
+    if phase == "provision":
+        phase_provision(ws)
+    elif phase == "join":
+        phase_join(ws)
+    else:
+        raise SystemExit(f"unknown phase: {phase}")
+    ws.close()
+  '';
+
+in
+
+pkgs.testers.runNixOSTest {
+  name = "ad-dc";
+
+  # ── The NASty box that hosts the domain ───────────────────────────
+  # Both nodes below are full NASty appliances (same imports/_module.args
+  # as ad-member.nix's "nasty" node), and both hit the same
+  # NetworkManager-vs-test-network snag it documents: nasty.nix hands
+  # networking to NetworkManager and force-clears `networking.interfaces`,
+  # but there's no DHCP on this test net, so scripted networking is
+  # reasserted on both (NM off, static IP above the module's mkForce).
+  # ad-member only needed this workaround on its single "nasty" node;
+  # here it applies to both, since there is no "nasty.nix doesn't apply"
+  # side of this topology.
+  nodes.dcbox = { lib, ... }: {
+    imports = [
+      ../modules/bcachefs.nix
+      ../modules/linuxquota.nix
+      ../modules/nasty.nix
+    ];
+    _module.args = {
+      inherit nasty-engine nasty-webui nasty-bcachefs-tools;
+      nasty-version = "test";
+    };
+
+    services.nasty = {
+      enable = true;
+      engine.package = nasty-engine;
+      webui.package = nasty-webui;
+      # SMB must stay on: it's what pulls in the DC-capable samba build
+      # (sambaAds) that samba-dc.service execs. The other share protocols
+      # are irrelevant here and only add boot time.
+      smb.enable = true;
+      nfs.enable = false;
+      iscsi.enable = false;
+      nvmeof.enable = false;
+    };
+
+    networking.networkmanager.enable = lib.mkForce false;
+    networking.interfaces = lib.mkOverride 10 {
+      eth1.ipv4.addresses = [
+        { address = "192.168.1.1"; prefixLength = 24; }
+      ];
+    };
+    # dc.provision writes its own resolved drop-in once the DC is up
+    # (DNS=127.0.0.1, samba's internal DNS) — nothing needed here
+    # upstream of that; this isolated test net has no real resolver.
+
+    # qemu-vm.nix forces timesyncd off; nasty.nix turns it on. Defer to
+    # the VM infra — clock sync is irrelevant in a transient test VM,
+    # and both guests share the host clock so Kerberos sees ~0 skew.
+    services.timesyncd.enable = lib.mkForce false;
+
+    # The driver script needs websocket-client at runtime in the guest.
+    environment.systemPackages = [ pythonWithWs ];
+
+    virtualisation.memorySize = 3072;
+  };
+
+  # ── The NASty box that joins it ───────────────────────────────────
+  nodes.member = { lib, ... }: {
+    imports = [
+      ../modules/bcachefs.nix
+      ../modules/linuxquota.nix
+      ../modules/nasty.nix
+    ];
+    _module.args = {
+      inherit nasty-engine nasty-webui nasty-bcachefs-tools;
+      nasty-version = "test";
+    };
+
+    services.nasty = {
+      enable = true;
+      engine.package = nasty-engine;
+      webui.package = nasty-webui;
+      # SMB must stay on — it's what pulls in winbindd, the winbind NSS
+      # modules, and the KRB5_CONFIG wiring the join depends on. The
+      # other share protocols are irrelevant here and only add boot time.
+      smb.enable = true;
+      nfs.enable = false;
+      iscsi.enable = false;
+      nvmeof.enable = false;
+    };
+
+    networking.networkmanager.enable = lib.mkForce false;
+    networking.interfaces = lib.mkOverride 10 {
+      eth1.ipv4.addresses = [
+        { address = "192.168.1.2"; prefixLength = 24; }
+      ];
+    };
+    # dcbox owns DNS for the realm once provisioned — the join
+    # preflight's SRV lookups resolve through it.
+    networking.nameservers = lib.mkForce [ "192.168.1.1" ];
+
+    services.timesyncd.enable = lib.mkForce false;
+
+    environment.systemPackages = [ pythonWithWs ];
+
+    virtualisation.memorySize = 2048;
+  };
+
+  testScript = ''
+    dcbox.start()
+    member.start()
+
+    dcbox.wait_for_unit("nasty-engine.service")
+
+    # ── Phase 1 (dcbox): provision the domain, create a user ──────────
+    dcbox.succeed("${pythonWithWs}/bin/python3 ${adDcScript} provision")
+
+    # DC's own DNS must answer the realm's SRV records locally before the
+    # member's join preflight can find it over the network.
+    dcbox.wait_until_succeeds(
+        "resolvectl query --type=SRV _ldap._tcp.${pkgs.lib.toLower realm}", timeout=60
+    )
+
+    # Pin the strip-samba's-line fix (#20 review finding): the
+    # operator-supplied dns_forwarder must be the config's EFFECTIVE
+    # value, not silently overridden by samba-tool provision's own
+    # resolv.conf-derived line (smb.conf is last-value-wins).
+    forwarder = dcbox.succeed(
+        "testparm -s --parameter-name='dns forwarder' /etc/samba/smb.dc.conf 2>/dev/null | tail -1"
+    ).strip()
+    assert forwarder == "${dnsForwarder}", (
+        f"effective dns forwarder mismatch: got {forwarder!r}, want ${dnsForwarder}"
+    )
+
+    # ── Phase 2 (member): join the domain dcbox now hosts ──────────────
+    member.wait_for_unit("nasty-engine.service")
+    member.wait_until_succeeds(
+        "resolvectl query --type=SRV _ldap._tcp.${pkgs.lib.toLower realm}", timeout=120
+    )
+    member.succeed("${pythonWithWs}/bin/python3 ${adDcScript} join")
+
+    # ── Out-of-band proof (spec-mandated money shot): from dcbox,
+    # authenticate as the domain user against member's IPC$ — exercises
+    # the full winbind auth path end to end (Kerberos/NTLM against the DC
+    # we just provisioned, winbind name resolution on member, smbd's own
+    # auth stack) without needing a share (IPC$ suffices — this harness,
+    # like ad-member's, publishes none).
+    member.wait_for_open_port(445)
+    dcbox.succeed(
+        "smbclient '//192.168.1.2/IPC$' -U 'NASTYDC\\alice%UserPass.123' -c 'exit'"
+    )
+  '';
+}

--- a/nixos/tests/ad-dc.nix
+++ b/nixos/tests/ad-dc.nix
@@ -161,8 +161,10 @@ let
         # configured through NASty's own network.* RPC (networking.json
         # never gets written), so the precondition can't confirm a static
         # address and downgrades Fail to Warn (dc.rs::static_ip_check).
-        # Provision must still succeed with a non-empty warnings array.
+        # Provision must still succeed with a non-empty warnings array —
+        # assert both the shape and that the Warn branch actually fired.
         assert isinstance(prov["warnings"], list), prov
+        assert len(prov["warnings"]) >= 1, prov
 
         # ── Poll until samba-dc.service reports healthy ─────────────────
         healthy_status = None
@@ -382,7 +384,7 @@ pkgs.testers.runNixOSTest {
     # like ad-member's, publishes none).
     member.wait_for_open_port(445)
     dcbox.succeed(
-        "smbclient '//192.168.1.2/IPC$' -U 'NASTYDC\\alice%UserPass.123' -c 'exit'"
+        "smbclient '//192.168.1.2/IPC$' -U '${workgroup}\\alice%${alicePass}' -c 'exit'"
     )
   '';
 }

--- a/webui/src/lib/dc.svelte.ts
+++ b/webui/src/lib/dc.svelte.ts
@@ -1,0 +1,74 @@
+/** AD Domain Controller role state + handlers (Settings → Directory card).
+ * Mirrors domain.svelte.ts's conventions: a shared `$state` object plus a
+ * small set of top-level lifecycle handlers. Per-principal CRUD (users,
+ * groups, computers) lives in DcPanel.svelte itself, same split as
+ * domain.svelte.ts (status/join/leave) vs. the SMB users/groups page. */
+import { getClient } from '$lib/client';
+import { withToast, info } from '$lib/toast.svelte';
+import type { DcStatus, DcPrincipal } from '$lib/types';
+
+const client = getClient();
+
+export const dc = $state({
+	status: null as DcStatus | null,
+	loading: true,
+	provisioning: false,
+	// provision form
+	realm: '',
+	adminPassword: '',
+	dnsForwarder: '',
+	// panel data (users/groups/computers tabs)
+	users: [] as DcPrincipal[],
+	groups: [] as DcPrincipal[],
+	computers: [] as DcPrincipal[],
+});
+
+export async function dcRefresh() {
+	try {
+		dc.status = await client.call<DcStatus>('dc.status');
+	} catch { /* engine without dc support */ }
+	dc.loading = false;
+}
+
+export async function dcProvision(): Promise<boolean> {
+	if (!dc.realm || !dc.adminPassword) return false;
+	dc.provisioning = true;
+	const params: Record<string, unknown> = {
+		realm: dc.realm.trim(),
+		admin_password: dc.adminPassword,
+	};
+	if (dc.dnsForwarder.trim()) params.dns_forwarder = dc.dnsForwarder.trim();
+	const res = await withToast(
+		() => client.call<{ status: DcStatus; warnings: string[] }>('dc.provision', params),
+		'Domain provisioned',
+	);
+	dc.adminPassword = '';
+	dc.provisioning = false;
+	if (!res) return false;
+	dc.status = res.status;
+	dc.realm = '';
+	dc.dnsForwarder = '';
+	for (const w of res.warnings ?? []) {
+		info(w);
+	}
+	return true;
+}
+
+export async function dcDemote(realmConfirmation: string): Promise<boolean> {
+	const ok = await withToast(
+		() => client.call('dc.demote', { realm_confirmation: realmConfirmation }),
+		'Domain demoted',
+	);
+	if (ok !== undefined) await dcRefresh();
+	return ok !== undefined;
+}
+
+export async function dcLoadPrincipals() {
+	try {
+		[dc.users, dc.groups, dc.computers] = await Promise.all([
+			client.call<DcPrincipal[]>('dc.user.list'),
+			client.call<DcPrincipal[]>('dc.group.list'),
+			client.call<DcPrincipal[]>('dc.computer.list'),
+		]);
+	} catch { /* surfaced by panel */ }
+}

--- a/webui/src/lib/directory/DcPanel.svelte
+++ b/webui/src/lib/directory/DcPanel.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getClient } from '$lib/client';
+	import { withToast, success } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
+	import { requiredFieldCls } from '$lib/utils';
+	import { dc, dcLoadPrincipals, dcDemote } from '$lib/dc.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+
+	const client = getClient();
+
+	let activeTab: 'users' | 'groups' | 'computers' = $state('users');
+
+	onMount(() => {
+		dcLoadPrincipals();
+	});
+
+	// ── Users tab ────────────────────────────────────────────────
+	let showAddUser = $state(false);
+	let newUserName = $state('');
+	let newUserPassword = $state('');
+	let newUserGiven = $state('');
+	let newUserSurname = $state('');
+	let newUserTried = $state(false);
+	let userBusy: string | null = $state(null);
+
+	let pwUser: string | null = $state(null);
+	let pwNew = $state('');
+	let pwTried = $state(false);
+
+	async function createUser() {
+		if (!newUserName.trim() || !newUserPassword) { newUserTried = true; return; }
+		newUserTried = false;
+		const params: Record<string, unknown> = {
+			name: newUserName.trim(),
+			password: newUserPassword,
+		};
+		if (newUserGiven.trim()) params.given_name = newUserGiven.trim();
+		if (newUserSurname.trim()) params.surname = newUserSurname.trim();
+		const ok = await withToast(
+			() => client.call('dc.user.create', params),
+			`User "${newUserName.trim()}" created`,
+		);
+		newUserPassword = '';
+		if (ok !== undefined) {
+			showAddUser = false;
+			newUserName = '';
+			newUserGiven = '';
+			newUserSurname = '';
+			newUserTried = false;
+			await dcLoadPrincipals();
+		}
+	}
+
+	async function deleteUser(name: string) {
+		if (!await confirm(`Delete user "${name}"?`, 'This permanently removes the AD account.')) return;
+		await withToast(() => client.call('dc.user.delete', { name }), `User "${name}" deleted`);
+		await dcLoadPrincipals();
+	}
+
+	async function setUserEnabled(name: string, enabled: boolean) {
+		userBusy = name;
+		await withToast(
+			() => client.call(enabled ? 'dc.user.enable' : 'dc.user.disable', { name }),
+			`User "${name}" ${enabled ? 'enabled' : 'disabled'}`,
+		);
+		userBusy = null;
+		await dcLoadPrincipals();
+	}
+
+	function openResetPassword(name: string) {
+		pwUser = pwUser === name ? null : name;
+		pwNew = '';
+		pwTried = false;
+	}
+
+	async function resetPassword() {
+		if (!pwUser) return;
+		if (!pwNew) { pwTried = true; return; }
+		pwTried = false;
+		const ok = await withToast(
+			() => client.call('dc.user.set_password', { name: pwUser, password: pwNew }),
+			`Password reset for "${pwUser}"`,
+		);
+		pwNew = '';
+		if (ok !== undefined) {
+			pwUser = null;
+			pwTried = false;
+			await dcLoadPrincipals();
+		}
+	}
+
+	// ── Groups tab ───────────────────────────────────────────────
+	let newGroupName = $state('');
+	let newGroupTried = $state(false);
+	let memberGroup = $state('');
+	let memberName = $state('');
+
+	async function createGroup() {
+		if (!newGroupName.trim()) { newGroupTried = true; return; }
+		newGroupTried = false;
+		const ok = await withToast(
+			() => client.call('dc.group.create', { name: newGroupName.trim() }),
+			`Group "${newGroupName.trim()}" created`,
+		);
+		if (ok !== undefined) {
+			newGroupName = '';
+			newGroupTried = false;
+			await dcLoadPrincipals();
+		}
+	}
+
+	async function deleteGroup(name: string) {
+		if (!await confirm(`Delete group "${name}"?`, 'Members lose whatever access this group granted.')) return;
+		await withToast(() => client.call('dc.group.delete', { name }), `Group "${name}" deleted`);
+		await dcLoadPrincipals();
+	}
+
+	async function addMember() {
+		if (!memberGroup.trim() || !memberName.trim()) return;
+		await withToast(
+			() => client.call('dc.group.add_member', { group: memberGroup.trim(), member: memberName.trim() }),
+			`Added "${memberName.trim()}" to "${memberGroup.trim()}"`,
+		);
+		memberName = '';
+		await dcLoadPrincipals();
+	}
+
+	async function removeMember() {
+		if (!memberGroup.trim() || !memberName.trim()) return;
+		await withToast(
+			() => client.call('dc.group.remove_member', { group: memberGroup.trim(), member: memberName.trim() }),
+			`Removed "${memberName.trim()}" from "${memberGroup.trim()}"`,
+		);
+		memberName = '';
+		await dcLoadPrincipals();
+	}
+
+	// ── Back up domain ───────────────────────────────────────────
+	let backupDest = $state('');
+	let backingUp = $state(false);
+
+	async function runBackup() {
+		if (!backupDest.trim()) return;
+		backingUp = true;
+		const res = await withToast(() => client.call<{ path: string }>('dc.backup', { dest: backupDest.trim() }));
+		backingUp = false;
+		if (res) {
+			success(`Backup written to ${res.path}`);
+			backupDest = '';
+		}
+	}
+
+	// ── Danger zone: demote ──────────────────────────────────────
+	let demoteOpen = $state(false);
+	let demoteTyped = $state('');
+	let demoting = $state(false);
+
+	async function doDemote() {
+		demoting = true;
+		const ok = await dcDemote(demoteTyped);
+		demoting = false;
+		if (ok) {
+			demoteOpen = false;
+			demoteTyped = '';
+		}
+	}
+</script>
+
+<!-- Header: realm, workgroup, health -->
+<div class="mb-5 flex flex-wrap items-center justify-between gap-3">
+	<div>
+		<div class="flex items-center gap-2">
+			<span class="text-sm font-medium font-mono">{dc.status?.realm ?? '—'}</span>
+			<Badge variant="outline" class="text-[0.65rem]">{dc.status?.workgroup ?? '—'}</Badge>
+		</div>
+		<div class="mt-1.5 flex items-center gap-1.5">
+			<span class="h-2 w-2 rounded-full shrink-0 {dc.status?.service_healthy ? 'bg-green-400' : 'bg-amber-400'}"></span>
+			<span class="text-xs text-muted-foreground">
+				{dc.status?.service_healthy ? 'Running' : 'Not running — check journalctl -u samba-dc'}
+			</span>
+		</div>
+	</div>
+</div>
+
+<!-- Tabs -->
+<div class="mb-4 flex w-fit rounded-md border border-border text-xs">
+	<button
+		onclick={() => activeTab = 'users'}
+		class="rounded-l-md px-3 py-1 font-medium transition-colors {activeTab === 'users' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+	>Users</button>
+	<button
+		onclick={() => activeTab = 'groups'}
+		class="px-3 py-1 font-medium transition-colors {activeTab === 'groups' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+	>Groups</button>
+	<button
+		onclick={() => activeTab = 'computers'}
+		class="rounded-r-md px-3 py-1 font-medium transition-colors {activeTab === 'computers' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+	>Computers</button>
+</div>
+
+{#if activeTab === 'users'}
+	{#if dc.users.length === 0}
+		<p class="mb-3 text-sm text-muted-foreground">No users.</p>
+	{:else}
+		<div class="mb-3 divide-y divide-border rounded-md border border-border">
+			{#each dc.users as user (user.name)}
+				<div class="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-sm">
+					<span class="font-mono">{user.name}</span>
+					<div class="flex flex-wrap gap-1.5">
+						<Button size="xs" variant="secondary" disabled={userBusy === user.name} onclick={() => setUserEnabled(user.name, true)}>Enable</Button>
+						<Button size="xs" variant="secondary" disabled={userBusy === user.name} onclick={() => setUserEnabled(user.name, false)}>Disable</Button>
+						<Button size="xs" variant="secondary" onclick={() => openResetPassword(user.name)}>Reset password</Button>
+						<Button size="xs" variant="destructive" onclick={() => deleteUser(user.name)}>Delete</Button>
+					</div>
+				</div>
+				{#if pwUser === user.name}
+					<div class="flex flex-wrap items-end gap-2 border-t border-border bg-muted/20 px-3 py-2">
+						<div class="min-w-[10rem] flex-1">
+							<label for="dc-pw-{user.name}" class="text-xs text-muted-foreground">New password {#if !pwNew && pwTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+							<input
+								id="dc-pw-{user.name}"
+								type="password"
+								bind:value={pwNew}
+								class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!pwNew, pwTried)}"
+							/>
+						</div>
+						<Button size="xs" onclick={resetPassword}>Save</Button>
+						<Button size="xs" variant="secondary" onclick={() => { pwUser = null; pwNew = ''; pwTried = false; }}>Cancel</Button>
+					</div>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+
+	<div class="mb-3">
+		<Button size="sm" onclick={() => showAddUser = !showAddUser}>{showAddUser ? 'Cancel' : 'Add user'}</Button>
+	</div>
+	{#if showAddUser}
+		<div class="mb-4 space-y-3 rounded-md border border-border p-3">
+			<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+				<div>
+					<label for="dc-new-user-name" class="text-xs text-muted-foreground">Name {#if !newUserName.trim() && newUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="dc-new-user-name"
+						type="text"
+						bind:value={newUserName}
+						placeholder="jdoe"
+						class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!newUserName.trim(), newUserTried)}"
+					/>
+				</div>
+				<div>
+					<label for="dc-new-user-pw" class="text-xs text-muted-foreground">Password {#if !newUserPassword && newUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="dc-new-user-pw"
+						type="password"
+						bind:value={newUserPassword}
+						class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!newUserPassword, newUserTried)}"
+					/>
+				</div>
+				<div>
+					<label for="dc-new-user-given" class="text-xs text-muted-foreground">Given name</label>
+					<input id="dc-new-user-given" type="text" bind:value={newUserGiven} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+				</div>
+				<div>
+					<label for="dc-new-user-surname" class="text-xs text-muted-foreground">Surname</label>
+					<input id="dc-new-user-surname" type="text" bind:value={newUserSurname} class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+				</div>
+			</div>
+			<!-- Stays enabled; createUser validates and triggers the amber decoration on a missing-field click. -->
+			<Button size="sm" onclick={createUser}>Create</Button>
+		</div>
+	{/if}
+{:else if activeTab === 'groups'}
+	{#if dc.groups.length === 0}
+		<p class="mb-3 text-sm text-muted-foreground">No groups.</p>
+	{:else}
+		<div class="mb-3 divide-y divide-border rounded-md border border-border">
+			{#each dc.groups as group (group.name)}
+				<div class="flex items-center justify-between gap-2 px-3 py-2 text-sm">
+					<span class="font-mono">{group.name}</span>
+					<Button size="xs" variant="destructive" onclick={() => deleteGroup(group.name)}>Delete</Button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<div class="mb-4 flex flex-wrap items-end gap-2">
+		<div>
+			<label for="dc-new-group" class="text-xs text-muted-foreground">New group {#if !newGroupName.trim() && newGroupTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+			<input
+				id="dc-new-group"
+				type="text"
+				bind:value={newGroupName}
+				placeholder="engineering"
+				class="mt-1 rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!newGroupName.trim(), newGroupTried)}"
+			/>
+		</div>
+		<Button size="sm" onclick={createGroup}>Add group</Button>
+	</div>
+
+	<div class="rounded-md border border-border p-3">
+		<h4 class="mb-2 text-xs font-semibold uppercase text-muted-foreground">Membership</h4>
+		<div class="flex flex-wrap items-end gap-2">
+			<div>
+				<label for="dc-member-group" class="text-xs text-muted-foreground">Group</label>
+				<select id="dc-member-group" bind:value={memberGroup} class="mt-1 h-8 rounded-md border border-input bg-transparent px-2 text-sm">
+					<option value="">Select group…</option>
+					{#each dc.groups as g (g.name)}
+						<option value={g.name}>{g.name}</option>
+					{/each}
+				</select>
+			</div>
+			<div>
+				<label for="dc-member-name" class="text-xs text-muted-foreground">Member (user or computer)</label>
+				<input id="dc-member-name" type="text" bind:value={memberName} placeholder="jdoe" class="mt-1 h-8 rounded-md border border-input bg-background px-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring" />
+			</div>
+			<Button size="xs" onclick={addMember} disabled={!memberGroup.trim() || !memberName.trim()}>Add</Button>
+			<Button size="xs" variant="secondary" onclick={removeMember} disabled={!memberGroup.trim() || !memberName.trim()}>Remove</Button>
+		</div>
+	</div>
+{:else}
+	{#if dc.computers.length === 0}
+		<p class="text-sm text-muted-foreground">No computers joined.</p>
+	{:else}
+		<div class="divide-y divide-border rounded-md border border-border">
+			{#each dc.computers as computer (computer.name)}
+				<div class="px-3 py-2 text-sm font-mono">{computer.name}</div>
+			{/each}
+		</div>
+	{/if}
+{/if}
+
+<div class="my-6 border-t border-border"></div>
+
+<!-- Back up domain -->
+<h3 class="mb-2 text-sm font-semibold">Back up domain</h3>
+<div class="mb-2 flex flex-wrap items-end gap-2">
+	<div class="min-w-[16rem] flex-1">
+		<label for="dc-backup-dest" class="text-xs text-muted-foreground">Destination</label>
+		<input
+			id="dc-backup-dest"
+			type="text"
+			bind:value={backupDest}
+			placeholder="/fs/tank/dc-backups/2026-07-10"
+			class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+		/>
+	</div>
+	<Button size="sm" disabled={!backupDest.trim() || backingUp} onclick={runBackup}>
+		{backingUp ? 'Backing up…' : 'Back up now'}
+	</Button>
+</div>
+
+<div class="my-6 border-t border-border"></div>
+
+<!-- Danger zone -->
+<h3 class="mb-1 text-sm font-semibold text-destructive">Danger zone</h3>
+{#if !demoteOpen}
+	<p class="mb-3 text-xs text-muted-foreground">Demoting destroys this domain — every user, group, and joined machine's trust.</p>
+	<Button size="sm" variant="destructive" onclick={() => demoteOpen = true}>Demote domain</Button>
+{:else}
+	<div class="space-y-3 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+		<p class="text-xs text-destructive">
+			Destroys the domain: every user, group, and joined machine's trust. A final backup is written to /fs first when a filesystem exists.
+		</p>
+		<div>
+			<label for="dc-demote-realm" class="text-xs text-muted-foreground">Type the realm ({dc.status?.realm}) to confirm</label>
+			<input
+				id="dc-demote-realm"
+				type="text"
+				bind:value={demoteTyped}
+				class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+			/>
+		</div>
+		<div class="flex gap-2">
+			<Button size="sm" variant="destructive" disabled={demoteTyped !== dc.status?.realm || demoting} onclick={doDemote}>
+				{demoting ? 'Demoting…' : 'Demote'}
+			</Button>
+			<Button size="sm" variant="secondary" onclick={() => { demoteOpen = false; demoteTyped = ''; }}>Cancel</Button>
+		</div>
+	</div>
+{/if}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -672,6 +672,22 @@ export interface DomainPrincipal {
 	name: string;
 }
 
+/** Returned by `dc.status` — Active Directory Domain Controller role (this
+ * box *hosts* a domain, as opposed to `DomainStatus`'s member mode). */
+export interface DcStatus {
+	hosting: boolean;
+	realm?: string | null;
+	workgroup?: string | null;
+	dns_forwarder?: string | null;
+	/** Whether samba-dc.service is active. Meaningful only when hosting. */
+	service_healthy: boolean;
+}
+
+/** One AD principal from `dc.user.list` / `dc.group.list` / `dc.computer.list`. */
+export interface DcPrincipal {
+	name: string;
+}
+
 export interface IscsiTarget {
 	id: string;
 	iqn: string;
@@ -1326,7 +1342,14 @@ export interface NetworkPendingTxn {
 
 export interface FirewallRule {
 	service: string;
-	ports: { port: number; transport: 'tcp' | 'udp'; source: string | null; iface: string | null }[];
+	ports: {
+		port: number;
+		/** End of a contiguous port range; absent = single port. */
+		to?: number | null;
+		transport: 'tcp' | 'udp';
+		source: string | null;
+		iface: string | null;
+	}[];
 	active: boolean;
 }
 

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -809,7 +809,7 @@
 		{ href: '/logs', label: 'Logs', keywords: ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'] },
 		{ href: '/update', label: 'Update', keywords: ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin'] },
 		{ href: '/users', label: 'Access Control', keywords: ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider'] },
-		{ href: '/settings', label: 'Settings', keywords: ['setting', 'hostname', 'timezone', 'clock', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance'] },
+		{ href: '/settings', label: 'Settings', keywords: ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance'] },
 	];
 
 	let sidebarSearch = $state('');

--- a/webui/src/routes/firewall/+page.svelte
+++ b/webui/src/routes/firewall/+page.svelte
@@ -182,7 +182,7 @@
 							<span class="h-2 w-2 rounded-full shrink-0 {rule.active ? 'bg-green-400' : 'bg-muted-foreground'}"></span>
 							<span class="font-medium w-20">{rule.service}</span>
 							<span class="font-mono text-xs text-muted-foreground">
-								{#each [...new Set(rule.ports.map(p => `${p.port}/${p.transport}`))] as port}
+								{#each [...new Set(rule.ports.map(p => `${p.to != null ? `${p.port}-${p.to}` : p.port}/${p.transport}`))] as port}
 									{port}{' '}
 								{/each}
 							</span>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -24,7 +24,7 @@
 	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
 	import { Copy, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
 
-	let activeTab: 'general' | 'network' | 'notifications' | 'metrics' | 'tuning' = $state('general');
+	let activeTab: 'general' | 'directory' | 'network' | 'notifications' | 'metrics' | 'tuning' = $state('general');
 
 	// Notifications tab
 	import type { NotificationConfig, NotificationChannel } from '$lib/types';
@@ -764,6 +764,12 @@
 			: 'text-muted-foreground hover:text-foreground'}"
 	>General</button>
 	<button
+		onclick={() => switchTab('directory')}
+		class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'directory'
+			? 'border-b-2 border-primary text-foreground'
+			: 'text-muted-foreground hover:text-foreground'}"
+	>Directory</button>
+	<button
 		onclick={() => switchTab('network')}
 		class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'network'
 			? 'border-b-2 border-primary text-foreground'
@@ -947,186 +953,192 @@
 				</Button>
 			</section>
 
-			<!-- Directory (Active Directory) -->
-			<section class="rounded-lg border border-border p-5">
-				<h2 class="mb-4 text-base font-semibold">Directory (Active Directory)</h2>
-
-				{#if domain.loading || dc.loading}
-					<p class="text-sm text-muted-foreground">Loading...</p>
-				{:else if dc.status?.hosting}
-					<DcPanel />
-				{:else if domain.status?.joined}
-					<div class="mb-3 flex items-center justify-between">
-						<span class="text-sm text-muted-foreground">Realm</span>
-						<span class="text-sm font-medium font-mono">{domain.status.realm ?? '—'}</span>
-					</div>
-					<div class="mb-4 flex items-center justify-between">
-						<span class="text-sm text-muted-foreground">Workgroup</span>
-						<span class="text-sm font-medium font-mono">{domain.status.workgroup ?? '—'}</span>
-					</div>
-
-					<div class="mb-4 flex flex-wrap gap-1.5">
-						<Badge
-							variant={domain.status.trust_ok ? 'default' : domain.status.trust_ok === false ? 'destructive' : 'secondary'}
-							class="text-[0.65rem]"
-						>Trust: {domain.status.trust_ok ? 'OK' : domain.status.trust_ok === false ? 'Broken' : 'Unknown'}</Badge>
-						<Badge
-							variant={domain.status.dc_reachable ? 'default' : domain.status.dc_reachable === false ? 'destructive' : 'secondary'}
-							class="text-[0.65rem]"
-						>DC: {domain.status.dc_reachable ? 'Reachable' : domain.status.dc_reachable === false ? 'Unreachable' : 'Unknown'}</Badge>
-						<Badge
-							variant="outline"
-							class="text-[0.65rem] {Math.abs(domain.status.clock_skew_seconds ?? 0) > 120 ? 'border-amber-500/40 bg-amber-500/10 text-amber-400' : ''}"
-						>Clock skew: {domain.status.clock_skew_seconds ?? 0}s</Badge>
-					</div>
-
-					{#if !domainLeaveOpen}
-						<Button size="sm" variant="destructive" onclick={() => domainLeaveOpen = true}>Leave Domain</Button>
-					{:else}
-						<div class="space-y-3 rounded-md border border-border p-3">
-							<div class="flex w-fit rounded-md border border-border text-xs">
-								<button
-									onclick={() => domainLeaveForce = false}
-									class="rounded-l-md px-3 py-1 font-medium transition-colors {!domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
-								>With credentials</button>
-								<button
-									onclick={() => domainLeaveForce = true}
-									class="rounded-r-md px-3 py-1 font-medium transition-colors {domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
-								>Force local</button>
-							</div>
-							{#if !domainLeaveForce}
-								<div>
-									<label for="domain-leave-user" class="text-xs text-muted-foreground">Username</label>
-									<input
-										id="domain-leave-user"
-										type="text"
-										bind:value={domainLeaveUsername}
-										placeholder="Administrator"
-										class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-									/>
-								</div>
-								<div>
-									<label for="domain-leave-pass" class="text-xs text-muted-foreground">Password</label>
-									<input
-										id="domain-leave-pass"
-										type="password"
-										bind:value={domainLeavePassword}
-										class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-									/>
-								</div>
-							{:else}
-								<p class="text-xs text-amber-500">Local-only leave: the computer account stays behind in AD until an admin removes it manually.</p>
-							{/if}
-							<div class="flex gap-2">
-								<Button size="sm" variant="destructive" onclick={domainLeaveConfirmed}>Confirm Leave</Button>
-								<Button size="sm" variant="secondary" onclick={() => { domainLeaveOpen = false; domainLeaveForce = false; domainLeaveUsername = ''; domainLeavePassword = ''; }}>Cancel</Button>
-							</div>
-						</div>
-					{/if}
-				{:else}
-					<h3 class="mb-3 text-sm font-semibold">Join an existing domain</h3>
-					<div class="mb-3">
-						<label for="domain-realm" class="text-sm text-muted-foreground">Realm {#if !domain.realm && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-realm"
-							type="text"
-							bind:value={domain.realm}
-							placeholder="corp.example.com"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.realm, domainJoinTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="domain-username" class="text-sm text-muted-foreground">Username {#if !domain.username && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-username"
-							type="text"
-							bind:value={domain.username}
-							placeholder="Administrator"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.username, domainJoinTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="domain-password" class="text-sm text-muted-foreground">Password {#if !domain.password && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-password"
-							type="password"
-							bind:value={domain.password}
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.password, domainJoinTried)}"
-						/>
-					</div>
-
-					<button
-						type="button"
-						onclick={() => domainAdvanced = !domainAdvanced}
-						class="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-					>
-						{#if domainAdvanced}<ChevronDown class="h-3 w-3" />{:else}<ChevronRight class="h-3 w-3" />{/if}
-						Advanced
-					</button>
-					{#if domainAdvanced}
-						<div class="mb-3">
-							<label for="domain-ou" class="text-sm text-muted-foreground">Organizational Unit</label>
-							<input
-								id="domain-ou"
-								type="text"
-								bind:value={domain.ou}
-								placeholder="OU=Servers,DC=corp,DC=example,DC=com"
-								class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
-							/>
-						</div>
-					{/if}
-
-					<Button size="sm" onclick={domainJoinGuarded} disabled={domain.joining}>
-						{domain.joining ? 'Joining… (this contacts the domain controller)' : 'Join'}
-					</Button>
-
-					<div class="my-6 border-t border-border"></div>
-
-					<h3 class="mb-3 text-sm font-semibold">Host a new domain</h3>
-					<p class="mb-3 text-sm text-muted-foreground">
-						This NASty becomes the Active Directory domain controller — clients and other NASty boxes join the domain it hosts. One DC per domain; back it up from this panel. Clients should use this box as their DNS server. Advanced administration (OUs, GPOs) works with Windows RSAT.
-					</p>
-					<div class="mb-4 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
-						Provisioning replaces any local SMB users — the domain's directory becomes the source of authentication for shares on this box.
-					</div>
-					<div class="mb-3">
-						<label for="dc-realm" class="text-sm text-muted-foreground">Realm {#if !dc.realm && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="dc-realm"
-							type="text"
-							bind:value={dc.realm}
-							placeholder="ad.example.lan"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.realm, dcProvisionTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="dc-admin-password" class="text-sm text-muted-foreground">Administrator password {#if !dc.adminPassword && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="dc-admin-password"
-							type="password"
-							bind:value={dc.adminPassword}
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.adminPassword, dcProvisionTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="dc-dns-forwarder" class="text-sm text-muted-foreground">DNS forwarder</label>
-						<input
-							id="dc-dns-forwarder"
-							type="text"
-							bind:value={dc.dnsForwarder}
-							placeholder="auto — current upstream"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-						/>
-					</div>
-					<Button size="sm" onclick={dcProvisionGuarded} disabled={dc.provisioning}>
-						{dc.provisioning ? 'Provisioning… (this can take a minute)' : 'Host domain'}
-					</Button>
-				{/if}
-			</section>
 
 			</div>
 		</div>
 	{/if}
+
+
+{:else if activeTab === 'directory'}
+
+	<div class="max-w-2xl">
+		<!-- Directory (Active Directory) -->
+		<section class="rounded-lg border border-border p-5">
+			<h2 class="mb-4 text-base font-semibold">Directory (Active Directory)</h2>
+
+			{#if domain.loading || dc.loading}
+				<p class="text-sm text-muted-foreground">Loading...</p>
+			{:else if dc.status?.hosting}
+				<DcPanel />
+			{:else if domain.status?.joined}
+				<div class="mb-3 flex items-center justify-between">
+					<span class="text-sm text-muted-foreground">Realm</span>
+					<span class="text-sm font-medium font-mono">{domain.status.realm ?? '—'}</span>
+				</div>
+				<div class="mb-4 flex items-center justify-between">
+					<span class="text-sm text-muted-foreground">Workgroup</span>
+					<span class="text-sm font-medium font-mono">{domain.status.workgroup ?? '—'}</span>
+				</div>
+
+				<div class="mb-4 flex flex-wrap gap-1.5">
+					<Badge
+						variant={domain.status.trust_ok ? 'default' : domain.status.trust_ok === false ? 'destructive' : 'secondary'}
+						class="text-[0.65rem]"
+					>Trust: {domain.status.trust_ok ? 'OK' : domain.status.trust_ok === false ? 'Broken' : 'Unknown'}</Badge>
+					<Badge
+						variant={domain.status.dc_reachable ? 'default' : domain.status.dc_reachable === false ? 'destructive' : 'secondary'}
+						class="text-[0.65rem]"
+					>DC: {domain.status.dc_reachable ? 'Reachable' : domain.status.dc_reachable === false ? 'Unreachable' : 'Unknown'}</Badge>
+					<Badge
+						variant="outline"
+						class="text-[0.65rem] {Math.abs(domain.status.clock_skew_seconds ?? 0) > 120 ? 'border-amber-500/40 bg-amber-500/10 text-amber-400' : ''}"
+					>Clock skew: {domain.status.clock_skew_seconds ?? 0}s</Badge>
+				</div>
+
+				{#if !domainLeaveOpen}
+					<Button size="sm" variant="destructive" onclick={() => domainLeaveOpen = true}>Leave Domain</Button>
+				{:else}
+					<div class="space-y-3 rounded-md border border-border p-3">
+						<div class="flex w-fit rounded-md border border-border text-xs">
+							<button
+								onclick={() => domainLeaveForce = false}
+								class="rounded-l-md px-3 py-1 font-medium transition-colors {!domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+							>With credentials</button>
+							<button
+								onclick={() => domainLeaveForce = true}
+								class="rounded-r-md px-3 py-1 font-medium transition-colors {domainLeaveForce ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent'}"
+							>Force local</button>
+						</div>
+						{#if !domainLeaveForce}
+							<div>
+								<label for="domain-leave-user" class="text-xs text-muted-foreground">Username</label>
+								<input
+									id="domain-leave-user"
+									type="text"
+									bind:value={domainLeaveUsername}
+									placeholder="Administrator"
+									class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+								/>
+							</div>
+							<div>
+								<label for="domain-leave-pass" class="text-xs text-muted-foreground">Password</label>
+								<input
+									id="domain-leave-pass"
+									type="password"
+									bind:value={domainLeavePassword}
+									class="mt-1 w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+								/>
+							</div>
+						{:else}
+							<p class="text-xs text-amber-500">Local-only leave: the computer account stays behind in AD until an admin removes it manually.</p>
+						{/if}
+						<div class="flex gap-2">
+							<Button size="sm" variant="destructive" onclick={domainLeaveConfirmed}>Confirm Leave</Button>
+							<Button size="sm" variant="secondary" onclick={() => { domainLeaveOpen = false; domainLeaveForce = false; domainLeaveUsername = ''; domainLeavePassword = ''; }}>Cancel</Button>
+						</div>
+					</div>
+				{/if}
+			{:else}
+				<h3 class="mb-3 text-sm font-semibold">Join an existing domain</h3>
+				<div class="mb-3">
+					<label for="domain-realm" class="text-sm text-muted-foreground">Realm {#if !domain.realm && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="domain-realm"
+						type="text"
+						bind:value={domain.realm}
+						placeholder="corp.example.com"
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.realm, domainJoinTried)}"
+					/>
+				</div>
+				<div class="mb-3">
+					<label for="domain-username" class="text-sm text-muted-foreground">Username {#if !domain.username && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="domain-username"
+						type="text"
+						bind:value={domain.username}
+						placeholder="Administrator"
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.username, domainJoinTried)}"
+					/>
+				</div>
+				<div class="mb-3">
+					<label for="domain-password" class="text-sm text-muted-foreground">Password {#if !domain.password && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="domain-password"
+						type="password"
+						bind:value={domain.password}
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.password, domainJoinTried)}"
+					/>
+				</div>
+
+				<button
+					type="button"
+					onclick={() => domainAdvanced = !domainAdvanced}
+					class="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+				>
+					{#if domainAdvanced}<ChevronDown class="h-3 w-3" />{:else}<ChevronRight class="h-3 w-3" />{/if}
+					Advanced
+				</button>
+				{#if domainAdvanced}
+					<div class="mb-3">
+						<label for="domain-ou" class="text-sm text-muted-foreground">Organizational Unit</label>
+						<input
+							id="domain-ou"
+							type="text"
+							bind:value={domain.ou}
+							placeholder="OU=Servers,DC=corp,DC=example,DC=com"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+						/>
+					</div>
+				{/if}
+
+				<Button size="sm" onclick={domainJoinGuarded} disabled={domain.joining}>
+					{domain.joining ? 'Joining… (this contacts the domain controller)' : 'Join'}
+				</Button>
+
+				<div class="my-6 border-t border-border"></div>
+
+				<h3 class="mb-3 text-sm font-semibold">Host a new domain</h3>
+				<p class="mb-3 text-sm text-muted-foreground">
+					This NASty becomes the Active Directory domain controller — clients and other NASty boxes join the domain it hosts. One DC per domain; back it up from this panel. Clients should use this box as their DNS server. Advanced administration (OUs, GPOs) works with Windows RSAT.
+				</p>
+				<div class="mb-4 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+					Provisioning replaces any local SMB users — the domain's directory becomes the source of authentication for shares on this box.
+				</div>
+				<div class="mb-3">
+					<label for="dc-realm" class="text-sm text-muted-foreground">Realm {#if !dc.realm && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="dc-realm"
+						type="text"
+						bind:value={dc.realm}
+						placeholder="ad.example.lan"
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.realm, dcProvisionTried)}"
+					/>
+				</div>
+				<div class="mb-3">
+					<label for="dc-admin-password" class="text-sm text-muted-foreground">Administrator password {#if !dc.adminPassword && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+					<input
+						id="dc-admin-password"
+						type="password"
+						bind:value={dc.adminPassword}
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.adminPassword, dcProvisionTried)}"
+					/>
+				</div>
+				<div class="mb-3">
+					<label for="dc-dns-forwarder" class="text-sm text-muted-foreground">DNS forwarder</label>
+					<input
+						id="dc-dns-forwarder"
+						type="text"
+						bind:value={dc.dnsForwarder}
+						placeholder="auto — current upstream"
+						class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+					/>
+				</div>
+				<Button size="sm" onclick={dcProvisionGuarded} disabled={dc.provisioning}>
+					{dc.provisioning ? 'Provisioning… (this can take a minute)' : 'Host domain'}
+				</Button>
+			{/if}
+		</section>
+	</div>
 
 {:else if activeTab === 'network'}
 

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -16,6 +16,8 @@
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { domain, domainRefresh, domainJoin, domainLeave } from '$lib/domain.svelte';
+	import { dc, dcRefresh, dcProvision } from '$lib/dc.svelte';
+	import DcPanel from '$lib/directory/DcPanel.svelte';
 	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -197,6 +199,15 @@
 		await domainJoin();
 	}
 
+	// Directory (Active Directory) — host-a-new-domain form
+	let dcProvisionTried = $state(false);
+
+	async function dcProvisionGuarded() {
+		if (!dc.realm || !dc.adminPassword) { dcProvisionTried = true; return; }
+		dcProvisionTried = false;
+		await dcProvision();
+	}
+
 	async function domainLeaveConfirmed() {
 		await domainLeave(domainLeaveForce, domainLeaveUsername, domainLeavePassword);
 		domainLeaveOpen = false;
@@ -284,7 +295,7 @@
 			logFilter = liveLogFilter;
 			syncNetworkForm();
 		});
-		await domainRefresh();
+		await Promise.all([domainRefresh(), dcRefresh()]);
 	});
 
 	function syncNetworkForm() {
@@ -940,64 +951,11 @@
 			<section class="rounded-lg border border-border p-5">
 				<h2 class="mb-4 text-base font-semibold">Directory (Active Directory)</h2>
 
-				{#if domain.loading}
+				{#if domain.loading || dc.loading}
 					<p class="text-sm text-muted-foreground">Loading...</p>
-				{:else if !domain.status?.joined}
-					<div class="mb-3">
-						<label for="domain-realm" class="text-sm text-muted-foreground">Realm {#if !domain.realm && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-realm"
-							type="text"
-							bind:value={domain.realm}
-							placeholder="corp.example.com"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.realm, domainJoinTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="domain-username" class="text-sm text-muted-foreground">Username {#if !domain.username && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-username"
-							type="text"
-							bind:value={domain.username}
-							placeholder="Administrator"
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.username, domainJoinTried)}"
-						/>
-					</div>
-					<div class="mb-3">
-						<label for="domain-password" class="text-sm text-muted-foreground">Password {#if !domain.password && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
-						<input
-							id="domain-password"
-							type="password"
-							bind:value={domain.password}
-							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.password, domainJoinTried)}"
-						/>
-					</div>
-
-					<button
-						type="button"
-						onclick={() => domainAdvanced = !domainAdvanced}
-						class="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-					>
-						{#if domainAdvanced}<ChevronDown class="h-3 w-3" />{:else}<ChevronRight class="h-3 w-3" />{/if}
-						Advanced
-					</button>
-					{#if domainAdvanced}
-						<div class="mb-3">
-							<label for="domain-ou" class="text-sm text-muted-foreground">Organizational Unit</label>
-							<input
-								id="domain-ou"
-								type="text"
-								bind:value={domain.ou}
-								placeholder="OU=Servers,DC=corp,DC=example,DC=com"
-								class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
-							/>
-						</div>
-					{/if}
-
-					<Button size="sm" onclick={domainJoinGuarded} disabled={domain.joining}>
-						{domain.joining ? 'Joining… (this contacts the domain controller)' : 'Join'}
-					</Button>
-				{:else}
+				{:else if dc.status?.hosting}
+					<DcPanel />
+				{:else if domain.status?.joined}
 					<div class="mb-3 flex items-center justify-between">
 						<span class="text-sm text-muted-foreground">Realm</span>
 						<span class="text-sm font-medium font-mono">{domain.status.realm ?? '—'}</span>
@@ -1065,6 +1023,104 @@
 							</div>
 						</div>
 					{/if}
+				{:else}
+					<h3 class="mb-3 text-sm font-semibold">Join an existing domain</h3>
+					<div class="mb-3">
+						<label for="domain-realm" class="text-sm text-muted-foreground">Realm {#if !domain.realm && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-realm"
+							type="text"
+							bind:value={domain.realm}
+							placeholder="corp.example.com"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.realm, domainJoinTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="domain-username" class="text-sm text-muted-foreground">Username {#if !domain.username && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-username"
+							type="text"
+							bind:value={domain.username}
+							placeholder="Administrator"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.username, domainJoinTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="domain-password" class="text-sm text-muted-foreground">Password {#if !domain.password && domainJoinTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="domain-password"
+							type="password"
+							bind:value={domain.password}
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!domain.password, domainJoinTried)}"
+						/>
+					</div>
+
+					<button
+						type="button"
+						onclick={() => domainAdvanced = !domainAdvanced}
+						class="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						{#if domainAdvanced}<ChevronDown class="h-3 w-3" />{:else}<ChevronRight class="h-3 w-3" />{/if}
+						Advanced
+					</button>
+					{#if domainAdvanced}
+						<div class="mb-3">
+							<label for="domain-ou" class="text-sm text-muted-foreground">Organizational Unit</label>
+							<input
+								id="domain-ou"
+								type="text"
+								bind:value={domain.ou}
+								placeholder="OU=Servers,DC=corp,DC=example,DC=com"
+								class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+							/>
+						</div>
+					{/if}
+
+					<Button size="sm" onclick={domainJoinGuarded} disabled={domain.joining}>
+						{domain.joining ? 'Joining… (this contacts the domain controller)' : 'Join'}
+					</Button>
+
+					<div class="my-6 border-t border-border"></div>
+
+					<h3 class="mb-3 text-sm font-semibold">Host a new domain</h3>
+					<p class="mb-3 text-sm text-muted-foreground">
+						This NASty becomes the Active Directory domain controller — clients and other NASty boxes join the domain it hosts. One DC per domain; back it up from this panel. Clients should use this box as their DNS server. Advanced administration (OUs, GPOs) works with Windows RSAT.
+					</p>
+					<div class="mb-4 rounded border border-amber-700/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+						Provisioning replaces any local SMB users — the domain's directory becomes the source of authentication for shares on this box.
+					</div>
+					<div class="mb-3">
+						<label for="dc-realm" class="text-sm text-muted-foreground">Realm {#if !dc.realm && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="dc-realm"
+							type="text"
+							bind:value={dc.realm}
+							placeholder="ad.example.lan"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.realm, dcProvisionTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="dc-admin-password" class="text-sm text-muted-foreground">Administrator password {#if !dc.adminPassword && dcProvisionTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</label>
+						<input
+							id="dc-admin-password"
+							type="password"
+							bind:value={dc.adminPassword}
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring {requiredFieldCls(!dc.adminPassword, dcProvisionTried)}"
+						/>
+					</div>
+					<div class="mb-3">
+						<label for="dc-dns-forwarder" class="text-sm text-muted-foreground">DNS forwarder</label>
+						<input
+							id="dc-dns-forwarder"
+							type="text"
+							bind:value={dc.dnsForwarder}
+							placeholder="auto — current upstream"
+							class="mt-1 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+						/>
+					</div>
+					<Button size="sm" onclick={dcProvisionGuarded} disabled={dc.provisioning}>
+						{dc.provisioning ? 'Provisioning… (this can take a minute)' : 'Host domain'}
+					</Button>
 				{/if}
 			</section>
 


### PR DESCRIPTION
Completes the second half of #20: NASty can now **host** an Active Directory domain — no Windows Server, no Synology Directory Server. The first half (joining an existing domain as a member) shipped in #627; together they close the issue. The #20 reporter runs a Synology as his only DC today — this is the drop-in replacement for that box.

## What you can do now
- **Create a domain from the WebUI**: Settings → Directory → "Host a new domain" — realm + Administrator password (+ optional DNS forwarder), and the box becomes a Samba AD DC with integrated DNS and Kerberos. Preconditions are checked up front with pointed errors (static IP, not already joined, port 53 free-able).
- **Your shares keep working**: the DC's own smbd serves the box's SMB shares through the existing include chain — share ACLs can reference the domain users the box itself hosts.
- **Manage the directory in the WebUI**: users (create / reset password / enable / disable / delete), groups (create / membership), joined computers (read-only). Windows RSAT works against the DC for everything advanced (OUs, GPOs, policies).
- **Fleet identity, NASty-only**: other NASty boxes join the hosted domain with the member mode that already shipped — one box is the DC, the rest of the fleet authenticates against it. The new two-node VM test proves exactly this pairing end to end.
- **Back up the domain**: `samba-tool domain backup` into a `/fs` path (jailed like #635's restore), where a backup profile ships it offsite. Demote requires typing the realm and takes a final parachute backup first.

## How it works
- New `dc.rs` module (sibling of member mode's `domain.rs`, which is untouched apart from the mutual-exclusion check): provision → engine-owned `/etc/samba/smb.dc.conf` (the nix-managed smb.conf stays a store symlink), `samba-dc.service` swaps member-mode samba out atomically via systemd `Conflicts=`, resolved releases :53 through a `/run` drop-in, and the `dc` firewall rule set opens (DNS/Kerberos/LDAP/SMB/GC + the dynamic RPC range — the firewall's first ranged service ports).
- **Credential hygiene**: passwords never ride argv — provision uses a random throwaway `--adminpass` and sets the real one over stdin; every user-password operation feeds stdin. The invariant is unit-tested.
- **Operator's DNS forwarder actually wins**: `samba-tool` writes its own `dns forwarder` line pointing at the just-disabled resolved stub; smb.conf is last-value-wins, so we strip it — the VM test asserts the effective value via `testparm`.
- **Boot-safe**: the DC restore phase only restores the service + DNS drop-in; the firewall opens after the base rules exist (a review catch — opening earlier would have locked SSH/WebUI out on every DC-box reboot). Enabling the standalone SMB protocol while hosting is refused with a pointed error (it would silently stop the DC via `Conflicts=`), and demote brings member SMB back per its toggle.
- Roles: `dc.status` readable by anyone; every mutation is Admin. The directory-enumerating `.list` methods are explicitly carved out of the read-only heuristic.

## Scope (deliberate v1)
Single DC per domain, new-domain provision only. Additional-DC join/replication (the HA story), GPO/OU management UI, BIND9 backend, signed NTP, and one-click domain *restore* are documented follow-ups — restore is a documented `samba-tool domain backup restore` procedure meanwhile.

## Testing
- Unit: static-IP precondition matrix, config surgery (incl. the forwarder-strip), backup-dest jail, argv-hygiene invariants, firewall range render/conflict math.
- **VM test `ad-dc`** (registered in the Integration workflow): a NASty box provisions `NASTYDC.LAN` over the same JSON-RPC path the WebUI uses (real `samba-dc.service`, real engine-managed nftables), creates a user; a second NASty joins with the shipped member flow, resolves the user through winbind, and authenticates over SMB cross-node. **This PR's CI run is the test's first real execution** — Type=notify readiness and timeout headroom are the named suspects if it needs iteration (fallbacks documented in the test header).
- Real-world validation planned: physical box + Windows client + RSAT against the hosted domain.

Design: `docs/ad-domain-controller.md` · Plan: `docs/superpowers/plans/2026-07-10-ad-domain-controller.md`

Closes #20.


