### PR TITLE
webui: add central navigation launcher

### DIFF
--- a/webui/src/lib/components/LauncherSidebarNav.svelte
+++ b/webui/src/lib/components/LauncherSidebarNav.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { LAUNCHER_NAV_ITEM } from '$lib/navigation';
+
+	interface Props {
+		collapsed: boolean;
+		active: boolean;
+	}
+
+	let { collapsed, active }: Props = $props();
+	const Icon = LAUNCHER_NAV_ITEM.icon;
+</script>
+
+<nav class="flex-1 px-2 py-3" aria-label="Primary navigation">
+	<a
+		href={LAUNCHER_NAV_ITEM.href}
+		aria-current={active ? 'page' : undefined}
+		title={collapsed ? 'Open launcher' : undefined}
+		aria-label={collapsed ? 'Open launcher' : undefined}
+		class="flex items-center rounded-lg border-2 no-underline transition-all
+			{collapsed ? 'justify-center py-2' : 'gap-3 px-3 py-3'}
+			{active
+				? 'border-blue-500/60 bg-blue-500/10 text-foreground shadow-[0_0_12px_rgba(96,165,250,0.18)]'
+				: 'border-border/70 text-muted-foreground hover:border-blue-400/50 hover:bg-accent/50 hover:text-foreground'}"
+	>
+		<span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500/10 text-blue-400">
+			<Icon size={18} />
+		</span>
+		{#if !collapsed}
+			<span class="min-w-0">
+				<span class="block text-sm font-semibold">Open Launcher</span>
+				<span class="mt-0.5 block text-[0.65rem] leading-tight text-muted-foreground">Browse categories and pages</span>
+			</span>
+		{/if}
+	</a>
+</nav>

--- a/webui/src/lib/navigation.test.ts
+++ b/webui/src/lib/navigation.test.ts
@@ -5,6 +5,7 @@ import {
 	currentNavigationItem,
 	flattenNavigation,
 	isNavGroup,
+	LAUNCHER_NAV_ITEM,
 	resolveNavigation,
 	searchNavigation
 } from './navigation';
@@ -56,6 +57,7 @@ describe('navigation model', () => {
 		expect(currentNavigationItem('/subvolumes/details', entries).href).toBe('/subvolumes');
 		expect(activeNavigationGroup('/subvolumes/details', entries)).toBe('storage');
 		expect(activeNavigationGroup('/sharing', entries)).toBeNull();
+		expect(currentNavigationItem('/menu', entries)).toBe(LAUNCHER_NAV_ITEM);
 	});
 
 	test('search uses item keywords and group labels', () => {

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -9,6 +9,7 @@ import {
 	Flame,
 	FolderOpen,
 	Globe,
+	Grid3X3,
 	HardDrive,
 	Layers,
 	LayoutDashboard,
@@ -53,6 +54,8 @@ export type NavEntry = NavItem | NavGroup;
 export interface NavigationContext {
 	kvmAvailable: boolean;
 }
+
+export const NAVIGATION_CONTEXT = Symbol('navigation');
 
 const item = (
 	id: string,
@@ -120,6 +123,8 @@ const NAVIGATION: NavEntry[] = [
 	}
 ];
 
+export const LAUNCHER_NAV_ITEM = item('launcher', '/menu', 'Launcher', Grid3X3, ['launcher', 'menu', 'navigation', 'pages']);
+
 export function isNavGroup(entry: NavEntry): entry is NavGroup {
 	return entry.kind === 'group';
 }
@@ -154,6 +159,7 @@ export function pathMatches(path: string, href: string): boolean {
 }
 
 export function currentNavigationItem(path: string, entries: NavEntry[]): NavItem {
+	if (path === LAUNCHER_NAV_ITEM.href) return LAUNCHER_NAV_ITEM;
 	const items = flattenNavigation(entries);
 	return [...items].sort((a, b) => b.href.length - a.href.length)
 		.find((entry) => pathMatches(path, entry.href)) ?? items[0];

--- a/webui/src/lib/uiPrefs.svelte.test.ts
+++ b/webui/src/lib/uiPrefs.svelte.test.ts
@@ -17,6 +17,10 @@ describe('uiPrefs', () => {
 		uiPrefs.setMenuStyle('classic');
 		expect(uiPrefs.menuStyle).toBe('classic');
 		expect(localStorage.getItem('nasty:menu_style')).toBe('classic');
+
+		uiPrefs.setMenuStyle('launcher');
+		expect(uiPrefs.menuStyle).toBe('launcher');
+		expect(localStorage.getItem('nasty:menu_style')).toBe('launcher');
 	});
 
 	test('keeps logo visibility behavior independent', () => {

--- a/webui/src/lib/uiPrefs.svelte.ts
+++ b/webui/src/lib/uiPrefs.svelte.ts
@@ -5,17 +5,14 @@ const LOGO_HIDDEN_KEY = 'nasty:sidebar_logo_hidden';
 const MENU_STYLE_KEY = 'nasty:menu_style';
 const ICON_GROUP_KEY = 'nasty:icon_nav_group';
 
-export type MenuStyle = 'classic' | 'icons';
+export type MenuStyle = 'classic' | 'icons' | 'launcher';
 
 function createUiPrefs() {
 	let logoHidden = $state<boolean>(
 		typeof localStorage !== 'undefined' && localStorage.getItem(LOGO_HIDDEN_KEY) === '1'
 	);
-	let menuStyle = $state<MenuStyle>(
-		typeof localStorage !== 'undefined' && localStorage.getItem(MENU_STYLE_KEY) === 'icons'
-			? 'icons'
-			: 'classic'
-	);
+	const storedMenuStyle = typeof localStorage !== 'undefined' ? localStorage.getItem(MENU_STYLE_KEY) : null;
+	let menuStyle = $state<MenuStyle>(storedMenuStyle === 'icons' || storedMenuStyle === 'launcher' ? storedMenuStyle : 'classic');
 	let iconGroupId = $state<string | null>(
 		typeof localStorage !== 'undefined' ? localStorage.getItem(ICON_GROUP_KEY) : null
 	);

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, setContext } from 'svelte';
 	import { page } from '$app/stores';
 	import { getClient, resetClient } from '$lib/client';
 	import { login as doLogin, logout as doLogout, loginWebauthn as doLoginWebauthn } from '$lib/auth';
@@ -11,6 +11,7 @@
 	import ReconnectSpinner from '$lib/components/ReconnectSpinner.svelte';
 	import ClassicSidebarNav from '$lib/components/ClassicSidebarNav.svelte';
 	import IconSidebarNav from '$lib/components/IconSidebarNav.svelte';
+	import LauncherSidebarNav from '$lib/components/LauncherSidebarNav.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
 	import type { BootStatus, BootPhase, SystemStatus } from '$lib/types';
@@ -21,6 +22,7 @@
 	import {
 		activeNavigationGroup,
 		currentNavigationItem,
+		NAVIGATION_CONTEXT,
 		navigationForMode,
 		resolveNavigation,
 		searchNavigation,
@@ -284,6 +286,9 @@
 
 	// Version info (loaded once after connect)
 	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_recommended_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
+	setContext(NAVIGATION_CONTEXT, {
+		get kvmAvailable() { return sysInfo?.kvm_available === true; }
+	});
 	// bcachefs "update available": the pin differs from the version this
 	// NASty build ships, so a one-click sync is offered. Distinct from
 	// "reboot pending" (bcachefs_is_custom), which the restart banner owns.
@@ -909,7 +914,7 @@
 			{/if}
 
 			<!-- Search bar -->
-			{#if !sidebarCollapsed}
+			{#if !sidebarCollapsed && uiPrefs.menuStyle !== 'launcher'}
 				<div class="shrink-0 px-2 pt-2 relative">
 					<div class="relative">
 						<Search size={13} class="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50" />
@@ -924,7 +929,7 @@
 			{/if}
 
 			<!-- Nav mode toggle (#588): Common short-list vs Full grouped tree — hidden while searching -->
-			{#if !sidebarCollapsed && !isSearching}
+			{#if !sidebarCollapsed && !isSearching && uiPrefs.menuStyle !== 'launcher'}
 				<div class="shrink-0 px-2 pt-2">
 					<div class="flex rounded-md border border-border p-0.5 text-[0.7rem]">
 						<button
@@ -942,7 +947,9 @@
 			{/if}
 
 			<!-- Nav — scrollable -->
-			{#if uiPrefs.menuStyle === 'icons'}
+			{#if uiPrefs.menuStyle === 'launcher'}
+				<LauncherSidebarNav collapsed={sidebarCollapsed} active={$page.url.pathname === '/menu'} />
+			{:else if uiPrefs.menuStyle === 'icons'}
 				<IconSidebarNav
 					entries={renderNav}
 					fullEntries={nav}

--- a/webui/src/routes/menu/+page.svelte
+++ b/webui/src/routes/menu/+page.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { getContext, tick } from 'svelte';
+	import { ChevronLeft, ChevronRight, Search } from '@lucide/svelte';
+	import {
+		flattenNavigation,
+		isNavGroup,
+		NAVIGATION_CONTEXT,
+		resolveNavigation,
+		searchNavigation,
+		type NavigationContext,
+		type NavGroup
+	} from '$lib/navigation';
+
+	const navigationContext = getContext<NavigationContext>(NAVIGATION_CONTEXT);
+	let query = $state('');
+	let selectedGroupId = $state<string | null>(null);
+	let launcherElement = $state<HTMLElement>();
+	let backButton = $state<HTMLButtonElement>();
+
+	let entries = $derived(resolveNavigation(navigationContext));
+	let selectedGroup = $derived.by((): NavGroup | null => {
+		const match = entries.find((entry) => isNavGroup(entry) && entry.id === selectedGroupId);
+		return match && isNavGroup(match) ? match : null;
+	});
+	let matches = $derived(searchNavigation(entries, query));
+	let searchItems = $derived(flattenNavigation(entries).filter((entry) => matches.has(entry.href)));
+	let isSearching = $derived(query.trim().length > 0);
+
+	$effect(() => {
+		if (selectedGroupId && !entries.some((entry) => isNavGroup(entry) && entry.id === selectedGroupId)) {
+			selectedGroupId = null;
+		}
+	});
+
+	async function openGroup(id: string) {
+		selectedGroupId = id;
+		query = '';
+		await tick();
+		backButton?.focus();
+	}
+
+	async function closeGroup() {
+		const id = selectedGroupId;
+		selectedGroupId = null;
+		await tick();
+		if (id) launcherElement?.querySelector<HTMLButtonElement>(`[data-launcher-group="${id}"]`)?.focus();
+	}
+</script>
+
+<div bind:this={launcherElement} class="mx-auto max-w-7xl">
+	<section class="relative mb-6 overflow-hidden rounded-2xl border border-border bg-card px-5 py-6 sm:px-7 sm:py-8">
+		<div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.14),transparent_45%)]"></div>
+		<div class="relative flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+			<div>
+				<p class="mb-2 font-mono text-[0.65rem] uppercase tracking-[0.28em] text-blue-400">NASty launcher</p>
+				<h1 class="text-2xl font-semibold tracking-tight sm:text-3xl">Where do you want to go?</h1>
+				<p class="mt-2 max-w-2xl text-sm text-muted-foreground">Open a category to browse its tools, or search every available page.</p>
+			</div>
+			<label class="relative block w-full lg:max-w-sm">
+				<span class="sr-only">Search navigation</span>
+				<Search size={17} class="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+				<input
+					type="search"
+					bind:value={query}
+					placeholder="Search pages and tools"
+					class="h-11 w-full rounded-xl border border-border bg-background/80 pl-10 pr-4 text-sm outline-none transition focus:border-blue-500/60 focus:ring-2 focus:ring-blue-500/20"
+				/>
+			</label>
+		</div>
+	</section>
+
+	{#if isSearching}
+		<div class="mb-4 flex items-center justify-between">
+			<div>
+				<h2 class="text-lg font-semibold">Search results</h2>
+				<p class="text-xs text-muted-foreground">{searchItems.length} page{searchItems.length === 1 ? '' : 's'} matched</p>
+			</div>
+			<button onclick={() => { query = ''; }} class="rounded-md px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">Clear search</button>
+		</div>
+		{#if searchItems.length > 0}
+			<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+				{#each searchItems as entry (entry.id)}
+					{@const Icon = entry.icon}
+					<a href={entry.href} class="group flex min-h-32 flex-col justify-between rounded-xl border border-border bg-card p-4 no-underline transition-all hover:-translate-y-0.5 hover:border-blue-400/60 hover:shadow-[0_12px_28px_rgba(15,23,42,0.22)]">
+						<span class="flex h-11 w-11 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400 transition-transform group-hover:scale-105"><Icon size={23} /></span>
+						<span class="mt-5 flex items-center justify-between gap-3">
+							<span class="font-medium text-foreground">{entry.label}</span>
+							<ChevronRight size={15} class="text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-blue-400" />
+						</span>
+					</a>
+				{/each}
+			</div>
+		{:else}
+			<div class="rounded-xl border border-dashed border-border px-6 py-12 text-center text-sm text-muted-foreground">No navigation entries match "{query.trim()}".</div>
+		{/if}
+	{:else if selectedGroup}
+		{@const GroupIcon = selectedGroup.icon}
+		<div class="mb-5 flex items-center gap-3">
+			<button
+				bind:this={backButton}
+				onclick={closeGroup}
+				class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border bg-card text-muted-foreground transition-colors hover:border-blue-400/60 hover:text-foreground"
+				aria-label="Back to launcher categories"
+			>
+				<ChevronLeft size={19} />
+			</button>
+			<span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400"><GroupIcon size={21} /></span>
+			<div>
+				<h2 class="text-xl font-semibold">{selectedGroup.label}</h2>
+				<p class="text-xs text-muted-foreground">{selectedGroup.children.length} available page{selectedGroup.children.length === 1 ? '' : 's'}</p>
+			</div>
+		</div>
+		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+			{#each selectedGroup.children as child (child.id)}
+				{@const Icon = child.icon}
+				<a href={child.href} class="group flex min-h-40 flex-col justify-between rounded-xl border border-border bg-card p-5 no-underline transition-all hover:-translate-y-0.5 hover:border-blue-400/60 hover:shadow-[0_12px_28px_rgba(15,23,42,0.22)]">
+					<span class="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400 transition-transform group-hover:scale-105"><Icon size={25} /></span>
+					<span class="mt-7 flex items-end justify-between gap-3">
+						<span>
+							<span class="block text-base font-semibold text-foreground">{child.label}</span>
+							<span class="mt-1 block text-xs text-muted-foreground">Open {child.label.toLowerCase()}</span>
+						</span>
+						<ChevronRight size={17} class="mb-0.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-blue-400" />
+					</span>
+				</a>
+			{/each}
+		</div>
+	{:else}
+		<div class="mb-4">
+			<h2 class="text-lg font-semibold">Categories</h2>
+			<p class="text-xs text-muted-foreground">The same navigation hierarchy, presented as a workspace.</p>
+		</div>
+		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+			{#each entries as entry (entry.id)}
+				{@const Icon = entry.icon}
+				{#if isNavGroup(entry)}
+					<button
+						onclick={() => openGroup(entry.id)}
+						data-launcher-group={entry.id}
+						class="group relative flex min-h-44 flex-col justify-between overflow-hidden rounded-xl border border-border bg-card p-5 text-left transition-all hover:-translate-y-0.5 hover:border-blue-400/60 hover:shadow-[0_12px_28px_rgba(15,23,42,0.22)]"
+					>
+						<span class="absolute inset-y-0 left-0 w-0.5 bg-blue-500/50 opacity-0 transition-opacity group-hover:opacity-100"></span>
+						<span class="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400 transition-transform group-hover:scale-105"><Icon size={25} /></span>
+						<span class="mt-7 flex w-full items-end justify-between gap-3">
+							<span>
+								<span class="block text-base font-semibold text-foreground">{entry.label}</span>
+								<span class="mt-1 block text-xs text-muted-foreground">{entry.children.length} page{entry.children.length === 1 ? '' : 's'}</span>
+							</span>
+							<ChevronRight size={17} class="mb-0.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-blue-400" />
+						</span>
+					</button>
+				{:else}
+					<a href={entry.href} class="group relative flex min-h-44 flex-col justify-between overflow-hidden rounded-xl border border-border bg-card p-5 no-underline transition-all hover:-translate-y-0.5 hover:border-blue-400/60 hover:shadow-[0_12px_28px_rgba(15,23,42,0.22)]">
+						<span class="absolute inset-y-0 left-0 w-0.5 bg-blue-500/50 opacity-0 transition-opacity group-hover:opacity-100"></span>
+						<span class="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400 transition-transform group-hover:scale-105"><Icon size={25} /></span>
+						<span class="mt-7 flex items-end justify-between gap-3">
+							<span>
+								<span class="block text-base font-semibold text-foreground">{entry.label}</span>
+								<span class="mt-1 block text-xs text-muted-foreground">Open page</span>
+							</span>
+							<ChevronRight size={17} class="mb-0.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-blue-400" />
+						</span>
+					</a>
+				{/if}
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -1016,8 +1016,8 @@
 
 				<fieldset class="mt-5">
 					<legend class="text-sm font-medium">Navigation style</legend>
-					<p class="mt-1 text-xs text-muted-foreground">Choose how the same menu hierarchy is presented in the sidebar.</p>
-					<div class="mt-3 grid max-w-md grid-cols-2 gap-3">
+					<p class="mt-1 text-xs text-muted-foreground">Choose how the same menu hierarchy is presented.</p>
+					<div class="mt-3 grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-3">
 						<label class="cursor-pointer rounded-lg border p-3 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background {uiPrefs.menuStyle === 'classic' ? 'border-blue-500/60 bg-blue-500/10' : 'border-border hover:bg-accent/40'}">
 							<input
 								type="radio"
@@ -1041,6 +1041,18 @@
 							/>
 							<span class="block text-sm font-medium">Icons</span>
 							<span class="mt-1 block text-xs text-muted-foreground">Category and page tiles</span>
+						</label>
+						<label class="cursor-pointer rounded-lg border p-3 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background {uiPrefs.menuStyle === 'launcher' ? 'border-blue-500/60 bg-blue-500/10' : 'border-border hover:bg-accent/40'}">
+							<input
+								type="radio"
+								name="navigation-style"
+								value="launcher"
+								checked={uiPrefs.menuStyle === 'launcher'}
+								onchange={() => uiPrefs.setMenuStyle('launcher')}
+								class="sr-only"
+							/>
+							<span class="block text-sm font-medium">Launcher</span>
+							<span class="mt-1 block text-xs text-muted-foreground">Central category workspace</span>
 						</label>
 					</div>
 				</fieldset>


### PR DESCRIPTION
## Summary
- add a third persisted Launcher navigation style with a central `/menu` workspace
- reuse the canonical navigation hierarchy, search metadata, route icons, and shell-owned KVM capability filtering
- add category drill-down, responsive page tiles, keyboard focus restoration, and a minimal launcher sidebar control
- preserve existing Classic and Icons navigation behavior

## Validation
- `npm run check`
- `npm test` (157 tests)
- `npm run build`
- `git diff --check`