### PR TITLE
webui: show scrub history in operations

### DIFF
--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -1052,6 +1052,9 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                     target: Some(dev.path.clone()),
                     state: "running".into(),
                     progress_percent: None,
+                    last_run_at: None,
+                    last_duration_secs: None,
+                    last_outcome: None,
                     detail,
                     control: "cancel".into(),
                 });
@@ -1077,6 +1080,12 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                     target: None,
                     state: "running".into(),
                     progress_percent: scrub.progress_percent,
+                    last_run_at: scrub.last_run_at,
+                    last_duration_secs: scrub.last_duration_secs,
+                    last_outcome: scrub
+                        .last_outcome
+                        .map(scrub_outcome_name)
+                        .map(str::to_string),
                     detail,
                     control: "cancel".into(),
                 });
@@ -1087,6 +1096,12 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                     target: None,
                     state: "idle".into(),
                     progress_percent: None,
+                    last_run_at: scrub.last_run_at,
+                    last_duration_secs: scrub.last_duration_secs,
+                    last_outcome: scrub
+                        .last_outcome
+                        .map(scrub_outcome_name)
+                        .map(str::to_string),
                     detail: scrub_idle_detail(&scrub),
                     control: "start".into(),
                 });
@@ -1113,6 +1128,9 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                 target: None,
                 state: st.into(),
                 progress_percent: None,
+                last_run_at: None,
+                last_duration_secs: None,
+                last_outcome: None,
                 detail,
                 control: ctrl.into(),
             });
@@ -1137,6 +1155,9 @@ async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
                 target: None,
                 state: st.into(),
                 progress_percent: None,
+                last_run_at: None,
+                last_duration_secs: None,
+                last_outcome: None,
                 detail,
                 control: ctrl.into(),
             });
@@ -1164,6 +1185,16 @@ fn scrub_idle_detail(s: &nasty_storage::filesystem::ScrubStatus) -> String {
     }
 }
 
+fn scrub_outcome_name(outcome: nasty_storage::filesystem::ScrubOutcome) -> &'static str {
+    use nasty_storage::filesystem::ScrubOutcome;
+    match outcome {
+        ScrubOutcome::Ok => "ok",
+        ScrubOutcome::Errors => "errors",
+        ScrubOutcome::Failed => "failed",
+        ScrubOutcome::Cancelled => "cancelled",
+    }
+}
+
 /// The single informational row shown when no device is evacuating, so the
 /// evacuate operation type is acknowledged rather than silently absent.
 /// Evacuations are started from the Disks device-removal flow.
