### PR TITLE
Operations page: the array-operations control center

### DIFF
--- a/docs/operations-control-center.md
+++ b/docs/operations-control-center.md
@@ -1,0 +1,156 @@
+# Operations page: the array-operations control center
+
+Make the **Operations** page the single, complete place to see and control
+bcachefs array operations across all pools — and stop duplicating those
+controls in the per-filesystem diagnostics panel.
+
+## Problem
+
+The Operations page (`system.operations.list` → `build_operations`) today
+lists only:
+
+- **reconcile** and **copygc** — always, because they're pausable background
+  jobs (idle/active/paused, with Pause/Resume);
+- **scrub** and **evacuate** — *only while running* (with Cancel).
+
+So on an idle box you see reconcile + copygc and nothing else, which reads as
+"scrub and evacuation are missing." You also can't *start* a scrub from here —
+that lives in the Filesystems → diagnostics **scrub tab** — and the diagnostics
+**reconcile tab** carries a second enable/disable toggle that duplicates
+Operations' Pause/Resume. Two places to control the same jobs, and a
+monitoring page that hides half the operations it names.
+
+## Goal
+
+Operations becomes the control center for pool-level array operations:
+every operation is *visible* (never silently absent), and everything that can
+sensibly be controlled from one cross-pool place is controlled here. The
+per-filesystem diagnostics panel drops the duplicated controls and becomes
+read-only telemetry with a pointer to Operations.
+
+## Scope
+
+**In scope:**
+- Always list a **scrub** row per mounted pool — idle (with a **Start**
+  action) or running (Cancel), instead of only when running.
+- Acknowledge **evacuate** even when idle: a single informational
+  "no evacuation in progress" row, plus the running per-device rows (Cancel)
+  as today.
+- Trim the diagnostics **scrub** and **reconcile** tabs to read-only
+  telemetry (drop Start-scrub and the reconcile enable/disable toggle);
+  point to Operations for the controls.
+
+**Out of scope:**
+- Starting an **evacuation** from Operations. Evacuation drains a specific
+  device to remove it, so it stays initiated from the Disks device-removal
+  flow (where you choose the device and its fate); Operations only monitors
+  and cancels a running one.
+- reconcile/copygc **start** actions — they're always-on background jobs;
+  Pause/Resume is the only control and already exists.
+- The diagnostics **usage / top / timestats** tabs — pure per-fs telemetry,
+  no Operations overlap, untouched.
+
+## Design
+
+### 1. `build_operations` (engine) — complete the list
+
+`build_operations` in `engine/nasty-engine/src/router/system.rs` loops over
+mounted filesystems. Changes:
+
+- **Scrub — always emit a row per pool.** When `scrub_status(fs).running`,
+  emit the existing running row (state `running`, `control: "cancel"`,
+  progress). Otherwise emit an **idle** row: state `idle`, a new
+  `control: "start"`, and a `detail` summarizing the last run when the engine
+  exposes it (e.g. "Scrub · <fs> — last run clean" / "never run"; fall back to
+  "Scrub · <fs> — idle" when no history is available). No behavior change to
+  the running case.
+- **Reconcile / copygc — unchanged.** They already emit a per-pool row every
+  time (idle/active/paused, Pause/Resume).
+- **Evacuate — acknowledge idle once.** Keep the per-device running rows
+  (`control: "cancel"`) exactly as now. After the per-filesystem loop, if
+  **no device on any pool** is evacuating, append **one** informational row:
+  `kind: "evacuate"`, `fs: ""` (or omitted), `state: "idle"`,
+  `control: "none"`, `detail: "No evacuation in progress"`. A device
+  evacuation is still started from the Disks page; this row exists only so
+  the operation type is never invisible.
+
+`Operation.control` gains the value **`"start"`** (documented in its enum
+comment alongside `cancel`/`pause`/`resume`/`none`). No schema-breaking
+change — it's an additional string value in an existing free-form field.
+
+### 2. Operations page (WebUI) — render + wire the new states
+
+`webui/src/routes/operations/+page.svelte`:
+
+- Render the **idle scrub** rows and the **evacuate "none in progress"** row
+  the engine now returns; the existing per-row layout (label, detail, state
+  chip, progress bar, control button) already generalizes.
+- Map the new `control === "start"` to a **Start** button that calls
+  `fs.scrub.start { name: op.fs }` (with a short confirm, matching the tone of
+  the existing cancel confirm), then refreshes. `control === "none"` renders no
+  button (the evacuate idle row; optionally a muted "start from Disks when
+  removing a device" hint).
+- The empty-state text ("Nothing running…") is no longer reachable in normal
+  operation (there's always at least reconcile/copygc/scrub per pool) — keep a
+  minimal fallback for the no-mounted-filesystem case.
+
+### 3. Diagnostics panel (WebUI) — controls out, telemetry stays
+
+`webui/src/lib/components/BcachefsDiagnostics.svelte`:
+
+- **Scrub tab:** keep the read-only readout (last-run outcome, progress
+  mirror, status). Remove the **Start scrub** button; replace with a one-line
+  pointer ("Run scrubs from the Operations page").
+- **Reconcile tab:** keep the status output + auto-refresh. Remove the
+  **enable/disable** toggle; same one-line pointer ("Pause/resume reconcile
+  from the Operations page").
+- **usage / top / timestats tabs:** unchanged.
+
+No capability is lost — the scrub launch and reconcile toggle move to
+Operations, they aren't deleted.
+
+## Roles / gating
+
+`fs.scrub.start` and `fs.scrub.cancel` are **Admin** (unchanged); the
+reconcile/copygc toggles are what they are today. The Operations page is
+readable by any role (`system.operations.list` is a read), so a non-admin
+still *sees* all operations and their live state — the **control buttons** are
+gated by the same central role check that already governs the existing
+Cancel/Pause/Resume actions. The new Start control inherits that gating with no
+new surface. Moving the diagnostics controls to Operations, and leaving the
+diagnostics tabs read-only, means a ReadOnly user can still inspect scrub/
+reconcile telemetry per filesystem — an improvement, not a regression.
+
+## Error handling
+
+- A failed `fs.scrub.start` (e.g. a scrub already running, or the pool
+  unmounted mid-click) surfaces via the existing toast path, same as the
+  current cancel/pause/resume error handling; the poll loop then reconciles
+  the row's state on its next tick.
+- If `scrub_status` or the last-run history is unavailable for a pool, the
+  idle scrub row falls back to the plain "idle" detail rather than omitting
+  the row — the row's *presence* is the point.
+- The evacuate idle row is display-only; it has no failure mode.
+
+## Testing
+
+- **Unit (engine):** extract the idle-scrub `detail` formatting and the
+  "emit one evacuate-idle row iff nothing is evacuating" decision as pure
+  helpers and test them (never-run vs last-clean vs unavailable-history; zero
+  evacuating devices → one row, ≥1 evacuating → running rows and no idle row).
+  The full `build_operations` aggregation stays integration territory (it
+  reads `filesystems.list` / `scrub_status` / `moving_ctxts`), as it is today.
+- **WebUI:** `npm run check` + existing suite; the page has no component-test
+  harness, so the render is validated against a real engine. Manually verify:
+  idle box shows scrub (Start) + reconcile + copygc per pool + one evacuate
+  "none in progress" row; starting a scrub flips that pool's row to running
+  with a progress bar; the diagnostics scrub/reconcile tabs are read-only with
+  the pointer.
+- **Regression:** confirm a running scrub / active evacuation still render and
+  cancel exactly as before (the running paths are unchanged).
+
+## Follow-ups (not now)
+
+- A per-pool scrub schedule ("scrub weekly") would fit naturally as a control
+  on the idle scrub row later.
+- If Operations grows more per-pool actions, consider grouping rows by pool.

--- a/docs/superpowers/plans/2026-07-13-operations-control-center.md
+++ b/docs/superpowers/plans/2026-07-13-operations-control-center.md
@@ -1,0 +1,391 @@
+# Operations Control Center Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Operations page show and control every bcachefs array operation across pools — scrub gains an always-present idle row with Start, evacuate is acknowledged when idle — and remove the duplicated scrub/reconcile controls from the per-filesystem diagnostics panel.
+
+**Architecture:** The engine's `build_operations` aggregator emits an idle scrub row (with a new `start` control) per pool and one "no evacuation in progress" row when nothing is draining; the Operations page wires the `start` control to `fs.scrub.start`; the `BcachefsDiagnostics` scrub/reconcile tabs lose their action buttons and become read-only telemetry with a pointer to Operations.
+
+**Tech Stack:** Rust (`nasty-engine`), Svelte 5 (`webui`).
+
+## Global Constraints
+
+- `Operation.control` gains one new value: **`"start"`** (for idle scrub). It's an additional string in an existing free-form field — not a schema break. Existing values (`cancel`/`pause`/`resume`/`none`) are unchanged.
+- **Scrub** emits a row per mounted pool *always*: running → `state:"running"`, `control:"cancel"` (unchanged); idle → `state:"idle"`, `control:"start"`.
+- **Evacuate**: per-device running rows (`control:"cancel"`) unchanged; when **no device on any pool** is evacuating, append exactly **one** row `kind:"evacuate"`, `fs:""`, `state:"idle"`, `control:"none"`, `detail:"No evacuation in progress"`.
+- **Reconcile / copygc** aggregation is unchanged (already always-present per pool).
+- Starting a scrub is **non-destructive** → no confirm dialog (unlike cancel). It calls `fs.scrub.start { name: <fs> }`.
+- The diagnostics **scrub** and **reconcile** tabs keep their read-only telemetry; only the Start-scrub button and the reconcile enable/disable toggle are removed (replaced by a one-line pointer to Operations). The **usage / top / timestats** tabs are untouched.
+- `fs.scrub.start` / `fs.scrub.cancel` are Admin-role (unchanged); the new Start control inherits the same central gating as the existing Cancel — no `is_operator_allowed`/registry changes in this feature.
+- Verification before every Rust commit (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`. For WebUI (from `webui/`): `npm run check && npm test`.
+
+---
+
+## File Structure
+
+- `engine/nasty-engine/src/router/system.rs` — **modify**: two pure helpers (`scrub_idle_detail`, `evacuate_idle_row`) + a `#[cfg(test)]` module for them; extend `build_operations` (idle scrub row, evacuate-idle row).
+- `webui/src/routes/operations/+page.svelte` — **modify**: `act()` + `actionLabel()` handle the `start` control; Start button variant; intro copy.
+- `webui/src/lib/components/BcachefsDiagnostics.svelte` — **modify**: remove the Start-scrub button and the reconcile enable/disable toggle (+ their now-unused handlers/state); add pointers to Operations.
+
+---
+
+## Task 1: Engine — idle scrub rows + evacuate-idle row
+
+**Files:**
+- Modify: `engine/nasty-engine/src/router/system.rs`
+- Test: `engine/nasty-engine/src/router/system.rs` (`#[cfg(test)] mod operations_tests`)
+
+**Interfaces:**
+- Consumes: `nasty_system::Operation`; `ScrubStatus` (the type `state.filesystems.scrub_status()` returns — `nasty_storage::filesystem::ScrubStatus`, with `running: bool`, `last_run_at: Option<i64>`, `last_outcome: Option<ScrubOutcome>`; `ScrubOutcome` variants `Ok | Errors | Failed | Cancelled`).
+- Produces:
+  - `fn scrub_idle_detail(fs: &str, s: &ScrubStatus) -> String`
+  - `fn evacuate_idle_row() -> nasty_system::Operation`
+  - `build_operations` now always emits a scrub row per pool and one evacuate-idle row when nothing is evacuating.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add at the bottom of `engine/nasty-engine/src/router/system.rs` (create the module if absent; import what it needs from `super`):
+
+```rust
+#[cfg(test)]
+mod operations_tests {
+    use super::{evacuate_idle_row, scrub_idle_detail};
+    use nasty_storage::filesystem::{ScrubOutcome, ScrubStatus};
+
+    fn status(last_run_at: Option<i64>, last_outcome: Option<ScrubOutcome>) -> ScrubStatus {
+        ScrubStatus {
+            running: false,
+            started_at: None,
+            progress_percent: None,
+            last_run_at,
+            last_duration_secs: None,
+            last_outcome,
+            last_output: None,
+            raw: String::new(),
+        }
+    }
+
+    #[test]
+    fn scrub_idle_detail_never_run() {
+        assert_eq!(scrub_idle_detail("tank", &status(None, None)), "Scrub tank — never run");
+    }
+
+    #[test]
+    fn scrub_idle_detail_summarizes_last_outcome() {
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), Some(ScrubOutcome::Ok))),
+            "Scrub tank — last run clean"
+        );
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), Some(ScrubOutcome::Errors))),
+            "Scrub tank — last run found errors"
+        );
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), Some(ScrubOutcome::Failed))),
+            "Scrub tank — last run failed"
+        );
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), Some(ScrubOutcome::Cancelled))),
+            "Scrub tank — last run cancelled"
+        );
+    }
+
+    #[test]
+    fn scrub_idle_detail_ran_but_no_outcome() {
+        // last_run_at present but outcome missing (older state) → plain idle.
+        assert_eq!(scrub_idle_detail("tank", &status(Some(1_700_000_000), None)), "Scrub tank — idle");
+    }
+
+    #[test]
+    fn evacuate_idle_row_shape() {
+        let r = evacuate_idle_row();
+        assert_eq!(r.kind, "evacuate");
+        assert_eq!(r.state, "idle");
+        assert_eq!(r.control, "none");
+        assert!(r.target.is_none());
+        assert_eq!(r.detail, "No evacuation in progress");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run (from `engine/`): `cargo test -p nasty-engine operations_tests`
+Expected: FAIL — `scrub_idle_detail` / `evacuate_idle_row` not found.
+
+- [ ] **Step 3: Add the two pure helpers**
+
+Near `build_operations` in `system.rs` (add `use nasty_storage::filesystem::ScrubStatus;` if not already imported for the helper signature — the aggregator already uses the type via `state.filesystems.scrub_status()`):
+
+```rust
+/// Detail line for an idle (not-running) scrub row, summarizing the most
+/// recent completed run when the engine has it.
+fn scrub_idle_detail(fs: &str, s: &nasty_storage::filesystem::ScrubStatus) -> String {
+    use nasty_storage::filesystem::ScrubOutcome;
+    match (s.last_run_at, s.last_outcome) {
+        (None, _) => format!("Scrub {fs} — never run"),
+        (Some(_), Some(ScrubOutcome::Ok)) => format!("Scrub {fs} — last run clean"),
+        (Some(_), Some(ScrubOutcome::Errors)) => format!("Scrub {fs} — last run found errors"),
+        (Some(_), Some(ScrubOutcome::Failed)) => format!("Scrub {fs} — last run failed"),
+        (Some(_), Some(ScrubOutcome::Cancelled)) => format!("Scrub {fs} — last run cancelled"),
+        (Some(_), None) => format!("Scrub {fs} — idle"),
+    }
+}
+
+/// The single informational row shown when no device is evacuating, so the
+/// evacuate operation type is acknowledged rather than silently absent.
+/// Evacuations are started from the Disks device-removal flow.
+fn evacuate_idle_row() -> nasty_system::Operation {
+    nasty_system::Operation {
+        kind: "evacuate".into(),
+        fs: String::new(),
+        target: None,
+        state: "idle".into(),
+        progress_percent: None,
+        detail: "No evacuation in progress".into(),
+        control: "none".into(),
+    }
+}
+```
+
+Note: `ScrubOutcome` derives `Copy` (it's a `#[derive(... Copy ...)]` enum), so `s.last_outcome` in the `match (s.last_run_at, s.last_outcome)` tuple copies rather than moves. If the compiler complains it isn't `Copy`, match on `s.last_outcome.as_ref()` and adjust the arms to `Some(&ScrubOutcome::Ok)` etc.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run (from `engine/`): `cargo test -p nasty-engine operations_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the helpers into `build_operations`**
+
+Two edits in `build_operations`:
+
+(a) **Scrub — emit an idle row when not running.** Find the scrub block:
+
+```rust
+        if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await
+            && scrub.running
+        {
+            // ... existing running-row push ...
+        }
+```
+
+Change it to also handle the idle case:
+
+```rust
+        if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await {
+            if scrub.running {
+                let mut detail = match scrub.progress_percent {
+                    Some(p) => format!("Scrub {} — {p:.0}%", fs.name),
+                    None => format!("Scrub {}", fs.name),
+                };
+                if let Some((seen, _)) = moved("scrub").filter(|&(s, _)| s > 0) {
+                    detail += &format!(" ({} scanned)", human_bytes(seen));
+                }
+                ops.push(nasty_system::Operation {
+                    kind: "scrub".into(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    state: "running".into(),
+                    progress_percent: scrub.progress_percent,
+                    detail,
+                    control: "cancel".into(),
+                });
+            } else {
+                ops.push(nasty_system::Operation {
+                    kind: "scrub".into(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    state: "idle".into(),
+                    progress_percent: None,
+                    detail: scrub_idle_detail(&fs.name, &scrub),
+                    control: "start".into(),
+                });
+            }
+        }
+```
+
+(The running branch is the same code as before, just moved inside `if scrub.running`.)
+
+(b) **Evacuate — one idle row when nothing is draining.** Add `let mut any_evacuating = false;` immediately before the `for fs in &filesystems {` loop. Inside the existing per-device evacuate push (where `dev.state.as_deref() == Some("evacuating")`), set `any_evacuating = true;` right after `ops.push(...)`. Then, after the `for fs` loop closes and before `ops` is returned, add:
+
+```rust
+    if !any_evacuating {
+        ops.push(evacuate_idle_row());
+    }
+    ops
+```
+
+- [ ] **Step 6: Update the `Operation.control` doc comment**
+
+In `engine/nasty-system/src/lib.rs`, the `control` field doc currently lists `"cancel" | "pause" | "resume" | "none"`. Add `"start"`:
+
+```rust
+    /// Action the UI offers: "start" (idle scrub) | "cancel"
+    /// (scrub/evacuate) | "pause" | "resume" (reconcile/copygc) | "none".
+    pub control: String,
+```
+
+- [ ] **Step 7: Full verification + commit**
+
+Run (from `engine/`): `cargo fmt --check && cargo clippy --workspace --all-targets --no-deps -- -D warnings && cargo test`
+Expected: clean; `operations_tests` pass.
+
+```bash
+cd engine && cargo fmt
+git add nasty-engine/src/router/system.rs nasty-system/src/lib.rs
+git commit -m "operations: always list idle scrub (start) + acknowledge idle evacuate"
+```
+
+---
+
+## Task 2: WebUI — Operations page renders & wires the new states
+
+**Files:**
+- Modify: `webui/src/routes/operations/+page.svelte`
+
+**Interfaces:**
+- Consumes: the engine list from Task 1 (`control:"start"` scrub rows; the `control:"none"` evacuate-idle row); `client.call('fs.scrub.start', { name })`.
+
+- [ ] **Step 1: Handle the `start` control in `act()`**
+
+In `act()`, the confirm block currently only fires for `cancel`; leave it (start needs no confirm). Replace the `method` and `verb` selection to add scrub-start:
+
+Change the `method` expression's scrub arm from `'fs.scrub.cancel'` to branch on control:
+
+```ts
+		const method =
+			op.kind === 'scrub'
+				? op.control === 'start'
+					? 'fs.scrub.start'
+					: 'fs.scrub.cancel'
+				: op.kind === 'evacuate'
+					? 'fs.device.evacuate.cancel'
+					: op.kind === 'reconcile'
+						? op.control === 'resume'
+							? 'fs.reconcile.enable'
+							: 'fs.reconcile.disable'
+						: op.control === 'resume'
+							? 'fs.copygc.enable'
+							: 'fs.copygc.disable';
+```
+
+And the toast `verb`:
+
+```ts
+		const verb =
+			op.control === 'start'
+				? 'started'
+				: op.control === 'cancel'
+					? 'cancelled'
+					: op.control === 'resume'
+						? 'resumed'
+						: 'paused';
+```
+
+(`params` is already `{ name: op.fs }` for scrub — correct for `fs.scrub.start`.)
+
+- [ ] **Step 2: Label + button variant for `start`**
+
+In `actionLabel`, add `start`:
+
+```ts
+	function actionLabel(op: Operation): string {
+		return (
+			{ start: 'Start', cancel: 'Cancel', pause: 'Pause', resume: 'Resume' }[op.control] ?? ''
+		);
+	}
+```
+
+In the row's `<Button>`, make Start the primary variant (cancel stays destructive, others outline):
+
+```svelte
+							<Button
+								variant={op.control === 'cancel' ? 'destructive' : op.control === 'start' ? 'default' : 'outline'}
+								size="sm"
+								disabled={busy === opKey(op)}
+								onclick={() => act(op)}
+							>
+```
+
+(The existing `{#if op.control !== 'none'}` guard already hides the button on the evacuate-idle row.)
+
+- [ ] **Step 3: Refresh the intro copy**
+
+Replace the intro `<span>` text:
+
+```svelte
+		<span>Live array operations across your pools — start or cancel a scrub, pause or resume
+		background reconcile and copy-GC, and watch evacuations in progress.</span>
+```
+
+- [ ] **Step 4: Check + test + commit**
+
+Run (from `webui/`): `npm run check && npm test`
+Expected: 0 errors/warnings; suite passes.
+
+```bash
+git add webui/src/routes/operations/+page.svelte
+git commit -m "webui: Operations page can start scrubs; shows idle scrub + evacuate rows"
+```
+
+---
+
+## Task 3: WebUI — trim diagnostics scrub/reconcile tabs to read-only
+
+**Files:**
+- Modify: `webui/src/lib/components/BcachefsDiagnostics.svelte`
+
+**Interfaces:**
+- Consumes: nothing new — this removes controls that now live on the Operations page.
+
+- [ ] **Step 1: Remove the Start-scrub control, keep the scrub telemetry**
+
+In the **scrub tab** markup, remove the button that triggers `startScrub()` (the "Start scrub" / "Run scrub" button) and replace it with a muted pointer line:
+
+```svelte
+			<p class="text-xs text-muted-foreground">Run scrubs from the <a href="/operations" class="underline">Operations</a> page.</p>
+```
+
+Keep every read-only element in that tab (last-run outcome, progress mirror, `scrubFull` summary, status text). Then delete the now-unused `startScrub()` function. If removing it leaves other symbols unused (e.g. a `scrubRunning`/`scrubLoading` flag only the button read), delete exactly those that `npm run check` reports as unused — do not remove state still read by the retained telemetry (`scrubFull`, `scrubOutput`, the poller).
+
+- [ ] **Step 2: Remove the reconcile toggle, keep the reconcile status**
+
+In the **reconcile tab** markup, remove the enable/disable button that calls `toggleReconcile()` and replace it with:
+
+```svelte
+			<p class="text-xs text-muted-foreground">Pause or resume reconcile from the <a href="/operations" class="underline">Operations</a> page.</p>
+```
+
+Keep the reconcile status output + auto-refresh toggle (read-only telemetry). Delete the now-unused `toggleReconcile()` function and the `reconcileToggling` state. Keep `reconcileEnabled` only if it's still read to render status text; if it becomes unused after the button is gone, delete it too — resolve exactly what `npm run check` flags.
+
+- [ ] **Step 3: Leave usage / top / timestats untouched**
+
+Confirm no edits to those tabs.
+
+- [ ] **Step 4: Check + test + commit**
+
+Run (from `webui/`): `npm run check && npm test`
+Expected: 0 errors/warnings (no unused-symbol complaints); suite passes.
+
+```bash
+git add webui/src/lib/components/BcachefsDiagnostics.svelte
+git commit -m "webui: diagnostics scrub/reconcile tabs are read-only (controls live in Operations)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/operations-control-center.md`):
+- Always-present idle scrub row + Start → Task 1 (engine emit) + Task 2 (render/wire).
+- Evacuate acknowledged when idle (one "no evacuation in progress" row) → Task 1.
+- reconcile/copygc unchanged → not touched (correct).
+- New `control:"start"` value + doc → Task 1.
+- Diagnostics scrub/reconcile → read-only with pointer; usage/top/timestats untouched → Task 3.
+- Roles (scrub start/cancel Admin; telemetry visible to ReadOnly; no allowlist/registry change) → inherent (no gating code touched; the Start control reuses the existing Admin-gated `fs.scrub.start`).
+- Error handling (scrub start failure via toast, poll reconciles; idle-detail fallback; evacuate row display-only) → Task 2 uses `withToast`; Task 1 helper has the `(Some, None) → idle` fallback tested.
+- Testing: pure helpers unit-tested (Task 1); WebUI via `npm run check`/`test` (Tasks 2–3); running-scrub/evacuate paths unchanged (Task 1 keeps the running branch verbatim).
+
+**Placeholder scan:** No TBD/TODO. The two "delete exactly what `npm run check` reports as unused" notes (Task 3) are concrete instructions with a named check, not deferred work — unused-symbol resolution genuinely depends on what the component reads after the buttons are removed, and the check is the deterministic arbiter.
+
+**Type consistency:** `scrub_idle_detail(&str, &ScrubStatus) -> String` and `evacuate_idle_row() -> Operation` are named identically in their defining task and the tests. `control:"start"` is produced in Task 1 and consumed in Task 2 (`act()` method/verb, `actionLabel`, button variant) with the exact same string. `Operation` field names (`kind/fs/target/state/progress_percent/detail/control`) match the struct in `nasty-system/src/lib.rs`. WebUI method names (`fs.scrub.start`, `fs.scrub.cancel`, `fs.device.evacuate.cancel`, `fs.reconcile.*`, `fs.copygc.*`) match the existing `act()` dispatch.

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -228,7 +228,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "system.operations.list",
-                    desc: "List controllable data operations across mounted filesystems for the Operations panel (#553): running scrubs/evacuations (cancellable) and the pausable background jobs reconcile and copygc, each with the action the UI can take.",
+                    desc: "List controllable data operations across mounted filesystems for the Operations panel (#553): per-pool scrubs (start when idle, cancel when running), device evacuations (cancel while draining, with an idle acknowledgement when none run), and the pausable background jobs reconcile and copygc, each with the action the UI can take.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<Operation>>(generator)),

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -993,14 +993,17 @@ async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
 }
 
 /// Gather the controllable data operations across all mounted filesystems
-/// for the Operations panel (#553): running scrubs and evacuations (Cancel),
-/// plus the pausable background jobs reconcile and copygc (Pause/Resume),
-/// shown even when idle so they can be toggled.
+/// for the Operations panel (#553): scrub (Cancel when running, Start when
+/// idle) and evacuate (Cancel per draining device, or a single idle
+/// acknowledgement row when nothing is draining), plus the pausable
+/// background jobs reconcile and copygc (Pause/Resume), shown even when
+/// idle so they can be toggled.
 async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
     let mut ops: Vec<nasty_system::Operation> = Vec::new();
     let Ok(filesystems) = state.filesystems.list().await else {
         return ops;
     };
+    let mut any_evacuating = false;
     for fs in &filesystems {
         if !fs.mounted {
             continue;
@@ -1033,30 +1036,42 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                     detail,
                     control: "cancel".into(),
                 });
+                any_evacuating = true;
             }
         }
