### PR TITLE
auth: add standard user file portal

### DIFF
--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -20,6 +20,10 @@ pub struct User {
     #[serde(default)]
     pub password_hash: Option<String>,
     pub role: Role,
+    /// SMB/local or domain principal used by the read-only file portal.
+    /// Absent on management users and on records persisted before issue #475.
+    #[serde(default)]
+    pub file_principal: Option<String>,
     /// When true, the user must change their password before accessing anything else.
     #[serde(default)]
     pub must_change_password: bool,
@@ -73,6 +77,9 @@ pub enum Role {
     /// Can create/delete/attach subvolumes and snapshots, read filesystems.
     /// Cannot destroy filesystems, manage users, or touch system settings.
     Operator,
+    /// Deny-by-default standard user with access only to explicitly allowed
+    /// self-service RPCs and the SMB-backed file portal.
+    User,
 }
 
 /// Login sessions expire after this many seconds.
@@ -83,6 +90,9 @@ pub struct Session {
     pub token: String,
     pub username: String,
     pub role: Role,
+    /// Principal bound to an interactive standard-user session.
+    #[serde(default)]
+    pub file_principal: Option<String>,
     /// For API tokens: restricts filesystem visibility to a single filesystem.
     #[serde(default)]
     pub filesystem: Option<String>,
@@ -103,8 +113,8 @@ pub struct Session {
 /// central JSON-RPC dispatcher.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EndpointAccess {
-    /// Any authenticated role. Filesystem/owner scope is enforced separately
-    /// by handlers that operate on scoped resources.
+    /// Any authenticated management role. Filesystem/owner scope is enforced
+    /// separately by handlers that operate on scoped resources.
     Read,
     /// Operator or Admin. Resource scope is enforced by the handler.
     Mutation,
@@ -115,6 +125,8 @@ pub enum EndpointAccess {
     /// Session-management operations that remain available while a password
     /// change is required, such as checking the current session or logout.
     SelfService,
+    /// Interactive, unscoped standard-user session with a bound principal.
+    PortalFiles,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -122,6 +134,8 @@ pub enum AccessDenied {
     PasswordChangeRequired,
     InsufficientRole,
     ScopedCredential,
+    MissingFilePrincipal,
+    InteractiveSessionRequired,
 }
 
 impl AccessDenied {
@@ -130,6 +144,8 @@ impl AccessDenied {
             Self::PasswordChangeRequired => "Password change required",
             Self::InsufficientRole => "Permission denied",
             Self::ScopedCredential => "Scoped credentials cannot access this endpoint",
+            Self::MissingFilePrincipal => "A file principal is required",
+            Self::InteractiveSessionRequired => "An interactive session is required",
         }
     }
 }
@@ -143,11 +159,13 @@ pub fn authorize_session(session: &Session, access: EndpointAccess) -> Result<()
     }
 
     let role_allowed = match access {
-        EndpointAccess::Read | EndpointAccess::SelfService => true,
+        EndpointAccess::Read => session.role != Role::User,
+        EndpointAccess::SelfService => true,
         EndpointAccess::Mutation | EndpointAccess::UnscopedMutation => {
             matches!(session.role, Role::Admin | Role::Operator)
         }
         EndpointAccess::RootEquivalent => session.role == Role::Admin,
+        EndpointAccess::PortalFiles => session.role == Role::User,
     };
     if !role_allowed {
         return Err(AccessDenied::InsufficientRole);
@@ -155,10 +173,21 @@ pub fn authorize_session(session: &Session, access: EndpointAccess) -> Result<()
 
     if matches!(
         access,
-        EndpointAccess::UnscopedMutation | EndpointAccess::RootEquivalent
+        EndpointAccess::UnscopedMutation
+            | EndpointAccess::RootEquivalent
+            | EndpointAccess::PortalFiles
     ) && (session.filesystem.is_some() || session.owner.is_some())
     {
         return Err(AccessDenied::ScopedCredential);
+    }
+
+    if access == EndpointAccess::PortalFiles {
+        if session.client_ip.is_none() {
+            return Err(AccessDenied::InteractiveSessionRequired);
+        }
+        if session.file_principal.as_deref().is_none_or(str::is_empty) {
+            return Err(AccessDenied::MissingFilePrincipal);
+        }
     }
 
     Ok(())
@@ -408,6 +437,9 @@ impl AuthService {
             token: token.clone(),
             username: user.username.clone(),
             role: user.role.clone(),
+            file_principal: (user.role == Role::User)
+                .then(|| user.file_principal.clone())
+                .flatten(),
             filesystem: None,
             owner: None,
             created_at: now,
@@ -474,6 +506,24 @@ impl AuthService {
                 && u.oidc_issuer.as_deref() == Some(&identity.issuer)
         });
 
+        if role == Role::User {
+            let safely_bound = existing_idx
+                .and_then(|idx| state.users[idx].file_principal.as_deref())
+                .is_some_and(|principal| !principal.is_empty());
+            if !safely_bound {
+                audit(
+                    "oidc_login_denied_unbound_user",
+                    identity
+                        .preferred_username
+                        .as_deref()
+                        .unwrap_or(&identity.subject),
+                    client_ip,
+                    "standard User role requires a pre-provisioned file principal",
+                );
+                return Err(AuthError::Forbidden);
+            }
+        }
+
         if existing_idx.is_none() {
             if !auto_provision {
                 audit(
@@ -492,6 +542,7 @@ impl AuthService {
                 username: username.clone(),
                 password_hash: None,
                 role: role.clone(),
+                file_principal: None,
                 must_change_password: false,
                 oidc_subject: Some(identity.subject.clone()),
                 oidc_issuer: Some(identity.issuer.clone()),
@@ -503,17 +554,27 @@ impl AuthService {
 
         let idx = existing_idx.expect("user index resolved above");
         let user = &mut state.users[idx];
-        if user.role != role {
+        let role_changed = user.role != role;
+        if role_changed {
             prior_role = Some(user.role.clone());
             user.role = role.clone();
+            if role != Role::User {
+                user.file_principal = None;
+            }
         }
 
         let username = user.username.clone();
+        if role_changed {
+            revoke_user_sessions(&mut state.sessions, &username);
+        }
         let token = generate_token();
         let session = Session {
             token: token.clone(),
             username: username.clone(),
             role: role.clone(),
+            file_principal: (role == Role::User)
+                .then(|| user.file_principal.clone())
+                .flatten(),
             filesystem: None,
             owner: None,
             created_at: now,
@@ -627,6 +688,7 @@ impl AuthService {
             token: token.to_string(),
             username: t.name.clone(),
             role: t.role.clone(),
+            file_principal: None,
             filesystem: t.filesystem.clone(),
             owner: if t.role == Role::Operator {
                 Some(t.name.clone())
@@ -652,10 +714,15 @@ impl AuthService {
         if session.role != Role::Admin {
             return Err(AuthError::Forbidden);
         }
+        if role == Role::User {
+            return Err(AuthError::Forbidden);
+        }
 
         let mut current = self.state.write().await;
         let mut state = current.clone();
-        if state.api_tokens.iter().any(|t| t.name == name) {
+        if state.api_tokens.iter().any(|t| t.name == name)
+            || state.users.iter().any(|user| user.username == name)
+        {
             return Err(AuthError::UserExists); // reuse: token name already taken
         }
 
@@ -770,6 +837,12 @@ impl AuthService {
         username: &str,
         new_password: &str,
     ) -> Result<(), AuthError> {
+        // API-token display names historically shared the same namespace as
+        // WebUI usernames. Never let a bearer token become a self-service
+        // password credential, including for persisted legacy collisions.
+        if session.client_ip.is_none() {
+            return Err(AuthError::Forbidden);
+        }
         if session.role != Role::Admin && session.username != username {
             return Err(AuthError::Forbidden);
         }
@@ -789,10 +862,12 @@ impl AuthService {
         user.password_hash = Some(hash_password(new_password)?);
         user.must_change_password = false;
 
-        // Also clear the flag on any active sessions for this user
-        for s in state.sessions.iter_mut().filter(|s| s.username == username) {
-            s.must_change_password = false;
-        }
+        revoke_sessions_after_password_change(
+            &mut state.sessions,
+            username,
+            &session.username,
+            &session.token,
+        );
 
         commit_state(&mut current, state).await?;
 
@@ -813,6 +888,8 @@ impl AuthService {
         username: &str,
         password: &str,
         role: Role,
+        file_principal: Option<String>,
+        smb: &nasty_sharing::smb::SmbService,
     ) -> Result<(), AuthError> {
         if session.role != Role::Admin {
             return Err(AuthError::Forbidden);
@@ -822,9 +899,18 @@ impl AuthService {
             return Err(AuthError::WeakPassword);
         }
 
+        let file_principal = validate_file_principal_binding(&role, file_principal.as_deref())?;
+        if let Some(principal) = file_principal.as_deref() {
+            smb.principal_authorization(principal)
+                .await
+                .map_err(|error| AuthError::InvalidFilePrincipal(error.to_string()))?;
+        }
+
         let mut current = self.state.write().await;
         let mut state = current.clone();
-        if state.users.iter().any(|u| u.username == username) {
+        if state.users.iter().any(|u| u.username == username)
+            || state.api_tokens.iter().any(|token| token.name == username)
+        {
             return Err(AuthError::UserExists);
         }
 
@@ -832,6 +918,7 @@ impl AuthService {
             username: username.to_string(),
             password_hash: Some(hash_password(password)?),
             role: role.clone(),
+            file_principal,
             must_change_password: false,
             oidc_subject: None,
             oidc_issuer: None,
@@ -889,6 +976,9 @@ impl AuthService {
             .map(|u| UserInfo {
                 username: u.username.clone(),
                 role: u.role.clone(),
+                file_principal: (u.role == Role::User)
+                    .then(|| u.file_principal.clone())
+                    .flatten(),
                 webauthn_credential_count: u.webauthn_credentials.len(),
             })
             .collect()
@@ -1198,6 +1288,9 @@ impl AuthService {
             token: token.clone(),
             username: user.username.clone(),
             role: user.role.clone(),
+            file_principal: (user.role == Role::User)
+                .then(|| user.file_principal.clone())
+                .flatten(),
             filesystem: None,
             owner: None,
             created_at: now,
@@ -1244,6 +1337,8 @@ impl AuthService {
 pub struct UserInfo {
     pub username: String,
     pub role: Role,
+    #[serde(default)]
+    pub file_principal: Option<String>,
     /// How many WebAuthn credentials are registered to this user.
     /// Drives the admin "Reset security keys" affordance on the
     /// /users page — admins only see the button on rows where
@@ -1251,6 +1346,41 @@ pub struct UserInfo {
     /// on every row.
     #[serde(default)]
     pub webauthn_credential_count: usize,
+}
+
+/// Normalize and enforce the persisted role/principal invariant. Callers that
+/// create a standard user must additionally resolve the returned principal
+/// through `SmbService` before committing the user.
+pub(crate) fn validate_file_principal_binding(
+    role: &Role,
+    file_principal: Option<&str>,
+) -> Result<Option<String>, AuthError> {
+    match role {
+        Role::User => {
+            let principal = file_principal
+                .map(str::trim)
+                .filter(|principal| !principal.is_empty())
+                .ok_or_else(|| {
+                    AuthError::InvalidFilePrincipal(
+                        "Role::User requires a non-empty file_principal".to_string(),
+                    )
+                })?;
+            if principal.len() > 256 || principal.chars().any(char::is_control) {
+                return Err(AuthError::InvalidFilePrincipal(
+                    "principal is too long or contains control characters".to_string(),
+                ));
+            }
+            Ok(Some(principal.to_string()))
+        }
+        Role::Admin | Role::Operator | Role::ReadOnly => {
+            if file_principal.is_some() {
+                return Err(AuthError::InvalidFilePrincipal(
+                    "file_principal is only valid for Role::User".to_string(),
+                ));
+            }
+            Ok(None)
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1273,6 +1403,8 @@ pub enum AuthError {
     NotFound,
     #[error("password must be at least 8 characters")]
     WeakPassword,
+    #[error("invalid file principal: {0}")]
+    InvalidFilePrincipal(String),
     #[error("password hash error: {0}")]
     HashError(String),
     #[error("auth state at {path} is corrupt: {source}")]
@@ -1356,6 +1488,91 @@ pub async fn read_audit_log(limit: usize) -> Vec<serde_json::Value> {
     entries
 }
 
+const MAX_MY_ACTIVITY_ENTRIES: usize = 500;
+const MAX_MY_ACTIVITY_TAIL_BYTES: usize = 4 * 1024 * 1024;
+
+/// Read only the authenticated user's structured audit entries. Filtering is
+/// performed before the caller-controlled limit so another user's activity
+/// cannot crowd the requested user's records out of the result.
+pub async fn read_audit_log_for_user(username: &str, limit: usize) -> Vec<serde_json::Value> {
+    let content = read_bounded_tail(Path::new(AUDIT_LOG_PATH), MAX_MY_ACTIVITY_TAIL_BYTES)
+        .await
+        .unwrap_or_default();
+    filter_audit_log_for_user(&String::from_utf8_lossy(&content), username, limit)
+}
+
+async fn read_bounded_tail(path: &Path, max_bytes: usize) -> std::io::Result<Vec<u8>> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let mut file = tokio::fs::File::open(path).await?;
+    let length = file.metadata().await?.len();
+    let start = length.saturating_sub(max_bytes as u64);
+    file.seek(std::io::SeekFrom::Start(start)).await?;
+    let mut content = Vec::with_capacity(max_bytes.min(length as usize));
+    file.take(max_bytes as u64)
+        .read_to_end(&mut content)
+        .await?;
+    if start > 0 {
+        match content.iter().position(|byte| *byte == b'\n') {
+            Some(end) => {
+                content.drain(..=end).count();
+            }
+            None => content.clear(),
+        }
+    }
+    Ok(content)
+}
+
+fn filter_audit_log_for_user(
+    content: &str,
+    username: &str,
+    limit: usize,
+) -> Vec<serde_json::Value> {
+    content
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|entry| {
+            let user = entry.get("user")?.as_str()?;
+            if user != username {
+                return None;
+            }
+            Some(serde_json::json!({
+                "ts": entry.get("ts")?.as_u64()?,
+                "event": entry.get("event")?.as_str()?,
+                "user": user,
+                "ip": entry.get("ip")?.as_str()?,
+                "detail": entry.get("detail")?.as_str()?,
+            }))
+        })
+        .take(limit.min(MAX_MY_ACTIVITY_ENTRIES))
+        .collect()
+}
+
+fn revoke_sessions_after_password_change(
+    sessions: &mut Vec<Session>,
+    target_username: &str,
+    actor_username: &str,
+    current_token: &str,
+) {
+    let changing_own_password = target_username == actor_username;
+    sessions.retain(|session| {
+        session.username != target_username
+            || (changing_own_password && ct_eq_str(&session.token, current_token))
+    });
+    if changing_own_password
+        && let Some(current) = sessions
+            .iter_mut()
+            .find(|session| ct_eq_str(&session.token, current_token))
+    {
+        current.must_change_password = false;
+    }
+}
+
+fn revoke_user_sessions(sessions: &mut Vec<Session>, username: &str) {
+    sessions.retain(|session| session.username != username);
+}
+
 pub(crate) fn hash_password(password: &str) -> Result<String, AuthError> {
     // Generate 16 random bytes for salt, encode as base64ct for SaltString
     let mut salt_bytes = [0u8; 16];
@@ -1437,12 +1654,13 @@ fn pick_username(existing: &[User], identity: &crate::auth_oidc::OidcIdentity) -
     unreachable!()
 }
 
-/// Parse a role string from configuration. Accepts `admin`, `operator`, `readonly`.
+/// Parse a role string from configuration.
 pub fn parse_role_str(s: &str) -> Option<Role> {
     match s.trim().to_ascii_lowercase().as_str() {
         "admin" => Some(Role::Admin),
         "operator" => Some(Role::Operator),
         "readonly" | "read_only" | "read-only" => Some(Role::ReadOnly),
+        "user" => Some(Role::User),
         _ => None,
     }
 }
@@ -1475,6 +1693,7 @@ async fn initialize_state(
             username: "admin".to_string(),
             password_hash: Some(hash_password("admin")?),
             role: Role::Admin,
+            file_principal: None,
             must_change_password: true,
             oidc_subject: None,
             oidc_issuer: None,
@@ -1797,6 +2016,7 @@ mod tests {
             username: name.to_string(),
             password_hash: Some("hash".to_string()),
             role,
+            file_principal: None,
             must_change_password: false,
             oidc_subject: None,
             oidc_issuer: None,
@@ -1809,6 +2029,7 @@ mod tests {
             token: "token".to_string(),
             username: "test".to_string(),
             role,
+            file_principal: None,
             filesystem: None,
             owner: None,
             created_at: 0,
@@ -2083,12 +2304,21 @@ mod tests {
         let admin = session(Role::Admin);
         let operator = session(Role::Operator);
         let read_only = session(Role::ReadOnly);
+        let user = session(Role::User);
 
         for access in [EndpointAccess::Read, EndpointAccess::SelfService] {
             assert_eq!(authorize_session(&admin, access), Ok(()));
             assert_eq!(authorize_session(&operator, access), Ok(()));
             assert_eq!(authorize_session(&read_only, access), Ok(()));
         }
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::Read),
+            Err(AccessDenied::InsufficientRole)
+        );
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::SelfService),
+            Ok(())
+        );
 
         assert_eq!(authorize_session(&admin, EndpointAccess::Mutation), Ok(()));
         assert_eq!(
@@ -2111,6 +2341,34 @@ mod tests {
     }
 
     #[test]
+    fn portal_access_requires_bound_interactive_unscoped_user() {
+        let mut user = session(Role::User);
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::PortalFiles),
+            Err(AccessDenied::InteractiveSessionRequired)
+        );
+        user.client_ip = Some("192.0.2.10".to_string());
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::PortalFiles),
+            Err(AccessDenied::MissingFilePrincipal)
+        );
+        user.file_principal = Some("CORP\\alice".to_string());
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::PortalFiles),
+            Ok(())
+        );
+        user.filesystem = Some("pool".to_string());
+        assert_eq!(
+            authorize_session(&user, EndpointAccess::PortalFiles),
+            Err(AccessDenied::ScopedCredential)
+        );
+        assert_eq!(
+            authorize_session(&session(Role::ReadOnly), EndpointAccess::PortalFiles),
+            Err(AccessDenied::InsufficientRole)
+        );
+    }
+
+    #[test]
     fn forced_password_change_only_allows_self_service() {
         let mut admin = session(Role::Admin);
         admin.must_change_password = true;
@@ -2124,6 +2382,7 @@ mod tests {
             EndpointAccess::Mutation,
             EndpointAccess::UnscopedMutation,
             EndpointAccess::RootEquivalent,
+            EndpointAccess::PortalFiles,
         ] {
             assert_eq!(
                 authorize_session(&admin, access),
@@ -2176,6 +2435,241 @@ mod tests {
     fn not_only_admin_when_user_isnt_admin() {
         let users = vec![user("alice", Role::Admin), user("bob", Role::Operator)];
         assert!(!is_only_admin(&users, "bob"));
+    }
+
+    #[test]
+    fn user_role_and_file_principal_are_backward_compatible_in_json() {
+        assert_eq!(serde_json::to_string(&Role::User).unwrap(), "\"user\"");
+        let old: User = serde_json::from_value(serde_json::json!({
+            "username": "reader",
+            "password_hash": null,
+            "role": "readonly"
+        }))
+        .unwrap();
+        assert_eq!(old.file_principal, None);
+        let old_session: Session = serde_json::from_value(serde_json::json!({
+            "token": "token",
+            "username": "reader",
+            "role": "readonly",
+            "created_at": 1
+        }))
+        .unwrap();
+        assert_eq!(old_session.file_principal, None);
+    }
+
+    #[test]
+    fn file_principal_binding_is_required_only_for_standard_users() {
+        assert!(validate_file_principal_binding(&Role::User, None).is_err());
+        assert!(validate_file_principal_binding(&Role::User, Some("  ")).is_err());
+        assert_eq!(
+            validate_file_principal_binding(&Role::User, Some(" CORP\\alice ")).unwrap(),
+            Some("CORP\\alice".to_string())
+        );
+        for role in [Role::Admin, Role::Operator, Role::ReadOnly] {
+            assert_eq!(validate_file_principal_binding(&role, None).unwrap(), None);
+            assert!(validate_file_principal_binding(&role, Some("alice")).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn api_token_creation_rejects_user_role() {
+        let service = AuthService {
+            state: Arc::new(RwLock::new(initialized_state())),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let error = service
+            .create_api_token(
+                &session(Role::Admin),
+                "portal-token",
+                Role::User,
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .expect_err("standard-user tokens must be rejected");
+        assert!(matches!(error, AuthError::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn api_token_name_cannot_equal_a_webui_username() {
+        let service = AuthService {
+            state: Arc::new(RwLock::new(initialized_state())),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let error = service
+            .create_api_token(
+                &session(Role::Admin),
+                "alice",
+                Role::ReadOnly,
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .expect_err("token/user audit identities must not collide");
+        assert!(matches!(error, AuthError::UserExists));
+    }
+
+    #[tokio::test]
+    async fn webui_username_cannot_equal_an_api_token_name() {
+        let mut state = initialized_state();
+        state.api_tokens.push(ApiToken {
+            id: "id".into(),
+            name: "automation".into(),
+            token: "hash".into(),
+            role: Role::ReadOnly,
+            created_at: 1,
+            filesystem: None,
+            expires_at: None,
+            allowed_ips: Vec::new(),
+        });
+        let service = AuthService {
+            state: Arc::new(RwLock::new(state)),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let error = service
+            .create_user(
+                &session(Role::Admin),
+                "automation",
+                "password123",
+                Role::ReadOnly,
+                None,
+                &nasty_sharing::smb::SmbService::new(),
+            )
+            .await
+            .expect_err("user/token audit identities must not collide");
+        assert!(matches!(error, AuthError::UserExists));
+    }
+
+    #[test]
+    fn password_change_revokes_other_interactive_sessions_only() {
+        let mut current = session(Role::User);
+        current.username = "alice".into();
+        current.token = "current".into();
+        current.must_change_password = true;
+        let mut other = current.clone();
+        other.token = "other".into();
+        let mut bob = current.clone();
+        bob.username = "bob".into();
+        bob.token = "bob-token".into();
+        let mut sessions = vec![current, other, bob];
+
+        revoke_sessions_after_password_change(&mut sessions, "alice", "alice", "current");
+
+        assert_eq!(sessions.len(), 2);
+        assert!(sessions.iter().any(|session| session.token == "bob-token"));
+        let current = sessions
+            .iter()
+            .find(|session| session.token == "current")
+            .unwrap();
+        assert!(!current.must_change_password);
+    }
+
+    #[test]
+    fn admin_password_reset_revokes_target_without_changing_admin_session() {
+        let mut admin = session(Role::Admin);
+        admin.username = "admin".into();
+        admin.token = "admin-token".into();
+        admin.must_change_password = true;
+        let mut alice = session(Role::User);
+        alice.username = "alice".into();
+        alice.token = "alice-token".into();
+        let mut sessions = vec![admin, alice];
+
+        revoke_sessions_after_password_change(&mut sessions, "alice", "admin", "admin-token");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].username, "admin");
+        assert!(sessions[0].must_change_password);
+    }
+
+    #[tokio::test]
+    async fn api_tokens_cannot_change_webui_passwords() {
+        let service = AuthService {
+            state: Arc::new(RwLock::new(initialized_state())),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let mut token_session = session(Role::Admin);
+        token_session.username = "admin".into();
+        token_session.client_ip = None;
+
+        let error = service
+            .change_password(&token_session, "admin", "new-password")
+            .await
+            .expect_err("API tokens must not act as password credentials");
+        assert!(matches!(error, AuthError::Forbidden));
+    }
+
+    #[test]
+    fn role_change_revokes_every_existing_user_session() {
+        let mut alice = session(Role::Admin);
+        alice.username = "alice".into();
+        let mut second_alice = alice.clone();
+        second_alice.token = "second".into();
+        let bob = session(Role::Operator);
+        let mut sessions = vec![alice, second_alice, bob];
+
+        revoke_user_sessions(&mut sessions, "alice");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].username, "test");
+    }
+
+    #[tokio::test]
+    async fn oidc_auto_provisioning_fails_closed_for_unbound_user_role() {
+        let service = AuthService {
+            state: Arc::new(RwLock::new(initialized_state())),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let identity = crate::auth_oidc::OidcIdentity {
+            issuer: "https://id.example.test".to_string(),
+            subject: "subject-1".to_string(),
+            email: Some("portal@example.test".to_string()),
+            preferred_username: Some("portal".to_string()),
+            groups: vec!["users".to_string()],
+        };
+        let error = service
+            .login_or_provision_oidc(&identity, Some(Role::User), true, "192.0.2.1")
+            .await
+            .expect_err("OIDC must not auto-provision an unbound standard user");
+        assert!(matches!(error, AuthError::Forbidden));
+        assert_eq!(service.state.read().await.users.len(), 1);
+        assert_eq!(parse_role_str("user"), Some(Role::User));
+    }
+
+    #[test]
+    fn my_activity_filters_exact_user_before_limit() {
+        let content = [
+            serde_json::json!({"ts": 1, "event": "one", "user": "alice", "ip": "a", "detail": ""}),
+            serde_json::json!({"ts": 2, "event": "other", "user": "alice2", "ip": "b", "detail": ""}),
+            serde_json::json!({"ts": 3, "event": "two", "user": "alice", "ip": "a", "detail": ""}),
+            serde_json::json!({"ts": 4, "event": "latest-other", "user": "bob", "ip": "c", "detail": ""}),
+        ]
+        .into_iter()
+        .map(|entry| entry.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+        let entries = filter_audit_log_for_user(&content, "alice", 2);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["event"], "two");
+        assert_eq!(entries[1]["event"], "one");
+        assert!(filter_audit_log_for_user(&content, "ali", 10).is_empty());
+    }
+
+    #[tokio::test]
+    async fn my_activity_tail_read_is_bounded_and_discards_partial_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        tokio::fs::write(&path, b"old-line\npartial-line\nnew-one\nnew-two\n")
+            .await
+            .unwrap();
+
+        let tail = read_bounded_tail(&path, 20).await.unwrap();
+
+        assert!(tail.len() <= 20);
+        assert_eq!(String::from_utf8(tail).unwrap(), "new-one\nnew-two\n");
     }
 
     #[test]

--- a/engine/nasty-engine/src/ingress_conflict.rs
+++ b/engine/nasty-engine/src/ingress_conflict.rs
@@ -11,6 +11,7 @@
 //!   - The chosen subdomain matches another engine-app's subdomain.
 //!   - The chosen subdomain matches NASty's own WebUI hostname
 //!     (would intercept the management interface).
+//!   - The chosen subdomain matches the dedicated files portal hostname.
 //!
 //! Path-prefix conflicts are not modelled here: `/apps/<name>/*` paths
 //! are derived from app names, names are DNS-safe and unique, and the
@@ -18,7 +19,81 @@
 //! prefixes. There's no realistic path collision an operator can
 //! produce through the install form.
 
+use std::sync::LazyLock;
+
 use crate::AppState;
+
+static HOSTNAME_RESERVATIONS: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+/// Serialize the check-and-commit sections for app host routes and the files
+/// portal hostname. Caddy otherwise accepts both and lets route order decide.
+pub async fn lock_hostname_reservations() -> tokio::sync::MutexGuard<'static, ()> {
+    HOSTNAME_RESERVATIONS.lock().await
+}
+
+fn reserved_hostname_conflict(
+    settings: &nasty_system::settings::Settings,
+    hostname: &str,
+) -> Option<String> {
+    if let Some(tls_domain) = settings.tls_domain.as_deref()
+        && tls_domain.eq_ignore_ascii_case(hostname)
+    {
+        return Some(format!(
+            "'{hostname}' is the NASty WebUI hostname — using it for an app would shadow the management interface"
+        ));
+    }
+    if let Some(files_domain) = settings.files_domain.as_deref()
+        && files_domain.eq_ignore_ascii_case(hostname)
+    {
+        return Some(format!(
+            "'{hostname}' is the files portal hostname — using it for an app would shadow the user portal"
+        ));
+    }
+    None
+}
+
+fn files_domain_app_conflict(
+    files_domain: &str,
+    ingresses: Result<&[nasty_apps::AppIngress], String>,
+) -> Result<Option<String>, String> {
+    let ingresses = ingresses?;
+    Ok(ingresses.iter().find_map(|ingress| {
+        ingress
+            .subdomain
+            .as_deref()
+            .filter(|host| host.eq_ignore_ascii_case(files_domain))
+            .map(|_| {
+                format!(
+                    "files portal domain '{files_domain}' is already used by app '{}'",
+                    ingress.name
+                )
+            })
+    }))
+}
+
+/// Reject a non-empty files portal hostname already claimed by an app route.
+/// An unavailable Caddy route snapshot is an error: settings updates fail
+/// closed rather than risking two host matchers for the same hostname.
+pub async fn ensure_files_domain_available(
+    state: &AppState,
+    files_domain: &str,
+) -> Result<(), String> {
+    let files_domain = files_domain.trim();
+    if files_domain.is_empty() {
+        return Ok(());
+    }
+    nasty_system::settings::validate_files_domain(files_domain)?;
+    let ingresses = state
+        .apps
+        .ingress_list()
+        .await
+        .map_err(|e| format!("cannot verify app hostname reservations: {e}"))?;
+    if let Some(reason) = files_domain_app_conflict(files_domain, Ok(&ingresses))? {
+        return Err(reason);
+    }
+    Ok(())
+}
 
 /// Returns a human-readable reason when `subdomain` would conflict with
 /// an existing engine-app ingress or the NASty WebUI hostname. Returns
@@ -37,17 +112,13 @@ pub async fn find_subdomain_conflict(
         return None;
     }
 
-    // WebUI hostname clash. The TLS settings always carry the FQDN the
-    // WebUI is served at; an app subdomain matching it would shadow the
-    // management interface (Caddy serves the most recent matching
-    // route — in this case the app's, not the WebUI's).
+    // Reserved NASty hostname clash. Caddy serves the most recent matching
+    // route, so an app could otherwise shadow either the management UI or
+    // the files portal. The portal hostname only selects presentation and
+    // routing; Role User authorization in the server remains the boundary.
     let settings = state.settings.get().await;
-    if let Some(tls_domain) = settings.tls_domain.as_deref()
-        && tls_domain.eq_ignore_ascii_case(subdomain)
-    {
-        return Some(format!(
-            "'{subdomain}' is the NASty WebUI hostname — using it for an app would shadow the management interface"
-        ));
+    if let Some(reason) = reserved_hostname_conflict(&settings, subdomain) {
+        return Some(reason);
     }
 
     // Another app's subdomain. We pull the current ingress list rather
@@ -70,4 +141,49 @@ pub async fn find_subdomain_conflict(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{files_domain_app_conflict, reserved_hostname_conflict};
+    use nasty_apps::AppIngress;
+    use nasty_system::settings::Settings;
+
+    fn ingress(name: &str, subdomain: Option<&str>) -> AppIngress {
+        AppIngress {
+            name: name.into(),
+            host_port: 8080,
+            path: format!("/apps/{name}/"),
+            subdomain: subdomain.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn app_hostname_rejects_configured_files_domain_case_insensitively() {
+        let settings = Settings {
+            files_domain: Some("Files.Example.com".into()),
+            ..Settings::default()
+        };
+        let reason = reserved_hostname_conflict(&settings, "files.example.com").unwrap();
+        assert!(reason.contains("files portal hostname"));
+    }
+
+    #[test]
+    fn files_domain_rejects_existing_app_hostname_case_insensitively() {
+        let ingresses = [
+            ingress("path-only", None),
+            ingress("jellyfin", Some("MEDIA.EXAMPLE.COM")),
+        ];
+        let reason = files_domain_app_conflict("media.example.com", Ok(&ingresses))
+            .unwrap()
+            .unwrap();
+        assert!(reason.contains("jellyfin"));
+    }
+
+    #[test]
+    fn files_domain_check_fails_closed_without_route_metadata() {
+        let result =
+            files_domain_app_conflict("files.example.com", Err("Caddy unavailable".into()));
+        assert_eq!(result.unwrap_err(), "Caddy unavailable");
+    }
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use axum::{
     Json, Router,
     extract::{
-        DefaultBodyLimit, Multipart, State,
+        DefaultBodyLimit, Extension, Multipart, State,
         ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::StatusCode,
@@ -34,6 +34,7 @@ mod subvolume_dependents;
 mod swagger_ui;
 mod telemetry;
 mod terminal;
+mod user_files;
 mod vm_console;
 mod vm_disk_import;
 
@@ -807,6 +808,12 @@ async fn main() -> anyhow::Result<()> {
             post(upload_vm_image_handler).layer(DefaultBodyLimit::max(10_737_418_240)),
         )
         .route("/api/files/browse", get(files_browse_handler))
+        .route("/api/user/files/roots", get(user_files::roots_handler))
+        .route("/api/user/files/browse", get(user_files::browse_handler))
+        .route(
+            "/api/user/files/content",
+            get(user_files::content_handler).head(user_files::content_head_handler),
+        )
         .route("/api/files/size", get(files_size_handler))
         .route("/api/files", delete(files_delete_handler))
         .route(
@@ -829,6 +836,10 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/auth/check", get(auth_check_handler))
         .route("/health", get(health))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            files_domain_guard,
+        ))
         .with_state(state);
 
     // 127.0.0.1 only — Caddy proxies https://nas:443/ → http://127.0.0.1:2137/.
@@ -848,6 +859,118 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct FilesDomainRequest(bool);
+
+async fn files_domain_guard(
+    State(state): State<Arc<AppState>>,
+    mut request: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let settings = state.settings.get().await;
+    let on_files_domain = host_matches_files_domain(
+        request
+            .headers()
+            .get(axum::http::header::HOST)
+            .and_then(|value| value.to_str().ok()),
+        settings.files_domain.as_deref(),
+    );
+    request
+        .extensions_mut()
+        .insert(FilesDomainRequest(on_files_domain));
+    if on_files_domain && !files_domain_path_allowed(request.uri().path()) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    next.run(request).await
+}
+
+fn host_matches_files_domain(host_header: Option<&str>, files_domain: Option<&str>) -> bool {
+    let (Some(host_header), Some(files_domain)) = (host_header, files_domain) else {
+        return false;
+    };
+    let Ok(authority) = host_header.parse::<http::uri::Authority>() else {
+        return false;
+    };
+    authority.host().eq_ignore_ascii_case(files_domain)
+}
+
+fn files_domain_path_allowed(path: &str) -> bool {
+    matches!(
+        path,
+        "/api/login"
+            | "/api/logout"
+            | "/api/auth/check"
+            | "/api/boot_status"
+            | "/api/auth/oidc/available"
+            | "/api/auth/webauthn/available"
+            | "/ws"
+            | "/health"
+    ) || path.starts_with("/api/user/files/")
+}
+
+#[cfg(test)]
+mod files_domain_guard_tests {
+    use super::{files_domain_path_allowed, host_matches_files_domain};
+
+    #[test]
+    fn files_domain_host_match_accepts_only_the_exact_host_with_optional_port() {
+        for host in ["files.example.com", "FILES.EXAMPLE.COM:443"] {
+            assert!(host_matches_files_domain(
+                Some(host),
+                Some("files.example.com")
+            ));
+        }
+        for host in [
+            "files.example.com.evil.test",
+            "evil-files.example.com",
+            "files.example.com.",
+            "https://files.example.com",
+            "files.example.com/path",
+        ] {
+            assert!(!host_matches_files_domain(
+                Some(host),
+                Some("files.example.com")
+            ));
+        }
+        assert!(!host_matches_files_domain(None, Some("files.example.com")));
+        assert!(!host_matches_files_domain(Some("files.example.com"), None));
+    }
+
+    #[test]
+    fn files_domain_path_allowlist_is_explicit_and_deny_by_default() {
+        for path in [
+            "/api/login",
+            "/api/logout",
+            "/api/auth/check",
+            "/api/boot_status",
+            "/api/auth/oidc/available",
+            "/api/auth/webauthn/available",
+            "/api/user/files/roots",
+            "/api/user/files/content",
+            "/ws",
+            "/health",
+        ] {
+            assert!(
+                files_domain_path_allowed(path),
+                "expected {path} to be allowed"
+            );
+        }
+        for path in [
+            "/api/v1/system/settings/get",
+            "/api/public/share/token",
+            "/api/openapi.json",
+            "/docs",
+            "/ws/terminal",
+            "/ws/apps/deploy",
+            "/api/auth/oidc/start",
+            "/api/auth/webauthn/login/start",
+            "/portal",
+        ] {
+            assert!(!files_domain_path_allowed(path), "accepted {path}");
+        }
+    }
 }
 
 /// Host interface facts for the apps Docker-network validator: each live
@@ -1709,6 +1832,7 @@ async fn validate_bearer(
 /// Returns 200 if the bearer token is valid, 401 otherwise.
 async fn auth_check_handler(
     headers: axum::http::HeaderMap,
+    Extension(FilesDomainRequest(on_files_domain)): Extension<FilesDomainRequest>,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
     match validate_bearer(
@@ -1719,7 +1843,10 @@ async fn auth_check_handler(
     )
     .await
     {
-        Ok(_) => StatusCode::OK.into_response(),
+        Ok(authenticated) if !on_files_domain || authenticated.session.role == auth::Role::User => {
+            StatusCode::OK.into_response()
+        }
+        Ok(_) => StatusCode::UNAUTHORIZED.into_response(),
         Err(e) => e.into_response(),
     }
 }
@@ -3180,6 +3307,7 @@ async fn webauthn_login_finish_handler(
 
 async fn login_handler(
     headers: axum::http::HeaderMap,
+    Extension(FilesDomainRequest(on_files_domain)): Extension<FilesDomainRequest>,
     State(state): State<Arc<AppState>>,
     Json(req): Json<LoginRequest>,
 ) -> impl IntoResponse {
@@ -3193,6 +3321,27 @@ async fn login_handler(
         .await
     {
         Ok(token) => {
+            if on_files_domain
+                && !matches!(
+                    state.auth.validate(&token, client_ip).await,
+                    Ok(Session {
+                        role: auth::Role::User,
+                        ..
+                    })
+                )
+            {
+                let _ = state.auth.logout(&token).await;
+                tracing::warn!(
+                    "Files portal login rejected non-user account '{}' from {}",
+                    req.username,
+                    client_ip
+                );
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({ "error": "invalid credentials" })),
+                )
+                    .into_response();
+            }
             info!(
                 "Login successful: user '{}' from {}",
                 req.username, client_ip
@@ -3677,7 +3826,13 @@ fn url_encode(s: &str) -> String {
 
 /// Tells the WebUI whether to render the "Sign in with SSO" button.
 /// No auth required — the response only exposes booleans / public config.
-async fn oidc_available_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+async fn oidc_available_handler(
+    Extension(FilesDomainRequest(on_files_domain)): Extension<FilesDomainRequest>,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    if on_files_domain {
+        return Json(serde_json::json!({ "enabled": false }));
+    }
     let oidc = state.settings.get().await.oidc;
     let configured = state.oidc.current().await.is_some();
     Json(serde_json::json!({
@@ -3698,7 +3853,13 @@ async fn oidc_available_handler(State(state): State<Arc<AppState>>) -> impl Into
 /// is acceptable for the same reason it is there: rendering the
 /// login page right requires answering this question before auth
 /// has happened.
-async fn webauthn_available_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+async fn webauthn_available_handler(
+    Extension(FilesDomainRequest(on_files_domain)): Extension<FilesDomainRequest>,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    if on_files_domain {
+        return Json(serde_json::json!({ "has_credentials": false }));
+    }
     let has_credentials = state.auth.any_webauthn_credentials_registered().await;
     Json(serde_json::json!({
         "has_credentials": has_credentials,
@@ -3865,6 +4026,7 @@ async fn openapi_handler() -> impl IntoResponse {
 async fn ws_handler(
     ws: WebSocketUpgrade,
     headers: axum::http::HeaderMap,
+    Extension(FilesDomainRequest(on_files_domain)): Extension<FilesDomainRequest>,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
     let client_ip = headers
@@ -3878,7 +4040,9 @@ async fn ws_handler(
     // and still send {"token": "..."} as the first message — handled in
     // handle_socket().
     let pre_auth_token = token_from_headers(&headers);
-    ws.on_upgrade(move |socket| handle_socket(socket, state, client_ip, pre_auth_token))
+    ws.on_upgrade(move |socket| {
+        handle_socket(socket, state, client_ip, pre_auth_token, on_files_domain)
+    })
 }
 
 async fn handle_socket(
@@ -3886,6 +4050,7 @@ async fn handle_socket(
     state: Arc<AppState>,
     client_ip: String,
     pre_auth_token: Option<String>,
+    on_files_domain: bool,
 ) {
     use futures_util::{SinkExt, StreamExt};
     use nasty_common::Notification;
@@ -3896,10 +4061,17 @@ async fn handle_socket(
         Some(s) => s,
         None => return,
     };
+    if on_files_domain && session.role != auth::Role::User {
+        let _ = socket
+            .send(Message::Text(r#"{"error":"invalid session"}"#.into()))
+            .await;
+        let _ = socket.send(Message::Close(None)).await;
+        return;
+    }
 
     info!("WebSocket authenticated as '{}'", session.username);
 
-    let mut event_rx = state.events.subscribe();
+    let mut event_rx = (session.role != auth::Role::User).then(|| state.events.subscribe());
     let (mut writer, mut reader) = socket.split();
 
     // Server-initiated WebSocket-level keepalive. Without this, a client
@@ -3934,7 +4106,17 @@ async fn handle_socket(
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         last_seen = std::time::Instant::now();
-                        let response = handle_rpc_request(&text, &state, &session).await;
+                        let fresh_session = match state.auth.validate(&session.token, &client_ip).await {
+                            Ok(fresh)
+                                if session_security_context_unchanged(&session, &fresh)
+                                    && (!on_files_domain || fresh.role == auth::Role::User) => fresh,
+                            _ => {
+                                disconnect_reason = "session expired, revoked, or changed".to_string();
+                                let _ = writer.send(Message::Close(None)).await;
+                                break;
+                            }
+                        };
+                        let response = handle_rpc_request(&text, &state, &fresh_session).await;
                         if writer.send(Message::Text(response.into())).await.is_err() {
                             disconnect_reason = "write failed (socket closed)".to_string();
                             break;
@@ -3969,8 +4151,13 @@ async fn handle_socket(
                     }
                 }
             }
-            event = event_rx.recv() => {
-                if let Ok(collection) = event {
+            event = async {
+                match event_rx.as_mut() {
+                    Some(receiver) => Some(receiver.recv().await),
+                    None => std::future::pending().await,
+                }
+            } => {
+                if let Some(Ok(collection)) = event {
                     let notification = Notification::new(
                         "event",
                         Some(serde_json::json!({ "collection": collection })),
@@ -3983,6 +4170,16 @@ async fn handle_socket(
                 }
             }
             _ = ping_ticker.tick() => {
+                if !matches!(
+                    state.auth.validate(&session.token, &client_ip).await,
+                    Ok(ref fresh)
+                        if session_security_context_unchanged(&session, fresh)
+                            && (!on_files_domain || fresh.role == auth::Role::User)
+                ) {
+                    disconnect_reason = "session expired, revoked, or changed on ping".to_string();
+                    let _ = writer.send(Message::Close(None)).await;
+                    break;
+                }
                 if last_seen.elapsed() > IDLE_TIMEOUT {
                     disconnect_reason = format!(
                         "server idle timeout ({}s no traffic)",
@@ -4005,6 +4202,17 @@ async fn handle_socket(
         connected_at.elapsed(),
         disconnect_reason
     );
+}
+
+fn session_security_context_unchanged(initial: &Session, fresh: &Session) -> bool {
+    initial.token == fresh.token
+        && initial.username == fresh.username
+        && initial.role == fresh.role
+        && initial.file_principal == fresh.file_principal
+        && initial.filesystem == fresh.filesystem
+        && initial.owner == fresh.owner
+        && initial.created_at == fresh.created_at
+        && initial.client_ip == fresh.client_ip
 }
 
 /// Pick the right auth path for a WebSocket connection. If the upgrade
@@ -4294,6 +4502,7 @@ mod restore_tests {
             token: "token".to_string(),
             username: "test".to_string(),
             role: Role::Operator,
+            file_principal: None,
             filesystem: filesystem.map(str::to_string),
             owner: owner.map(str::to_string),
             created_at: 0,

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -89,6 +89,9 @@ pub struct CreateUserRequest {
     pub password: String,
     /// Role to assign to the new user.
     pub role: Role,
+    /// Required SMB/local or domain principal for Role::User; omitted for
+    /// management roles.
+    pub file_principal: Option<String>,
 }
 
 /// Mirror of the anonymous inline `struct P` in `router/auth.rs` that
@@ -123,6 +126,7 @@ pub struct WebauthnRegisterStartRequest {
 struct AuthMeResult {
     username: String,
     role: Role,
+    file_principal: Option<String>,
     scoped: bool,
 }
 
@@ -1259,21 +1263,38 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
         // ── Audit log ────────────────────────────────────────────────────
         (
             "Audit",
-            vec![Method {
-                name: "audit.list",
-                desc: "Return the most recent audit-log entries (default 200, capped by `limit`), parsed line-by-line in reverse chronological order. Entry shape depends on the action being audited.",
-                role: MethodRole::Any,
-                params: MethodParams::AdHoc(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "limit": {"type": "integer", "minimum": 0, "default": 200, "description": "Maximum number of entries to return."}
-                    }
-                })),
-                result: Some(serde_json::json!({
-                    "type": "array",
-                    "items": {"type": "object", "description": "Parsed JSON line from the audit log — schema varies by event."}
-                })),
-            }],
+            vec![
+                Method {
+                    name: "audit.list",
+                    desc: "Return the most recent audit-log entries (default 200, capped by `limit`), parsed line-by-line in reverse chronological order. Entry shape depends on the action being audited.",
+                    role: MethodRole::Any,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "limit": {"type": "integer", "minimum": 0, "default": 200, "description": "Maximum number of entries to return."}
+                        }
+                    })),
+                    result: Some(serde_json::json!({
+                        "type": "array",
+                        "items": {"type": "object", "description": "Parsed JSON line from the audit log — schema varies by event."}
+                    })),
+                },
+                Method {
+                    name: "audit.mine",
+                    desc: "Return only the current authenticated user's recent structured audit entries, filtered server-side before the bounded limit is applied.",
+                    role: MethodRole::Any,
+                    params: MethodParams::AdHoc(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "limit": {"type": "integer", "minimum": 0, "maximum": 500, "default": 200}
+                        }
+                    })),
+                    result: Some(serde_json::json!({
+                        "type": "array",
+                        "items": {"type": "object"}
+                    })),
+                },
+            ],
         ),
         // ── System (additions to the existing System group) ─────────────
         (

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -343,6 +343,7 @@ pub(super) async fn try_route(
         },
         "apps.ingress.set" => match parse_params::<nasty_apps::SetIngressRequest>(req) {
             Ok(p) => {
+                let _reservation = crate::ingress_conflict::lock_hostname_reservations().await;
                 // Gate the set on a subdomain-conflict check — catches the
                 // "two apps claim the same hostname" / "app subdomain ==
                 // WebUI hostname" cases that Caddy would silently let the

--- a/engine/nasty-engine/src/router/audit.rs
+++ b/engine/nasty-engine/src/router/audit.rs
@@ -26,6 +26,18 @@ pub(super) async fn try_route(
                 .unwrap_or(200) as usize;
             ok(req, crate::auth::read_audit_log(limit).await)
         }
+        "audit.mine" => {
+            let limit = req
+                .params
+                .as_ref()
+                .and_then(|p| p.get("limit"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(200) as usize;
+            ok(
+                req,
+                crate::auth::read_audit_log_for_user(&session.username, limit).await,
+            )
+        }
         _ => return None,
     })
 }

--- a/engine/nasty-engine/src/router/auth.rs
+++ b/engine/nasty-engine/src/router/auth.rs
@@ -22,6 +22,7 @@ pub(super) async fn try_route(
             serde_json::json!({
                 "username": session.username,
                 "role": session.role,
+                "file_principal": session.file_principal,
                 "scoped": session.filesystem.is_some() || session.owner.is_some(),
             }),
         ),
@@ -53,11 +54,19 @@ pub(super) async fn try_route(
                 username: String,
                 password: String,
                 role: Role,
+                file_principal: Option<String>,
             }
             match parse_params::<P>(req) {
                 Ok(p) => match state
                     .auth
-                    .create_user(session, &p.username, &p.password, p.role)
+                    .create_user(
+                        session,
+                        &p.username,
+                        &p.password,
+                        p.role,
+                        p.file_principal,
+                        &state.smb,
+                    )
                     .await
                 {
                     Ok(()) => ok(req, "ok"),

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -48,6 +48,24 @@ fn is_universally_allowed(method: &str) -> bool {
         )
 }
 
+/// Standard users are intentionally disconnected from suffix heuristics. A
+/// new `.list` or `.get` method is denied until it is explicitly reviewed and
+/// added here.
+fn is_user_allowed(method: &str) -> bool {
+    matches!(
+        method,
+        "auth.me"
+            | "auth.logout"
+            | "auth.change_password"
+            | "auth.webauthn.config"
+            | "auth.webauthn.list"
+            | "auth.webauthn.register.start"
+            | "auth.webauthn.register.finish"
+            | "auth.webauthn.delete"
+            | "audit.mine"
+    )
+}
+
 /// Methods an operator token is allowed to call (in addition to
 /// everything in `is_universally_allowed`).
 fn is_operator_allowed(method: &str) -> bool {
@@ -308,6 +326,7 @@ fn is_read_only(method: &str) -> bool {
                 | "system.log.level"
                 | "system.settings.timezones"
                 | "audit.list"
+                | "audit.mine"
                 | "apps.check_ports"
                 | "apps.check_devices"
                 | "apps.check_volumes"
@@ -435,6 +454,7 @@ pub async fn handle_rpc_request(raw: &str, state: &AppState, session: &Session) 
         Role::Admin => false,
         Role::ReadOnly => !is_universally_allowed(&request.method),
         Role::Operator => !is_operator_allowed(&request.method),
+        Role::User => !is_user_allowed(&request.method),
     };
     if denied {
         // Record role-based denials so an attempted role-escalation
@@ -1375,7 +1395,35 @@ pub(super) async fn read_bcachefs_error_count(uuid: &str) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_operator_allowed, is_read_only, is_universally_allowed};
+    use super::{is_operator_allowed, is_read_only, is_universally_allowed, is_user_allowed};
+
+    #[test]
+    fn standard_user_rpc_policy_is_explicit_and_deny_by_default() {
+        for method in [
+            "auth.me",
+            "auth.logout",
+            "auth.change_password",
+            "auth.webauthn.config",
+            "auth.webauthn.list",
+            "auth.webauthn.register.start",
+            "auth.webauthn.register.finish",
+            "auth.webauthn.delete",
+            "audit.mine",
+        ] {
+            assert!(is_user_allowed(method), "expected {method} to be allowed");
+        }
+        for method in [
+            "audit.list",
+            "auth.list_users",
+            "fs.list",
+            "share.smb.list",
+            "new.feature.list",
+            "auth.token.create",
+            "auth.webauthn.reset_for_user",
+        ] {
+            assert!(!is_user_allowed(method), "expected {method} to be denied");
+        }
+    }
 
     /// Regression for the Filesystems-page refresh loop on .71:
     /// before this fix, `fs.tpm.status` was classified as a write

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -527,13 +527,33 @@ pub(super) async fn try_route(
             Err(e) => err(req, e),
         },
         "system.settings.get" => ok(req, state.settings.get().await),
-        "system.settings.update" => match parse_params(req) {
-            Ok(p) => match state.settings.update(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
-            Err(e) => invalid(req, e),
-        },
+        "system.settings.update" => {
+            match parse_params::<nasty_system::settings::SettingsUpdate>(req) {
+                Ok(p) => match p.files_domain.as_deref() {
+                    Some(files_domain) => {
+                        let _reservation =
+                            crate::ingress_conflict::lock_hostname_reservations().await;
+                        match crate::ingress_conflict::ensure_files_domain_available(
+                            state,
+                            files_domain,
+                        )
+                        .await
+                        {
+                            Ok(()) => match state.settings.update(p).await {
+                                Ok(v) => ok(req, v),
+                                Err(e) => err(req, e),
+                            },
+                            Err(e) => err(req, e),
+                        }
+                    }
+                    None => match state.settings.update(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    },
+                },
+                Err(e) => invalid(req, e),
+            }
+        }
         "system.acme.status" => ok(req, nasty_system::settings::get_acme_status()),
         "system.acme.reset" => {
             nasty_system::settings::reset_acme_status();

--- a/engine/nasty-engine/src/user_files.rs
+++ b/engine/nasty-engine/src/user_files.rs
@@ -1,0 +1,508 @@
+//! Read-only file portal for standard users.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{Arc, LazyLock};
+use std::task::{Context, Poll};
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use nasty_sharing::smb::{SmbShare, share_allows_principal};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, ReadBuf};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::auth::EndpointAccess;
+use crate::file_boundary::{self, BoundaryNode};
+use crate::{AppState, validate_bearer};
+
+const FILES_ROOT: &str = "/fs";
+const MAX_PORTAL_ROOTS: usize = 256;
+const MAX_DIRECTORY_ENTRIES: usize = 1_000;
+const MAX_PATH_BYTES: usize = 4_096;
+const MAX_COMPONENT_BYTES: usize = 255;
+const MAX_CONCURRENT_CONTROL_OPERATIONS: usize = 32;
+const MAX_CONCURRENT_DOWNLOADS: usize = 8;
+
+static PORTAL_CONTROL_OPERATIONS: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_CONCURRENT_CONTROL_OPERATIONS)));
+static PORTAL_DOWNLOADS: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_CONCURRENT_DOWNLOADS)));
+
+#[derive(Serialize)]
+struct PortalRoot {
+    id: String,
+    name: String,
+}
+
+#[derive(Serialize)]
+struct PortalEntry {
+    name: String,
+    is_dir: bool,
+    size: u64,
+    modified: u64,
+}
+
+#[derive(Serialize)]
+struct BrowseResult {
+    path: String,
+    entries: Vec<PortalEntry>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct PortalPathQuery {
+    share: String,
+    #[serde(default)]
+    path: String,
+}
+
+pub(crate) async fn roots_handler(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let authenticated = match validate_bearer(
+        &headers,
+        &state.auth,
+        EndpointAccess::PortalFiles,
+        "user.files.roots",
+    )
+    .await
+    {
+        Ok(authenticated) => authenticated,
+        Err(error) => return error.into_response(),
+    };
+    let _permit = match control_permit() {
+        Ok(permit) => permit,
+        Err(()) => return unavailable(StatusCode::TOO_MANY_REQUESTS),
+    };
+    let shares = match authorized_shares(&state, &authenticated.session).await {
+        Ok(shares) => shares,
+        Err(()) => return unavailable(StatusCode::SERVICE_UNAVAILABLE),
+    };
+    let roots: Vec<PortalRoot> = shares
+        .into_iter()
+        .map(|share| PortalRoot {
+            id: share.id,
+            name: share.name,
+        })
+        .collect();
+    Json(roots).into_response()
+}
+
+pub(crate) async fn browse_handler(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<PortalPathQuery>,
+) -> Response {
+    let authenticated = match validate_bearer(
+        &headers,
+        &state.auth,
+        EndpointAccess::PortalFiles,
+        "user.files.browse",
+    )
+    .await
+    {
+        Ok(authenticated) => authenticated,
+        Err(error) => return error.into_response(),
+    };
+    let _permit = match control_permit() {
+        Ok(permit) => permit,
+        Err(()) => return unavailable(StatusCode::TOO_MANY_REQUESTS),
+    };
+    let relative = match portal_relative_path(&query.path, true) {
+        Ok(path) => path,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let share = match authorized_share(&state, &authenticated.session, &query.share).await {
+        Ok(share) => share,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let display_path = query.path.clone();
+    let result = tokio::task::spawn_blocking(move || browse_share(&share, &relative, display_path))
+        .await
+        .ok()
+        .and_then(Result::ok);
+    match result {
+        Some(result) => Json(result).into_response(),
+        None => unavailable(StatusCode::NOT_FOUND),
+    }
+}
+
+pub(crate) async fn content_handler(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<PortalPathQuery>,
+) -> Response {
+    let authenticated = match validate_bearer(
+        &headers,
+        &state.auth,
+        EndpointAccess::PortalFiles,
+        "user.files.content",
+    )
+    .await
+    {
+        Ok(authenticated) => authenticated,
+        Err(error) => return error.into_response(),
+    };
+    let permit = match download_permit() {
+        Ok(permit) => permit,
+        Err(()) => return unavailable(StatusCode::TOO_MANY_REQUESTS),
+    };
+    let relative = match portal_relative_path(&query.path, false) {
+        Ok(path) => path,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let disposition = match content_disposition(&relative) {
+        Some(disposition) => disposition,
+        None => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let share = match authorized_share(&state, &authenticated.session, &query.share).await {
+        Ok(share) => share,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let share_id = share.id.clone();
+    let audit_path = query.path.clone();
+    let opened = tokio::task::spawn_blocking(move || {
+        let root = file_boundary::open_root_beneath(Path::new(FILES_ROOT), Path::new(&share.path))?;
+        file_boundary::open_regular_from_root(root, &relative)
+    })
+    .await
+    .ok()
+    .and_then(Result::ok);
+    let file = match opened {
+        Some(file) => file,
+        None => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let length = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(_) => return unavailable(StatusCode::NOT_FOUND),
+    };
+
+    crate::auth::audit(
+        "user.files.content",
+        &authenticated.session.username,
+        &authenticated.client_ip,
+        &format!("share={share_id} path={audit_path}"),
+    );
+
+    let reader = PortalReader {
+        file: tokio::fs::File::from_std(file),
+        _permit: permit,
+    };
+    let body = axum::body::Body::from_stream(tokio_util::io::ReaderStream::new(reader));
+    let mut response = body.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/octet-stream"),
+    );
+    response
+        .headers_mut()
+        .insert(header::CONTENT_DISPOSITION, disposition);
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("private, no-store"),
+    );
+    if let Ok(value) = axum::http::HeaderValue::from_str(&length.to_string()) {
+        response.headers_mut().insert(header::CONTENT_LENGTH, value);
+    }
+    response
+}
+
+pub(crate) async fn content_head_handler(
+    headers: HeaderMap,
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<PortalPathQuery>,
+) -> Response {
+    let authenticated = match validate_bearer(
+        &headers,
+        &state.auth,
+        EndpointAccess::PortalFiles,
+        "user.files.content.head",
+    )
+    .await
+    {
+        Ok(authenticated) => authenticated,
+        Err(error) => return error.into_response(),
+    };
+    let _permit = match control_permit() {
+        Ok(permit) => permit,
+        Err(()) => return unavailable(StatusCode::TOO_MANY_REQUESTS),
+    };
+    let relative = match portal_relative_path(&query.path, false) {
+        Ok(path) => path,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let disposition = match content_disposition(&relative) {
+        Some(disposition) => disposition,
+        None => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let share = match authorized_share(&state, &authenticated.session, &query.share).await {
+        Ok(share) => share,
+        Err(()) => return unavailable(StatusCode::NOT_FOUND),
+    };
+    let opened = tokio::task::spawn_blocking(move || {
+        let root = file_boundary::open_root_beneath(Path::new(FILES_ROOT), Path::new(&share.path))?;
+        file_boundary::open_regular_from_root(root, &relative)
+    })
+    .await
+    .ok()
+    .and_then(Result::ok);
+    let length = match opened.and_then(|file| file.metadata().ok().map(|metadata| metadata.len())) {
+        Some(length) => length,
+        None => return unavailable(StatusCode::NOT_FOUND),
+    };
+
+    let mut response = StatusCode::OK.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/octet-stream"),
+    );
+    response
+        .headers_mut()
+        .insert(header::CONTENT_DISPOSITION, disposition);
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("private, no-store"),
+    );
+    if let Ok(value) = axum::http::HeaderValue::from_str(&length.to_string()) {
+        response.headers_mut().insert(header::CONTENT_LENGTH, value);
+    }
+    response
+}
+
+fn control_permit() -> Result<OwnedSemaphorePermit, ()> {
+    PORTAL_CONTROL_OPERATIONS
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| ())
+}
+
+fn download_permit() -> Result<OwnedSemaphorePermit, ()> {
+    PORTAL_DOWNLOADS.clone().try_acquire_owned().map_err(|_| ())
+}
+
+async fn authorized_shares(
+    state: &AppState,
+    session: &crate::auth::Session,
+) -> Result<Vec<SmbShare>, ()> {
+    let principal = session.file_principal.as_deref().ok_or(())?;
+    let authorization = state
+        .smb
+        .principal_authorization(principal)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                "Portal principal lookup failed for '{}': {error}",
+                session.username
+            );
+        })?;
+    let shares = state.smb.list().await.map_err(|error| {
+        tracing::warn!("Portal share lookup failed: {error}");
+    })?;
+    if shares.len() > MAX_PORTAL_ROOTS {
+        tracing::warn!("Portal share count exceeds {MAX_PORTAL_ROOTS}");
+        return Err(());
+    }
+    Ok(shares
+        .into_iter()
+        .filter(|share| {
+            share_allows_principal(share, &authorization.principal, &authorization.groups)
+        })
+        .collect())
+}
+
+async fn authorized_share(
+    state: &AppState,
+    session: &crate::auth::Session,
+    share_id: &str,
+) -> Result<SmbShare, ()> {
+    if share_id.is_empty() || share_id.len() > 128 || share_id.chars().any(char::is_control) {
+        return Err(());
+    }
+    authorized_shares(state, session)
+        .await?
+        .into_iter()
+        .find(|share| share.id == share_id)
+        .ok_or(())
+}
+
+fn browse_share(
+    share: &SmbShare,
+    relative: &Path,
+    display_path: String,
+) -> std::io::Result<BrowseResult> {
+    let root = file_boundary::open_root_beneath(Path::new(FILES_ROOT), Path::new(&share.path))?;
+    let directory = file_boundary::open_directory_from_root(root, relative)?;
+    let names = directory.entry_names(MAX_DIRECTORY_ENTRIES)?;
+    let mut entries = Vec::with_capacity(names.len());
+    for name in names {
+        let Some(name_string) = supported_name(&name) else {
+            continue;
+        };
+        let Ok(node) = directory.open_child(&name) else {
+            continue;
+        };
+        let metadata = node.metadata()?;
+        let is_dir = matches!(node, BoundaryNode::Directory(_));
+        let modified = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        entries.push(PortalEntry {
+            name: name_string.to_string(),
+            is_dir,
+            size: if is_dir { 0 } else { metadata.len() },
+            modified,
+        });
+    }
+    entries.sort_by(|left, right| {
+        right.is_dir.cmp(&left.is_dir).then_with(|| {
+            left.name
+                .to_ascii_lowercase()
+                .cmp(&right.name.to_ascii_lowercase())
+        })
+    });
+    Ok(BrowseResult {
+        path: display_path,
+        entries,
+    })
+}
+
+fn portal_relative_path(raw: &str, allow_empty: bool) -> Result<PathBuf, ()> {
+    if raw.len() > MAX_PATH_BYTES {
+        return Err(());
+    }
+    if raw.is_empty() {
+        return allow_empty.then(PathBuf::new).ok_or(());
+    }
+    if raw.starts_with('/') || raw.ends_with('/') || raw.contains('\\') {
+        return Err(());
+    }
+    let mut path = PathBuf::new();
+    for component in raw.split('/') {
+        if component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.len() > MAX_COMPONENT_BYTES
+            || component.chars().any(char::is_control)
+        {
+            return Err(());
+        }
+        path.push(component);
+    }
+    Ok(path)
+}
+
+fn supported_name(name: &OsStr) -> Option<&str> {
+    let name = name.to_str()?;
+    (!name.is_empty()
+        && name.len() <= MAX_COMPONENT_BYTES
+        && !name.contains(['/', '\\'])
+        && !name.chars().any(char::is_control))
+    .then_some(name)
+}
+
+fn content_disposition(relative: &Path) -> Option<axum::http::HeaderValue> {
+    let name = relative.file_name().and_then(supported_name)?;
+    let mut encoded = String::with_capacity(name.len());
+    for byte in name.as_bytes() {
+        if byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'!' | b'#' | b'$' | b'&' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
+            )
+        {
+            encoded.push(*byte as char);
+        } else {
+            use std::fmt::Write;
+            write!(&mut encoded, "%{byte:02X}").ok()?;
+        }
+    }
+    axum::http::HeaderValue::from_str(&format!("attachment; filename*=UTF-8''{encoded}")).ok()
+}
+
+fn unavailable(status: StatusCode) -> Response {
+    (
+        status,
+        Json(serde_json::json!({"error": "Resource unavailable"})),
+    )
+        .into_response()
+}
+
+struct PortalReader {
+    file: tokio::fs::File,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl AsyncRead for PortalReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.file).poll_read(cx, buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portal_path_policy_accepts_only_normal_relative_components() {
+        assert_eq!(portal_relative_path("", true).unwrap(), PathBuf::new());
+        assert_eq!(
+            portal_relative_path("reports/2026.txt", false).unwrap(),
+            PathBuf::from("reports/2026.txt")
+        );
+        for path in [
+            "",
+            "/etc/passwd",
+            "../secret",
+            "reports/../secret",
+            "reports//secret",
+            "reports/",
+            "reports\\secret",
+            "reports/\nsecret",
+        ] {
+            assert!(
+                portal_relative_path(path, false).is_err(),
+                "accepted {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn portal_path_policy_bounds_path_and_component_bytes() {
+        assert!(portal_relative_path(&"a".repeat(MAX_COMPONENT_BYTES + 1), false).is_err());
+        let oversized = vec!["abcd"; MAX_PATH_BYTES / 4 + 1].join("/");
+        assert!(portal_relative_path(&oversized, false).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unsupported_directory_names_are_not_exposed() {
+        use std::os::unix::ffi::OsStrExt;
+
+        assert_eq!(supported_name(OsStr::new("report.txt")), Some("report.txt"));
+        assert!(supported_name(OsStr::from_bytes(b"bad\nname")).is_none());
+        assert!(supported_name(OsStr::from_bytes(b"bad\xffname")).is_none());
+    }
+
+    #[test]
+    fn content_disposition_uses_rfc5987_encoding_for_the_final_component() {
+        assert_eq!(
+            content_disposition(Path::new("reports/Q3 report \"final\".txt"))
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "attachment; filename*=UTF-8''Q3%20report%20%22final%22.txt"
+        );
+        assert_eq!(content_disposition(Path::new("reports/caf\n.txt")), None);
+    }
+}

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
 
 use nasty_common::{HasId, StateDir};
 use schemars::JsonSchema;
@@ -31,6 +33,8 @@ pub enum SmbError {
     TimeMachineRequiresAuth,
     #[error("samba reload failed: {0}")]
     ReloadFailed(String),
+    #[error("principal lookup failed: {0}")]
+    PrincipalLookup(String),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -139,6 +143,13 @@ fn state_dir() -> StateDir {
 
 pub struct SmbService;
 
+/// Current NSS/winbind view of a portal user's identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrincipalAuthorization {
+    pub principal: String,
+    pub groups: Vec<String>,
+}
+
 impl Default for SmbService {
     fn default() -> Self {
         Self::new()
@@ -175,6 +186,23 @@ impl SmbService {
             .load::<SmbShare>(id)
             .await
             .ok_or_else(|| SmbError::NotFound(id.to_string()))
+    }
+
+    /// Resolve a local or domain principal and all of its current groups via
+    /// NSS/winbind. Commands receive the principal as a single argv value;
+    /// numeric GIDs are resolved separately so group names containing spaces
+    /// are never split on whitespace.
+    pub async fn principal_authorization(
+        &self,
+        principal: &str,
+    ) -> Result<PrincipalAuthorization, SmbError> {
+        validate_file_principal(principal)?;
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            resolve_principal_authorization(principal),
+        )
+        .await
+        .map_err(|_| SmbError::PrincipalLookup("lookup timed out".to_string()))?
     }
 
     pub async fn create(&self, req: CreateSmbShareRequest) -> Result<SmbShare, SmbError> {
@@ -307,6 +335,195 @@ impl SmbService {
         info!("Deleted SMB share '{}'", req.id);
         Ok(())
     }
+}
+
+/// Pure portal policy. Samba principal names are ASCII case-insensitive, but
+/// matches remain exact so similarly named users and groups cannot collide.
+pub fn share_allows_principal(share: &SmbShare, principal: &str, groups: &[String]) -> bool {
+    // Raw directives are evaluated by Samba and can override path, valid
+    // users, invalid users, and access semantics. The portal cannot safely
+    // reproduce that effective policy, so any such share is portal-ineligible.
+    if !share.enabled
+        || share.guest_ok
+        || share.valid_users.is_empty()
+        || !share.extra_params.is_empty()
+    {
+        return false;
+    }
+
+    share.valid_users.iter().any(|allowed| {
+        if let Some(group) = allowed.strip_prefix('@') {
+            groups
+                .iter()
+                .any(|current| current.eq_ignore_ascii_case(group))
+        } else {
+            allowed.eq_ignore_ascii_case(principal)
+        }
+    })
+}
+
+fn validate_file_principal(principal: &str) -> Result<(), SmbError> {
+    if principal.is_empty() || principal.trim() != principal || principal.starts_with('@') {
+        return Err(SmbError::InvalidName(
+            "file principal must be a non-empty user principal".to_string(),
+        ));
+    }
+    validate_valid_users(&[principal.to_string()])
+}
+
+const MAX_NSS_OUTPUT: usize = 64 * 1024;
+const MAX_PRINCIPAL_GROUPS: usize = 128;
+
+struct BoundedOutput {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+async fn resolve_principal_authorization(
+    principal: &str,
+) -> Result<PrincipalAuthorization, SmbError> {
+    let output = run_bounded_command("id", &["-G", "--", principal]).await?;
+    if !output.status.success() {
+        return Err(SmbError::PrincipalLookup(format!(
+            "principal does not exist: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let gids = std::str::from_utf8(&output.stdout)
+        .map_err(|_| SmbError::PrincipalLookup("id returned non-UTF-8 output".to_string()))?;
+    let mut unique_gids = HashSet::new();
+    let gids: Vec<String> = gids
+        .split_whitespace()
+        .map(|gid| {
+            gid.parse::<u32>()
+                .map(|_| gid.to_string())
+                .map_err(|_| SmbError::PrincipalLookup("id returned an invalid GID".to_string()))
+        })
+        .collect::<Result<_, _>>()?;
+    let gids: Vec<String> = gids
+        .into_iter()
+        .filter(|gid| unique_gids.insert(gid.clone()))
+        .collect();
+    if gids.is_empty() || gids.len() > MAX_PRINCIPAL_GROUPS {
+        return Err(SmbError::PrincipalLookup(
+            "principal has no groups or exceeds the group limit".to_string(),
+        ));
+    }
+
+    let mut groups = Vec::with_capacity(gids.len());
+    for gid in gids {
+        let output = run_bounded_command("getent", &["group", &gid]).await?;
+        if !output.status.success() {
+            return Err(SmbError::PrincipalLookup(format!(
+                "could not resolve GID {gid}"
+            )));
+        }
+        let record = std::str::from_utf8(&output.stdout).map_err(|_| {
+            SmbError::PrincipalLookup("getent returned non-UTF-8 output".to_string())
+        })?;
+        let name = record
+            .lines()
+            .next()
+            .and_then(|line| line.split_once(':').map(|(name, _)| name))
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                SmbError::PrincipalLookup(format!(
+                    "getent returned an invalid record for GID {gid}"
+                ))
+            })?;
+        groups.push(name.to_string());
+    }
+
+    // Local portal principals must exist in both NSS and Samba's current
+    // passdb. Domain principals remain governed by the NSS/winbind lookup
+    // above because they are not local passdb entries.
+    if !principal.contains('\\') {
+        let output = run_bounded_command("pdbedit", &["--list", "--user", principal]).await?;
+        if !output.status.success() || !local_passdb_contains_principal(principal, &output.stdout) {
+            return Err(SmbError::PrincipalLookup(
+                "local principal is not present in Samba passdb".to_string(),
+            ));
+        }
+    }
+
+    Ok(PrincipalAuthorization {
+        principal: principal.to_string(),
+        groups,
+    })
+}
+
+fn local_passdb_contains_principal(principal: &str, output: &[u8]) -> bool {
+    let Ok(output) = std::str::from_utf8(output) else {
+        return false;
+    };
+    output.lines().any(|line| {
+        line.split_once(':')
+            .is_some_and(|(name, _)| name.eq_ignore_ascii_case(principal))
+    })
+}
+
+async fn run_bounded_command(program: &str, args: &[&str]) -> Result<BoundedOutput, SmbError> {
+    use tokio::io::AsyncReadExt;
+
+    let mut child = tokio::process::Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|error| SmbError::PrincipalLookup(format!("start {program}: {error}")))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| SmbError::PrincipalLookup(format!("capture {program} stdout")))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| SmbError::PrincipalLookup(format!("capture {program} stderr")))?;
+
+    let collect = async {
+        let read_stdout = async {
+            let mut bytes = Vec::new();
+            stdout
+                .take((MAX_NSS_OUTPUT + 1) as u64)
+                .read_to_end(&mut bytes)
+                .await
+                .map(|_| bytes)
+        };
+        let read_stderr = async {
+            let mut bytes = Vec::new();
+            stderr
+                .take((MAX_NSS_OUTPUT + 1) as u64)
+                .read_to_end(&mut bytes)
+                .await
+                .map(|_| bytes)
+        };
+        let (stdout, stderr, status) = tokio::join!(read_stdout, read_stderr, child.wait());
+        let stdout = stdout.map_err(|error| {
+            SmbError::PrincipalLookup(format!("read {program} stdout: {error}"))
+        })?;
+        let stderr = stderr.map_err(|error| {
+            SmbError::PrincipalLookup(format!("read {program} stderr: {error}"))
+        })?;
+        let status = status
+            .map_err(|error| SmbError::PrincipalLookup(format!("wait for {program}: {error}")))?;
+        if stdout.len() > MAX_NSS_OUTPUT || stderr.len() > MAX_NSS_OUTPUT {
+            return Err(SmbError::PrincipalLookup(format!(
+                "{program} output exceeded the limit"
+            )));
+        }
+        Ok(BoundedOutput {
+            status,
+            stdout,
+            stderr,
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(2), collect)
+        .await
+        .map_err(|_| SmbError::PrincipalLookup(format!("{program} timed out")))?
 }
 
 /// Strip characters that could inject new Samba config directives.
@@ -1182,6 +1399,91 @@ mod tests {
         );
         assert!(validate_valid_users(&["".into()]).is_err());
         assert!(validate_valid_users(&["THISNETBIOSNAMEISTOOLONG\\alice".into()]).is_err());
+    }
+
+    #[test]
+    fn portal_share_policy_matches_direct_users_exactly_and_case_insensitively() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["CORP\\Alice".into()];
+
+        assert!(share_allows_principal(&share, "corp\\alice", &[]));
+        assert!(!share_allows_principal(&share, "CORP\\alice2", &[]));
+        assert!(!share_allows_principal(&share, "alice", &[]));
+    }
+
+    #[test]
+    fn portal_share_policy_matches_local_and_domain_groups_with_spaces() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["@staff".into(), "@CORP\\Domain Users".into()];
+
+        assert!(share_allows_principal(&share, "alice", &["STAFF".into()]));
+        assert!(share_allows_principal(
+            &share,
+            "CORP\\alice",
+            &["corp\\domain users".into()]
+        ));
+        assert!(!share_allows_principal(
+            &share,
+            "CORP\\alice",
+            &["CORP\\Domain User".into()]
+        ));
+    }
+
+    #[test]
+    fn portal_share_policy_denies_disabled_guest_and_unrestricted_shares() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["alice".into()];
+
+        share.enabled = false;
+        assert!(!share_allows_principal(&share, "alice", &[]));
+        share.enabled = true;
+        share.guest_ok = true;
+        assert!(!share_allows_principal(&share, "alice", &[]));
+        share.guest_ok = false;
+        share.valid_users.clear();
+        assert!(!share_allows_principal(&share, "alice", &[]));
+    }
+
+    #[test]
+    fn portal_share_policy_denies_all_raw_samba_parameters() {
+        let mut share = minimal_share();
+        share.valid_users = vec!["alice".into()];
+
+        for key in ["valid users", "invalid users", "path", "read only"] {
+            share.extra_params.clear();
+            share.extra_params.insert(key.into(), "override".into());
+            assert!(!share_allows_principal(&share, "alice", &[]));
+        }
+    }
+
+    #[test]
+    fn local_passdb_membership_requires_an_exact_principal_record() {
+        assert!(local_passdb_contains_principal(
+            "alice",
+            b"alice:1001:Alice Example\n"
+        ));
+        assert!(local_passdb_contains_principal(
+            "ALICE",
+            b"alice:1001:Alice Example\n"
+        ));
+        assert!(!local_passdb_contains_principal(
+            "alice",
+            b"alice2:1002:Alice Two\n"
+        ));
+        assert!(!local_passdb_contains_principal("alice", b"not-a-record\n"));
+        assert!(!local_passdb_contains_principal(
+            "alice",
+            b"bad\xffrecord\n"
+        ));
+    }
+
+    #[test]
+    fn file_principal_validation_accepts_users_but_not_groups_or_whitespace() {
+        assert!(validate_file_principal("alice").is_ok());
+        assert!(validate_file_principal("CORP\\Alice Smith").is_ok());
+        assert!(validate_file_principal("@staff").is_err());
+        assert!(validate_file_principal(" alice").is_err());
+        assert!(validate_file_principal("").is_err());
     }
 
     // ── render_share_conf ──────────────────────────────────────────

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -242,6 +242,11 @@ pub struct Settings {
     /// Domain name for Let's Encrypt TLS (e.g. "nasty.example.com"). Empty = self-signed.
     #[serde(default)]
     pub tls_domain: Option<String>,
+    /// Optional hostname presenting the Role User files portal. This is
+    /// routing/presentation only; server-side Role User authorization remains
+    /// the security boundary for every portal operation.
+    #[serde(default)]
+    pub files_domain: Option<String>,
     /// Email address for Let's Encrypt ACME notifications.
     #[serde(default)]
     pub tls_acme_email: Option<String>,
@@ -512,6 +517,7 @@ impl Default for Settings {
             clock_24h: default_clock_24h(),
             temp_unit: TempUnit::default(),
             tls_domain: None,
+            files_domain: None,
             tls_acme_email: None,
             tls_acme_enabled: false,
             tls_challenge_type: default_challenge_type(),
@@ -539,6 +545,8 @@ pub struct SettingsUpdate {
     pub temp_unit: Option<TempUnit>,
     /// Domain name for Let's Encrypt TLS (set to empty string to disable).
     pub tls_domain: Option<String>,
+    /// Optional files portal FQDN (set to empty string to clear).
+    pub files_domain: Option<String>,
     /// Email address for ACME notifications.
     pub tls_acme_email: Option<String>,
     /// Enable/disable Let's Encrypt.
@@ -655,7 +663,16 @@ impl SettingsService {
     }
 
     pub async fn update(&self, update: SettingsUpdate) -> Result<Settings, String> {
-        let mut settings = self.state.write().await;
+        let mut current = self.state.write().await;
+        let mut settings = current.clone();
+        // Validate and stage the coupled TLS fields before applying any
+        // external side effects such as timezone or hostname changes.
+        let mut tls_changed = apply_domain_updates(
+            &mut settings,
+            update.tls_domain.as_deref(),
+            update.files_domain.as_deref(),
+            update.tls_acme_enabled,
+        )?;
         if let Some(tz) = update.timezone {
             apply_timezone(&tz).await?;
             settings.timezone = tz;
@@ -678,18 +695,6 @@ impl SettingsService {
         if let Some(unit) = update.temp_unit {
             settings.temp_unit = unit;
         }
-        let mut tls_changed = false;
-        if let Some(domain) = update.tls_domain {
-            let domain = if domain.trim().is_empty() {
-                None
-            } else {
-                Some(domain.trim().to_string())
-            };
-            if settings.tls_domain != domain {
-                settings.tls_domain = domain;
-                tls_changed = true;
-            }
-        }
         if let Some(email) = update.tls_acme_email {
             let email = if email.trim().is_empty() {
                 None
@@ -700,12 +705,6 @@ impl SettingsService {
                 settings.tls_acme_email = email;
                 tls_changed = true;
             }
-        }
-        if let Some(enabled) = update.tls_acme_enabled
-            && settings.tls_acme_enabled != enabled
-        {
-            settings.tls_acme_enabled = enabled;
-            tls_changed = true;
         }
         if let Some(ct) = update.tls_challenge_type
             && settings.tls_challenge_type != ct
@@ -776,6 +775,7 @@ impl SettingsService {
         // empty, already encrypted, or the backend is unavailable).
         encrypt_dns_credentials_in_place(&mut settings).await;
         save(&settings).await.map_err(|e| e.to_string())?;
+        *current = settings.clone();
         if tls_changed {
             // Always re-apply on a TLS change — even when ACME is now
             // disabled, the automation policy must be cleared so Caddy
@@ -788,8 +788,118 @@ impl SettingsService {
                 }
             });
         }
-        Ok(settings.clone())
+        Ok(settings)
     }
+}
+
+/// Validate a non-empty files portal hostname as an ASCII FQDN suitable for a
+/// Caddy host matcher and ACME subject. Schemes, paths, ports, wildcards,
+/// whitespace, control characters, and non-ASCII names all fail the label
+/// character rules rather than being interpreted or normalized implicitly.
+pub fn validate_files_domain(host: &str) -> Result<(), String> {
+    if host.is_empty() {
+        return Err("files portal domain must not be empty".into());
+    }
+    if host.len() > 253 {
+        return Err(format!(
+            "files portal domain is too long ({} > 253 characters)",
+            host.len()
+        ));
+    }
+    if !host.is_ascii() {
+        return Err("files portal domain must contain ASCII characters only".into());
+    }
+    if !host.contains('.') {
+        return Err("files portal domain must be a fully-qualified hostname".into());
+    }
+    for label in host.split('.') {
+        if label.is_empty() {
+            return Err("files portal domain contains an empty label".into());
+        }
+        if label.len() > 63 {
+            return Err(format!(
+                "files portal domain label '{label}' is longer than 63 characters"
+            ));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!(
+                "files portal domain label '{label}' may not start or end with '-'"
+            ));
+        }
+        if !label
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || c == b'-')
+        {
+            return Err(format!(
+                "files portal domain label '{label}' contains invalid characters"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Apply the two hostname updates atomically after validating their effective
+/// values. Keeping this pure makes persisted-state compatibility and clear/set
+/// behavior testable without writing the singleton settings file.
+fn apply_domain_updates(
+    settings: &mut Settings,
+    tls_domain_update: Option<&str>,
+    files_domain_update: Option<&str>,
+    acme_enabled_update: Option<bool>,
+) -> Result<bool, String> {
+    let next_tls_domain = tls_domain_update.map(|domain| {
+        let domain = domain.trim();
+        if domain.is_empty() {
+            None
+        } else {
+            Some(domain.to_string())
+        }
+    });
+    let next_files_domain = match files_domain_update {
+        Some(domain) => {
+            let domain = domain.trim();
+            if domain.is_empty() {
+                Some(None)
+            } else {
+                validate_files_domain(domain)?;
+                Some(Some(domain.to_string()))
+            }
+        }
+        None => None,
+    };
+
+    let effective_tls_domain = next_tls_domain.as_ref().unwrap_or(&settings.tls_domain);
+    let effective_files_domain = next_files_domain.as_ref().unwrap_or(&settings.files_domain);
+    let effective_acme_enabled = acme_enabled_update.unwrap_or(settings.tls_acme_enabled);
+    if let (Some(files), Some(main)) = (effective_files_domain, effective_tls_domain)
+        && files.eq_ignore_ascii_case(main)
+    {
+        return Err("files portal domain must differ from the main TLS domain".into());
+    }
+    if effective_files_domain.is_some() && !effective_acme_enabled {
+        return Err("files portal domain requires ACME to be enabled".into());
+    }
+
+    let mut changed = false;
+    if let Some(domain) = next_tls_domain
+        && settings.tls_domain != domain
+    {
+        settings.tls_domain = domain;
+        changed = true;
+    }
+    if let Some(domain) = next_files_domain
+        && settings.files_domain != domain
+    {
+        settings.files_domain = domain;
+        changed = true;
+    }
+    if let Some(enabled) = acme_enabled_update
+        && settings.tls_acme_enabled != enabled
+    {
+        settings.tls_acme_enabled = enabled;
+        changed = true;
+    }
+    Ok(changed)
 }
 
 pub async fn list_timezones() -> Result<Vec<String>, String> {
@@ -898,8 +1008,8 @@ async fn save(settings: &Settings) -> Result<(), std::io::Error> {
 //      `CADDY_ACME_ENV_PATH` EnvironmentFile so Caddy can resolve
 //      `{env.X}` references in admin-pushed config.
 //   2. Push a `tls.automation.policies[]` block to Caddy's admin API
-//      describing every hostname we want a cert for (main domain +
-//      per-app subdomains). Caddy issues + renews + staples.
+//      describing every hostname we want a cert for (main domain + files
+//      portal domain + per-app subdomains). Caddy issues + renews + staples.
 //   3. Read back what Caddy ends up serving so the WebUI can show
 //      issuer / expiry / status.
 //
@@ -1039,9 +1149,9 @@ pub async fn apply_caddy_tls_with_apps(
         }
     }
 
-    // Build the desired policy set: main domain (when ACME enabled) +
-    // every app subdomain. Empty ⇒ Caddy clears automation and falls
-    // back to the static-cert :443 block.
+    // Build the desired policy set: main domain + files portal domain (when
+    // ACME is enabled) + every app subdomain. Empty ⇒ Caddy clears automation
+    // and falls back to the static-cert :443 block.
     let policies = build_policy_set(settings, app_subdomains);
     let issuer = nasty_apps::caddy::TlsIssuer {
         email: settings.tls_acme_email.clone(),
@@ -1215,25 +1325,23 @@ fn build_policy_set(
     if !settings.tls_acme_enabled {
         return Vec::new();
     }
-    let mut policies = Vec::new();
-    if let Some(domain) = settings.tls_domain.as_deref()
-        && !domain.trim().is_empty()
+    let mut policies: Vec<nasty_apps::caddy::TlsPolicy> = Vec::new();
+    for host in settings
+        .tls_domain
+        .iter()
+        .chain(settings.files_domain.iter())
+        .chain(app_subdomains.iter())
     {
-        policies.push(nasty_apps::caddy::TlsPolicy {
-            host: domain.trim().to_string(),
-        });
-    }
-    for sub in app_subdomains {
-        let sub = sub.trim();
-        if sub.is_empty() {
-            continue;
-        }
-        // Deduplicate against the main domain.
-        if policies.iter().any(|p| p.host == sub) {
+        let host = host.trim();
+        if host.is_empty()
+            || policies
+                .iter()
+                .any(|policy| policy.host.eq_ignore_ascii_case(host))
+        {
             continue;
         }
         policies.push(nasty_apps::caddy::TlsPolicy {
-            host: sub.to_string(),
+            host: host.to_string(),
         });
     }
     policies
@@ -1699,8 +1807,9 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        EncryptedBlob, OidcSettings, Settings, build_policy_set, caddy_acme_env, merge_host_lists,
-        redact_oidc_secret, resolve_dns_credentials, to_nix_string,
+        EncryptedBlob, OidcSettings, Settings, SettingsUpdate, apply_domain_updates,
+        build_policy_set, caddy_acme_env, merge_host_lists, redact_oidc_secret,
+        resolve_dns_credentials, to_nix_string, validate_files_domain,
     };
 
     fn fake_blob() -> EncryptedBlob {
@@ -1801,6 +1910,110 @@ mod tests {
     // ── build_policy_set ──
 
     #[test]
+    fn settings_deserializes_state_without_files_domain() {
+        let mut value = serde_json::to_value(Settings::default()).unwrap();
+        value.as_object_mut().unwrap().remove("files_domain");
+        let settings: Settings = serde_json::from_value(value).unwrap();
+        assert_eq!(settings.files_domain, None);
+    }
+
+    #[test]
+    fn files_domain_defaults_to_none() {
+        assert_eq!(Settings::default().files_domain, None);
+        let update: SettingsUpdate = serde_json::from_str("{}").unwrap();
+        assert!(update.files_domain.is_none());
+    }
+
+    #[test]
+    fn files_domain_update_sets_and_clears_trimmed_value() {
+        let mut settings = Settings::default();
+        assert!(
+            apply_domain_updates(&mut settings, None, Some(" files.example.com "), Some(true))
+                .unwrap()
+        );
+        assert_eq!(settings.files_domain.as_deref(), Some("files.example.com"));
+        assert!(apply_domain_updates(&mut settings, None, Some("  "), None).unwrap());
+        assert_eq!(settings.files_domain, None);
+    }
+
+    #[test]
+    fn files_domain_update_rejects_invalid_or_redundant_host() {
+        let mut settings = Settings {
+            tls_domain: Some("nas.example.com".into()),
+            ..Settings::default()
+        };
+        assert!(
+            apply_domain_updates(
+                &mut settings,
+                None,
+                Some("https://files.example.com"),
+                Some(true)
+            )
+            .is_err()
+        );
+        assert!(
+            apply_domain_updates(&mut settings, None, Some("NAS.EXAMPLE.COM"), Some(true)).is_err()
+        );
+        assert_eq!(
+            settings.files_domain, None,
+            "failed updates must not mutate settings"
+        );
+
+        settings.files_domain = Some("files.example.com".into());
+        settings.tls_acme_enabled = true;
+        assert!(
+            apply_domain_updates(&mut settings, Some("FILES.EXAMPLE.COM"), None, None).is_err()
+        );
+        assert_eq!(settings.tls_domain.as_deref(), Some("nas.example.com"));
+    }
+
+    #[test]
+    fn files_domain_requires_acme_and_acme_cannot_be_disabled_while_retained() {
+        let mut settings = Settings::default();
+        assert!(
+            apply_domain_updates(&mut settings, None, Some("files.example.com"), None).is_err()
+        );
+        assert_eq!(settings.files_domain, None);
+        assert!(!settings.tls_acme_enabled);
+
+        apply_domain_updates(&mut settings, None, Some("files.example.com"), Some(true)).unwrap();
+        let before = settings.clone();
+        assert!(apply_domain_updates(&mut settings, None, None, Some(false)).is_err());
+        assert_eq!(settings.files_domain, before.files_domain);
+        assert_eq!(settings.tls_acme_enabled, before.tls_acme_enabled);
+
+        assert!(apply_domain_updates(&mut settings, None, Some(""), Some(false)).unwrap());
+        assert_eq!(settings.files_domain, None);
+        assert!(!settings.tls_acme_enabled);
+    }
+
+    #[test]
+    fn files_domain_validation_accepts_safe_fqdns_and_rejects_unsafe_values() {
+        assert!(validate_files_domain("files.example.com").is_ok());
+        assert!(validate_files_domain("files-2.eu.example.com").is_ok());
+        for invalid in [
+            "files",
+            "https://files.example.com",
+            "files.example.com/path",
+            "files.example.com:443",
+            "*.example.com",
+            "files example.com",
+            "files\n.example.com",
+            "fíles.example.com",
+            "-files.example.com",
+            "files-.example.com",
+            "files..example.com",
+        ] {
+            assert!(
+                validate_files_domain(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+        }
+        assert!(validate_files_domain(&format!("{}.example.com", "a".repeat(64))).is_err());
+        assert!(validate_files_domain(&format!("{}.com", "a".repeat(250))).is_err());
+    }
+
+    #[test]
     fn policy_set_empty_when_acme_disabled() {
         // ACME off ⇒ no policies ⇒ engine PUTs an empty array ⇒ Caddy
         // stops renewing. Per-app subdomains are ignored in this state
@@ -1818,6 +2031,25 @@ mod tests {
         let policies = build_policy_set(&s, &[]);
         assert_eq!(policies.len(), 1);
         assert_eq!(policies[0].host, "nas.example.com");
+    }
+
+    #[test]
+    fn policy_set_includes_files_domain() {
+        let mut s = acme_enabled_settings("dns");
+        s.files_domain = Some("files.example.com".into());
+        let policies = build_policy_set(&s, &[]);
+        let hosts: Vec<_> = policies.iter().map(|policy| policy.host.as_str()).collect();
+        assert_eq!(hosts, vec!["nas.example.com", "files.example.com"]);
+    }
+
+    #[test]
+    fn policy_set_dedupes_files_domain_case_insensitively_against_all_hosts() {
+        let mut s = acme_enabled_settings("dns");
+        s.files_domain = Some("FILES.EXAMPLE.COM".into());
+        let policies =
+            build_policy_set(&s, &["files.example.com".into(), "NAS.EXAMPLE.COM".into()]);
+        let hosts: Vec<_> = policies.iter().map(|policy| policy.host.as_str()).collect();
+        assert_eq!(hosts, vec!["nas.example.com", "FILES.EXAMPLE.COM"]);
     }
 
     #[test]

--- a/webui/src/lib/access.test.ts
+++ b/webui/src/lib/access.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { canAccessAuthenticatedRoute, redirectForRole } from './access';
+
+describe('authenticated route policy', () => {
+	test('standard users can access only the portal route', () => {
+		expect(canAccessAuthenticatedRoute('user', '/portal')).toBe(true);
+		expect(canAccessAuthenticatedRoute('user', '/portal/files')).toBe(true);
+		for (const path of ['/', '/files', '/users', '/menu', '/settings']) {
+			expect(canAccessAuthenticatedRoute('user', path)).toBe(false);
+			expect(redirectForRole('user', path)).toBe('/portal');
+		}
+	});
+
+	test('management roles retain management routes and cannot open the portal', () => {
+		for (const role of ['admin', 'operator', 'readonly']) {
+			expect(canAccessAuthenticatedRoute(role, '/files')).toBe(true);
+			expect(redirectForRole(role, '/files')).toBeNull();
+			expect(redirectForRole(role, '/portal')).toBe('/');
+		}
+	});
+});

--- a/webui/src/lib/access.ts
+++ b/webui/src/lib/access.ts
@@ -1,0 +1,21 @@
+import type { UserRole } from './types';
+
+export const PORTAL_PATH = '/portal';
+
+export function isStandardUser(role: string | null | undefined): role is 'user' {
+	return role === 'user';
+}
+
+export function isManagementRole(role: string | null | undefined): role is Exclude<UserRole, 'user'> {
+	return role === 'admin' || role === 'operator' || role === 'readonly';
+}
+
+export function canAccessAuthenticatedRoute(role: string, path: string): boolean {
+	const portalRoute = path === PORTAL_PATH || path.startsWith(`${PORTAL_PATH}/`);
+	return isStandardUser(role) ? portalRoute : !portalRoute;
+}
+
+export function redirectForRole(role: string, path: string): string | null {
+	if (canAccessAuthenticatedRoute(role, path)) return null;
+	return isStandardUser(role) ? PORTAL_PATH : '/';
+}

--- a/webui/src/lib/navigation.test.ts
+++ b/webui/src/lib/navigation.test.ts
@@ -6,6 +6,7 @@ import {
 	flattenNavigation,
 	isNavGroup,
 	LAUNCHER_NAV_ITEM,
+	navigationForMode,
 	resolveNavigation,
 	searchNavigation
 } from './navigation';
@@ -71,5 +72,15 @@ describe('navigation model', () => {
 	test('search cannot expose capability-gated entries', () => {
 		const entries = resolveNavigation({ kvmAvailable: false });
 		expect(searchNavigation(entries, 'virtual machine')).toEqual(new Set());
+	});
+
+	test('standard users cannot recover management links through any navigation mode', () => {
+		const entries = resolveNavigation({ kvmAvailable: true, role: 'user' });
+		expect(flattenNavigation(entries).map((item) => item.href)).toEqual(['/portal']);
+		expect(flattenNavigation(navigationForMode(entries, 'full')).map((item) => item.href)).toEqual(['/portal']);
+		expect(flattenNavigation(navigationForMode(entries, 'common')).map((item) => item.href)).toEqual([]);
+		expect(searchNavigation(entries, 'filesystem')).toEqual(new Set());
+		expect(searchNavigation(entries, 'access control')).toEqual(new Set());
+		expect(currentNavigationItem('/menu', entries)).toBe(LAUNCHER_NAV_ITEM);
 	});
 });

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -26,6 +26,7 @@ import {
 	Terminal,
 	Wrench
 } from '@lucide/svelte';
+import { isStandardUser } from './access';
 
 export type NavIcon = typeof LayoutDashboard;
 export type NavMode = 'full' | 'common';
@@ -53,6 +54,7 @@ export type NavEntry = NavItem | NavGroup;
 
 export interface NavigationContext {
 	kvmAvailable: boolean;
+	role?: string | null;
 }
 
 export const NAVIGATION_CONTEXT = Symbol('navigation');
@@ -124,6 +126,7 @@ const NAVIGATION: NavEntry[] = [
 ];
 
 export const LAUNCHER_NAV_ITEM = item('launcher', '/menu', 'Launcher', Grid3X3, ['launcher', 'menu', 'navigation', 'pages']);
+export const PORTAL_NAV_ITEM = item('portal', '/portal', 'Files Portal', FolderOpen, ['files', 'folders', 'activity', 'account']);
 
 export function isNavGroup(entry: NavEntry): entry is NavGroup {
 	return entry.kind === 'group';
@@ -134,6 +137,7 @@ function isVisible(item: NavItem, context: NavigationContext): boolean {
 }
 
 export function resolveNavigation(context: NavigationContext): NavEntry[] {
+	if (isStandardUser(context.role)) return [PORTAL_NAV_ITEM];
 	return NAVIGATION.map((entry) => {
 		if (!isNavGroup(entry)) return entry;
 		return { ...entry, children: entry.children.filter((child) => isVisible(child, context)) };

--- a/webui/src/lib/portal.test.ts
+++ b/webui/src/lib/portal.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import {
+	joinPortalPath,
+	parentPortalPath,
+	portalBreadcrumbs,
+	portalFilesUrl,
+	portalPathSegments,
+} from './portal';
+
+describe('portal file helpers', () => {
+	test('joins and ascends relative descriptor paths', () => {
+		expect(joinPortalPath('', 'Projects')).toBe('Projects');
+		expect(joinPortalPath('Projects', 'Q3 reports')).toBe('Projects/Q3 reports');
+		expect(parentPortalPath('Projects/Q3 reports')).toBe('Projects');
+		expect(parentPortalPath('Projects')).toBe('');
+	});
+
+	test('rejects absolute, traversal, and separator-bearing segments', () => {
+		for (const path of ['/etc', '../etc', 'one/../two', 'one\\two']) {
+			expect(() => portalPathSegments(path)).toThrow();
+		}
+		expect(() => joinPortalPath('safe', '../secret')).toThrow('Invalid portal path segment');
+		expect(() => joinPortalPath('safe', 'one/two')).toThrow('Invalid portal path segment');
+	});
+
+	test('builds cumulative breadcrumbs without decoding names', () => {
+		expect(portalBreadcrumbs('Team files/2026/Q3')).toEqual([
+			{ label: 'Team files', path: 'Team files' },
+			{ label: '2026', path: 'Team files/2026' },
+			{ label: 'Q3', path: 'Team files/2026/Q3' },
+		]);
+	});
+
+	test('encodes share IDs and relative paths in endpoint URLs', () => {
+		const url = portalFilesUrl('content', 'share & one', 'Reports/Q3 #1.pdf');
+		expect(url).toBe('/api/user/files/content?share=share+%26+one&path=Reports%2FQ3+%231.pdf');
+	});
+});

--- a/webui/src/lib/portal.ts
+++ b/webui/src/lib/portal.ts
@@ -1,0 +1,45 @@
+export interface PortalBreadcrumb {
+	label: string;
+	path: string;
+}
+
+function validateSegment(segment: string): string {
+	if (!segment || segment === '.' || segment === '..' || segment.includes('/') || segment.includes('\\')) {
+		throw new Error('Invalid portal path segment');
+	}
+	if ([...segment].some((character) => character.charCodeAt(0) < 32)) {
+		throw new Error('Invalid portal path segment');
+	}
+	return segment;
+}
+
+export function portalPathSegments(path: string): string[] {
+	if (!path) return [];
+	if (path.startsWith('/') || path.includes('\\')) throw new Error('Portal paths must be relative');
+	return path.split('/').map(validateSegment);
+}
+
+export function joinPortalPath(path: string, name: string): string {
+	return [...portalPathSegments(path), validateSegment(name)].join('/');
+}
+
+export function parentPortalPath(path: string): string {
+	return portalPathSegments(path).slice(0, -1).join('/');
+}
+
+export function portalBreadcrumbs(path: string): PortalBreadcrumb[] {
+	const segments = portalPathSegments(path);
+	return segments.map((label, index) => ({
+		label,
+		path: segments.slice(0, index + 1).join('/'),
+	}));
+}
+
+export function portalFilesUrl(
+	action: 'browse' | 'content',
+	share: string,
+	path = '',
+): string {
+	const params = new URLSearchParams({ share, path });
+	return `/api/user/files/${action}?${params.toString()}`;
+}

--- a/webui/src/lib/rpc.test.ts
+++ b/webui/src/lib/rpc.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { NastyClient } from './rpc';
+import { isReconnectAuthError, NastyClient } from './rpc';
 
 // ── Mock WebSocket ──────────────────────────────────────────────────
 // Tests drive the lifecycle synchronously: construct, then call open(),
@@ -82,6 +82,12 @@ afterEach(() => {
 // ── Auth handshake ──────────────────────────────────────────────────
 
 describe('auth handshake', () => {
+	test('matches the server invalid-session reconnect error case-insensitively', () => {
+		expect(isReconnectAuthError(new Error('invalid session'))).toBe(true);
+		expect(isReconnectAuthError(new Error('INVALID SESSION'))).toBe(true);
+		expect(isReconnectAuthError(new Error('WebSocket connection failed'))).toBe(false);
+	});
+
 	test('connect resolves with AuthResult on success', async () => {
 		const client = new NastyClient('ws://localhost/api');
 		const promise = client.connect();

--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -1,5 +1,7 @@
 /** JSON-RPC 2.0 client over WebSocket with token auth */
 
+import type { UserRole } from './types';
+
 interface RpcError {
 	code: number;
 	message: string;
@@ -16,8 +18,14 @@ export type EventHandler = (method: string, params: unknown) => void;
 export interface AuthResult {
 	authenticated: boolean;
 	username: string;
-	role: string;
+	role: UserRole;
 	must_change_password?: boolean;
+}
+
+export function isReconnectAuthError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message.toLowerCase();
+	return message.includes('invalid') || message.includes('unauthorized') || message.includes('expired');
 }
 
 export class NastyClient {
@@ -268,11 +276,7 @@ export class NastyClient {
 			this.connect().catch((err) => {
 				// Auth failure after reboot (cookie invalidated) — force page reload.
 				// The new page will show the login form.
-				if (err instanceof Error && (
-					err.message.includes('Invalid') ||
-					err.message.includes('Unauthorized') ||
-					err.message.includes('expired')
-				)) {
+				if (isReconnectAuthError(err)) {
 					location.reload();
 					return;
 				}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -749,9 +749,12 @@ export interface NvmeofPort {
 	addr_family: string;
 }
 
+export type UserRole = 'admin' | 'readonly' | 'operator' | 'user';
+
 export interface UserInfo {
 	username: string;
-	role: 'admin' | 'readonly' | 'operator';
+	role: UserRole;
+	file_principal?: string | null;
 	/** Number of registered WebAuthn credentials. Defaults to 0 for
 	 * compat with engines that pre-date the field. Drives the admin
 	 * "Reset security keys" button visibility on the /users page. */
@@ -766,6 +769,38 @@ export interface ApiTokenInfo {
 	filesystem: string | null;
 	expires_at: number | null;
 	allowed_ips: string[];
+}
+
+export interface AuthMe {
+	username: string;
+	role: UserRole;
+	file_principal: string | null;
+	scoped: boolean;
+}
+
+export interface PortalFileRoot {
+	id: string;
+	name: string;
+}
+
+export interface PortalFileEntry {
+	name: string;
+	is_dir: boolean;
+	size: number;
+	modified: number;
+}
+
+export interface PortalBrowseResult {
+	path: string;
+	entries: PortalFileEntry[];
+}
+
+export interface MyActivityEntry {
+	ts: number;
+	event: string;
+	user: string;
+	ip: string;
+	detail: string;
 }
 
 export interface ApiTokenCreated extends ApiTokenInfo {
@@ -1127,6 +1162,7 @@ export interface Settings {
 	clock_24h: boolean;
 	temp_unit: TempUnit;
 	tls_domain: string | null;
+	files_domain: string | null;
 	tls_acme_email: string | null;
 	tls_acme_enabled: boolean;
 	tls_challenge_type: 'tls-alpn' | 'http' | 'dns';

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -64,6 +64,7 @@
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
+	import { isManagementRole, isStandardUser, redirectForRole } from '$lib/access';
 
 	let { children } = $props();
 	let connected = $state(false);
@@ -235,7 +236,7 @@
 		typeof localStorage !== 'undefined' && localStorage.getItem(SSH_DISMISSED_KEY) === '1'
 	);
 	async function checkSshStatus() {
-		if (!connected || sshPasswordAuthDismissed) return;
+		if (!connected || !isManagementRole(authInfo?.role) || sshPasswordAuthDismissed) return;
 		try {
 			const result = await getClient().call<{ password_auth: boolean; keys: string[] }>('system.ssh.status');
 			sshPasswordAuth = result.password_auth;
@@ -254,7 +255,7 @@
 		typeof localStorage !== 'undefined' && localStorage.getItem(BACKUP_DISMISSED_KEY) === '1'
 	);
 	async function checkConfigBackup() {
-		if (!connected || configBackupDismissed) return;
+		if (!connected || !isManagementRole(authInfo?.role) || configBackupDismissed) return;
 		try {
 			const profiles = await getClient().call<{ sources: string[] }[]>('backup.profile.list');
 			configBackupMissing = !profiles.some(p => p.sources.some(s => s.includes('/var/lib/nasty')));
@@ -289,7 +290,8 @@
 	// Version info (loaded once after connect)
 	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_recommended_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
 	setContext(NAVIGATION_CONTEXT, {
-		get kvmAvailable() { return sysInfo?.kvm_available === true; }
+		get kvmAvailable() { return sysInfo?.kvm_available === true; },
+		get role() { return authInfo?.role; }
 	});
 	// bcachefs "update available": the pin differs from the version this
 	// NASty build ships, so a one-click sync is offered. Distinct from
@@ -332,7 +334,7 @@
 
 	$effect(() => {
 		const _r = sysInfoRefresh.count; // track refresh triggers
-		if (connected) {
+		if (connected && isManagementRole(authInfo?.role)) {
 			getClient().call('system.info').then((info: any) => { sysInfo = info; }).catch(() => {});
 			getClient().call('system.settings.get').then((s: any) => {
 				clock24h = s.clock_24h ?? true;
@@ -354,7 +356,7 @@
 	}
 
 	function checkRebootRequired() {
-		if (connected) {
+		if (connected && isManagementRole(authInfo?.role)) {
 			getClient().call<boolean>('system.reboot_required').then((v) => {
 				if (v) rebootState.set(); else rebootState.clear();
 			}).catch(() => {});
@@ -383,7 +385,7 @@
 			|| systemStatus.critical_count + systemStatus.warning_count > 0)
 	);
 	function refreshSystemStatus() {
-		if (!connected || document.hidden) return;
+		if (!connected || !isManagementRole(authInfo?.role) || document.hidden) return;
 		getClient().call<SystemStatus>('system.status')
 			.then((s) => { systemStatus = s; })
 			.catch(() => {});
@@ -402,7 +404,7 @@
 	// already been torn down. The txn is still alive server-side; this
 	// fetch puts the banner back so the user can confirm.
 	$effect(() => {
-		if (connected) loadPendingRollback();
+		if (connected && isManagementRole(authInfo?.role)) loadPendingRollback();
 	});
 
 	// Clock
@@ -430,6 +432,9 @@
 	// the page bare (no sidebar, no login gate) — it talks to the engine
 	// only through the unauthenticated /api/public/share/* endpoints.
 	const isPublicShare = $derived($page.url.pathname.startsWith('/share/'));
+	const isPortalRoute = $derived(
+		$page.url.pathname === '/portal' || $page.url.pathname.startsWith('/portal/')
+	);
 
 	onMount(() => {
 		if (isPublicShare) return;
@@ -529,10 +534,14 @@
 		try {
 			const client = getClient();
 			authInfo = await client.connect();
+			const destination = redirectForRole(authInfo.role, $page.url.pathname);
+			if (destination) await goto(destination, { replaceState: true });
 			connected = true;
 			showLogin = false;
-			checkSshStatus();
-			checkConfigBackup();
+			if (isManagementRole(authInfo.role)) {
+				checkSshStatus();
+				checkConfigBackup();
+			}
 			// Capture engine commit on first connect for reconnect version check
 			if (!initialCommit) {
 				try {
@@ -670,7 +679,17 @@
 		try { await getClient().call('system.shutdown'); } catch { /* expected — engine dies */ }
 	}
 
-	const nav = $derived.by((): NavEntry[] => resolveNavigation({ kvmAvailable: sysInfo?.kvm_available === true }));
+	const nav = $derived.by((): NavEntry[] => resolveNavigation({
+		kvmAvailable: sysInfo?.kvm_available === true,
+		role: authInfo?.role,
+	}));
+	const roleRedirect = $derived.by(() => {
+		const session = authInfo as AuthResult | null;
+		return session && !isPublicShare ? redirectForRole(session.role, $page.url.pathname) : null;
+	});
+	$effect(() => {
+		if (connected && roleRedirect) void goto(roleRedirect, { replaceState: true });
+	});
 
 	// ── Nav mode (#588): opt-in "Common" short menu vs the full grouped tree ──
 	const NAV_MODE_KEY = 'nasty:nav_mode';
@@ -851,6 +870,23 @@
 				<Button type="submit" class="w-full">Set password</Button>
 			</form>
 		</div>
+	</div>
+{:else if roleRedirect}
+	<div class="flex min-h-screen items-center justify-center bg-background text-sm text-muted-foreground">
+		Opening your workspace...
+	</div>
+{:else if isStandardUser(authInfo?.role) || (!authInfo && isPortalRoute)}
+	<div class="relative min-h-screen bg-background">
+		{#if connected}
+			{@render children()}
+		{:else}
+			<div class="flex min-h-screen items-center justify-center text-sm text-muted-foreground">Connecting...</div>
+		{/if}
+		{#if reconnecting}
+			<div class="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-[2px]">
+				<ReconnectSpinner />
+			</div>
+		{/if}
 	</div>
 {:else}
 	<div class="relative flex h-screen overflow-hidden">

--- a/webui/src/routes/portal/+page.svelte
+++ b/webui/src/routes/portal/+page.svelte
@@ -1,0 +1,433 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getClient, resetClient } from '$lib/client';
+	import { logout } from '$lib/auth';
+	import { formatBytes } from '$lib/format';
+	import {
+		joinPortalPath,
+		parentPortalPath,
+		portalBreadcrumbs,
+		portalFilesUrl,
+	} from '$lib/portal';
+	import type {
+		AuthMe,
+		MyActivityEntry,
+		PortalBrowseResult,
+		PortalFileEntry,
+		PortalFileRoot,
+	} from '$lib/types';
+	import logoLight from '$lib/assets/nasty.svg';
+	import logoDark from '$lib/assets/nasty-white.svg';
+	import { theme } from '$lib/theme.svelte';
+	import {
+		Activity,
+		ArrowLeft,
+		ChevronRight,
+		Download,
+		File,
+		Folder,
+		FolderOpen,
+		KeyRound,
+		LogOut,
+		RefreshCw,
+		UserRound,
+	} from '@lucide/svelte';
+
+	type PortalTab = 'files' | 'activity' | 'account';
+
+	const client = getClient();
+	let activeTab: PortalTab = $state('files');
+	let identity: AuthMe | null = $state(null);
+	let identityError = $state('');
+
+	let roots: PortalFileRoot[] = $state([]);
+	let rootsLoading = $state(true);
+	let rootsError = $state('');
+	let rootsRequest = 0;
+
+	let activeShare: PortalFileRoot | null = $state(null);
+	let currentPath = $state('');
+	let entries: PortalFileEntry[] = $state([]);
+	let browseLoading = $state(false);
+	let browseError = $state('');
+	let browseRequest = 0;
+
+	let activityEntries: MyActivityEntry[] = $state([]);
+	let activityLoading = $state(false);
+	let activityLoaded = $state(false);
+	let activityError = $state('');
+	let activityRequest = 0;
+
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let passwordPending = $state(false);
+	let passwordError = $state('');
+	let passwordSuccess = $state('');
+
+	const breadcrumbs = $derived(portalBreadcrumbs(currentPath));
+	const sortedEntries = $derived.by(() => [...entries].sort((a, b) => {
+		if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+		return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+	}));
+
+	function errorMessage(error: unknown, fallback: string): string {
+		if (error instanceof Error) return error.message;
+		if (error && typeof error === 'object' && 'message' in error) {
+			return String((error as { message: unknown }).message);
+		}
+		return fallback;
+	}
+
+	async function fetchJson<T>(url: string): Promise<T> {
+		const response = await fetch(url);
+		if (!response.ok) {
+			const body = await response.json().catch(() => ({}));
+			const detail = (body as { error?: string }).error;
+			throw new Error(detail ?? `Request failed (HTTP ${response.status})`);
+		}
+		return response.json() as Promise<T>;
+	}
+
+	async function loadIdentity() {
+		identityError = '';
+		try {
+			identity = await client.call<AuthMe>('auth.me');
+		} catch (error) {
+			identityError = errorMessage(error, 'Unable to load your account.');
+		}
+	}
+
+	async function loadRoots() {
+		const request = ++rootsRequest;
+		rootsLoading = true;
+		rootsError = '';
+		try {
+			const result = await fetchJson<PortalFileRoot[]>('/api/user/files/roots');
+			if (request !== rootsRequest) return;
+			roots = result;
+		} catch (error) {
+			if (request !== rootsRequest) return;
+			rootsError = errorMessage(error, 'Unable to load your shared folders.');
+		} finally {
+			if (request === rootsRequest) rootsLoading = false;
+		}
+	}
+
+	async function browse(share: PortalFileRoot, path: string) {
+		const request = ++browseRequest;
+		activeShare = share;
+		currentPath = path;
+		browseLoading = true;
+		browseError = '';
+		try {
+			const result = await fetchJson<PortalBrowseResult>(portalFilesUrl('browse', share.id, path));
+			if (request !== browseRequest) return;
+			currentPath = result.path;
+			entries = result.entries;
+		} catch (error) {
+			if (request !== browseRequest) return;
+			entries = [];
+			browseError = errorMessage(error, 'Unable to open this folder.');
+		} finally {
+			if (request === browseRequest) browseLoading = false;
+		}
+	}
+
+	function openFolder(entry: PortalFileEntry) {
+		if (activeShare && entry.is_dir) void browse(activeShare, joinPortalPath(currentPath, entry.name));
+	}
+
+	function goBack() {
+		if (!activeShare) return;
+		if (currentPath) {
+			void browse(activeShare, parentPortalPath(currentPath));
+		} else {
+			browseRequest++;
+			activeShare = null;
+			entries = [];
+			browseError = '';
+		}
+	}
+
+	async function loadActivity() {
+		const request = ++activityRequest;
+		activityLoading = true;
+		activityError = '';
+		try {
+			const result = await client.call<MyActivityEntry[]>('audit.mine', { limit: 200 });
+			if (request !== activityRequest) return;
+			activityEntries = result;
+			activityLoaded = true;
+		} catch (error) {
+			if (request !== activityRequest) return;
+			activityError = errorMessage(error, 'Unable to load your activity.');
+		} finally {
+			if (request === activityRequest) activityLoading = false;
+		}
+	}
+
+	function selectTab(tab: PortalTab) {
+		activeTab = tab;
+		if (tab === 'activity' && !activityLoaded && !activityLoading) void loadActivity();
+	}
+
+	function formatDate(unixSeconds: number): string {
+		const date = new Date(unixSeconds * 1000);
+		return Number.isNaN(date.getTime()) ? 'Unknown' : date.toLocaleString();
+	}
+
+	function readableEvent(event: string): string {
+		return event.replace(/[._-]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+	}
+
+	async function changePassword() {
+		passwordError = '';
+		passwordSuccess = '';
+		if (newPassword.length < 8) {
+			passwordError = 'Password must be at least 8 characters.';
+			return;
+		}
+		if (newPassword !== confirmPassword) {
+			passwordError = 'Passwords do not match.';
+			return;
+		}
+		if (!identity) {
+			passwordError = 'Your account information is not available. Refresh and try again.';
+			return;
+		}
+		passwordPending = true;
+		try {
+			await client.call('auth.change_password', {
+				username: identity.username,
+				new_password: newPassword,
+			});
+			newPassword = '';
+			confirmPassword = '';
+			activityLoaded = false;
+			passwordSuccess = 'Your password has been changed.';
+		} catch (error) {
+			passwordError = errorMessage(error, 'Unable to change your password.');
+		} finally {
+			passwordPending = false;
+		}
+	}
+
+	async function signOut() {
+		await logout();
+		resetClient();
+		window.location.assign('/');
+	}
+
+	onMount(() => {
+		void Promise.all([loadIdentity(), loadRoots()]);
+	});
+</script>
+
+<svelte:head>
+	<title>My Files - NASty</title>
+</svelte:head>
+
+<div class="min-h-screen bg-background">
+	<header class="sticky top-0 z-30 border-b border-border bg-card/95 backdrop-blur">
+		<div class="mx-auto flex h-16 max-w-6xl items-center gap-3 px-4 sm:px-6">
+			<img src={theme.isDark ? logoDark : logoLight} alt="NASty" class="h-10 w-auto shrink-0" />
+			<div class="hidden h-6 w-px bg-border sm:block"></div>
+			<p class="hidden text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground sm:block">File portal</p>
+			<div class="ml-auto min-w-0 text-right">
+				<p class="truncate text-sm font-medium">{identity?.username ?? 'Signed in'}</p>
+				{#if identity?.file_principal}<p class="hidden truncate text-xs text-muted-foreground sm:block">{identity.file_principal}</p>{/if}
+			</div>
+			<button
+				type="button"
+				onclick={signOut}
+				class="flex h-9 items-center gap-2 rounded-lg border border-border px-3 text-sm text-muted-foreground transition-colors hover:border-blue-500/50 hover:text-foreground"
+				aria-label="Sign out"
+			>
+				<LogOut size={16} />
+				<span class="hidden sm:inline">Sign out</span>
+			</button>
+		</div>
+	</header>
+
+	<div class="mx-auto max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
+		<div class="mb-6 flex gap-1 overflow-x-auto rounded-xl border border-border bg-card p-1.5 sm:w-fit" aria-label="Portal navigation">
+			<button type="button" onclick={() => selectTab('files')} aria-current={activeTab === 'files' ? 'page' : undefined} class="flex min-w-fit flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors sm:flex-none {activeTab === 'files' ? 'bg-blue-500/15 text-blue-500 dark:text-blue-400' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">
+				<FolderOpen size={16} /> Files
+			</button>
+			<button type="button" onclick={() => selectTab('activity')} aria-current={activeTab === 'activity' ? 'page' : undefined} class="flex min-w-fit flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors sm:flex-none {activeTab === 'activity' ? 'bg-blue-500/15 text-blue-500 dark:text-blue-400' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">
+				<Activity size={16} /> Activity
+			</button>
+			<button type="button" onclick={() => selectTab('account')} aria-current={activeTab === 'account' ? 'page' : undefined} class="flex min-w-fit flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors sm:flex-none {activeTab === 'account' ? 'bg-blue-500/15 text-blue-500 dark:text-blue-400' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">
+				<UserRound size={16} /> Account
+			</button>
+		</div>
+
+		{#if activeTab === 'files'}
+			<section aria-labelledby="files-title">
+				<div class="mb-5">
+					<p class="mb-1 font-mono text-[0.65rem] uppercase tracking-[0.24em] text-blue-500 dark:text-blue-400">Your storage</p>
+					<h1 id="files-title" class="text-2xl font-semibold tracking-tight sm:text-3xl">{activeShare?.name ?? 'Shared folders'}</h1>
+					<p class="mt-1 text-sm text-muted-foreground">{activeShare ? 'Browse and download files available to your account.' : 'Choose a shared folder to get started.'}</p>
+				</div>
+
+				{#if !activeShare}
+					{#if rootsLoading}
+						<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3" aria-live="polite" aria-label="Loading shared folders">
+							{#each [1, 2, 3] as item}
+								<div class="h-28 animate-pulse rounded-xl border border-border bg-card" aria-hidden="true"></div>
+							{/each}
+						</div>
+					{:else if rootsError}
+						<div class="rounded-xl border border-destructive/30 bg-destructive/5 p-5" role="alert">
+							<p class="text-sm text-destructive">{rootsError}</p>
+							<button type="button" onclick={loadRoots} class="mt-3 flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm hover:bg-accent"><RefreshCw size={15} /> Try again</button>
+						</div>
+					{:else if roots.length === 0}
+						<div class="rounded-xl border border-dashed border-border bg-card/40 px-6 py-14 text-center">
+							<FolderOpen size={32} class="mx-auto mb-3 text-muted-foreground/60" />
+							<h2 class="font-medium">No shared folders</h2>
+							<p class="mt-1 text-sm text-muted-foreground">No SMB shares are currently available to your account.</p>
+						</div>
+					{:else}
+						<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+							{#each roots as root (root.id)}
+								<button type="button" onclick={() => browse(root, '')} class="group flex min-h-28 items-center gap-4 rounded-xl border border-border bg-card p-5 text-left transition-all hover:-translate-y-0.5 hover:border-blue-500/50 hover:shadow-lg">
+									<span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-blue-500/10 text-blue-500 dark:text-blue-400"><Folder size={25} /></span>
+									<span class="min-w-0 flex-1">
+										<span class="block truncate font-semibold">{root.name}</span>
+										<span class="mt-1 block text-xs text-muted-foreground">Open shared folder</span>
+									</span>
+									<ChevronRight size={18} class="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-blue-500" />
+								</button>
+							{/each}
+						</div>
+					{/if}
+				{:else}
+					<div class="overflow-hidden rounded-xl border border-border bg-card">
+						<div class="flex min-h-14 items-center gap-2 border-b border-border px-3 sm:px-4">
+							<button type="button" onclick={goBack} class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground" aria-label={currentPath ? 'Go to parent folder' : 'Back to shared folders'}><ArrowLeft size={18} /></button>
+							<nav class="flex min-w-0 items-center gap-1 overflow-x-auto whitespace-nowrap text-sm" aria-label="Folder breadcrumbs">
+								<button type="button" onclick={() => activeShare && browse(activeShare, '')} class="max-w-44 truncate rounded-md px-2 py-1 font-medium hover:bg-accent">{activeShare.name}</button>
+								{#each breadcrumbs as crumb (crumb.path)}
+									<ChevronRight size={14} class="shrink-0 text-muted-foreground" />
+									<button type="button" onclick={() => activeShare && browse(activeShare, crumb.path)} class="max-w-44 truncate rounded-md px-2 py-1 text-muted-foreground hover:bg-accent hover:text-foreground" aria-current={crumb.path === currentPath ? 'location' : undefined}>{crumb.label}</button>
+								{/each}
+							</nav>
+						</div>
+
+						{#if browseLoading}
+							<div class="space-y-1 p-3" aria-live="polite" aria-label="Loading folder">
+								{#each [1, 2, 3, 4] as item}
+									<div class="h-12 animate-pulse rounded-lg bg-muted/60" aria-hidden="true"></div>
+								{/each}
+							</div>
+						{:else if browseError}
+							<div class="px-5 py-12 text-center" role="alert">
+								<p class="text-sm text-destructive">{browseError}</p>
+								<button type="button" onclick={() => activeShare && browse(activeShare, currentPath)} class="mx-auto mt-3 flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm hover:bg-accent"><RefreshCw size={15} /> Try again</button>
+							</div>
+						{:else if entries.length === 0}
+							<div class="px-5 py-14 text-center">
+								<FolderOpen size={30} class="mx-auto mb-3 text-muted-foreground/50" />
+								<p class="font-medium">This folder is empty</p>
+								<p class="mt-1 text-sm text-muted-foreground">There are no files or folders here.</p>
+							</div>
+						{:else}
+							<div class="grid grid-cols-[minmax(0,1fr)_auto] border-b border-border bg-muted/30 px-4 py-2 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground sm:grid-cols-[minmax(0,1fr)_7rem_12rem_3rem]">
+								<span>Name</span><span class="hidden sm:block">Size</span><span class="hidden sm:block">Modified</span><span class="sr-only">Action</span>
+							</div>
+							<div class="divide-y divide-border/70">
+								{#each sortedEntries as entry (entry.name)}
+									<div class="grid min-h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 transition-colors hover:bg-accent/40 sm:grid-cols-[minmax(0,1fr)_7rem_12rem_3rem] sm:px-4">
+										{#if entry.is_dir}
+											<button type="button" onclick={() => openFolder(entry)} class="flex min-w-0 items-center gap-3 rounded-md py-2 text-left font-medium hover:text-blue-500">
+												<Folder size={19} class="shrink-0 text-blue-500 dark:text-blue-400" />
+												<span class="min-w-0">
+													<span class="block truncate">{entry.name}</span>
+													<span class="mt-0.5 block text-xs font-normal text-muted-foreground sm:hidden">{formatDate(entry.modified)}</span>
+												</span>
+											</button>
+										{:else}
+											<div class="flex min-w-0 items-center gap-3 py-2">
+												<File size={19} class="shrink-0 text-muted-foreground" />
+												<span class="min-w-0">
+													<span class="block truncate">{entry.name}</span>
+													<span class="mt-0.5 block text-xs text-muted-foreground sm:hidden">{formatBytes(entry.size)} | {formatDate(entry.modified)}</span>
+												</span>
+											</div>
+										{/if}
+										<span class="hidden text-xs tabular-nums text-muted-foreground sm:block">{entry.is_dir ? '-' : formatBytes(entry.size)}</span>
+										<time class="hidden text-xs text-muted-foreground sm:block" datetime={new Date(entry.modified * 1000).toISOString()}>{formatDate(entry.modified)}</time>
+										{#if entry.is_dir}
+											<ChevronRight size={16} class="justify-self-center text-muted-foreground" />
+										{:else}
+											<a href={portalFilesUrl('content', activeShare.id, joinPortalPath(currentPath, entry.name))} download={entry.name} class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground" aria-label={`Download ${entry.name}`} title={`Download ${entry.name}`}><Download size={17} /></a>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</section>
+		{:else if activeTab === 'activity'}
+			<section aria-labelledby="activity-title">
+				<div class="mb-5 flex items-end justify-between gap-4">
+					<div>
+						<p class="mb-1 font-mono text-[0.65rem] uppercase tracking-[0.24em] text-blue-500 dark:text-blue-400">Audit trail</p>
+						<h1 id="activity-title" class="text-2xl font-semibold tracking-tight sm:text-3xl">My activity</h1>
+						<p class="mt-1 text-sm text-muted-foreground">Recent actions recorded for your account.</p>
+					</div>
+					<button type="button" onclick={loadActivity} disabled={activityLoading} class="flex h-9 items-center gap-2 rounded-lg border border-border px-3 text-sm text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50" aria-label="Refresh activity"><RefreshCw size={15} class={activityLoading ? 'animate-spin' : ''} /><span class="hidden sm:inline">Refresh</span></button>
+				</div>
+				<div class="overflow-hidden rounded-xl border border-border bg-card">
+					{#if activityLoading && !activityLoaded}
+						<div class="space-y-2 p-4" aria-live="polite" aria-label="Loading activity">{#each [1, 2, 3, 4] as item}<div class="h-16 animate-pulse rounded-lg bg-muted/60" aria-hidden="true"></div>{/each}</div>
+					{:else if activityError}
+						<div class="px-5 py-12 text-center" role="alert"><p class="text-sm text-destructive">{activityError}</p><button type="button" onclick={loadActivity} class="mt-3 rounded-lg border border-border px-3 py-2 text-sm hover:bg-accent">Try again</button></div>
+					{:else if activityEntries.length === 0}
+						<div class="px-5 py-14 text-center"><Activity size={30} class="mx-auto mb-3 text-muted-foreground/50" /><p class="font-medium">No activity yet</p><p class="mt-1 text-sm text-muted-foreground">Actions for your account will appear here.</p></div>
+					{:else}
+						<ul class="divide-y divide-border">
+							{#each activityEntries as entry, index (`${entry.ts}-${entry.event}-${index}`)}
+								<li class="grid gap-2 px-4 py-4 sm:grid-cols-[10rem_minmax(0,1fr)] sm:px-5">
+									<time class="text-xs tabular-nums text-muted-foreground" datetime={new Date(entry.ts * 1000).toISOString()}>{formatDate(entry.ts)}</time>
+									<div class="min-w-0"><p class="text-sm font-medium">{readableEvent(entry.event)}</p>{#if entry.detail}<p class="mt-1 break-words font-mono text-xs leading-relaxed text-muted-foreground">{entry.detail}</p>{/if}{#if entry.ip}<p class="mt-1 text-[0.68rem] text-muted-foreground/70">From {entry.ip}</p>{/if}</div>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			</section>
+		{:else}
+			<section aria-labelledby="account-title">
+				<div class="mb-5">
+					<p class="mb-1 font-mono text-[0.65rem] uppercase tracking-[0.24em] text-blue-500 dark:text-blue-400">Profile and security</p>
+					<h1 id="account-title" class="text-2xl font-semibold tracking-tight sm:text-3xl">My account</h1>
+					<p class="mt-1 text-sm text-muted-foreground">Review your identity and update your password.</p>
+				</div>
+				{#if identityError}<div class="mb-4 rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive" role="alert">{identityError}</div>{/if}
+				<div class="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+					<div class="rounded-xl border border-border bg-card p-5 sm:p-6">
+						<div class="mb-5 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-500 dark:text-blue-400"><UserRound size={24} /></div>
+						<h2 class="font-semibold">Signed-in identity</h2>
+						<dl class="mt-5 space-y-4 text-sm">
+							<div><dt class="text-xs uppercase tracking-wider text-muted-foreground">Username</dt><dd class="mt-1 font-medium">{identity?.username ?? 'Loading...'}</dd></div>
+							<div><dt class="text-xs uppercase tracking-wider text-muted-foreground">File principal</dt><dd class="mt-1 break-all font-mono text-xs">{identity?.file_principal ?? 'Not available'}</dd></div>
+						</dl>
+					</div>
+					<div class="rounded-xl border border-border bg-card p-5 sm:p-6">
+						<div class="mb-4 flex items-center gap-3"><span class="flex h-10 w-10 items-center justify-center rounded-xl bg-muted text-muted-foreground"><KeyRound size={20} /></span><div><h2 class="font-semibold">Change password</h2><p class="text-xs text-muted-foreground">Use at least 8 characters.</p></div></div>
+						<form onsubmit={(event) => { event.preventDefault(); void changePassword(); }} class="space-y-4">
+							<label class="block"><span class="text-sm font-medium">New password</span><input type="password" bind:value={newPassword} autocomplete="new-password" class="mt-1.5 h-10 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-blue-500/30" /></label>
+							<label class="block"><span class="text-sm font-medium">Confirm password</span><input type="password" bind:value={confirmPassword} autocomplete="new-password" class="mt-1.5 h-10 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-blue-500/30" /></label>
+							{#if passwordError}<p class="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{passwordError}</p>{/if}
+							{#if passwordSuccess}<p class="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600 dark:text-emerald-400" role="status">{passwordSuccess}</p>{/if}
+							<button type="submit" disabled={passwordPending} class="h-10 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50">{passwordPending ? 'Changing...' : 'Change password'}</button>
+						</form>
+					</div>
+				</div>
+			</section>
+		{/if}
+	</div>
+</div>

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -10,6 +10,8 @@
 
 	let settings: Settings | null = $state(null);
 	let tlsDomain = $state('');
+	let filesDomain = $state('');
+	let configuredFilesDomain = $state('');
 	let tlsAcmeEmail = $state('');
 	let tlsAcmeEnabled = $state(false);
 	let acmeStatus: { state: string; message: string; domain?: string; expires?: string; issued?: string; issuer?: string; last_attempt?: string } | null = $state(null);
@@ -30,6 +32,25 @@
 	let tlsChanged = $state(false);
 	let editing = $state(false);
 	const certActive = $derived.by(() => Boolean(acmeStatus && acmeStatus.state === 'success' && tlsAcmeEnabled));
+	const configuredFilesPortalUrl = $derived(configuredFilesDomain ? `https://${configuredFilesDomain}/portal` : '');
+	const filesDomainError = $derived(validateOptionalFilesDomain(filesDomain, tlsDomain));
+
+	function validateOptionalFilesDomain(value: string, mainDomain: string): string | null {
+		const host = value.trim();
+		if (!host) return null;
+		if (!/^[\x00-\x7F]+$/.test(host)) return 'Use an ASCII hostname.';
+		if (host.length > 253) return 'Hostname must be 253 characters or fewer.';
+		if (!host.includes('.')) return 'Enter a fully-qualified hostname containing a dot.';
+		if (host.toLowerCase() === mainDomain.trim().toLowerCase()) return 'Use a hostname different from the main TLS domain.';
+		for (const label of host.split('.')) {
+			if (!label) return 'Hostname labels cannot be empty.';
+			if (label.length > 63) return 'Each hostname label must be 63 characters or fewer.';
+			if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label)) {
+				return 'Use only letters, numbers, and internal hyphens in each label.';
+			}
+		}
+		return null;
+	}
 
 	// DNS-01 plugins compiled into the Caddy binary shipped with NASty
 	// (see `pkgs.caddy.withPlugins` in nixos/modules/nasty.nix). Picking
@@ -50,6 +71,8 @@
 	onMount(async () => {
 		settings = await client.call<Settings>('system.settings.get');
 		tlsDomain = settings?.tls_domain ?? '';
+		filesDomain = settings?.files_domain ?? '';
+		configuredFilesDomain = filesDomain;
 		tlsAcmeEmail = settings?.tls_acme_email ?? '';
 		tlsAcmeEnabled = settings?.tls_acme_enabled ?? false;
 		tlsChallengeType = settings?.tls_challenge_type ?? 'tls-alpn';
@@ -188,6 +211,7 @@
 		const result = await withToast(
 			() => client.call<Settings>('system.settings.update', {
 				tls_domain: tlsDomain || null,
+				files_domain: tlsAcmeEnabled ? filesDomain.trim() : '',
 				tls_acme_email: tlsAcmeEmail || null,
 				tls_acme_enabled: tlsAcmeEnabled,
 				tls_challenge_type: tlsChallengeType,
@@ -205,6 +229,8 @@
 		);
 		if (result !== undefined) {
 			settings = result;
+			filesDomain = result.files_domain ?? '';
+			configuredFilesDomain = filesDomain;
 			tlsChanged = false;
 			editing = false;
 			tlsDnsCredentials = '';
@@ -218,6 +244,12 @@
 
 <div>
 	<p class="text-sm text-muted-foreground mt-0.5">Manage HTTPS certificates for the NASty web interface.</p>
+	{#if configuredFilesPortalUrl}
+		<p class="mt-1 text-sm">
+			Files portal:
+			<a class="font-mono text-primary hover:underline break-all" href={configuredFilesPortalUrl}>{configuredFilesPortalUrl}</a>
+		</p>
+	{/if}
 </div>
 
 <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -268,7 +300,7 @@
 
 		{#if tlsAcmeEnabled}
 			<div class="mb-4">
-				<label for="tls-domain" class="mb-1 block text-xs text-muted-foreground">Domain Name</label>
+				<label for="tls-domain" class="mb-1 block text-xs text-muted-foreground">Main TLS domain</label>
 				<input
 					id="tls-domain"
 					type="text"
@@ -278,6 +310,29 @@
 					placeholder="nasty.example.com"
 				/>
 				<span class="mt-1 block text-xs text-muted-foreground">Must resolve to this machine's public IP.</span>
+			</div>
+
+			<div class="mb-4">
+				<label for="files-domain" class="mb-1 block text-xs text-muted-foreground">
+					Files portal domain <span class="font-normal">(optional)</span>
+				</label>
+				<input
+					id="files-domain"
+					type="text"
+					bind:value={filesDomain}
+					oninput={() => tlsChanged = true}
+					aria-invalid={filesDomainError ? 'true' : undefined}
+					class="w-full rounded-md border bg-background px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring {filesDomainError ? 'border-destructive' : 'border-input'}"
+					placeholder="files.example.com"
+				/>
+				{#if filesDomainError}
+					<span class="mt-1 block text-xs text-destructive">{filesDomainError}</span>
+				{:else}
+					<span class="mt-1 block text-xs text-muted-foreground">
+						Point this hostname's DNS to this box. Users sign in separately on this hostname;
+						session cookies are host-only and are not shared with app subdomains.
+					</span>
+				{/if}
 			</div>
 
 			<div class="mb-4">
@@ -434,7 +489,7 @@
 		{/if}
 
 		<div class="flex gap-2">
-			<Button size="sm" onclick={saveTls} disabled={savingTls || !tlsChanged}>
+			<Button size="sm" onclick={saveTls} disabled={savingTls || !tlsChanged || !!filesDomainError}>
 				{savingTls ? 'Saving…' : 'Save'}
 			</Button>
 			{#if tlsAcmeEnabled && acmeStatus?.state !== 'running'}

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -14,6 +14,7 @@
 		WebauthnConfigInfo,
 		WebauthnCredentialSummary,
 		WebauthnRegisterStart,
+		UserRole,
 	} from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -40,7 +41,7 @@
 	const sortedUsers = $derived.by(() => {
 		const sign = userSortDir === 'asc' ? 1 : -1;
 		// admin > operator > read-only when descending.
-		const roleRank = (r: string) => (r === 'admin' ? 3 : r === 'operator' ? 2 : 1);
+		const roleRank = (r: string) => (r === 'admin' ? 4 : r === 'operator' ? 3 : r === 'readonly' ? 2 : 1);
 		return [...users].sort((a, b) => {
 			let cmp =
 				userSortKey === 'role'
@@ -59,7 +60,23 @@
 	let newUsername = $state('');
 	let newPassword = $state('');
 	let newPasswordConfirm = $state('');
-	let newRole = $state<'admin' | 'readonly' | 'operator'>('readonly');
+	let newRole = $state<UserRole>('readonly');
+	let newFilePrincipal = $state('');
+	const newRoleDescription = $derived(
+		newRole === 'admin' ? 'Full system management access.'
+		: newRole === 'operator' ? 'Can operate storage and services without full administrative access.'
+		: newRole === 'readonly' ? 'Can view management information without making changes.'
+		: 'Personal file portal only. Requires an existing SMB or domain user principal.'
+	);
+	const newFilePrincipalError = $derived.by((): string | null => {
+		if (newRole !== 'user') return null;
+		const principal = newFilePrincipal.trim();
+		if (!principal) return 'A file principal is required.';
+		if (principal.length > 256 || [...principal].some((character) => character.charCodeAt(0) < 32)) {
+			return 'Principal must be 256 characters or fewer and contain no control characters.';
+		}
+		return null;
+	});
 
 	let newTokenName = $state('');
 	let newTokenRole = $state<'admin' | 'readonly' | 'operator'>('operator');
@@ -344,12 +361,14 @@
 		if (!newUsername || !newPassword || !newPasswordConfirm) { createUserTried = true; return; }
 		if (newPassword.length < 8) { createUserTried = true; return; }
 		if (newPassword !== newPasswordConfirm) { createUserTried = true; return; }
+		if (newRole === 'user' && (!newFilePrincipal.trim() || newFilePrincipalError)) { createUserTried = true; return; }
 		createUserTried = false;
 		const ok = await withToast(
 			() => client.call('auth.create_user', {
 				username: newUsername,
 				password: newPassword,
 				role: newRole,
+				...(newRole === 'user' ? { file_principal: newFilePrincipal.trim() } : {}),
 			}),
 			`User "${newUsername}" created`
 		);
@@ -359,6 +378,7 @@
 			newPassword = '';
 			newPasswordConfirm = '';
 			newRole = 'readonly';
+			newFilePrincipal = '';
 			createUserTried = false;
 			await refresh();
 		}
@@ -559,7 +579,7 @@
 
 <h2 class="mb-3 text-xl font-semibold">WebUI Users</h2>
 <p class="mb-4 text-sm text-muted-foreground">
-	Login accounts for the NASty web interface. These control who can manage the system, not who can access shares.
+	Login accounts for system management or the personal file portal. File portal accounts must be bound explicitly to an existing SMB or domain principal.
 </p>
 
 <div class="mb-4">
@@ -598,8 +618,26 @@
 					<option value="readonly">Read Only</option>
 					<option value="admin">Admin</option>
 					<option value="operator">Operator</option>
+					<option value="user">User (Files Portal)</option>
 				</select>
+				<span class="mt-1 block text-xs text-muted-foreground">{newRoleDescription}</span>
 			</div>
+			{#if newRole === 'user'}
+				<div class="mb-4">
+					<Label for="new-file-principal">File Principal {#if !newFilePrincipal.trim() && createUserTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
+					<Input id="new-file-principal" list="file-principal-options" bind:value={newFilePrincipal} placeholder="Select an SMB user or enter DOMAIN\\user" autocomplete="off" aria-invalid={!!newFilePrincipalError && (!!newFilePrincipal.trim() || createUserTried) ? 'true' : undefined} aria-describedby="new-file-principal-help" class="mt-1 {requiredFieldCls(!newFilePrincipal.trim(), createUserTried) || requiredFieldCls(!!newFilePrincipal.trim() && !!newFilePrincipalError)}" />
+					<datalist id="file-principal-options">
+						{#each systemUsers as systemUser (systemUser.username)}
+							<option value={systemUser.username}>{systemUser.username} (local SMB user)</option>
+						{/each}
+					</datalist>
+					{#if newFilePrincipalError && (newFilePrincipal.trim() || createUserTried)}
+						<span id="new-file-principal-help" class="mt-1 block text-xs text-destructive">{newFilePrincipalError}</span>
+					{:else}
+						<span id="new-file-principal-help" class="mt-1 block text-xs text-muted-foreground">Choose a local SMB user above, or enter the exact existing domain principal. The username is never inferred.</span>
+					{/if}
+				</div>
+			{/if}
 			<!-- Stays enabled; createUser validates and triggers the amber
 			     decoration on a missing-field click. -->
 			<Button onclick={createUser}>Create</Button>
@@ -612,11 +650,13 @@
 {:else if users.length === 0}
 	<p class="text-muted-foreground">No users configured.</p>
 {:else}
-	<table class="mb-10 w-full text-sm">
+	<div class="mb-10 overflow-x-auto">
+	<table class="w-full text-sm">
 		<thead>
 			<tr>
 				<SortTh label="Username" active={userSortKey === 'username'} dir={userSortDir} onclick={() => toggleUserSort('username')} />
 				<SortTh label="Role" active={userSortKey === 'role'} dir={userSortDir} onclick={() => toggleUserSort('role')} />
+				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">File Principal</th>
 				<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
 			</tr>
 		</thead>
@@ -627,11 +667,13 @@
 					<td class="p-3">
 						<Badge variant="secondary" class={
 							user.role === 'admin' ? 'bg-blue-950 text-blue-400' :
-							user.role === 'operator' ? 'bg-amber-950 text-amber-400' : ''
+							user.role === 'operator' ? 'bg-amber-950 text-amber-400' :
+							user.role === 'user' ? 'bg-emerald-950 text-emerald-400' : ''
 						}>
-							{user.role === 'admin' ? 'Admin' : user.role === 'operator' ? 'Operator' : 'Read Only'}
+							{user.role === 'admin' ? 'Admin' : user.role === 'operator' ? 'Operator' : user.role === 'user' ? 'User' : 'Read Only'}
 						</Badge>
 					</td>
+					<td class="p-3 font-mono text-xs text-muted-foreground">{user.role === 'user' ? (user.file_principal ?? 'Missing') : '-'}</td>
 					<td class="p-3">
 						<div class="flex gap-2">
 							<Button variant="secondary" size="xs" onclick={() => { pwUser = user.username; pwNew = ''; pwConfirm = ''; }}>
@@ -662,6 +704,7 @@
 			{/each}
 		</tbody>
 	</table>
+	</div>
 {/if}
 
 
@@ -1365,5 +1408,3 @@
 {/if}
 
 {/if}
-
-


### PR DESCRIPTION
## Summary
- add a deny-by-default `User` role explicitly bound to an existing local SMB or domain principal
- add a responsive `/portal` for authorized share browsing/downloads, personal audit activity, password changes, and sign-out
- add an optional ACME-managed files hostname with host-only login cookies and a restricted API/WebSocket surface
- add Admin account-creation support for explicit file-principal selection without exposing `User` through API tokens or OIDC auto-provisioning

## File authorization
- expose only enabled, non-guest SMB shares with explicit non-empty `valid_users` matching the current principal or one of its current NSS/winbind groups
- revalidate principal, passdb membership, groups, share policy, session, and role on every request
- exclude shares with raw Samba parameters because their effective access policy cannot be reproduced safely
- browse and stream through retained descriptors with traversal, symlink, magic-link, mount-crossing, and special-file rejection
- keep the v0.0.15 portal read-only; uploads, edits, deletes, moves, guest-link creation, and management RPCs remain unavailable

## Security
- isolate standard users behind an explicit RPC allowlist and dedicated direct-HTTP access class
- revalidate established WebSocket sessions before RPCs and keep global management notifications away from standard users
- revoke other sessions after password changes and all stale sessions after OIDC role changes
- prevent API-token/user audit-identity collisions and deny password changes from API tokens
- bound principal lookup, directories, path metadata, audit tails, control operations, and download streams
- serialize app/files hostname reservations and reject conflicting routes in both directions

## Verification
- `cargo test --workspace --all-targets`
- `cargo test -p nasty-engine` (208 tests)
- `cargo test -p nasty-sharing` (80 tests)
- `cargo test -p nasty-system` (397 tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run check`
- `npm test` (168 tests)
- `npm run build`
- `git diff --check`

Live NSS/winbind, Samba passdb, and files-host ACME behavior remain covered by Linux/Nix CI rather than this macOS development host.

Closes #475