### PR TITLE
webui: restore live update progress

### DIFF
--- a/webui/src/lib/update-progress.test.ts
+++ b/webui/src/lib/update-progress.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+	reachedUpdatePhase,
+	shouldShowUpdateStatus,
+	versionUpdatePhases
+} from './update-progress';
+
+describe('version update progress', () => {
+	it('tracks the transactional update markers in order', () => {
+		let log = '';
+		expect(reachedUpdatePhase(log, versionUpdatePhases)).toBe(-1);
+
+		for (let i = 0; i < versionUpdatePhases.length; i++) {
+			log += `${versionUpdatePhases[i].marker}\n`;
+			expect(reachedUpdatePhase(log, versionUpdatePhases)).toBe(i);
+		}
+	});
+
+	it('keeps a running transaction visible before a marker is recognized', () => {
+		expect(shouldShowUpdateStatus('running')).toBe(true);
+		expect(reachedUpdatePhase('preparing transaction\n', versionUpdatePhases)).toBe(-1);
+	});
+
+	it('keeps completed and failed transaction output available', () => {
+		expect(shouldShowUpdateStatus('success')).toBe(true);
+		expect(shouldShowUpdateStatus('failed')).toBe(true);
+		expect(shouldShowUpdateStatus('idle')).toBe(false);
+		expect(shouldShowUpdateStatus(null)).toBe(false);
+	});
+});

--- a/webui/src/lib/update-progress.ts
+++ b/webui/src/lib/update-progress.ts
@@ -1,0 +1,23 @@
+export interface UpdatePhase {
+	label: string;
+	marker: string;
+}
+
+export const versionUpdatePhases = [
+	{ label: 'Fetch', marker: '==> Updating staged system flake...' },
+	{ label: 'Build', marker: '==> Building staged system...' },
+	{ label: 'Activate', marker: '==> Activating verified system closure...' },
+	{ label: 'Done', marker: '==> Update complete!' }
+] as const satisfies readonly UpdatePhase[];
+
+export function reachedUpdatePhase(log: string, phases: readonly UpdatePhase[]): number {
+	let reached = -1;
+	for (let i = 0; i < phases.length; i++) {
+		if (log.includes(phases[i].marker)) reached = i;
+	}
+	return reached;
+}
+
+export function shouldShowUpdateStatus(state: string | null): boolean {
+	return state !== null && state !== 'idle';
+}

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -23,6 +23,11 @@
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
+	import {
+		reachedUpdatePhase,
+		shouldShowUpdateStatus,
+		versionUpdatePhases
+	} from '$lib/update-progress';
 
 	type Tab = 'version' | 'generations' | 'firmware';
 	type VersionRow = {
@@ -111,12 +116,7 @@
 	// tooltip so the wording stays consistent across surfaces.
 	let firmwareConstraints: FirmwareConstraints | null = $state(null);
 
-	const phases = [
-		{ label: 'Fetch', marker: '==> Updating local system flake' },
-		{ label: 'Build', marker: '==> Rebuilding' },
-		{ label: 'Activate', marker: 'activating the configuration' },
-		{ label: 'Done', marker: '==> Update complete!' }
-	];
+	const phases = versionUpdatePhases;
 
 	const genPhases = [
 		{ label: 'Switch', marker: '==> Switching to generation' },
@@ -125,21 +125,11 @@
 	];
 
 	const currentPhase = $derived.by(() => {
-		const log = status?.log ?? '';
-		let reached = -1;
-		for (let i = 0; i < phases.length; i++) {
-			if (log.includes(phases[i].marker)) reached = i;
-		}
-		return reached;
+		return reachedUpdatePhase(status?.log ?? '', phases);
 	});
 
 	const genCurrentPhase = $derived.by(() => {
-		const log = status?.log ?? '';
-		let reached = -1;
-		for (let i = 0; i < genPhases.length; i++) {
-			if (log.includes(genPhases[i].marker)) reached = i;
-		}
-		return reached;
+		return reachedUpdatePhase(status?.log ?? '', genPhases);
 	});
 
 	const versionDirty = $derived.by(() =>
@@ -178,9 +168,7 @@
 	);
 
 	const versionStatusVisible = $derived.by(() => {
-		if (!status || status.state === 'idle') return false;
-		const log = status.log ?? '';
-		return currentPhase >= 0 || log.includes('No flake.lock changes detected');
+		return shouldShowUpdateStatus(status?.state ?? null);
 	});
 
 	const generationStatusVisible = $derived.by(() => {


### PR DESCRIPTION
## Summary
- match the transactional update markers introduced in #666 so phase progress advances again
- show the update status card for every non-idle transaction so unknown markers cannot hide live logs
- cover phase parsing and status visibility with regression tests

## Tests
- npm test
- npm run check
- npm run build
- git diff --check