-        // Running scrub. Percent stays from the CLI (bcachefs computes it
+        // Scrub — always shown, running or idle, so the operator can start
+        // one from here. Percent stays from the CLI (bcachefs computes it
         // with the replication denominator); moving_ctxts adds a reliable
         // live "scanned" figure on top.
-        if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await
-            && scrub.running
-        {
-            let mut detail = match scrub.progress_percent {
-                Some(p) => format!("Scrub {} — {p:.0}%", fs.name),
-                None => format!("Scrub {}", fs.name),
-            };
-            if let Some((seen, _)) = moved("scrub").filter(|&(s, _)| s > 0) {
-                detail += &format!(" ({} scanned)", human_bytes(seen));
+        if let Ok(scrub) = state.filesystems.scrub_status(&fs.name).await {
+            if scrub.running {
+                let mut detail = match scrub.progress_percent {
+                    Some(p) => format!("Scrub {} — {p:.0}%", fs.name),
+                    None => format!("Scrub {}", fs.name),
+                };
+                if let Some((seen, _)) = moved("scrub").filter(|&(s, _)| s > 0) {
+                    detail += &format!(" ({} scanned)", human_bytes(seen));
+                }
+                ops.push(nasty_system::Operation {
+                    kind: "scrub".into(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    state: "running".into(),
+                    progress_percent: scrub.progress_percent,
+                    detail,
+                    control: "cancel".into(),
+                });
+            } else {
+                ops.push(nasty_system::Operation {
+                    kind: "scrub".into(),
+                    fs: fs.name.clone(),
+                    target: None,
+                    state: "idle".into(),
+                    progress_percent: None,
+                    detail: scrub_idle_detail(&fs.name, &scrub),
+                    control: "start".into(),
+                });
             }
-            ops.push(nasty_system::Operation {
-                kind: "scrub".into(),
-                fs: fs.name.clone(),
-                target: None,
-                state: "running".into(),
-                progress_percent: scrub.progress_percent,
-                detail,
-                control: "cancel".into(),
-            });
         }
         // Reconcile — pausable background rebalance. moving_ctxts confirms
         // whether it's actually moving data right now.
@@ -1116,7 +1131,39 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
             });
         }
     }
