### PR TITLE
WebUI: show supported image formats in the disk-import dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ NASty is a NAS operating system built on NixOS and bcachefs. It turns commodity 
 
 ### Apps & VMs
 - **Apps** — Docker containers and Compose stacks with image pull progress, container inspect, live per-app resource usage (CPU %, memory, network and disk I/O), and custom `.env` files for compose stacks, and an `allow_unsafe` escape hatch for stacks that need privileged options
-- **Virtual machines** — QEMU/KVM with VNC console, disk snapshots, USB passthrough (editable on existing VMs), bridge selection, and an inline disk-import wizard for qcow2 / raw / vmdk images
+- **Virtual machines** — QEMU/KVM with VNC console, disk snapshots, USB passthrough (editable on existing VMs), bridge selection, and an inline disk-import wizard for qcow2, raw, img, vdi, and vmdk images (optionally .xz/.gz/.bz2 compressed)
 - **Hardware passthrough** — IOMMU group view, USB device inventory, vfio-pci toggles that survive reboots, and SR-IOV virtual-function management (per-VF VLAN, MAC, trust, spoof-check)
 - **Network bridges** — Linux bridges for attaching VMs (and apps) to L2 networks alongside the host
 

--- a/webui/src/routes/vms/+page.svelte
+++ b/webui/src/routes/vms/+page.svelte
@@ -288,6 +288,10 @@
 	// (xz/gz/bz2) are accepted around any disk format — the engine
 	// decompresses to a sibling tmp file before running qemu-img.
 	const IMPORTABLE_BASE_EXTS = ['.qcow2', '.img', '.raw', '.vdi', '.vmdk'];
+	// Human hint derived from the same list, so the dialog copy can't drift
+	// from what the uploader/importer actually accept.
+	const IMPORT_FORMATS_HINT = IMPORTABLE_BASE_EXTS.map((e) => e.slice(1)).join(', ')
+		+ ' — optionally .xz/.gz/.bz2 compressed';
 	const IMPORTABLE_COMPRESSION = ['', '.xz', '.gz', '.bz2'];
 	const IMPORTABLE_EXTS = IMPORTABLE_BASE_EXTS.flatMap((b) =>
 		IMPORTABLE_COMPRESSION.map((c) => `${b}${c}`),
@@ -2032,6 +2036,9 @@
 							/>
 						{/if}
 					</div>
+					<p class="mt-1 text-xs text-muted-foreground">
+						Accepts {IMPORT_FORMATS_HINT}. ISO images boot directly — no import needed.
+					</p>
 					{#if noImagesSubvolume && filesystems.length > 0}
 						<div class="mt-1 rounded border border-dashed border-muted-foreground/30 p-3 text-xs text-muted-foreground">
 							<p class="mb-2">No image storage found. Create a <span class="font-mono">vms/images</span> subvolume to upload to:</p>
@@ -2045,7 +2052,7 @@
 						</div>
 					{:else if importableImages.length === 0}
 						<p class="mt-1 text-xs text-muted-foreground">
-							No disk images uploaded yet — supported: qcow2 / img / raw / vdi / vmdk, optionally .xz / .gz / .bz2. Use "Upload new…" above to add one.
+							No disk images uploaded yet — use "Upload new…" above to add one.
 						</p>
 					{:else}
 						<select


### PR DESCRIPTION
The Import disk image dialog gave no visible hint of what it accepts unless you happened to be in the empty state — once images were uploaded, the format guidance disappeared behind the select.

- Added an **always-visible** line under *Source image*: "Accepts qcow2, img, raw, vdi, vmdk — optionally .xz/.gz/.bz2 compressed. ISO images boot directly — no import needed." It's derived from the existing `IMPORTABLE_BASE_EXTS` constant, so it can't drift from what the uploader/importer actually accept.
- Clarified the **ISO nuance** — it's accepted for upload (a valid boot medium) but the importer rejects it, since converting an installer to a raw disk isn't bootable.
- De-duped the now-redundant format list from the empty-state copy.
- Corrected the **README** VM bullet, which listed only `qcow2 / raw / vmdk` (missing img, vdi, and the compressed forms the engine handles).