### PR TITLE
deps: layerchart off prerelease → 2.0.1 (chart tooltip migrated to v2 API)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-Iwpl21DXdJrVCDhkux4PCQOlzD0KvCdPkdq6BmyBGck=";
+      npmDepsHash = "sha256-Y+lqlVPgFmOnlSysXCpSMkt2BywIjFF1mO8xDQznrjM=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -32,7 +32,7 @@
 				"@types/node": "^25.6.1",
 				"bits-ui": "^2.18.0",
 				"clsx": "^2.1.1",
-				"layerchart": "2.0.0-next.46",
+				"layerchart": "^2.0.1",
 				"svelte": "^5.56.4",
 				"svelte-check": "^4.7.1",
 				"tailwind-merge": "^3.5.0",
@@ -1162,6 +1162,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1173,6 +1191,13 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1492,12 +1517,38 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-color": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
 			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
 			"dev": true,
 			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -2025,9 +2076,9 @@
 			}
 		},
 		"node_modules/layerchart": {
-			"version": "2.0.0-next.46",
-			"resolved": "https://registry.npmjs.org/layerchart/-/layerchart-2.0.0-next.46.tgz",
-			"integrity": "sha512-fpdnvexCG/chonAIunDdLbqrUrD0IZ2v6MG/kbI5v7/yi0bIC47er1Kz31sACQNuoK+sxMIvWeebMHqiQP5XSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layerchart/-/layerchart-2.0.1.tgz",
+			"integrity": "sha512-ss19hUjjZawMni60dgYsm+ZT/Fq/HYh8YSQt6D9xhN+Dc9HB6TH77FOeOl1avf7Wlpc2MG7X16SFuMGh8nR+Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2036,8 +2087,11 @@
 				"@layerstack/svelte-state": "0.1.0-next.23",
 				"@layerstack/tailwind": "2.0.0-next.21",
 				"@layerstack/utils": "2.0.0-next.18",
+				"@types/d3-contour": "^3.0.6",
 				"d3-array": "^3.2.4",
+				"d3-chord": "^3.0.1",
 				"d3-color": "^3.1.0",
+				"d3-contour": "^4.0.2",
 				"d3-delaunay": "^6.0.4",
 				"d3-dsv": "^3.0.1",
 				"d3-force": "^3.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -24,7 +24,7 @@
 		"@types/node": "^25.6.1",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
-		"layerchart": "2.0.0-next.46",
+		"layerchart": "^2.0.1",
 		"svelte": "^5.56.4",
 		"svelte-check": "^4.7.1",
 		"tailwind-merge": "^3.5.0",

--- a/webui/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/webui/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -2,7 +2,7 @@
 	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
 	import type { HTMLAttributes } from "svelte/elements";
 	import { getPayloadConfigFromPayload, useChart, type TooltipPayload } from "./chart-utils.js";
-	import { getTooltipContext, Tooltip as TooltipPrimitive } from "layerchart";
+	import { getChartContext, Tooltip as TooltipPrimitive } from "layerchart";
 	import type { Snippet } from "svelte";
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,13 +48,13 @@
 	} = $props();
 
 	const chart = useChart();
-	const tooltipCtx = getTooltipContext();
+	const tooltipCtx = getChartContext().tooltip;
 
 	const formattedLabel = $derived.by(() => {
-		if (hideLabel || !tooltipCtx.payload?.length) return null;
+		if (hideLabel || !tooltipCtx.series?.length) return null;
 
-		const [item] = tooltipCtx.payload;
-		const key = labelKey ?? item?.label ?? item?.name ?? "value";
+		const [item] = tooltipCtx.series;
+		const key = labelKey ?? item?.label ?? item?.key ?? "value";
 
 		const itemConfig = getPayloadConfigFromPayload(chart.config, item, key);
 
@@ -65,10 +65,10 @@
 
 		if (value === undefined) return null;
 		if (!labelFormatter) return value;
-		return labelFormatter(value, tooltipCtx.payload);
+		return labelFormatter(value, tooltipCtx.series);
 	});
 
