### PR TITLE
security: open guest downloads by descriptor

### DIFF
--- a/engine/nasty-engine/src/file_boundary.rs
+++ b/engine/nasty-engine/src/file_boundary.rs
@@ -1,0 +1,286 @@
+//! Descriptor-relative filesystem access for untrusted paths.
+
+use std::ffi::{CString, OsStr};
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Component, Path};
+
+/// Open a regular file under a configured shared root without ever resolving
+/// and reopening a pathname. Symlinks are not followed at either level.
+pub fn open_regular_beneath(
+    files_root: &Path,
+    shared_root: &Path,
+    relative: &Path,
+) -> io::Result<File> {
+    let shared_relative = shared_root
+        .strip_prefix(files_root)
+        .map_err(|_| invalid_path("shared root is outside the files root"))?;
+    validate_relative(shared_relative, false)?;
+    validate_relative(relative, true)?;
+
+    let files_fd = open_directory(files_root)?;
+    let shared_fd = open_relative(&files_fd, shared_relative, false)?;
+    let shared_meta = metadata_for_fd(&shared_fd)?;
+
+    if relative.as_os_str().is_empty() {
+        return readable_regular_file(shared_fd, None);
+    }
+    if !shared_meta.is_dir() {
+        return Err(invalid_path("relative path supplied for a file share"));
+    }
+
+    let shared_device = shared_meta.dev();
+    let target_fd = open_relative(&shared_fd, relative, true)?;
+    readable_regular_file(target_fd, Some(shared_device))
+}
+
+fn readable_regular_file(fd: OwnedFd, expected_device: Option<u64>) -> io::Result<File> {
+    let metadata = metadata_for_fd(&fd)?;
+    if !metadata.is_file() || expected_device.is_some_and(|device| metadata.dev() != device) {
+        return Err(invalid_path(
+            "target is not a regular file on the shared filesystem",
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // `O_PATH` lets us inspect special files without opening them for I/O.
+        // Reopening this stable descriptor cannot be redirected by path races.
+        let path = format!("/proc/self/fd/{}", fd.as_raw_fd());
+        let file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
+            .open(path)?;
+        let reopened = file.metadata()?;
+        if reopened.dev() != metadata.dev() || reopened.ino() != metadata.ino() {
+            return Err(invalid_path("reopened descriptor identity changed"));
+        }
+        Ok(file)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(File::from(fd))
+    }
+}
+
+fn validate_relative(path: &Path, allow_empty: bool) -> io::Result<()> {
+    if path.as_os_str().is_empty() {
+        return if allow_empty {
+            Ok(())
+        } else {
+            Err(invalid_path("empty relative path"))
+        };
+    }
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(invalid_path(
+            "path must contain only normal relative components",
+        ));
+    }
+    Ok(())
+}
+
+fn open_directory(path: &Path) -> io::Result<OwnedFd> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(path)?;
+    Ok(file.into())
+}
+
+#[cfg(target_os = "linux")]
+fn open_relative(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<OwnedFd> {
+    #[repr(C)]
+    struct OpenHow {
+        flags: u64,
+        mode: u64,
+        resolve: u64,
+    }
+
+    const RESOLVE_NO_XDEV: u64 = 0x01;
+    const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+    const RESOLVE_NO_SYMLINKS: u64 = 0x04;
+    const RESOLVE_BENEATH: u64 = 0x08;
+
+    let path = c_string(relative.as_os_str())?;
+    let mut resolve = RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_SYMLINKS;
+    if no_xdev {
+        resolve |= RESOLVE_NO_XDEV;
+    }
+    let how = OpenHow {
+        flags: (libc::O_PATH | libc::O_CLOEXEC | libc::O_NOFOLLOW) as u64,
+        mode: 0,
+        resolve,
+    };
+    let fd = unsafe {
+        libc::syscall(
+            libc::SYS_openat2,
+            base.as_raw_fd(),
+            path.as_ptr(),
+            &how,
+            std::mem::size_of::<OpenHow>(),
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as libc::c_int) })
+}
+
+/// macOS development/tests use component-at-a-time `openat`. The appliance
+/// uses the Linux implementation above; unsupported Linux kernels fail closed.
+#[cfg(not(target_os = "linux"))]
+fn open_relative(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<OwnedFd> {
+    let components: Vec<&OsStr> = relative
+        .components()
+        .map(|component| match component {
+            Component::Normal(value) => Ok(value),
+            _ => Err(invalid_path("invalid relative component")),
+        })
+        .collect::<io::Result<_>>()?;
+    let expected_device = if no_xdev {
+        Some(metadata_for_fd(base)?.dev())
+    } else {
+        None
+    };
+    let mut current: Option<OwnedFd> = None;
+
+    for (index, component) in components.iter().enumerate() {
+        let parent = current.as_ref().unwrap_or(base).as_raw_fd();
+        let name = c_string(component)?;
+        let mut flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK;
+        if index + 1 < components.len() {
+            flags |= libc::O_DIRECTORY;
+        }
+        let fd = unsafe { libc::openat(parent, name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let opened = unsafe { OwnedFd::from_raw_fd(fd) };
+        if let Some(device) = expected_device
+            && metadata_for_fd(&opened)?.dev() != device
+        {
+            return Err(io::Error::from_raw_os_error(libc::EXDEV));
+        }
+        current = Some(opened);
+    }
+
+    current.ok_or_else(|| invalid_path("empty relative path"))
+}
+
+fn metadata_for_fd(fd: &OwnedFd) -> io::Result<std::fs::Metadata> {
+    let duplicated = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let file = File::from(unsafe { OwnedFd::from_raw_fd(duplicated) });
+    file.metadata()
+}
+
+fn c_string(value: &OsStr) -> io::Result<CString> {
+    CString::new(value.as_bytes()).map_err(|_| invalid_path("path contains a NUL byte"))
+}
+
+fn invalid_path(message: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn opens_nested_and_single_file_shares() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        std::fs::create_dir_all(shared.join("nested")).unwrap();
+        std::fs::write(shared.join("nested/report.txt"), b"report").unwrap();
+        let single = files.join("pool/single.txt");
+        std::fs::write(&single, b"single").unwrap();
+
+        let mut nested =
+            open_regular_beneath(&files, &shared, Path::new("nested/report.txt")).unwrap();
+        let mut nested_bytes = Vec::new();
+        nested.read_to_end(&mut nested_bytes).unwrap();
+        assert_eq!(nested_bytes, b"report");
+
+        let mut one = open_regular_beneath(&files, &single, Path::new("")).unwrap();
+        let mut one_bytes = Vec::new();
+        one.read_to_end(&mut one_bytes).unwrap();
+        assert_eq!(one_bytes, b"single");
+    }
+
+    #[test]
+    fn rejects_traversal_directories_and_outside_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("ok.txt"), b"ok").unwrap();
+
+        assert!(open_regular_beneath(&files, &shared, Path::new("../ok.txt")).is_err());
+        assert!(open_regular_beneath(&files, &shared, Path::new("/etc/passwd")).is_err());
+        assert!(open_regular_beneath(&files, &shared, Path::new("")).is_err());
+        assert!(open_regular_beneath(&files, tmp.path(), Path::new("outside")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_final_and_intermediate_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), b"secret").unwrap();
+        symlink(outside.join("secret.txt"), shared.join("file-link")).unwrap();
+        symlink(&outside, shared.join("dir-link")).unwrap();
+
+        assert!(open_regular_beneath(&files, &shared, Path::new("file-link")).is_err());
+        assert!(open_regular_beneath(&files, &shared, Path::new("dir-link/secret.txt")).is_err());
+    }
+
+    #[test]
+    fn opened_descriptor_is_stable_after_path_replacement() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        std::fs::create_dir_all(&shared).unwrap();
+        let target = shared.join("report.txt");
+        std::fs::write(&target, b"original").unwrap();
+
+        let mut opened = open_regular_beneath(&files, &shared, Path::new("report.txt")).unwrap();
+        std::fs::rename(&target, shared.join("old-report.txt")).unwrap();
+        std::fs::write(&target, b"replacement").unwrap();
+
+        let mut bytes = Vec::new();
+        opened.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"original");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_fifo_without_blocking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        std::fs::create_dir_all(&shared).unwrap();
+        let fifo = shared.join("pipe");
+        let fifo_path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+
+        assert!(open_regular_beneath(&files, &shared, Path::new("pipe")).is_err());
+    }
+}

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -17,6 +17,7 @@
 //! [`create`]: GuestShareService::create
 
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 
@@ -45,6 +46,8 @@ const UNLOCK_REQUEST_MAX: usize = 30;
 const UNLOCK_REQUEST_WINDOW_SECS: i64 = 60;
 const UNLOCK_MAX_TRACKED_IPS: usize = 4096;
 const MAX_CONCURRENT_PASSWORD_CHECKS: usize = 4;
