### PR TITLE
WebUI: drop redundant per-page titles (top bar already shows them)

### DIFF
--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -246,8 +246,6 @@
 	}
 </script>
 
-<h1 class="mb-4 text-2xl font-bold">Dashboard</h1>
-
 {#if alerts.length > 0}
 	<div class="mb-4 flex flex-col gap-2">
 		{#each alerts as alert}

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -724,7 +724,6 @@
 
 <div class="space-y-4">
 	<div>
-		<h1 class="text-2xl font-bold">Backups</h1>
 		<p class="text-sm text-muted-foreground mt-0.5">Deduplicating, encrypted backups with retention policies.</p>
 	</div>
 

--- a/webui/src/routes/firewall/+page.svelte
+++ b/webui/src/routes/firewall/+page.svelte
@@ -163,7 +163,6 @@
 </script>
 
 <div>
-	<h1 class="text-2xl font-bold">Firewall</h1>
 	<p class="text-sm text-muted-foreground mt-0.5">Dynamic nftables firewall — ports open and close automatically with services.</p>
 </div>
 

--- a/webui/src/routes/hardware/+page.svelte
+++ b/webui/src/routes/hardware/+page.svelte
@@ -273,7 +273,6 @@
 
 <div class="mb-4 flex items-center justify-between">
 	<div>
-		<h1 class="text-2xl font-semibold">Hardware</h1>
 		<p class="text-sm text-muted-foreground">
 			Hardware overview and IOMMU groupings. Devices in the same IOMMU group must be passed through
 			together.

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -462,7 +462,6 @@
 
 <div class="space-y-6">
 	<div>
-		<h1 class="text-2xl font-bold">Help & Glossary</h1>
 		<p class="text-sm text-muted-foreground mt-0.5">Storage terms, protocols, and guidance for getting started with NASty.</p>
 	</div>
 

--- a/webui/src/routes/ingress/+page.svelte
+++ b/webui/src/routes/ingress/+page.svelte
@@ -109,7 +109,6 @@
 <svelte:head><title>Ingress · NASty</title></svelte:head>
 
 <div class="mb-4">
-	<h1 class="text-2xl font-semibold">Ingress</h1>
 	<p class="mt-1 text-sm text-muted-foreground">
 		Every route Caddy is currently serving — both engine-managed app ingresses and the
 		Caddyfile-baked WebUI / API / WebSocket routes. Read-only here; edit engine-app rows

--- a/webui/src/routes/logs/+page.svelte
+++ b/webui/src/routes/logs/+page.svelte
@@ -139,7 +139,6 @@
 </script>
 
 <div>
-	<h1 class="text-2xl font-bold">Logs</h1>
 	<p class="text-sm text-muted-foreground mt-0.5">View and stream systemd journal logs for NASty services.</p>
 </div>
 

--- a/webui/src/routes/operations/+page.svelte
+++ b/webui/src/routes/operations/+page.svelte
@@ -104,15 +104,12 @@
 </script>
 
 <div class="mx-auto max-w-4xl p-6">
-	<div class="mb-1 flex items-center gap-2">
-		<h1 class="text-2xl font-semibold">Operations</h1>
+	<p class="mb-6 flex items-center gap-2 text-muted-foreground">
+		<span>Live array operations across your pools — cancel a scrub or evacuation, pause or resume
+		background reconcile and copy-GC.</span>
 		{#if loading}
 			<RefreshCw class="h-4 w-4 animate-spin text-muted-foreground" />
 		{/if}
-	</div>
-	<p class="mb-6 text-muted-foreground">
-		Live array operations across your pools — cancel a scrub or evacuation, pause or resume
-		background reconcile and copy-GC.
 	</p>
 
 	{#if !loading && operations.length === 0}

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -217,7 +217,6 @@
 </script>
 
 <div>
-	<h1 class="text-2xl font-bold">TLS Certificate</h1>
 	<p class="text-sm text-muted-foreground mt-0.5">Manage HTTPS certificates for the NASty web interface.</p>
 </div>
 

--- a/webui/src/routes/ups/+page.svelte
+++ b/webui/src/routes/ups/+page.svelte
@@ -137,7 +137,6 @@
 </script>
 
 <div>
-	<h1 class="text-2xl font-bold">UPS</h1>
 	<p class="text-sm text-muted-foreground mt-0.5">Uninterruptible power supply monitoring and shutdown policy via NUT.</p>
 </div>
 

--- a/webui/src/routes/vpn/+page.svelte
+++ b/webui/src/routes/vpn/+page.svelte
@@ -19,7 +19,6 @@
 </script>
 
 <div>
-	<h1 class="text-2xl font-bold">VPN</h1>
 	<p class="text-sm text-muted-foreground mt-0.5">Secure remote access via Tailscale.</p>
 </div>
 


### PR DESCRIPTION
The top bar renders the current page's title with its icon on every page — but 11 pages *also* repeated it as a big `<h1>` immediately below, so you saw the same title twice (e.g. "Dashboard" / "Dashboard", "Firewall" / "Firewall"). **Sharing and Settings already didn't do this** — this makes every page match them.

- Removed the duplicate `<h1>` from: **Dashboard, Firewall, TLS, Ingress, VPN, Hardware, Logs, Backups, Help, UPS, Operations**.
- **Kept the description line** under each title — that's genuine page context the top-bar title doesn't carry.
- **Operations** shared its title row with a loading spinner; the spinner is relocated inline into the description so the loading affordance isn't lost.
- **Untouched:** Licenses (footer-linked legal page, not in the nav) and the public `/share/[token]` page — both render without the top bar, so their headings are their only title.

`svelte-check` 0/0, 144/144. Net −14 lines.