### PR TITLE
files: label calculated empty directories

### DIFF
--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -781,7 +781,7 @@
 						{#if !entry.is_dir}
 							{formatSize(entry.size)}
 						{:else if typeof folderSizes[entry.name] === 'number'}
-							{formatSize(folderSizes[entry.name] as number)}
+							{folderSizes[entry.name] === 0 ? 'Empty' : formatSize(folderSizes[entry.name] as number)}
 						{:else if folderSizes[entry.name] === 'loading'}
 							<Loader2 size={14} class="inline animate-spin" />
 						{:else}


### PR DESCRIPTION
## Summary

- show `Empty` after a calculated directory size returns zero
- preserve existing formatting for non-empty directories and regular files

Closes #670

## Testing

- `npm test`
- `npm run check`
- `npm run build`