### PR TITLE
nixos: support persistent custom configuration

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -28,6 +28,10 @@ Because a NAS appliance should be a single atomic unit that you can update, roll
 
 Traditional NAS distros (FreeNAS/TrueNAS, OpenMediaVault) use FreeBSD or Debian with mutable package management. NASty uses NixOS because a storage appliance should be the last thing that breaks during an update.
 
+## Can I add my own NixOS configuration?
+
+Yes. Advanced users can drop settings the WebUI doesn't expose into `/etc/nixos/custom.nix` — extra NixOS options, packages, systemd units, whatever. NASty imports it automatically when present, and never writes or overwrites it: only the generated `flake.nix` is re-rendered on upgrade, so your `custom.nix` survives reboots *and* upgrades. Use `lib.mkForce` where you need to override a value a NASty module already sets; import order alone does not override equal-priority NixOS definitions. Apply changes with `nixos-rebuild switch --flake /etc/nixos#nasty`. A syntax or build error fails the rebuild safely — the running generation keeps working — so just fix it and rebuild.
+
 ## Is this production-ready?
 
 No. NASty is experimental and under active development. bcachefs itself is still maturing.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ NASty is a NAS operating system built on NixOS and bcachefs. It turns commodity 
 ### System
 - **Web UI** — manage filesystems, subvolumes, snapshots, shares, disks, services, and more
 - **Web terminal** — built-in shell with command cheatsheets and diagnostic tools
