### PR TITLE
nixos: bump diskwatch to 0.1.3

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -795,12 +795,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.1.2";
-          hash = "sha256-8tQXcbY/sguw42vE0p5Q8/psmwfYQihWcSIsApI4OmE=";
+          rev = "v0.1.3";
+          hash = "sha256-CGt9954nwgVMcNJg6QjRLjhN8N9rQ6+bRuCzqQAUXGc=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.1.2";
+        version = "0.1.3";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";


### PR DESCRIPTION
## Summary

- bump the bundled diskwatch release from 0.1.2 to 0.1.3
- update the pinned GitHub source hash

## Testing

- `cargo check --locked` against the v0.1.3 source
- built the x86_64-linux Nix package on the NASty VM
- verified the packaged binary reports `diskwatch 0.1.3`