### PR TITLE
WebUI: option to hide the sidebar logo for more menu space

### DIFF
--- a/webui/src/lib/uiPrefs.svelte.ts
+++ b/webui/src/lib/uiPrefs.svelte.ts
@@ -1,0 +1,24 @@
+// Per-browser sidebar/chrome UI preferences, persisted in localStorage and
+// shared reactively across components (same shape as theme.svelte.ts) so the
+// sidebar and the Settings toggle stay in sync without a page reload.
+const LOGO_HIDDEN_KEY = 'nasty:sidebar_logo_hidden';
+
+function createUiPrefs() {
+	let logoHidden = $state<boolean>(
+		typeof localStorage !== 'undefined' && localStorage.getItem(LOGO_HIDDEN_KEY) === '1'
+	);
+
+	return {
+		get logoHidden() {
+			return logoHidden;
+		},
+		setLogoHidden(v: boolean) {
+			logoHidden = v;
+			if (typeof localStorage !== 'undefined') {
+				localStorage.setItem(LOGO_HIDDEN_KEY, v ? '1' : '0');
+			}
+		},
+	};
+}
+
+export const uiPrefs = createUiPrefs();

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
+	import { uiPrefs } from '$lib/uiPrefs.svelte';
 	import '../app.css';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
@@ -63,6 +64,7 @@
 		ScrollText,
 		Search,
 		AlertTriangle,
+		EyeOff,
 	} from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 	import { refreshState } from '$lib/refresh.svelte';
@@ -969,11 +971,22 @@
 						<PanelLeftOpen size={18} />
 					</button>
 				</div>
+			{:else if uiPrefs.logoHidden}
+				<!-- Logo hidden (restore via Settings → Appearance). Slim bar keeps
+				     the collapse toggle reachable and reclaims the logo's height. -->
+				<div class="shrink-0 border-b border-border px-2 py-1.5 flex justify-end">
+					<button onclick={toggleSidebar} class="text-muted-foreground/50 hover:text-foreground transition-colors" title="Collapse sidebar">
+						<PanelLeftClose size={15} />
+					</button>
+				</div>
 			{:else}
 				<div class="shrink-0 border-b border-border px-4 py-4 relative">
 					<a href="https://github.com/nasty-project" target="_blank" rel="noopener noreferrer">
 					<img src={theme.isDark ? logoDark : logoLight} alt="NASty" class="h-40" />
 				</a>
+					<button onclick={() => uiPrefs.setLogoHidden(true)} class="absolute top-2 right-7 text-muted-foreground/50 hover:text-foreground transition-colors" title="Hide logo (restore in Settings → Appearance)">
+						<EyeOff size={15} />
+					</button>
 					<button onclick={toggleSidebar} class="absolute top-2 right-2 text-muted-foreground/50 hover:text-foreground transition-colors" title="Collapse sidebar">
 						<PanelLeftClose size={15} />
 					</button>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/network';
 	import { confirm } from '$lib/confirm.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
+	import { uiPrefs } from '$lib/uiPrefs.svelte';
 	import { domain, domainRefresh, domainJoin, domainLeave } from '$lib/domain.svelte';
 	import { dc, dcRefresh, dcProvision } from '$lib/dc.svelte';
 	import DcPanel from '$lib/directory/DcPanel.svelte';
@@ -951,6 +952,20 @@
 				<Button size="sm" onclick={sendTelemetry} disabled={sendingTelemetry || !settings.telemetry_enabled}>
 					{sendingTelemetry ? 'Sending…' : 'Send Now'}
 				</Button>
+			</section>
+
+			<!-- Appearance -->
+			<section class="rounded-lg border border-border p-5">
+				<h2 class="mb-2 text-base font-semibold">Appearance</h2>
+				<label class="flex items-center gap-2 text-sm">
+					<input
+						type="checkbox"
+						checked={!uiPrefs.logoHidden}
+						onchange={(e) => uiPrefs.setLogoHidden(!(e.currentTarget as HTMLInputElement).checked)}
+					/>
+					Show the NASty logo in the sidebar
+				</label>
+				<p class="mt-1 text-xs text-muted-foreground">Hiding the logo frees vertical space for the menu. You can also hide it from the small icon next to the logo.</p>
 			</section>
 
 


### PR DESCRIPTION
The sidebar logo (with tagline) takes ~160px of vertical space at the top. This adds a way to reclaim it for the menu.

- **Hide it in place:** a small eye-off icon next to the logo (beside the existing collapse toggle) hides the logo; the header shrinks to a slim bar that still carries the collapse toggle.
- **Restore it:** Settings → General → **Appearance** → *Show the NASty logo in the sidebar*. (Once hidden there's no logo to click, so the restore lives in Settings — as requested.)
- **Persistence:** per-browser via a small shared reactive store (`uiPrefs.svelte.ts`, same pattern as `theme`), so the sidebar and the Settings toggle stay in sync without a reload.

A couple of choices I made — easy to change:
- Used an **eye-off** icon rather than a lightbulb (clearer 'hide this'); say the word if you prefer a bulb or something else.
- Preference is **per-browser** (localStorage), not a server-side appliance setting — it's a personal UI-density choice, matching how theme and the Common/Full nav toggle already work.

`svelte-check` 0/0, 144/144.