+- **Custom NixOS config** — advanced users can drop settings the WebUI doesn't expose into `/etc/nixos/custom.nix`; NASty never overwrites it, so they persist across reboots and upgrades
 - **Glossary** — built-in help page with storage terms, protocol guidance, and FAQ
 - **Networking** — NetworkManager-based with confirm-or-rollback: edits stage, apply, and auto-revert if you don't confirm in time, so a typo can't lock you out over SSH
 - **Let's Encrypt** — automatic TLS certificates via ACME (TLS-ALPN and DNS challenges)

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -234,6 +234,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     result: Some(gen_schema::<Vec<Operation>>(generator)),
                 },
                 Method {
+                    name: "system.custom_config.get",
+                    desc: "Read /etc/nixos/custom.nix — the operator's own NixOS overlay (advanced, edited from the terminal). Returns whether the file exists and its contents for a read-only WebUI view; NASty never writes this file, so anything in it survives upgrades.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<nasty_system::CustomConfig>(generator)),
+                },
+                Method {
                     name: "system.stats",
                     desc: "Return current CPU, memory, network interface, and disk I/O statistics.",
                     role: MethodRole::Any,

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -236,6 +236,11 @@ fn is_read_only(method: &str) -> bool {
             // the central gate agrees with the impl and the declared
             // role, instead of relying on the inline check alone.
             | "auth.token.list"
+            // `system.custom_config.get` returns the raw contents of the
+            // operator's `/etc/nixos/custom.nix` — system-level NixOS config that
+            // can hold sensitive settings. Its `.get` suffix would otherwise slip
+            // it into the universally-allowed read set; keep it Admin-only.
+            | "system.custom_config.get"
     ) {
         return false;
     }
@@ -1413,6 +1418,12 @@ mod tests {
         assert!(!is_read_only("dc.group.list"));
         assert!(!is_read_only("dc.computer.list"));
         assert!(is_read_only("dc.status")); // status is a safe read
+    }
+
+    #[test]
+    fn custom_config_contents_are_admin_only() {
+        assert!(!is_read_only("system.custom_config.get"));
+        assert!(!is_operator_allowed("system.custom_config.get"));
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -88,6 +88,10 @@ pub(super) async fn try_route(
             ok(req, status)
         }
         "system.operations.list" => ok(req, build_operations(state).await),
+        "system.custom_config.get" => match custom_config_get().await {
+            Ok(config) => ok(req, config),
+            Err(e) => err(req, format!("read /etc/nixos/custom.nix: {e}")),
+        },
         "system.hardware.iommu" => ok(req, nasty_system::hardware::iommu_groups().await),
         "system.hardware.summary" => ok(req, nasty_system::hardware::system_summary().await),
         "system.secure_boot.readiness" => ok(req, nasty_system::secure_boot::readiness().await),
@@ -990,6 +994,25 @@ async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
         top_warning,
         operations,
     )
+}
+
+/// Read `/etc/nixos/custom.nix` for the read-only WebUI view. A missing file is
+/// the normal "not created yet" state; other I/O failures remain visible.
+async fn custom_config_get() -> std::io::Result<nasty_system::CustomConfig> {
+    const PATH: &str = "/etc/nixos/custom.nix";
+    match tokio::fs::read_to_string(PATH).await {
+        Ok(content) => Ok(nasty_system::CustomConfig {
+            path: PATH.to_string(),
+            exists: true,
+            content,
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(nasty_system::CustomConfig {
+            path: PATH.to_string(),
+            exists: false,
+            content: String::new(),
+        }),
+        Err(e) => Err(e),
+    }
 }
 
 /// Gather the controllable data operations across all mounted filesystems

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -152,6 +152,19 @@ pub struct ActiveOperation {
     pub detail: String,
 }
 
+/// The operator's own NixOS overlay at `/etc/nixos/custom.nix`, surfaced
+/// read-only in the WebUI. NASty never writes this file — advanced operators
+/// edit it from the terminal, and it survives reboots and upgrades.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CustomConfig {
+    /// Absolute path of the overlay file.
+    pub path: String,
+    /// Whether the file currently exists.
+    pub exists: bool,
+    /// File contents (empty when absent).
+    pub content: String,
+}
+
 /// A controllable data operation for the Operations panel (#553). Unlike
 /// [`ActiveOperation`] (band-only, active jobs), this carries the action the
 /// UI can take, and includes pausable background jobs even when idle so they

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -3452,6 +3452,38 @@ outputs = { nixpkgs, nasty, ... }: {
         assert_eq!(rendered, rendered2);
     }
 
+    #[tokio::test]
+    async fn bootstrap_imports_and_preserves_existing_custom_config() {
+        let dir = tempfile::tempdir().expect("temporary system-flake directory");
+        let dest_dir = dir.path().to_str().expect("UTF-8 temporary path");
+        let custom_path = dir.path().join("custom.nix");
+        let custom = "{ pkgs, ... }: { environment.systemPackages = [ pkgs.hello ]; }\n";
+        tokio::fs::write(&custom_path, custom)
+            .await
+            .expect("write operator custom config");
+
+        super::bootstrap_system_flake_from_template(
+            super::EMBEDDED_WRAPPER_TEMPLATE,
+            dest_dir,
+            "0.0.14",
+            "x86_64-linux",
+        )
+        .await
+        .expect("bootstrap wrapper flake");
+
+        let preserved = tokio::fs::read_to_string(&custom_path)
+            .await
+            .expect("read preserved custom config");
+        assert_eq!(preserved, custom);
+
+        let wrapper = tokio::fs::read_to_string(dir.path().join("flake.nix"))
+            .await
+            .expect("read rendered wrapper");
+        assert!(wrapper.contains("builtins.pathExists ./custom.nix"));
+        assert!(wrapper.contains("nixpkgs.lib.optional"));
+        assert!(wrapper.contains("./custom.nix;"));
+    }
+
     #[test]
     fn bootstrap_wrapper_inherits_canonical_bcachefs_ref() {
         // A fresh install must pin the bcachefs-tools the running system

--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -322,8 +322,8 @@ in
 
       # nixos-generate-config writes a 3-line header telling the user to edit
       # /etc/nixos/configuration.nix — a file the NASty appliance has no copy of
-      # (the system config lives in the `nasty` flake input; the only local
-      # hand-editable file is /etc/nixos/flake.nix). Left as-is it sends
+      # (the system config lives in the `nasty` flake input; local overrides
+      # belong in /etc/nixos/custom.nix). Left as-is it sends
       # NixOS-literate operators chasing a missing file (issue #575). Replace it
       # with a header that describes the actual flake-based layout.
       if head -n1 /tmp/hw-config/hardware-configuration.nix | grep -q 'Do not modify this file'; then
@@ -338,8 +338,9 @@ in
             '#     (github:nasty-project/nasty), imported by /etc/nixos/flake.nix.' \
             '#   * Network, TLS, shares, apps and the upstream ref are managed by the' \
             '#     NASty engine / WebUI — not by hand-editing .nix files.' \
-            '#   * To track a different nasty/bcachefs ref or add overlays, edit the' \
-            '#     wrapper flake /etc/nixos/flake.nix (also in the WebUI Upstream section).'
+            '#   * Put extra NixOS options, packages, and units in /etc/nixos/custom.nix.' \
+            '#     NASty imports that file when present and never overwrites it.' \
+            '#   * To track a different nasty/bcachefs ref, use the WebUI Upstream section.'
           tail -n +4 /tmp/hw-config/hardware-configuration.nix
         } > /tmp/hw-config/hardware-configuration.nix.nasty \
           && mv /tmp/hw-config/hardware-configuration.nix.nasty /tmp/hw-config/hardware-configuration.nix

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -140,7 +140,18 @@
           # lanzaboote auto-enroll knobs. Absent on every fresh
           # install (the wizard hasn't run); `pathExists` keeps
           # the import optional so eval doesn't fail.
-          ++ nixpkgs.lib.optional (builtins.pathExists ./secure-boot.nix) ./secure-boot.nix;
+          ++ nixpkgs.lib.optional (builtins.pathExists ./secure-boot.nix) ./secure-boot.nix
+          # Operator's own NixOS config — hand-edited at /etc/nixos/custom.nix by
+          # advanced users who want settings the WebUI doesn't expose. NASty never
+          # writes or re-renders this file; only the generated flake.nix is
+          # re-rendered on upgrade, so anything here survives reboots AND upgrades.
+          # Use `lib.mkForce`/`lib.mkOverride` where a NASty module already sets a
+          # value; module import order alone does not change definition priority.
+          # Optional via `pathExists` — absent on a fresh install. A broken
+          # custom.nix fails the rebuild, but safely: the running generation stays
+          # active and the update wrapper restores the previous lock — fix it and
+          # rebuild.
+          ++ nixpkgs.lib.optional (builtins.pathExists ./custom.nix) ./custom.nix;
         };
     in {
       # Content-hash placeholder substituted at render time by

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -45,6 +45,12 @@ export interface WebauthnRegisterStart {
 	creation_options: unknown;
 }
 
+export interface CustomConfig {
+	path: string;
+	exists: boolean;
+	content: string;
+}
+
 export interface SystemInfo {
 	hostname: string;
 	version: string;

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -811,7 +811,7 @@
 		{ href: '/logs', label: 'Logs', keywords: ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'] },
 		{ href: '/update', label: 'Update', keywords: ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin'] },
 		{ href: '/users', label: 'Access Control', keywords: ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider'] },
-		{ href: '/settings', label: 'Settings', keywords: ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance'] },
+		{ href: '/settings', label: 'Settings', keywords: ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'] },
 	];
 
 	let sidebarSearch = $state('');

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -19,7 +19,7 @@
 	import { domain, domainRefresh, domainJoin, domainLeave } from '$lib/domain.svelte';
 	import { dc, dcRefresh, dcProvision } from '$lib/dc.svelte';
 	import DcPanel from '$lib/directory/DcPanel.svelte';
-	import type { Settings, SystemInfo, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
+	import type { Settings, SystemInfo, CustomConfig, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
@@ -90,6 +90,10 @@
 
 	// Network
 	let networkState: NetworkState | null = $state(null);
+	// Read-only view of /etc/nixos/custom.nix (advanced operator overlay).
+	let customConfig: CustomConfig | null = $state(null);
+	let customConfigLoaded = $state(false);
+	let customConfigError = $state(false);
 	const network = $derived.by((): NetworkConfig | null => {
 		return networkState?.config ?? null;
 	});
@@ -294,6 +298,13 @@
 			]);
 			hostnameInput = settings.hostname ?? info.hostname;
 			logFilter = liveLogFilter;
+			try {
+				customConfig = await client.call<CustomConfig>('system.custom_config.get');
+			} catch {
+				customConfigError = true;
+			} finally {
+				customConfigLoaded = true;
+			}
 			syncNetworkForm();
 		});
 		await Promise.all([domainRefresh(), dcRefresh()]);
@@ -887,6 +898,42 @@
 						<Button size="sm" onclick={saveTimezone} disabled={saving}>
 							{saving ? 'Saving…' : 'Apply'}
 						</Button>
+					</div>
+				</section>
+
+				<!-- Custom configuration -->
+				<section class="rounded-lg border border-border p-5">
+					<h2 class="mb-2 text-base font-semibold">Custom configuration <span class="ml-1 align-middle text-xs font-normal text-muted-foreground">advanced</span></h2>
+					<p class="mb-4 text-sm text-muted-foreground">
+						Settings the WebUI doesn't expose go in
+						<code class="rounded bg-muted px-1 py-0.5 text-xs">/etc/nixos/custom.nix</code> — any NixOS
+						options, extra packages, or systemd units. NASty never overwrites this file, so it survives
+						reboots and upgrades. Edit it from the terminal, then run
+						<code class="break-all rounded bg-muted px-1 py-0.5 text-xs">nixos-rebuild switch --flake /etc/nixos#nasty</code>.
+						A broken file fails the rebuild safely; use
+						<code class="rounded bg-muted px-1 py-0.5 text-xs">lib.mkForce</code> when overriding a value NASty already sets.
+					</p>
+					{#if !customConfigLoaded}
+						<p class="text-xs text-muted-foreground">Loading custom configuration...</p>
+					{:else if customConfigError}
+						<p class="text-xs text-muted-foreground italic">
+							The custom configuration could not be read. Only administrators can view it; check the engine log if you are already an administrator.
+						</p>
+					{:else if customConfig?.exists}
+						<pre class="max-h-80 overflow-auto rounded-md border border-border bg-secondary/20 p-3 font-mono text-xs whitespace-pre">{customConfig.content}</pre>
+					{:else}
+						<p class="text-xs text-muted-foreground italic">
+							Not created yet — <code class="rounded bg-muted px-1 py-0.5">custom.nix</code> doesn't exist.
+							Create it from a terminal to add custom config.
+						</p>
+					{/if}
+					<div class="mt-3">
+						<a
+							href={`/terminal?cmd=${encodeURIComponent('cd /etc/nixos')}`}
+							class="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted"
+						>
+							Open a terminal in /etc/nixos
+						</a>
 					</div>
 				</section>
 


### PR DESCRIPTION
## Summary

- optionally import `/etc/nixos/custom.nix` from the generated system wrapper without ever managing or overwriting the operator file
- expose an Admin-only read view in Settings > General, with explicit loading, missing, and error states
- update installer guidance and documentation, and add bootstrap preservation and authorization regression tests

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p nasty-system update::tests` (55 passed)
- `cargo test -p nasty-engine router::tests` (8 passed)
- `npm run check`
- `npm test -- --run` (144 passed)
- `npm run build`
- `nix-instantiate --parse nixos/system-flake/flake.nix.template`
- `git diff --check`

## VM validation

Tested end-to-end on an x86_64 NASty v0.0.14 VM under Proxmox:

- created `custom.nix` before wrapper migration and confirmed bootstrap preserved its checksum byte-for-byte
- applied a harmless `/etc/nasty-custom-test` marker through the imported module
- confirmed engine, Caddy, metrics, recovery service, OpenAPI registration, and unauthenticated HTTP 401 behavior
- rebooted and confirmed the custom file, applied marker, wrapper hash, and service health persisted
- introduced an invalid NixOS option and confirmed rebuild exited 1 without changing the active generation or interrupting the engine
- restored the valid file and rebuilt successfully
- manually confirmed the Settings > General card displays the custom configuration
- returned the VM to the exact original v0.0.14 generation and matching wrapper/lock checksums after testing