### PR TITLE
release: bump workspace version to 0.0.14

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-apps"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-backup"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "cron",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-common"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "base64 0.22.1",
  "schemars 1.2.1",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-engine"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-metrics"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-sharing"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",
@@ -3005,14 +3005,14 @@ dependencies = [
 
 [[package]]
 name = "nasty-snapshot"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "nasty-storage",
 ]
 
 [[package]]
 name = "nasty-storage"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "libc",
  "nasty-common",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-system"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "nasty-vm"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "nasty-common",
  "schemars 1.2.1",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 license = "GPL-3.0-only"
 


### PR DESCRIPTION
Bumps the workspace version 0.0.13 → 0.0.14 so the shipped engine reports the right version for the release. `Cargo.toml` (workspace version) + `Cargo.lock` (the workspace crates' version entries) — version-only, no dependency changes, matching the prior release bump.

The v0.0.14 (and v0.0.13 backfill) changelog is already on main (#660), and all feature PRs are merged. **This is the last step before tagging `v0.0.14`** — once it merges and CI is green, main is ready to tag.

Reminder from the changelog's Upgrading section: prime `nasty.cachix.org` with the lanzaboote `lzbt` v1.1.0 build before the tag reaches Secure-Boot boxes.