### PR TITLE
apps/storage: validate path-derived identifiers

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -87,6 +87,8 @@ pub enum AppsError {
     ForbiddenBind(String),
     #[error("invalid network: {0}")]
     InvalidNetwork(String),
+    #[error("invalid app name: {0}")]
+    InvalidName(String),
 }
 
 impl AppsError {
@@ -102,8 +104,80 @@ impl AppsError {
             Self::Io(_) => -33008,
             Self::ForbiddenBind(_) => -33009,
             Self::InvalidNetwork(_) => -33010,
+            Self::InvalidName(_) => -33011,
         }
     }
+}
+
+fn invalid_name(msg: impl Into<String>) -> AppsError {
+    AppsError::InvalidName(msg.into())
+}
+
+/// Validate an app name that may already exist on disk. Older releases allowed
+/// dots, so lifecycle operations retain that safe single-component grammar.
+pub fn validate_app_name(name: &str) -> Result<(), AppsError> {
+    let mut chars = name.chars();
+    if name.is_empty() || name.len() > 250 {
+        return Err(invalid_name("name must be 1-250 bytes"));
+    }
+    if !chars.next().is_some_and(|c| c.is_ascii_alphanumeric())
+        || !chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+    {
+        return Err(invalid_name(
+            "existing app names must be a single component of [A-Za-z0-9._-] starting with a letter or number",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate names for new apps. This grammar is stable across filesystem,
+/// Docker, Compose, Caddy route, and URL path identifiers.
+pub fn validate_new_app_name(name: &str) -> Result<(), AppsError> {
+    let mut bytes = name.bytes();
+    if name.is_empty() || name.len() > 63 {
+        return Err(invalid_name("name must be 1-63 bytes"));
+    }
+    if !bytes
+        .next()
+        .is_some_and(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+        || !bytes.all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'_' | b'-'))
+    {
+        return Err(invalid_name(
+            "new app names must match [a-z0-9][a-z0-9_-]{0,62}",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_volume_name(name: &str) -> Result<(), AppsError> {
+    if name.is_empty() || name.len() > 255 {
+        return Err(invalid_name("volume name must be 1-255 bytes"));
+    }
+    if matches!(name, "." | "..") || name.contains('/') || name.chars().any(char::is_control) {
+        return Err(invalid_name(
+            "volume name must be one normal path component without control characters",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_auto_volume_names(req: &InstallAppRequest) -> Result<(), AppsError> {
+    for volume in &req.volumes {
+        if volume.host_path.is_empty() {
+            validate_volume_name(&volume.name)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_new_app_request(req: &InstallAppRequest) -> Result<(), AppsError> {
+    validate_new_app_name(&req.name)?;
+    validate_auto_volume_names(req)
+}
+
+fn validate_existing_app_request(req: &InstallAppRequest) -> Result<(), AppsError> {
+    validate_app_name(&req.name)?;
+    validate_auto_volume_names(req)
 }
 
 // ── Managed Docker networks ─────────────────────────────────────
@@ -1847,7 +1921,7 @@ pub struct SubPathRecipe {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InstallAppRequest {
-    /// App name. Must be DNS-safe.
+    /// App name matching `[a-z0-9][a-z0-9_-]{0,62}`.
     pub name: String,
     /// Container image (e.g. "lscr.io/linuxserver/plex:latest").
     pub image: String,
@@ -1943,7 +2017,7 @@ pub struct AppVolume {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InstallComposeRequest {
-    /// App name (used as compose project name).
+    /// App name matching `[a-z0-9][a-z0-9_-]{0,62}` (used as compose project name).
     pub name: String,
     /// Contents of docker-compose.yml.
     pub compose_file: String,
@@ -2853,6 +2927,19 @@ impl AppsService {
     // ── Simple app management ───────────────────────────────
 
     pub async fn install(&self, req: InstallAppRequest) -> Result<App, AppsError> {
+        self.install_inner(req, true).await
+    }
+
+    async fn install_inner(
+        &self,
+        req: InstallAppRequest,
+        require_new_name: bool,
+    ) -> Result<App, AppsError> {
+        if require_new_name {
+            validate_new_app_request(&req)?;
+        } else {
+            validate_existing_app_request(&req)?;
+        }
         self.require_ready().await?;
 
         let cname = container_name(&req.name);
@@ -3231,6 +3318,7 @@ impl AppsService {
     }
 
     pub async fn update(&self, req: InstallAppRequest) -> Result<App, AppsError> {
+        validate_existing_app_request(&req)?;
         self.require_ready().await?;
 
         let cname = container_name(&req.name);
@@ -3263,10 +3351,11 @@ impl AppsService {
             .await;
 
         // Reinstall with new config
-        self.install(req).await
+        self.install_inner(req, false).await
     }
 
     pub async fn remove(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let cname = container_name(name);
@@ -3456,6 +3545,10 @@ impl AppsService {
             let name = entry.file_name().to_string_lossy().to_string();
 
             if path.is_dir() {
+                if let Err(e) = validate_app_name(&name) {
+                    warn!("apps: ignoring unsafe compose directory name '{name}': {e}");
+                    continue;
+                }
                 // Compose app: directory with docker-compose.yml
                 let compose_path = path.join("docker-compose.yml");
                 if compose_path.exists() {
@@ -3536,7 +3629,12 @@ impl AppsService {
                     .get("allow_unsafe")
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
-                if !app_name.is_empty() {
+                if let Err(e) = validate_app_name(&app_name) {
+                    warn!(
+                        "apps: ignoring unsafe app name in manifest {}: {e}",
+                        path.display()
+                    );
+                } else {
                     let proxy_disabled_reason = manifest
                         .get("proxy_disabled_reason")
                         .and_then(|s| s.as_str())
@@ -3585,7 +3683,11 @@ impl AppsService {
                 .cloned()
                 .unwrap_or_default();
 
-            if app_name.is_empty() || seen_names.contains(&app_name) {
+            if let Err(e) = validate_app_name(&app_name) {
+                warn!("apps: ignoring unsafe app name from Docker label '{app_name}': {e}");
+                continue;
+            }
+            if seen_names.contains(&app_name) {
                 continue;
             }
             seen_names.insert(app_name.clone());
@@ -3642,6 +3744,10 @@ impl AppsService {
             while let Some(entry) = entries.next_entry().await.map_err(AppsError::Io)? {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if seen_names.contains(&name) {
+                    continue;
+                }
+                if let Err(e) = validate_app_name(&name) {
+                    warn!("apps: ignoring unsafe compose directory name '{name}': {e}");
                     continue;
                 }
                 let compose_path = entry.path().join("docker-compose.yml");
@@ -3743,6 +3849,7 @@ impl AppsService {
     }
 
     pub async fn inspect(&self, name: &str) -> Result<serde_json::Value, AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
         let cname = container_name(name);
         let info = self
@@ -3755,6 +3862,7 @@ impl AppsService {
     }
 
     pub async fn get(&self, name: &str) -> Result<App, AppsError> {
+        validate_app_name(name)?;
         let apps = self.list().await?;
         apps.into_iter()
             .find(|a| a.name == name)
@@ -3762,6 +3870,7 @@ impl AppsService {
     }
 
     pub async fn get_config(&self, name: &str) -> Result<AppConfig, AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let cname = container_name(name);
@@ -3944,6 +4053,7 @@ impl AppsService {
     }
 
     pub async fn logs(&self, name: &str, tail: Option<u32>) -> Result<String, AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let cname = container_name(name);
@@ -4007,6 +4117,7 @@ impl AppsService {
     // ── Stop / Start ────────────────────────────────────────
 
     pub async fn stop(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         // Check if it's a compose app
@@ -4049,6 +4160,7 @@ impl AppsService {
     }
 
     pub async fn start(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         // Check if it's a compose app
@@ -4090,12 +4202,13 @@ impl AppsService {
     // ── Compose app management ──────────────────────────────
 
     pub async fn compose_install(&self, req: InstallComposeRequest) -> Result<App, AppsError> {
+        validate_new_app_name(&req.name)?;
         self.require_ready().await?;
 
         let project_dir = format!("{}/{}", COMPOSE_DIR, req.name);
 
         // Check if already exists
-        if Path::new(&project_dir).join("docker-compose.yml").exists() {
+        if Path::new(&project_dir).exists() {
             return Err(AppsError::AppAlreadyExists(req.name));
         }
 
@@ -4214,6 +4327,7 @@ impl AppsService {
     }
 
     pub async fn compose_update(&self, req: InstallComposeRequest) -> Result<App, AppsError> {
+        validate_app_name(&req.name)?;
         self.require_ready().await?;
 
         let project_dir = format!("{}/{}", COMPOSE_DIR, req.name);
@@ -4294,6 +4408,7 @@ impl AppsService {
         order: u32,
         delay_secs: u32,
     ) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
         let project_dir = format!("{}/{}", COMPOSE_DIR, name);
         if !Path::new(&project_dir).join("docker-compose.yml").exists() {
@@ -4357,6 +4472,10 @@ impl AppsService {
                     continue;
                 }
                 let name = entry.file_name().to_string_lossy().to_string();
+                if let Err(e) = validate_app_name(&name) {
+                    warn!("apps: ignoring unsafe compose directory name '{name}': {e}");
+                    continue;
+                }
                 let cfg = load_startup_config(&name).await;
                 out.push(ComposeStartupEntry {
                     name,
@@ -4371,6 +4490,7 @@ impl AppsService {
     }
 
     pub async fn compose_remove(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let project_dir = format!("{}/{}", COMPOSE_DIR, name);
@@ -4423,6 +4543,7 @@ impl AppsService {
     }
 
     pub async fn compose_get(&self, name: &str) -> Result<ComposeContent, AppsError> {
+        validate_app_name(name)?;
         let dir = format!("{}/{}", COMPOSE_DIR, name);
         let compose_file = tokio::fs::read_to_string(format!("{dir}/docker-compose.yml"))
             .await
@@ -4440,6 +4561,7 @@ impl AppsService {
     }
 
     pub async fn compose_logs(&self, name: &str, tail: Option<u32>) -> Result<String, AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let project_dir = format!("{}/{}", COMPOSE_DIR, name);
@@ -4590,6 +4712,7 @@ impl AppsService {
     }
 
     pub async fn ingress_set(&self, req: SetIngressRequest) -> Result<AppIngress, AppsError> {
+        validate_app_name(&req.name)?;
         // Treat "" as None — the WebUI submits an empty string when
         // the operator clears the field rather than omitting it.
         let subdomain = req
@@ -4669,6 +4792,7 @@ impl AppsService {
     }
 
     pub async fn ingress_remove(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         // Check existence first so the API contract (404 on
         // unknown) stays the same — caddy's DELETE is idempotent
         // by design (404 → Ok).
@@ -5058,6 +5182,10 @@ impl AppsService {
                     continue;
                 }
                 let name = entry.file_name().to_string_lossy().to_string();
+                if let Err(e) = validate_app_name(&name) {
+                    warn!("apps: refusing to restore unsafe compose directory name '{name}': {e}");
+                    continue;
+                }
                 let cfg = load_startup_config(&name).await;
                 if cfg.managed {
                     managed.push((name, cfg));
@@ -5240,6 +5368,7 @@ impl AppsService {
     // ── Restart ──────────────────────────────────────────────
 
     pub async fn restart(&self, name: &str) -> Result<(), AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
@@ -5283,6 +5412,7 @@ impl AppsService {
     // ── Pull (update image) ─────────────────────────────────
 
     pub async fn pull(&self, name: &str) -> Result<App, AppsError> {
+        validate_app_name(name)?;
         self.require_ready().await?;
 
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
@@ -5389,7 +5519,7 @@ impl AppsService {
                 network: config.network,
                 static_ip: config.static_ip,
             };
-            return self.install(req).await;
+            return self.install_inner(req, false).await;
         }
 
         self.get(name).await
@@ -5541,6 +5671,7 @@ impl AppsService {
     /// Return the docker exec command string for a given app.
     /// The WebUI can use this to pre-fill the Terminal page.
     pub async fn exec_command(&self, name: &str) -> Result<String, AppsError> {
+        validate_app_name(name)?;
         let compose_file = format!("{}/{}/docker-compose.yml", COMPOSE_DIR, name);
         let container = if Path::new(&compose_file).exists() {
             // Look up the first running container in the compose project
@@ -6550,10 +6681,87 @@ async fn fetch_manifest_json(
 #[cfg(test)]
 mod tests {
     use super::{
-        AppVolume, StartupConfig, compose_file_args, docker_data_root_status, extract_user_env,
-        render_env_file, render_startup_override, validate_simple_volumes,
+        AppVolume, InstallAppRequest, StartupConfig, compose_file_args, docker_data_root_status,
+        extract_user_env, render_env_file, render_startup_override, validate_app_name,
+        validate_new_app_name, validate_new_app_request, validate_simple_volumes,
+        validate_volume_name,
     };
     use std::path::PathBuf;
+
+    #[test]
+    fn new_app_name_accepts_conservative_grammar() {
+        for name in ["a", "app-1", "app_1", &"x".repeat(63)] {
+            assert!(validate_new_app_name(name).is_ok(), "{name}");
+        }
+    }
+
+    #[test]
+    fn new_app_name_rejects_unsafe_or_noncanonical_names() {
+        for name in [
+            "",
+            "App",
+            "old.app",
+            "-app",
+            "_app",
+            "../app",
+            "app/name",
+            "app\nname",
+            "app name",
+            "app!",
+            &"x".repeat(64),
+        ] {
+            assert!(validate_new_app_name(name).is_err(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn existing_app_name_keeps_safe_legacy_names_manageable() {
+        for name in ["old.app", "Legacy-App_1", &"x".repeat(250)] {
+            assert!(validate_app_name(name).is_ok(), "{name}");
+        }
+        for name in [
+            ".hidden",
+            "../app",
+            "app/name",
+            "app\nname",
+            &"x".repeat(251),
+        ] {
+            assert!(validate_app_name(name).is_err(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn generated_volume_name_must_be_one_component() {
+        for name in ["config", "media files", ".cache"] {
+            assert!(validate_volume_name(name).is_ok(), "{name}");
+        }
+        for name in ["", ".", "..", "../data", "data/cache", "line\nbreak"] {
+            assert!(validate_volume_name(name).is_err(), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn new_app_request_rejects_generated_volume_traversal() {
+        let request = InstallAppRequest {
+            name: "safe-app".to_string(),
+            image: "example/image:latest".to_string(),
+            ports: Vec::new(),
+            env: Vec::new(),
+            volumes: vec![AppVolume {
+                name: "../escape".to_string(),
+                mount_path: "/data".to_string(),
+                host_path: String::new(),
+            }],
+            cpu_limit: None,
+            memory_limit: None,
+            allow_unsafe: false,
+            subdomain: None,
+            network: None,
+            static_ip: None,
+        };
+
+        assert!(validate_new_app_request(&request).is_err());
+    }
 
     #[test]
     fn env_file_project_name_only_when_no_user_env() {

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -173,6 +173,11 @@ async fn handle_deploy(
         _ => return,
     };
 
+    if let Err(e) = nasty_apps::validate_app_name(&req.name) {
+        report_error(&mut socket, "<invalid>", "validate", &e.to_string()).await;
+        return;
+    }
+
     let token = match pre_auth_token.or_else(|| req.token.clone()) {
         Some(t) => t,
         None => {
@@ -246,6 +251,10 @@ async fn deploy_simple(
     session: &crate::auth::Session,
     client_ip: &str,
 ) {
+    if let Err(e) = nasty_apps::validate_new_app_name(&req.name) {
+        report_error(socket, &req.name, "validate", &e.to_string()).await;
+        return;
+    }
     let image = match &req.image {
         Some(img) => img.clone(),
         None => {
@@ -277,6 +286,10 @@ async fn deploy_simple(
     // Top-level flag wins over anything embedded in install_params, so the
     // privileged-deploy decision is plainly visible in the deploy request.
     params.allow_unsafe = req.allow_unsafe;
+    if let Err(e) = nasty_apps::validate_new_app_request(&params) {
+        report_error(socket, &req.name, "validate", &e.to_string()).await;
+        return;
+    }
     if let Some(ref s) = params.subdomain
         && let Some(reason) =
             crate::ingress_conflict::find_subdomain_conflict(state, &params.name, s).await
@@ -421,6 +434,20 @@ async fn deploy_compose(
 
     // Check if already exists (for new installs)
     let is_update = std::path::Path::new(&compose_path).exists();
+    if std::path::Path::new(&compose_dir).exists() && !is_update {
+        report_error(
+            socket,
+            &req.name,
+            "validate",
+            "app state directory already exists without a compose file",
+        )
+        .await;
+        return;
+    }
+    if !is_update && let Err(e) = nasty_apps::validate_new_app_name(&req.name) {
+        report_error(socket, &req.name, "validate", &e.to_string()).await;
+        return;
+    }
 
     // Write compose file
     if let Err(e) = tokio::fs::create_dir_all(&compose_dir).await {

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -946,6 +946,11 @@ pub(super) async fn vm_snapshot(
         return Err("no block subvolumes found for this VM".to_string());
     }
 
+    for disk in &disks {
+        nasty_storage::subvolume::validate_snapshot_name(&disk.subvolume, &req.name)
+            .map_err(|e| e.to_string())?;
+    }
+
     // VM should ideally be stopped or paused for consistent snapshots
     if vm_status.running {
         // Send sync to guest via QMP if possible (best-effort)
@@ -998,10 +1003,19 @@ pub(super) async fn vm_clone(
 
     let disks = resolve_vm_disks(state, &vm_status.config).await;
 
+    let clone_names = disks
+        .iter()
+        .map(|disk| {
+            let name = format!("{}-{}", disk.subvolume, req.new_name);
+            nasty_storage::subvolume::validate_subvolume_name(&name)
+                .map(|()| name)
+                .map_err(|e| e.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
     // Clone each block subvolume
     let mut new_disks = Vec::new();
-    for disk in &disks {
-        let clone_name = format!("{}-{}", disk.subvolume, req.new_name);
+    for (disk, clone_name) in disks.iter().zip(clone_names) {
         let clone_req = nasty_storage::subvolume::CloneSubvolumeRequest {
             filesystem: disk.filesystem.clone(),
             name: disk.subvolume.clone(),

--- a/engine/nasty-engine/src/subvol_rollback.rs
+++ b/engine/nasty-engine/src/subvol_rollback.rs
@@ -17,7 +17,9 @@ use std::time::Duration;
 
 use nasty_sharing::nfs::UpdateNfsShareRequest;
 use nasty_sharing::smb::UpdateSmbShareRequest;
-use nasty_storage::subvolume::{RollbackResult, RollbackSnapshotRequest, SubvolumeType};
+use nasty_storage::subvolume::{
+    RollbackResult, RollbackSnapshotRequest, SubvolumeType, validate_existing_snapshot_name,
+};
 use tracing::{info, warn};
 
 use crate::AppState;
@@ -35,6 +37,7 @@ pub async fn rollback_with_dependents(
     req: RollbackSnapshotRequest,
     owner_filter: Option<&str>,
 ) -> Result<RollbackResult, String> {
+    validate_existing_snapshot_name(&req.subvolume, &req.snapshot).map_err(|e| e.to_string())?;
     let sv = state
         .subvolumes
         .get(&req.filesystem, &req.subvolume, owner_filter)

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -94,7 +94,7 @@ const MAX_VOLSIZE_BYTES: u64 = 256 * 1024 * 1024 * 1024 * 1024; // 256 TiB
 /// (bcachefs uses `@` as the snapshot separator — colliding here
 /// corrupts snapshot lookups) or control characters (would smuggle
 /// newlines into log lines and config files downstream).
-fn validate_subvolume_name(name: &str) -> Result<(), SubvolumeError> {
+pub fn validate_subvolume_name(name: &str) -> Result<(), SubvolumeError> {
     if name.is_empty() {
         return Err(SubvolumeError::InvalidName("name is empty".to_string()));
     }
@@ -136,6 +136,60 @@ fn validate_subvolume_name(name: &str) -> Result<(), SubvolumeError> {
                 "name must not contain control characters".to_string(),
             ));
         }
+    }
+    Ok(())
+}
+
+/// Snapshot names are always one component appended to the source subvolume's
+/// final component as `<subvolume>@<snapshot>`.
+pub fn validate_snapshot_name(subvolume: &str, snapshot: &str) -> Result<(), SubvolumeError> {
+    validate_existing_snapshot_name(subvolume, snapshot)?;
+    if snapshot.len() > 200 {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name exceeds 200 bytes".to_string(),
+        ));
+    }
+    if snapshot.starts_with('.') {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name must not start with '.'".to_string(),
+        ));
+    }
+    if snapshot.contains('@') {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name must not contain '@'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a snapshot that may predate strict creation rules. Lifecycle
+/// operations still require a confined component but must not strand safe
+/// names that older releases allowed, such as `.before` or `before@upgrade`.
+pub fn validate_existing_snapshot_name(
+    subvolume: &str,
+    snapshot: &str,
+) -> Result<(), SubvolumeError> {
+    validate_subvolume_name(subvolume)?;
+    if snapshot.is_empty() {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name is empty".to_string(),
+        ));
+    }
+    if snapshot.contains('/') {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name must be one path component".to_string(),
+        ));
+    }
+    if snapshot.chars().any(char::is_control) {
+        return Err(SubvolumeError::InvalidName(
+            "snapshot name must not contain control characters".to_string(),
+        ));
+    }
+    let source_component = subvolume.rsplit('/').next().unwrap_or(subvolume);
+    if source_component.len() + 1 + snapshot.len() > 255 {
+        return Err(SubvolumeError::InvalidName(
+            "combined subvolume@snapshot name exceeds 255 bytes".to_string(),
+        ));
     }
     Ok(())
 }
@@ -969,7 +1023,9 @@ impl SubvolumeService {
             let snapshots: Vec<Snapshot> = info
                 .snapshot_flags
                 .iter()
-                .filter(|(p, _)| p.starts_with(&snap_prefix) && !p.contains('/'))
+                .filter(|(p, _)| {
+                    p.starts_with(&snap_prefix) && !p[snap_prefix.len()..].contains('/')
+                })
                 .map(|(p, &read_only)| {
                     let snap_name = p[snap_prefix.len()..].to_string();
                     let parent = info.snapshot_parents.get(p).cloned();
@@ -1755,6 +1811,7 @@ impl SubvolumeService {
         req: CreateSnapshotRequest,
         owner_filter: Option<&str>,
     ) -> Result<Snapshot, SubvolumeError> {
+        validate_snapshot_name(&req.subvolume, &req.name)?;
         // Verify ownership of the parent subvolume
         self.get(&req.filesystem, &req.subvolume, owner_filter)
             .await?;
@@ -1817,6 +1874,7 @@ impl SubvolumeService {
         req: DeleteSnapshotRequest,
         owner_filter: Option<&str>,
     ) -> Result<(), SubvolumeError> {
+        validate_existing_snapshot_name(&req.subvolume, &req.name)?;
         // Verify ownership if the parent subvolume still exists.
         // The parent may have been deleted (DR scenario) — orphaned snapshots
         // should still be deletable.
@@ -1851,6 +1909,7 @@ impl SubvolumeService {
         fs_name: &str,
         subvol_name: &str,
     ) -> Result<Vec<Snapshot>, SubvolumeError> {
+        validate_subvolume_name(subvol_name)?;
         let mount_point = self.fs_mount_point(fs_name).await?;
         let subvol_path = subvol_path(&mount_point, subvol_name);
 
@@ -1863,7 +1922,7 @@ impl SubvolumeService {
         let snapshots = info
             .snapshot_flags
             .into_iter()
-            .filter(|(p, _)| p.starts_with(&snap_prefix) && !p.contains('/'))
+            .filter(|(p, _)| p.starts_with(&snap_prefix) && !p[snap_prefix.len()..].contains('/'))
             .map(|(p, read_only)| {
                 let snap_name = p[snap_prefix.len()..].to_string();
                 Snapshot {
@@ -1903,15 +1962,14 @@ impl SubvolumeService {
 
         let mut all_snapshots = Vec::new();
         for (rel_path, read_only) in info.snapshot_flags {
-            // Snapshots live directly at filesystem root: "subvol@snap" (no '/')
-            if rel_path.contains('/') {
-                continue;
-            }
             let Some(at_pos) = rel_path.find('@') else {
                 continue;
             };
             let subvol_name = rel_path[..at_pos].to_string();
             let snap_name = rel_path[at_pos + 1..].to_string();
+            if subvol_name.is_empty() || snap_name.is_empty() || snap_name.contains('/') {
+                continue;
+            }
             if let Some(ref set) = owned
                 && !set.contains(&subvol_name)
             {
@@ -1939,6 +1997,7 @@ impl SubvolumeService {
         req: CloneSnapshotRequest,
         owner_filter: Option<&str>,
     ) -> Result<Subvolume, SubvolumeError> {
+        validate_existing_snapshot_name(&req.subvolume, &req.snapshot)?;
         validate_subvolume_name(&req.new_name)?;
         let _destination_guard = self.lock_destination(&req.filesystem, &req.new_name).await;
 
@@ -2013,6 +2072,7 @@ impl SubvolumeService {
         req: RollbackSnapshotRequest,
         owner_filter: Option<&str>,
     ) -> Result<RollbackResult, SubvolumeError> {
+        validate_existing_snapshot_name(&req.subvolume, &req.snapshot)?;
         let _destination_guard = self.lock_destination(&req.filesystem, &req.subvolume).await;
         let subvol = self
             .get(&req.filesystem, &req.subvolume, owner_filter)
@@ -2118,6 +2178,7 @@ impl SubvolumeService {
         req: CloneSubvolumeRequest,
         owner_filter: Option<&str>,
     ) -> Result<Subvolume, SubvolumeError> {
+        validate_subvolume_name(&req.name)?;
         validate_subvolume_name(&req.new_name)?;
         let _destination_guard = self.lock_destination(&req.filesystem, &req.new_name).await;
 
@@ -2988,6 +3049,55 @@ mod tests {
     }
 
     #[test]
+    fn validate_snapshot_name_accepts_one_component_for_nested_subvolume() {
+        assert!(validate_snapshot_name("projects/web", "before-upgrade").is_ok());
+        assert!(validate_snapshot_name("projects/web", "snap_2026.07.22").is_ok());
+    }
+
+    #[test]
+    fn validate_snapshot_name_rejects_path_and_separator_injection() {
+        for name in [
+            "",
+            ".hidden",
+            "..",
+            "../etc",
+            "/absolute",
+            "nested/snap",
+            "other@snap",
+            "line\nbreak",
+        ] {
+            assert!(
+                validate_snapshot_name("projects/web", name).is_err(),
+                "{name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_snapshot_name_enforces_filesystem_component_limit() {
+        assert!(validate_snapshot_name(&"s".repeat(200), &"x".repeat(54)).is_ok());
+        assert!(validate_snapshot_name(&"s".repeat(200), &"x".repeat(55)).is_err());
+        assert!(validate_snapshot_name("nested/source", &"x".repeat(200)).is_ok());
+        assert!(validate_snapshot_name("nested/source", &"x".repeat(201)).is_err());
+    }
+
+    #[test]
+    fn existing_snapshot_name_keeps_safe_legacy_names_manageable() {
+        for name in [".before", "before@upgrade", &"x".repeat(248)] {
+            assert!(
+                validate_existing_snapshot_name("source", name).is_ok(),
+                "{name:?}"
+            );
+        }
+        for name in ["", "../escape", "nested/snapshot", "line\nbreak"] {
+            assert!(
+                validate_existing_snapshot_name("source", name).is_err(),
+                "{name:?}"
+            );
+        }
+    }
+
+    #[test]
     fn validate_volsize_bytes_accepts_sensible_sizes() {
         assert!(validate_volsize_bytes(1024).is_ok());
         assert!(validate_volsize_bytes(1024 * 1024 * 1024).is_ok()); // 1 GiB
@@ -3084,6 +3194,61 @@ mod tests {
 
         let error = service.create(request, None).await.unwrap_err();
         assert!(matches!(error, SubvolumeError::InvalidName(_)));
+    }
+
+    #[tokio::test]
+    async fn snapshot_mutations_reject_invalid_names_before_storage_access() {
+        let service = SubvolumeService::new(FilesystemService::new());
+
+        let create = service
+            .create_snapshot(
+                CreateSnapshotRequest {
+                    filesystem: "missing".to_string(),
+                    subvolume: "safe".to_string(),
+                    name: "../../escape".to_string(),
+                    read_only: Some(true),
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(create, Err(SubvolumeError::InvalidName(_))));
+
+        let delete = service
+            .delete_snapshot(
+                DeleteSnapshotRequest {
+                    filesystem: "missing".to_string(),
+                    subvolume: "safe".to_string(),
+                    name: "../escape".to_string(),
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(delete, Err(SubvolumeError::InvalidName(_))));
+
+        let clone = service
+            .clone_snapshot(
+                CloneSnapshotRequest {
+                    filesystem: "missing".to_string(),
+                    subvolume: "safe".to_string(),
+                    snapshot: "nested/snapshot".to_string(),
+                    new_name: "clone".to_string(),
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(clone, Err(SubvolumeError::InvalidName(_))));
+
+        let rollback = service
+            .rollback(
+                RollbackSnapshotRequest {
+                    filesystem: "missing".to_string(),
+                    subvolume: "../escape".to_string(),
+                    snapshot: "safe".to_string(),
+                },
+                None,
+            )
+            .await;
+        assert!(matches!(rollback, Err(SubvolumeError::InvalidName(_))));
     }
 
     #[test]

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -653,10 +653,15 @@
 	 * the page silently stale until the user reloads. Lighter cadence
 	 * than the 2s stats poll: list cardinality changes are rare. */
 	let listPoll: ReturnType<typeof setInterval> | null = null;
-	const APP_NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+	const APP_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,62}$/;
+	const EXISTING_APP_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,249}$/;
 
 	function isValidAppName(name: string): boolean {
-		return name.length > 0 && name.length <= 53 && APP_NAME_RE.test(name);
+		return APP_NAME_RE.test(name);
+	}
+
+	function isValidExistingAppName(name: string): boolean {
+		return EXISTING_APP_NAME_RE.test(name);
 	}
 
 	async function inspectImage() {
@@ -1205,7 +1210,7 @@
 		if (!await waitForDocker()) return;
 		const appName = newName.toLowerCase();
 		if (!isValidAppName(appName)) {
-			await withToast(async () => { throw new Error('Invalid app name: use lowercase letters, numbers, hyphens, and dots (max 53 chars)'); }, '');
+			await withToast(async () => { throw new Error('Invalid app name: use lowercase letters, numbers, hyphens, and underscores (max 63 chars)'); }, '');
 			return;
 		}
 		const params: Record<string, unknown> = {
@@ -1526,8 +1531,8 @@
 		if (!composeName || !composeContent.trim()) { composeTried = true; return; }
 		composeTried = false;
 		if (!await waitForDocker()) return;
-		const name = composeName.toLowerCase();
-		if (!isValidAppName(name)) {
+		const name = editingCompose ? composeName : composeName.toLowerCase();
+		if (!(editingCompose ? isValidExistingAppName(name) : isValidAppName(name))) {
 			await withToast(async () => { throw new Error('Invalid app name'); }, '');
 			return;
 		}
@@ -1978,15 +1983,15 @@
 				     check stays always-on (user just typed something wrong,
 				     they want to know immediately). -->
 				{@const appNameMissing = !editingApp && !newName && installTried}
-				{@const appNameInvalid = !!newName && !isValidAppName(newName)}
+				{@const appNameInvalid = !!newName && !(editingApp ? isValidExistingAppName(newName) : isValidAppName(newName))}
 				{@const imageMissing = !editingApp && !newImage && installTried}
 				<div class="mb-4">
 					<Label for="app-name">App Name {#if appNameMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 					<Input id="app-name" value={newName} oninput={(e) => { newName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="whoami" class="mt-1 {requiredFieldCls(appNameMissing || appNameInvalid)}" disabled={!!editingApp} />
 					{#if appNameInvalid}
-						<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, dots. Max 53 chars.</span>
+						<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, or underscores. Max 63 chars.</span>
 					{:else}
-						<span class="mt-1 block text-xs text-muted-foreground">Must be DNS-safe (lowercase, no spaces).</span>
+						<span class="mt-1 block text-xs text-muted-foreground">Lowercase letters, numbers, hyphens, and underscores.</span>
 					{/if}
 				</div>
 				<div class="mb-4">
@@ -2214,7 +2219,7 @@
 				     clean. composeNameInvalid stays always-on because that's
 				     "you typed something invalid", not "you forgot a field". -->
 				{@const composeNameMissing = !editingCompose && !composeName && composeTried}
-				{@const composeNameInvalid = !!composeName && !isValidAppName(composeName)}
+				{@const composeNameInvalid = !!composeName && !(editingCompose ? isValidExistingAppName(composeName) : isValidAppName(composeName))}
 				{@const composeContentMissing = !composeContent.trim() && composeTried}
 				<!-- Compose form: two columns at lg+ — form on the left, warnings + ingress picker on the right. -->
 				<div class="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,360px)]">
@@ -2223,7 +2228,7 @@
 							<Label for="compose-name">App Name {#if composeNameMissing}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 							<Input id="compose-name" value={composeName} oninput={(e) => { composeName = (e.currentTarget as HTMLInputElement).value.toLowerCase(); }} placeholder="my-stack" class="mt-1 {requiredFieldCls(composeNameMissing || composeNameInvalid)}" disabled={!!editingCompose} />
 							{#if composeNameInvalid}
-								<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, dots. Max 53 chars.</span>
+								<span class="mt-1 block text-xs text-red-500">Must be lowercase letters, numbers, hyphens, or underscores. Max 63 chars.</span>
 							{/if}
 						</div>
 						<div class="mb-4">


### PR DESCRIPTION
## Summary
- validate new and persisted app identifiers at service, streaming deploy, startup, and cleanup boundaries
- reject unsafe generated volume, snapshot, and clone path components before external side effects while preserving safe legacy names
- preflight VM snapshot/clone operations, restore nested snapshot listing, and align WebUI app-name validation
- refuse compose installation over pre-existing unowned state directories

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p nasty-apps -p nasty-storage -p nasty-engine`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run check`
- `npm test`
- `npm run build`

## Scope
This covers DATA-4 lexical identifier validation. Descriptor-relative/no-follow filesystem operations remain a separate architectural follow-up.