### PR TITLE
nixos: bump nasty-top to 0.0.9

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -767,12 +767,12 @@ in {
         nastyTopSrc = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
-          rev = "v0.0.8";
-          hash = "sha256-IIWxrlTQg5bVCZTO1qaAlV5acN5sPnblaQXBVmmSdWQ=";
+          rev = "v0.0.9";
+          hash = "sha256-Qm2e1pk7cgcIPxL60A2bmYPbaniQGvuOEc/8OpWpXYQ=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.8";
+        version = "0.0.9";
         src = nastyTopSrc;
         # Vendor via Cargo.lock instead of a separate cargoHash so a
         # `cargo update` in nasty-top doesn't silently break this build.


### PR DESCRIPTION
## Summary

- bump the bundled `nasty-top` release from 0.0.8 to 0.0.9
- update the pinned GitHub source hash
- bring in the bcachefs 1.38.8 by-UUID discovery fix and monitoring hardening from nasty-project/nasty-top#22

Release: https://github.com/nasty-project/nasty-top/releases/tag/v0.0.9

## Testing

- `nix-instantiate --parse nixos/modules/nasty.nix`
- evaluated the exact archived NASty flake on x86_64-linux as `nasty-top-0.0.9`
- built the package with its nine Nix check-phase tests passing
- verified the built binary reports `nasty-top 0.0.9`
- live NASty VM test on bcachefs 1.38.8 correctly identifies filesystem `first` and restores the terminal on exit