@@ -1174,6 +1205,9 @@ fn evacuate_idle_row() -> nasty_system::Operation {
         target: None,
         state: "idle".into(),
         progress_percent: None,
+        last_run_at: None,
+        last_duration_secs: None,
+        last_outcome: None,
         detail: "No evacuation in progress".into(),
         control: "none".into(),
     }

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -185,6 +185,15 @@ pub struct Operation {
     /// Progress 0–100 when known (scrub); `None` otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress_percent: Option<f32>,
+    /// Unix seconds when the most recent scrub completed; scrub rows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<i64>,
+    /// Duration of the most recent scrub in seconds; scrub rows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_duration_secs: Option<u64>,
+    /// "ok" | "errors" | "failed" | "cancelled"; scrub rows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_outcome: Option<String>,
     /// Short operator-facing line, e.g. "Evacuating sdc" or "Scrub 42%".
     pub detail: String,
     /// Action the UI offers: "start" (idle scrub) | "cancel"

--- a/webui/src/lib/operations.test.ts
+++ b/webui/src/lib/operations.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { operationDetail } from './operations';
+import type { Operation } from './types';
+
+function scrub(overrides: Partial<Operation> = {}): Operation {
+	return {
+		kind: 'scrub',
+		fs: 'first',
+		state: 'idle',
+		detail: 'Last run clean',
+		control: 'start',
+		...overrides,
+	};
+}
+
+describe('operation details', () => {
+	test('shows scrub age, outcome, and duration', () => {
+		expect(operationDetail(scrub({
+			last_run_at: 1_000,
+			last_duration_secs: 7_260,
+			last_outcome: 'ok',
+		}), 1_000 + 3 * 86400)).toBe('Last run 3d ago · clean · took 2h 1m');
+	});
+
+	test('preserves live and non-scrub details', () => {
+		expect(operationDetail(scrub({ state: 'running', detail: '42%' }), 2_000)).toBe('42%');
+		expect(operationDetail({
+			kind: 'reconcile', fs: 'first', state: 'idle', detail: 'Enabled', control: 'pause',
+		}, 2_000)).toBe('Enabled');
+	});
+
+	test('falls back for old responses without structured history', () => {
+		expect(operationDetail(scrub(), 2_000)).toBe('Last run clean');
+	});
+
+	test('shows a zero-second duration', () => {
+		expect(operationDetail(scrub({
+			last_run_at: 1_000,
+			last_duration_secs: 0,
+			last_outcome: 'ok',
+		}), 1_000)).toBe('Last run 0s ago · clean · took 0s');
+	});
+});

--- a/webui/src/lib/operations.ts
+++ b/webui/src/lib/operations.ts
@@ -1,0 +1,37 @@
+import type { Operation } from './types';
+
+function relativeAge(unixSeconds: number, nowSeconds: number): string {
+	const delta = Math.max(0, Math.floor(nowSeconds) - unixSeconds);
+	if (delta < 60) return `${delta}s ago`;
+	if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+	if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
+	return `${Math.floor(delta / 86400)}d ago`;
+}
+
+function duration(seconds: number): string {
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+export function operationDetail(
+	operation: Operation,
+	nowSeconds = Date.now() / 1000,
+): string {
+	if (operation.kind !== 'scrub' || operation.state === 'running' || operation.last_run_at == null) {
+		return operation.detail;
+	}
+	const outcomeLabels = {
+		ok: 'clean',
+		errors: 'found errors',
+		failed: 'failed',
+		cancelled: 'cancelled',
+	} satisfies Record<NonNullable<Operation['last_outcome']>, string>;
+	const outcome = operation.last_outcome ? outcomeLabels[operation.last_outcome] : 'completed';
+	const took = operation.last_duration_secs != null
+		? ` · took ${duration(operation.last_duration_secs)}`
+		: '';
+	return `Last run ${relativeAge(operation.last_run_at, nowSeconds)} · ${outcome}${took}`;
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -98,6 +98,9 @@ export interface Operation {
 	target?: string | null;
 	state: string; // "running" | "active" | "idle" | "paused"
 	progress_percent?: number | null;
+	last_run_at?: number | null;
+	last_duration_secs?: number | null;
+	last_outcome?: 'ok' | 'errors' | 'failed' | 'cancelled' | null;
 	detail: string;
 	control: string; // "start" | "cancel" | "pause" | "resume" | "none"
 }

--- a/webui/src/routes/operations/+page.svelte
+++ b/webui/src/routes/operations/+page.svelte
@@ -4,6 +4,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { Operation } from '$lib/types';
+	import { operationDetail } from '$lib/operations';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { RefreshCw } from '@lucide/svelte';
@@ -141,7 +142,12 @@
 							{/if}
 						</div>
 						<div class="min-w-0 flex-1">
-							<div class="truncate text-sm">{op.detail}</div>
+							<div
+								class="truncate text-sm"
+								title={op.kind === 'scrub' && op.state !== 'running' && op.last_run_at != null
+									? new Date(op.last_run_at * 1000).toLocaleString()
+									: undefined}
+							>{operationDetail(op)}</div>
 							<div class="text-xs {stateClass(op.state)}">{op.state}</div>
 							{#if op.progress_percent != null}
 								<div class="mt-1 h-1.5 w-full overflow-hidden rounded bg-muted">


### PR DESCRIPTION
## Summary

- expose the latest scrub timestamp, duration, and outcome through `system.operations.list`
- show localized relative scrub history on idle Operations rows while preserving live progress
- cover history formatting and backward-compatible responses with unit tests

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run check`
- `npm test`
- `npm run build`