### PR TITLE
flake: make wrapper bcachefs pin effective

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,17 @@ jobs:
     #    operator's box. follows closes that hole — the wrapper's
     #    resolved closure is byte-identical to what CI built against.
     #
-    # 2. `bcachefs-tools.url = "..."` (an actual ref, NOT a follows).
+    # 2. `bcachefs-tools.url = "..."` remains operator-owned, while
+    #    `nasty.inputs.bcachefs-tools.follows = "bcachefs-tools"` wires that
+    #    pin into the package and DKMS module exported by nasty.
     #    Nothing in nasty's binary closure links bcachefs-tools; it's
     #    used purely as a runtime CLI + kernel module. Pinning it
     #    independently gives the operator a real escape hatch when an
     #    upstream bcachefs-tools rev regresses on their hardware —
     #    they can stay on a known-good version across nasty bumps.
-    #    Following nasty here removes that capability for no cachix
-    #    win, since nasty's binaries don't depend on it.
+    #    Making the top-level input follow nasty would remove that capability.
+    #    The nested follows goes the other direction: nasty consumes the
+    #    wrapper pin, so the Version page controls what is installed.
     #
     # The bcachefs-tools URL is hardcoded with a real ref (e.g.
     # "v1.38.3") rather than a `@BCACHEFS_TOOLS_REF@` placeholder.
@@ -132,7 +135,7 @@ jobs:
     # a clean wrapper. Per-operator bcachefs-tools customization
     # happens via a post-render `rewrite_flake_input_urls` pass on
     # the caller side (see update.rs).
-    name: Installer template canonical shape (nixpkgs follows, bcachefs.url)
+    name: Installer template canonical shape and effective bcachefs pin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -155,12 +158,12 @@ jobs:
 
       - name: Assert template pins bcachefs-tools with its own .url (hardcoded ref, no placeholder)
         run: |
-          if grep -qE 'bcachefs-tools\.follows\s*=' nixos/system-flake/flake.nix.template; then
-            echo "::error::installer template declares bcachefs-tools.follows — should pin its own .url so operators can independently override"
+          if grep -qE '^\s*bcachefs-tools\.follows\s*=' nixos/system-flake/flake.nix.template; then
+            echo "::error::installer template declares top-level bcachefs-tools.follows — should pin its own .url so operators can independently override"
             echo "Template should declare:"
             echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/<vX.Y.Z>\";"
             echo "instead of:"
-            grep -nE 'bcachefs-tools\.follows' nixos/system-flake/flake.nix.template
+            grep -nE '^\s*bcachefs-tools\.follows' nixos/system-flake/flake.nix.template
             exit 1
           fi
           if grep -qE 'bcachefs-tools\.url\s*=\s*"[^"]*@[A-Z_]+@' nixos/system-flake/flake.nix.template; then
@@ -177,7 +180,18 @@ jobs:
             echo "  bcachefs-tools.url = \"github:koverstreet/bcachefs-tools/v1.38.3\";"
             exit 1
           fi
+          if ! grep -qE '^\s*nasty\.inputs\.bcachefs-tools\.follows\s*=\s*"bcachefs-tools";' nixos/system-flake/flake.nix.template; then
+            echo "::error::nasty's nested bcachefs-tools input must follow the operator-owned wrapper input"
+            echo "Template must declare:"
+            echo '  nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";'
+            exit 1
+          fi
+          if ! grep -qE '^\s*bcachefs-tools\.inputs\.nixpkgs\.follows\s*=\s*"nixpkgs";' nixos/system-flake/flake.nix.template; then
+            echo "::error::wrapper bcachefs-tools must share the wrapper's nixpkgs input"
+            exit 1
+          fi
           echo "Installer template correctly pins bcachefs-tools.url with a hardcoded semver tag."
+          echo "nasty correctly consumes the operator-owned bcachefs-tools pin."
 
   installer-lock-shape:
     # The dynamic counterpart to `installer-flake-template` above.
@@ -260,4 +274,122 @@ jobs:
             exit 1
           fi
 
