### PR TITLE
guestshare: add public folder navigation

### DIFF
--- a/engine/nasty-engine/src/file_boundary.rs
+++ b/engine/nasty-engine/src/file_boundary.rs
@@ -78,6 +78,19 @@ impl BoundaryDirectory {
     }
 }
 
+impl BoundaryNode {
+    pub fn metadata(&self) -> io::Result<std::fs::Metadata> {
+        match self {
+            Self::File(file) => file.metadata(),
+            Self::Directory(directory) => metadata_for_fd(&directory.fd),
+        }
+    }
+
+    pub fn is_directory(&self) -> bool {
+        matches!(self, Self::Directory(_))
+    }
+}
+
 /// Open a shared file or directory as the root of a descriptor-relative walk.
 pub fn open_root_beneath(files_root: &Path, shared_root: &Path) -> io::Result<BoundaryNode> {
     let shared_relative = shared_root
@@ -90,8 +103,30 @@ pub fn open_root_beneath(files_root: &Path, shared_root: &Path) -> io::Result<Bo
     classify_node(shared_fd, None)
 }
 
+pub fn open_directory_from_root(
+    root: BoundaryNode,
+    relative: &Path,
+) -> io::Result<BoundaryDirectory> {
+    validate_relative(relative, true)?;
+    let mut directory = match root {
+        BoundaryNode::Directory(directory) => directory,
+        BoundaryNode::File(_) => return Err(invalid_path("shared root is not a directory")),
+    };
+    for component in relative.components() {
+        let Component::Normal(name) = component else {
+            return Err(invalid_path("invalid directory component"));
+        };
+        directory = match directory.open_child(name)? {
+            BoundaryNode::Directory(child) => child,
+            BoundaryNode::File(_) => return Err(invalid_path("target is not a directory")),
+        };
+    }
+    Ok(directory)
+}
+
 /// Open a regular file under a configured shared root without ever resolving
 /// and reopening a pathname. Symlinks are not followed at either level.
+#[cfg(test)]
 pub fn open_regular_beneath(
     files_root: &Path,
     shared_root: &Path,
@@ -107,6 +142,30 @@ pub fn open_regular_beneath(
     let shared_fd = open_relative(&files_fd, shared_relative, false)?;
     let shared_meta = metadata_for_fd(&shared_fd)?;
 
+    open_regular_from_root_fd(shared_fd, shared_meta, relative)
+}
+
+pub fn open_regular_from_root(root: BoundaryNode, relative: &Path) -> io::Result<File> {
+    validate_relative(relative, true)?;
+    match root {
+        BoundaryNode::File(file) if relative.as_os_str().is_empty() => Ok(file),
+        BoundaryNode::File(_) => Err(invalid_path("relative path supplied for a file share")),
+        BoundaryNode::Directory(_) if relative.as_os_str().is_empty() => {
+            Err(invalid_path("target is not a regular file"))
+        }
+        BoundaryNode::Directory(directory) => {
+            let target_fd = open_relative(&directory.fd, relative, true)?;
+            readable_regular_file(target_fd, Some(directory.device))
+        }
+    }
+}
+
+#[cfg(test)]
+fn open_regular_from_root_fd(
+    shared_fd: OwnedFd,
+    shared_meta: std::fs::Metadata,
+    relative: &Path,
+) -> io::Result<File> {
     if relative.as_os_str().is_empty() {
         return readable_regular_file(shared_fd, None);
     }

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -47,11 +47,14 @@ const UNLOCK_REQUEST_MAX: usize = 30;
 const UNLOCK_REQUEST_WINDOW_SECS: i64 = 60;
 const UNLOCK_MAX_TRACKED_IPS: usize = 4096;
 const MAX_CONCURRENT_PASSWORD_CHECKS: usize = 4;
+const MAX_CONCURRENT_BROWSES: usize = 16;
+const MAX_PUBLIC_DIRECTORY_ENTRIES: usize = 10_000;
+const MAX_PUBLIC_PATH_BYTES: usize = 4096;
+const MAX_SHARE_ROOTS: usize = 32;
 /// Bound descriptors held by guest downloads, including slow clients.
 const MAX_CONCURRENT_DOWNLOADS: usize = 32;
 /// ZIP compression is substantially heavier than streaming one file.
 const MAX_CONCURRENT_ARCHIVES: usize = 4;
-const MAX_ARCHIVE_ROOTS: usize = 32;
 const MAX_ARCHIVE_ENTRIES: usize = 50_000;
 const MAX_ARCHIVE_DIRECTORY_ENTRIES: usize = 25_000;
 const MAX_ARCHIVE_DEPTH: usize = 64;
@@ -68,6 +71,8 @@ pub enum GuestShareError {
     NotRevoked(String),
     #[error("no paths supplied")]
     NoPaths,
+    #[error("too many paths supplied")]
+    TooManyPaths,
     #[error("path does not exist: {0}")]
     PathNotFound(String),
     #[error("path is not within a NASty filesystem: {0}")]
@@ -203,9 +208,24 @@ impl From<&GuestShare> for GuestShareInfo {
 /// One entry shown to a guest on the public share page.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PublicEntry {
+    pub root: usize,
     pub name: String,
     pub is_dir: bool,
     pub size: u64,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PublicDirectoryEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PublicDirectoryListing {
+    pub root: usize,
+    pub path: String,
+    pub entries: Vec<PublicDirectoryEntry>,
 }
 
 /// Public metadata for a share — deliberately minimal and leaks no absolute
@@ -214,6 +234,7 @@ pub struct PublicEntry {
 pub struct PublicShareMeta {
     pub entries: Vec<PublicEntry>,
     pub password_required: bool,
+    pub unlocked: bool,
     pub expires_at: Option<i64>,
 }
 
@@ -224,33 +245,6 @@ fn is_accessible(s: &GuestShare, now: i64) -> bool {
     !s.revoked
         && s.expires_at.is_none_or(|e| now < e)
         && s.max_downloads.is_none_or(|m| s.downloads < m)
-}
-
-/// Build the guest-visible metadata for a share. Lists each shared root by
-/// basename only (name/is_dir/size) — never the absolute `/fs/...` path.
-fn public_meta(share: &GuestShare) -> PublicShareMeta {
-    let entries = share
-        .paths
-        .iter()
-        .map(|p| {
-            let path = Path::new(p);
-            let md = std::fs::metadata(path).ok();
-            PublicEntry {
-                name: path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("file")
-                    .to_string(),
-                is_dir: md.as_ref().map(|m| m.is_dir()).unwrap_or(false),
-                size: md.as_ref().map(|m| m.len()).unwrap_or(0),
-            }
-        })
-        .collect();
-    PublicShareMeta {
-        entries,
-        password_required: share.password_hash.is_some(),
-        expires_at: share.expires_at,
-    }
 }
 
 pub struct OpenedGuestFile {
@@ -571,6 +565,41 @@ fn canonicalize_under(root: &Path, requested: &str) -> Result<String, GuestShare
     Ok(canonical.to_string_lossy().into_owned())
 }
 
+fn public_relative_path(requested: &str) -> Option<(PathBuf, String)> {
+    if requested.len() > MAX_PUBLIC_PATH_BYTES
+        || requested
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '"' | '\'' | '\\'))
+    {
+        return None;
+    }
+    let path = Path::new(requested);
+    if path.is_absolute() {
+        return None;
+    }
+    let mut normalized = PathBuf::new();
+    let mut names = Vec::new();
+    for component in path.components() {
+        let std::path::Component::Normal(name) = component else {
+            return None;
+        };
+        let name = name.to_str()?;
+        if !public_name_is_supported(name) {
+            return None;
+        }
+        normalized.push(name);
+        names.push(name);
+    }
+    Some((normalized, names.join("/")))
+}
+
+fn public_name_is_supported(name: &str) -> bool {
+    !name.is_empty()
+        && !name
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '"' | '\'' | '\\'))
+}
+
 /// A live password-unlock grant: proof a guest entered the right password
 /// for `share_id`, valid until `expires_at` (Unix seconds).
 struct GrantEntry {
@@ -680,6 +709,8 @@ pub struct GuestShareService {
     active_downloads: Arc<tokio::sync::Semaphore>,
     /// Bounds CPU-heavy archive producers for their full streaming lifetime.
     active_archives: Arc<tokio::sync::Semaphore>,
+    /// Bounds descriptor walks triggered by guest navigation and metadata.
+    browse_operations: Arc<tokio::sync::Semaphore>,
 }
 
 impl Default for GuestShareService {
@@ -705,6 +736,7 @@ impl GuestShareService {
             password_checks: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PASSWORD_CHECKS)),
             active_downloads: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DOWNLOADS)),
             active_archives: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_ARCHIVES)),
