### PR TITLE
files: Calculate folder sizes on demand (#654)

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -771,6 +771,7 @@ async fn main() -> anyhow::Result<()> {
             post(upload_vm_image_handler).layer(DefaultBodyLimit::max(10_737_418_240)),
         )
         .route("/api/files/browse", get(files_browse_handler))
+        .route("/api/files/size", get(files_size_handler))
         .route("/api/files", delete(files_delete_handler))
         .route(
             "/api/files/upload",
@@ -1313,6 +1314,106 @@ fn safe_path(requested: &str) -> Result<std::path::PathBuf, StatusCode> {
         return Err(StatusCode::FORBIDDEN);
     }
     Ok(canonical)
+}
+
+/// Total the apparent size of a directory tree. GET /api/files/size?path=first/sub
+///
+/// On-demand only (the browse listing never totals folders — that would make
+/// every listing walk the whole tree). Bounded by a timeout so a pathological
+/// directory returns "too large to total" instead of hanging the request.
+async fn files_size_handler(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let token = match token_from_headers(&headers) {
+        Some(t) => t,
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Missing token"})),
+            )
+                .into_response();
+        }
+    };
+    let client_ip = headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    if state.auth.validate(&token, client_ip).await.is_err() {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid token"})),
+        )
+            .into_response();
+    }
+
+    let req_path = params.get("path").map(|s| s.as_str()).unwrap_or("");
+    let dir = match safe_path(req_path) {
+        Ok(p) => p,
+        Err(status) => {
+            return (status, Json(serde_json::json!({"error": "Invalid path"}))).into_response();
+        }
+    };
+    match tokio::fs::metadata(&dir).await {
+        Ok(m) if m.is_dir() => {}
+        Ok(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Not a directory"})),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Not found"})),
+            )
+                .into_response();
+        }
+    }
+
+    // Apparent (logical) recursive size via `du -sb`, so it matches the per-file
+    // sizes the browser already shows. `du` doesn't follow symlinks, `safe_path`
+    // confined `dir` to FILES_ROOT, and `--` guards the canonical path from being
+    // read as an option. Timeout-bounded so a huge tree can't wedge the request.
+    let du = tokio::process::Command::new("du")
+        .arg("-sb")
+        .arg("--")
+        .arg(dir.as_os_str())
+        .output();
+    let stdout = match tokio::time::timeout(std::time::Duration::from_secs(60), du).await {
+        Ok(Ok(o)) if o.status.success() => o.stdout,
+        Ok(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "Could not total the directory"})),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            return (
+                StatusCode::REQUEST_TIMEOUT,
+                Json(serde_json::json!({
+                    "error": "Directory is too large to total quickly (timed out)"
+                })),
+            )
+                .into_response();
+        }
+    };
+    // `du -sb` prints "<bytes>\t<path>"; take the leading integer.
+    match String::from_utf8_lossy(&stdout)
+        .split_whitespace()
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        Some(bytes) => (StatusCode::OK, Json(serde_json::json!({ "size": bytes }))).into_response(),
+        None => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "Could not read the directory size"})),
+        )
+            .into_response(),
+    }
 }
 
 /// List directory contents. GET /api/files/browse?path=/first

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput, Share2, Check, RotateCcw } from '@lucide/svelte';
+	import { FolderOpen, File, ArrowUp, Upload, FolderPlus, Trash2, Image, Film, Music, FileText, Download, Pencil, Copy, FolderInput, Share2, Check, RotateCcw, Calculator, Loader2 } from '@lucide/svelte';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import PathPicker from '$lib/components/PathPicker.svelte';
 	import { getClient } from '$lib/client';
@@ -202,7 +202,10 @@
 	// current directory — clears automatically on browse() since
 	// `selected` is reset whenever currentPath changes.
 	let selected: Set<string> = $state(new Set());
-	$effect(() => { void currentPath; selected = new Set(); });
+	// On-demand recursive folder sizes (the Calculate-size action), keyed by
+	// entry.name within the current directory. Cleared on navigate.
+	let folderSizes: Record<string, number | 'loading' | 'error'> = $state({});
+	$effect(() => { void currentPath; selected = new Set(); folderSizes = {}; });
 
 	// Copy / Move picker. `pickerMode` controls which API the chosen
 	// destination is fed into; `pickerTargets` is the list of entries