+          jq -e '
+            . as $lock
+            | .root as $root
+            | $lock.nodes[$root].inputs.nasty as $nasty
+            | $lock.nodes[$root].inputs["bcachefs-tools"] as $bcachefs
+            | ($lock.nodes[$nasty].inputs["bcachefs-tools"] == ["bcachefs-tools"])
+              and ($lock.nodes[$bcachefs].inputs.nixpkgs == ["nixpkgs"])
+              and
+              ([
+                $lock.nodes[]
+                | select(
+                    .locked.owner? == "koverstreet"
+                    and .locked.repo? == "bcachefs-tools"
+                  )
+              ] | length == 1)
+          ' flake.lock >/dev/null
+          echo "Wrapper and nasty resolve one shared bcachefs-tools source node."
+
           echo "Wrapper-lock shape is stable across two consecutive nix flake lock passes."
+
+      - name: Prove wrapper pin changes userspace and DKMS derivations
+        run: |
+          set -euo pipefail
+          ROOT=$(mktemp -d)
+
+          make_source() {
+            local destination="$1"
+            local version="$2"
+            mkdir -p "$destination"
+            cat > "$destination/flake.nix" <<'FLAKE'
+          {
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+            outputs = { self, nixpkgs }: { };
+          }
+          FLAKE
+            cat > "$destination/Cargo.toml" <<EOF
+          [package]
+          name = "bcachefs-tools"
+          version = "$version"
+          EOF
+            cat > "$destination/Cargo.lock" <<EOF
+          version = 4
+
+          [[package]]
+          name = "bcachefs-tools"
+          version = "$version"
+          EOF
+          }
+
+          render_wrapper() {
+            local destination="$1"
+            local source="$2"
+            mkdir -p "$destination"
+            sed -e 's|"github:nasty-project/nasty/@NASTY_VERSION@"|"path:'"$GITHUB_WORKSPACE"'"|' \
+                -e 's|bcachefs-tools.url = "github:koverstreet/bcachefs-tools/[^"]*";|bcachefs-tools.url = "path:'"$source"'";|' \
+                -e 's|@LOCAL_SYSTEM@|x86_64-linux|g' \
+                -e 's|@WRAPPER_FLAKE_VERSION@|ci-bcachefs-pin|g' \
+                nixos/system-flake/flake.nix.template > "$destination/flake.nix"
+            cat > "$destination/hardware-configuration.nix" <<'STUB'
+          { ... }: { }
+          STUB
+            cat > "$destination/networking.nix" <<'STUB'
+          { ... }: { }
+          STUB
+            (cd "$destination" && nix flake lock)
+          }
+
+          evaluate_wrapper() {
+            local wrapper="$1"
+            nix eval --json "$wrapper#nixosConfigurations.nasty.config" \
+              --apply '
+                config:
+                let
+                  package = config.boot.bcachefs.package;
+                  module = config.boot.bcachefs.modulePackage;
+                in {
+                  package = {
+                    inherit (package) pname version drvPath;
+                    src = toString package.src;
+                    dkms = toString package.dkms;
+                  };
+                  module = {
+                    inherit (module) name drvPath;
+                    src = toString module.src;
+                  };
+                  moduleUsesPackageDkms = toString module.src == toString package.dkms;
+                  moduleInExtraModulePackages = builtins.any
+                    (candidate: candidate.drvPath == module.drvPath)
+                    config.boot.extraModulePackages;
+                }
+              ' > "$wrapper/eval.json"
+          }
+
+          make_source "$ROOT/source-a" "1.38.801"
+          make_source "$ROOT/source-b" "1.38.802"
+          render_wrapper "$ROOT/wrapper-a" "$ROOT/source-a"
+          render_wrapper "$ROOT/wrapper-b" "$ROOT/source-b"
+          evaluate_wrapper "$ROOT/wrapper-a"
+          evaluate_wrapper "$ROOT/wrapper-b"
+
+          jq -e '
+            .package.version == "1.38.801"
+            and .moduleUsesPackageDkms
+            and .moduleInExtraModulePackages
+          ' "$ROOT/wrapper-a/eval.json" >/dev/null
+          jq -e '
+            .package.version == "1.38.802"
+            and .moduleUsesPackageDkms
+            and .moduleInExtraModulePackages
+          ' "$ROOT/wrapper-b/eval.json" >/dev/null
+          jq -s -e '
+            .[0].package.src != .[1].package.src
+            and .[0].package.drvPath != .[1].package.drvPath
+            and .[0].package.dkms != .[1].package.dkms
+            and .[0].module.src != .[1].module.src
+            and .[0].module.drvPath != .[1].module.drvPath
+          ' "$ROOT/wrapper-a/eval.json" "$ROOT/wrapper-b/eval.json" >/dev/null
+
+          echo "Changing only the wrapper pin changes the installed userspace and DKMS derivations."

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -2076,7 +2076,9 @@ fn render_system_flake_template_with_ref(
 
 /// Whether the wrapper is in the canonical 0.0.9 shape:
 /// `nixpkgs.follows = "nasty/nixpkgs"` (no `.url`) AND
-/// `bcachefs-tools.url = "..."` (no `.follows`) AND lanzaboote's
+/// `bcachefs-tools.url = "..."` (no top-level `.follows`) AND
+/// `bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs"` AND
+/// `nasty.inputs.bcachefs-tools.follows = "bcachefs-tools"` AND lanzaboote's
 /// presence matches the SB overlay's presence (declared iff
 /// `secure-boot.nix` exists on disk, since lanzaboote is engine-
 /// injected per-box at enrollment).
@@ -2103,6 +2105,18 @@ fn wrapper_is_canonical_shape(content: &str, overlay_present: bool) -> bool {
     if !urls.contains_key("bcachefs-tools") {
         return false;
     }
+    // The system consumes nasty.packages.<system>.bcachefs-tools, so nasty's
+    // nested source must follow the operator-owned wrapper pin.
+    if !has_flake_string_attr(
+        content,
+        "nasty.inputs.bcachefs-tools.follows",
+        "bcachefs-tools",
+    ) {
+        return false;
+    }
+    if !has_flake_string_attr(content, "bcachefs-tools.inputs.nixpkgs.follows", "nixpkgs") {
+        return false;
+    }
     // Lanzaboote must be present iff the SB overlay is on disk.
     // Drift in either direction (overlay without input, or input
     // without overlay) is non-canonical and needs reconciliation
@@ -2112,6 +2126,37 @@ fn wrapper_is_canonical_shape(content: &str, overlay_present: bool) -> bool {
         return false;
     }
     true
+}
+
+fn has_flake_string_attr(content: &str, attr: &str, expected: &str) -> bool {
+    let parsed = rnix::Root::parse(content);
+    if !parsed.errors().is_empty() {
+        return false;
+    }
+
+    parsed
+        .tree()
+        .syntax()
+        .descendants()
+        .filter_map(ast::AttrpathValue::cast)
+        .any(|node| {
+            let Some(attrpath) = node.attrpath() else {
+                return false;
+            };
+            let normalized = attrpath
+                .syntax()
+                .text()
+                .to_string()
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect::<String>();
+            if normalized != attr {
+                return false;
+            }
+            node.value()
+                .and_then(|value| unquote_nix_string(&value.syntax().text().to_string()))
+                .is_some_and(|value| value == expected)
+        })
 }
 
 /// Re-render the wrapper-flake into the canonical 0.0.9 shape by
@@ -3565,14 +3610,16 @@ outputs = { nixpkgs, nasty, ... }: {
 
     #[test]
     fn wrapper_is_canonical_shape_accepts_canonical() {
-        // The 0.0.9 canonical shape: nasty.url, nixpkgs.follows,
-        // bcachefs-tools.url. nixpkgs must NOT have a .url; bcachefs
-        // MUST have one. No SB overlay on disk → no lanzaboote.
+        // The canonical shape: nasty.url, nixpkgs.follows, an operator-owned
+        // bcachefs-tools.url, and nasty's nested bcachefs input following it.
+        // No SB overlay on disk means no lanzaboote.
         let canonical = r#"{
   inputs = {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         assert!(super::wrapper_is_canonical_shape(canonical, false));
@@ -3587,6 +3634,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
     lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
     lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
   };
@@ -3604,6 +3653,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
     lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
   };
 }"#;
@@ -3619,6 +3670,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         assert!(!super::wrapper_is_canonical_shape(drift, true));
@@ -3636,6 +3689,18 @@ outputs = { nixpkgs, nasty, ... }: {
   };
 }"#;
         assert!(!super::wrapper_is_canonical_shape(legacy, false));
