### PR TITLE
firewall: make nftables replacement transactional

### DIFF
--- a/docs/firewall-custom-rules.md
+++ b/docs/firewall-custom-rules.md
@@ -23,7 +23,8 @@ supported way to open a port that isn't tied to a NASty service.
 - Arbitrary port *sets* / lists in one rule (`{80, 443, 8000-8010}`). A rule
   is one port or one contiguous range; several disjoint ranges are several
   rules.
-- Outbound/egress or forward-chain rules. This is the `input` chain only.
+- Outbound/egress rules. Custom rules apply to host input and matching inbound
+  DNAT traffic in the forward hook.
 - Protocols other than TCP/UDP.
 
 ## Where it matters (and where it doesn't)
@@ -31,11 +32,13 @@ supported way to open a port that isn't tied to a NASty service.
 - **`network_mode: host` apps** and anything an operator runs directly on the
   host outside NASty's service model — their ports bind on the host and land
   on the default-deny `input` chain, with no UI path to open them today.
-- **Bridge-networked apps do NOT need this.** Docker DNATs published ports in
-  `prerouting` straight to the container, bypassing the `inet nasty` input
-  chain — the Firewall page already lists those read-only. The UI copy must
-  say so, or first-time users add redundant rules for apps that were reachable
-  all along (that is effectively what happened in #591).
+- **NASty-managed bridge apps do NOT need this.** Their persisted host ports
+  are rendered into the forward allowlist automatically. Other inbound DNAT is
+  dropped unless a custom rule explicitly permits the original host port.
+- The appliance firewall owns all original-direction inbound DNAT by original
+  destination port. NASty-managed app ports are allowed automatically; DNAT
+  created by another container or virtualization manager needs an explicit
+  custom rule. Reply traffic and non-DNAT forwarding remain untouched.
 
 ## Principle: the engine owns the ruleset
 
@@ -67,9 +70,9 @@ never use.
 ## Persistence
 
 A new `/var/lib/nasty/firewall-custom.json` holding the `Vec<CustomRule>`,
-loaded at engine init and held in `FirewallService` in a mutex alongside the
-existing `restrictions` mutex, saved on every mutation. Same load/save shape
-as the existing `firewall-restrictions.json`. No secrets in the file.
+loaded at engine init and held in the serialized `FirewallService` config,
+staged and atomically renamed on every successful live-policy mutation. No
+secrets are stored in the file.
 
 ## Validation (on add / update)
 
@@ -87,26 +90,21 @@ as the existing `firewall-restrictions.json`. No secrets in the file.
    source + iface as an existing rule. Overlapping (non-identical) custom
    ranges are allowed — they are additive and harmless.
 4. **Docker-published overlap → allow + warn.** If the range intersects a host
-   port a Docker app publishes, the rule is still created, but the response
-   carries a warning ("port already reachable via `<app>`; bridge apps publish
-   past the firewall"). Because the firewall module is deliberately
-   Docker-agnostic — only the router joins `apps.list` for published ports —
-   this warning is computed at the router layer, the same place `status()`
-   already attaches `published_app_ports`. It never blocks.
+   port already allowed for a NASty app, the rule is still created but the
+   response explains that it is redundant.
 
 ## Engine surface
 
-`FirewallService` gains a `custom` mutex beside `state`/`restrictions` and
-three methods:
+`FirewallService` exposes three custom-rule methods through the same candidate
+state transaction used for service and forward rules:
 
 - `add_custom_rule(input) -> Result<CustomRule, String>` — generate the UUID,
-  run validations 1–3, push to the store, save JSON, re-apply nft, return the
-  created rule.
+  run validations 1–3, validate/apply nft, persist, then commit in-memory state.
 - `update_custom_rule(id, input) -> Result<CustomRule, String>` — find by id,
-  re-validate (the duplicate check excludes the rule itself), replace, save,
-  apply. The row toggle is an `update` with `enabled` flipped — there is no
-  separate toggle method.
-- `remove_custom_rule(id) -> Result<(), String>` — drop by id, save, apply.
+  re-validate (the duplicate check excludes the rule itself), then commit the
+  candidate transaction. The row toggle is an `update` with `enabled` flipped.
+- `remove_custom_rule(id) -> Result<(), String>` — drop by id and commit the
+  candidate transaction.
 
 RPC arms in `engine/nasty-engine/src/router/system.rs`, registered in
 `registry/methods.rs`:
@@ -125,42 +123,40 @@ accepted by the Admin branch of the authorization gate and are not listed in
 `MethodRole::Operator` methods) does not apply to them.
 
 The `add`/`update` arms compute the Docker-overlap warning at the router layer
-(fetching published ports exactly as `system.firewall.status` does) and attach
-it to the response; the firewall module never learns about Docker.
+(fetching published ports from the app service) and attach it to the response.
+The router also synchronizes those ports into `FirewallConfig` for forward-rule
+rendering.
 
 ## Rendering
 
-`apply_nftables` takes a new `custom: &[CustomRule]` parameter and, after the
-service-rule loop, emits one line per **enabled** rule, reusing the same
-condition builder as service ports:
+The renderer receives one complete `FirewallConfig` snapshot and, after the
+service-rule loop, emits one line per **enabled** custom rule:
 
 ```
 [iifname "<iface>"] [ip saddr <cidr>] <tcp|udp> dport <from>[-<to>] accept # custom:<label>
 ```
 
 A single port (`from == to`) renders as a bare `dport <from>`; a range renders
-as `dport <from>-<to>` (nft supports ranges natively, so a range stays one
-rule / one line). The signature change touches the existing callers
-(`set_service_ports`, the restrict path, `open_rdma`/`close_rdma`) — each
-passes the service's current custom slice. Lock acquisition order is fixed as
-**state → restrictions → custom** everywhere to avoid deadlock.
+as `dport <from>-<to>`. All firewall inputs share one serialized config mutex,
+so a candidate cannot mix snapshots from concurrent mutations. The exact same
+atomic table-replacement batch is passed to `nft --check` and then `nft -f`.
 
 ## Status
 
 `FirewallStatus` gains `custom_rules: Vec<CustomRule>`, filled by `status()`.
-The `system.firewall.status` arm is otherwise unchanged (it still joins the
-read-only `published_app_ports`).
+It also reports the published app ports held in the same committed config.
 
 ## Error handling
 
 - **Validation failure** (range, collision, duplicate) → method error
   (`InvalidParams`) with the pointed message; nothing is persisted, and the UI
   shows it inline.
-- **nft apply failure after a successful persist** → mirror the existing
-  module convention (`restrict` / `set_service_ports` already persist-then-
-  apply and surface the apply error). The rule stays in JSON and takes effect
-  on the next successful apply or reboot; there is no bespoke rollback —
-  consistency with the existing code beats a one-off transaction.
+- **nft validation/application failure** → discard the staged JSON and preserve
+  live, persisted, and in-memory state.
+- **Persistence failure after live apply** → submit the previous rules as a
+  compensating transaction. If that rollback also fails, emit a critical error
+  and retain the candidate in memory so status still reflects the live kernel;
+  persisted state remains unchanged and the RPC reports failure.
 - **Interface disappearance needs no special handling.** The renderer emits
   `iifname "<iface>"` (a per-packet string match), not `iif <index>`.
   `iifname` tolerates an absent interface: the rule simply matches no traffic
@@ -204,6 +200,6 @@ read-only `published_app_ports`).
 ## Follow-ups (not v1)
 
 - Arbitrary port sets / multiple disjoint ranges per rule.
-- Egress / forward-chain rules.
+- Egress rules and non-DNAT forwarding policy.
 - A "clone from published app port" shortcut for the rare host-mode app that
   genuinely needs a matching rule.

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2658,17 +2658,12 @@ impl AppsService {
         if let Ok(apps) = self.list().await {
             for app in &apps {
                 if app.status == "running"
-                    && let Ok(docker) = self.docker()
+                    && let Err(e) = self.stop(&app.name).await
                 {
-                    let _ = docker
-                        .stop_container(
-                            &container_name(&app.name),
-                            Some(StopContainerOptions {
-                                t: Some(10),
-                                signal: None,
-                            }),
-                        )
-                        .await;
+                    warn!(
+                        "failed to stop app '{}' while disabling apps: {e}",
+                        app.name
+                    );
                 }
             }
         }
@@ -3635,9 +3630,16 @@ impl AppsService {
             });
         }
 
