### PR TITLE
domain: remove machine keytab on AD leave (fixes orphaned keytab blocking NFS upgrades)

### DIFF
--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -128,6 +128,11 @@ pub const DOMAIN_SMB_CONF_PATH: &str = "/etc/samba/nasty-domain.conf";
 /// Path to the Kerberos configuration.
 pub const KRB5_CONF_PATH: &str = "/etc/samba/nasty-krb5.conf";
 
+/// System machine keytab that `net ads join` writes — samba's default location
+/// under `kerberos method = secrets and keytab` (we set no `dedicated keytab
+/// file`). Removed on leave so it doesn't outlive the membership.
+pub const SYSTEM_KRB5_KEYTAB_PATH: &str = "/etc/krb5.keytab";
+
 /// Render the `[global]`-scope Samba configuration block for Active Directory.
 ///
 /// Produces configuration suitable for `/etc/samba/nasty-domain.conf`.
@@ -463,6 +468,9 @@ async fn unwind_join_artifacts(leave_ad: Option<(&str, &str)>) {
     }
     let _ = tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await;
     let _ = tokio::fs::write(KRB5_CONF_PATH, "").await;
+    // A partial join may already have written the machine keytab; drop it so a
+    // failed join doesn't orphan it (see leave() for why an orphan matters).
+    let _ = tokio::fs::remove_file(SYSTEM_KRB5_KEYTAB_PATH).await;
     if tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await.is_ok() {
         let _ = systemctl("restart", "systemd-resolved.service").await;
     }
@@ -830,6 +838,14 @@ impl DomainService {
         }
         tokio::fs::write(DOMAIN_SMB_CONF_PATH, "").await?;
         tokio::fs::write(KRB5_CONF_PATH, "").await?;
+        // Remove the machine keytab `net ads join` wrote. Left behind it orphans
+        // a keytab holding only HOST/ (machine) principals — which flips
+        // `rpc-svcgssd` on (it is gated purely on
+        // `ConditionPathExists=/etc/krb5.keytab` and is `PartOf` nfs-server) and
+        // then fails every activation looking for an `nfs/` principal that was
+        // never there, turning `switch-to-configuration` into exit 4 and
+        // blocking upgrades on any box that serves NFS.
+        let _ = tokio::fs::remove_file(SYSTEM_KRB5_KEYTAB_PATH).await;
         let _ = tokio::fs::remove_file(RESOLVED_DROPIN_PATH).await;
         let _ = systemctl("restart", "systemd-resolved.service").await;
         let _ = systemctl("stop", "samba-winbindd.service").await;


### PR DESCRIPTION
Makes AD-member **leave** fully clean up after itself, so a box that joins then leaves AD stays upgradeable.

## The bug (diagnosed live on the dev box)

An AD-member **leave** cleared `krb5.conf`, the resolved drop-in, and winbind — but left `/etc/krb5.keytab` behind. That orphaned keytab holds only the machine principals (`HOST/…`, `RestrictedKrbHost/…`) — no `nfs/` one.

`rpc-svcgssd` (the NFS server's Kerberos daemon) is gated purely on `ConditionPathExists=/etc/krb5.keytab` and is `PartOf=nfs-server.service`. So the orphaned keytab flips it on: it starts on every activation and fails looking for an `nfs/host@REALM` principal that was never there. Newer `switch-to-configuration` (systemd 260) treats a unit that fails to start during the switch as **exit 4** — which fails the whole rebuild:

```
rpc.svcgssd: ERROR: gss_acquire_cred(): GSS_S_NO_CRED - No key table entry found matching nfs/@
switching to system configuration ... failed (status 4)
```

**Any box that joins AD as a member, later leaves, and serves NFS would hit this upgrade wall.**

## The fix

Remove the machine keytab (`/etc/krb5.keytab`, samba's default under `kerberos method = secrets and keytab`) in both teardown paths:
- `leave()` — the normal AD-member leave.
- `unwind_join_artifacts()` — the failed-join rollback (a partial join can write the keytab too).

Best-effort `remove_file`, matching the existing resolved-drop-in cleanup.

## Validation

- Code: `cargo fmt` / `clippy --workspace --all-targets --no-deps -D warnings` / `cargo test -p nasty-system` (369 passed) all clean.
- Root cause was confirmed live on the dev box (orphaned keytab from an earlier member-join test; removing it made `rpc-svcgssd` skip on its condition and `switch-to-configuration test` return 0).
- **Pending:** a full live join → leave → confirm-keytab-gone run against the Synology AD test box — deferred so as not to disrupt the in-flight upgrade on that same box; happy to run it once it's free.

## Note

This is a forward fix. A box that *already* left AD on an older engine still has the stray keytab (it won't be retroactively cleaned) — that's a one-line manual `rm /etc/krb5.keytab` on such boxes, same as was done on the dev box.