+    if !any_evacuating {
+        ops.push(evacuate_idle_row());
+    }
     ops
+}
+
+/// Detail line for an idle (not-running) scrub row, summarizing the most
+/// recent completed run when the engine has it.
+fn scrub_idle_detail(fs: &str, s: &nasty_storage::filesystem::ScrubStatus) -> String {
+    use nasty_storage::filesystem::ScrubOutcome;
+    match (s.last_run_at, s.last_outcome) {
+        (None, _) => format!("Scrub {fs} — never run"),
+        (Some(_), Some(ScrubOutcome::Ok)) => format!("Scrub {fs} — last run clean"),
+        (Some(_), Some(ScrubOutcome::Errors)) => format!("Scrub {fs} — last run found errors"),
+        (Some(_), Some(ScrubOutcome::Failed)) => format!("Scrub {fs} — last run failed"),
+        (Some(_), Some(ScrubOutcome::Cancelled)) => format!("Scrub {fs} — last run cancelled"),
+        (Some(_), None) => format!("Scrub {fs} — idle"),
+    }
+}
+
+/// The single informational row shown when no device is evacuating, so the
+/// evacuate operation type is acknowledged rather than silently absent.
+/// Evacuations are started from the Disks device-removal flow.
+fn evacuate_idle_row() -> nasty_system::Operation {
+    nasty_system::Operation {
+        kind: "evacuate".into(),
+        fs: String::new(),
+        target: None,
+        state: "idle".into(),
+        progress_percent: None,
+        detail: "No evacuation in progress".into(),
+        control: "none".into(),
+    }
 }
 
 /// Compact binary byte formatter for operation detail strings.