+            browse_operations: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_BROWSES)),
         }
     }
 
@@ -754,11 +786,13 @@ impl GuestShareService {
         if req.paths.is_empty() {
             return Err(GuestShareError::NoPaths);
         }
+        if req.paths.len() > MAX_SHARE_ROOTS {
+            return Err(GuestShareError::TooManyPaths);
+        }
         let mut canonical_paths = Vec::with_capacity(req.paths.len());
         for p in &req.paths {
             canonical_paths.push(canonicalize_under(&self.fs_root, p)?);
         }
-
         let password_hash = match req.password.as_deref() {
             Some(pw) if !pw.is_empty() => Some(
                 crate::auth::hash_password(pw).map_err(|e| GuestShareError::Hash(e.to_string()))?,
@@ -847,34 +881,144 @@ impl GuestShareService {
             .load_all::<GuestShare>()
             .await
             .into_iter()
-            .find(|s| s.token_hash == hash && is_accessible(s, now))
+            .find(|share| share.token_hash == hash && is_accessible(share, now))
     }
 
     /// Public metadata for the guest landing page.
-    pub fn meta(share: &GuestShare) -> PublicShareMeta {
-        public_meta(share)
+    pub async fn meta(&self, share: &GuestShare, unlocked: bool) -> Option<PublicShareMeta> {
+        let password_required = share.password_hash.is_some();
+        if password_required && !unlocked {
+            return Some(PublicShareMeta {
+                entries: Vec::new(),
+                password_required,
+                unlocked: false,
+                expires_at: share.expires_at,
+            });
+        }
+        if share.paths.len() > MAX_SHARE_ROOTS {
+            return None;
+        }
+        let permit = self.browse_operations.clone().try_acquire_owned().ok()?;
+        let files_root = self.fs_root.clone();
+        let paths = share.paths.clone();
+        let expires_at = share.expires_at;
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let entries = paths
+                .into_iter()
+                .enumerate()
+                .filter_map(|(root, path)| {
+                    let path = PathBuf::from(path);
+                    let node = crate::file_boundary::open_root_beneath(&files_root, &path).ok()?;
+                    let metadata = node.metadata().ok()?;
+                    Some(PublicEntry {
+                        root,
+                        name: path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or("file")
+                            .to_string(),
+                        is_dir: node.is_directory(),
+                        size: if metadata.is_file() {
+                            metadata.len()
+                        } else {
+                            0
+                        },
+                    })
+                })
+                .collect();
+            PublicShareMeta {
+                entries,
+                password_required,
+                unlocked: true,
+                expires_at,
+            }
+        })
+        .await
+        .ok()
+    }
+
+    /// List one guest-visible directory through retained descriptors.
+    pub async fn browse_directory(
+        &self,
+        share: &GuestShare,
+        root: usize,
+        requested: &str,
+    ) -> Option<PublicDirectoryListing> {
+        let (relative, path) = public_relative_path(requested)?;
+        let shared_root = PathBuf::from(share.paths.get(root)?);
+        let permit = self.browse_operations.clone().try_acquire_owned().ok()?;
+        let files_root = self.fs_root.clone();
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let root_node =
+                crate::file_boundary::open_root_beneath(&files_root, &shared_root).ok()?;
+            let directory =
+                crate::file_boundary::open_directory_from_root(root_node, &relative).ok()?;
+            let names = directory.entry_names(MAX_PUBLIC_DIRECTORY_ENTRIES).ok()?;
+            let mut entries = Vec::with_capacity(names.len());
+            for name in names {
+                let Some(name) = name.to_str().filter(|name| public_name_is_supported(name)) else {
+                    continue;
+                };
+                let Ok(node) = directory.open_child(std::ffi::OsStr::new(name)) else {
+                    continue;
+                };
+                let Ok(metadata) = node.metadata() else {
+                    continue;
+                };
+                entries.push(PublicDirectoryEntry {
+                    name: name.to_string(),
+                    is_dir: node.is_directory(),
+                    size: if metadata.is_file() {
+                        metadata.len()
+                    } else {
+                        0
+                    },
+                });
+            }
+            entries.sort_by(|left, right| {
+                right.is_dir.cmp(&left.is_dir).then_with(|| {
+                    left.name
+                        .to_lowercase()
+                        .cmp(&right.name.to_lowercase())
+                        .then_with(|| left.name.cmp(&right.name))
+                })
+            });
+            Some(PublicDirectoryListing {
+                root,
+                path,
+                entries,
+            })
+        })
+        .await
+        .ok()
+        .flatten()
     }
 
     /// Open a guest file beneath one of the share roots. The returned
     /// descriptor is the object that was authorized; callers never reopen a
     /// validated pathname.
