### PR TITLE
Apps: remove external Docker networks from the UI

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2319,17 +2319,17 @@ impl AppsService {
                     }
                 }
             };
-            let attached_apps = if managed {
-                docker
-                    .inspect_network(&name, None::<InspectNetworkOptions>)
-                    .await
-                    .ok()
-                    .and_then(|ni| ni.containers)
-                    .map(|c| c.into_values().filter_map(|e| e.name).collect())
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
+            // Computed for every network, managed or external, so the UI can
+            // disable "Remove" while containers are still attached. The engine's
+            // network_remove refuses an in-use network regardless, but the count
+            // lets the button reflect that up front.
+            let attached_apps = docker
+                .inspect_network(&name, None::<InspectNetworkOptions>)
+                .await
+                .ok()
+                .and_then(|ni| ni.containers)
+                .map(|c| c.into_values().filter_map(|e| e.name).collect())
+                .unwrap_or_default();
             seen.insert(name);
             out.push(NetworkSummary {
                 spec,

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -488,9 +488,20 @@
 		}
 	}
 
-	async function removeNetwork(name: string) {
+	async function removeNetwork(n: NetworkSummary) {
+		// External networks weren't created by NASty (left behind by an app that
+		// brings its own, or made outside NASty), so confirm before removing one.
+		// Managed networks keep the existing one-click behaviour.
+		if (
+			!n.managed &&
+			!(await confirm(
+				`Remove external network "${n.name}"?`,
+				"NASty didn't create this network. Removing it only affects Docker networking; anything still attached would lose connectivity.",
+			))
+		)
+			return;
 		const r = await withToast(
-			() => client.call('apps.networks.remove', { name }),
+			() => client.call('apps.networks.remove', { name: n.name }),
 			'Network removed',
 		);
 		if (r !== undefined) await loadAppNetworks();
@@ -2444,11 +2455,14 @@
 							<td class="p-2 font-mono">{n.subnet ?? '—'}</td>
 							<td class="p-2">{n.attached_apps.length > 0 ? n.attached_apps.join(', ') : '—'}</td>
 							<td class="p-2 text-right">
-								{#if n.managed}
-									<Button size="xs" variant="ghost" disabled={n.attached_apps.length > 0} title={n.attached_apps.length > 0 ? 'Detach all apps first' : 'Remove network'} onclick={() => removeNetwork(n.name)}>Remove</Button>
-								{:else}
-									<span class="text-xs text-muted-foreground" title="Not created by NASty">external</span>
-								{/if}
+								<div class="flex items-center justify-end gap-2">
+									{#if !n.managed}
+										<span class="text-xs text-muted-foreground" title="Not created by NASty">external</span>
+									{/if}
+									{#if n.name !== 'bridge'}
+										<Button size="xs" variant="ghost" disabled={n.attached_apps.length > 0} title={n.attached_apps.length > 0 ? 'Detach all apps first' : 'Remove network'} onclick={() => removeNetwork(n)}>Remove</Button>
+									{/if}
+								</div>
 							</td>
 						</tr>
 					{/each}


### PR DESCRIPTION
Closes #651.

When an app brings its own Docker network (or you create one outside NASty), NASty lists it under **Apps → Networks** but marks it "external" with no way to remove it — so a leftover like Sencho's `sencho-mesh` could only be cleaned up from the terminal.

NASty's app teardown already runs `docker compose down -v --remove-orphans`, which correctly leaves external networks alone (other stacks can share them, so auto-removing one would be the real footgun). So the missing piece isn't auto-removal — it's a deliberate manual cleanup from the UI.

Now external networks get a **Remove** button too, next to the "external" tag:

- **Confirms first** — it's not a NASty-created network.
- **Disabled while containers are still attached.** The engine already refuses to remove an in-use network; this also drops the managed-only gate so `network_list` computes `attached_apps` for external networks, so the button reflects that up front and the Attached column shows what's using it.
- **Docker's built-in `bridge` stays untouchable** (it's unremovable anyway).

No new engine method — `apps.networks.remove` already handles any network and guards in-use; this just surfaces it in the UI and makes the attached-apps count honest for external networks.

Verified: engine `cargo fmt --check` / `clippy --workspace --all-targets --no-deps -D warnings` / `cargo test` clean; webui `npm run check` 0 errors/0 warnings + `npm test` 144/144.