@@ -1197,5 +1244,80 @@ mod tests {
             &[pub_port(8080, "tcp", "a"), pub_port(8090, "tcp", "b")],
         );
         assert_eq!(w.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod operations_tests {
+    use super::{evacuate_idle_row, scrub_idle_detail};
+    use nasty_storage::filesystem::{ScrubOutcome, ScrubStatus};
+
+    fn status(last_run_at: Option<i64>, last_outcome: Option<ScrubOutcome>) -> ScrubStatus {
+        ScrubStatus {
+            running: false,
+            started_at: None,
+            progress_percent: None,
+            last_run_at,
+            last_duration_secs: None,
+            last_outcome,
+            last_output: None,
+            raw: String::new(),
+        }
+    }
+
+    #[test]
+    fn scrub_idle_detail_never_run() {
+        assert_eq!(
+            scrub_idle_detail("tank", &status(None, None)),
+            "Scrub tank — never run"
+        );
+    }
+
+    #[test]
+    fn scrub_idle_detail_summarizes_last_outcome() {
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), Some(ScrubOutcome::Ok))),
+            "Scrub tank — last run clean"
+        );
+        assert_eq!(
+            scrub_idle_detail(
+                "tank",
+                &status(Some(1_700_000_000), Some(ScrubOutcome::Errors))
+            ),
+            "Scrub tank — last run found errors"
+        );
+        assert_eq!(
+            scrub_idle_detail(
+                "tank",
+                &status(Some(1_700_000_000), Some(ScrubOutcome::Failed))
+            ),
+            "Scrub tank — last run failed"
+        );
+        assert_eq!(
+            scrub_idle_detail(
+                "tank",
+                &status(Some(1_700_000_000), Some(ScrubOutcome::Cancelled))
+            ),
+            "Scrub tank — last run cancelled"
+        );
+    }
+
+    #[test]
+    fn scrub_idle_detail_ran_but_no_outcome() {
+        // last_run_at present but outcome missing (older state) → plain idle.
+        assert_eq!(
+            scrub_idle_detail("tank", &status(Some(1_700_000_000), None)),
+            "Scrub tank — idle"
+        );
+    }
+
+    #[test]
+    fn evacuate_idle_row_shape() {
+        let r = evacuate_idle_row();
+        assert_eq!(r.kind, "evacuate");
+        assert_eq!(r.state, "idle");
+        assert_eq!(r.control, "none");
+        assert!(r.target.is_none());
+        assert_eq!(r.detail, "No evacuation in progress");
     }
 }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -174,8 +174,8 @@ pub struct Operation {
     pub progress_percent: Option<f32>,
     /// Short operator-facing line, e.g. "Evacuating sdc" or "Scrub 42%".
     pub detail: String,
-    /// Action the UI offers: "cancel" (scrub/evacuate) | "pause" |
-    /// "resume" (reconcile/copygc) | "none".
+    /// Action the UI offers: "start" (idle scrub) | "cancel"
+    /// (scrub/evacuate) | "pause" | "resume" (reconcile/copygc) | "none".
     pub control: String,
 }
 