@@ -415,6 +418,25 @@
 	function formatDate(epoch: number): string {
 		if (!epoch) return '—';
 		return new Date(epoch * 1000).toLocaleString();
+	}
+
+	// Total a folder's apparent size on demand (server walks it with `du`).
+	async function calcFolderSize(entry: FileEntry) {
+		const path = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+		folderSizes = { ...folderSizes, [entry.name]: 'loading' };
+		try {
+			const res = await fetch(`/api/files/size?path=${encodeURIComponent(path)}`);
+			const data = await res.json();
+			if (res.ok && typeof data.size === 'number') {
+				folderSizes = { ...folderSizes, [entry.name]: data.size };
+			} else {
+				folderSizes = { ...folderSizes, [entry.name]: 'error' };
+				toastError(data.error || 'Could not total the folder');
+			}
+		} catch {
+			folderSizes = { ...folderSizes, [entry.name]: 'error' };
+			toastError('Could not total the folder');
+		}
 	}
 
 	const breadcrumbs = $derived.by(() => {
@@ -755,11 +777,30 @@
 							</button>
 						{/if}
 					</td>
-					<td class="p-3 text-right text-muted-foreground tabular-nums">{entry.is_dir ? '—' : formatSize(entry.size)}</td>
+					<td class="p-3 text-right text-muted-foreground tabular-nums">
+						{#if !entry.is_dir}
+							{formatSize(entry.size)}
+						{:else if typeof folderSizes[entry.name] === 'number'}
+							{formatSize(folderSizes[entry.name] as number)}
+						{:else if folderSizes[entry.name] === 'loading'}
+							<Loader2 size={14} class="inline animate-spin" />
+						{:else}
+							—
+						{/if}
+					</td>
 					<td class="p-3 text-right text-muted-foreground text-xs tabular-nums">{formatDate(entry.modified)}</td>
 					{#if !isRoot}
 						<td class="p-3 text-right">
 							<div class="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100">
+								{#if entry.is_dir}
+									<button
+										class="text-muted-foreground/40 hover:text-foreground transition-colors"
+										onclick={() => calcFolderSize(entry)}
+										disabled={folderSizes[entry.name] === 'loading'}
+										title="Calculate size">
+										<Calculator size={14} />
+									</button>
+								{/if}
 								{#if !entry.is_dir}
 									<a
 										href={contentUrl(entry)}


### PR DESCRIPTION
Closes #654.

Adds an on-demand **Calculate size** action to folders in the file browser — a calculator icon in each folder row's hover actions. Click it and the folder's "—" size cell fills in with the recursive total (spinner while it runs).

## How it works

- **Engine:** new `GET /api/files/size?path=…`. Auth + the existing `safe_path()` confinement (can't escape `/fs`, canonicalizes/rejects symlink escapes), then `du -sb -- <dir>` → `{ size }`. **Apparent** size (sum of file lengths), matching the per-file sizes the browser already shows. `du` doesn't follow symlinks; `--` guards the canonical path; and the call is **timeout-bounded (60s)** so a pathological tree returns "too large to total quickly" instead of wedging the request.
- **WebUI:** per-folder calculator icon → fetches the endpoint, caches the result in state keyed by name, and renders it in the size column (cleared on navigate). Errors/timeouts surface a toast.

On-demand only — the directory listing never totals folders (that would make every listing walk the whole tree). `du` resolves on the engine service's PATH (NixOS ships coreutils on the default systemd path — verified on a live box), so no nix change is needed.

## Validation

- Engine: `cargo fmt` / `clippy -p nasty-engine --all-targets --no-deps -D warnings` clean; endpoint reuses the same auth + `safe_path` as the other file handlers.
- WebUI: `npm run check` 0 errors/0 warnings + `npm test` 144/144.
- **Pending:** a live click-through in the browser (calculate a real folder, check display + the timeout path) — deferred so as not to collide with the in-flight upgrade on the dev box; happy to run it there once it's free, or it's easy to try on this branch.