+/// Bound descriptors held by guest downloads, including slow clients.
+const MAX_CONCURRENT_DOWNLOADS: usize = 32;
 
 #[derive(Debug, Error)]
 pub enum GuestShareError {
@@ -239,35 +242,36 @@ fn public_meta(share: &GuestShare) -> PublicShareMeta {
     }
 }
 
-/// Resolve a guest-supplied relative path to a concrete file inside one of
-/// the share's roots. Returns `None` unless the canonicalized target is a
-/// regular file that stays within a root — the download-time analog of the
-/// create-time `/fs` guard, blocking `..`/symlink escape out of the share.
-///
-/// `rel` is relative to the share (empty = a single-file share's own file),
-/// so absolute server paths never cross the wire.
-fn resolve_within(share: &GuestShare, rel: &str) -> Option<PathBuf> {
-    if rel
-        .chars()
-        .any(|c| c.is_control() || matches!(c, '"' | '\'' | '\\'))
-    {
-        return None;
-    }
-    for root in &share.paths {
-        let root = Path::new(root);
-        let candidate = if rel.is_empty() {
-            root.to_path_buf()
-        } else {
-            root.join(rel.trim_start_matches('/'))
+pub struct OpenedGuestFile {
+    file: File,
+    name: String,
+    size: u64,
+    permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl OpenedGuestFile {
+    pub fn into_parts(self) -> (GuestDownloadReader, String, u64) {
+        let reader = GuestDownloadReader {
+            file: tokio::fs::File::from_std(self.file),
+            _permit: self.permit,
         };
-        let Ok(canonical) = std::fs::canonicalize(&candidate) else {
-            continue;
-        };
-        if canonical.starts_with(root) && canonical.is_file() {
-            return Some(canonical);
-        }
+        (reader, self.name, self.size)
     }
-    None
+}
+
+pub struct GuestDownloadReader {
+    file: tokio::fs::File,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl tokio::io::AsyncRead for GuestDownloadReader {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.file).poll_read(cx, buf)
+    }
 }
 
 /// Write a ZIP of every `root` into `writer`, entries named relative to each
@@ -348,6 +352,14 @@ fn canonicalize_under(root: &Path, requested: &str) -> Result<String, GuestShare
         .map_err(|_| GuestShareError::PathNotFound(requested.to_string()))?;
     if !canonical.starts_with(root) {
         return Err(GuestShareError::PathNotInFilesystem(requested.to_string()));
+    }
+    if canonical == root {
+        return Err(GuestShareError::InvalidPath(requested.to_string()));
+    }
+    let metadata = std::fs::metadata(&canonical)
+        .map_err(|_| GuestShareError::PathNotFound(requested.to_string()))?;
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(GuestShareError::InvalidPath(requested.to_string()));
     }
     Ok(canonical.to_string_lossy().into_owned())
 }
@@ -453,10 +465,12 @@ pub struct GuestShareService {
     unlock_requests: StdMutex<BoundedRateLimiter>,
     /// Serializes every record load-modify-save operation. Using separate
     /// locks for counters and revocation would let stale writers resurrect a share.
-    state_lock: tokio::sync::Mutex<()>,
+    state_lock: Arc<tokio::sync::Mutex<()>>,
     /// Argon2 is intentionally expensive. Keep verification off async worker
     /// threads and cap global concurrency to prevent unlock CPU exhaustion.
     password_checks: Arc<tokio::sync::Semaphore>,
+    /// Bounds guest descriptors for their full streaming lifetime.
+    active_downloads: Arc<tokio::sync::Semaphore>,
 }
 
 impl Default for GuestShareService {
@@ -478,13 +492,32 @@ impl GuestShareService {
             grants: StdMutex::new(HashMap::new()),
             unlock_failures: StdMutex::new(BoundedRateLimiter::default()),
             unlock_requests: StdMutex::new(BoundedRateLimiter::default()),
-            state_lock: tokio::sync::Mutex::new(()),
+            state_lock: Arc::new(tokio::sync::Mutex::new(())),
             password_checks: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PASSWORD_CHECKS)),
+            active_downloads: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DOWNLOADS)),
         }
     }
 
     fn state_dir(&self) -> StateDir {
         StateDir::new(self.dir.clone())
+    }
+
+    /// Keep the lock inside an independently owned task so cancellation of an
+    /// HTTP request cannot release it while Tokio filesystem work continues.
+    async fn mutate_state<T, F, Fut>(&self, operation: F) -> Result<T, GuestShareError>
+    where
+        T: Send + 'static,
+        F: FnOnce(StateDir) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<T, GuestShareError>> + Send + 'static,
+    {
+        let state_lock = Arc::clone(&self.state_lock);
+        let state_dir = self.state_dir();
+        tokio::spawn(async move {
+            let _guard = state_lock.lock().await;
+            operation(state_dir).await
+        })
+        .await
+        .map_err(|error| GuestShareError::Io(std::io::Error::other(error)))?
     }
 
     /// List every share (including revoked ones). Never includes a