+    }
+
+    #[test]
+    fn wrapper_is_canonical_shape_rejects_ineffective_bcachefs_pin() {
+        let old_shape = r#"{
+  inputs = {
+    nasty.url = "github:nasty-project/nasty/v0.0.14";
+    nixpkgs.follows = "nasty/nixpkgs";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
+  };
+}"#;
+        assert!(!super::wrapper_is_canonical_shape(old_shape, false));
     }
 
     #[test]
@@ -3672,6 +3737,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         let out = super::inject_lanzaboote_input(wrapper).expect("inject");
@@ -3689,6 +3756,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
     lanzaboote.url = "github:nix-community/lanzaboote/v1.0.0";
     lanzaboote.inputs.nixpkgs.follows = "nasty/nixpkgs";
   };
@@ -3707,6 +3776,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         assert_eq!(super::strip_lanzaboote_input(wrapper), wrapper);
@@ -3719,6 +3790,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         let injected = super::inject_lanzaboote_input(wrapper).expect("inject");
@@ -3736,6 +3809,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         assert!(!super::wrapper_is_canonical_shape(pre, true));
@@ -3781,6 +3856,8 @@ outputs = { nixpkgs, nasty, ... }: {
         );
         // Follows is in place for nixpkgs:
         assert!(migrated.contains(r#"nixpkgs.follows = "nasty/nixpkgs""#));
+        assert!(migrated.contains(r#"nasty.inputs.bcachefs-tools.follows = "bcachefs-tools""#));
+        assert!(migrated.contains(r#"bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs""#));
     }
 
     #[tokio::test]
@@ -3790,6 +3867,8 @@ outputs = { nixpkgs, nasty, ... }: {
     nasty.url = "github:nasty-project/nasty/v0.0.9";
     nixpkgs.follows = "nasty/nixpkgs";
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.3";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
   };
 }"#;
         let out = super::migrate_wrapper_to_canonical_shape(canonical, "x86_64-linux", false)

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -22,11 +22,11 @@
     #
     # bcachefs-tools doesn't have the same problem: nasty's binary
     # closure doesn't link it, it's used purely as a runtime CLI +
-    # kernel module. The cost of the operator pinning a different
-    # bcachefs-tools rev is rebuilding bcachefs-tools itself + the
-    # kernel module — real, but a fair trade for the ability to
-    # stick with a known-good version when an upstream rev regresses
-    # on their hardware.
+    # kernel module. The wrapper owns the URL, while nasty's nested
+    # input follows that operator-owned pin. The cost of selecting a
+    # different rev is rebuilding bcachefs-tools itself + the kernel
+    # module — real, but a fair trade for the ability to stick with a
+    # known-good version when an upstream rev regresses on hardware.
     nasty.url = "github:nasty-project/nasty/@NASTY_VERSION@";
     nixpkgs.follows = "nasty/nixpkgs";
     # bcachefs-tools defaults to the same rev nasty's CI is tested
@@ -68,6 +68,12 @@
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
     bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
+    bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
+    # `nasty.packages.<system>.bcachefs-tools` is the package wired into
+    # boot.bcachefs.package below. Override nasty's nested source with the
+    # wrapper pin so changing the Version page actually changes both the
+    # userspace tools and DKMS module that the appliance installs.
+    nasty.inputs.bcachefs-tools.follows = "bcachefs-tools";
 
     # NOTE: lanzaboote is intentionally NOT declared as a top-level
     # input here. Secure Boot is per-box opt-in: when the operator


### PR DESCRIPTION
## Summary

- keep the wrapper bcachefs-tools URL operator-owned while making nasty consume that source for both userspace tools and DKMS
- migrate wrappers missing the nested follows wiring through the existing transactional update path
- add lock-graph and derivation tests proving a wrapper-only pin change reaches both outputs

## Testing

- `cargo test -p nasty-system`
- `cargo clippy -p nasty-system --all-targets -- -D warnings`
- `nix-instantiate --parse nixos/system-flake/flake.nix.template`
- installer lock-shape and synthetic derivation CI scripts locally
- NASty VM transactional switch `v1.38.8 -> v1.38.7 -> v1.38.8`, verifying userspace and DKMS derivations, shared lock source, health, rollback safety, and successful boots on both module closures