-	const nestLabel = $derived(tooltipCtx.payload.length === 1 && indicator !== "dot");
+	const nestLabel = $derived(tooltipCtx.series.length === 1 && indicator !== "dot");
 </script>
 
 {#snippet TooltipLabel()}
@@ -95,23 +95,23 @@
 			{@render TooltipLabel()}
 		{/if}
 		<div class="grid gap-1.5">
-			{#each tooltipCtx.payload as item, i (item.key + i)}
-				{@const key = `${nameKey || item.key || item.name || "value"}`}
+			{#each tooltipCtx.series as item, i (item.key + i)}
+				{@const key = `${nameKey || item.key || "value"}`}
 				{@const itemConfig = getPayloadConfigFromPayload(chart.config, item, key)}
-				{@const indicatorColor = color || item.payload?.color || item.color}
+				{@const indicatorColor = color || item.color}
 				<div
 					class={cn(
 						"[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5",
 						indicator === "dot" && "items-center"
 					)}
 				>
-					{#if formatter && item.value !== undefined && item.name}
+					{#if formatter && item.value !== undefined && item.label}
 						{@render formatter({
 							value: item.value,
-							name: item.name,
+							name: item.label,
 							item,
 							index: i,
-							payload: tooltipCtx.payload,
+							payload: tooltipCtx.series,
 						})}
 					{:else}
 						{#if itemConfig?.icon}
@@ -142,7 +142,7 @@
 									{@render TooltipLabel()}
 								{/if}
 								<span class="text-muted-foreground">
-									{itemConfig?.label || item.name}
+									{itemConfig?.label || item.label}
 								</span>
 							</div>
 							{#if item.value !== undefined}

--- a/webui/src/lib/components/ui/chart/chart-utils.ts
+++ b/webui/src/lib/components/ui/chart/chart-utils.ts
@@ -1,5 +1,4 @@
-import type { Tooltip } from "layerchart";
-import { getContext, setContext, type Component, type ComponentProps, type Snippet } from "svelte";
+import { getContext, setContext, type Component } from "svelte";
 
 export const THEMES = { light: "", dark: ".dark" } as const;
 
@@ -13,13 +12,23 @@ export type ChartConfig = {
 	);
 };
 
-export type ExtractSnippetParams<T> = T extends Snippet<[infer P]> ? P : never;
+// One series entry from layerchart v2's tooltip state
+// (`getChartContext().tooltip.series[number]`). Mirrors layerchart's internal
+// `TooltipSeries` (not re-exported at the package root); replaces the old
+// recharts-style payload item — note `label` where that had `name`, and there
+// is no longer a per-item nested raw datum (that's the shared `tooltip.data`).
+export type TooltipPayload = {
+	key: string;
+	label: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	value: any;
+	color?: string;
+	visible?: boolean;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	config?: any;
+};
 
-export type TooltipPayload = ExtractSnippetParams<
-	ComponentProps<typeof Tooltip.Root>["children"]
->["payload"][number];
-
-// Helper to extract item config from a payload.
+// Helper to extract item config from a tooltip series entry.
 export function getPayloadConfigFromPayload(
 	config: ChartConfig,
 	payload: TooltipPayload,
@@ -27,25 +36,12 @@ export function getPayloadConfigFromPayload(
 ) {
 	if (typeof payload !== "object" || payload === null) return undefined;
 
-	const payloadPayload =
-		"payload" in payload && typeof payload.payload === "object" && payload.payload !== null
-			? payload.payload
-			: undefined;
-
 	let configLabelKey: string = key;
 
 	if (payload.key === key) {
 		configLabelKey = payload.key;
-	} else if (payload.name === key) {
-		configLabelKey = payload.name;
-	} else if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
-		configLabelKey = payload[key as keyof typeof payload] as string;
-	} else if (
-		payloadPayload !== undefined &&
-		key in payloadPayload &&
-		typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
-	) {
-		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+	} else if (payload.label === key) {
+		configLabelKey = payload.label;
 	}
 
 	return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];


### PR DESCRIPTION
Moves layerchart off the pinned **prerelease** (`2.0.0-next.46`) onto the stable **2.0.1** release — the last exact-pinned dependency in `webui`, now on a caret range like its siblings.

## ⚠️ Needs a visual smoke-test before merge

layerchart v2 is a **breaking** tooltip API change, so this isn't a pure bump — it required migrating our vendored shadcn-svelte chart primitives. It's type-clean and tests pass, but **type-checking can't confirm the charts render correctly**. Please eyeball the dashboard **network/disk IO + history charts** (hover the tooltips — single-series and the dual in/out series) on this branch before merging.

## What changed

layerchart v2 dropped the recharts-style tooltip model:
- `getTooltipContext()` removed → `getChartContext().tooltip`.
- Tooltip payload changed from a `.payload` **array** (one entry per series) to `TooltipState.data` (single hovered datum) + a `.series: TooltipSeries[]` array.

Migration in the two affected files (`chart-tooltip.svelte`, `chart-utils.ts`):
- Iterate `tooltipCtx.series` instead of `tooltipCtx.payload` (`TooltipSeries` mirrors the old payload item: `key`/`label`/`value`/`color`).
- `.name` → `.label`, `.key` where appropriate; dropped the per-item nested raw datum (that's now the shared `tooltip.data`).
- `TooltipPayload` redefined structurally to mirror layerchart's internal `TooltipSeries` (not re-exported at the package root); `getPayloadConfigFromPayload` simplified to key/label matching.

`AreaChart` and the `Tooltip` component API are otherwise unchanged; v2.0.1 over v2.0.0 is just CSS cascade-layer fixes.

Verified: `npm run check` 0 errors/0 warnings + `npm test` 144/144; `npmDepsHash` regenerated for the new lockfile.