@@ -540,10 +573,12 @@ impl GuestShareService {
             note: req.note,
         };
 
-        {
-            let _guard = self.state_lock.lock().await;
-            self.state_dir().save(&share.id, &share).await?;
-        }
+        let saved_share = share.clone();
+        self.mutate_state(move |state_dir| async move {
+            state_dir.save(&saved_share.id, &saved_share).await?;
+            Ok(())
+        })
+        .await?;
         let info = GuestShareInfo::from(&share);
         Ok(CreateGuestShareResult { share: info, token })
     }
@@ -551,13 +586,19 @@ impl GuestShareService {
     /// Revoke a share. The record is kept (marked `revoked`) so history and
     /// audit survive — only the public surface stops honoring it.
     pub async fn revoke(&self, id: &str) -> Result<GuestShare, GuestShareError> {
-        let _guard = self.state_lock.lock().await;
-        let mut share = self.get(id).await?;
-        if !share.revoked {
-            share.revoked = true;
-            self.state_dir().save(&share.id, &share).await?;
-        }
-        Ok(share)
+        let id = id.to_string();
+        self.mutate_state(move |state_dir| async move {
+            let mut share = state_dir
+                .load::<GuestShare>(&id)
+                .await
+                .ok_or_else(|| GuestShareError::NotFound(id.clone()))?;
+            if !share.revoked {
+                share.revoked = true;
+                state_dir.save(&share.id, &share).await?;
+            }
+            Ok(share)
+        })
+        .await
     }
 
     /// Soft-remove a share: hide it from the default management list while
@@ -565,16 +606,22 @@ impl GuestShareService {
     /// can be removed — the UI revokes first, so a live link is never
     /// silently dropped. Idempotent.
     pub async fn remove(&self, id: &str) -> Result<(), GuestShareError> {
-        let _guard = self.state_lock.lock().await;
-        let mut share = self.get(id).await?;
-        if !share.revoked {
-            return Err(GuestShareError::NotRevoked(id.to_string()));
-        }
-        if !share.hidden {
-            share.hidden = true;
-            self.state_dir().save(&share.id, &share).await?;
-        }
-        Ok(())
+        let id = id.to_string();
+        self.mutate_state(move |state_dir| async move {
+            let mut share = state_dir
+                .load::<GuestShare>(&id)
+                .await
+                .ok_or_else(|| GuestShareError::NotFound(id.clone()))?;
+            if !share.revoked {
+                return Err(GuestShareError::NotRevoked(id));
+            }
+            if !share.hidden {
+                share.hidden = true;
+                state_dir.save(&share.id, &share).await?;
+            }
+            Ok(())
+        })
+        .await
     }
 
     // ── Public access surface ───────────────────────────────────────────
@@ -598,10 +645,49 @@ impl GuestShareService {
         public_meta(share)
     }
 
-    /// Resolve a guest's relative path to a real file inside a share root,
-    /// or `None` if it escapes / isn't a file.
-    pub fn resolve_download(share: &GuestShare, rel: &str) -> Option<PathBuf> {
-        resolve_within(share, rel)
+    /// Open a guest file beneath one of the share roots. The returned
+    /// descriptor is the object that was authorized; callers never reopen a
+    /// validated pathname.
+    pub async fn open_download(&self, share: &GuestShare, rel: &str) -> Option<OpenedGuestFile> {
+        if rel
+            .chars()
+            .any(|c| c.is_control() || matches!(c, '"' | '\'' | '\\'))
+        {
+            return None;
+        }
+        let permit = self.active_downloads.clone().try_acquire_owned().ok()?;
+        let files_root = self.fs_root.clone();
+        let roots = share.paths.clone();
+        let relative = PathBuf::from(rel);
+        tokio::task::spawn_blocking(move || {
+            for root in roots {
+                let root = PathBuf::from(root);
+                let Ok(file) =
+                    crate::file_boundary::open_regular_beneath(&files_root, &root, &relative)
+                else {
+                    continue;
+                };
+                let size = file.metadata().ok()?.len();
+                let name = if relative.as_os_str().is_empty() {
+                    root.file_name()
+                } else {
+                    relative.file_name()
+                }
+                .and_then(|name| name.to_str())
+                .unwrap_or("file")
+                .to_string();
+                return Some(OpenedGuestFile {
+                    file,
+                    name,
+                    size,
+                    permit,
+                });
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten()
     }
 
     /// Whether `share` is password-protected.
@@ -639,13 +725,44 @@ impl GuestShareService {
     pub async fn record_view(&self, id: &str) {
         // Never queue public view writes ahead of revoke. At most one disk
         // mutation is delayed by a view; contended increments are dropped.
-        let Ok(_guard) = self.state_lock.try_lock() else {
+        let Ok(guard) = Arc::clone(&self.state_lock).try_lock_owned() else {
             return;
         };
-        if let Some(mut s) = self.state_dir().load::<GuestShare>(id).await {
-            s.views = s.views.saturating_add(1);
-            let _ = self.state_dir().save(id, &s).await;
-        }
+        let state_dir = self.state_dir();
+        let id = id.to_string();
+        let _ = tokio::spawn(async move {
+            let _guard = guard;
+            if let Some(mut share) = state_dir.load::<GuestShare>(&id).await {
+                share.views = share.views.saturating_add(1);
+                let _ = state_dir.save(&id, &share).await;
+            }
+        })
+        .await;
+    }
+
+    async fn register_download_holding<T>(
+        &self,
+        id: &str,
+        now: i64,
+        held: T,
+    ) -> Result<T, GuestShareError>
+    where
+        T: Send + 'static,
+    {
+        let id = id.to_string();
+        self.mutate_state(move |state_dir| async move {
+            let mut share = state_dir
+                .load::<GuestShare>(&id)
+                .await
+                .ok_or_else(|| GuestShareError::NotFound(id.clone()))?;
+            if !is_accessible(&share, now) {
+                return Err(GuestShareError::NotFound(id));
+            }
+            share.downloads = share.downloads.saturating_add(1);
+            state_dir.save(&share.id, &share).await?;
+            Ok(held)
+        })
+        .await
     }
 
     /// Count a download, enforcing `max_downloads`. Serialized with every
@@ -653,14 +770,19 @@ impl GuestShareService {
     /// Returns `Err(NotFound)` if the share went inactive between lookup and
     /// here — the handler maps that to the same generic "not available".
     pub async fn register_download(&self, id: &str, now: i64) -> Result<(), GuestShareError> {
-        let _guard = self.state_lock.lock().await;
-        let mut s = self.get(id).await?;
-        if !is_accessible(&s, now) {
-            return Err(GuestShareError::NotFound(id.to_string()));
-        }
-        s.downloads = s.downloads.saturating_add(1);
-        self.state_dir().save(id, &s).await?;
-        Ok(())
+        self.register_download_holding(id, now, ()).await
+    }
+
+    /// Register a single-file download while retaining its descriptor slot.
+    /// If the request is cancelled, the detached state mutation remains
+    /// bounded by the same semaphore as active streams.
+    pub async fn register_opened_download(
+        &self,
+        id: &str,
+        now: i64,
+        opened: OpenedGuestFile,
+    ) -> Result<OpenedGuestFile, GuestShareError> {
+        self.register_download_holding(id, now, opened).await
     }
 
     /// Stream a ZIP of all the share's roots into a pipe, returning the read
@@ -806,6 +928,12 @@ mod tests {
         // Inside the root: accepted, returns a canonical path under root.
         let got = canonicalize_under(&root, inside.to_str().unwrap()).unwrap();
         assert!(Path::new(&got).starts_with(&root));
+
+        // Sharing all of /fs would bypass the intended filesystem boundary.
+        assert!(matches!(
+            canonicalize_under(&root, root.to_str().unwrap()),
+            Err(GuestShareError::InvalidPath(_))
+        ));
 
         // `..`-escape that resolves outside the root (inside is root/share,
         // so ../.. lands at the tempdir root where `outside` lives): rejected.
@@ -1058,6 +1186,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_request_does_not_cancel_state_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (svc, fs_root) = service(tmp.path());
+        let svc = Arc::new(svc);
+        let file = fs_root.join("cancel.txt");
+        std::fs::write(&file, b"content").unwrap();
+        let share = put_share(&svc, "cancel", |share| {
+            share.paths = vec![file.to_string_lossy().into_owned()];
+        })
+        .await;
+        let opened = svc.open_download(&share, "").await.unwrap();
+        assert_eq!(
+            svc.active_downloads.available_permits(),
+            MAX_CONCURRENT_DOWNLOADS - 1
+        );
+        let guard = svc.state_lock.lock().await;
+
+        let task = {
+            let svc = Arc::clone(&svc);
+            let id = share.id.clone();
+            tokio::spawn(async move { svc.register_opened_download(&id, 10, opened).await })
+        };
+        tokio::task::yield_now().await;
+        task.abort();
+        let _ = task.await;
+        assert_eq!(
+            svc.active_downloads.available_permits(),
+            MAX_CONCURRENT_DOWNLOADS - 1,
+            "cancelled admission must retain its descriptor slot"
+        );
+        drop(guard);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if svc.get(&share.id).await.unwrap().downloads == 1
+                    && svc.active_downloads.available_permits() == MAX_CONCURRENT_DOWNLOADS
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached state mutation should complete");
+    }
+
+    #[tokio::test]
     async fn concurrent_mutations_preserve_revocation_and_counters() {
         let tmp = tempfile::tempdir().unwrap();
         let (svc, _) = service(tmp.path());
@@ -1295,10 +1470,11 @@ mod tests {
         assert!(svc.verify_share_password(&open, "anything").await.unwrap());
     }
 
-    #[test]
-    fn resolve_download_stays_within_share_roots() {
+    #[tokio::test]
+    async fn open_download_stays_within_share_roots() {
         let tmp = tempfile::tempdir().unwrap();
         let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let svc = GuestShareService::with_dirs(root.join("state"), root.clone());
         let dir = root.join("folder");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("a.txt"), b"hi").unwrap();
@@ -1314,20 +1490,54 @@ mod tests {
             ..bare("f")
         };
         // Relative file inside the shared folder (including a subdir): ok.
-        assert!(resolve_within(&folder_share, "a.txt").is_some());
-        assert!(resolve_within(&folder_share, "sub/b.txt").is_some());
+        assert!(svc.open_download(&folder_share, "a.txt").await.is_some());
+        assert!(
+            svc.open_download(&folder_share, "sub/b.txt")
+                .await
+                .is_some()
+        );
         // Escapes and non-files: rejected.
-        assert!(resolve_within(&folder_share, "../secret.txt").is_none());
-        assert!(resolve_within(&folder_share, "sub").is_none()); // a dir, not a file
-        assert!(resolve_within(&folder_share, "missing.txt").is_none());
-        assert!(resolve_within(&folder_share, "a\\b").is_none()); // backslash rejected
+        assert!(
+            svc.open_download(&folder_share, "../secret.txt")
+                .await
+                .is_none()
+        );
+        assert!(svc.open_download(&folder_share, "sub").await.is_none()); // a dir, not a file
+        assert!(
+            svc.open_download(&folder_share, "missing.txt")
+                .await
+                .is_none()
+        );
+        assert!(svc.open_download(&folder_share, "a\\b").await.is_none()); // backslash rejected
 
         // Single-file share: empty path resolves to the file itself.
         let file_share = GuestShare {
             paths: vec![single.to_string_lossy().into_owned()],
             ..bare("s")
         };
-        assert!(resolve_within(&file_share, "").is_some());
+        assert!(svc.open_download(&file_share, "").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn open_download_limits_active_descriptors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let svc = GuestShareService::with_dirs(root.join("state"), root.clone());
+        let file = root.join("file.txt");
+        std::fs::write(&file, b"content").unwrap();
+        let share = GuestShare {
+            paths: vec![file.to_string_lossy().into_owned()],
+            ..bare("limit")
+        };
+
+        let mut opened = Vec::new();
+        for _ in 0..MAX_CONCURRENT_DOWNLOADS {
+            opened.push(svc.open_download(&share, "").await.unwrap());
+        }
+        assert!(svc.open_download(&share, "").await.is_none());
+
+        opened.pop();
+        assert!(svc.open_download(&share, "").await.is_some());
     }
 
     #[test]

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -20,6 +20,7 @@ mod auth;
 mod auth_oidc;
 mod auth_webauthn;
 mod boot_status;
+mod file_boundary;
 mod fs_dependents;
 mod fs_lock;
 mod guestshare;
@@ -3424,31 +3425,22 @@ async fn public_share_download_handler(
     }
 
     let rel = params.get("path").map(|s| s.as_str()).unwrap_or("");
-    let Some(target) = guestshare::GuestShareService::resolve_download(&share, rel) else {
+    // Opening first ensures invalid paths do not consume download quota. The
+    // service bounds descriptors for the full lifetime of each stream.
+    let Some(opened) = state.guest_shares.open_download(&share, rel).await else {
         return share_not_available();
     };
 
-    // Count + enforce the cap before opening the stream. A failure here means
-    // the share went inactive (e.g. hit its cap) between lookup and now.
-    if state
+    let opened = match state
         .guest_shares
-        .register_download(&share.id, now)
+        .register_opened_download(&share.id, now_unix_i64(), opened)
         .await
-        .is_err()
     {
-        return share_not_available();
-    }
-
-    let file = match tokio::fs::File::open(&target).await {
-        Ok(f) => f,
+        Ok(opened) => opened,
         Err(_) => return share_not_available(),
     };
-    let size = file.metadata().await.map(|m| m.len()).unwrap_or(0);
-    let name = target
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("file")
-        .to_string();
+
+    let (file, name, size) = opened.into_parts();
 
     crate::auth::audit(
         "guest_share_download",


### PR DESCRIPTION
## Summary
- authorize guest single-file downloads from the opened descriptor instead of canonicalizing and reopening a pathname
- use Linux `openat2` with beneath, no-symlink, no-magiclink, and no-mount-crossing resolution constraints
- reject non-regular share roots and targets, including sharing the entire `/fs` boundary
- cap guest file streams at 32 descriptors and move filesystem opens onto Tokio's blocking pool
- keep quota/revocation mutations serialized and cancellation-safe while retaining admission slots through persistence
- cover traversal, symlink, FIFO, path-replacement, descriptor-limit, and cancellation behavior

Foundation work for #558 and #475. Descriptor-relative ZIP traversal remains a separate change.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine` (176 tests)
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- direct Linux-target `rustc` metadata compilation of `file_boundary.rs`
- `git diff --check`

A full macOS-to-Linux `cargo check --target x86_64-unknown-linux-gnu` reaches native dependencies but requires `x86_64-linux-gnu-gcc`, which is not installed on this host.