-        // Discover compose apps from the compose directory
-        if let Ok(mut entries) = tokio::fs::read_dir(COMPOSE_DIR).await {
-            while let Ok(Some(entry)) = entries.next_entry().await {
+        // Discover compose apps from the compose directory. Once Docker is
+        // live, inventory errors must fail the whole snapshot; returning a
+        // partial list would make the firewall silently drop omitted ports.
+        let mut entries = match tokio::fs::read_dir(COMPOSE_DIR).await {
+            Ok(entries) => Some(entries),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(AppsError::Io(e)),
+        };
+        if let Some(entries) = entries.as_mut() {
+            while let Some(entry) = entries.next_entry().await.map_err(AppsError::Io)? {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if seen_names.contains(&name) {
                     continue;
@@ -3660,8 +3662,7 @@ impl AppsService {
                         filters: Some(pf),
                         ..Default::default()
                     }))
-                    .await
-                    .unwrap_or_default();
+                    .await?;
 
                 // Collect all containers, ports, and derive overall status
                 let mut containers = Vec::new();
@@ -3703,8 +3704,7 @@ impl AppsService {
                     });
                 }
 
-                all_ports.sort_by_key(|p| p.host_port);
-                all_ports.dedup_by_key(|p| p.host_port);
+                sort_and_dedup_ports(&mut all_ports);
 
                 let overall_status = if compose_containers.is_empty() {
                     "stopped".to_string()
@@ -4981,9 +4981,9 @@ impl AppsService {
 
     // ── Restore on boot ─────────────────────────────────────
 
-    pub async fn restore(&self) {
+    pub async fn restore(&self) -> Option<tokio::sync::mpsc::UnboundedReceiver<()>> {
         if !self.is_enabled() {
-            return;
+            return None;
         }
         // Heal the stable /appdata symlink (#436). Pre-feature installs
         // have no appdata_path yet — set it up on the apps storage
@@ -5037,12 +5037,12 @@ impl AppsService {
                  Not starting Docker to avoid a crash loop; unlock/mount the filesystem, then \
                  re-enable apps or reboot."
             );
-            return;
+            return None;
         }
         info!("Apps runtime enabled — ensuring Docker is running");
         if let Err(e) = run_cmd("systemctl", &["start", DOCKER_SERVICE]).await {
             error!("Failed to start Docker: {e}");
-            return;
+            return None;
         }
 
         // Bring up compose apps. NASty-managed stacks (#437) start in a
@@ -5076,6 +5076,7 @@ impl AppsService {
             // delays must never risk timing it out. Ordering is preserved
             // within the task; a stack that fails to come up is logged and
             // the sequence continues (stack 1 broken must not block 2..n).
+            let (updates, receiver) = tokio::sync::mpsc::unbounded_channel();
             tokio::spawn(async move {
                 for (name, cfg) in managed {
                     info!("Starting managed stack '{name}' (order {})", cfg.order);
@@ -5089,6 +5090,7 @@ impl AppsService {
                             cfg.order
                         );
                     }
+                    let _ = updates.send(());
                     if cfg.delay_secs > 0 {
                         info!(
                             "Settling {}s after '{name}' before the next stack",
@@ -5100,6 +5102,9 @@ impl AppsService {
                 }
                 info!("Managed compose startup sequence complete");
             });
+            Some(receiver)
+        } else {
+            None
         }
     }
 
@@ -5747,9 +5752,17 @@ fn extract_ports(c: &bollard::models::ContainerSummary) -> Vec<MappedPort> {
             }
         }
     }
-    ports.sort_by_key(|p| p.host_port);
-    ports.dedup_by_key(|p| p.host_port);
+    sort_and_dedup_ports(&mut ports);
     ports
+}
+
+fn sort_and_dedup_ports(ports: &mut Vec<MappedPort>) {
+    ports.sort_by(|a, b| {
+        a.host_port
+            .cmp(&b.host_port)
+            .then_with(|| a.protocol.cmp(&b.protocol))
+    });
+    ports.dedup_by(|a, b| a.host_port == b.host_port && a.protocol == b.protocol);
 }
 
 fn container_status_str(c: &bollard::models::ContainerSummary) -> String {
@@ -7707,7 +7720,7 @@ services:
 
     // ── resolve_ingress_port ──
 
-    use super::{MappedPort, resolve_ingress_port};
+    use super::{MappedPort, resolve_ingress_port, sort_and_dedup_ports};
 
     fn port(host: u16, proto: &str) -> MappedPort {
         MappedPort {
@@ -7740,6 +7753,21 @@ services:
         // dial a dead port; fall back to the first TCP port.
         let ports = vec![port(2300, "tcp"), port(8080, "tcp")];
         assert_eq!(resolve_ingress_port(Some(9999), &ports), Some(2300));
+    }
+
+    #[test]
+    fn mapped_ports_preserve_tcp_and_udp_on_the_same_host_port() {
+        let mut ports = vec![port(53, "udp"), port(53, "tcp"), port(53, "udp")];
+        sort_and_dedup_ports(&mut ports);
+        assert_eq!(ports.len(), 2);
+        assert_eq!(
+            (ports[0].host_port, ports[0].protocol.as_str()),
+            (53, "tcp")
+        );
+        assert_eq!(
+            (ports[1].host_port, ports[1].protocol.as_str()),
+            (53, "udp")
+        );
     }
 }
 

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -228,6 +228,15 @@ async fn handle_deploy(
             report_error(&mut socket, &req.name, "dispatch", "unknown deploy kind").await;
         }
     }
+    if let Err(e) = crate::router::apps::sync_published_firewall_ports(&state).await {
+        crate::auth::audit(
+            "app_firewall_sync_failed",
+            &session.username,
+            &client_ip,
+            &format!("app={} error={e}", req.name),
+        );
+        warn!("deploy '{}': firewall reconciliation failed: {e}", req.name);
+    }
 }
 
 async fn deploy_simple(
@@ -339,6 +348,10 @@ async fn deploy_simple(
         Ok(app) => {
             if chose_subdomain {
                 tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+            }
+            if let Err(e) = crate::router::apps::sync_published_firewall_ports(state).await {
+                report_error(socket, &req.name, "firewall", &e).await;
+                return;
             }
             let _ = socket
                 .send(Message::Text(
@@ -622,6 +635,10 @@ async fn deploy_compose(
         }
     }
 
+    if let Err(e) = crate::router::apps::sync_published_firewall_ports(state).await {
+        report_error(socket, &req.name, "firewall", &e).await;
+        return;
+    }
     let action = if is_update { "updated" } else { "deployed" };
     let _ = socket
         .send(Message::Text(
@@ -746,6 +763,10 @@ async fn deploy_pull(socket: &mut WebSocket, state: &AppState, req: &DeployReque
         }
     }
 
+    if let Err(e) = crate::router::apps::sync_published_firewall_ports(state).await {
+        report_error(socket, &req.name, "firewall", &e).await;
+        return;
+    }
     let _ = socket
         .send(Message::Text(
             DeployMessage::log(&format!("Image update complete for '{}'", req.name)).into(),

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -85,6 +85,8 @@ pub struct AppState {
     pub nvmeof: Arc<nasty_sharing::NvmeofService>,
     pub vms: nasty_vm::VmService,
     pub apps: nasty_apps::AppsService,
+    pub app_firewall_sync: tokio::sync::Mutex<()>,
+    pub portal_firewall_sync: tokio::sync::Mutex<()>,
     pub backups: nasty_backup::BackupService,
     pub firmware: nasty_system::firmware::FirmwareService,
     /// Cached alerts result (timestamp, json value). Avoids re-evaluating
@@ -230,6 +232,8 @@ async fn main() -> anyhow::Result<()> {
         nvmeof,
         vms: nasty_vm::VmService::new(),
         apps: nasty_apps::AppsService::new(),
+        app_firewall_sync: tokio::sync::Mutex::new(()),
+        portal_firewall_sync: tokio::sync::Mutex::new(()),
         backups: nasty_backup::BackupService::new(),
         firmware: nasty_system::firmware::FirmwareService::new(),
         alerts_cache: tokio::sync::Mutex::new(None),
@@ -245,6 +249,9 @@ async fn main() -> anyhow::Result<()> {
             "subvolumes.restore_block_devices",
             "nvmeof.remap_device_paths",
             "iscsi.remap_device_paths",
+            "network.restore_pending_revert",
+            "network.reconcile_orphans",
+            "firewall.init",
             "protocols.restore",
             "smb.scaffold_config",
             "domain.restore",
@@ -253,8 +260,6 @@ async fn main() -> anyhow::Result<()> {
             "vms.restore",
             "apps.restore",
             "tailscale.restore",
-            "network.restore_pending_revert",
-            "network.reconcile_orphans",
             "subvolumes.reconcile_project_ids",
             "apps.reconcile_app_routes",
             "apps.reconcile_networks",
@@ -263,7 +268,6 @@ async fn main() -> anyhow::Result<()> {
             "oidc.migrate_secrets",
             "iscsi.migrate_secrets",
             "notifications.migrate_secrets",
-            "firewall.init",
             "nvmeof.ensure_tailscale_ports",
             "caches.warm",
         ]),
@@ -336,6 +340,70 @@ async fn main() -> anyhow::Result<()> {
             )
             .await;
     }
+
+    // Settle any interrupted network transaction and remove orphaned profiles
+    // before rendering interface-restricted firewall rules.
+    state
+        .boot_status
+        .run_phase(
+            "network.restore_pending_revert",
+            secs(60), // file check is instant; revert path runs nmcli
+            state.network.restore_pending_revert(),
+        )
+        .await;
+    state
+        .boot_status
+        .run_phase(
+            "network.reconcile_orphans",
+            secs(30), // a handful of NM connection deletes at most
+            state.network.reconcile_orphans(),
+        )
+        .await;
+
+    // Install the complete dynamic policy before restoring any listener,
+    // VM, app, or VPN. The declarative NixOS baseline remains default-drop
+    // until this transaction succeeds; failure is fatal so systemd retries
+    // instead of exposing services behind an incomplete firewall.
+    let firewall_result = state
+        .boot_status
+        .run_phase("firewall.init", secs(15), {
+            let state = state.clone();
+            async move {
+                use nasty_system::protocol::Protocol;
+                let result = async {
+                    let mut proto_states = Vec::new();
+                    for proto in Protocol::ALL {
+                        proto_states.push((*proto, state.protocols.is_enabled(*proto).await));
+                    }
+                    let rdma_enabled = nasty_system::rdma::enabled().await;
+                    let dc_enabled = nasty_system::dc::DcService::load_config().await.is_some();
+                    let (iscsi_ports, nvmeof_ports) =
+                        router::share::portal_firewall_ports(&state).await?;
+                    let published = router::apps::published_firewall_ports(&state).await?;
+                    state
+                        .firewall
+                        .init(
+                            &proto_states,
+                            rdma_enabled,
+                            dc_enabled,
+                            iscsi_ports,
+                            nvmeof_ports,
+                            published,
+                        )
+                        .await?;
+                    Ok::<(), String>(())
+                }
+                .await;
+                Some(result)
+            }
+        })
+        .await;
+    match firewall_result {
+        Some(Ok(())) => {}
+        Some(Err(e)) => return Err(anyhow::anyhow!("firewall initialization failed: {e}")),
+        None => return Err(anyhow::anyhow!("firewall initialization timed out")),
+    }
+
     state
         .boot_status
         .run_phase(
@@ -344,6 +412,21 @@ async fn main() -> anyhow::Result<()> {
             state.protocols.restore(),
         )
         .await;
+    // Protocol restore disables persisted entries whose daemons fail to start.
+    // Close those rules as one follow-up transaction before restoring anything
+    // else that could independently bring a listener back.
+    {
+        use nasty_system::protocol::Protocol;
+        let mut actual_states = Vec::new();
+        for proto in Protocol::ALL {
+            actual_states.push((*proto, state.protocols.is_enabled(*proto).await));
+        }
+        state
+            .firewall
+            .set_protocol_states(&actual_states)
+            .await
+            .map_err(|e| anyhow::anyhow!("firewall protocol reconciliation failed: {e}"))?;
+    }
 
     // Rebuild the smb.nasty.conf include chain before anything AD-related
     // runs. tmpfiles ships that file empty and only a share mutation ever
@@ -387,10 +470,8 @@ async fn main() -> anyhow::Result<()> {
     // /run resolved drop-in (tmpfs — empty after reboot) and start
     // samba-dc (Conflicts= swaps member-mode samba out). Must run after
     // the smb.nasty.conf reconcile above — the DC config includes it.
-    // The DC firewall opens later, in firewall.init: at this point in
-    // boot `state.rules` holds nothing yet, so opening here would
-    // rebuild the nftables table before the base (webui/ssh) rules
-    // exist, locking management out until firewall.init runs.
+    // The DC firewall was installed before service restoration above, so the
+    // listener never starts ahead of its rule.
     state
         .boot_status
         .run_phase("dc.restore", secs(30), {
@@ -424,7 +505,7 @@ async fn main() -> anyhow::Result<()> {
             state.vms.restore(),
         )
         .await;
-    state
+    let mut app_restore_updates = state
         .boot_status
         .run_phase(
             "apps.restore",
@@ -432,44 +513,25 @@ async fn main() -> anyhow::Result<()> {
             state.apps.restore(),
         )
         .await;
+    router::apps::sync_published_firewall_ports(&state)
+        .await
+        .map_err(|e| anyhow::anyhow!("app firewall reconciliation failed after restore: {e}"))?;
+    if let Some(mut updates) = app_restore_updates.take() {
+        let state = state.clone();
+        tokio::spawn(async move {
+            while updates.recv().await.is_some() {
+                if let Err(e) = router::apps::sync_published_firewall_ports(&state).await {
+                    error!("managed app startup firewall reconciliation failed: {e}");
+                }
+            }
+        });
+    }
     state
         .boot_status
         .run_phase(
             "tailscale.restore",
             secs(60), // network round-trip to login.tailscale.com
             state.tailscale.restore(),
-        )
-        .await;
-
-    // If the engine was killed mid-apply (or restarted before the user
-    // confirmed a risky network change), restore the prior config from
-    // /var/lib/nasty/networking.json.pending-revert. No-op if the file
-    // doesn't exist. Runs before the HTTP server starts accepting calls
-    // so a confirm can't race the rollback.
-    state
-        .boot_status
-        .run_phase(
-            "network.restore_pending_revert",
-            secs(60), // file check is instant; revert path runs nmcli
-            state.network.restore_pending_revert(),
-        )
-        .await;
-
-    // Idempotent sweep: drop networking.json `interfaces[]` entries
-    // that no longer correspond to any live device or virtual
-    // master, and the matching `nasty-*` NM connection profiles.
-    // Happens automatically on every boot — needed because the
-    // kernel can rename devices across reboots (Mellanox multi-port
-    // adapters: `enp6s0f0` → `enp6s0f0np0`), and because the
-    // engine's apply path doesn't garbage-collect dead profiles
-    // otherwise.  Runs before firewall.init so the firewall mirrors
-    // the cleaned-on-disk state.
-    state
-        .boot_status
-        .run_phase(
-            "network.reconcile_orphans",
-            secs(30), // a handful of NM connection deletes at most
-            state.network.reconcile_orphans(),
         )
         .await;
 
@@ -588,39 +650,6 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async {
         nasty_system::settings::reapply_tls_from_disk().await;
     });
-
-    // Initialize firewall based on current protocol states
-    state
-        .boot_status
-        .run_phase("firewall.init", secs(15), {
-            let state = state.clone();
-            async move {
-                use nasty_system::protocol::Protocol;
-                let mut proto_states = Vec::new();
-                for p in Protocol::ALL {
-                    let enabled = state.protocols.is_enabled(*p).await;
-                    proto_states.push((*p, enabled));
-                }
-                state.firewall.init(&proto_states).await;
-                // RDMA transports are a per-box opt-in orthogonal to the
-                // protocol list; restore its firewall rule when enabled.
-                if nasty_system::rdma::enabled().await {
-                    state.firewall.open_rdma().await;
-                }
-                // DC role (#20): open the AD service ports once the base rules exist.
-                // dc.restore (earlier) only restarts the service + DNS drop-in — opening
-                // the firewall there would rebuild the table before webui/ssh rules are
-                // in state, locking management out until this point.
-                if nasty_system::dc::DcService::load_config().await.is_some() {
-                    state.firewall.open_dc().await;
-                }
-                // iSCSI/NVMe-oF rules follow configured portal ports
-                // (#602); replace the static defaults with the real
-                // port sets from restored targets.
-                router::share::sync_portal_firewall_ports(&state).await;
-            }
-        })
-        .await;
 
     // Sync NVMe-oF ports with Tailscale IP (if Tailscale reconnected on boot)
     state

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1741,7 +1741,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "system.firewall.status",
-                    desc: "Return the current firewall rules, per-service source/interface restrictions, and the host ports Docker-managed apps publish (read-only — these bypass the nftables firewall and are listed for visibility only).",
+                    desc: "Return the current firewall rules, per-service source/interface restrictions, and Docker-managed app ports allowed by the forward policy.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<FirewallStatus>(generator)),

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -11,12 +11,47 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+pub(crate) async fn published_firewall_ports(
+    state: &AppState,
+) -> Result<Vec<nasty_system::firewall::PublishedAppPort>, String> {
+    let apps = state
+        .apps
+        .list()
+        .await
+        .map_err(|e| format!("list apps for firewall: {e}"))?;
+    let mut published: Vec<nasty_system::firewall::PublishedAppPort> = apps
+        .iter()
+        .flat_map(|app| {
+            app.ports
+                .iter()
+                .map(move |port| nasty_system::firewall::PublishedAppPort {
+                    app: app.name.clone(),
+                    host_port: port.host_port,
+                    container_port: port.container_port,
+                    transport: port.protocol.to_ascii_lowercase(),
+                })
+        })
+        .collect();
+    published.sort_by(|a, b| {
+        a.host_port
+            .cmp(&b.host_port)
+            .then_with(|| a.app.cmp(&b.app))
+    });
+    Ok(published)
+}
+
+pub(crate) async fn sync_published_firewall_ports(state: &AppState) -> Result<(), String> {
+    let _sync = state.app_firewall_sync.lock().await;
+    let published = published_firewall_ports(state).await?;
+    state.firewall.set_published_app_ports(published).await
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
-    Some(match req.method.as_str() {
+    let response = match req.method.as_str() {
         "apps.status" => ok(req, state.apps.status().await),
         "apps.enable" => {
             let p: nasty_apps::EnableAppsRequest = parse_params(req).unwrap_or_default();
@@ -426,5 +461,28 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         _ => return None,
-    })
+    };
+    let changes_published_ports = matches!(
+        req.method.as_str(),
+        "apps.enable"
+            | "apps.disable"
+            | "apps.install"
+            | "apps.update"
+            | "apps.remove"
+            | "apps.pull"
+            | "apps.compose.install"
+            | "apps.compose.update"
+            | "apps.compose.remove"
+            | "apps.compose.set_startup"
+    );
+    if changes_published_ports && let Err(e) = sync_published_firewall_ports(state).await {
+        if response.error.is_none() {
+            return Some(err(
+                req,
+                format!("app state changed but firewall synchronization failed: {e}"),
+            ));
+        }
+        tracing::warn!("app firewall reconciliation after failed request also failed: {e}");
+    }
+    Some(response)
 }

--- a/engine/nasty-engine/src/router/dc.rs
+++ b/engine/nasty-engine/src/router/dc.rs
@@ -41,11 +41,18 @@ pub(super) async fn try_route(
             Ok(p) => match state.dc.provision(p).await {
                 Ok((status, warnings)) => {
                     // DC ports open only after a successful provision.
-                    state.firewall.open_dc().await;
-                    ok(
-                        req,
-                        serde_json::json!({ "status": status, "warnings": warnings }),
-                    )
+                    match state.firewall.open_dc().await {
+                        Ok(()) => ok(
+                            req,
+                            serde_json::json!({ "status": status, "warnings": warnings }),
+                        ),
+                        Err(e) => err(
+                            req,
+                            format!(
+                                "domain controller provisioned but firewall update failed: {e}"
+                            ),
+                        ),
+                    }
                 }
                 Err(e) => err(req, e),
             },
@@ -54,7 +61,7 @@ pub(super) async fn try_route(
         "dc.demote" => match parse_params::<nasty_system::dc::DemoteRequest>(req) {
             Ok(p) => match state.dc.demote(p).await {
                 Ok(()) => {
-                    state.firewall.close_dc().await;
+                    let firewall_result = state.firewall.close_dc().await;
                     // Teardown (inside dc.demote) stops samba-dc.service,
                     // but nothing else restarts the member-mode SMB units
                     // it had Conflicts=-swapped out — bring SMB back under
@@ -72,7 +79,13 @@ pub(super) async fn try_route(
                     {
                         tracing::warn!("dc.demote: failed to restart SMB after demote: {e}");
                     }
-                    ok(req, "ok")
+                    match firewall_result {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(
+                            req,
+                            format!("domain controller demoted but firewall update failed: {e}"),
+                        ),
+                    }
                 }
                 Err(e) => err(req, e),
             },

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -2,7 +2,7 @@ use nasty_common::{ErrorCode, Request, Response};
 use tracing::debug;
 
 mod alerts;
-mod apps;
+pub(crate) mod apps;
 mod audit;
 mod auth;
 mod backup;

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -19,24 +19,49 @@ pub(super) async fn try_route(
     Some(match req.method.as_str() {
         "service.protocol.list" => ok(req, state.protocols.list().await),
         "service.protocol.enable" => match require_str(req, "name") {
-            Ok(name) => match state.protocols.enable(name).await {
-                Ok(v) => {
-                    if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
-                        state.firewall.open(proto).await;
+            Ok(name) => {
+                if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
+                    match state.firewall.open(proto).await {
+                        Err(e) => err(req, format!("firewall update failed: {e}")),
+                        Ok(()) => match state.protocols.enable(name).await {
+                            Ok(v) => ok(req, v),
+                            Err(service_error) => {
+                                let rollback = state.firewall.close(proto).await;
+                                match rollback {
+                                    Ok(()) => err(req, service_error),
+                                    Err(firewall_error) => err(
+                                        req,
+                                        format!(
+                                            "{service_error}; firewall rollback also failed: {firewall_error}"
+                                        ),
+                                    ),
+                                }
+                            }
+                        },
                     }
-                    ok(req, v)
+                } else {
+                    match state.protocols.enable(name).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
                 }
-                Err(e) => err(req, e),
-            },
+            }
             Err(r) => r,
         },
         "service.protocol.disable" => match require_str(req, "name") {
             Ok(name) => match state.protocols.disable(name).await {
                 Ok(v) => {
                     if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
-                        state.firewall.close(proto).await;
+                        match state.firewall.close(proto).await {
+                            Ok(()) => ok(req, v),
+                            Err(e) => err(
+                                req,
+                                format!("protocol disabled but firewall update failed: {e}"),
+                            ),
+                        }
+                    } else {
+                        ok(req, v)
                     }
-                    ok(req, v)
                 }
                 Err(e) => err(req, e),
             },

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -21,21 +21,26 @@ pub(super) async fn try_route(
     // (#602). Resync after any mutation that can change them; gate
     // refusals and errors return early above or carry `error`, so only
     // real changes pay the recompute.
-    if resp.error.is_none()
-        && matches!(
-            req.method.as_str(),
-            "share.iscsi.create"
-                | "share.iscsi.delete"
-                | "share.iscsi.add_portal"
-                | "share.iscsi.remove_portal"
-                | "share.iscsi.set_portals"
-                | "share.nvmeof.create"
-                | "share.nvmeof.delete"
-                | "share.nvmeof.add_port"
-                | "share.nvmeof.remove_port"
-        )
-    {
-        sync_portal_firewall_ports(state).await;
+    let changes_portals = matches!(
+        req.method.as_str(),
+        "share.iscsi.create"
+            | "share.iscsi.delete"
+            | "share.iscsi.add_portal"
+            | "share.iscsi.remove_portal"
+            | "share.iscsi.set_portals"
+            | "share.nvmeof.create"
+            | "share.nvmeof.delete"
+            | "share.nvmeof.add_port"
+            | "share.nvmeof.remove_port"
+    );
+    if changes_portals && let Err(e) = sync_portal_firewall_ports(state).await {
+        if resp.error.is_none() {
+            return Some(err(
+                req,
+                format!("share changed but firewall port synchronization failed: {e}"),
+            ));
+        }
+        tracing::warn!("portal firewall reconciliation after failed request also failed: {e}");
     }
     Some(resp)
 }
@@ -46,9 +51,16 @@ pub(super) async fn try_route(
 /// `create` will bind. NVMe-oF RDMA listeners are excluded — RoCE
 /// rides udp/4791 under the separate `rdma` rule, and native IB never
 /// traverses netfilter.
-pub(crate) async fn sync_portal_firewall_ports(state: &AppState) {
+pub(crate) async fn portal_firewall_ports(
+    state: &AppState,
+) -> Result<
+    (
+        Vec<nasty_system::firewall::PortSpec>,
+        Vec<nasty_system::firewall::PortSpec>,
+    ),
+    String,
+> {
     use nasty_system::firewall::{PortSpec, Transport};
-    use nasty_system::protocol::Protocol;
     use std::collections::BTreeSet;
 
     let tcp = |port: u16| PortSpec {
@@ -60,40 +72,49 @@ pub(crate) async fn sync_portal_firewall_ports(state: &AppState) {
     };
 
     let mut iscsi_ports: BTreeSet<u16> = BTreeSet::new();
-    if let Ok(targets) = state.iscsi.list().await {
-        iscsi_ports.extend(
-            targets
-                .iter()
-                .flat_map(|t| t.portals.iter().map(|p| p.port)),
-        );
-    }
+    let targets = state
+        .iscsi
+        .list()
+        .await
+        .map_err(|e| format!("list iSCSI targets: {e}"))?;
+    iscsi_ports.extend(
+        targets
+            .iter()
+            .flat_map(|target| target.portals.iter().map(|portal| portal.port)),
+    );
     if iscsi_ports.is_empty() {
         iscsi_ports.insert(3260);
     }
-    state
-        .firewall
-        .set_service_ports(Protocol::Iscsi, iscsi_ports.into_iter().map(tcp).collect())
-        .await;
 
     let mut nvmeof_ports: BTreeSet<u16> = BTreeSet::new();
-    if let Ok(subsystems) = state.nvmeof.list().await {
-        nvmeof_ports.extend(subsystems.iter().flat_map(|s| {
-            s.ports
-                .iter()
-                .filter(|p| p.transport == "tcp")
-                .filter_map(|p| p.service_id.parse::<u16>().ok())
-        }));
-    }
+    let subsystems = state
+        .nvmeof
+        .list()
+        .await
+        .map_err(|e| format!("list NVMe-oF subsystems: {e}"))?;
+    nvmeof_ports.extend(subsystems.iter().flat_map(|subsystem| {
+        subsystem
+            .ports
+            .iter()
+            .filter(|port| port.transport == "tcp")
+            .filter_map(|port| port.service_id.parse::<u16>().ok())
+    }));
     if nvmeof_ports.is_empty() {
         nvmeof_ports.insert(4420);
     }
+    Ok((
+        iscsi_ports.into_iter().map(tcp).collect(),
+        nvmeof_ports.into_iter().map(tcp).collect(),
+    ))
+}
+
+pub(crate) async fn sync_portal_firewall_ports(state: &AppState) -> Result<(), String> {
+    let _sync = state.portal_firewall_sync.lock().await;
+    let (iscsi_ports, nvmeof_ports) = portal_firewall_ports(state).await?;
     state
         .firewall
-        .set_service_ports(
-            Protocol::Nvmeof,
-            nvmeof_ports.into_iter().map(tcp).collect(),
-        )
-        .await;
+        .set_portal_ports(iscsi_ports, nvmeof_ports)
+        .await
 }
 
 async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Option<Response> {
@@ -410,27 +431,21 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                                 let ts = state.tailscale.get().await;
                                 if ts.connected
                                     && let Some(ref ip) = ts.ip
+                                    && let Err(e) = state
+                                        .nvmeof
+                                        .add_port(nasty_sharing::nvmeof::AddPortRequest {
+                                            subsystem_id: v.id.clone(),
+                                            transport: Some("tcp".to_string()),
+                                            addr: Some(ip.clone()),
+                                            service_id: Some(4420),
+                                            addr_family: Some("ipv4".to_string()),
+                                        })
+                                        .await
                                 {
-                                    let nvmeof = state.nvmeof.clone();
-                                    let id = v.id.clone();
-                                    let ip = ip.clone();
-                                    let nqn_for_log = v.nqn.clone();
-                                    tokio::spawn(async move {
-                                        if let Err(e) = nvmeof
-                                            .add_port(nasty_sharing::nvmeof::AddPortRequest {
-                                                subsystem_id: id,
-                                                transport: Some("tcp".to_string()),
-                                                addr: Some(ip.clone()),
-                                                service_id: Some(4420),
-                                                addr_family: Some("ipv4".to_string()),
-                                            })
-                                            .await
-                                        {
-                                            tracing::warn!(
-                                                "auto-add Tailscale port for '{nqn_for_log}' on {ip} failed: {e}"
-                                            );
-                                        }
-                                    });
+                                    tracing::warn!(
+                                        "auto-add Tailscale port for '{}' on {ip} failed: {e}",
+                                        v.nqn
+                                    );
                                 }
                             }
                             ok(req, v)

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -18,9 +18,8 @@ struct CustomRuleUpdateParams {
     input: nasty_system::firewall::CustomRuleInput,
 }
 
-/// Warnings (never errors) for a custom rule that overlaps a Docker-published
-/// host port. Bridge apps publish past the firewall, so the rule is redundant
-/// — surfaced so the operator doesn't think the port was closed.
+/// Warnings (never errors) for a custom rule that overlaps an app port already
+/// allowed by the generated Docker forward policy.
 pub(crate) fn docker_overlap_warnings(
     rule: &nasty_system::firewall::CustomRule,
     published: &[nasty_system::firewall::PublishedAppPort],
@@ -35,7 +34,7 @@ pub(crate) fn docker_overlap_warnings(
         .filter(|p| p.transport == proto && p.host_port >= rule.from && p.host_port <= rule.to)
         .map(|p| {
             format!(
-                "{}/{} is already reachable via app '{}' (bridge apps publish past the firewall)",
+                "{}/{} is already allowed for app '{}' by the Docker forward policy",
                 proto, p.host_port, p.app
             )
         })
@@ -56,7 +55,7 @@ async fn published_ports(state: &AppState) -> Vec<nasty_system::firewall::Publis
                         app: app.name.clone(),
                         host_port: p.host_port,
                         container_port: p.container_port,
-                        transport: p.protocol.clone(),
+                        transport: p.protocol.to_ascii_lowercase(),
                     })
             })
             .collect(),
@@ -179,12 +178,18 @@ pub(super) async fn try_route(
                 }
                 match nasty_system::rdma::set_enabled(p.enabled).await {
                     Ok(status) => {
-                        if p.enabled {
-                            state.firewall.open_rdma().await;
+                        let firewall_result = if p.enabled {
+                            state.firewall.open_rdma().await
                         } else {
-                            state.firewall.close_rdma().await;
+                            state.firewall.close_rdma().await
+                        };
+                        match firewall_result {
+                            Ok(()) => ok(req, status),
+                            Err(e) => err(
+                                req,
+                                format!("RDMA setting changed but firewall update failed: {e}"),
+                            ),
                         }
-                        ok(req, status)
                     }
                     Err(e) => err(req, e),
                 }
@@ -817,36 +822,7 @@ pub(super) async fn try_route(
             Ok(()) => ok(req, "ok"),
             Err(e) => err(req, e),
         },
-        "system.firewall.status" => {
-            // Enrich the service-rule view with the host ports Docker apps
-            // publish. These bypass the nftables firewall (DNAT in
-            // prerouting), so the firewall module can't see them — but
-            // surfacing them here gives the operator a complete
-            // "what's listening on this box" picture in one place.
-            let mut status = state.firewall.status().await;
-            if let Ok(apps) = state.apps.list().await {
-                let mut published: Vec<nasty_system::firewall::PublishedAppPort> = apps
-                    .iter()
-                    .flat_map(|app| {
-                        app.ports
-                            .iter()
-                            .map(move |p| nasty_system::firewall::PublishedAppPort {
-                                app: app.name.clone(),
-                                host_port: p.host_port,
-                                container_port: p.container_port,
-                                transport: p.protocol.clone(),
-                            })
-                    })
-                    .collect();
-                published.sort_by(|a, b| {
-                    a.host_port
-                        .cmp(&b.host_port)
-                        .then_with(|| a.app.cmp(&b.app))
-                });
-                status.published_app_ports = published;
-            }
-            ok(req, status)
-        }
+        "system.firewall.status" => ok(req, state.firewall.status().await),
         "system.firewall.restrict" => {
             let service = match require_str(req, "service") {
                 Ok(s) => s.to_string(),

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -7,6 +7,9 @@ use crate::protocol::Protocol;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tracing::{error, info, warn};
 
@@ -26,18 +29,14 @@ pub struct FirewallRestrictions {
 }
 
 impl FirewallRestrictions {
-    pub fn load() -> Self {
-        std::fs::read_to_string(RESTRICTIONS_PATH)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
-    }
-
-    pub async fn save(&self) -> Result<(), String> {
-        let json = serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {e}"))?;
-        tokio::fs::write(RESTRICTIONS_PATH, json)
-            .await
-            .map_err(|e| format!("write {RESTRICTIONS_PATH}: {e}"))
+    fn load(path: &Path) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(json) => {
+                serde_json::from_str(&json).map_err(|e| format!("parse {}: {e}", path.display()))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(format!("read {}: {e}", path.display())),
+        }
     }
 
     /// Drop every reference to interfaces in `removed` from this
@@ -133,18 +132,14 @@ const CUSTOM_PATH: &str = "/var/lib/nasty/firewall-custom.json";
 
 /// Load persisted custom rules; empty on missing/corrupt file (same
 /// tolerance as `FirewallRestrictions::load`).
-fn load_custom_rules() -> Vec<CustomRule> {
-    std::fs::read_to_string(CUSTOM_PATH)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
-}
-
-async fn save_custom_rules(rules: &[CustomRule]) -> Result<(), String> {
-    let json = serde_json::to_string_pretty(rules).map_err(|e| format!("serialize: {e}"))?;
-    tokio::fs::write(CUSTOM_PATH, json)
-        .await
-        .map_err(|e| format!("write {CUSTOM_PATH}: {e}"))
+fn load_custom_rules(path: &Path) -> Result<Vec<CustomRule>, String> {
+    match std::fs::read_to_string(path) {
+        Ok(json) => {
+            serde_json::from_str(&json).map_err(|e| format!("parse {}: {e}", path.display()))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
+    }
 }
 
 fn default_true() -> bool {
@@ -261,14 +256,9 @@ pub struct FirewallStatus {
     pub restrictions: HashMap<String, Vec<String>>,
     /// Per-service interface restrictions.
     pub interface_restrictions: HashMap<String, Vec<String>>,
-    /// Ports that Docker-managed apps publish on the host. These are NOT
-    /// governed by this firewall — Docker DNATs published ports in
-    /// `prerouting` straight to the container, so they bypass the `inet
-    /// nasty` input chain entirely. Listed here for visibility only, so an
-    /// operator sees the full "what's open on this box" picture in one
-    /// place; their only real gate is the upstream/cloud firewall. The
-    /// engine layer fills this from `apps.list`; the firewall module
-    /// itself has no knowledge of Docker.
+    /// Ports that Docker-managed apps publish on the host. The firewall's
+    /// early forward hook permits these explicitly by original DNAT port and
+    /// drops other original-direction inbound DNAT traffic.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub published_app_ports: Vec<PublishedAppPort>,
     /// User-managed custom port rules (issue #620). Rendered into the
@@ -280,7 +270,7 @@ pub struct FirewallStatus {
 /// One host port published by a Docker-managed app. Read-only; surfaced
 /// on the firewall page alongside the service rules. See
 /// [`FirewallStatus::published_app_ports`].
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PublishedAppPort {
     /// App that published the port.
     pub app: String,
@@ -380,10 +370,23 @@ pub fn dc_ports() -> Vec<PortSpec> {
 
 // ── Firewall service ───────────────────────────────────────────
 
+#[derive(Clone, Default)]
+struct FirewallConfig {
+    state: FirewallState,
+    restrictions: FirewallRestrictions,
+    custom: Vec<CustomRule>,
+    published: Vec<PublishedAppPort>,
+}
+
+struct FirewallPaths {
+    restrictions: PathBuf,
+    custom: PathBuf,
+}
+
 pub struct FirewallService {
-    state: tokio::sync::Mutex<FirewallState>,
-    restrictions: tokio::sync::Mutex<FirewallRestrictions>,
-    custom: tokio::sync::Mutex<Vec<CustomRule>>,
+    config: tokio::sync::Mutex<FirewallConfig>,
+    paths: FirewallPaths,
+    nft_program: PathBuf,
 }
 
 impl Default for FirewallService {
@@ -395,296 +398,470 @@ impl Default for FirewallService {
 impl FirewallService {
     pub fn new() -> Self {
         Self {
-            state: tokio::sync::Mutex::new(FirewallState::default()),
-            restrictions: tokio::sync::Mutex::new(FirewallRestrictions::default()),
-            custom: tokio::sync::Mutex::new(Vec::new()),
+            config: tokio::sync::Mutex::new(FirewallConfig::default()),
+            paths: FirewallPaths {
+                restrictions: PathBuf::from(RESTRICTIONS_PATH),
+                custom: PathBuf::from(CUSTOM_PATH),
+            },
+            nft_program: PathBuf::from("nft"),
         }
     }
 
-    /// Initialize firewall with current protocol states.
-    /// Called at engine startup after protocol restore.
-    pub async fn init(&self, enabled_protocols: &[(Protocol, bool)]) {
-        let mut state = self.state.lock().await;
-        let mut restrictions = self.restrictions.lock().await;
-        *restrictions = FirewallRestrictions::load();
-        let mut custom = self.custom.lock().await;
-        *custom = load_custom_rules();
+    async fn commit_candidate(
+        &self,
+        current: &mut FirewallConfig,
+        candidate: FirewallConfig,
+        staged: Option<StagedJson>,
+    ) -> Result<(), String> {
+        if let Err(e) = apply_nftables_with(
+            &self.nft_program,
+            &candidate.state,
+            &candidate.custom,
+            &candidate.published,
+        )
+        .await
+        {
+            if let Some(staged) = staged {
+                staged.discard().await;
+            }
+            return Err(e);
+        }
 
-        // WebUI is always open
-        let webui_sources = restrictions
+        if let Some(staged) = staged
+            && let Err(persist_error) = staged.commit().await
+        {
+            let rollback = apply_nftables_with(
+                &self.nft_program,
+                &current.state,
+                &current.custom,
+                &current.published,
+            )
+            .await;
+            if let Err(rollback_error) = rollback {
+                error!(
+                    "CRITICAL: firewall persistence failed and live-rule rollback also failed: \
+                     persist={persist_error}; rollback={rollback_error}"
+                );
+                // The candidate is still live in the kernel. Keep status and
+                // subsequent transactions aligned with reality even though
+                // disk remains stale; the returned error forces the caller to
+                // surface the degraded persistence state.
+                *current = candidate;
+                return Err(format!(
+                    "persist firewall state: {persist_error}; live rollback also failed: \
+                     {rollback_error}; in-memory state reflects the live candidate"
+                ));
+            }
+            return Err(format!(
+                "persist firewall state: {persist_error}; previous live rules restored"
+            ));
+        }
+
+        *current = candidate;
+        Ok(())
+    }
+
+    async fn set_rule_active(
+        &self,
+        service: &str,
+        base_ports: Vec<PortSpec>,
+        active: bool,
+    ) -> Result<(), String> {
+        if base_ports.is_empty() {
+            return Ok(());
+        }
+        let mut current = self.config.lock().await;
+        let mut candidate = current.clone();
+        if let Some(rule) = candidate
+            .state
+            .rules
+            .iter_mut()
+            .find(|rule| rule.service == service)
+        {
+            if rule.active == active {
+                return Ok(());
+            }
+            rule.active = active;
+        } else {
+            let sources = candidate
+                .restrictions
+                .services
+                .get(service)
+                .cloned()
+                .unwrap_or_default();
+            let ifaces = candidate
+                .restrictions
+                .interfaces
+                .get(service)
+                .cloned()
+                .unwrap_or_default();
+            candidate.state.rules.push(FirewallRule {
+                service: service.to_string(),
+                ports: apply_restrictions(base_ports, &sources, &ifaces),
+                active,
+            });
+        }
+        self.commit_candidate(&mut current, candidate, None).await
+    }
+
+    /// Initialize the complete firewall policy in one transaction before any
+    /// engine-managed network-facing services are restored.
+    pub async fn init(
+        &self,
+        enabled_protocols: &[(Protocol, bool)],
+        rdma_enabled: bool,
+        dc_enabled: bool,
+        iscsi_ports: Vec<PortSpec>,
+        nvmeof_ports: Vec<PortSpec>,
+        published: Vec<PublishedAppPort>,
+    ) -> Result<(), String> {
+        let mut current = self.config.lock().await;
+        let restrictions = FirewallRestrictions::load(&self.paths.restrictions)?;
+        let custom = load_custom_rules(&self.paths.custom)?;
+        let mut candidate = FirewallConfig {
+            state: FirewallState::default(),
+            restrictions,
+            custom,
+            published,
+        };
+
+        let webui_sources = candidate
+            .restrictions
             .services
             .get("webui")
             .cloned()
             .unwrap_or_default();
-        let webui_ifaces = restrictions
+        let webui_ifaces = candidate
+            .restrictions
             .interfaces
             .get("webui")
             .cloned()
             .unwrap_or_default();
-        state.rules.push(FirewallRule {
+        candidate.state.rules.push(FirewallRule {
             service: "webui".to_string(),
             ports: apply_restrictions(webui_ports(), &webui_sources, &webui_ifaces),
             active: true,
         });
 
-        // Add rules for each protocol
         for (proto, enabled) in enabled_protocols {
-            let mut ports = ports_for_protocol(*proto);
+            let ports = ports_for_protocol(*proto);
             if ports.is_empty() {
                 continue;
             }
-            let sources = restrictions
+            let sources = candidate
+                .restrictions
                 .services
                 .get(proto.name())
                 .cloned()
                 .unwrap_or_default();
-            let ifaces = restrictions
+            let ifaces = candidate
+                .restrictions
                 .interfaces
                 .get(proto.name())
                 .cloned()
                 .unwrap_or_default();
-            ports = apply_restrictions(ports, &sources, &ifaces);
-            state.rules.push(FirewallRule {
+            candidate.state.rules.push(FirewallRule {
                 service: proto.name().to_string(),
-                ports,
+                ports: apply_restrictions(ports, &sources, &ifaces),
                 active: *enabled,
             });
         }
 
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to apply initial firewall rules: {e}");
-        } else {
-            info!("Firewall initialized with {} rules", state.rules.len());
-        }
-    }
-
-    /// Open ports for a protocol (called when a service is enabled).
-    pub async fn open(&self, proto: Protocol) {
-        let mut state = self.state.lock().await;
-        let name = proto.name();
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == name) {
-            if rule.active {
-                return; // already open
-            }
-            rule.active = true;
-        } else {
-            let ports = ports_for_protocol(proto);
-            if ports.is_empty() {
-                return;
-            }
-            state.rules.push(FirewallRule {
-                service: name.to_string(),
-                ports,
-                active: true,
-            });
-        }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to open firewall for {name}: {e}");
-        } else {
-            info!("Firewall: opened ports for {name}");
-        }
-    }
-
-    /// Close ports for a protocol (called when a service is disabled).
-    pub async fn close(&self, proto: Protocol) {
-        let mut state = self.state.lock().await;
-        let name = proto.name();
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == name) {
-            if !rule.active {
-                return; // already closed
-            }
-            rule.active = false;
-        }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to close firewall for {name}: {e}");
-        } else {
-            info!("Firewall: closed ports for {name}");
-        }
-    }
-
-    /// Open the named RDMA transport rule (per-box opt-in, #602).
-    pub async fn open_rdma(&self) {
-        let mut state = self.state.lock().await;
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "rdma") {
-            if rule.active {
-                return;
-            }
-            rule.active = true;
-        } else {
-            state.rules.push(FirewallRule {
+        if rdma_enabled {
+            let sources = candidate
+                .restrictions
+                .services
+                .get("rdma")
+                .cloned()
+                .unwrap_or_default();
+            let ifaces = candidate
+                .restrictions
+                .interfaces
+                .get("rdma")
+                .cloned()
+                .unwrap_or_default();
+            candidate.state.rules.push(FirewallRule {
                 service: "rdma".to_string(),
-                ports: rdma_ports(),
+                ports: apply_restrictions(rdma_ports(), &sources, &ifaces),
                 active: true,
             });
         }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to open firewall for rdma: {e}");
-        } else {
-            info!("Firewall: opened ports for rdma");
-        }
-    }
-
-    /// Close the named RDMA transport rule.
-    pub async fn close_rdma(&self) {
-        let mut state = self.state.lock().await;
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "rdma") {
-            if !rule.active {
-                return;
-            }
-            rule.active = false;
-        }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to close firewall for rdma: {e}");
-        } else {
-            info!("Firewall: closed ports for rdma");
-        }
-    }
-
-    /// Open the named Active Directory DC rule (#20, per-box opt-in).
-    pub async fn open_dc(&self) {
-        let mut state = self.state.lock().await;
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "dc") {
-            if rule.active {
-                return;
-            }
-            rule.active = true;
-        } else {
-            state.rules.push(FirewallRule {
+        if dc_enabled {
+            let sources = candidate
+                .restrictions
+                .services
+                .get("dc")
+                .cloned()
+                .unwrap_or_default();
+            let ifaces = candidate
+                .restrictions
+                .interfaces
+                .get("dc")
+                .cloned()
+                .unwrap_or_default();
+            candidate.state.rules.push(FirewallRule {
                 service: "dc".to_string(),
-                ports: dc_ports(),
+                ports: apply_restrictions(dc_ports(), &sources, &ifaces),
                 active: true,
             });
         }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to open firewall for dc: {e}");
-        } else {
-            info!("Firewall: opened ports for dc");
-        }
+        replace_rule_ports(
+            &mut candidate.state,
+            &candidate.restrictions,
+            Protocol::Iscsi.name(),
+            iscsi_ports,
+        );
+        replace_rule_ports(
+            &mut candidate.state,
+            &candidate.restrictions,
+            Protocol::Nvmeof.name(),
+            nvmeof_ports,
+        );
+
+        let rule_count = candidate.state.rules.len();
+        self.commit_candidate(&mut current, candidate, None).await?;
+        info!("Firewall initialized with {rule_count} rules");
+        Ok(())
     }
 
-    /// Close the named Active Directory DC rule.
-    pub async fn close_dc(&self) {
-        let mut state = self.state.lock().await;
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == "dc") {
-            if !rule.active {
-                return;
+    /// Reconcile protocol rules after service restoration, which may disable a
+    /// persisted protocol whose daemon failed to start.
+    pub async fn set_protocol_states(
+        &self,
+        enabled_protocols: &[(Protocol, bool)],
+    ) -> Result<(), String> {
+        let mut current = self.config.lock().await;
+        let mut candidate = current.clone();
+        let mut changed = false;
+        for (proto, enabled) in enabled_protocols {
+            if let Some(rule) = candidate
+                .state
+                .rules
+                .iter_mut()
+                .find(|rule| rule.service == proto.name())
+                && rule.active != *enabled
+            {
+                rule.active = *enabled;
+                changed = true;
             }
-            rule.active = false;
         }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to close firewall for dc: {e}");
-        } else {
-            info!("Firewall: closed ports for dc");
+        if !changed {
+            return Ok(());
         }
+        self.commit_candidate(&mut current, candidate, None).await
     }
 
-    /// Get current firewall status including restrictions.
+    /// Replace the Docker DNAT allowlist rendered into the early forward hook.
+    pub async fn set_published_app_ports(
+        &self,
+        mut published: Vec<PublishedAppPort>,
+    ) -> Result<(), String> {
+        published.sort_by(|a, b| {
+            a.transport
+                .cmp(&b.transport)
+                .then_with(|| a.host_port.cmp(&b.host_port))
+                .then_with(|| a.app.cmp(&b.app))
+        });
+        published.dedup_by(|a, b| {
+            a.transport == b.transport && a.host_port == b.host_port && a.app == b.app
+        });
+        let mut current = self.config.lock().await;
+        if current.published == published {
+            return Ok(());
+        }
+        let mut candidate = current.clone();
+        candidate.published = published;
+        self.commit_candidate(&mut current, candidate, None).await
+    }
+
+    pub async fn open(&self, proto: Protocol) -> Result<(), String> {
+        let name = proto.name();
+        self.set_rule_active(name, ports_for_protocol(proto), true)
+            .await?;
+        info!("Firewall: opened ports for {name}");
+        Ok(())
+    }
+
+    pub async fn close(&self, proto: Protocol) -> Result<(), String> {
+        let name = proto.name();
+        self.set_rule_active(name, ports_for_protocol(proto), false)
+            .await?;
+        info!("Firewall: closed ports for {name}");
+        Ok(())
+    }
+
+    pub async fn open_rdma(&self) -> Result<(), String> {
+        self.set_rule_active("rdma", rdma_ports(), true).await?;
+        info!("Firewall: opened ports for rdma");
+        Ok(())
+    }
+
+    pub async fn close_rdma(&self) -> Result<(), String> {
+        self.set_rule_active("rdma", rdma_ports(), false).await?;
+        info!("Firewall: closed ports for rdma");
+        Ok(())
+    }
+
+    pub async fn open_dc(&self) -> Result<(), String> {
+        self.set_rule_active("dc", dc_ports(), true).await?;
+        info!("Firewall: opened ports for dc");
+        Ok(())
+    }
+
+    pub async fn close_dc(&self) -> Result<(), String> {
+        self.set_rule_active("dc", dc_ports(), false).await?;
+        info!("Firewall: closed ports for dc");
+        Ok(())
+    }
+
     pub async fn status(&self) -> FirewallStatus {
-        let state = self.state.lock().await;
-        let restrictions = self.restrictions.lock().await;
-        let custom = self.custom.lock().await;
+        let config = self.config.lock().await;
         FirewallStatus {
             active: true,
-            rules: state.rules.clone(),
-            restrictions: restrictions.services.clone(),
-            interface_restrictions: restrictions.interfaces.clone(),
-            // Populated by the engine layer (router) which has the apps
-            // handle; the firewall module has no Docker knowledge.
-            published_app_ports: Vec::new(),
-            custom_rules: custom.clone(),
+            rules: config.state.rules.clone(),
+            restrictions: config.restrictions.services.clone(),
+            interface_restrictions: config.restrictions.interfaces.clone(),
+            published_app_ports: config.published.clone(),
+            custom_rules: config.custom.clone(),
         }
     }
 
-    /// Set source IP and/or interface restrictions for a service and rebuild firewall.
     pub async fn set_restriction(
         &self,
         service: &str,
         sources: Vec<String>,
         ifaces: Vec<String>,
     ) -> Result<(), String> {
-        // Update persisted restrictions
-        {
-            let mut restrictions = self.restrictions.lock().await;
-            if sources.is_empty() {
-                restrictions.services.remove(service);
-            } else {
-                restrictions
-                    .services
-                    .insert(service.to_string(), sources.clone());
+        for source in &sources {
+            if !valid_source(source) {
+                return Err(format!("invalid source (expected an IP or CIDR): {source}"));
             }
-            if ifaces.is_empty() {
-                restrictions.interfaces.remove(service);
-            } else {
-                restrictions
-                    .interfaces
-                    .insert(service.to_string(), ifaces.clone());
-            }
-            restrictions.save().await?;
         }
+        for iface in &ifaces {
+            if !valid_iface(iface) {
+                return Err(format!("invalid interface name: {iface}"));
+            }
+        }
+        let default_ports = if service == "webui" {
+            webui_ports()
+        } else if service == "rdma" {
+            rdma_ports()
+        } else if service == "dc" {
+            dc_ports()
+        } else if let Some(proto) = Protocol::from_name(service) {
+            ports_for_protocol(proto)
+        } else {
+            return Err(format!("unknown service: {service}"));
+        };
 
-        // Update rules in state
-        let mut state = self.state.lock().await;
-        if let Some(rule) = state.rules.iter_mut().find(|r| r.service == service) {
-            let base_ports = if service == "webui" {
-                webui_ports()
-            } else if service == "rdma" {
-                rdma_ports()
-            } else if service == "dc" {
-                dc_ports()
-            } else if let Some(proto) = Protocol::from_name(service) {
-                ports_for_protocol(proto)
-            } else {
-                return Err(format!("unknown service: {service}"));
-            };
+        let mut current = self.config.lock().await;
+        let base_ports = current
+            .state
+            .rules
+            .iter()
+            .find(|rule| rule.service == service)
+            .map(|rule| {
+                let mut ports = Vec::new();
+                for mut port in rule.ports.iter().cloned() {
+                    port.source = None;
+                    port.iface = None;
+                    if !ports.contains(&port) {
+                        ports.push(port);
+                    }
+                }
+                ports
+            })
+            .unwrap_or(default_ports);
+        let mut candidate = current.clone();
+        if sources.is_empty() {
+            candidate.restrictions.services.remove(service);
+        } else {
+            candidate
+                .restrictions
+                .services
+                .insert(service.to_string(), sources.clone());
+        }
+        if ifaces.is_empty() {
+            candidate.restrictions.interfaces.remove(service);
+        } else {
+            candidate
+                .restrictions
+                .interfaces
+                .insert(service.to_string(), ifaces.clone());
+        }
+        if let Some(rule) = candidate
+            .state
+            .rules
+            .iter_mut()
+            .find(|rule| rule.service == service)
+        {
             rule.ports = apply_restrictions(base_ports, &sources, &ifaces);
         }
 
-        let custom = self.custom.lock().await;
-        apply_nftables(&state, &custom).await?;
+        let staged = StagedJson::stage(&self.paths.restrictions, &candidate.restrictions).await?;
+        self.commit_candidate(&mut current, candidate, Some(staged))
+            .await?;
         info!("Firewall: updated restrictions for {service}");
         Ok(())
     }
 
-    /// Get restrictions for a specific service.
     pub async fn get_restrictions(&self) -> HashMap<String, Vec<String>> {
-        self.restrictions.lock().await.services.clone()
+        self.config.lock().await.restrictions.services.clone()
     }
 
-    /// Point a service's firewall rule at a new port set. iSCSI and
-    /// NVMe-oF listen on operator-chosen portal ports, so their rules
-    /// follow the configured portals instead of the protocol default
-    /// (#602: a portal on a custom port was silently unreachable).
-    /// Preserves the rule's open/closed state; no-op (and no nft
-    /// apply) when the effective set is unchanged.
-    pub async fn set_service_ports(&self, proto: Protocol, ports: Vec<PortSpec>) {
-        let mut state = self.state.lock().await;
-        let restrictions = self.restrictions.lock().await;
-        if !replace_rule_ports(&mut state, &restrictions, proto.name(), ports) {
-            return;
+    pub async fn set_service_ports(
+        &self,
+        proto: Protocol,
+        ports: Vec<PortSpec>,
+    ) -> Result<(), String> {
+        let mut current = self.config.lock().await;
+        let mut candidate = current.clone();
+        if !replace_rule_ports(
+            &mut candidate.state,
+            &candidate.restrictions,
+            proto.name(),
+            ports,
+        ) {
+            return Ok(());
         }
-        let custom = self.custom.lock().await;
-        if let Err(e) = apply_nftables(&state, &custom).await {
-            error!("Failed to update firewall ports for {}: {e}", proto.name());
-        } else {
-            info!("Firewall: updated ports for {}", proto.name());
-        }
+        self.commit_candidate(&mut current, candidate, None).await?;
+        info!("Firewall: updated ports for {}", proto.name());
+        Ok(())
     }
 
-    /// Create a custom port rule. Validates input + service-port collision +
-    /// exact-duplicate, persists, and rebuilds the firewall. Returns the
-    /// created rule (with its assigned id). Duplicate/collision/validation
-    /// failures return an `Err` and change nothing.
+    pub async fn set_portal_ports(
+        &self,
+        iscsi_ports: Vec<PortSpec>,
+        nvmeof_ports: Vec<PortSpec>,
+    ) -> Result<(), String> {
+        let mut current = self.config.lock().await;
+        let mut candidate = current.clone();
+        let iscsi_changed = replace_rule_ports(
+            &mut candidate.state,
+            &candidate.restrictions,
+            Protocol::Iscsi.name(),
+            iscsi_ports,
+        );
+        let nvmeof_changed = replace_rule_ports(
+            &mut candidate.state,
+            &candidate.restrictions,
+            Protocol::Nvmeof.name(),
+            nvmeof_ports,
+        );
+        if !iscsi_changed && !nvmeof_changed {
+            return Ok(());
+        }
+        self.commit_candidate(&mut current, candidate, None).await?;
+        info!("Firewall: updated iSCSI and NVMe-oF portal ports");
+        Ok(())
+    }
+
     pub async fn add_custom_rule(&self, input: CustomRuleInput) -> Result<CustomRule, String> {
         validate_custom_input(&input)?;
-
-        let state = self.state.lock().await;
-        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+        let mut current = self.config.lock().await;
+        if let Some(owner) =
+            service_port_conflict(&current.state, input.transport, input.from, input.to)
+        {
             return Err(format!(
                 "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
                 transport_str(input.transport),
@@ -692,8 +869,7 @@ impl FirewallService {
                 input.to,
             ));
         }
-        let mut custom = self.custom.lock().await;
-        if custom.iter().any(|r| same_rule(r, &input)) {
+        if current.custom.iter().any(|rule| same_rule(rule, &input)) {
             return Err("an identical custom rule already exists".into());
         }
 
@@ -707,24 +883,25 @@ impl FirewallService {
             iface: input.iface.clone(),
             enabled: input.enabled,
         };
-        custom.push(rule.clone());
-        save_custom_rules(&custom).await?;
-        apply_nftables(&state, &custom).await?;
+        let mut candidate = current.clone();
+        candidate.custom.push(rule.clone());
+        let staged = StagedJson::stage(&self.paths.custom, &candidate.custom).await?;
+        self.commit_candidate(&mut current, candidate, Some(staged))
+            .await?;
         info!("Firewall: added custom rule {} ({})", rule.id, rule.label);
         Ok(rule)
     }
 
-    /// Update an existing custom rule by id (full replace of the mutable
-    /// fields). Re-validates; the duplicate check ignores the rule itself.
     pub async fn update_custom_rule(
         &self,
         id: &str,
         input: CustomRuleInput,
     ) -> Result<CustomRule, String> {
         validate_custom_input(&input)?;
-
-        let state = self.state.lock().await;
-        if let Some(owner) = service_port_conflict(&state, input.transport, input.from, input.to) {
+        let mut current = self.config.lock().await;
+        if let Some(owner) =
+            service_port_conflict(&current.state, input.transport, input.from, input.to)
+        {
             return Err(format!(
                 "{}/{}-{} overlaps ports managed by {owner} — enable {owner} to open them",
                 transport_str(input.transport),
@@ -732,11 +909,16 @@ impl FirewallService {
                 input.to,
             ));
         }
-        let mut custom = self.custom.lock().await;
-        if custom.iter().any(|r| r.id != id && same_rule(r, &input)) {
+        if current
+            .custom
+            .iter()
+            .any(|rule| rule.id != id && same_rule(rule, &input))
+        {
             return Err("an identical custom rule already exists".into());
         }
-        let Some(rule) = custom.iter_mut().find(|r| r.id == id) else {
+
+        let mut candidate = current.clone();
+        let Some(rule) = candidate.custom.iter_mut().find(|rule| rule.id == id) else {
             return Err(format!("custom rule not found: {id}"));
         };
         rule.label = input.label.trim().to_string();
@@ -747,25 +929,24 @@ impl FirewallService {
         rule.iface = input.iface.clone();
         rule.enabled = input.enabled;
         let updated = rule.clone();
-
-        save_custom_rules(&custom).await?;
-        apply_nftables(&state, &custom).await?;
+        let staged = StagedJson::stage(&self.paths.custom, &candidate.custom).await?;
+        self.commit_candidate(&mut current, candidate, Some(staged))
+            .await?;
         info!("Firewall: updated custom rule {id}");
         Ok(updated)
     }
 
-    /// Remove a custom rule by id and rebuild the firewall. No-op error if the
-    /// id is unknown.
     pub async fn remove_custom_rule(&self, id: &str) -> Result<(), String> {
-        let state = self.state.lock().await;
-        let mut custom = self.custom.lock().await;
-        let before = custom.len();
-        custom.retain(|r| r.id != id);
-        if custom.len() == before {
+        let mut current = self.config.lock().await;
+        let mut candidate = current.clone();
+        let before = candidate.custom.len();
+        candidate.custom.retain(|rule| rule.id != id);
+        if candidate.custom.len() == before {
             return Err(format!("custom rule not found: {id}"));
         }
-        save_custom_rules(&custom).await?;
-        apply_nftables(&state, &custom).await?;
+        let staged = StagedJson::stage(&self.paths.custom, &candidate.custom).await?;
+        self.commit_candidate(&mut current, candidate, Some(staged))
+            .await?;
         info!("Firewall: removed custom rule {id}");
         Ok(())
     }
@@ -875,49 +1056,167 @@ fn same_rule(r: &CustomRule, input: &CustomRuleInput) -> bool {
         && r.iface == input.iface
 }
 
-// ── nftables application ───────────────────────────────────────
+struct StagedJson {
+    temp: PathBuf,
+    destination: PathBuf,
+    finished: bool,
+}
 
-/// Generate and apply the full nftables ruleset atomically.
-async fn apply_nftables(state: &FirewallState, custom: &[CustomRule]) -> Result<(), String> {
-    let rules = render_ruleset(state, custom);
+impl StagedJson {
+    async fn stage<T: Serialize>(destination: &Path, value: &T) -> Result<Self, String> {
+        let parent = destination
+            .parent()
+            .ok_or_else(|| format!("{} has no parent directory", destination.display()))?;
+        let name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("invalid state path: {}", destination.display()))?;
+        let temp = parent.join(format!(".{name}.{}.tmp", uuid::Uuid::new_v4()));
+        let json = serde_json::to_vec_pretty(value).map_err(|e| format!("serialize: {e}"))?;
 
-    // Apply atomically: flush + load
-    let flush = Command::new("nft")
-        .args(["delete", "table", "inet", "nasty"])
-        .output()
-        .await;
-    // Ignore flush errors (table may not exist yet)
-    if let Ok(o) = &flush
-        && !o.status.success()
-    {
-        let stderr = String::from_utf8_lossy(&o.stderr);
-        if !stderr.contains("No such file") && !stderr.contains("does not exist") {
-            warn!("nft delete table warning: {stderr}");
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temp)
+            .await
+            .map_err(|e| format!("create {}: {e}", temp.display()))?;
+        if let Err(e) = file.write_all(&json).await {
+            let _ = tokio::fs::remove_file(&temp).await;
+            return Err(format!("write {}: {e}", temp.display()));
+        }
+        if let Err(e) = file.sync_all().await {
+            let _ = tokio::fs::remove_file(&temp).await;
+            return Err(format!("sync {}: {e}", temp.display()));
+        }
+        drop(file);
+
+        Ok(Self {
+            temp,
+            destination: destination.to_path_buf(),
+            finished: false,
+        })
+    }
+
+    async fn commit(mut self) -> Result<(), String> {
+        tokio::fs::rename(&self.temp, &self.destination)
+            .await
+            .map_err(|e| {
+                format!(
+                    "rename {} to {}: {e}",
+                    self.temp.display(),
+                    self.destination.display()
+                )
+            })?;
+        self.finished = true;
+        if let Some(parent) = self.destination.parent() {
+            match tokio::fs::File::open(parent).await {
+                Ok(directory) => {
+                    if let Err(e) = directory.sync_all().await {
+                        warn!("sync firewall state directory {}: {e}", parent.display());
+                    }
+                }
+                Err(e) => warn!(
+                    "open firewall state directory {} for sync: {e}",
+                    parent.display()
+                ),
+            }
+        }
+        Ok(())
+    }
+
+    async fn discard(mut self) {
+        let _ = tokio::fs::remove_file(&self.temp).await;
+        self.finished = true;
+    }
+}
+
+impl Drop for StagedJson {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = std::fs::remove_file(&self.temp);
         }
     }
+}
 
-    // Apply the ruleset by writing it to a temp file and pointing nft at it.
-    // An earlier version tried `nft -f -` with piped stdin but never wrote to
-    // the pipe, so nft hung waiting for EOF until the spawn went out of scope.
-    let tmp = "/tmp/nasty-firewall.nft";
-    tokio::fs::write(tmp, &rules)
+// ── nftables application ───────────────────────────────────────
+
+/// Validate the exact replacement batch, then submit it once. nft sends each
+/// file as one netlink transaction, so a failure leaves the current table
+/// untouched instead of exposing the host between delete and reload commands.
+async fn apply_nftables_with(
+    nft_program: &Path,
+    state: &FirewallState,
+    custom: &[CustomRule],
+    published: &[PublishedAppPort],
+) -> Result<(), String> {
+    let transaction = render_transaction(state, custom, published);
+    run_nft(
+        nft_program,
+        &["--check", "--file", "-"],
+        &transaction,
+        "validation",
+    )
+    .await?;
+    run_nft(nft_program, &["--file", "-"], &transaction, "apply").await
+}
+
+async fn run_nft(
+    nft_program: &Path,
+    args: &[&str],
+    transaction: &str,
+    stage: &str,
+) -> Result<(), String> {
+    let mut command = Command::new(nft_program);
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("spawn nft {stage}: {e}"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| format!("open nft {stage} stdin"))?;
+    let transaction = transaction.as_bytes().to_vec();
+    let writer_stage = stage.to_string();
+    let writer = tokio::spawn(async move {
+        stdin
+            .write_all(&transaction)
+            .await
+            .map_err(|e| format!("write nft {writer_stage} stdin: {e}"))
+    });
+    let (write_result, output_result) =
+        tokio::time::timeout(std::time::Duration::from_secs(10), async move {
+            tokio::join!(writer, child.wait_with_output())
+        })
         .await
-        .map_err(|e| format!("write {tmp}: {e}"))?;
-
-    let output = Command::new("nft")
-        .args(["-f", tmp])
-        .output()
-        .await
-        .map_err(|e| format!("nft -f: {e}"))?;
-
-    let _ = tokio::fs::remove_file(tmp).await;
-
+        .map_err(|_| format!("nft {stage} timed out"))?;
+    write_result.map_err(|e| format!("join nft {stage} stdin writer: {e}"))??;
+    let output = output_result.map_err(|e| format!("wait for nft {stage}: {e}"))?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("nft apply failed: {stderr}"));
+        return Err(format!(
+            "nft {stage} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
     }
-
     Ok(())
+}
+
+fn render_transaction(
+    state: &FirewallState,
+    custom: &[CustomRule],
+    published: &[PublishedAppPort],
+) -> String {
+    let mut transaction = String::from("destroy table inet nasty\n");
+    transaction.push_str(&render_ruleset_with_published(state, custom, published));
+    transaction
 }
 
 /// nft source-address clause with the correct family: `ip6 saddr` for an
@@ -935,6 +1234,14 @@ fn saddr_clause(src: &str) -> String {
 /// Build the full `table inet nasty` ruleset text from the service rules and
 /// the custom rules. Pure — no I/O — so it can be unit-tested.
 pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
+    render_ruleset_with_published(state, custom, &[])
+}
+
+fn render_ruleset_with_published(
+    state: &FirewallState,
+    custom: &[CustomRule],
+    published: &[PublishedAppPort],
+) -> String {
     let mut rules = String::new();
     rules.push_str("table inet nasty {\n");
     rules.push_str("    chain input {\n");
@@ -1004,6 +1311,55 @@ pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
     }
 
     rules.push_str("    }\n");
+    rules.push_str("    chain forward {\n");
+    rules.push_str("        type filter hook forward priority -10; policy accept;\n");
+    rules.push_str("        # Explicitly allowed Docker-published host ports\n");
+    for port in published {
+        let proto = if port.transport.eq_ignore_ascii_case("tcp") {
+            "tcp"
+        } else if port.transport.eq_ignore_ascii_case("udp") {
+            "udp"
+        } else {
+            continue;
+        };
+        rules.push_str(&format!(
+            "        ct direction original ct status dnat meta l4proto {proto} ct original proto-dst {} accept # app-published\n",
+            port.host_port
+        ));
+    }
+    // Custom host-port rules also authorize matching inbound DNAT traffic.
+    for rule in custom {
+        if !rule.enabled {
+            continue;
+        }
+        let proto = match rule.transport {
+            Transport::Tcp => "tcp",
+            Transport::Udp => "udp",
+        };
+        let mut conditions = vec![
+            "ct direction original".to_string(),
+            "ct status dnat".to_string(),
+        ];
+        if let Some(ref iface) = rule.iface {
+            conditions.push(format!("iifname \"{iface}\""));
+        }
+        if let Some(ref src) = rule.source {
+            conditions.push(saddr_clause(src));
+        }
+        conditions.push(format!("meta l4proto {proto}"));
+        if rule.from == rule.to {
+            conditions.push(format!("ct original proto-dst {}", rule.from));
+        } else {
+            conditions.push(format!("ct original proto-dst {}-{}", rule.from, rule.to));
+        }
+        rules.push_str(&format!(
+            "        {} accept # custom:{}\n",
+            conditions.join(" "),
+            rule.id
+        ));
+    }
+    rules.push_str("        ct direction original ct status dnat drop\n");
+    rules.push_str("    }\n");
     rules.push_str("}\n");
     rules
 }
@@ -1011,6 +1367,28 @@ pub fn render_ruleset(state: &FirewallState, custom: &[CustomRule]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn mock_nft(dir: &Path, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = dir.join("mock-nft");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    fn test_service(dir: &Path, nft_program: PathBuf, config: FirewallConfig) -> FirewallService {
+        FirewallService {
+            config: tokio::sync::Mutex::new(config),
+            paths: FirewallPaths {
+                restrictions: dir.join("restrictions.json"),
+                custom: dir.join("custom.json"),
+            },
+            nft_program,
+        }
+    }
 
     #[test]
     fn smb_opens_serving_and_wsdd_discovery_ports() {
@@ -1170,6 +1548,107 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn setting_restriction_preserves_custom_portal_ports() {
+        let dir = tempfile::tempdir().unwrap();
+        let nft = mock_nft(dir.path(), "cat >/dev/null\nexit 0");
+        let config = FirewallConfig {
+            state: state_with_rule("iscsi", vec![tcp(3261)], true),
+            ..FirewallConfig::default()
+        };
+        let service = test_service(dir.path(), nft, config);
+
+        service
+            .set_restriction(
+                "iscsi",
+                vec!["10.0.0.0/8".into(), "192.168.0.0/16".into()],
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+        service
+            .set_restriction(
+                "iscsi",
+                vec!["10.0.0.0/8".into(), "192.168.0.0/16".into()],
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+
+        let rule = service
+            .status()
+            .await
+            .rules
+            .into_iter()
+            .find(|rule| rule.service == "iscsi")
+            .unwrap();
+        assert_eq!(rule.ports.len(), 2, "re-saving must not multiply ports");
+        assert!(rule.ports.iter().all(|port| port.port == 3261));
+        assert_eq!(rule.ports[0].source.as_deref(), Some("10.0.0.0/8"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn portal_ports_commit_in_one_firewall_transaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let invocations = dir.path().join("invocations");
+        let nft = mock_nft(
+            dir.path(),
+            &format!("cat >> \"{}\"\nexit 0", invocations.display()),
+        );
+        let config = FirewallConfig {
+            state: FirewallState {
+                rules: vec![
+                    FirewallRule {
+                        service: "iscsi".into(),
+                        ports: vec![tcp(3260)],
+                        active: true,
+                    },
+                    FirewallRule {
+                        service: "nvmeof".into(),
+                        ports: vec![tcp(4420)],
+                        active: true,
+                    },
+                ],
+            },
+            ..FirewallConfig::default()
+        };
+        let service = test_service(dir.path(), nft, config);
+
+        service
+            .set_portal_ports(vec![tcp(3261)], vec![tcp(4421)])
+            .await
+            .unwrap();
+
+        let status = service.status().await;
+        assert_eq!(
+            status
+                .rules
+                .iter()
+                .find(|rule| rule.service == "iscsi")
+                .unwrap()
+                .ports[0]
+                .port,
+            3261
+        );
+        assert_eq!(
+            status
+                .rules
+                .iter()
+                .find(|rule| rule.service == "nvmeof")
+                .unwrap()
+                .ports[0]
+                .port,
+            4421
+        );
+        // One check and one apply, both carrying the complete two-service batch.
+        let recorded = std::fs::read_to_string(invocations).unwrap();
+        assert_eq!(recorded.matches("destroy table inet nasty").count(), 2);
+        assert_eq!(recorded.matches("3261").count(), 2);
+        assert_eq!(recorded.matches("4421").count(), 2);
+    }
+
     #[test]
     fn replace_rule_ports_creates_inactive_rule_for_unknown_service() {
         // A resync can land before the service was ever opened; the
@@ -1211,6 +1690,272 @@ mod tests {
             out.contains("tcp dport 32400 accept # custom:id1"),
             "got:\n{out}"
         );
+    }
+
+    #[test]
+    fn transaction_destroys_and_replaces_table_in_one_batch() {
+        let transaction = render_transaction(&FirewallState::default(), &[], &[]);
+        assert!(transaction.starts_with("destroy table inet nasty\n"));
+        assert_eq!(transaction.matches("destroy table inet nasty").count(), 1);
+        assert_eq!(transaction.matches("table inet nasty {").count(), 1);
+        assert!(!transaction.contains("delete table"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_failure_preserves_in_memory_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = FirewallConfig {
+            state: state_with_rule("ssh", vec![tcp(22)], false),
+            ..Default::default()
+        };
+        let service = test_service(dir.path(), dir.path().join("missing-nft-program"), config);
+
+        assert!(service.open(Protocol::Ssh).await.is_err());
+        let status = service.status().await;
+        assert!(!status.rules[0].active);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn validation_failure_preserves_in_memory_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let nft = mock_nft(
+            dir.path(),
+            "cat >/dev/null\necho validation rejected >&2\nexit 1",
+        );
+        let config = FirewallConfig {
+            state: state_with_rule("ssh", vec![tcp(22)], false),
+            ..Default::default()
+        };
+        let service = test_service(dir.path(), nft, config);
+
+        let error = service.open(Protocol::Ssh).await.unwrap_err();
+        assert!(error.contains("validation rejected"));
+        assert!(!service.status().await.rules[0].active);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn apply_failure_preserves_in_memory_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let nft = mock_nft(
+            dir.path(),
+            "cat >/dev/null\nif [ \"$1\" = \"--check\" ]; then exit 0; fi\necho apply rejected >&2\nexit 1",
+        );
+        let config = FirewallConfig {
+            state: state_with_rule("ssh", vec![tcp(22)], false),
+            ..Default::default()
+        };
+        let service = test_service(dir.path(), nft, config);
+
+        let error = service.open(Protocol::Ssh).await.unwrap_err();
+        assert!(error.contains("apply rejected"));
+        assert!(!service.status().await.rules[0].active);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_and_apply_receive_the_identical_transaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("transactions");
+        let nft = mock_nft(
+            dir.path(),
+            &format!(
+                "cat >> \"{}\"\nprintf '\\n---transaction---\\n' >> \"{}\"\nexit 0",
+                log.display(),
+                log.display()
+            ),
+        );
+
+        apply_nftables_with(&nft, &state_with_rule("ssh", vec![tcp(22)], true), &[], &[])
+            .await
+            .unwrap();
+        let recorded = std::fs::read_to_string(log).unwrap();
+        let transactions: Vec<&str> = recorded
+            .split("---transaction---")
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .collect();
+        assert_eq!(transactions.len(), 2);
+        assert_eq!(transactions[0], transactions[1]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn corrupt_persisted_state_aborts_initialization_without_applying() {
+        let dir = tempfile::tempdir().unwrap();
+        let invocations = dir.path().join("invocations");
+        let nft = mock_nft(
+            dir.path(),
+            &format!(
+                "cat >/dev/null\nprintf x >> \"{}\"\nexit 0",
+                invocations.display()
+            ),
+        );
+        std::fs::write(dir.path().join("restrictions.json"), "{not-json").unwrap();
+        let config = FirewallConfig {
+            state: state_with_rule("ssh", vec![tcp(22)], false),
+            ..Default::default()
+        };
+        let service = test_service(dir.path(), nft, config);
+
+        let error = service
+            .init(&[], false, false, vec![tcp(3260)], vec![tcp(4420)], vec![])
+            .await
+            .unwrap_err();
+        assert!(error.contains("parse"));
+        assert!(!invocations.exists());
+        assert!(!service.status().await.rules[0].active);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn initialization_applies_special_and_portal_rules_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let invocations = dir.path().join("invocations");
+        let nft = mock_nft(
+            dir.path(),
+            &format!(
+                "cat >/dev/null\nprintf x >> \"{}\"\nexit 0",
+                invocations.display()
+            ),
+        );
+        let service = test_service(dir.path(), nft, FirewallConfig::default());
+
+        service
+            .init(
+                &[(Protocol::Iscsi, true), (Protocol::Nvmeof, true)],
+                true,
+                true,
+                vec![tcp(3261)],
+                vec![tcp(4421)],
+                vec![PublishedAppPort {
+                    app: "media".into(),
+                    host_port: 32400,
+                    container_port: 32400,
+                    transport: "tcp".into(),
+                }],
+            )
+            .await
+            .unwrap();
+        let status = service.status().await;
+        assert!(status.rules.iter().any(|rule| rule.service == "rdma"));
+        assert!(status.rules.iter().any(|rule| rule.service == "dc"));
+        assert_eq!(status.published_app_ports.len(), 1);
+        assert_eq!(
+            status
+                .rules
+                .iter()
+                .find(|rule| rule.service == "iscsi")
+                .unwrap()
+                .ports[0]
+                .port,
+            3261
+        );
+        assert_eq!(
+            status
+                .rules
+                .iter()
+                .find(|rule| rule.service == "nvmeof")
+                .unwrap()
+                .ports[0]
+                .port,
+            4421
+        );
+        assert_eq!(std::fs::read_to_string(invocations).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn forward_policy_allows_managed_and_custom_dnat_then_drops_the_rest() {
+        let custom = vec![CustomRule {
+            id: "external".into(),
+            label: "external container".into(),
+            transport: Transport::Udp,
+            from: 9000,
+            to: 9010,
+            source: Some("10.0.0.0/8".into()),
+            iface: Some("eth0".into()),
+            enabled: true,
+        }];
+        let published = vec![PublishedAppPort {
+            app: "media".into(),
+            host_port: 32400,
+            container_port: 32400,
+            transport: "tcp".into(),
+        }];
+        let rules = render_ruleset_with_published(&FirewallState::default(), &custom, &published);
+        assert!(rules.contains(
+            "ct direction original ct status dnat meta l4proto tcp ct original proto-dst 32400 accept # app-published"
+        ));
+        assert!(rules.contains(
+            "ct direction original ct status dnat iifname \"eth0\" ip saddr 10.0.0.0/8 meta l4proto udp ct original proto-dst 9000-9010 accept # custom:external"
+        ));
+        assert!(rules.contains("ct direction original ct status dnat drop"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn persistence_failure_restores_live_and_in_memory_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let invocations = dir.path().join("invocations");
+        let nft = mock_nft(
+            dir.path(),
+            &format!(
+                "cat >> \"{}\"\nprintf '\\n---transaction---\\n' >> \"{}\"\nexit 0",
+                invocations.display(),
+                invocations.display()
+            ),
+        );
+        // Renaming the staged JSON over a directory fails after candidate rules
+        // were applied, forcing the compensating old-rules transaction.
+        std::fs::create_dir(dir.path().join("custom.json")).unwrap();
+        let service = test_service(dir.path(), nft, FirewallConfig::default());
+
+        let error = service
+            .add_custom_rule(input(9000, 9000, Transport::Tcp))
+            .await
+            .unwrap_err();
+        assert!(error.contains("previous live rules restored"));
+        assert!(service.status().await.custom_rules.is_empty());
+        let recorded = std::fs::read_to_string(invocations).unwrap();
+        let transactions: Vec<&str> = recorded
+            .split("---transaction---")
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .collect();
+        assert_eq!(transactions.len(), 4);
+        assert!(transactions[0].contains("9000"));
+        assert!(transactions[1].contains("9000"));
+        assert!(!transactions[2].contains("9000"));
+        assert!(!transactions[3].contains("9000"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rollback_failure_tracks_the_candidate_that_remains_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let count = dir.path().join("count");
+        let nft = mock_nft(
+            dir.path(),
+            &format!(
+                "cat >/dev/null\nn=$(/bin/cat \"{}\" 2>/dev/null || printf 0)\n\
+                 n=$((n + 1))\nprintf '%s' \"$n\" > \"{}\"\n\
+                 if [ \"$n\" -ge 3 ]; then exit 1; fi\nexit 0",
+                count.display(),
+                count.display()
+            ),
+        );
+        std::fs::create_dir(dir.path().join("custom.json")).unwrap();
+        let service = test_service(dir.path(), nft, FirewallConfig::default());
+
+        let error = service
+            .add_custom_rule(input(9000, 9000, Transport::Tcp))
+            .await
+            .unwrap_err();
+
+        assert!(error.contains("in-memory state reflects the live candidate"));
+        assert_eq!(service.status().await.custom_rules.len(), 1);
     }
 
     #[test]

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -5,6 +5,28 @@ let
   inherit (lib) mkEnableOption mkOption mkIf types;
   nastySystemFlakeSnapshot = args.nastySystemFlakeSnapshot or null;
 
+  # Boot-time fail-closed policy. The engine atomically replaces this table
+  # with its complete dynamic rules before restoring network-facing services.
+  nastyFirewallBaselineText = ''
+    destroy table inet nasty
+    table inet nasty {
+      chain input {
+        type filter hook input priority 0; policy drop;
+        ct state established,related accept
+        ct state invalid drop
+        iif lo accept
+        ip protocol icmp accept
+        ip6 nexthdr icmpv6 accept
+        udp dport 546 accept
+      }
+      chain forward {
+        type filter hook forward priority -10; policy accept;
+        ct direction original ct status dnat drop
+      }
+    }
+  '';
+  nastyFirewallBaseline = pkgs.writeText "nasty-firewall-baseline.nft" nastyFirewallBaselineText;
+
   # Secure Boot integration is opt-in per box. The wrapper flake at
   # /etc/nixos/flake.nix passes the lanzaboote input through as a
   # specialArg when it has the input declared; pre-#324-era wrappers
@@ -1500,7 +1522,9 @@ in {
     systemd.services.nasty-metrics = {
       description = "NASty Metrics Collector";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network.target" "nftables.service" ];
+      requires = [ "nftables.service" ];
+      partOf = [ "nftables.service" ];
 
       path = with pkgs; [
         smartmontools         # smartctl for disk health
@@ -1589,8 +1613,11 @@ in {
       # (vs `requires`) means a broken Caddy doesn't block the engine
       # from running — the admin-API client has retry/backoff and
       # logs a warn! if it can't reach :2019.
-      after = [ "network.target" "nasty-metrics.service" "caddy.service" ];
+      after = [ "network.target" "nftables.service" "nasty-metrics.service" "caddy.service" ];
+      requires = [ "nftables.service" ];
+      partOf = [ "nftables.service" ];
       wants = [ "nasty-metrics.service" "caddy.service" ];
+      restartTriggers = [ nastyFirewallBaseline ];
 
       path = with pkgs; [
         bashInteractive  # bash for terminal
@@ -2395,8 +2422,12 @@ in {
     # challenge) from this EnvironmentFile. The `-` prefix means
     # "ignore if missing" so the unit still starts on a fresh box
     # before the engine has written anything.
-    systemd.services.caddy.serviceConfig.EnvironmentFile =
-      mkIf (cfg.webui.package != null) "-/var/lib/nasty/caddy/acme.env";
+    systemd.services.caddy = mkIf (cfg.webui.package != null) {
+      after = [ "nftables.service" ];
+      requires = [ "nftables.service" ];
+      partOf = [ "nftables.service" ];
+      serviceConfig.EnvironmentFile = "-/var/lib/nasty/caddy/acme.env";
+    };
 
     # ── Journald ───────────────────────────────────────────────
     services.journald.extraConfig = ''
@@ -2440,10 +2471,30 @@ in {
     };
 
     # ── Firewall ───────────────────────────────────────────────
-    # Disable NixOS's static iptables firewall — the engine manages
-    # nftables rules dynamically via `table inet nasty`.
+    # Disable NixOS's static iptables firewall. nftables installs a
+    # default-drop baseline before the engine starts; the engine replaces the
+    # same table transactionally after validating its complete dynamic policy.
     networking.firewall.enable = false;
     networking.nftables.enable = true;
+    # Never flush unrelated Docker/CNI tables when loading our baseline.
+    networking.nftables.flushRuleset = lib.mkForce false;
+    networking.nftables.ruleset = nastyFirewallBaselineText;
+    # Loading the static baseline without restarting the engine would discard
+    # its dynamic state. Disable direct reloads and make NixOS activation use a
+    # restart; PartOf then restarts each listener and the engine after the
+    # baseline is back in place.
+    systemd.services.nftables.reloadIfChanged = lib.mkForce false;
+    systemd.services.nftables.serviceConfig.ExecReload = lib.mkForce "";
+    systemd.services.sshd = {
+      after = [ "nftables.service" ];
+      requires = [ "nftables.service" ];
+      partOf = [ "nftables.service" ];
+    };
+    systemd.services.avahi-daemon = {
+      after = [ "nftables.service" ];
+      requires = [ "nftables.service" ];
+      partOf = [ "nftables.service" ];
+    };
 
     # ── Networking backend (NetworkManager) ───────────────────
     # As of v0.0.7 NASty manages the host network via NetworkManager

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2485,12 +2485,12 @@ in {
     # baseline is back in place.
     systemd.services.nftables.reloadIfChanged = lib.mkForce false;
     systemd.services.nftables.serviceConfig.ExecReload = lib.mkForce "";
-    systemd.services.sshd = {
+    systemd.services.sshd = mkIf config.services.openssh.enable {
       after = [ "nftables.service" ];
       requires = [ "nftables.service" ];
       partOf = [ "nftables.service" ];
     };
-    systemd.services.avahi-daemon = {
+    systemd.services.avahi-daemon = mkIf config.services.avahi.enable {
       after = [ "nftables.service" ];
       requires = [ "nftables.service" ];
       partOf = [ "nftables.service" ];

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -190,6 +190,14 @@ let
                 "protocol": "tcp",
             }],
         })
+        call(ws, "system.firewall.custom.add", 4, {
+            "label": "restricted external forward",
+            "transport": "tcp",
+            "from": 18082,
+            "to": 18082,
+            "source": "192.168.1.0/24",
+            "enabled": True,
+        })
     finally:
         ws.close()
   '';
@@ -219,6 +227,10 @@ in
 
 pkgs.testers.runNixOSTest {
   name = "appliance-smoke";
+
+  nodes.client = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.curl ];
+  };
 
   nodes.machine = { lib, ... }: {
     imports = [
@@ -260,6 +272,7 @@ pkgs.testers.runNixOSTest {
     # VM-test infrastructure since clock sync is irrelevant inside a
     # transient test VM.
     services.timesyncd.enable = lib.mkForce false;
+    services.avahi.enable = true;
 
     # The rpc-smoke script needs websocket-client at runtime in the guest.
     environment.systemPackages = [ pythonWithWs ];
@@ -272,7 +285,60 @@ pkgs.testers.runNixOSTest {
     import shlex
 
     machine.start()
+    client.start()
+
+    # nftables must establish a default-drop baseline independently of the
+    # engine. Restart nftables as separate stop/start operations so PartOf stops
+    # the engine without restarting it; inspect the baseline, then start the
+    # engine and verify it installs its dynamic management rules before ready.
+    machine.wait_for_unit("nftables.service")
+    machine.succeed("systemctl stop nftables.service")
+    machine.succeed("systemctl start nftables.service")
+    baseline = machine.succeed("nft list table inet nasty")
+    assert "policy drop" in baseline, f"missing fail-closed baseline: {baseline}"
+    assert "ct direction original ct status dnat drop" in baseline, (
+        f"baseline does not block DNAT forwarding: {baseline}"
+    )
+    assert "dport 443" not in baseline, f"baseline unexpectedly exposes WebUI: {baseline}"
+    machine.succeed(
+        "systemctl start nasty-engine.service sshd.service avahi-daemon.service"
+    )
     machine.wait_for_unit("nasty-engine.service")
+    machine.wait_for_unit("sshd.service")
+    machine.wait_for_unit("avahi-daemon.service")
+
+    dynamic_firewall = machine.succeed("nft list table inet nasty")
+    assert "tcp dport 443 accept" in dynamic_firewall, (
+        f"engine did not install dynamic WebUI policy: {dynamic_firewall}"
+    )
+    machine.fail("systemctl reload nftables.service")
+    after_rejected_reload = machine.succeed("nft list table inet nasty")
+    assert "tcp dport 443 accept" in after_rejected_reload, (
+        f"rejected nftables reload discarded dynamic policy: {after_rejected_reload}"
+    )
+    machine.succeed("systemctl restart nftables.service")
+    for unit in [
+        "nasty-engine.service",
+        "nasty-metrics.service",
+        "caddy.service",
+        "sshd.service",
+        "avahi-daemon.service",
+    ]:
+        machine.wait_for_unit(unit)
+    after_restart = machine.succeed("nft list table inet nasty")
+    assert "tcp dport 443 accept" in after_restart, (
+        f"nftables restart did not restore dynamic policy: {after_restart}"
+    )
+
+    # A valid batch whose final command references a missing chain must fail as
+    # a whole. The named sentinel in the old table proves the leading destroy
+    # command was rolled back by nft's netlink transaction.
+    machine.succeed("nft add counter inet nasty transaction_sentinel")
+    machine.fail(
+        "printf 'destroy table inet nasty\\nadd table inet nasty\\n"
+        "add rule inet nasty missing_chain counter\\n' | nft --file -"
+    )
+    machine.succeed("nft list counter inet nasty transaction_sentinel")
 
     # ── /health (no auth) ───────────────────────────────────────────
     # Hit the engine directly on its loopback port to skip TLS / Caddy.
@@ -405,5 +471,19 @@ pkgs.testers.runNixOSTest {
         f"path-strip regression — /apps/smoke/index.html didn't reach "
         f"the container's /index.html: {subpath!r}"
     )
+
+    forward_policy = machine.succeed("nft list table inet nasty")
+    assert "ct original proto-dst 18080 accept" in forward_policy, (
+        f"managed app port missing from Docker forward policy: {forward_policy}"
+    )
+    client.wait_until_succeeds("curl -fsS --max-time 2 http://machine:18080/")
+    machine.succeed(
+        "docker run -d --name unmanaged-smoke -p 18081:80 nasty-smoke-app:test"
+    )
+    client.fail("curl -fsS --max-time 2 http://machine:18081/")
+    machine.succeed(
+        "docker run -d --name restricted-smoke -p 18082:80 nasty-smoke-app:test"
+    )
+    client.wait_until_succeeds("curl -fsS --max-time 2 http://machine:18082/")
   '';
 }

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -272,6 +272,7 @@ pkgs.testers.runNixOSTest {
     # VM-test infrastructure since clock sync is irrelevant inside a
     # transient test VM.
     services.timesyncd.enable = lib.mkForce false;
+    services.openssh.enable = true;
     services.avahi.enable = true;
 
     # The rpc-smoke script needs websocket-client at runtime in the guest.

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -195,7 +195,7 @@ let
             "transport": "tcp",
             "from": 18082,
             "to": 18082,
-            "source": "192.168.1.0/24",
+            "source": "192.0.2.0/24",
             "enabled": True,
         })
     finally:
@@ -227,10 +227,6 @@ in
 
 pkgs.testers.runNixOSTest {
   name = "appliance-smoke";
-
-  nodes.client = { pkgs, ... }: {
-    environment.systemPackages = [ pkgs.curl ];
-  };
 
   nodes.machine = { lib, ... }: {
     imports = [
@@ -286,7 +282,6 @@ pkgs.testers.runNixOSTest {
     import shlex
 
     machine.start()
-    client.start()
 
     # nftables must establish a default-drop baseline independently of the
     # engine. Restart nftables as separate stop/start operations so PartOf stops
@@ -477,14 +472,30 @@ pkgs.testers.runNixOSTest {
     assert "ct original proto-dst 18080 accept" in forward_policy, (
         f"managed app port missing from Docker forward policy: {forward_policy}"
     )
-    client.wait_until_succeeds("curl -fsS --max-time 2 http://machine:18080/")
+    # Exercise Docker DNAT from a non-loopback ingress without relying on the
+    # VM test LAN, which NetworkManager may reconfigure during engine startup.
+    machine.succeed("ip netns add fwclient")
+    machine.succeed("ip link add fw-host type veth peer name fw-client")
+    machine.succeed("ip addr add 192.0.2.1/24 dev fw-host")
+    machine.succeed("ip link set fw-host up")
+    machine.succeed("ip link set fw-client netns fwclient")
+    machine.succeed("ip netns exec fwclient ip link set lo up")
+    machine.succeed("ip netns exec fwclient ip addr add 192.0.2.2/24 dev fw-client")
+    machine.succeed("ip netns exec fwclient ip link set fw-client up")
+    machine.wait_until_succeeds(
+        "ip netns exec fwclient curl -fsS --max-time 2 http://192.0.2.1:18080/"
+    )
     machine.succeed(
         "docker run -d --name unmanaged-smoke -p 18081:80 nasty-smoke-app:test"
     )
-    client.fail("curl -fsS --max-time 2 http://machine:18081/")
+    machine.fail(
+        "ip netns exec fwclient curl -fsS --max-time 2 http://192.0.2.1:18081/"
+    )
     machine.succeed(
         "docker run -d --name restricted-smoke -p 18082:80 nasty-smoke-app:test"
     )
-    client.wait_until_succeeds("curl -fsS --max-time 2 http://machine:18082/")
+    machine.wait_until_succeeds(
+        "ip netns exec fwclient curl -fsS --max-time 2 http://192.0.2.1:18082/"
+    )
   '';
 }

--- a/webui/src/routes/firewall/+page.svelte
+++ b/webui/src/routes/firewall/+page.svelte
@@ -256,10 +256,8 @@
 			<section class="mt-6 rounded-lg border border-border p-5">
 				<h2 class="text-sm font-semibold">App ports (published by Docker)</h2>
 				<p class="mt-1 text-xs text-muted-foreground">
-					These host ports are opened directly by Docker for your apps and bypass this firewall —
-					Docker forwards them straight to the container, so the rules above don't apply.
-					Their only gate is your upstream/cloud firewall. Shown here so you can see everything
-					that's reachable on this box in one place.
+					These host ports are forwarded by Docker and explicitly allowed by NASty's forward policy.
+					Other inbound port forwards are blocked unless you add a matching custom rule.
 				</p>
 				<div class="mt-3 space-y-1">
 					{#each collapsedAppPorts as p}
@@ -285,8 +283,8 @@
 					<h2 class="text-sm font-semibold">Custom port rules</h2>
 					<p class="mt-1 text-xs text-muted-foreground">
 						Open a port for something running directly on the host (e.g. a <code>network_mode: host</code> app).
-						Bridge-networked apps don't need a rule — their published ports (listed above, if any) already bypass
-						this firewall.
+						Bridge-networked NASty apps don't need a rule — their published ports are allowed automatically.
+						Use a custom rule for an independently managed container.
 					</p>
 				</div>
 				<Button size="xs" onclick={startAddCustom}>Add rule</Button>

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -286,7 +286,7 @@
 				{
 					term: 'Firewall',
 					summary: 'A packet filter that controls which traffic reaches NASty and its services.',
-					detail: 'NASty uses nftables for firewall rules, managed from the Firewall page. Each service (NFS, SMB, SSH, etc.) lists its port and current rule — open to all, restricted to specific source IPs or networks, or closed. Rules apply to selected interfaces (LAN, VPN) independently. Published app ports also appear here for visibility. The firewall is deny-by-default: only explicitly opened traffic is accepted. For anything running outside NASty\'s service model — a network_mode: host app, or software you run on the box yourself — add a custom port rule: a single port or a range, with the same optional source and interface restrictions, persisted across reboots. Ports NASty\'s own services manage are refused (enable the service instead), and bridge-networked apps never need a rule — Docker publishes their ports past the firewall.',
+					detail: 'NASty uses nftables for firewall rules, managed from the Firewall page. Each service (NFS, SMB, SSH, etc.) lists its port and current rule — open to all, restricted to specific source IPs or networks, or closed. Rules apply to selected interfaces (LAN, VPN) independently. Published NASty app ports are allowed automatically; other inbound port forwards are blocked. For a network_mode: host app, independently managed container, virtualized service, or software you run directly on the box, add a custom port rule with optional source and interface restrictions.',
 				},
 			],
 		},


### PR DESCRIPTION
## Summary
- replace the NASty nftables table through one validated atomic transaction and preserve live/in-memory/persisted state on failures
- install a fail-closed boot baseline, serialize startup and runtime firewall reconciliation, and harden nftables systemd ordering/reload behavior
- govern original-direction inbound DNAT, automatically allow managed app ports, and synchronize app/portal lifecycle changes without stale snapshots
- add rollback, port-reconciliation, Docker forwarding, service-ordering, WebUI, and documentation coverage

## Testing
- `cargo test -p nasty-system -p nasty-engine -p nasty-apps` (382 + 148 + 135 passed)
- `cargo clippy -p nasty-engine -p nasty-system -p nasty-apps --all-targets -- -D warnings`
- `npm run check` (0 errors, 0 warnings)
- `npm test` (144 passed)
- `nix flake check --no-build`
- `git diff --check`

## Environment limitation
- `nix build .#checks.x86_64-linux.appliance-smoke -L` cannot execute on the local `aarch64-darwin` host because no `x86_64-linux` builder is available; the two-node VM test is included for Linux CI.