### PR TITLE
webui: preserve launcher category context

### DIFF
--- a/webui/src/lib/components/LauncherSidebarNav.svelte
+++ b/webui/src/lib/components/LauncherSidebarNav.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
-	import { LAUNCHER_NAV_ITEM } from '$lib/navigation';
+	import { LAUNCHER_NAV_ITEM, type NavGroup } from '$lib/navigation';
 
 	interface Props {
 		collapsed: boolean;
 		active: boolean;
+		group: NavGroup | null;
 	}
 
-	let { collapsed, active }: Props = $props();
+	let { collapsed, active, group }: Props = $props();
 	const Icon = LAUNCHER_NAV_ITEM.icon;
 </script>
 
-<nav class="flex-1 px-2 py-3" aria-label="Primary navigation">
+<nav class="flex-1 space-y-2 px-2 py-3" aria-label="Primary navigation">
 	<a
 		href={LAUNCHER_NAV_ITEM.href}
 		aria-current={active ? 'page' : undefined}
@@ -32,4 +33,25 @@
 			</span>
 		{/if}
 	</a>
+
+	{#if group}
+		{@const GroupIcon = group.icon}
+		<a
+			href={`/menu?group=${encodeURIComponent(group.id)}`}
+			title={collapsed ? `Open ${group.label} category` : undefined}
+			aria-label={collapsed ? `Open ${group.label} category` : undefined}
+			class="flex items-center rounded-lg border border-blue-500/35 bg-blue-500/5 text-foreground no-underline transition-colors hover:border-blue-400/60 hover:bg-blue-500/10
+				{collapsed ? 'justify-center py-2' : 'gap-3 px-3 py-2.5'}"
+		>
+			<span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500/10 text-blue-400">
+				<GroupIcon size={18} />
+			</span>
+			{#if !collapsed}
+				<span class="min-w-0">
+					<span class="block truncate text-sm font-semibold">{group.label}</span>
+					<span class="mt-0.5 block text-[0.65rem] leading-tight text-muted-foreground">Return to category</span>
+				</span>
+			{/if}
+		</a>
+	{/if}
 </nav>

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -22,11 +22,13 @@
 	import {
 		activeNavigationGroup,
 		currentNavigationItem,
+		isNavGroup,
 		NAVIGATION_CONTEXT,
 		navigationForMode,
 		resolveNavigation,
 		searchNavigation,
 		type NavEntry,
+		type NavGroup,
 		type NavMode
 	} from '$lib/navigation';
 	import '../app.css';
@@ -711,6 +713,10 @@
 	}
 
 	const activeGroup = $derived(activeNavigationGroup($page.url.pathname, nav));
+	const launcherGroup = $derived.by((): NavGroup | null => {
+		const entry = nav.find((candidate) => candidate.id === activeGroup);
+		return entry && isNavGroup(entry) ? entry : null;
+	});
 
 	// ── Sidebar search ──────────────────────────────
 	let sidebarSearch = $state('');
@@ -948,7 +954,7 @@
 
 			<!-- Nav — scrollable -->
 			{#if uiPrefs.menuStyle === 'launcher'}
-				<LauncherSidebarNav collapsed={sidebarCollapsed} active={$page.url.pathname === '/menu'} />
+				<LauncherSidebarNav collapsed={sidebarCollapsed} active={$page.url.pathname === '/menu'} group={launcherGroup} />
 			{:else if uiPrefs.menuStyle === 'icons'}
 				<IconSidebarNav
 					entries={renderNav}

--- a/webui/src/routes/menu/+page.svelte
+++ b/webui/src/routes/menu/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { getContext, tick } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { ChevronLeft, ChevronRight, Search } from '@lucide/svelte';
 	import {
 		flattenNavigation,
@@ -13,11 +15,11 @@
 
 	const navigationContext = getContext<NavigationContext>(NAVIGATION_CONTEXT);
 	let query = $state('');
-	let selectedGroupId = $state<string | null>(null);
 	let launcherElement = $state<HTMLElement>();
 	let backButton = $state<HTMLButtonElement>();
 
 	let entries = $derived(resolveNavigation(navigationContext));
+	let selectedGroupId = $derived($page.url.searchParams.get('group'));
 	let selectedGroup = $derived.by((): NavGroup | null => {
 		const match = entries.find((entry) => isNavGroup(entry) && entry.id === selectedGroupId);
 		return match && isNavGroup(match) ? match : null;
@@ -26,22 +28,16 @@
 	let searchItems = $derived(flattenNavigation(entries).filter((entry) => matches.has(entry.href)));
 	let isSearching = $derived(query.trim().length > 0);
 
-	$effect(() => {
-		if (selectedGroupId && !entries.some((entry) => isNavGroup(entry) && entry.id === selectedGroupId)) {
-			selectedGroupId = null;
-		}
-	});
-
 	async function openGroup(id: string) {
-		selectedGroupId = id;
 		query = '';
+		await goto(`/menu?group=${encodeURIComponent(id)}`, { keepFocus: true, noScroll: true });
 		await tick();
 		backButton?.focus();
 	}
 
 	async function closeGroup() {
 		const id = selectedGroupId;
-		selectedGroupId = null;
+		await goto('/menu', { keepFocus: true, noScroll: true });
 		await tick();
 		if (id) launcherElement?.querySelector<HTMLButtonElement>(`[data-launcher-group="${id}"]`)?.focus();
 	}


### PR DESCRIPTION
## Summary
- show the active parent category beneath Open Launcher while viewing one of its pages
- link the category shortcut directly back to its launcher tiles
- store launcher drill-down in the URL so browser Back and direct category links preserve context
- keep the contextual category icon available when the sidebar is collapsed

Follow-up to #684.

## Validation
- `npm run check`
- `npm test` (157 tests)
- `npm run build`
- `git diff --check`