--- a/webui/src/lib/components/BcachefsDiagnostics.svelte
+++ b/webui/src/lib/components/BcachefsDiagnostics.svelte
@@ -436,7 +436,6 @@
 					Refresh
 				</button>
 			</div>
-			<p class="text-xs text-muted-foreground">Run scrubs from the <a href="/operations" class="underline">Operations</a> page.</p>
 
 		<!-- reconcile tab controls -->
 		{:else if activeTab === 'reconcile'}
@@ -458,7 +457,6 @@
 					{reconcileAutoRefresh ? 'Live (3s)' : 'Live'}
 				</button>
 			</div>
-			<p class="text-xs text-muted-foreground">Pause or resume reconcile from the <a href="/operations" class="underline">Operations</a> page.</p>
 
 		<!-- top tab controls -->
 		{:else if activeTab === 'top'}
@@ -484,6 +482,11 @@
 	</div>
 
 	<p class="text-xs text-muted-foreground">{TAB_META[activeTab].description}</p>
+	{#if activeTab === 'scrub'}
+		<p class="text-xs text-muted-foreground">Run scrubs from the <a href="/operations" class="underline">Operations</a> page.</p>
+	{:else if activeTab === 'reconcile'}
+		<p class="text-xs text-muted-foreground">Pause or resume reconcile from the <a href="/operations" class="underline">Operations</a> page.</p>
+	{/if}
 
 	<!-- ═══ Usage output ═══ -->
 	{#if activeTab === 'usage'}
@@ -566,7 +569,7 @@
 			{:else if scrubOutput === '' && scrubLoading}
 				<p class="p-6 text-sm text-muted-foreground">Loading...</p>
 			{:else if scrubOutput === ''}
-				<p class="p-6 text-sm text-muted-foreground">No scrub data available. Start a scrub to verify checksums.</p>
+				<p class="p-6 text-sm text-muted-foreground">No scrub data available yet — run a scrub from the Operations page to verify checksums.</p>
 			{:else}
 				<div class="p-4">
 					{#if scrubRunning}

--- a/webui/src/lib/components/BcachefsDiagnostics.svelte
+++ b/webui/src/lib/components/BcachefsDiagnostics.svelte
@@ -63,8 +63,6 @@
 	let scrubFull: ScrubStatus | null = $state(null);
 	let reconcileOutput = $state('');
 	let reconcileLoading = $state(false);
-	let reconcileEnabled = $state(true);
-	let reconcileToggling = $state(false);
 	let reconcileAutoRefresh = $state(false);
 	let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
 
@@ -213,18 +211,6 @@
 		return m ? `${h}h${m}m` : `${h}h`;
 	}
 
-	async function startScrub() {
-		if (!selectedFs) return;
-		try {
-			await getClient().call('fs.scrub.start', { name: selectedFs });
-			scrubRunning = true;
-			await refreshScrub();
-			startScrubPolling();
-		} catch (e) {
-			showError(e instanceof Error ? e.message : String(e));
-		}
-	}
-
 	// ── Reconcile tab ──────────────────────────────────────────
 
 	async function refreshReconcile() {
@@ -233,7 +219,6 @@
 		try {
 			const result = await getClient().call<{ raw: string; enabled: boolean }>('fs.reconcile.status', { name: selectedFs });
 			reconcileOutput = result.raw || 'No reconcile data available.';
-			reconcileEnabled = result.enabled;
 		} catch (e) {
 			reconcileOutput = e instanceof Error ? e.message : String(e);
 		} finally {
@@ -254,21 +239,6 @@
 	function toggleReconcileAutoRefresh() {
 		reconcileAutoRefresh = !reconcileAutoRefresh;
 		if (reconcileAutoRefresh) startReconcileAutoRefresh(); else stopReconcileAutoRefresh();
-	}
-
-	async function toggleReconcile() {
-		if (!selectedFs) return;
-		reconcileToggling = true;
-		try {
-			const method = reconcileEnabled ? 'fs.reconcile.disable' : 'fs.reconcile.enable';
-			await getClient().call(method, { name: selectedFs });
-			reconcileEnabled = !reconcileEnabled;
-			await refreshReconcile();
-		} catch (e) {
-			reconcileOutput = e instanceof Error ? e.message : String(e);
-		} finally {
-			reconcileToggling = false;
-		}
 	}
 
 	// ── Top tab ──────────────────────────────────────────────
@@ -465,25 +435,12 @@
 					<RefreshCw size={12} class={scrubLoading ? 'animate-spin' : ''} />
 					Refresh
 				</button>
-				<button
-					onclick={startScrub}
-					disabled={!selectedFs || scrubRunning}
-					class="rounded px-3 py-1 text-xs bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-				>
-					{scrubRunning ? 'Running...' : 'Start Scrub'}
-				</button>
 			</div>
+			<p class="text-xs text-muted-foreground">Run scrubs from the <a href="/operations" class="underline">Operations</a> page.</p>
 
 		<!-- reconcile tab controls -->
 		{:else if activeTab === 'reconcile'}
 			<div class="ml-auto flex items-center gap-2 pb-1">
-				<button
-					onclick={toggleReconcile}
-					disabled={!selectedFs || reconcileToggling}
-					class="rounded px-3 py-1 text-xs {reconcileEnabled ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'bg-destructive text-destructive-foreground hover:bg-destructive/90'} disabled:opacity-50"
-				>
-					{reconcileToggling ? '...' : reconcileEnabled ? 'Enabled' : 'Disabled'}
-				</button>
 				<button
 					onclick={refreshReconcile}
 					disabled={!selectedFs || reconcileLoading}
@@ -501,6 +458,7 @@
 					{reconcileAutoRefresh ? 'Live (3s)' : 'Live'}
 				</button>
 			</div>
+			<p class="text-xs text-muted-foreground">Pause or resume reconcile from the <a href="/operations" class="underline">Operations</a> page.</p>
 
 		<!-- top tab controls -->
 		{:else if activeTab === 'top'}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -93,7 +93,7 @@ export interface Operation {
 	state: string; // "running" | "active" | "idle" | "paused"
 	progress_percent?: number | null;
 	detail: string;
-	control: string; // "cancel" | "pause" | "resume" | "none"
+	control: string; // "start" | "cancel" | "pause" | "resume" | "none"
 }
 
 /** One IOMMU group with its constituent PCI devices, returned by

--- a/webui/src/routes/operations/+page.svelte
+++ b/webui/src/routes/operations/+page.svelte
@@ -73,7 +73,9 @@
 		busy = key;
 		const method =
 			op.kind === 'scrub'
-				? 'fs.scrub.cancel'
+				? op.control === 'start'
+					? 'fs.scrub.start'
+					: 'fs.scrub.cancel'
 				: op.kind === 'evacuate'
 					? 'fs.device.evacuate.cancel'
 					: op.kind === 'reconcile'
@@ -87,7 +89,13 @@
 			op.kind === 'evacuate' ? { filesystem: op.fs, device: op.target } : { name: op.fs };
 
 		const verb =
-			op.control === 'cancel' ? 'cancelled' : op.control === 'resume' ? 'resumed' : 'paused';
+			op.control === 'start'
+				? 'started'
+				: op.control === 'cancel'
+					? 'cancelled'
+					: op.control === 'resume'
+						? 'resumed'
+						: 'paused';
 		const ok = await withToast(
 			() => client.call(method, params),
 			`${kindLabel(op.kind)} on ${op.fs} ${verb}`
@@ -98,15 +106,15 @@
 
 	function actionLabel(op: Operation): string {
 		return (
-			{ cancel: 'Cancel', pause: 'Pause', resume: 'Resume' }[op.control] ?? ''
+			{ start: 'Start', cancel: 'Cancel', pause: 'Pause', resume: 'Resume' }[op.control] ?? ''
 		);
 	}
 </script>
 
 <div class="mx-auto max-w-4xl p-6">
 	<p class="mb-6 flex items-center gap-2 text-muted-foreground">
-		<span>Live array operations across your pools — cancel a scrub or evacuation, pause or resume
-		background reconcile and copy-GC.</span>
+		<span>Live array operations across your pools — start or cancel a scrub, pause or resume
+		background reconcile and copy-GC, and watch evacuations in progress.</span>
 		{#if loading}
 			<RefreshCw class="h-4 w-4 animate-spin text-muted-foreground" />
 		{/if}
@@ -141,7 +149,7 @@
 						</div>
 						{#if op.control !== 'none'}
 							<Button
-								variant={op.control === 'cancel' ? 'destructive' : 'outline'}
+								variant={op.control === 'cancel' ? 'destructive' : op.control === 'start' ? 'default' : 'outline'}
 								size="sm"
 								disabled={busy === opKey(op)}
 								onclick={() => act(op)}


### PR DESCRIPTION
Makes the **Operations** page the single place to see and control every bcachefs array operation across your pools — and removes the duplicated scrub/reconcile controls from the per-filesystem diagnostics panel.

## What's new

- **Every operation is always visible.** Scrub now shows a per-pool row whenever a filesystem is mounted — idle (with a **Start** button and a last-run summary) or running (with Cancel) — instead of appearing only mid-scrub. Evacuate is acknowledged even when idle with a single "No evacuation in progress" row alongside the running per-device rows.
- **Start a scrub from Operations.** The idle scrub row's Start button launches `fs.scrub.start` directly (non-destructive, no confirm), so scrub start now sits next to Cancel/Pause/Resume for every pool.
- **One home for the controls.** The Filesystems → Diagnostics **scrub** and **reconcile** tabs become read-only telemetry with a pointer to Operations; the Start-scrub button and the reconcile enable/disable toggle now live only on the Operations page rather than in two places. The usage / top / timestats tabs are unchanged.

## Details

- **Engine:** `build_operations` always emits a scrub row per pool (`control: "start"` when idle, `"cancel"` when running) and appends one idle-evacuate acknowledgement row when nothing is draining. `Operation.control` gains the additive value `"start"` — no schema break; reconcile/copygc aggregation is unchanged.
- **Roles unchanged:** `fs.scrub.start`/`fs.scrub.cancel` stay Admin, and the operations list stays readable by any role — telemetry is visible to everyone while the controls are gated exactly as before.
- **Status band unaffected:** idle rows feed only the Operations list, not the sidebar activity band, so an idle box stays green.

Verified: engine `cargo fmt --check` / `clippy --workspace --all-targets --no-deps -D warnings` / `cargo test` all clean; webui `npm run check` 0 errors/0 warnings + `npm test` 144/144.
