### PR TITLE
deps: bump @types/node 25 → 26

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-Iwpl21DXdJrVCDhkux4PCQOlzD0KvCdPkdq6BmyBGck=";
+      npmDepsHash = "sha256-CjCqLhask3BQuVZryVFDXD5+IeV9CzV2fYEvxyeNk+E=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -29,7 +29,7 @@
 				"@sveltejs/kit": "^2.68.0",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
 				"@tailwindcss/vite": "^4.2.4",
-				"@types/node": "^25.6.1",
+				"@types/node": "^26.1.1",
 				"bits-ui": "^2.18.0",
 				"clsx": "^2.1.1",
 				"layerchart": "2.0.0-next.46",
@@ -1177,13 +1177,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
-			"integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -2924,9 +2924,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/webui/package.json
+++ b/webui/package.json
@@ -21,7 +21,7 @@
 		"@sveltejs/kit": "^2.68.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.4",
-		"@types/node": "^25.6.1",
+		"@types/node": "^26.1.1",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"layerchart": "2.0.0-next.46",


### PR DESCRIPTION
Bumps `@types/node` 25 → **26.1.1**.

Type-definitions only — no runtime code changes. Verified: `npm run check` 0 errors/0 warnings + `npm test` 144/144; `npmDepsHash` regenerated for the new lockfile.

**Note on alignment:** CI/build targets **Node 22** (`ci.yml`, `security.yml`; no `.nvmrc`/`engines`), so `@types/node@26` sits slightly ahead of the runtime. That's the existing situation (was `@25` on Node 22), just a wider gap — and it's low-risk here since the webui barely touches Node APIs directly and svelte-check is clean. If you'd rather keep the types aligned to the runtime, the alternatives are pinning `@types/node@22` or bumping the CI Node version — say the word and I'll switch to either.