-    pub async fn open_download(&self, share: &GuestShare, rel: &str) -> Option<OpenedGuestFile> {
-        if rel
-            .chars()
-            .any(|c| c.is_control() || matches!(c, '"' | '\'' | '\\'))
-        {
-            return None;
-        }
+    pub async fn open_download(
+        &self,
+        share: &GuestShare,
+        root: Option<usize>,
+        rel: &str,
+    ) -> Option<OpenedGuestFile> {
+        let (relative, _) = public_relative_path(rel)?;
         let permit = self.active_downloads.clone().try_acquire_owned().ok()?;
         let files_root = self.fs_root.clone();
-        let roots = share.paths.clone();
-        let relative = PathBuf::from(rel);
+        let roots = match root {
+            Some(root) => vec![share.paths.get(root)?.clone()],
+            None => share.paths.clone(),
+        };
         tokio::task::spawn_blocking(move || {
             for root in roots {
                 let root = PathBuf::from(root);
-                let Ok(file) =
-                    crate::file_boundary::open_regular_beneath(&files_root, &root, &relative)
-                else {
+                let Ok(node) = crate::file_boundary::open_root_beneath(&files_root, &root) else {
+                    continue;
+                };
+                let Ok(file) = crate::file_boundary::open_regular_from_root(node, &relative) else {
                     continue;
                 };
                 let size = file.metadata().ok()?.len();
@@ -998,7 +1142,7 @@ impl GuestShareService {
     /// Open and retain every archive root before registering the download.
     pub async fn prepare_archive(&self, share: &GuestShare) -> Option<OpenedGuestArchive> {
         let permit = self.active_archives.clone().try_acquire_owned().ok()?;
-        if share.paths.is_empty() || share.paths.len() > MAX_ARCHIVE_ROOTS {
+        if share.paths.is_empty() || share.paths.len() > MAX_SHARE_ROOTS {
             return None;
         }
         let files_root = self.fs_root.clone();
@@ -1343,6 +1487,20 @@ mod tests {
             .await,
             Err(GuestShareError::NoPaths)
         ));
+        assert!(matches!(
+            svc.create(
+                CreateGuestShareRequest {
+                    paths: vec![shared.to_string_lossy().into_owned(); MAX_SHARE_ROOTS + 1],
+                    expires_at: None,
+                    password: None,
+                    max_downloads: None,
+                    note: None,
+                },
+                "bob",
+            )
+            .await,
+            Err(GuestShareError::TooManyPaths)
+        ));
     }
 
     /// Build and persist a share with field overrides, returning it. Lets a
@@ -1429,7 +1587,7 @@ mod tests {
             share.paths = vec![file.to_string_lossy().into_owned()];
         })
         .await;
-        let opened = svc.open_download(&share, "").await.unwrap();
+        let opened = svc.open_download(&share, None, "").await.unwrap();
         assert_eq!(
             svc.active_downloads.available_permits(),
             MAX_CONCURRENT_DOWNLOADS - 1
@@ -1723,32 +1881,44 @@ mod tests {
             ..bare("f")
         };
         // Relative file inside the shared folder (including a subdir): ok.
-        assert!(svc.open_download(&folder_share, "a.txt").await.is_some());
         assert!(
-            svc.open_download(&folder_share, "sub/b.txt")
+            svc.open_download(&folder_share, None, "a.txt")
+                .await
+                .is_some()
+        );
+        assert!(
+            svc.open_download(&folder_share, None, "sub/b.txt")
                 .await
                 .is_some()
         );
         // Escapes and non-files: rejected.
         assert!(
-            svc.open_download(&folder_share, "../secret.txt")
+            svc.open_download(&folder_share, None, "../secret.txt")
                 .await
                 .is_none()
         );
-        assert!(svc.open_download(&folder_share, "sub").await.is_none()); // a dir, not a file
         assert!(
-            svc.open_download(&folder_share, "missing.txt")
+            svc.open_download(&folder_share, None, "sub")
+                .await
+                .is_none()
+        ); // a dir, not a file
+        assert!(
+            svc.open_download(&folder_share, None, "missing.txt")
                 .await
                 .is_none()
         );
-        assert!(svc.open_download(&folder_share, "a\\b").await.is_none()); // backslash rejected
+        assert!(
+            svc.open_download(&folder_share, None, "a\\b")
+                .await
+                .is_none()
+        ); // backslash rejected
 
         // Single-file share: empty path resolves to the file itself.
         let file_share = GuestShare {
             paths: vec![single.to_string_lossy().into_owned()],
             ..bare("s")
         };
-        assert!(svc.open_download(&file_share, "").await.is_some());
+        assert!(svc.open_download(&file_share, None, "").await.is_some());
     }
 
     #[tokio::test]
@@ -1765,16 +1935,16 @@ mod tests {
 
         let mut opened = Vec::new();
         for _ in 0..MAX_CONCURRENT_DOWNLOADS {
-            opened.push(svc.open_download(&share, "").await.unwrap());
+            opened.push(svc.open_download(&share, None, "").await.unwrap());
         }
-        assert!(svc.open_download(&share, "").await.is_none());
+        assert!(svc.open_download(&share, None, "").await.is_none());
 
         opened.pop();
-        assert!(svc.open_download(&share, "").await.is_some());
+        assert!(svc.open_download(&share, None, "").await.is_some());
     }
 
-    #[test]
-    fn public_meta_lists_basenames_not_abspaths() {
+    #[tokio::test]
+    async fn public_meta_lists_basenames_not_abspaths() {
         let tmp = tempfile::tempdir().unwrap();
         let root = std::fs::canonicalize(tmp.path()).unwrap();
         let dir = root.join("docs");
@@ -1792,8 +1962,14 @@ mod tests {
             expires_at: Some(42),
             ..bare("m")
         };
-        let meta = public_meta(&share);
+        let svc = GuestShareService::with_dirs(root.join("state"), root);
+        let locked = svc.meta(&share, false).await.unwrap();
+        assert!(locked.entries.is_empty());
+        assert!(!locked.unlocked);
+
+        let meta = svc.meta(&share, true).await.unwrap();
         assert!(meta.password_required);
+        assert!(meta.unlocked);
         assert_eq!(meta.expires_at, Some(42));
         assert_eq!(meta.entries.len(), 2);
         let names: Vec<&str> = meta.entries.iter().map(|e| e.name.as_str()).collect();
@@ -1808,6 +1984,94 @@ mod tests {
             .unwrap();
         assert!(!pdf.is_dir);
         assert_eq!(pdf.size, 8);
+        assert_eq!(pdf.root, 1);
+    }
+
+    #[tokio::test]
+    async fn browse_directory_is_sorted_and_stays_within_selected_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(first.join("sub")).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        std::fs::write(first.join("z.txt"), b"z").unwrap();
+        std::fs::write(first.join("A.txt"), b"alpha").unwrap();
+        std::fs::write(first.join("sub/nested.txt"), b"nested").unwrap();
+        std::fs::write(second.join("other.txt"), b"other").unwrap();
+        std::fs::write(first.join("bad\"name.txt"), b"hidden").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+
+            std::os::unix::fs::symlink(&second, first.join("escape")).unwrap();
+            let fifo = first.join("pipe");
+            let fifo = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+            assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o600) }, 0);
+        }
+        let svc = GuestShareService::with_dirs(root.join("state"), root);
+        let share = GuestShare {
+            paths: vec![
+                first.to_string_lossy().into_owned(),
+                second.to_string_lossy().into_owned(),
+            ],
+            ..bare("browse")
+        };
+
+        let listing = svc.browse_directory(&share, 0, "").await.unwrap();
+        assert_eq!(listing.root, 0);
+        assert_eq!(listing.path, "");
+        let names: Vec<&str> = listing
+            .entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["sub", "A.txt", "z.txt"]);
+        assert!(listing.entries[0].is_dir);
+        assert_eq!(listing.entries[1].size, 5);
+
+        let nested = svc.browse_directory(&share, 0, "sub").await.unwrap();
+        assert_eq!(nested.path, "sub");
+        assert_eq!(nested.entries[0].name, "nested.txt");
+        assert!(svc.browse_directory(&share, 0, "../second").await.is_none());
+        assert!(svc.browse_directory(&share, 2, "").await.is_none());
+        assert!(svc.browse_directory(&share, 0, "z.txt").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_root_index_disambiguates_shared_roots() {
+        use tokio::io::AsyncReadExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        std::fs::write(first.join("same.txt"), b"first").unwrap();
+        std::fs::write(second.join("same.txt"), b"second").unwrap();
+        let svc = GuestShareService::with_dirs(root.join("state"), root);
+        let share = GuestShare {
+            paths: vec![
+                first.to_string_lossy().into_owned(),
+                second.to_string_lossy().into_owned(),
+            ],
+            ..bare("root-index")
+        };
+
+        let opened = svc
+            .open_download(&share, Some(1), "same.txt")
+            .await
+            .unwrap();
+        let (mut reader, _, _) = opened.into_parts();
+        let mut content = Vec::new();
+        reader.read_to_end(&mut content).await.unwrap();
+        assert_eq!(content, b"second");
+        assert!(
+            svc.open_download(&share, Some(2), "same.txt")
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1975,7 +2239,7 @@ mod tests {
         assert!(svc.prepare_archive(&missing).await.is_none());
 
         let excessive = GuestShare {
-            paths: vec![file.to_string_lossy().into_owned(); MAX_ARCHIVE_ROOTS + 1],
+            paths: vec![file.to_string_lossy().into_owned(); MAX_SHARE_ROOTS + 1],
             ..bare("excess-roots")
         };
         assert!(svc.prepare_archive(&excessive).await.is_none());

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -758,8 +758,29 @@ async fn main() -> anyhow::Result<()> {
         .route("/ws/vm/{vm_id}/serial", get(vm_console::serial_handler))
         .layer(axum::middleware::from_fn(ws_origin_check));
 
+    let public_share_routes = Router::new()
+        .route("/api/public/share/{token}", get(public_share_meta_handler))
+        .route(
+            "/api/public/share/{token}/unlock",
+            post(public_share_unlock_handler),
+        )
+        .route(
+            "/api/public/share/{token}/browse",
+            get(public_share_browse_handler),
+        )
+        .route(
+            "/api/public/share/{token}/download",
+            get(public_share_download_handler).head(public_share_download_head_handler),
+        )
+        .route(
+            "/api/public/share/{token}/zip",
+            get(public_share_zip_handler).head(public_share_zip_head_handler),
+        )
+        .layer(axum::middleware::from_fn(public_share_no_store));
+
     let app = Router::new()
         .merge(ws_routes)
+        .merge(public_share_routes)
         .merge(rest_gateway::routes())
         .merge(swagger_ui::routes())
         .route("/api/openapi.json", get(openapi_handler))
@@ -779,21 +800,6 @@ async fn main() -> anyhow::Result<()> {
             get(webauthn_available_handler),
         )
         .route("/api/boot_status", get(boot_status_handler))
-        // Public guest-share access (#474) — unauthenticated by design; the
-        // URL token + optional unlock grant are the only credentials.
-        .route("/api/public/share/{token}", get(public_share_meta_handler))
-        .route(
-            "/api/public/share/{token}/unlock",
-            post(public_share_unlock_handler),
-        )
-        .route(
-            "/api/public/share/{token}/download",
-            get(public_share_download_handler),
-        )
-        .route(
-            "/api/public/share/{token}/zip",
-            get(public_share_zip_handler),
-        )
         .route("/api/auth/oidc/start", get(oidc_start_handler))
         .route("/api/auth/oidc/callback", get(oidc_callback_handler))
         .route(
@@ -3250,14 +3256,29 @@ async fn logout_handler(
 // short-lived unlock grant cookie. Every "unavailable" reason collapses to
 // one generic response so a token-guesser gets no oracle.
 
-const SHARE_GRANT_COOKIE: &str = "nasty_share_grant";
+const SHARE_GRANT_COOKIE: &str = "nasty_share_grant_v2";
 
-fn build_share_grant_cookie(token: &str) -> String {
+async fn public_share_no_store(
+    request: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let mut response = next.run(request).await;
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        "private, no-store".parse().unwrap(),
+    );
+    response
+        .headers_mut()
+        .insert(axum::http::header::VARY, "Cookie".parse().unwrap());
+    response
+}
+
+fn build_share_grant_cookie(share_token: &str, grant: &str) -> String {
     // Scoped to the public share path and short-lived to match the grant
     // TTL. SameSite=Strict is fine while shares are served same-origin
     // (path-based); the future share.* subdomain work revisits this.
     format!(
-        "{SHARE_GRANT_COOKIE}={token}; HttpOnly; Secure; SameSite=Strict; Path=/api/public/share; Max-Age=3600"
+        "{SHARE_GRANT_COOKIE}={grant}; HttpOnly; Secure; SameSite=Strict; Path=/api/public/share/{share_token}; Max-Age=3600"
     )
 }
 
@@ -3288,6 +3309,18 @@ fn share_client_ip(headers: &axum::http::HeaderMap) -> String {
         .to_string()
 }
 
+fn share_is_unlocked(
+    state: &AppState,
+    share: &guestshare::GuestShare,
+    headers: &axum::http::HeaderMap,
+    now: i64,
+) -> bool {
+    !guestshare::GuestShareService::needs_password(share)
+        || share_grant_from_cookie(headers)
+            .map(|grant| state.guest_shares.check_grant(&grant, &share.id, now))
+            .unwrap_or(false)
+}
+
 /// One generic "not available" for unknown / expired / revoked / exhausted /
 /// unresolvable — no oracle for token or path guessing.
 fn share_not_available() -> axum::response::Response {
@@ -3301,14 +3334,51 @@ fn share_not_available() -> axum::response::Response {
 /// `GET /api/public/share/{token}` → guest landing metadata. Counts a view.
 async fn public_share_meta_handler(
     axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
     let now = now_unix_i64();
     let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
         return share_not_available();
     };
+    let unlocked = share_is_unlocked(&state, &share, &headers, now);
+    let Some(meta) = state.guest_shares.meta(&share, unlocked).await else {
+        return share_not_available();
+    };
     state.guest_shares.record_view(&share.id).await;
-    Json(guestshare::GuestShareService::meta(&share)).into_response()
+    Json(meta).into_response()
+}
+
+/// `GET /api/public/share/{token}/browse?root=N&path=...` → one directory.
+async fn public_share_browse_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+    if !share_is_unlocked(&state, &share, &headers, now) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Password required"})),
+        )
+            .into_response();
+    }
+    let Some(root) = params.get("root").and_then(|root| root.parse().ok()) else {
+        return share_not_available();
+    };
+    let path = params.get("path").map(String::as_str).unwrap_or("");
+    let Some(listing) = state
+        .guest_shares
+        .browse_directory(&share, root, path)
+        .await
+    else {
+        return share_not_available();
+    };
+    Json(listing).into_response()
 }
 
 #[derive(Deserialize)]
@@ -3367,7 +3437,16 @@ async fn public_share_unlock_handler(
     };
 
     if password_matches {
+        // A correct password is a success even if metadata capacity is
+        // momentarily busy below; never let retries accumulate a lockout.
         state.guest_shares.clear_unlock_failures(&client_ip, &token);
+        let now = now_unix_i64();
+        let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+            return share_not_available();
+        };
+        let Some(meta) = state.guest_shares.meta(&share, true).await else {
+            return share_not_available();
+        };
         let grant = state.guest_shares.mint_grant(&share.id, now);
         crate::auth::audit(
             "guest_share_unlock",
@@ -3378,14 +3457,9 @@ async fn public_share_unlock_handler(
         let mut resp_headers = axum::http::HeaderMap::new();
         resp_headers.insert(
             axum::http::header::SET_COOKIE,
-            build_share_grant_cookie(&grant).parse().unwrap(),
+            build_share_grant_cookie(&token, &grant).parse().unwrap(),
         );
-        return (
-            StatusCode::OK,
-            resp_headers,
-            Json(serde_json::json!({"ok": true})),
-        )
-            .into_response();
+        return (StatusCode::OK, resp_headers, Json(meta)).into_response();
     }
 
     (
@@ -3411,23 +3485,25 @@ async fn public_share_download_handler(
         return share_not_available();
     };
 
-    if guestshare::GuestShareService::needs_password(&share) {
-        let granted = share_grant_from_cookie(&headers)
-            .map(|g| state.guest_shares.check_grant(&g, &share.id, now))
-            .unwrap_or(false);
-        if !granted {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"error": "Password required"})),
-            )
-                .into_response();
-        }
+    if !share_is_unlocked(&state, &share, &headers, now) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Password required"})),
+        )
+            .into_response();
     }
 
     let rel = params.get("path").map(|s| s.as_str()).unwrap_or("");
+    let root = match params.get("root") {
+        Some(root) => match root.parse::<usize>() {
+            Ok(root) => Some(root),
+            Err(_) => return share_not_available(),
+        },
+        None => None,
+    };
     // Opening first ensures invalid paths do not consume download quota. The
     // service bounds descriptors for the full lifetime of each stream.
-    let Some(opened) = state.guest_shares.open_download(&share, rel).await else {
+    let Some(opened) = state.guest_shares.open_download(&share, root, rel).await else {
         return share_not_available();
     };
 
@@ -3469,6 +3545,36 @@ async fn public_share_download_handler(
     (StatusCode::OK, resp_headers, body).into_response()
 }
 
+/// Validate a download without consuming quota. The WebUI uses this before
+/// triggering the browser-managed GET, and generic HEAD probes remain harmless.
+async fn public_share_download_head_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+    if !share_is_unlocked(&state, &share, &headers, now) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let root = match params.get("root") {
+        Some(root) => match root.parse::<usize>() {
+            Ok(root) => Some(root),
+            Err(_) => return share_not_available(),
+        },
+        None => None,
+    };
+    let path = params.get("path").map(String::as_str).unwrap_or("");
+    let Some(opened) = state.guest_shares.open_download(&share, root, path).await else {
+        return share_not_available();
+    };
+    drop(opened);
+    StatusCode::NO_CONTENT.into_response()
+}
+
 /// `GET /api/public/share/{token}/zip` → stream a ZIP of the whole share
 /// (folders walked recursively, symlinks skipped). Same gates as download;
 /// counts as a single download against `max_downloads`.
@@ -3484,17 +3590,12 @@ async fn public_share_zip_handler(
         return share_not_available();
     };
 
-    if guestshare::GuestShareService::needs_password(&share) {
-        let granted = share_grant_from_cookie(&headers)
-            .map(|g| state.guest_shares.check_grant(&g, &share.id, now))
-            .unwrap_or(false);
-        if !granted {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"error": "Password required"})),
-            )
-                .into_response();
-        }
+    if !share_is_unlocked(&state, &share, &headers, now) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Password required"})),
+        )
+            .into_response();
     }
 
     let Some(archive) = state.guest_shares.prepare_archive(&share).await else {
@@ -3532,6 +3633,26 @@ async fn public_share_zip_handler(
             .unwrap(),
     );
     (StatusCode::OK, resp_headers, body).into_response()
+}
+
+/// Validate archive availability without starting compression or counting it.
+async fn public_share_zip_head_handler(
+    axum::extract::Path(token): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let now = now_unix_i64();
+    let Some(share) = state.guest_shares.lookup_active(&token, now).await else {
+        return share_not_available();
+    };
+    if !share_is_unlocked(&state, &share, &headers, now) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let Some(archive) = state.guest_shares.prepare_archive(&share).await else {
+        return share_not_available();
+    };
+    drop(archive);
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// 8h, matches SESSION_TTL_SECS in auth.rs (kept in sync by hand).

--- a/webui/src/lib/public-share.test.ts
+++ b/webui/src/lib/public-share.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import {
+	joinSharePath,
+	parentSharePath,
+	shareBreadcrumbs,
+	shareBrowseUrl,
+	shareDownloadUrl,
+	shareZipUrl
+} from './public-share';
+
+describe('public share navigation', () => {
+	test('joins paths and walks to parents', () => {
+		expect(joinSharePath('', 'Photos')).toBe('Photos');
+		expect(joinSharePath('Photos/2026', 'July')).toBe('Photos/2026/July');
+		expect(parentSharePath('Photos/2026/July')).toBe('Photos/2026');
+		expect(parentSharePath('Photos')).toBe('');
+		expect(parentSharePath('')).toBe('');
+	});
+
+	test('builds cumulative breadcrumbs', () => {
+		expect(shareBreadcrumbs('Media', 'Photos/2026')).toEqual([
+			{ label: 'Media', path: '' },
+			{ label: 'Photos', path: 'Photos' },
+			{ label: '2026', path: 'Photos/2026' }
+		]);
+	});
+
+	test('encodes tokens and query paths', () => {
+		expect(shareBrowseUrl('token/value', 2, 'Family Photos/July #1')).toBe(
+			'/api/public/share/token%2Fvalue/browse?root=2&path=Family+Photos%2FJuly+%231'
+		);
+		expect(shareDownloadUrl('abc', 0, 'reports/Q2 & Q3.pdf')).toBe(
+			'/api/public/share/abc/download?root=0&path=reports%2FQ2+%26+Q3.pdf'
+		);
+		expect(shareZipUrl('abc')).toBe('/api/public/share/abc/zip');
+	});
+});

--- a/webui/src/lib/public-share.ts
+++ b/webui/src/lib/public-share.ts
@@ -1,0 +1,70 @@
+export interface PublicShareRoot {
+	root: number;
+	name: string;
+	is_dir: boolean;
+	size: number;
+}
+
+export interface PublicShareMeta {
+	entries: PublicShareRoot[];
+	password_required: boolean;
+	unlocked: boolean;
+	expires_at: number | null;
+}
+
+export interface PublicDirectoryEntry {
+	name: string;
+	is_dir: boolean;
+	size: number;
+}
+
+export interface PublicDirectoryListing {
+	root: number;
+	path: string;
+	entries: PublicDirectoryEntry[];
+}
+
+export interface ShareBreadcrumb {
+	label: string;
+	path: string;
+}
+
+export function joinSharePath(path: string, name: string): string {
+	return path ? `${path}/${name}` : name;
+}
+
+export function parentSharePath(path: string): string {
+	const separator = path.lastIndexOf('/');
+	return separator < 0 ? '' : path.slice(0, separator);
+}
+
+export function shareBreadcrumbs(rootName: string, path: string): ShareBreadcrumb[] {
+	const breadcrumbs: ShareBreadcrumb[] = [{ label: rootName, path: '' }];
+	let current = '';
+	for (const component of path.split('/').filter(Boolean)) {
+		current = joinSharePath(current, component);
+		breadcrumbs.push({ label: component, path: current });
+	}
+	return breadcrumbs;
+}
+
+function shareEndpoint(token: string, action = ''): string {
+	const base = `/api/public/share/${encodeURIComponent(token)}`;
+	return action ? `${base}/${action}` : base;
+}
+
+export function shareBrowseUrl(token: string, root: number, path: string): string {
+	const params = new URLSearchParams({ root: String(root) });
+	if (path) params.set('path', path);
+	return `${shareEndpoint(token, 'browse')}?${params}`;
+}
+
+export function shareDownloadUrl(token: string, root: number, path: string): string {
+	const params = new URLSearchParams({ root: String(root) });
+	if (path) params.set('path', path);
+	return `${shareEndpoint(token, 'download')}?${params}`;
+}
+
+export function shareZipUrl(token: string): string {
+	return shareEndpoint(token, 'zip');
+}

--- a/webui/src/routes/share/[token]/+page.svelte
+++ b/webui/src/routes/share/[token]/+page.svelte
@@ -1,197 +1,419 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { tick } from 'svelte';
 	import { page } from '$app/stores';
 	import { theme } from '$lib/theme.svelte';
+	import { formatBytes } from '$lib/format';
+	import {
+		joinSharePath,
+		parentSharePath,
+		shareBreadcrumbs,
+		shareBrowseUrl,
+		shareDownloadUrl,
+		shareZipUrl,
+		type PublicDirectoryEntry,
+		type PublicDirectoryListing,
+		type PublicShareMeta,
+		type PublicShareRoot
+	} from '$lib/public-share';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
-	import { File, Folder, Download, Lock } from '@lucide/svelte';
+	import { ArrowLeft, ChevronRight, Download, File, FolderOpen, Home, Lock } from '@lucide/svelte';
 
-	// Public, unauthenticated guest landing page for a share link. It talks
-	// to the engine only through /api/public/share/* — no session, no RPC.
-	// The root layout renders this route bare (no sidebar) via its
-	// `isPublicShare` bypass.
-
-	interface PublicEntry {
-		name: string;
-		is_dir: boolean;
-		size: number;
-	}
-	interface ShareMeta {
-		entries: PublicEntry[];
-		password_required: boolean;
-		expires_at: number | null;
-	}
-
-	const token = $derived($page.params.token);
+	const token = $derived($page.params.token ?? '');
 
 	let loading = $state(true);
-	let meta = $state<ShareMeta | null>(null);
+	let meta = $state<PublicShareMeta | null>(null);
 	let notAvailable = $state(false);
+	let selectedRoot = $state<PublicShareRoot | null>(null);
+	let listing = $state<PublicDirectoryListing | null>(null);
+	let browseLoading = $state(false);
+	let browseError = $state('');
+	let browseRequest = 0;
+	let shareGeneration = 0;
+	let shareAbortController: AbortController | null = null;
+	let downloadError = $state('');
+	let downloadPending = $state(false);
+	let breadcrumbNav = $state<HTMLElement | null>(null);
 
-	// Password unlock state.
 	let unlocked = $state(false);
 	let password = $state('');
 	let unlocking = $state(false);
 	let unlockError = $state('');
 
 	const needsUnlock = $derived(!!meta?.password_required && !unlocked);
-
-	function fmtSize(n: number): string {
-		if (n < 1024) return `${n} B`;
-		const units = ['KB', 'MB', 'GB', 'TB'];
-		let v = n / 1024;
-		let i = 0;
-		while (v >= 1024 && i < units.length - 1) {
-			v /= 1024;
-			i++;
-		}
-		return `${v.toFixed(1)} ${units[i]}`;
-	}
+	const breadcrumbs = $derived(
+		selectedRoot && listing ? shareBreadcrumbs(selectedRoot.name, listing.path) : []
+	);
 
 	function fmtExpiry(secs: number | null): string {
 		if (!secs) return '';
 		return new Date(secs * 1000).toLocaleString();
 	}
 
-	async function loadMeta() {
+	function resetShareState() {
+		browseRequest++;
+		meta = null;
+		notAvailable = false;
+		selectedRoot = null;
+		listing = null;
+		browseLoading = false;
+		browseError = '';
+		downloadError = '';
+		downloadPending = false;
+		unlocked = false;
+		password = '';
+		unlocking = false;
+		unlockError = '';
+	}
+
+	async function loadMeta(requestToken: string, generation: number, signal: AbortSignal) {
 		loading = true;
 		notAvailable = false;
 		try {
-			const res = await fetch(`/api/public/share/${token}`);
-			if (!res.ok) {
+			const response = await fetch(`/api/public/share/${encodeURIComponent(requestToken)}`, { signal });
+			if (generation !== shareGeneration) return;
+			if (!response.ok) {
 				notAvailable = true;
 				return;
 			}
-			meta = (await res.json()) as ShareMeta;
-			unlocked = !meta.password_required;
+			const nextMeta = (await response.json()) as PublicShareMeta;
+			if (generation !== shareGeneration) return;
+			meta = nextMeta;
+			unlocked = nextMeta.unlocked;
 		} catch {
-			notAvailable = true;
+			if (generation === shareGeneration) notAvailable = true;
 		} finally {
-			loading = false;
+			if (generation === shareGeneration) loading = false;
 		}
 	}
 
-	async function unlock(e: Event) {
-		e.preventDefault();
+	async function unlock(event: Event) {
+		event.preventDefault();
 		if (!password) return;
 		unlocking = true;
 		unlockError = '';
+		const requestToken = token;
+		const generation = shareGeneration;
+		const signal = shareAbortController?.signal;
 		try {
-			const res = await fetch(`/api/public/share/${token}/unlock`, {
+			const response = await fetch(`/api/public/share/${encodeURIComponent(requestToken)}/unlock`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ password })
+				body: JSON.stringify({ password }),
+				signal
 			});
-			if (res.ok) {
-				// The grant cookie is now set; downloads will carry it.
-				unlocked = true;
+			if (generation !== shareGeneration) return;
+			if (response.ok) {
+				const nextMeta = (await response.json()) as PublicShareMeta;
+				if (generation !== shareGeneration) return;
 				password = '';
-			} else if (res.status === 429) {
+				meta = nextMeta;
+				unlocked = nextMeta.unlocked;
+			} else if (response.status === 429) {
 				unlockError = 'Too many attempts. Please try again later.';
-			} else if (res.status === 404) {
+			} else if (response.status === 404) {
 				notAvailable = true;
 			} else {
 				unlockError = 'Incorrect password.';
 			}
 		} catch {
-			unlockError = 'Something went wrong. Please try again.';
+			if (generation === shareGeneration) unlockError = 'Something went wrong. Please try again.';
 		} finally {
-			unlocking = false;
+			if (generation === shareGeneration) unlocking = false;
 		}
 	}
 
-	// Per-file download. Shares created from the WebUI have a single root, so
-	// a file entry downloads with no path (the share root *is* the file). The
-	// grant cookie, if any, rides along automatically (same-origin, same-site).
-	function downloadUrl(): string {
-		return `/api/public/share/${token}/download`;
+	async function browse(root: PublicShareRoot, path: string) {
+		const request = ++browseRequest;
+		browseLoading = true;
+		browseError = '';
+		try {
+			const response = await fetch(shareBrowseUrl(token, root.root, path));
+			if (response.status === 401) {
+				if (request !== browseRequest) return;
+				showRoots();
+				unlocked = false;
+				unlockError = 'Your unlock expired. Enter the password again.';
+				return;
+			}
+			if (!response.ok) {
+				if (request !== browseRequest) return;
+				browseError = 'This folder is no longer available.';
+				return;
+			}
+			const nextListing = (await response.json()) as PublicDirectoryListing;
+			if (request !== browseRequest) return;
+			selectedRoot = root;
+			listing = nextListing;
+			await tick();
+			if (request === browseRequest) {
+				breadcrumbNav?.scrollTo({ left: breadcrumbNav.scrollWidth, behavior: 'smooth' });
+			}
+		} catch {
+			if (request === browseRequest) browseError = 'Could not load this folder. Please try again.';
+		} finally {
+			if (request === browseRequest) browseLoading = false;
+		}
 	}
 
-	// Folder shares download as a streamed ZIP of the whole folder.
-	function zipUrl(): string {
-		return `/api/public/share/${token}/zip`;
+	function showRoots() {
+		browseRequest++;
+		browseLoading = false;
+		browseError = '';
+		downloadError = '';
+		selectedRoot = null;
+		listing = null;
 	}
 
-	onMount(loadMeta);
+	function openDirectory(entry: PublicDirectoryEntry) {
+		if (!selectedRoot || !listing) return;
+		void browse(selectedRoot, joinSharePath(listing.path, entry.name));
+	}
+
+	function goUp() {
+		if (!selectedRoot || !listing) return;
+		if (!listing.path) {
+			showRoots();
+			return;
+		}
+		void browse(selectedRoot, parentSharePath(listing.path));
+	}
+
+	async function startDownload(event: MouseEvent, url: string, name: string) {
+		event.preventDefault();
+		if (downloadPending) return;
+		downloadPending = true;
+		downloadError = '';
+		const generation = shareGeneration;
+		let started = false;
+		try {
+			const response = await fetch(url, { method: 'HEAD' });
+			if (generation !== shareGeneration) return;
+			if (response.status === 401) {
+				showRoots();
+				unlocked = false;
+				unlockError = 'Your unlock expired. Enter the password again.';
+				return;
+			}
+			if (!response.ok) {
+				downloadError = 'This download is no longer available.';
+				return;
+			}
+			const link = document.createElement('a');
+			link.href = url;
+			link.download = name;
+			link.click();
+			started = true;
+		} catch {
+			if (generation === shareGeneration) {
+				downloadError = 'Could not start the download. Please try again.';
+			}
+		} finally {
+			if (generation !== shareGeneration) return;
+			if (started) {
+				window.setTimeout(() => {
+					if (generation === shareGeneration) downloadPending = false;
+				}, 1000);
+			} else {
+				downloadPending = false;
+			}
+		}
+	}
+
+	$effect(() => {
+		const requestToken = token;
+		shareAbortController?.abort();
+		const controller = new AbortController();
+		shareAbortController = controller;
+		const generation = ++shareGeneration;
+		resetShareState();
+		if (requestToken) void loadMeta(requestToken, generation, controller.signal);
+		return () => controller.abort();
+	});
 </script>
 
 <svelte:head>
-	<title>Shared files — NASty</title>
+	<title>Shared files - NASty</title>
 </svelte:head>
 
-<div class="flex min-h-screen items-center justify-center bg-background p-6">
-	<div class="w-full max-w-lg rounded-xl border border-border bg-card p-8">
-		<img src={theme.isDark ? logoDark : logoLight} alt="NASty" class="mb-6 h-16 mx-auto" />
+<div class="flex min-h-screen items-center justify-center bg-background p-3 sm:p-6">
+	<div class="w-full max-w-3xl rounded-xl border border-border bg-card p-4 shadow-sm sm:p-8">
+		<img src={theme.isDark ? logoDark : logoLight} alt="NASty" class="mx-auto mb-6 h-16" />
 
 		{#if loading}
-			<p class="text-center text-sm text-muted-foreground">Loading…</p>
+			<p class="text-center text-sm text-muted-foreground">Loading...</p>
 		{:else if notAvailable}
 			<h1 class="text-center text-lg font-semibold">This share is not available</h1>
 			<p class="mt-2 text-center text-sm text-muted-foreground">
 				The link may have expired, been revoked, or reached its download limit.
 			</p>
 		{:else if meta}
-			<h1 class="text-center text-lg font-semibold">Shared with you</h1>
-			{#if meta.expires_at}
-				<p class="mt-1 text-center text-xs text-muted-foreground">
-					Available until {fmtExpiry(meta.expires_at)}
-				</p>
-			{/if}
+			<div class="text-center">
+				<h1 class="text-xl font-semibold">Shared with you</h1>
+				{#if meta.expires_at}
+					<p class="mt-1 text-xs text-muted-foreground">
+						Available until {fmtExpiry(meta.expires_at)}
+					</p>
+				{/if}
+			</div>
 
 			{#if needsUnlock}
 				<form onsubmit={unlock} class="mx-auto mt-6 max-w-xs">
 					<div class="mb-2 flex items-center justify-center gap-2 text-sm text-muted-foreground">
 						<Lock size={14} /> This share is password protected
 					</div>
+					<label for="share-password" class="sr-only">Share password</label>
 					<input
+						id="share-password"
 						type="password"
 						bind:value={password}
 						placeholder="Password"
-						autocomplete="off"
+						autocomplete="current-password"
+						aria-invalid={unlockError ? 'true' : undefined}
+						aria-describedby={unlockError ? 'share-password-error' : undefined}
 						class="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm" />
 					{#if unlockError}
-						<p class="mt-2 text-sm text-destructive">{unlockError}</p>
+						<p id="share-password-error" role="alert" class="mt-2 text-sm text-destructive">{unlockError}</p>
 					{/if}
 					<button
 						type="submit"
 						disabled={unlocking || !password}
 						class="mt-3 h-9 w-full rounded-md bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50">
-						{unlocking ? 'Unlocking…' : 'Unlock'}
+						{unlocking ? 'Unlocking...' : 'Unlock'}
 					</button>
 				</form>
 			{:else}
-				<ul class="mt-6 divide-y divide-border/60">
-					{#each meta.entries as entry (entry.name)}
-						<li class="flex items-center justify-between gap-3 py-3">
-							<div class="flex min-w-0 items-center gap-2">
+				<div class="mt-6 flex flex-col gap-3 border-b border-border pb-4 sm:flex-row sm:items-center sm:justify-between">
+					<p class="text-sm text-muted-foreground">
+						{selectedRoot ? 'Browse and download individual files.' : `${meta.entries.length} shared item${meta.entries.length === 1 ? '' : 's'}`}
+					</p>
+					<a
+						href={shareZipUrl(token)}
+						download="shared-files.zip"
+						aria-disabled={downloadPending}
+						onclick={(event) => void startDownload(event, shareZipUrl(token), 'shared-files.zip')}
+						class="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md border border-border px-3 text-sm font-medium hover:bg-accent {downloadPending ? 'pointer-events-none opacity-50' : ''}">
+						<Download size={15} /> Download all as ZIP
+					</a>
+				</div>
+
+				{#if selectedRoot && listing}
+					<div class="mt-4 flex items-center gap-2">
+						<button
+							type="button"
+							onclick={goUp}
+							class="inline-flex size-9 shrink-0 items-center justify-center rounded-md border border-border hover:bg-accent"
+							aria-label="Go up">
+							<ArrowLeft size={16} />
+						</button>
+						<nav bind:this={breadcrumbNav} class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto text-sm" aria-label="Folder path">
+							<button
+								type="button"
+								onclick={showRoots}
+								class="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-1 text-muted-foreground hover:bg-accent hover:text-foreground">
+								<Home size={14} /> Shared items
+							</button>
+							{#each breadcrumbs as crumb, index (crumb.path)}
+								<ChevronRight size={14} class="shrink-0 text-muted-foreground" />
+								<button
+									type="button"
+									onclick={() => selectedRoot && void browse(selectedRoot, crumb.path)}
+									disabled={index === breadcrumbs.length - 1}
+									aria-current={index === breadcrumbs.length - 1 ? 'page' : undefined}
+									class="max-w-48 shrink-0 truncate rounded px-1.5 py-1 hover:bg-accent disabled:font-medium disabled:text-foreground">
+									{crumb.label}
+								</button>
+							{/each}
+						</nav>
+					</div>
+				{/if}
+
+				{#if browseError}
+					<p role="alert" class="mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+						{browseError}
+					</p>
+				{/if}
+				{#if downloadError}
+					<p role="alert" class="mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+						{downloadError}
+					</p>
+				{/if}
+
+				{#if browseLoading}
+					<p role="status" class="py-10 text-center text-sm text-muted-foreground">Loading folder...</p>
+				{:else if listing && selectedRoot}
+					{#if listing.entries.length === 0}
+						<p class="py-10 text-center text-sm text-muted-foreground">This folder is empty.</p>
+					{:else}
+						<ul class="mt-2 divide-y divide-border/60">
+							{#each listing.entries as entry (entry.name)}
+								<li class="flex min-w-0 items-center gap-3 py-3">
+									{#if entry.is_dir}
+										<button
+											type="button"
+											onclick={() => openDirectory(entry)}
+											class="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left hover:text-primary">
+											<FolderOpen size={19} class="shrink-0 text-amber-500" />
+											<span class="truncate text-sm font-medium">{entry.name}</span>
+										</button>
+										<ChevronRight size={16} class="shrink-0 text-muted-foreground" />
+									{:else}
+										<div class="flex min-w-0 flex-1 items-center gap-3">
+											<File size={18} class="shrink-0 text-muted-foreground" />
+											<div class="min-w-0 flex-1">
+												<p class="truncate text-sm">{entry.name}</p>
+												<p class="text-xs text-muted-foreground">{formatBytes(entry.size)}</p>
+											</div>
+										</div>
+										<a
+											href={shareDownloadUrl(token, selectedRoot.root, joinSharePath(listing.path, entry.name))}
+											download={entry.name}
+											aria-label={`Download ${entry.name}`}
+											aria-disabled={downloadPending}
+											onclick={(event) => void startDownload(event, shareDownloadUrl(token, selectedRoot!.root, joinSharePath(listing!.path, entry.name)), entry.name)}
+											class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 text-sm hover:bg-accent {downloadPending ? 'pointer-events-none opacity-50' : ''}">
+											<Download size={14} /> <span class="hidden sm:inline">Download</span>
+										</a>
+									{/if}
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				{:else}
+					<ul class="mt-2 divide-y divide-border/60">
+						{#each meta.entries as entry (entry.root)}
+							<li class="flex min-w-0 items-center gap-3 py-3">
 								{#if entry.is_dir}
-									<Folder size={16} class="shrink-0 text-muted-foreground" />
+									<button
+										type="button"
+										onclick={() => void browse(entry, '')}
+										class="flex min-w-0 flex-1 items-center gap-3 rounded-md text-left hover:text-primary">
+										<FolderOpen size={20} class="shrink-0 text-amber-500" />
+										<span class="truncate text-sm font-medium">{entry.name}</span>
+									</button>
+									<ChevronRight size={16} class="shrink-0 text-muted-foreground" />
 								{:else}
-									<File size={16} class="shrink-0 text-muted-foreground" />
+									<div class="flex min-w-0 flex-1 items-center gap-3">
+										<File size={18} class="shrink-0 text-muted-foreground" />
+										<div class="min-w-0 flex-1">
+											<p class="truncate text-sm">{entry.name}</p>
+											<p class="text-xs text-muted-foreground">{formatBytes(entry.size)}</p>
+										</div>
+									</div>
+									<a
+										href={shareDownloadUrl(token, entry.root, '')}
+										download={entry.name}
+										aria-label={`Download ${entry.name}`}
+										aria-disabled={downloadPending}
+										onclick={(event) => void startDownload(event, shareDownloadUrl(token, entry.root, ''), entry.name)}
+										class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 text-sm hover:bg-accent {downloadPending ? 'pointer-events-none opacity-50' : ''}">
+										<Download size={14} /> <span class="hidden sm:inline">Download</span>
+									</a>
 								{/if}
-								<span class="truncate text-sm">{entry.name}</span>
-								{#if !entry.is_dir}
-									<span class="shrink-0 text-xs text-muted-foreground">{fmtSize(entry.size)}</span>
-								{/if}
-							</div>
-							{#if entry.is_dir}
-								<a
-									href={zipUrl()}
-									download={`${entry.name}.zip`}
-									class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">
-									<Download size={14} /> Download as ZIP
-								</a>
-							{:else}
-								<a
-									href={downloadUrl()}
-									download={entry.name}
-									class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">
-									<Download size={14} /> Download
-								</a>
-							{/if}
-						</li>
-					{/each}
-				</ul>
+							</li>
+						{/each}
+					</ul>
+				{/if}
 			{/if}
 		{/if}
 


### PR DESCRIPTION
## Summary
- add a root-indexed public browse API that walks retained descriptors and rejects symlinks, mount crossings, traversal, and unsupported entries
- add responsive guest folder navigation with breadcrumbs, password-expiry recovery, stale-request suppression, and per-file downloads
- add non-counting HEAD preflights, private no-store responses, exact-path grant cookies, and bounded browse/root limits

## Verification
- `cargo test -p nasty-engine`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `npm run check`
- `npm test`
- `npm run build`
- `git diff --check`
- direct Linux-target compilation of `file_boundary.rs`

Closes #558