### PR TITLE
flake: bump lanzaboote v1.0.0 → v1.1.0 (Secure Boot)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1765145449,
-        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -76,15 +76,15 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -139,16 +139,16 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1765382359,
-        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "lastModified": 1782141370,
+        "narHash": "sha256-hqijVSEETttmo8Okql9/LG0Ua34hdciKW1a5zzlj8mU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "rev": "7c9a54a7f87b4539ddbd8bda09a8a5f5f9361aa9",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v1.0.0",
+        "ref": "v1.1.0",
         "repo": "lanzaboote",
         "type": "github"
       }
@@ -215,11 +215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765016596,
-        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -264,11 +264,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765075567,
-        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     # nixpkgs.follows: keeps lanzaboote's nixpkgs aligned with
     # nasty's, so cachix-substituted artifacts match by content
     # hash and we don't ship a second nixpkgs in the closure.
-    lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
+    lanzaboote.url = "github:nix-community/lanzaboote/v1.1.0";
     lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
Bumps the pinned lanzaboote input from **v1.0.0 → v1.1.0**.

## Validated live on real firmware

Not just a build — tested end-to-end on a Proxmox VM with OVMF Secure Boot + a virtual TPM 2.0:

- The full NASty Secure Boot system **builds** with v1.1.0 (`lzbt`, `lzbt-systemd`, `lanzaboote-stub` all compile).
- `lzbt` v1.1.0 **signs** the UKIs correctly (`sbctl verify` ✓ on every generation).
- The box **enrolls keys** (firmware Setup Mode → user) and **boots under enforcing Secure Boot** — `Current Stub: lanzastub 1.1.0`, `sbctl`: Setup Mode disabled / Secure Boot enabled.

## Compatibility with NASty's usage

- Module import `nixosModules.lanzaboote` and every option NASty sets are intact: `enable`, `pkiBundle`, `autoGenerateKeys.enable`, `autoEnrollKeys.enable`/`.autoReboot`.
- The `autoGenerateKeys` flow (install unsigned → `generate-sb-keys` creates keys → `prepare-sb-auto-enroll` re-signs with `lzbt` → enroll) is **byte-identical to v1.0.0** — not a regression. The only v1.1.0 delta is a more precise key-presence check (`!pkiBundle/keys` vs `!pkiBundle`).
- NASty seals bcachefs keys to **PCR-7** (firmware Secure-Boot policy). v1.1.0's changed kernel/initrd measurement lands on **PCR-11**, so TPM2 auto-unlock is unaffected — no re-seal needed on upgrade.
- Removed `boot.bootspec.enable` — NASty never set it. New v1.1.0 features (systemd-pcrlock measured boot, boot counting) are opt-in; NASty enables none.

## Release note

`lzbt` v1.1.0 isn't in any binary cache yet and builds from source (~30 min on a 4-vCPU VM). Prime nasty's cachix with it before shipping, otherwise every box enrolling Secure Boot eats that compile on first rebuild.
