### PR TITLE
webui: add configurable icon navigation

### DIFF
--- a/webui/src/lib/components/ClassicSidebarNav.svelte
+++ b/webui/src/lib/components/ClassicSidebarNav.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { ChevronRight } from '@lucide/svelte';
+	import { isNavGroup, type NavEntry } from '$lib/navigation';
+
+	interface Props {
+		entries: NavEntry[];
+		currentHref: string;
+		activeGroupId: string | null;
+		expandedGroups: Record<string, boolean>;
+		collapsed: boolean;
+		isSearching: boolean;
+		searchMatches: Set<string>;
+		onToggleGroup: (id: string) => void;
+		onNavigate: () => void;
+	}
+
+	let {
+		entries,
+		currentHref,
+		activeGroupId,
+		expandedGroups,
+		collapsed,
+		isSearching,
+		searchMatches,
+		onToggleGroup,
+		onNavigate
+	}: Props = $props();
+
+	function isExpanded(id: string): boolean {
+		return expandedGroups[id] || activeGroupId === id;
+	}
+</script>
+
+<nav class="flex-1 overflow-y-auto py-2" aria-label="Primary navigation">
+	{#each entries as entry (entry.id)}
+		{#if isNavGroup(entry)}
+			{@const GroupIcon = entry.icon}
+			{@const expanded = isExpanded(entry.id)}
+			{@const groupActive = activeGroupId === entry.id}
+			{@const matchingChildren = isSearching ? entry.children.filter((child) => searchMatches.has(child.href)) : entry.children}
+			{#if matchingChildren.length === 0 && isSearching}
+				<!-- Group has no matching children during search. -->
+			{:else if collapsed}
+				{#each matchingChildren as child (child.id)}
+					{@const ChildIcon = child.icon}
+					{@const active = currentHref === child.href}
+					<a
+						href={child.href}
+						title={child.label}
+						aria-label={child.label}
+						aria-current={active ? 'page' : undefined}
+						class="relative mx-2 flex items-center justify-center rounded-md py-2 text-sm no-underline transition-all border-2
+							{active
+								? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
+								: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
+					>
+						<ChildIcon size={15} class="shrink-0" />
+					</a>
+				{/each}
+			{:else if isSearching}
+				{#each matchingChildren as child (child.id)}
+					{@const ChildIcon = child.icon}
+					{@const active = currentHref === child.href}
+					<a
+						href={child.href}
+						onclick={onNavigate}
+						aria-current={active ? 'page' : undefined}
+						class="relative mx-2 flex items-center gap-2.5 rounded-md py-2 pl-4 pr-4 text-sm no-underline transition-all border-2
+							{active
+								? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
+								: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
+					>
+						<ChildIcon size={14} class="shrink-0" />
+						{child.label}
+					</a>
+				{/each}
+			{:else}
+				<button
+					onclick={() => onToggleGroup(entry.id)}
+					aria-expanded={expanded}
+					class="mx-2 flex w-[calc(100%-1rem)] items-center gap-2.5 rounded-md py-2 pl-4 pr-3 text-sm transition-colors
+						{groupActive ? 'text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'}"
+				>
+					<GroupIcon size={15} class="shrink-0" />
+					{entry.label}
+					<ChevronRight size={13} class="ml-auto shrink-0 transition-transform duration-200 {expanded ? 'rotate-90' : ''}" />
+				</button>
+				{#if expanded}
+					{#each entry.children as child (child.id)}
+						{@const ChildIcon = child.icon}
+						{@const active = currentHref === child.href}
+						<a
+							href={child.href}
+							aria-current={active ? 'page' : undefined}
+							class="relative mx-2 flex items-center gap-2.5 rounded-md py-1.5 pl-8 pr-4 text-sm no-underline transition-all border-2
+								{active
+									? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
+									: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
+						>
+							<ChildIcon size={14} class="shrink-0" />
+							{child.label}
+						</a>
+					{/each}
+				{/if}
+			{/if}
+		{:else if !isSearching || searchMatches.has(entry.href)}
+			{@const Icon = entry.icon}
+			{@const active = currentHref === entry.href}
+			<a
+				href={entry.href}
+				onclick={() => { if (isSearching) onNavigate(); }}
+				title={collapsed ? entry.label : undefined}
+				aria-label={collapsed ? entry.label : undefined}
+				aria-current={active ? 'page' : undefined}
+				class="relative mx-2 flex items-center rounded-md py-2 text-sm no-underline transition-all border-2
+					{collapsed ? 'justify-center px-0' : 'gap-2.5 pl-4 pr-4'}
+					{active
+						? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
+						: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
+			>
+				<Icon size={15} class="shrink-0" />
+				{#if !collapsed}{entry.label}{/if}
+			</a>
+		{/if}
+	{/each}
+</nav>

--- a/webui/src/lib/components/IconSidebarNav.svelte
+++ b/webui/src/lib/components/IconSidebarNav.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
+	import { flattenNavigation, isNavGroup, type NavEntry, type NavGroup, type NavMode } from '$lib/navigation';
+	import { uiPrefs } from '$lib/uiPrefs.svelte';
+
+	interface Props {
+		entries: NavEntry[];
+		fullEntries: NavEntry[];
+		mode: NavMode;
+		currentHref: string;
+		activeGroupId: string | null;
+		collapsed: boolean;
+		isSearching: boolean;
+		searchMatches: Set<string>;
+		onNavigate: () => void;
+	}
+
+	let {
+		entries,
+		fullEntries,
+		mode,
+		currentHref,
+		activeGroupId,
+		collapsed,
+		isSearching,
+		searchMatches,
+		onNavigate
+	}: Props = $props();
+
+	let selectedGroupId = $state<string | null>(null);
+	let previousCurrentHref = $state('');
+	let previousMode = $state<NavMode | null>(null);
+	let initialized = $state(false);
+	let navElement = $state<HTMLElement>();
+	let backButton = $state<HTMLButtonElement>();
+	let selectedGroup = $derived.by((): NavGroup | null => {
+		const match = fullEntries.find((entry) => isNavGroup(entry) && entry.id === selectedGroupId);
+		return match && isNavGroup(match) ? match : null;
+	});
+	let searchItems = $derived(flattenNavigation(entries).filter((item) => searchMatches.has(item.href)));
+
+	$effect(() => {
+		if (!initialized) {
+			const persisted = uiPrefs.iconGroupId;
+			selectedGroupId = activeGroupId ?? (persisted && fullEntries.some((entry) => isNavGroup(entry) && entry.id === persisted) ? persisted : null);
+			previousCurrentHref = currentHref;
+			previousMode = mode;
+			initialized = true;
+		} else if (currentHref !== previousCurrentHref) {
+			selectedGroupId = activeGroupId;
+			previousCurrentHref = currentHref;
+		}
+		if (mode !== previousMode) {
+			if (mode === 'full') selectedGroupId = activeGroupId ?? uiPrefs.iconGroupId;
+			previousMode = mode;
+		}
+		if (selectedGroupId && !fullEntries.some((entry) => isNavGroup(entry) && entry.id === selectedGroupId)) {
+			selectedGroupId = null;
+			uiPrefs.setIconGroupId(null);
+		}
+	});
+
+	function selectGroup(id: string | null) {
+		selectedGroupId = id;
+		uiPrefs.setIconGroupId(id);
+	}
+
+	async function openGroup(id: string) {
+		selectGroup(id);
+		await tick();
+		backButton?.focus();
+	}
+
+	async function closeGroup() {
+		const id = selectedGroupId;
+		selectGroup(null);
+		await tick();
+		if (id) navElement?.querySelector<HTMLButtonElement>(`[data-nav-group="${id}"]`)?.focus();
+	}
+
+	function navigateDirect() {
+		selectGroup(null);
+		onNavigate();
+	}
+
+	function navigateSearch(href: string) {
+		onNavigate();
+		if (href === currentHref) selectGroup(activeGroupId);
+	}
+</script>
+
+<nav bind:this={navElement} class="flex-1 overflow-y-auto px-2 py-3" aria-label="Primary navigation">
+	{#if collapsed && isSearching}
+		<div class="space-y-1" aria-label="Navigation search results">
+			{#each searchItems as entry (entry.id)}
+				{@const Icon = entry.icon}
+				{@const active = currentHref === entry.href}
+				<a
+					href={entry.href}
+					onclick={() => navigateSearch(entry.href)}
+					title={entry.label}
+					aria-label={entry.label}
+					aria-current={active ? 'page' : undefined}
+					class="flex min-h-12 flex-col items-center justify-center gap-1 rounded-md border-2 px-0.5 py-1.5 no-underline transition-all
+						{active ? 'border-blue-500/50 text-foreground shadow-[0_0_8px_rgba(96,165,250,0.25)]' : 'border-transparent text-muted-foreground hover:border-blue-400/50 hover:text-foreground'}"
+				>
+					<Icon size={16} />
+					<span class="w-full text-center text-[0.625rem] font-medium leading-tight">{entry.label}</span>
+				</a>
+			{/each}
+		</div>
+	{:else if collapsed && mode === 'full' && selectedGroup}
+		<div class="space-y-1">
+			<button
+				bind:this={backButton}
+				onclick={closeGroup}
+				class="mb-2 flex min-h-12 w-full flex-col items-center justify-center gap-1 rounded-md border border-border py-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				aria-label="Back to navigation categories"
+				title="Back to categories"
+			>
+				<ChevronLeft size={16} />
+				<span class="text-[0.625rem] font-medium">Back</span>
+			</button>
+			{#each selectedGroup.children as child (child.id)}
+				{@const Icon = child.icon}
+				{@const active = currentHref === child.href}
+				<a
+					href={child.href}
+					onclick={onNavigate}
+					title={child.label}
+					aria-label={child.label}
+					aria-current={active ? 'page' : undefined}
+					class="flex min-h-12 flex-col items-center justify-center gap-1 rounded-md border-2 px-0.5 py-1.5 no-underline transition-all
+						{active ? 'border-blue-500/50 text-foreground shadow-[0_0_8px_rgba(96,165,250,0.25)]' : 'border-transparent text-muted-foreground hover:border-blue-400/50 hover:text-foreground'}"
+				>
+					<Icon size={16} />
+					<span class="w-full text-center text-[0.625rem] font-medium leading-tight">{child.label}</span>
+				</a>
+			{/each}
+		</div>
+	{:else if collapsed}
+		<div class="space-y-1">
+			{#each entries as entry (entry.id)}
+				{@const Icon = entry.icon}
+				{@const active = isNavGroup(entry) ? activeGroupId === entry.id : currentHref === entry.href}
+				{#if isNavGroup(entry)}
+					<button
+						onclick={() => openGroup(entry.id)}
+						data-nav-group={entry.id}
+						title={entry.label}
+						aria-label={`Open ${entry.label}`}
+						class="flex min-h-12 w-full flex-col items-center justify-center gap-1 rounded-md border-2 px-0.5 py-1.5 transition-all
+							{active ? 'border-blue-500/50 text-foreground shadow-[0_0_8px_rgba(96,165,250,0.25)]' : 'border-transparent text-muted-foreground hover:border-blue-400/50 hover:text-foreground'}"
+					>
+						<Icon size={16} />
+						<span class="w-full text-center text-[0.625rem] font-medium leading-tight">{entry.label}</span>
+					</button>
+				{:else}
+					<a
+						href={entry.href}
+						onclick={navigateDirect}
+						title={entry.label}
+						aria-label={entry.label}
+						aria-current={active ? 'page' : undefined}
+						class="flex min-h-12 flex-col items-center justify-center gap-1 rounded-md border-2 px-0.5 py-1.5 no-underline transition-all
+							{active ? 'border-blue-500/50 text-foreground shadow-[0_0_8px_rgba(96,165,250,0.25)]' : 'border-transparent text-muted-foreground hover:border-blue-400/50 hover:text-foreground'}"
+					>
+						<Icon size={16} />
+						<span class="w-full text-center text-[0.625rem] font-medium leading-tight">{entry.label}</span>
+					</a>
+				{/if}
+			{/each}
+		</div>
+	{:else if isSearching}
+		<div class="grid grid-cols-2 gap-2" aria-label="Navigation search results">
+			{#each searchItems as entry (entry.id)}
+				{@const Icon = entry.icon}
+				{@const active = currentHref === entry.href}
+				<a
+					href={entry.href}
+					onclick={() => navigateSearch(entry.href)}
+					aria-current={active ? 'page' : undefined}
+					class="group flex min-h-20 flex-col items-center justify-center gap-2 rounded-lg border px-2 py-3 text-center no-underline transition-all
+						{active ? 'border-blue-500/60 bg-blue-500/10 text-foreground shadow-[0_0_12px_rgba(96,165,250,0.18)]' : 'border-border/70 text-muted-foreground hover:border-blue-400/50 hover:bg-accent/50 hover:text-foreground'}"
+				>
+					<Icon size={20} class="transition-transform group-hover:scale-110" />
+					<span class="text-[0.7rem] font-medium leading-tight">{entry.label}</span>
+				</a>
+			{/each}
+		</div>
+	{:else if mode === 'full' && selectedGroup}
+		{@const GroupIcon = selectedGroup.icon}
+		<div class="mb-3 flex items-center gap-2 border-b border-border/70 pb-2">
+			<button
+				bind:this={backButton}
+				onclick={closeGroup}
+				class="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				aria-label="Back to navigation categories"
+				title="Back to categories"
+			>
+				<ChevronLeft size={16} />
+			</button>
+			<div class="flex min-w-0 items-center gap-2">
+				<GroupIcon size={17} class="shrink-0 text-blue-400" />
+				<span class="truncate text-sm font-semibold">{selectedGroup.label}</span>
+			</div>
+		</div>
+		<div class="grid grid-cols-2 gap-2">
+			{#each selectedGroup.children as child (child.id)}
+				{@const Icon = child.icon}
+				{@const active = currentHref === child.href}
+				<a
+					href={child.href}
+					onclick={onNavigate}
+					aria-current={active ? 'page' : undefined}
+					class="group flex min-h-20 flex-col items-center justify-center gap-2 rounded-lg border px-2 py-3 text-center no-underline transition-all
+						{active ? 'border-blue-500/60 bg-blue-500/10 text-foreground shadow-[0_0_12px_rgba(96,165,250,0.18)]' : 'border-border/70 text-muted-foreground hover:border-blue-400/50 hover:bg-accent/50 hover:text-foreground'}"
+				>
+					<Icon size={21} class="transition-transform group-hover:scale-110" />
+					<span class="text-[0.7rem] font-medium leading-tight">{child.label}</span>
+				</a>
+			{/each}
+		</div>
+	{:else}
+		<div class="grid grid-cols-2 gap-2">
+			{#each entries as entry (entry.id)}
+				{@const Icon = entry.icon}
+				{@const active = isNavGroup(entry) ? activeGroupId === entry.id : currentHref === entry.href}
+				{#if isNavGroup(entry)}
+					<button
+						onclick={() => openGroup(entry.id)}
+						data-nav-group={entry.id}
+						class="group relative flex min-h-20 flex-col items-center justify-center gap-2 rounded-lg border px-2 py-3 text-center transition-all
+							{active ? 'border-blue-500/60 bg-blue-500/10 text-foreground shadow-[0_0_12px_rgba(96,165,250,0.18)]' : 'border-border/70 text-muted-foreground hover:border-blue-400/50 hover:bg-accent/50 hover:text-foreground'}"
+						aria-label={`Open ${entry.label}`}
+					>
+						<Icon size={22} class="transition-transform group-hover:scale-110" />
+						<span class="text-[0.7rem] font-medium leading-tight">{entry.label}</span>
+						<ChevronRight size={12} class="absolute right-1.5 top-1.5 text-muted-foreground/50" />
+					</button>
+				{:else}
+					<a
+						href={entry.href}
+						onclick={navigateDirect}
+						aria-current={active ? 'page' : undefined}
+						class="group flex min-h-20 flex-col items-center justify-center gap-2 rounded-lg border px-2 py-3 text-center no-underline transition-all
+							{active ? 'border-blue-500/60 bg-blue-500/10 text-foreground shadow-[0_0_12px_rgba(96,165,250,0.18)]' : 'border-border/70 text-muted-foreground hover:border-blue-400/50 hover:bg-accent/50 hover:text-foreground'}"
+					>
+						<Icon size={22} class="transition-transform group-hover:scale-110" />
+						<span class="text-[0.7rem] font-medium leading-tight">{entry.label}</span>
+					</a>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</nav>

--- a/webui/src/lib/navigation.test.ts
+++ b/webui/src/lib/navigation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+import {
+	activeNavigationGroup,
+	commonNavigation,
+	currentNavigationItem,
+	flattenNavigation,
+	isNavGroup,
+	resolveNavigation,
+	searchNavigation
+} from './navigation';
+
+describe('navigation model', () => {
+	test('preserves the full hierarchy and order', () => {
+		const entries = resolveNavigation({ kvmAvailable: true });
+		expect(entries.map((entry) => entry.label)).toEqual([
+			'Dashboard', 'Storage', 'Sharing', 'Protection', 'Compute', 'Terminal', 'System'
+		]);
+		const storage = entries.find((entry) => entry.id === 'storage');
+		expect(storage && isNavGroup(storage) ? storage.children.map((item) => item.label) : [])
+			.toEqual(['Filesystems', 'Subvolumes', 'Disks', 'Operations', 'Files']);
+		expect(flattenNavigation(entries).map((entry) => entry.href)).toEqual([
+			'/',
+			'/filesystems', '/subvolumes', '/disks', '/operations', '/files',
+			'/sharing',
+			'/backups', '/alerts', '/firewall', '/tls', '/ingress', '/vpn',
+			'/vms', '/apps',
+			'/terminal',
+			'/services', '/hardware', '/logs', '/update', '/users', '/settings'
+		]);
+	});
+
+	test('uses unique stable IDs and routes', () => {
+		const items = flattenNavigation(resolveNavigation({ kvmAvailable: true }));
+		expect(new Set(items.map((entry) => entry.id)).size).toBe(items.length);
+		expect(new Set(items.map((entry) => entry.href)).size).toBe(items.length);
+	});
+
+	test('gates VMs on KVM without changing Apps', () => {
+		const withoutKvm = flattenNavigation(resolveNavigation({ kvmAvailable: false }));
+		expect(withoutKvm.some((item) => item.href === '/vms')).toBe(false);
+		expect(withoutKvm.some((item) => item.href === '/apps')).toBe(true);
+
+		const withKvm = flattenNavigation(resolveNavigation({ kvmAvailable: true }));
+		expect(withKvm.some((item) => item.href === '/vms')).toBe(true);
+	});
+
+	test('derives the existing Common menu order', () => {
+		const common = commonNavigation(resolveNavigation({ kvmAvailable: true }));
+		expect(common.map((item) => item.href)).toEqual([
+			'/', '/filesystems', '/subvolumes', '/disks', '/files', '/apps', '/vms', '/backups', '/logs'
+		]);
+	});
+
+	test('matches active items and their owning group', () => {
+		const entries = resolveNavigation({ kvmAvailable: true });
+		expect(currentNavigationItem('/subvolumes/details', entries).href).toBe('/subvolumes');
+		expect(activeNavigationGroup('/subvolumes/details', entries)).toBe('storage');
+		expect(activeNavigationGroup('/sharing', entries)).toBeNull();
+	});
+
+	test('search uses item keywords and group labels', () => {
+		const entries = resolveNavigation({ kvmAvailable: true });
+		expect(searchNavigation(entries, 'copygc')).toEqual(new Set(['/operations']));
+		expect(searchNavigation(entries, 'storage')).toEqual(new Set([
+			'/filesystems', '/subvolumes', '/disks', '/operations', '/files'
+		]));
+	});
+
+	test('search cannot expose capability-gated entries', () => {
+		const entries = resolveNavigation({ kvmAvailable: false });
+		expect(searchNavigation(entries, 'virtual machine')).toEqual(new Set());
+	});
+});

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -1,0 +1,186 @@
+import {
+	Activity,
+	Archive,
+	Bell,
+	Box,
+	CircuitBoard,
+	Cpu,
+	Database,
+	Flame,
+	FolderOpen,
+	Globe,
+	HardDrive,
+	Layers,
+	LayoutDashboard,
+	Lock,
+	Monitor,
+	Network,
+	RefreshCw,
+	ScrollText,
+	Server,
+	Settings,
+	Share2,
+	Shield,
+	ShieldCheck,
+	Terminal,
+	Wrench
+} from '@lucide/svelte';
+
+export type NavIcon = typeof LayoutDashboard;
+export type NavMode = 'full' | 'common';
+
+export interface NavItem {
+	kind: 'item';
+	id: string;
+	href: string;
+	label: string;
+	icon: NavIcon;
+	keywords: string[];
+	commonRank?: number;
+	requires?: 'kvm';
+}
+
+export interface NavGroup {
+	kind: 'group';
+	id: string;
+	label: string;
+	icon: NavIcon;
+	children: NavItem[];
+}
+
+export type NavEntry = NavItem | NavGroup;
+
+export interface NavigationContext {
+	kvmAvailable: boolean;
+}
+
+const item = (
+	id: string,
+	href: string,
+	label: string,
+	icon: NavIcon,
+	keywords: string[],
+	options: Pick<NavItem, 'commonRank' | 'requires'> = {}
+): NavItem => ({ kind: 'item', id, href, label, icon, keywords, ...options });
+
+const NAVIGATION: NavEntry[] = [
+	item('dashboard', '/', 'Dashboard', LayoutDashboard, ['dashboard', 'overview', 'stats', 'cpu', 'memory', 'load', 'charts', 'home'], { commonRank: 0 }),
+	{
+		kind: 'group',
+		id: 'storage',
+		label: 'Storage',
+		icon: Database,
+		children: [
+			item('filesystems', '/filesystems', 'Filesystems', Database, ['filesystem', 'pool', 'bcachefs', 'format', 'mount', 'unmount', 'create', 'encryption', 'replicas', 'erasure', 'tiering', 'compression', 'scrub', 'fsck', 'check', 'repair', 'balance', 'rebuild', 'defrag', 'add disk', 'remove disk', 'tpm', 'tpm2', 'seal', 'unlock', 'key', 'quota'], { commonRank: 1 }),
+			item('subvolumes', '/subvolumes', 'Subvolumes', Layers, ['subvolume', 'snapshot', 'quota', 'block device', 'dataset', 'clone', 'send', 'receive', 'replication', 'volume', 'zvol', 'lun', 'namespace'], { commonRank: 2 }),
+			item('disks', '/disks', 'Disks', HardDrive, ['disk', 'drive', 'smart', 'health', 'temperature', 'ssd', 'hdd', 'sas', 'nvme', 'topology', 'device', 'wipe', 'format', 'partition', 'serial', 'model', 'firmware', 'pcie', 'endurance', 'wear', 'scan'], { commonRank: 3 }),
+			item('operations', '/operations', 'Operations', Activity, ['operation', 'scrub', 'reconcile', 'balance', 'copygc', 'evacuate', 'progress', 'activity', 'job']),
+			item('files', '/files', 'Files', FolderOpen, ['file', 'browser', 'folder', 'directory', 'upload', 'download', 'rename', 'move', 'copy', 'permissions'], { commonRank: 4 })
+		]
+	},
+	item('sharing', '/sharing', 'Sharing', Share2, ['share', 'nfs', 'smb', 'samba', 'cifs', 'iscsi', 'nvmeof', 'nvme-of', 'export', 'target', 'lun', 'acl', 'chap', 'portal', 'subsystem', 'nqn', 'iqn', 'client', 'username']),
+	{
+		kind: 'group',
+		id: 'protection',
+		label: 'Protection',
+		icon: Shield,
+		children: [
+			item('backups', '/backups', 'Backups', Archive, ['backup', 'restore', 'rustic', 'restic', 'snapshot', 'retention', 'schedule', 'offsite', 'encrypt', 'cron', 's3', 'b2', 'sftp', 'rest', 'repository', 'repo', 'init', 'prune', 'check', 'cacert', 'ca cert', 'password'], { commonRank: 7 }),
+			item('alerts', '/alerts', 'Alerts', Bell, ['alert', 'notification', 'warning', 'critical', 'rule', 'threshold', 'monitor', 'webhook', 'email', 'telegram', 'discord', 'notify', 'severity', 'acknowledge', 'resolve']),
+			item('firewall', '/firewall', 'Firewall', Flame, ['firewall', 'port', 'nftables', 'restrict', 'ip', 'interface', 'security', 'network', 'rule', 'block', 'allow', 'tcp', 'udp']),
+			item('tls', '/tls', 'TLS', Lock, ['tls', 'ssl', 'certificate', 'cert', 'https', 'encrypt', 'letsencrypt', 'acme', 'dns', 'cloudflare', 'domain', 'ca', 'caddy', 'internal', 'self-signed', 'selfsigned', 'staging', 'renew', 'root']),
+			item('ingress', '/ingress', 'Ingress', Network, ['ingress', 'reverse', 'proxy', 'route', 'caddy', 'subdomain', 'host', 'path', 'apps', 'domain', 'https', 'redirect']),
+			item('vpn', '/vpn', 'VPN', Globe, ['vpn', 'tailscale', 'remote', 'access', 'tunnel', 'wireguard', 'connect', 'auth key', 'exit node', 'subnet', 'peer'])
+		]
+	},
+	{
+		kind: 'group',
+		id: 'compute',
+		label: 'Compute',
+		icon: Cpu,
+		children: [
+			item('vms', '/vms', 'VMs', Monitor, ['vm', 'virtual', 'machine', 'qemu', 'kvm', 'cpu', 'vnc', 'passthrough', 'iso', 'cdrom', 'disk', 'memory', 'ram', 'boot', 'uefi', 'ovmf', 'spice', 'bridge', 'console'], { commonRank: 6, requires: 'kvm' }),
+			item('apps', '/apps', 'Apps', Box, ['app', 'docker', 'container', 'compose', 'install', 'image', 'port', 'volume', 'env', 'pull', 'logs', 'restart', 'stop', 'start'], { commonRank: 5 })
+		]
+	},
+	item('terminal', '/terminal', 'Terminal', Terminal, ['terminal', 'shell', 'ssh', 'console', 'command', 'bash', 'web', 'tty']),
+	{
+		kind: 'group',
+		id: 'system',
+		label: 'System',
+		icon: Wrench,
+		children: [
+			item('services', '/services', 'Services', Server, ['service', 'protocol', 'nfs', 'smb', 'iscsi', 'smart', 'avahi', 'mdns', 'enable', 'disable', 'rest server', 'backup server', 'receiver', 'htpasswd', 'docker', 'container', 'runtime', 'ups', 'nut', 'battery', 'power', 'shutdown', 'uninterruptible']),
+			item('hardware', '/hardware', 'Hardware', CircuitBoard, ['hardware', 'pci', 'iommu', 'group', 'passthrough', 'vfio', 'gpu', 'device', 'driver', 'lspci', 'tpm', 'tpm2', 'secure boot', 'secureboot', 'cpu', 'memory', 'ram', 'dmi', 'bios', 'firmware', 'motherboard', 'mainboard', 'usb', 'nic']),
+			item('logs', '/logs', 'Logs', ScrollText, ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'], { commonRank: 8 }),
+			item('update', '/update', 'Update', RefreshCw, ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin']),
+			item('users', '/users', 'Access Control', ShieldCheck, ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider']),
+			item('settings', '/settings', 'Settings', Settings, ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'])
+		]
+	}
+];
+
+export function isNavGroup(entry: NavEntry): entry is NavGroup {
+	return entry.kind === 'group';
+}
+
+function isVisible(item: NavItem, context: NavigationContext): boolean {
+	return item.requires !== 'kvm' || context.kvmAvailable;
+}
+
+export function resolveNavigation(context: NavigationContext): NavEntry[] {
+	return NAVIGATION.map((entry) => {
+		if (!isNavGroup(entry)) return entry;
+		return { ...entry, children: entry.children.filter((child) => isVisible(child, context)) };
+	}).filter((entry) => isNavGroup(entry) ? entry.children.length > 0 : isVisible(entry, context));
+}
+
+export function flattenNavigation(entries: NavEntry[]): NavItem[] {
+	return entries.flatMap((entry) => isNavGroup(entry) ? entry.children : [entry]);
+}
+
+export function commonNavigation(entries: NavEntry[]): NavItem[] {
+	return flattenNavigation(entries)
+		.filter((entry) => entry.commonRank !== undefined)
+		.sort((a, b) => (a.commonRank ?? 0) - (b.commonRank ?? 0));
+}
+
+export function navigationForMode(entries: NavEntry[], mode: NavMode): NavEntry[] {
+	return mode === 'common' ? commonNavigation(entries) : entries;
+}
+
+export function pathMatches(path: string, href: string): boolean {
+	return path === href || (href !== '/' && path.startsWith(href));
+}
+
+export function currentNavigationItem(path: string, entries: NavEntry[]): NavItem {
+	const items = flattenNavigation(entries);
+	return [...items].sort((a, b) => b.href.length - a.href.length)
+		.find((entry) => pathMatches(path, entry.href)) ?? items[0];
+}
+
+export function activeNavigationGroup(path: string, entries: NavEntry[]): string | null {
+	return entries.find((entry) => isNavGroup(entry) && entry.children.some((child) => pathMatches(path, child.href)))?.id ?? null;
+}
+
+export function searchNavigation(entries: NavEntry[], query: string): Set<string> {
+	const normalized = query.trim().toLowerCase();
+	if (!normalized) return new Set();
+
+	const matches = new Set<string>();
+	for (const entry of entries) {
+		if (isNavGroup(entry)) {
+			const groupMatches = entry.label.toLowerCase().includes(normalized);
+			for (const child of entry.children) {
+				if (groupMatches || itemMatches(child, normalized)) matches.add(child.href);
+			}
+		} else if (itemMatches(entry, normalized)) {
+			matches.add(entry.href);
+		}
+	}
+	return matches;
+}
+
+function itemMatches(item: NavItem, query: string): boolean {
+	return item.label.toLowerCase().includes(query) || item.keywords.some((keyword) => keyword.includes(query));
+}

--- a/webui/src/lib/uiPrefs.svelte.test.ts
+++ b/webui/src/lib/uiPrefs.svelte.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { uiPrefs } from './uiPrefs.svelte';
+
+beforeEach(() => {
+	uiPrefs.setLogoHidden(false);
+	uiPrefs.setMenuStyle('classic');
+	uiPrefs.setIconGroupId(null);
+	localStorage.clear();
+});
+
+describe('uiPrefs', () => {
+	test('persists the selected menu presentation', () => {
+		uiPrefs.setMenuStyle('icons');
+		expect(uiPrefs.menuStyle).toBe('icons');
+		expect(localStorage.getItem('nasty:menu_style')).toBe('icons');
+
+		uiPrefs.setMenuStyle('classic');
+		expect(uiPrefs.menuStyle).toBe('classic');
+		expect(localStorage.getItem('nasty:menu_style')).toBe('classic');
+	});
+
+	test('keeps logo visibility behavior independent', () => {
+		uiPrefs.setMenuStyle('icons');
+		uiPrefs.setLogoHidden(true);
+		expect(uiPrefs.logoHidden).toBe(true);
+		expect(uiPrefs.menuStyle).toBe('icons');
+	});
+
+	test('persists and clears the selected icon category', () => {
+		uiPrefs.setIconGroupId('storage');
+		expect(uiPrefs.iconGroupId).toBe('storage');
+		expect(localStorage.getItem('nasty:icon_nav_group')).toBe('storage');
+
+		uiPrefs.setIconGroupId(null);
+		expect(uiPrefs.iconGroupId).toBeNull();
+		expect(localStorage.getItem('nasty:icon_nav_group')).toBeNull();
+	});
+});

--- a/webui/src/lib/uiPrefs.svelte.ts
+++ b/webui/src/lib/uiPrefs.svelte.ts
@@ -2,10 +2,22 @@
 // shared reactively across components (same shape as theme.svelte.ts) so the
 // sidebar and the Settings toggle stay in sync without a page reload.
 const LOGO_HIDDEN_KEY = 'nasty:sidebar_logo_hidden';
+const MENU_STYLE_KEY = 'nasty:menu_style';
+const ICON_GROUP_KEY = 'nasty:icon_nav_group';
+
+export type MenuStyle = 'classic' | 'icons';
 
 function createUiPrefs() {
 	let logoHidden = $state<boolean>(
 		typeof localStorage !== 'undefined' && localStorage.getItem(LOGO_HIDDEN_KEY) === '1'
+	);
+	let menuStyle = $state<MenuStyle>(
+		typeof localStorage !== 'undefined' && localStorage.getItem(MENU_STYLE_KEY) === 'icons'
+			? 'icons'
+			: 'classic'
+	);
+	let iconGroupId = $state<string | null>(
+		typeof localStorage !== 'undefined' ? localStorage.getItem(ICON_GROUP_KEY) : null
 	);
 
 	return {
@@ -17,6 +29,24 @@ function createUiPrefs() {
 			if (typeof localStorage !== 'undefined') {
 				localStorage.setItem(LOGO_HIDDEN_KEY, v ? '1' : '0');
 			}
+		},
+		get menuStyle() {
+			return menuStyle;
+		},
+		setMenuStyle(style: MenuStyle) {
+			menuStyle = style;
+			if (typeof localStorage !== 'undefined') {
+				localStorage.setItem(MENU_STYLE_KEY, style);
+			}
+		},
+		get iconGroupId() {
+			return iconGroupId;
+		},
+		setIconGroupId(id: string | null) {
+			iconGroupId = id;
+			if (typeof localStorage === 'undefined') return;
+			if (id) localStorage.setItem(ICON_GROUP_KEY, id);
+			else localStorage.removeItem(ICON_GROUP_KEY);
 		},
 	};
 }

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -9,6 +9,8 @@
 	import ConfirmDangerousDialog from '$lib/components/ConfirmDangerousDialog.svelte';
 	import UnlockFsDialog from '$lib/components/UnlockFsDialog.svelte';
 	import ReconnectSpinner from '$lib/components/ReconnectSpinner.svelte';
+	import ClassicSidebarNav from '$lib/components/ClassicSidebarNav.svelte';
+	import IconSidebarNav from '$lib/components/IconSidebarNav.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
 	import type { BootStatus, BootPhase, SystemStatus } from '$lib/types';
@@ -16,24 +18,22 @@
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
 	import { uiPrefs } from '$lib/uiPrefs.svelte';
+	import {
+		activeNavigationGroup,
+		currentNavigationItem,
+		navigationForMode,
+		resolveNavigation,
+		searchNavigation,
+		type NavEntry,
+		type NavMode
+	} from '$lib/navigation';
 	import '../app.css';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import {
-		LayoutDashboard,
-		Database,
-		Layers,
-		Activity,
-		Share2,
-		HardDrive,
-		Archive,
-		Bell,
 		Settings,
 		RefreshCw,
-		Terminal,
-		ShieldCheck,
-		Network,
 		Power,
 		RotateCcw,
 		PowerOff,
@@ -44,24 +44,10 @@
 		PanelLeftClose,
 		PanelLeftOpen,
 		Bug,
-		Monitor,
-		Box,
-		FolderOpen,
 		CircleHelp,
 		ExternalLink,
 		MessageCircle,
 		Code2,
-		ChevronRight,
-		Shield,
-		Flame,
-		Lock,
-		Zap,
-		Globe,
-		Cpu,
-		CircuitBoard,
-		Server,
-		Wrench,
-		ScrollText,
 		Search,
 		AlertTriangle,
 		EyeOff,
@@ -677,163 +663,58 @@
 		try { await getClient().call('system.shutdown'); } catch { /* expected — engine dies */ }
 	}
 
-	type NavItem = { href: string; label: string; icon: any };
-	type NavGroup = { label: string; icon: any; children: NavItem[] };
-	type NavEntry = NavItem | NavGroup;
-	function isGroup(e: NavEntry): e is NavGroup { return 'children' in e; }
-
-	const nav = $derived.by((): NavEntry[] => {
-		const computeChildren: NavItem[] = [{ href: '/apps', label: 'Apps', icon: Box }];
-		if (sysInfo?.kvm_available) {
-			computeChildren.unshift({ href: '/vms', label: 'VMs', icon: Monitor });
-		}
-		return [
-			{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
-			{ label: 'Storage', icon: Database, children: [
-				{ href: '/filesystems', label: 'Filesystems', icon: Database },
-				{ href: '/subvolumes', label: 'Subvolumes', icon: Layers },
-				{ href: '/disks',      label: 'Disks',       icon: HardDrive },
-				{ href: '/operations', label: 'Operations',  icon: Activity },
-				{ href: '/files',      label: 'Files',       icon: FolderOpen },
-			]},
-			{ href: '/sharing', label: 'Sharing', icon: Share2 },
-			{ label: 'Protection', icon: Shield, children: [
-				{ href: '/backups',  label: 'Backups',  icon: Archive },
-				{ href: '/alerts',   label: 'Alerts',   icon: Bell },
-				{ href: '/firewall', label: 'Firewall', icon: Flame },
-				{ href: '/tls',      label: 'TLS',      icon: Lock },
-				{ href: '/ingress',  label: 'Ingress',  icon: Network },
-				{ href: '/vpn',      label: 'VPN',      icon: Globe },
-			]},
-			{ label: 'Compute', icon: Cpu, children: computeChildren },
-			{ href: '/terminal', label: 'Terminal', icon: Terminal },
-			{ label: 'System', icon: Wrench, children: [
-				{ href: '/services', label: 'Services',       icon: Server },
-				{ href: '/hardware', label: 'Hardware',       icon: CircuitBoard },
-				{ href: '/logs',     label: 'Logs',           icon: ScrollText },
-				{ href: '/update',   label: 'Update',         icon: RefreshCw },
-				{ href: '/users',    label: 'Access Control', icon: ShieldCheck },
-				{ href: '/settings', label: 'Settings',       icon: Settings },
-			]},
-		];
-	});
-
-	// Flatten all nav items for matching
-	const allNavItems = $derived.by((): NavItem[] => {
-		const items: NavItem[] = [];
-		for (const entry of nav) {
-			if (isGroup(entry)) items.push(...entry.children);
-			else items.push(entry);
-		}
-		return items;
-	});
+	const nav = $derived.by((): NavEntry[] => resolveNavigation({ kvmAvailable: sysInfo?.kvm_available === true }));
 
 	// ── Nav mode (#588): opt-in "Common" short menu vs the full grouped tree ──
 	const NAV_MODE_KEY = 'nasty:nav_mode';
-	let navMode: 'full' | 'common' = $state(
+	let navMode: NavMode = $state(
 		typeof localStorage !== 'undefined' && localStorage.getItem(NAV_MODE_KEY) === 'common'
 			? 'common'
 			: 'full'
 	);
-	function setNavMode(m: 'full' | 'common') {
+	function setNavMode(m: NavMode) {
 		navMode = m;
 		if (typeof localStorage !== 'undefined') localStorage.setItem(NAV_MODE_KEY, m);
 	}
 
-	// Curated flat short-list of the most-used pages for "Common" mode. Anything
-	// off this list is still reachable via the search box or by flipping to Full.
-	const commonNav = $derived.by((): NavItem[] => {
-		const items: NavItem[] = [
-			{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
-			{ href: '/filesystems', label: 'Filesystems', icon: Database },
-			{ href: '/subvolumes', label: 'Subvolumes', icon: Layers },
-			{ href: '/disks', label: 'Disks', icon: HardDrive },
-			{ href: '/files', label: 'Files', icon: FolderOpen },
-			{ href: '/apps', label: 'Apps', icon: Box },
-		];
-		if (sysInfo?.kvm_available) items.push({ href: '/vms', label: 'VMs', icon: Monitor });
-		items.push({ href: '/backups', label: 'Backups', icon: Archive });
-		items.push({ href: '/logs', label: 'Logs', icon: ScrollText });
-		return items;
-	});
-
-	// Derive current nav entry from path
-	const currentNav = $derived.by(() => {
-		const path = $page.url.pathname;
-		return [...allNavItems].sort((a, b) => b.href.length - a.href.length)
-			.find(n => path === n.href || (n.href !== '/' && path.startsWith(n.href))) ?? allNavItems[0];
-	});
+	const currentNav = $derived(currentNavigationItem($page.url.pathname, nav));
 
 	// Track which groups are expanded — auto-expand based on active route
 	const SIDEBAR_GROUPS_KEY = 'nasty:sidebar_groups';
-	let expandedGroups: Record<string, boolean> = $state(
-		typeof localStorage !== 'undefined'
-			? JSON.parse(localStorage.getItem(SIDEBAR_GROUPS_KEY) || '{}')
-			: {}
-	);
+	function loadExpandedGroups(): Record<string, boolean> {
+		if (typeof localStorage === 'undefined') return {};
+		try {
+			const stored = JSON.parse(localStorage.getItem(SIDEBAR_GROUPS_KEY) || '{}') as Record<string, boolean>;
+			return {
+				...stored,
+				storage: stored.storage ?? stored.Storage ?? false,
+				protection: stored.protection ?? stored.Protection ?? false,
+				compute: stored.compute ?? stored.Compute ?? false,
+				system: stored.system ?? stored.System ?? false
+			};
+		} catch {
+			return {};
+		}
+	}
+	let expandedGroups: Record<string, boolean> = $state(loadExpandedGroups());
 
-	function toggleGroup(label: string) {
-		expandedGroups[label] = !expandedGroups[label];
-		localStorage.setItem(SIDEBAR_GROUPS_KEY, JSON.stringify(expandedGroups));
+	function toggleGroup(id: string) {
+		expandedGroups[id] = !expandedGroups[id];
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(SIDEBAR_GROUPS_KEY, JSON.stringify(expandedGroups));
+		}
 	}
 
-	// Auto-expand the group containing the active route
-	const activeGroup = $derived.by((): string | null => {
-		const path = $page.url.pathname;
-		for (const entry of nav) {
-			if (isGroup(entry) && entry.children.some(c => path === c.href || (c.href !== '/' && path.startsWith(c.href)))) {
-				return entry.label;
-			}
-		}
-		return null;
-	});
+	const activeGroup = $derived(activeNavigationGroup($page.url.pathname, nav));
 
 	// ── Sidebar search ──────────────────────────────
-	interface SearchEntry { href: string; label: string; keywords: string[] }
-	const searchIndex: SearchEntry[] = [
-		{ href: '/', label: 'Dashboard', keywords: ['dashboard', 'overview', 'stats', 'cpu', 'memory', 'load', 'charts', 'home'] },
-		{ href: '/filesystems', label: 'Filesystems', keywords: ['filesystem', 'pool', 'bcachefs', 'format', 'mount', 'unmount', 'create', 'encryption', 'replicas', 'erasure', 'tiering', 'compression', 'scrub', 'fsck', 'check', 'repair', 'balance', 'rebuild', 'defrag', 'add disk', 'remove disk', 'tpm', 'tpm2', 'seal', 'unlock', 'key', 'quota'] },
-		{ href: '/subvolumes', label: 'Subvolumes', keywords: ['subvolume', 'snapshot', 'quota', 'block device', 'dataset', 'clone', 'send', 'receive', 'replication', 'volume', 'zvol', 'lun', 'namespace'] },
-		{ href: '/disks', label: 'Disks', keywords: ['disk', 'drive', 'smart', 'health', 'temperature', 'ssd', 'hdd', 'sas', 'nvme', 'topology', 'device', 'wipe', 'format', 'partition', 'serial', 'model', 'firmware', 'pcie', 'endurance', 'wear', 'scan'] },
-		{ href: '/files', label: 'Files', keywords: ['file', 'browser', 'folder', 'directory', 'upload', 'download', 'rename', 'move', 'copy', 'permissions'] },
-		{ href: '/sharing', label: 'Sharing', keywords: ['share', 'nfs', 'smb', 'samba', 'cifs', 'iscsi', 'nvmeof', 'nvme-of', 'export', 'target', 'lun', 'acl', 'chap', 'portal', 'subsystem', 'nqn', 'iqn', 'client', 'username'] },
-		{ href: '/backups', label: 'Backups', keywords: ['backup', 'restore', 'rustic', 'restic', 'snapshot', 'retention', 'schedule', 'offsite', 'encrypt', 'cron', 's3', 'b2', 'sftp', 'rest', 'repository', 'repo', 'init', 'prune', 'check', 'cacert', 'ca cert', 'password'] },
-		{ href: '/alerts', label: 'Alerts', keywords: ['alert', 'notification', 'warning', 'critical', 'rule', 'threshold', 'monitor', 'webhook', 'email', 'telegram', 'discord', 'notify', 'severity', 'acknowledge', 'resolve'] },
-		{ href: '/firewall', label: 'Firewall', keywords: ['firewall', 'port', 'nftables', 'restrict', 'ip', 'interface', 'security', 'network', 'rule', 'block', 'allow', 'tcp', 'udp'] },
-		{ href: '/tls', label: 'TLS', keywords: ['tls', 'ssl', 'certificate', 'cert', 'https', 'encrypt', 'letsencrypt', 'acme', 'dns', 'cloudflare', 'domain', 'ca', 'caddy', 'internal', 'self-signed', 'selfsigned', 'staging', 'renew', 'root'] },
-		{ href: '/ingress', label: 'Ingress', keywords: ['ingress', 'reverse', 'proxy', 'route', 'caddy', 'subdomain', 'host', 'path', 'apps', 'domain', 'https', 'redirect'] },
-		{ href: '/vpn', label: 'VPN', keywords: ['vpn', 'tailscale', 'remote', 'access', 'tunnel', 'wireguard', 'connect', 'auth key', 'exit node', 'subnet', 'peer'] },
-		{ href: '/vms', label: 'VMs', keywords: ['vm', 'virtual', 'machine', 'qemu', 'kvm', 'cpu', 'vnc', 'passthrough', 'iso', 'cdrom', 'disk', 'memory', 'ram', 'boot', 'uefi', 'ovmf', 'spice', 'bridge', 'console'] },
-		{ href: '/apps', label: 'Apps', keywords: ['app', 'docker', 'container', 'compose', 'install', 'image', 'port', 'volume', 'env', 'pull', 'logs', 'restart', 'stop', 'start'] },
-		{ href: '/terminal', label: 'Terminal', keywords: ['terminal', 'shell', 'ssh', 'console', 'command', 'bash', 'web', 'tty'] },
-		{ href: '/services', label: 'Services', keywords: ['service', 'protocol', 'nfs', 'smb', 'iscsi', 'smart', 'avahi', 'mdns', 'enable', 'disable', 'rest server', 'backup server', 'receiver', 'htpasswd', 'docker', 'container', 'runtime', 'ups', 'nut', 'battery', 'power', 'shutdown', 'uninterruptible'] },
-		{ href: '/hardware', label: 'Hardware', keywords: ['hardware', 'pci', 'iommu', 'group', 'passthrough', 'vfio', 'gpu', 'device', 'driver', 'lspci', 'tpm', 'tpm2', 'secure boot', 'secureboot', 'cpu', 'memory', 'ram', 'dmi', 'bios', 'firmware', 'motherboard', 'mainboard', 'usb', 'nic'] },
-		{ href: '/logs', label: 'Logs', keywords: ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'] },
-		{ href: '/update', label: 'Update', keywords: ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin'] },
-		{ href: '/users', label: 'Access Control', keywords: ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider'] },
-		{ href: '/settings', label: 'Settings', keywords: ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'] },
-	];
-
 	let sidebarSearch = $state('');
-	const searchMatches = $derived.by((): Set<string> => {
-		const q = sidebarSearch.trim().toLowerCase();
-		if (!q) return new Set();
-		return new Set(
-			searchIndex
-				.filter(e => e.label.toLowerCase().includes(q) || e.keywords.some(k => k.includes(q)))
-				.map(e => e.href)
-		);
-	});
+	const searchMatches = $derived(searchNavigation(nav, sidebarSearch));
 	const isSearching = $derived(sidebarSearch.trim().length > 0);
 
 	// While searching, render the full grouped tree so search can reach every page;
 	// otherwise honor the chosen nav mode (Full grouped tree vs Common short-list).
-	const displayNav = $derived(navMode === 'common' ? commonNav : nav);
-	const renderNav = $derived<NavEntry[]>(isSearching ? nav : displayNav);
-
-	function isGroupExpanded(label: string): boolean {
-		return expandedGroups[label] || activeGroup === label;
-	}
+	const renderNav = $derived<NavEntry[]>(isSearching ? nav : navigationForMode(nav, navMode));
 </script>
 
 <svelte:head>
@@ -963,7 +844,7 @@
 {:else}
 	<div class="relative flex h-screen overflow-hidden">
 		<!-- Sidebar -->
-		<aside class="flex {sidebarCollapsed ? 'w-[52px]' : 'w-[200px]'} shrink-0 flex-col border-r border-border bg-card transition-[width] duration-200">
+		<aside class="flex {sidebarCollapsed ? (uiPrefs.menuStyle === 'icons' ? 'w-[72px]' : 'w-[52px]') : 'w-[200px]'} shrink-0 flex-col border-r border-border bg-card transition-[width] duration-200">
 			<!-- Logo / collapse toggle -->
 			{#if sidebarCollapsed}
 				<div class="shrink-0 border-b border-border flex items-center justify-center py-3">
@@ -1061,95 +942,31 @@
 			{/if}
 
 			<!-- Nav — scrollable -->
-			<nav class="flex-1 overflow-y-auto py-2">
-				{#each renderNav as entry}
-					{#if isGroup(entry)}
-						{@const GroupIcon = entry.icon}
-						{@const expanded = isGroupExpanded(entry.label)}
-						{@const groupActive = activeGroup === entry.label}
-						{@const matchingChildren = isSearching ? entry.children.filter(c => searchMatches.has(c.href)) : entry.children}
-						{#if matchingChildren.length === 0 && isSearching}
-							<!-- Group has no matching children during search — hide entirely -->
-						{:else if sidebarCollapsed}
-							{#each matchingChildren as child}
-								{@const ChildIcon = child.icon}
-								{@const active = currentNav.href === child.href}
-								<a
-									href={child.href}
-									title={child.label}
-									class="relative mx-2 flex items-center justify-center rounded-md py-2 text-sm no-underline transition-all border-2
-										{active
-											? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
-											: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
-								>
-									<ChildIcon size={15} class="shrink-0" />
-								</a>
-							{/each}
-						{:else if isSearching}
-							<!-- During search: show matching children flat, no group header -->
-							{#each matchingChildren as child}
-								{@const ChildIcon = child.icon}
-								{@const active = currentNav.href === child.href}
-								<a
-									href={child.href}
-									onclick={() => { sidebarSearch = ''; }}
-									class="relative mx-2 flex items-center gap-2.5 rounded-md py-2 pl-4 pr-4 text-sm no-underline transition-all border-2
-										{active
-											? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
-											: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
-								>
-									<ChildIcon size={14} class="shrink-0" />
-									{child.label}
-								</a>
-							{/each}
-						{:else}
-							<button
-								onclick={() => toggleGroup(entry.label)}
-								class="mx-2 flex w-[calc(100%-1rem)] items-center gap-2.5 rounded-md py-2 pl-4 pr-3 text-sm transition-colors
-									{groupActive ? 'text-foreground font-medium' : 'text-muted-foreground hover:text-foreground'}"
-							>
-								<GroupIcon size={15} class="shrink-0" />
-								{entry.label}
-								<ChevronRight size={13} class="ml-auto shrink-0 transition-transform duration-200 {expanded ? 'rotate-90' : ''}" />
-							</button>
-							{#if expanded}
-								{#each entry.children as child}
-									{@const ChildIcon = child.icon}
-									{@const active = currentNav.href === child.href}
-									<a
-										href={child.href}
-										class="relative mx-2 flex items-center gap-2.5 rounded-md py-1.5 pl-8 pr-4 text-sm no-underline transition-all border-2
-											{active
-												? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
-												: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
-									>
-										<ChildIcon size={14} class="shrink-0" />
-										{child.label}
-									</a>
-								{/each}
-							{/if}
-						{/if}
-					{:else}
-						{#if !isSearching || searchMatches.has(entry.href)}
-						{@const Icon = entry.icon}
-						{@const active = currentNav.href === entry.href}
-						<a
-							href={entry.href}
-							onclick={() => { if (isSearching) sidebarSearch = ''; }}
-							title={sidebarCollapsed ? entry.label : undefined}
-							class="relative mx-2 flex items-center rounded-md py-2 text-sm no-underline transition-all border-2
-								{sidebarCollapsed ? 'justify-center px-0' : 'gap-2.5 pl-4 pr-4'}
-								{active
-									? 'text-foreground font-medium border-blue-500/50 shadow-[0_0_8px_rgba(96,165,250,0.25)]'
-									: 'text-muted-foreground border-transparent hover:text-foreground hover:border-blue-400/50 hover:shadow-[0_0_10px_rgba(96,165,250,0.25)]'}"
-						>
-							<Icon size={15} class="shrink-0" />
-							{#if !sidebarCollapsed}{entry.label}{/if}
-						</a>
-						{/if}
-					{/if}
-				{/each}
-			</nav>
+			{#if uiPrefs.menuStyle === 'icons'}
+				<IconSidebarNav
+					entries={renderNav}
+					fullEntries={nav}
+					mode={navMode}
+					currentHref={currentNav.href}
+					activeGroupId={activeGroup}
+					collapsed={sidebarCollapsed}
+					{isSearching}
+					{searchMatches}
+					onNavigate={() => { sidebarSearch = ''; }}
+				/>
+			{:else}
+				<ClassicSidebarNav
+					entries={renderNav}
+					currentHref={currentNav.href}
+					activeGroupId={activeGroup}
+					{expandedGroups}
+					collapsed={sidebarCollapsed}
+					{isSearching}
+					{searchMatches}
+					onToggleGroup={toggleGroup}
+					onNavigate={() => { sidebarSearch = ''; }}
+				/>
+			{/if}
 
 			{#if !sidebarCollapsed}
 				<!-- Clock — centered above the footer separator -->

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -1013,6 +1013,37 @@
 					Show the NASty logo in the sidebar
 				</label>
 				<p class="mt-1 text-xs text-muted-foreground">Hiding the logo frees vertical space for the menu. You can also hide it from the small icon next to the logo.</p>
+
+				<fieldset class="mt-5">
+					<legend class="text-sm font-medium">Navigation style</legend>
+					<p class="mt-1 text-xs text-muted-foreground">Choose how the same menu hierarchy is presented in the sidebar.</p>
+					<div class="mt-3 grid max-w-md grid-cols-2 gap-3">
+						<label class="cursor-pointer rounded-lg border p-3 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background {uiPrefs.menuStyle === 'classic' ? 'border-blue-500/60 bg-blue-500/10' : 'border-border hover:bg-accent/40'}">
+							<input
+								type="radio"
+								name="navigation-style"
+								value="classic"
+								checked={uiPrefs.menuStyle === 'classic'}
+								onchange={() => uiPrefs.setMenuStyle('classic')}
+								class="sr-only"
+							/>
+							<span class="block text-sm font-medium">Classic</span>
+							<span class="mt-1 block text-xs text-muted-foreground">Compact grouped list</span>
+						</label>
+						<label class="cursor-pointer rounded-lg border p-3 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background {uiPrefs.menuStyle === 'icons' ? 'border-blue-500/60 bg-blue-500/10' : 'border-border hover:bg-accent/40'}">
+							<input
+								type="radio"
+								name="navigation-style"
+								value="icons"
+								checked={uiPrefs.menuStyle === 'icons'}
+								onchange={() => uiPrefs.setMenuStyle('icons')}
+								class="sr-only"
+							/>
+							<span class="block text-sm font-medium">Icons</span>
+							<span class="mt-1 block text-xs text-muted-foreground">Category and page tiles</span>
+						</label>
+					</div>
+				</fieldset>
 			</section>
 
 


### PR DESCRIPTION
## Summary
- extract one typed navigation model for hierarchy, routes, icons, search metadata, Common ordering, active matching, and capability gates
- move the existing sidebar into a behavior-compatible classic renderer
- add an icon-first renderer with category drill-down and child page tiles
- add a persisted Classic / Icons preference under Settings → Appearance
- preserve Common/Full mode, search, current-page titles, KVM visibility, collapsed navigation, and classic group expansion
- support collapsed mobile drill-down with visible labels and adequate touch targets
- transfer and restore keyboard focus when entering or leaving icon categories

## Tests
- navigation hierarchy and route coverage
- unique stable IDs and routes
- Common menu ordering
- KVM capability filtering
- active item and owning-group matching
- keyword and group-label search
- menu presentation and category persistence

## Validation
- `npm run check`
- `npm test` (157 tests)
- `npm run build`
- `git diff --check`

The build continues to emit the pre-existing `theme.svelte.ts` reactivity warning; this PR introduces no new Svelte diagnostics.