### PR TITLE
Harden upload, rollback, and session state safety

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1955,6 +1955,17 @@ async fn files_upload_handler(
     };
 
     let req_path = params.get("path").map(|s| s.as_str()).unwrap_or("");
+    let overwrite = match params.get("overwrite").map(String::as_str) {
+        None | Some("false") => false,
+        Some("true") => true,
+        Some(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "overwrite must be true or false"})),
+            )
+                .into_response();
+        }
+    };
     let dir = match safe_path_for_request(req_path, &authenticated, "files.upload") {
         Ok(p) => p,
         Err(status) => {
@@ -2004,12 +2015,46 @@ async fn files_upload_handler(
     }
 
     let dest = dir.join(&file_name);
-    let temp = dir.join(format!(
-        ".{file_name}.nasty-upload-{}",
-        uuid::Uuid::new_v4()
-    ));
+    match tokio::fs::symlink_metadata(&dest).await {
+        Ok(meta) => {
+            if meta.is_dir() {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "Destination is a directory",
+                        "overwrite_allowed": false,
+                    })),
+                )
+                    .into_response();
+            }
+            if !overwrite {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "Destination already exists",
+                        "overwrite_allowed": true,
+                    })),
+                )
+                    .into_response();
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+                .into_response();
+        }
+    }
 
-    let mut file = match tokio::fs::File::create(&temp).await {
+    let temp = dir.join(format!(".nasty-upload-{}", uuid::Uuid::new_v4()));
+
+    let file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+    {
         Ok(f) => f,
         Err(e) => {
             return (
@@ -2019,6 +2064,8 @@ async fn files_upload_handler(
                 .into_response();
         }
     };
+    let mut file = tokio::fs::File::from_std(file);
+    let mut temp_guard = UploadTempGuard::new(temp.clone(), &file);
 
     let mut total: u64 = 0;
     let t0 = std::time::Instant::now();
@@ -2056,14 +2103,32 @@ async fn files_upload_handler(
         )
             .into_response();
     }
-    drop(file);
-    if let Err(e) = tokio::fs::rename(&temp, &dest).await {
-        let _ = tokio::fs::remove_file(&temp).await;
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": format!("Failed to finalize upload: {e}")})),
-        )
-            .into_response();
+    match publish_upload(&temp, &dest, overwrite).await {
+        Ok(UploadPublish::Published) => temp_guard.disarm(),
+        Ok(UploadPublish::Conflict) => {
+            let overwrite_allowed = tokio::fs::symlink_metadata(&dest)
+                .await
+                .is_ok_and(|meta| !meta.is_dir());
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": if overwrite_allowed {
+                        "Destination already exists"
+                    } else {
+                        "Destination is a directory"
+                    },
+                    "overwrite_allowed": overwrite_allowed,
+                })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Failed to finalize upload: {e}")})),
+            )
+                .into_response();
+        }
     }
 
     let elapsed = t0.elapsed();
@@ -2076,7 +2141,10 @@ async fn files_upload_handler(
         "files.upload",
         &authenticated.session.username,
         &authenticated.client_ip,
-        &format!("path={} bytes={total}", dest.display()),
+        &format!(
+            "path={} bytes={total} overwrite={overwrite}",
+            dest.display()
+        ),
     );
     let _ = state.events.send("files".to_string());
 
@@ -2089,6 +2157,99 @@ async fn files_upload_handler(
         })),
     )
         .into_response()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UploadPublish {
+    Published,
+    Conflict,
+}
+
+struct UploadTempGuard {
+    path: std::path::PathBuf,
+    active: bool,
+    #[cfg(target_os = "linux")]
+    fd: std::os::fd::RawFd,
+}
+
+impl UploadTempGuard {
+    fn new(path: std::path::PathBuf, _file: &tokio::fs::File) -> Self {
+        Self {
+            path,
+            active: true,
+            #[cfg(target_os = "linux")]
+            fd: std::os::fd::AsRawFd::as_raw_fd(_file),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for UploadTempGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        #[cfg(target_os = "linux")]
+        let path = std::fs::read_link(format!("/proc/self/fd/{}", self.fd))
+            .unwrap_or_else(|_| self.path.clone());
+        #[cfg(not(target_os = "linux"))]
+        let path = &self.path;
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Publish a fully-written sibling temporary file. The default path uses a
+/// hard link so destination creation is atomic and cannot replace an entry
+/// created after the handler's early collision check.
+async fn publish_upload(
+    temp: &std::path::Path,
+    dest: &std::path::Path,
+    overwrite: bool,
+) -> std::io::Result<UploadPublish> {
+    if overwrite {
+        return match tokio::fs::rename(temp, dest).await {
+            Ok(()) => Ok(UploadPublish::Published),
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::AlreadyExists
+                        | std::io::ErrorKind::IsADirectory
+                        | std::io::ErrorKind::NotADirectory
+                ) =>
+            {
+                let _ = tokio::fs::remove_file(temp).await;
+                Ok(UploadPublish::Conflict)
+            }
+            Err(e) => {
+                let _ = tokio::fs::remove_file(temp).await;
+                Err(e)
+            }
+        };
+    }
+
+    match tokio::fs::hard_link(temp, dest).await {
+        Ok(()) => {
+            if let Err(e) = tokio::fs::remove_file(temp).await {
+                tracing::warn!(
+                    "upload published at {} but temporary link {} could not be removed: {e}",
+                    dest.display(),
+                    temp.display()
+                );
+            }
+            Ok(UploadPublish::Published)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = tokio::fs::remove_file(temp).await;
+            Ok(UploadPublish::Conflict)
+        }
+        Err(e) => {
+            let _ = tokio::fs::remove_file(temp).await;
+            Err(e)
+        }
+    }
 }
 
 /// Create a directory.  POST /api/files/mkdir?path=first/subdir/newdir
@@ -4490,6 +4651,120 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
             ),
         }
     });
+}
+
+#[cfg(test)]
+mod upload_tests {
+    use super::{UploadPublish, UploadTempGuard, publish_upload};
+
+    #[test]
+    fn temp_guard_removes_abandoned_upload() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp");
+        std::fs::write(&temp, b"partial").unwrap();
+
+        let file =
+            tokio::fs::File::from_std(std::fs::OpenOptions::new().write(true).open(&temp).unwrap());
+        drop(UploadTempGuard::new(temp.clone(), &file));
+
+        assert!(!temp.exists());
+    }
+
+    #[tokio::test]
+    async fn publish_without_overwrite_creates_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp");
+        let dest = dir.path().join("dest");
+        tokio::fs::write(&temp, b"new").await.unwrap();
+
+        assert_eq!(
+            publish_upload(&temp, &dest, false).await.unwrap(),
+            UploadPublish::Published
+        );
+        assert_eq!(tokio::fs::read(&dest).await.unwrap(), b"new");
+        assert!(!temp.exists());
+    }
+
+    #[tokio::test]
+    async fn publish_without_overwrite_preserves_existing_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp");
+        let dest = dir.path().join("dest");
+        tokio::fs::write(&temp, b"new").await.unwrap();
+        tokio::fs::write(&dest, b"old").await.unwrap();
+
+        assert_eq!(
+            publish_upload(&temp, &dest, false).await.unwrap(),
+            UploadPublish::Conflict
+        );
+        assert_eq!(tokio::fs::read(&dest).await.unwrap(), b"old");
+        assert!(!temp.exists());
+    }
+
+    #[tokio::test]
+    async fn publish_with_overwrite_atomically_replaces_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp");
+        let dest = dir.path().join("dest");
+        tokio::fs::write(&temp, b"new").await.unwrap();
+        tokio::fs::write(&dest, b"old").await.unwrap();
+
+        assert_eq!(
+            publish_upload(&temp, &dest, true).await.unwrap(),
+            UploadPublish::Published
+        );
+        assert_eq!(tokio::fs::read(&dest).await.unwrap(), b"new");
+        assert!(!temp.exists());
+    }
+
+    #[tokio::test]
+    async fn publish_with_overwrite_does_not_replace_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let temp = dir.path().join("temp");
+        let dest = dir.path().join("dest");
+        tokio::fs::write(&temp, b"new").await.unwrap();
+        tokio::fs::create_dir(&dest).await.unwrap();
+
+        assert_eq!(
+            publish_upload(&temp, &dest, true).await.unwrap(),
+            UploadPublish::Conflict
+        );
+        assert!(dest.is_dir());
+        assert!(!temp.exists());
+    }
+
+    #[tokio::test]
+    async fn concurrent_publish_without_overwrite_has_one_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first");
+        let second = dir.path().join("second");
+        let dest = dir.path().join("dest");
+        tokio::fs::write(&first, b"first").await.unwrap();
+        tokio::fs::write(&second, b"second").await.unwrap();
+
+        let (a, b) = tokio::join!(
+            publish_upload(&first, &dest, false),
+            publish_upload(&second, &dest, false)
+        );
+        let results = [a.unwrap(), b.unwrap()];
+
+        assert_eq!(
+            results
+                .iter()
+                .filter(|&&r| r == UploadPublish::Published)
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|&&r| r == UploadPublish::Conflict)
+                .count(),
+            1
+        );
+        let data = tokio::fs::read(&dest).await.unwrap();
+        assert!(data == b"first" || data == b"second");
+    }
 }
 
 #[cfg(test)]

--- a/engine/nasty-system/src/network.rs
+++ b/engine/nasty-system/src/network.rs
@@ -707,6 +707,10 @@ pub struct NetworkService {
     /// performs the rollback). Wrapped in `Arc` so spawned tasks can
     /// remove their own entry on completion.
     transactions: std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, PendingTxn>>>,
+    /// Serializes network updates, confirmation, and rollback execution.
+    /// Only one unconfirmed update may exist because its rollback snapshot
+    /// is stored at a single well-known path.
+    transaction_lifecycle: std::sync::Arc<tokio::sync::Mutex<()>>,
 }
 
 struct PendingTxn {
@@ -718,7 +722,9 @@ struct PendingTxn {
     /// Why the server scheduled this rollback (human-readable). Same
     /// rationale as `revert_at_unix`.
     risk_reason: String,
-    cancel: tokio::sync::oneshot::Sender<()>,
+    /// Present while the confirmation window is active. Once timeout wins,
+    /// this becomes `None` so a failed rollback cannot later be confirmed.
+    cancel: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 /// Snapshot of one pending rollback, returned by
@@ -744,6 +750,7 @@ impl NetworkService {
             transactions: std::sync::Arc::new(tokio::sync::Mutex::new(
                 std::collections::HashMap::new(),
             )),
+            transaction_lifecycle: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -762,6 +769,21 @@ impl NetworkService {
         request: UpdateRequest,
         mgmt_iface: Option<String>,
     ) -> Result<UpdateResponse, String> {
+        let _lifecycle = self.transaction_lifecycle.lock().await;
+        if let Some(txn_id) = self.transactions.lock().await.keys().next().cloned() {
+            return Err(format!(
+                "network transaction {txn_id} is still awaiting confirmation"
+            ));
+        }
+        if tokio::fs::symlink_metadata(PENDING_REVERT_PATH)
+            .await
+            .is_ok()
+        {
+            return Err(
+                "a pending network rollback snapshot requires recovery before another update"
+                    .to_string(),
+            );
+        }
         let config = request.config;
 
         // Validate input. `Inherit` is allowed here — `resolve_inherit`
@@ -945,22 +967,36 @@ impl NetworkService {
     /// the pending-revert file. Returns an error if the txn_id is unknown
     /// (already confirmed, already reverted, or never existed).
     pub async fn confirm(&self, txn_id: &str) -> Result<(), String> {
-        let removed = self.transactions.lock().await.remove(txn_id);
-        match removed {
-            Some(txn) => {
-                // Best-effort cancel: if the rollback task already started
-                // executing, the receive end is gone — that's OK, we just
-                // race to clean up below.
-                let _ = txn.cancel.send(());
-                let _ = tokio::fs::remove_file(PENDING_REVERT_PATH).await;
-                info!("Network txn {txn_id} confirmed");
-                // NM keyfiles already persisted as part of the apply
-                // that scheduled this rollback. No explicit rebuild
-                // step needed on confirm.
-                Ok(())
+        let _lifecycle = self.transaction_lifecycle.lock().await;
+        {
+            let transactions = self.transactions.lock().await;
+            let Some(txn) = transactions.get(txn_id) else {
+                return Err(format!("unknown or already-completed txn_id {txn_id}"));
+            };
+            if txn.cancel.is_none() {
+                return Err(format!(
+                    "network txn {txn_id} rollback is already in progress or failed"
+                ));
             }
-            None => Err(format!("unknown or already-completed txn_id {txn_id}")),
         }
+        if let Err(e) = tokio::fs::remove_file(PENDING_REVERT_PATH).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(format!("remove pending network rollback snapshot: {e}"));
+        }
+        let txn = self
+            .transactions
+            .lock()
+            .await
+            .remove(txn_id)
+            .expect("transaction checked while lifecycle lock is held");
+        if let Some(cancel) = txn.cancel {
+            let _ = cancel.send(());
+        }
+        info!("Network txn {txn_id} confirmed");
+        // NM keyfiles already persisted as part of the apply that scheduled
+        // this rollback. No explicit rebuild step needed on confirm.
+        Ok(())
     }
 
     /// Called once at engine startup. If a `pending-revert` file exists, the
@@ -1010,29 +1046,49 @@ impl NetworkService {
     ) {
         let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
         let transactions = std::sync::Arc::clone(&self.transactions);
+        let transaction_lifecycle = std::sync::Arc::clone(&self.transaction_lifecycle);
         let txn_id_for_task = txn_id.clone();
-        tokio::spawn(async move {
-            let timer = tokio::time::sleep(std::time::Duration::from_secs(secs));
-            tokio::pin!(timer);
-            tokio::select! {
-                _ = &mut timer => {
-                    warn!("Network txn {txn_id_for_task} not confirmed in {secs}s — rolling back");
-                    perform_rollback(&txn_id_for_task).await;
-                }
-                _ = cancel_rx => {
-                    // Confirmed; nothing to do, confirm() already cleaned up.
-                }
-            }
-            transactions.lock().await.remove(&txn_id_for_task);
-        });
         self.transactions.lock().await.insert(
             txn_id,
             PendingTxn {
                 revert_at_unix,
                 risk_reason,
-                cancel: cancel_tx,
+                cancel: Some(cancel_tx),
             },
         );
+        tokio::spawn(async move {
+            let timer = tokio::time::sleep(std::time::Duration::from_secs(secs));
+            tokio::pin!(timer);
+            tokio::select! {
+                _ = &mut timer => {
+                    let _lifecycle = transaction_lifecycle.lock().await;
+                    let should_rollback = {
+                        let mut transactions = transactions.lock().await;
+                        transactions.get_mut(&txn_id_for_task).is_some_and(|txn| {
+                            txn.cancel = None;
+                            true
+                        })
+                    };
+                    if should_rollback {
+                        warn!("Network txn {txn_id_for_task} not confirmed in {secs}s — rolling back");
+                        match perform_rollback(&txn_id_for_task).await {
+                            Ok(()) => {
+                                transactions.lock().await.remove(&txn_id_for_task);
+                            }
+                            Err(error) => {
+                                warn!("rollback {txn_id_for_task}: {error}");
+                                if let Some(txn) = transactions.lock().await.get_mut(&txn_id_for_task) {
+                                    txn.risk_reason = format!("Automatic rollback failed: {error}");
+                                }
+                            }
+                        }
+                    }
+                }
+                _ = cancel_rx => {
+                    // Confirmed; nothing to do, confirm() already cleaned up.
+                }
+            }
+        });
     }
 
     /// List physical interfaces (for UI to show available interfaces).
@@ -1174,35 +1230,34 @@ impl NetworkService {
 /// Top-level helper for the rollback timer. Reads the pending-revert file,
 /// applies it, and removes it. Best-effort — failures are logged but don't
 /// panic the spawned task.
-async fn perform_rollback(txn_id: &str) {
+async fn perform_rollback(txn_id: &str) -> Result<(), String> {
     let contents = match tokio::fs::read(PENDING_REVERT_PATH).await {
         Ok(c) => c,
         Err(e) => {
-            warn!("rollback {txn_id}: pending-revert file disappeared: {e}");
-            return;
+            return Err(format!("pending-revert file disappeared: {e}"));
         }
     };
     let prev: NetworkConfig = match serde_json::from_slice(&contents) {
         Ok(c) => c,
         Err(e) => {
-            warn!("rollback {txn_id}: unparseable pending-revert: {e}");
-            return;
+            return Err(format!("unparseable pending-revert: {e}"));
         }
     };
     if let Err(e) = persist_config(&prev).await {
-        warn!("rollback {txn_id}: persist failed: {e}");
-        return;
+        return Err(format!("persist failed: {e}"));
     }
     // Rollback runs from a tokio task without a session — no mgmt
     // iface to prefer. Same as `restore_pending_revert`: pre-existing
     // masters in the rolled-back config fall back to first-member
     // MAC, which matches what was applied originally.
     if let Err(e) = apply_config(&prev, None).await {
-        warn!("rollback {txn_id}: apply failed: {e}");
-        return;
+        return Err(format!("apply failed: {e}"));
     }
-    let _ = tokio::fs::remove_file(PENDING_REVERT_PATH).await;
+    tokio::fs::remove_file(PENDING_REVERT_PATH)
+        .await
+        .map_err(|e| format!("remove pending-revert after apply: {e}"))?;
     warn!("rollback {txn_id}: completed; previous config restored");
+    Ok(())
 }
 
 fn new_txn_id() -> String {

--- a/webui/src/lib/client.test.ts
+++ b/webui/src/lib/client.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getClient, registerSessionReset, resetClient } from './client';
+
+beforeEach(() => resetClient());
+
+describe('client session lifecycle', () => {
+	test('creates a fresh client after reset', () => {
+		const first = getClient();
+		expect(getClient()).toBe(first);
+
+		resetClient();
+
+		expect(getClient()).not.toBe(first);
+	});
+
+	test('runs registered session reset handlers', () => {
+		const reset = vi.fn();
+		const unregister = registerSessionReset(reset);
+
+		resetClient();
+		expect(reset).toHaveBeenCalledOnce();
+
+		unregister();
+		resetClient();
+		expect(reset).toHaveBeenCalledOnce();
+	});
+});

--- a/webui/src/lib/client.ts
+++ b/webui/src/lib/client.ts
@@ -2,6 +2,8 @@ import { NastyClient } from './rpc';
 
 /** Singleton RPC client shared across all pages */
 let instance: NastyClient | null = null;
+const sessionResetHandlers = new Set<() => void>();
+let sessionGeneration = 0;
 
 export function getClient(): NastyClient {
 	if (!instance) {
@@ -13,8 +15,20 @@ export function getClient(): NastyClient {
 }
 
 export function resetClient() {
+	sessionGeneration++;
 	if (instance) {
 		instance.disconnect();
 		instance = null;
 	}
+	for (const reset of sessionResetHandlers) reset();
+}
+
+export function getSessionGeneration(): number {
+	return sessionGeneration;
+}
+
+/** Register state that must be cleared when the authenticated session ends. */
+export function registerSessionReset(reset: () => void): () => void {
+	sessionResetHandlers.add(reset);
+	return () => sessionResetHandlers.delete(reset);
 }

--- a/webui/src/lib/components/ConfirmDangerousDialog.svelte
+++ b/webui/src/lib/components/ConfirmDangerousDialog.svelte
@@ -15,13 +15,17 @@
 	let matches = $derived(inputValue === confirmDangerousState.expectedValue);
 
 	$effect(() => {
-		if (confirmDangerousState.open) {
-			inputValue = '';
-		}
+		void confirmDangerousState.open;
+		inputValue = '';
 	});
 </script>
 
-<Dialog bind:open={confirmDangerousState.open}>
+<Dialog
+	open={confirmDangerousState.open}
+	onOpenChange={(open) => {
+		if (!open && confirmDangerousState.open) confirmDangerousRespond(false);
+	}}
+>
 	<DialogContent class="max-w-lg">
 		<DialogHeader>
 			<DialogTitle>{confirmDangerousState.title}</DialogTitle>

--- a/webui/src/lib/components/ConfirmDialog.svelte
+++ b/webui/src/lib/components/ConfirmDialog.svelte
@@ -11,7 +11,12 @@
 	import { Button } from '$lib/components/ui/button';
 </script>
 
-<Dialog bind:open={confirmState.open}>
+<Dialog
+	open={confirmState.open}
+	onOpenChange={(open) => {
+		if (!open && confirmState.open) confirmRespond(false);
+	}}
+>
 	<DialogContent class="max-w-lg">
 		<DialogHeader>
 			<DialogTitle>{confirmState.title}</DialogTitle>

--- a/webui/src/lib/components/UnlockFsDialog.svelte
+++ b/webui/src/lib/components/UnlockFsDialog.svelte
@@ -36,14 +36,12 @@
 		unlockFsRespond(false);
 	}
 
-	// Wipe the passphrase whenever the dialog re-opens for a different
-	// filesystem so a typed-but-not-submitted secret doesn't leak
-	// across opens.
+	// Wipe the passphrase whenever the dialog opens or closes so session
+	// reset cannot leave a typed secret in this persistent component.
 	$effect(() => {
-		if (unlockFsState.open) {
-			passphrase = '';
-			submitting = false;
-		}
+		void unlockFsState.open;
+		passphrase = '';
+		submitting = false;
 	});
 </script>
 

--- a/webui/src/lib/confirm-dangerous.svelte.ts
+++ b/webui/src/lib/confirm-dangerous.svelte.ts
@@ -4,6 +4,8 @@
  *   if (!await confirmDangerous('Delete X?', 'Type "X" to confirm', 'X')) return;
  */
 
+import { registerSessionReset } from './client';
+
 interface ConfirmDangerousState {
 	open: boolean;
 	title: string;
@@ -22,6 +24,7 @@ export const confirmDangerousState = $state<ConfirmDangerousState>({
 
 export function confirmDangerous(title: string, message: string, expectedValue: string): Promise<boolean> {
 	return new Promise((resolve) => {
+		confirmDangerousState.resolve?.(false);
 		confirmDangerousState.title = title;
 		confirmDangerousState.message = message;
 		confirmDangerousState.expectedValue = expectedValue;
@@ -34,4 +37,9 @@ export function confirmDangerousRespond(value: boolean) {
 	confirmDangerousState.open = false;
 	confirmDangerousState.resolve?.(value);
 	confirmDangerousState.resolve = null;
+	confirmDangerousState.title = '';
+	confirmDangerousState.message = '';
+	confirmDangerousState.expectedValue = '';
 }
+
+registerSessionReset(() => confirmDangerousRespond(false));

--- a/webui/src/lib/confirm.svelte.ts
+++ b/webui/src/lib/confirm.svelte.ts
@@ -4,6 +4,8 @@
  *   if (!await confirm('Title', 'Message')) return;
  */
 
+import { registerSessionReset } from './client';
+
 interface ConfirmState {
 	open: boolean;
 	title: string;
@@ -29,6 +31,7 @@ interface ConfirmOptions {
 
 export function confirm(title: string, message?: string, options?: ConfirmOptions): Promise<boolean> {
 	return new Promise((resolve) => {
+		confirmState.resolve?.(false);
 		confirmState.title = title;
 		confirmState.message = message ?? '';
 		confirmState.confirmLabel = options?.confirmLabel ?? 'Confirm';
@@ -42,4 +45,10 @@ export function confirmRespond(value: boolean) {
 	confirmState.open = false;
 	confirmState.resolve?.(value);
 	confirmState.resolve = null;
+	confirmState.title = '';
+	confirmState.message = '';
+	confirmState.confirmLabel = 'Confirm';
+	confirmState.cancelLabel = 'Cancel';
 }
+
+registerSessionReset(() => confirmRespond(false));

--- a/webui/src/lib/dc.svelte.ts
+++ b/webui/src/lib/dc.svelte.ts
@@ -3,31 +3,41 @@
  * small set of top-level lifecycle handlers. Per-principal CRUD (users,
  * groups, computers) lives in DcPanel.svelte itself, same split as
  * domain.svelte.ts (status/join/leave) vs. the SMB users/groups page. */
-import { getClient } from '$lib/client';
+import { getClient, getSessionGeneration, registerSessionReset } from '$lib/client';
 import { withToast, info } from '$lib/toast.svelte';
 import type { DcStatus, DcPrincipal } from '$lib/types';
 
-const client = getClient();
+function initialDcState() {
+	return {
+		status: null as DcStatus | null,
+		loading: true,
+		provisioning: false,
+		// provision form
+		realm: '',
+		adminPassword: '',
+		dnsForwarder: '',
+		// panel data (users/groups/computers tabs)
+		users: [] as DcPrincipal[],
+		groups: [] as DcPrincipal[],
+		computers: [] as DcPrincipal[],
+	};
+}
 
-export const dc = $state({
-	status: null as DcStatus | null,
-	loading: true,
-	provisioning: false,
-	// provision form
-	realm: '',
-	adminPassword: '',
-	dnsForwarder: '',
-	// panel data (users/groups/computers tabs)
-	users: [] as DcPrincipal[],
-	groups: [] as DcPrincipal[],
-	computers: [] as DcPrincipal[],
-});
+export const dc = $state(initialDcState());
+
+export function resetDcState() {
+	Object.assign(dc, initialDcState());
+}
+
+registerSessionReset(resetDcState);
 
 export async function dcRefresh() {
+	const generation = getSessionGeneration();
 	try {
-		dc.status = await client.call<DcStatus>('dc.status');
+		const status = await getClient().call<DcStatus>('dc.status');
+		if (generation === getSessionGeneration()) dc.status = status;
 	} catch { /* engine without dc support */ }
-	dc.loading = false;
+	if (generation === getSessionGeneration()) dc.loading = false;
 }
 
 export async function dcProvision(): Promise<boolean> {
@@ -39,7 +49,7 @@ export async function dcProvision(): Promise<boolean> {
 	};
 	if (dc.dnsForwarder.trim()) params.dns_forwarder = dc.dnsForwarder.trim();
 	const res = await withToast(
-		() => client.call<{ status: DcStatus; warnings: string[] }>('dc.provision', params),
+		() => getClient().call<{ status: DcStatus; warnings: string[] }>('dc.provision', params),
 		'Domain provisioned',
 	);
 	dc.adminPassword = '';
@@ -56,7 +66,7 @@ export async function dcProvision(): Promise<boolean> {
 
 export async function dcDemote(realmConfirmation: string): Promise<boolean> {
 	const ok = await withToast(
-		() => client.call('dc.demote', { realm_confirmation: realmConfirmation }),
+		() => getClient().call('dc.demote', { realm_confirmation: realmConfirmation }),
 		'Domain demoted',
 	);
 	if (ok !== undefined) await dcRefresh();
@@ -65,6 +75,7 @@ export async function dcDemote(realmConfirmation: string): Promise<boolean> {
 
 export async function dcLoadPrincipals() {
 	try {
+		const client = getClient();
 		[dc.users, dc.groups, dc.computers] = await Promise.all([
 			client.call<DcPrincipal[]>('dc.user.list'),
 			client.call<DcPrincipal[]>('dc.group.list'),

--- a/webui/src/lib/domain.svelte.ts
+++ b/webui/src/lib/domain.svelte.ts
@@ -1,27 +1,37 @@
 /** AD membership state + handlers (Settings → Directory card). */
-import { getClient } from '$lib/client';
+import { getClient, getSessionGeneration, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import { confirm } from '$lib/confirm.svelte';
 import type { DomainStatus, DomainPrincipal } from '$lib/types';
 
-const client = getClient();
+function initialDomainState() {
+	return {
+		status: null as DomainStatus | null,
+		loading: true,
+		joining: false,
+		// join form
+		realm: '',
+		username: '',
+		password: '',
+		ou: '',
+	};
+}
 
-export const domain = $state({
-	status: null as DomainStatus | null,
-	loading: true,
-	joining: false,
-	// join form
-	realm: '',
-	username: '',
-	password: '',
-	ou: '',
-});
+export const domain = $state(initialDomainState());
+
+export function resetDomainState() {
+	Object.assign(domain, initialDomainState());
+}
+
+registerSessionReset(resetDomainState);
 
 export async function domainRefresh() {
+	const generation = getSessionGeneration();
 	try {
-		domain.status = await client.call<DomainStatus>('domain.status');
+		const status = await getClient().call<DomainStatus>('domain.status');
+		if (generation === getSessionGeneration()) domain.status = status;
 	} catch { /* engine without domain support */ }
-	domain.loading = false;
+	if (generation === getSessionGeneration()) domain.loading = false;
 }
 
 export async function domainJoin() {
@@ -33,7 +43,7 @@ export async function domainJoin() {
 		password: domain.password,
 	};
 	if (domain.ou.trim()) params.ou = domain.ou.trim();
-	const ok = await withToast(() => client.call<DomainStatus>('domain.join', params), 'Joined domain');
+	const ok = await withToast(() => getClient().call<DomainStatus>('domain.join', params), 'Joined domain');
 	domain.password = '';
 	if (ok !== undefined) {
 		domain.status = ok;
@@ -50,7 +60,7 @@ export async function domainLeave(force: boolean, username?: string, password?: 
 			: 'The computer account will be removed from AD. Shares referencing domain users keep their entries but domain logons stop working.'
 	)) return;
 	const params: Record<string, unknown> = force ? { force: true } : { username, password };
-	await withToast(() => client.call('domain.leave', params), 'Left domain');
+	await withToast(() => getClient().call('domain.leave', params), 'Left domain');
 	await domainRefresh();
 }
 
@@ -58,7 +68,7 @@ export async function domainLeave(force: boolean, username?: string, password?: 
 export async function domainSearchUsers(prefix: string): Promise<DomainPrincipal[]> {
 	if (prefix.trim().length < 2 || !domain.status?.joined) return [];
 	try {
-		return await client.call<DomainPrincipal[]>('domain.user.list', { prefix: prefix.trim() });
+		return await getClient().call<DomainPrincipal[]>('domain.user.list', { prefix: prefix.trim() });
 	} catch {
 		return [];
 	}

--- a/webui/src/lib/rollbackState.svelte.test.ts
+++ b/webui/src/lib/rollbackState.svelte.test.ts
@@ -2,19 +2,142 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the underlying RPC client so we can drive `loadPendingRollback`
 // deterministically — no real WebSocket needed for these tests.
-const callMock = vi.fn();
+const { callMock, toastErrorMock } = vi.hoisted(() => ({
+	callMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
 vi.mock('./client', () => ({
 	getClient: () => ({ call: callMock }),
+	getSessionGeneration: () => 0,
+	registerSessionReset: vi.fn(),
 }));
 vi.mock('./toast.svelte', () => ({
-	withToast: async (fn: () => Promise<unknown>) => fn(),
+	withToast: async (fn: () => Promise<unknown>) => {
+		try {
+			return await fn();
+		} catch {
+			return undefined;
+		}
+	},
+	error: toastErrorMock,
 }));
 
-import { loadPendingRollback, rollbackState } from './rollbackState.svelte';
+import { applyNetworkUpdate, confirmRollback, loadPendingRollback, recoverPendingRollback, rollbackState } from './rollbackState.svelte';
 
 beforeEach(() => {
 	callMock.mockReset();
+	toastErrorMock.mockReset();
 	rollbackState.clear();
+});
+
+describe('confirmRollback', () => {
+	it('clears matching state after successful confirmation', async () => {
+		rollbackState.set({ txnId: 'txn-1', revertAtUnix: 2000, riskReason: null });
+		callMock.mockResolvedValueOnce(undefined);
+
+		await confirmRollback();
+
+		expect(callMock).toHaveBeenCalledWith('system.network.confirm', { txn_id: 'txn-1' });
+		expect(rollbackState.pending).toBeNull();
+		expect(rollbackState.confirmationError).toBeNull();
+	});
+
+	it('retains the transaction and error when confirmation fails', async () => {
+		rollbackState.set({ txnId: 'txn-1', revertAtUnix: 2000, riskReason: null });
+		callMock.mockRejectedValueOnce({ code: -32000, message: 'WebSocket disconnected' });
+
+		await confirmRollback();
+
+		expect(rollbackState.pending?.txnId).toBe('txn-1');
+		expect(rollbackState.confirmationError).toBe('WebSocket disconnected');
+		expect(toastErrorMock).toHaveBeenCalledWith('WebSocket disconnected');
+	});
+
+	it('preserves an error when the same transaction reloads', async () => {
+		rollbackState.set({ txnId: 'txn-1', revertAtUnix: 2000, riskReason: null });
+		callMock.mockRejectedValueOnce(new Error('Request timed out'));
+		await confirmRollback();
+		callMock.mockResolvedValueOnce([
+			{ txn_id: 'txn-1', revert_at_unix: 2100, risk_reason: 'management changed' },
+		]);
+
+		await loadPendingRollback();
+
+		expect(rollbackState.confirmationError).toBe('Request timed out');
+		expect(rollbackState.pending?.revertAtUnix).toBe(2100);
+	});
+
+	it('does not attach a stale failure to a newer transaction', async () => {
+		let rejectConfirmation: (error: unknown) => void = () => {};
+		callMock.mockImplementationOnce(() => new Promise((_, reject) => {
+			rejectConfirmation = reject;
+		}));
+		rollbackState.set({ txnId: 'txn-1', revertAtUnix: 2000, riskReason: null });
+		const confirmation = confirmRollback();
+		rollbackState.set({ txnId: 'txn-2', revertAtUnix: 3000, riskReason: null });
+		rejectConfirmation(new Error('old failure'));
+
+		await confirmation;
+
+		expect(rollbackState.pending?.txnId).toBe('txn-2');
+		expect(rollbackState.confirmationError).toBeNull();
+		expect(toastErrorMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('applyNetworkUpdate', () => {
+	it('blocks overlapping updates while a rollback decision is pending', async () => {
+		rollbackState.set({
+			txnId: 'txn-1',
+			revertAtUnix: Math.floor(Date.now() / 1000) + 30,
+			riskReason: null,
+		});
+
+		const result = await applyNetworkUpdate({
+			interfaces: [],
+			dns: [],
+			bonds: [],
+			vlans: [],
+			bridges: [],
+		}, 'Applied');
+
+		expect(result).toBeUndefined();
+		expect(callMock).not.toHaveBeenCalled();
+		expect(toastErrorMock).toHaveBeenCalledWith(
+			'Confirm or wait for the pending network change before applying another update',
+		);
+	});
+
+	it('blocks a second update while the first RPC is in flight', async () => {
+		let resolveUpdate: (value: unknown) => void = () => {};
+		callMock.mockImplementationOnce(() => new Promise((resolve) => {
+			resolveUpdate = resolve;
+		}));
+		const payload = { interfaces: [], dns: [], bonds: [], vlans: [], bridges: [] };
+		const first = applyNetworkUpdate(payload, 'Applied');
+
+		const second = await applyNetworkUpdate(payload, 'Applied again');
+
+		expect(second).toBeUndefined();
+		expect(callMock).toHaveBeenCalledOnce();
+		resolveUpdate({});
+		await first;
+	});
+
+	it('recovers a transaction registered after an ambiguous update failure', async () => {
+		callMock
+			.mockRejectedValueOnce(new Error('Request timed out'))
+			.mockResolvedValueOnce([{ txn_id: 'txn-after-timeout', revert_at_unix: 3000, risk_reason: 'IP changed' }]);
+
+		const result = await applyNetworkUpdate(
+			{ interfaces: [], dns: [], bonds: [], vlans: [], bridges: [] },
+			'Applied',
+		);
+		await vi.waitFor(() => expect(rollbackState.pending?.txnId).toBe('txn-after-timeout'));
+
+		expect(result).toBeUndefined();
+		expect(callMock).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe('loadPendingRollback', () => {
@@ -82,5 +205,25 @@ describe('loadPendingRollback', () => {
 		]);
 		await loadPendingRollback();
 		expect(rollbackState.pending?.riskReason).toBeNull();
+	});
+
+	it('continues recovery when transaction registration takes more than four seconds', async () => {
+		vi.useFakeTimers();
+		try {
+			callMock
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([{ txn_id: 'txn-late', revert_at_unix: 3000, risk_reason: 'IP changed' }]);
+			const recovery = recoverPendingRollback();
+
+			await vi.advanceTimersByTimeAsync(9000);
+			await recovery;
+
+			expect(rollbackState.pending?.txnId).toBe('txn-late');
+			expect(callMock).toHaveBeenCalledTimes(4);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/webui/src/lib/rollbackState.svelte.ts
+++ b/webui/src/lib/rollbackState.svelte.ts
@@ -8,7 +8,7 @@
  * rendered persistently in the root layout — the user might navigate away
  * from the settings page during the confirm window. */
 
-import { getClient } from './client';
+import { getClient, getSessionGeneration, registerSessionReset } from './client';
 import { error as toastError, withToast } from './toast.svelte';
 import type { NetworkPendingTxn, NetworkUpdateRequest, NetworkUpdateResponse } from './types';
 
@@ -19,16 +19,49 @@ export interface PendingRollback {
 }
 
 let _pending = $state<PendingRollback | null>(null);
+let _confirmationError = $state<{ txnId: string; message: string } | null>(null);
+let _confirmingTxnId = $state<string | null>(null);
+let _applying = $state(false);
+let expiryRefresh: Promise<void> | null = null;
+let recoveryGeneration = 0;
+
+function setPending(pending: PendingRollback | null) {
+	if (pending?.txnId !== _pending?.txnId) {
+		_confirmationError = null;
+		_confirmingTxnId = null;
+	}
+	_pending = pending;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error
+		? error.message
+		: typeof error === 'object' && error !== null && 'message' in error
+			? String((error as { message: unknown }).message)
+			: String(error);
+}
 
 export const rollbackState = {
 	get pending(): PendingRollback | null {
 		return _pending;
 	},
 	set(p: PendingRollback) {
-		_pending = p;
+		setPending(p);
 	},
 	clear() {
-		_pending = null;
+		setPending(null);
+		_applying = false;
+	},
+	get confirmationError(): string | null {
+		return _confirmationError && _confirmationError.txnId === _pending?.txnId
+			? _confirmationError.message
+			: null;
+	},
+	get confirming(): boolean {
+		return _confirmingTxnId !== null && _confirmingTxnId === _pending?.txnId;
+	},
+	get applying(): boolean {
+		return _applying;
 	},
 	/** Compute remaining seconds until the server-side rollback fires. */
 	secondsRemaining(): number {
@@ -38,6 +71,11 @@ export const rollbackState = {
 	},
 };
 
+registerSessionReset(() => {
+	recoveryGeneration++;
+	rollbackState.clear();
+});
+
 /** Submit a network config change. Captures the response and, if the server
  * scheduled a rollback, populates the global store so the layout banner
  * shows up. Always shows a toast on success/error. */
@@ -45,32 +83,43 @@ export async function applyNetworkUpdate(
 	payload: NetworkUpdateRequest,
 	successMsg: string,
 ): Promise<NetworkUpdateResponse | undefined> {
+	if (_applying || _pending) {
+		toastError('Confirm or wait for the pending network change before applying another update');
+		return undefined;
+	}
+	_applying = true;
+	const generation = getSessionGeneration();
 	const client = getClient();
-	const res = await withToast(
-		() => client.call<NetworkUpdateResponse>('system.network.update', payload),
-		successMsg,
-	);
-	if (res?.txn_id && res.revert_at_unix) {
-		_pending = {
-			txnId: res.txn_id,
-			revertAtUnix: res.revert_at_unix,
-			riskReason: res.risk_reason ?? null,
-		};
-	}
-	// Surface per-connection NM errors as an explicit error toast.
-	// The success toast above already fired — engine treats partial
-	// failures as overall success — but the user needs to know that
-	// not everything went through.  Without this, a bond that NM
-	// rejected silently looks like it "worked" in the UI.
-	if (res?.apply_errors && res.apply_errors.length > 0) {
-		const lines = res.apply_errors
-			.map((e) => `${e.connection_id}: ${e.message}`)
-			.join('\n');
-		toastError(
-			`Network applied, but ${res.apply_errors.length} connection(s) reported errors:\n${lines}`,
+	try {
+		const res = await withToast(
+			() => client.call<NetworkUpdateResponse>('system.network.update', payload),
+			successMsg,
 		);
+		if (generation !== getSessionGeneration()) return undefined;
+		if (!res) {
+			void recoverPendingRollback();
+			return undefined;
+		}
+		if (res?.txn_id && res.revert_at_unix) {
+			setPending({
+				txnId: res.txn_id,
+				revertAtUnix: res.revert_at_unix,
+				riskReason: res.risk_reason ?? null,
+			});
+		}
+		// Surface per-connection NM errors as an explicit error toast.
+		if (res?.apply_errors && res.apply_errors.length > 0) {
+			const lines = res.apply_errors
+				.map((e) => `${e.connection_id}: ${e.message}`)
+				.join('\n');
+			toastError(
+				`Network applied, but ${res.apply_errors.length} connection(s) reported errors:\n${lines}`,
+			);
+		}
+		return res;
+	} finally {
+		if (generation === getSessionGeneration()) _applying = false;
 	}
-	return res;
 }
 
 /** Query the server for any active rollback transactions and populate the
@@ -84,6 +133,7 @@ export async function applyNetworkUpdate(
  * pending — pathological in practice (the in-memory table rarely has more
  * than one entry) but we want stable behavior. */
 export async function loadPendingRollback(): Promise<void> {
+	const generation = getSessionGeneration();
 	const client = getClient();
 	let txns: NetworkPendingTxn[];
 	try {
@@ -91,34 +141,63 @@ export async function loadPendingRollback(): Promise<void> {
 	} catch {
 		return;
 	}
+	if (generation !== getSessionGeneration()) return;
 	if (txns.length === 0) {
 		// Server says nothing pending — clear local in case we'd been
 		// holding a stale entry from a prior session.
-		_pending = null;
+		setPending(null);
 		return;
 	}
 	const soonest = txns.reduce((a, b) => (a.revert_at_unix <= b.revert_at_unix ? a : b));
-	_pending = {
+	setPending({
 		txnId: soonest.txn_id,
 		revertAtUnix: soonest.revert_at_unix,
 		riskReason: soonest.risk_reason || null,
-	};
+	});
 }
 
-/** Confirm a pending rollback — keeps the change. Clears the local store
- * even if the RPC fails (the server may have already reverted, in which
- * case the banner should disappear regardless). */
+/** Re-query instead of trusting the browser clock when a countdown expires. */
+export function reconcileExpiredRollback(): void {
+	if (!_pending || rollbackState.secondsRemaining() > 0 || expiryRefresh) return;
+	expiryRefresh = loadPendingRollback().finally(() => {
+		expiryRefresh = null;
+	});
+}
+
+/** Retry after reconnect because a risky update may register after connectivity returns. */
+export async function recoverPendingRollback(): Promise<void> {
+	const generation = getSessionGeneration();
+	const recovery = ++recoveryGeneration;
+	for (const delay of [0, 1000, 3000, 5000, 7000, 7000, 7000]) {
+		if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+		if (generation !== getSessionGeneration() || recovery !== recoveryGeneration) return;
+		await loadPendingRollback();
+		if (_pending) return;
+	}
+}
+
+/** Confirm a pending rollback and clear only after the server acknowledges it. */
 export async function confirmRollback(): Promise<void> {
 	const txn = _pending;
-	if (!txn) return;
+	if (!txn || _confirmingTxnId === txn.txnId) return;
+	_confirmingTxnId = txn.txnId;
+	const generation = getSessionGeneration();
 	const client = getClient();
 	try {
 		await client.call('system.network.confirm', { txn_id: txn.txnId });
-	} finally {
-		// Clear regardless: if the server didn't know the txn, the rollback
-		// already fired and the banner is stale.
+		if (generation !== getSessionGeneration()) return;
 		if (_pending?.txnId === txn.txnId) {
-			_pending = null;
+			setPending(null);
+		}
+	} catch (error) {
+		if (generation !== getSessionGeneration()) return;
+		if (_pending?.txnId !== txn.txnId) return;
+		const message = errorMessage(error);
+		_confirmationError = { txnId: txn.txnId, message };
+		toastError(message);
+	} finally {
+		if (generation === getSessionGeneration() && _confirmingTxnId === txn.txnId) {
+			_confirmingTxnId = null;
 		}
 	}
 }

--- a/webui/src/lib/rpc.test.ts
+++ b/webui/src/lib/rpc.test.ts
@@ -6,6 +6,7 @@ import { isReconnectAuthError, NastyClient } from './rpc';
 // receive(...), fireClose(), fireError() to simulate server activity.
 
 let mockInstances: MockWebSocket[] = [];
+let closeFiresEvent = true;
 
 class MockWebSocket {
 	static CONNECTING = 0;
@@ -33,7 +34,7 @@ class MockWebSocket {
 	// so tests can verify cleanup without awaiting.
 	close() {
 		this.readyState = MockWebSocket.CLOSED;
-		this.onclose?.({} as CloseEvent);
+		if (closeFiresEvent) this.onclose?.({} as CloseEvent);
 	}
 
 	// ── Test driver helpers ───────────────────────────────────────
@@ -72,6 +73,7 @@ async function connectAuthed(): Promise<NastyClient> {
 
 beforeEach(() => {
 	mockInstances = [];
+	closeFiresEvent = true;
 	vi.stubGlobal('WebSocket', MockWebSocket);
 });
 
@@ -100,6 +102,20 @@ describe('auth handshake', () => {
 		expect(client.authenticated).toBe(true);
 	});
 
+	test('concurrent connect calls share one socket and handshake', async () => {
+		const client = new NastyClient('ws://localhost/api');
+		const first = client.connect();
+		const second = client.connect();
+		expect(second).toBe(first);
+		expect(mockInstances).toHaveLength(1);
+
+		mockInstances[0].open();
+		mockInstances[0].receive({ authenticated: true, username: 'admin', role: 'admin' });
+
+		await expect(first).resolves.toMatchObject({ username: 'admin' });
+		await expect(second).resolves.toMatchObject({ username: 'admin' });
+	});
+
 	test('connect rejects when server returns an error', async () => {
 		const client = new NastyClient('ws://localhost/api');
 		const promise = client.connect();
@@ -124,6 +140,21 @@ describe('auth handshake', () => {
 		const promise = client.connect();
 		mockInstances[0].fireError();
 		await expect(promise).rejects.toThrow(/WebSocket connection failed/);
+	});
+
+	test('connect rejects when the socket closes before auth', async () => {
+		const client = new NastyClient('ws://localhost/api');
+		const promise = client.connect();
+		mockInstances[0].fireClose();
+		await expect(promise).rejects.toThrow(/closed before authentication/);
+	});
+
+	test('disconnect rejects an in-progress auth handshake', async () => {
+		closeFiresEvent = false;
+		const client = new NastyClient('ws://localhost/api');
+		const promise = client.connect();
+		client.disconnect();
+		await expect(promise).rejects.toThrow(/closed before authentication/);
 	});
 });
 
@@ -247,6 +278,47 @@ describe('connection lifecycle', () => {
 		expect(client.authenticated).toBe(false);
 		// No second WebSocket gets constructed — disconnect is one-shot.
 		expect(mockInstances).toHaveLength(1);
+	});
+
+	test('disconnect() rejects pending calls before the close event', async () => {
+		const client = await connectAuthed();
+		const callPromise = client.call('slow');
+		closeFiresEvent = false;
+
+		client.disconnect();
+
+		await expect(callPromise).rejects.toMatchObject({
+			code: -32000,
+			message: 'WebSocket disconnected'
+		});
+	});
+
+	test('disconnect() releases calls waiting for reconnect', async () => {
+		const client = await connectAuthed();
+		mockInstances[0].fireClose();
+		const callPromise = client.call('waiting');
+
+		client.disconnect();
+
+		await expect(callPromise).rejects.toThrow('Not connected or not authenticated');
+	});
+
+	test('disconnect() releases waiters after a failed reconnect attempt', async () => {
+		vi.useFakeTimers();
+		try {
+			const client = await connectAuthed();
+			mockInstances[0].fireClose();
+			const callPromise = client.call('waiting');
+			await vi.advanceTimersByTimeAsync(1000);
+			mockInstances[1].fireError();
+			await vi.advanceTimersByTimeAsync(0);
+
+			client.disconnect();
+
+			await expect(callPromise).rejects.toThrow('Not connected or not authenticated');
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('forces page reload after enough consecutive failed reconnects', async () => {

--- a/webui/src/lib/rpc.ts
+++ b/webui/src/lib/rpc.ts
@@ -105,11 +105,20 @@ export class NastyClient {
 			: NastyClient.NORMAL_MAX_ATTEMPTS_BEFORE_RELOAD;
 	}
 	private _authenticated = false;
+	private _connectReject: ((error: Error) => void) | null = null;
+	private _connectPromise: Promise<AuthResult> | null = null;
 	/** Set to true after the first successful auth; cleared by disconnect(). */
 	private _shouldReconnect = false;
-	/** Resolves when the next successful auth completes; replaced on each disconnect. */
+	/** Resolves when the current reconnect cycle next authenticates successfully. */
 	private _readyResolve: (() => void) | null = null;
 	private _readyPromise: Promise<void> = Promise.resolve();
+
+	private rejectPendingCalls() {
+		for (const pending of this.pending.values()) {
+			pending.reject({ code: -32000, message: 'WebSocket disconnected' });
+		}
+		this.pending.clear();
+	}
 
 	constructor(private url: string) {}
 
@@ -122,20 +131,31 @@ export class NastyClient {
 	 *  message itself. The server replies first with `{authenticated: true}`
 	 *  or `{error: ...}`. */
 	connect(): Promise<AuthResult> {
-		return new Promise((resolve, reject) => {
-			this.ws = new WebSocket(this.url);
+		if (this._connectPromise) return this._connectPromise;
+		const connection = new Promise<AuthResult>((resolve, reject) => {
+			const socket = new WebSocket(this.url);
+			this.ws = socket;
 			let authResolved = false;
+			const failAuth = (error: Error) => {
+				if (authResolved) return;
+				authResolved = true;
+				if (this._connectReject === failAuth) this._connectReject = null;
+				reject(error);
+			};
+			this._connectReject = failAuth;
 
-			this.ws.onopen = () => {
+			socket.onopen = () => {
 				// Cookie auth: nothing to send on open. Server speaks first.
 			};
 
-			this.ws.onmessage = (event) => {
+			socket.onmessage = (event) => {
+				if (this.ws !== socket) return;
 				const msg = JSON.parse(event.data);
 
 				// Handle auth response (first message back)
 				if (!authResolved) {
 					authResolved = true;
+					if (this._connectReject === failAuth) this._connectReject = null;
 					if (msg.error) {
 						this._authenticated = false;
 						reject(new Error(msg.error));
@@ -183,13 +203,17 @@ export class NastyClient {
 				}
 			};
 
-			this.ws.onclose = (ev) => {
-				this._authenticated = false;
-				// Reject all pending calls so awaiting code doesn't hang forever
-				for (const pending of this.pending.values()) {
-					pending.reject({ code: -32000, message: 'WebSocket disconnected' });
+			socket.onclose = (ev) => {
+				if (this.ws !== socket) {
+					failAuth(new Error('WebSocket connection superseded'));
+					return;
 				}
-				this.pending.clear();
+				this._authenticated = false;
+				if (!authResolved) {
+					failAuth(new Error('WebSocket closed before authentication'));
+				}
+				// Reject all pending calls so awaiting code doesn't hang forever
+				this.rejectPendingCalls();
 				if (NastyClient.debug) {
 					console.debug(
 						`[rpc] ws closed (code=${ev.code}, reason="${ev.reason}", clean=${ev.wasClean}, _shouldReconnect=${this._shouldReconnect}, firing ${this._shouldReconnect ? this.disconnectHandlers.length : 0} disconnect handlers)`
@@ -202,8 +226,14 @@ export class NastyClient {
 				}
 			};
 
-			this.ws.onerror = () => {
-				if (!authResolved) reject(new Error('WebSocket connection failed'));
+			socket.onerror = () => {
+				if (this.ws !== socket) {
+					failAuth(new Error('WebSocket connection superseded'));
+					return;
+				}
+				if (!authResolved) {
+					failAuth(new Error('WebSocket connection failed'));
+				}
 				// If this was a reconnect attempt that failed to even open,
 				// onclose may not fire, so schedule retry here too.
 				if (this._shouldReconnect && !this._authenticated) {
@@ -211,6 +241,16 @@ export class NastyClient {
 				}
 			};
 		});
+		this._connectPromise = connection;
+		void connection.then(
+			() => {
+				if (this._connectPromise === connection) this._connectPromise = null;
+			},
+			() => {
+				if (this._connectPromise === connection) this._connectPromise = null;
+			},
+		);
+		return connection;
 	}
 
 	async call<T = unknown>(method: string, params?: unknown, timeoutMs = 10000): Promise<T> {
@@ -260,7 +300,9 @@ export class NastyClient {
 	 *  during a longer outage (a stuck client used to spam ~20 attempts/min). */
 	private _scheduleReconnect() {
 		if (this.reconnectTimer) return; // already scheduled
-		this._readyPromise = new Promise((res) => { this._readyResolve = res; });
+		if (!this._readyResolve) {
+			this._readyPromise = new Promise((res) => { this._readyResolve = res; });
+		}
 		const delay = this.reconnectDelayMs;
 		this.reconnectDelayMs = Math.min(
 			this.reconnectDelayMs * 2,
@@ -368,10 +410,15 @@ export class NastyClient {
 
 	disconnect() {
 		this._shouldReconnect = false;
+		this._readyResolve?.();
 		this._readyResolve = null;
 		this._readyPromise = Promise.resolve();
 		if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
 		this._authenticated = false;
+		this.rejectPendingCalls();
+		this._connectReject?.(new Error('WebSocket closed before authentication'));
+		this._connectReject = null;
+		this._connectPromise = null;
 		this.ws?.close();
 	}
 }

--- a/webui/src/lib/sessionState.svelte.test.ts
+++ b/webui/src/lib/sessionState.svelte.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { resetClient } from './client';
+import { domain } from './domain.svelte';
+import { dc } from './dc.svelte';
+import { rollbackState } from './rollbackState.svelte';
+import { terminalStatus } from './terminalStatus.svelte';
+import { confirm, confirmState } from './confirm.svelte';
+import { confirmDangerous, confirmDangerousState } from './confirm-dangerous.svelte';
+import { error as toastError, getToasts } from './toast.svelte';
+import { unlockFs, unlockFsState } from './unlock-fs.svelte';
+import { rdma } from './sharing/rdma.svelte';
+import { nfs } from './sharing/nfs.svelte';
+import { smb } from './sharing/smb.svelte';
+import { iscsi } from './sharing/iscsi.svelte';
+import { nvme } from './sharing/nvmeof.svelte';
+
+beforeEach(() => resetClient());
+
+describe('session state reset', () => {
+	test('clears loaded stores and plaintext credentials without replacing proxies', () => {
+		const identities = { domain, dc, rdma, nfs, smb, iscsi, nvme };
+		domain.password = 'domain secret';
+		dc.adminPassword = 'dc secret';
+		rdma.loading = true;
+		nfs.newHost = '192.0.2.1';
+		smb.newName = 'private';
+		iscsi.addAclPass = 'chap secret';
+		nvme.addHostNqn = 'nqn.2026-01.test:host';
+		rollbackState.set({ txnId: 'txn-1', revertAtUnix: 1234, riskReason: null });
+		terminalStatus.set('connected');
+
+		resetClient();
+
+		expect(domain).toBe(identities.domain);
+		expect(dc).toBe(identities.dc);
+		expect(rdma).toBe(identities.rdma);
+		expect(nfs).toBe(identities.nfs);
+		expect(smb).toBe(identities.smb);
+		expect(iscsi).toBe(identities.iscsi);
+		expect(nvme).toBe(identities.nvme);
+		expect(domain.password).toBe('');
+		expect(dc.adminPassword).toBe('');
+		expect(rdma.loading).toBe(false);
+		expect(nfs.newHost).toBe('');
+		expect(smb.newName).toBe('');
+		expect(iscsi.addAclPass).toBe('');
+		expect(nvme.addHostNqn).toBe('');
+		expect(rollbackState.pending).toBeNull();
+		expect(terminalStatus.value).toBe('idle');
+	});
+
+	test('settles dialogs and clears transient messages', async () => {
+		const confirmation = confirm('Delete private data?');
+		const dangerous = confirmDangerous('Destroy pool?', 'Type pool name', 'private');
+		const unlock = unlockFs('private');
+		toastError('private path failed');
+
+		resetClient();
+
+		await expect(confirmation).resolves.toBe(false);
+		await expect(dangerous).resolves.toBe(false);
+		await expect(unlock).resolves.toBe(false);
+		expect(confirmState.open).toBe(false);
+		expect(confirmDangerousState.open).toBe(false);
+		expect(confirmDangerousState.expectedValue).toBe('');
+		expect(unlockFsState.open).toBe(false);
+		expect(unlockFsState.fsName).toBe('');
+		expect(getToasts()).toEqual([]);
+	});
+});

--- a/webui/src/lib/sharing/iscsi.svelte.ts
+++ b/webui/src/lib/sharing/iscsi.svelte.ts
@@ -6,62 +6,70 @@
  * carry LUNs + ACLs (CHAP credentials), so the surface is bigger
  * than NFS but smaller than SMB. */
 
-import { getClient } from '$lib/client';
+import { getClient, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import { confirm } from '$lib/confirm.svelte';
 import type { IscsiTarget, Subvolume, ProtocolStatus } from '$lib/types';
 
-const client = getClient();
+function initialIscsiState() {
+	return {
+		targets: [] as IscsiTarget[],
+		loading: true,
+		protocol: null as ProtocolStatus | null,
+		showCreate: false,
+		blockSubvolumes: [] as Subvolume[],
+		expanded: {} as Record<string, boolean>,
+		newName: '',
+		newDevice: '',
+		addLunTarget: '',
+		addLunPath: '',
+		addLunType: '',
+		addAclTarget: '',
+		addAclIqn: '',
+		addAclUser: '',
+		addAclPass: '',
+		addPortalTarget: '',
+		addPortalIp: '',
+		addPortalPort: 3260,
+		addPortalFamily: 'ipv4' as 'ipv4' | 'ipv6',
+		addPortalIser: false,
+		// Edit mode reuses the addPortal* form fields; these remember which
+		// portal is being replaced so set_portals can swap it in one call
+		// (same-port wildcard→specific swaps included).
+		editPortalTarget: '',
+		editPortalOrigIp: '',
+		editPortalOrigPort: 0,
+		search: '',
+		sortDir: 'asc' as 'asc' | 'desc',
+	};
+}
 
-export const iscsi = $state({
-	targets: [] as IscsiTarget[],
-	loading: true,
-	protocol: null as ProtocolStatus | null,
-	showCreate: false,
-	blockSubvolumes: [] as Subvolume[],
-	expanded: {} as Record<string, boolean>,
-	newName: '',
-	newDevice: '',
-	addLunTarget: '',
-	addLunPath: '',
-	addLunType: '',
-	addAclTarget: '',
-	addAclIqn: '',
-	addAclUser: '',
-	addAclPass: '',
-	addPortalTarget: '',
-	addPortalIp: '',
-	addPortalPort: 3260,
-	addPortalFamily: 'ipv4' as 'ipv4' | 'ipv6',
-	addPortalIser: false,
-	// Edit mode reuses the addPortal* form fields; these remember which
-	// portal is being replaced so set_portals can swap it in one call
-	// (same-port wildcard→specific swaps included).
-	editPortalTarget: '',
-	editPortalOrigIp: '',
-	editPortalOrigPort: 0,
-	search: '',
-	sortDir: 'asc' as 'asc' | 'desc',
-});
+export const iscsi = $state(initialIscsiState());
+
+export function resetIscsiState() {
+	Object.assign(iscsi, initialIscsiState());
+}
+
+registerSessionReset(resetIscsiState);
 
 export function iscsiToggleSort() {
 	iscsi.sortDir = iscsi.sortDir === 'asc' ? 'desc' : 'asc';
 }
 
 export async function iscsiRefresh() {
-	await withToast(async () => { iscsi.targets = await client.call<IscsiTarget[]>('share.iscsi.list'); });
+	await withToast(async () => { iscsi.targets = await getClient().call<IscsiTarget[]>('share.iscsi.list'); });
 }
 
 export async function iscsiLoadProtocol() {
 	try {
-		const all = await client.call<ProtocolStatus[]>('service.protocol.list');
+		const all = await getClient().call<ProtocolStatus[]>('service.protocol.list');
 		iscsi.protocol = all.find(p => p.name === 'iscsi') ?? null;
 	} catch { /* ignore */ }
 }
 
 export async function iscsiLoadSubvolumes() {
 	await withToast(async () => {
-		const all = await client.call<Subvolume[]>('subvolume.list_all');
+		const all = await getClient().call<Subvolume[]>('subvolume.list_all');
 		iscsi.blockSubvolumes = all.filter(s => s.subvolume_type === 'block' && s.block_device);
 	});
 }
@@ -76,7 +84,7 @@ export function iscsiOnDeviceSelect() {
 export async function iscsiCreate() {
 	if (!iscsi.newName || !iscsi.newDevice) return;
 	const ok = await withToast(
-		() => client.call('share.iscsi.create', { name: iscsi.newName, device_path: iscsi.newDevice }),
+		() => getClient().call('share.iscsi.create', { name: iscsi.newName, device_path: iscsi.newDevice }),
 		'iSCSI target created'
 	);
 	if (ok !== undefined) {
@@ -89,7 +97,7 @@ export async function iscsiCreate() {
 
 export async function iscsiRemove(id: string) {
 	if (!await confirm('Delete this iSCSI target?', 'All its LUNs will also be removed.')) return;
-	await withToast(() => client.call('share.iscsi.delete', { id }), 'iSCSI target deleted');
+	await withToast(() => getClient().call('share.iscsi.delete', { id }), 'iSCSI target deleted');
 	await iscsiRefresh();
 }
 
@@ -97,7 +105,7 @@ export async function iscsiAddLun() {
 	if (!iscsi.addLunTarget || !iscsi.addLunPath) return;
 	const params: Record<string, unknown> = { target_id: iscsi.addLunTarget, backstore_path: iscsi.addLunPath };
 	if (iscsi.addLunType) params.backstore_type = iscsi.addLunType;
-	await withToast(() => client.call('share.iscsi.add_lun', params), 'LUN added');
+	await withToast(() => getClient().call('share.iscsi.add_lun', params), 'LUN added');
 	iscsi.addLunTarget = '';
 	iscsi.addLunPath = '';
 	iscsi.addLunType = '';
@@ -106,7 +114,7 @@ export async function iscsiAddLun() {
 
 export async function iscsiRemoveLun(targetId: string, lunId: number) {
 	if (!await confirm(`Remove LUN ${lunId}?`)) return;
-	await withToast(() => client.call('share.iscsi.remove_lun', { target_id: targetId, lun_id: lunId }), 'LUN removed');
+	await withToast(() => getClient().call('share.iscsi.remove_lun', { target_id: targetId, lun_id: lunId }), 'LUN removed');
 	await iscsiRefresh();
 }
 
@@ -115,7 +123,7 @@ export async function iscsiAddAcl() {
 	const params: Record<string, unknown> = { target_id: iscsi.addAclTarget, initiator_iqn: iscsi.addAclIqn };
 	if (iscsi.addAclUser) params.userid = iscsi.addAclUser;
 	if (iscsi.addAclPass) params.password = iscsi.addAclPass;
-	await withToast(() => client.call('share.iscsi.add_acl', params), 'ACL added');
+	await withToast(() => getClient().call('share.iscsi.add_acl', params), 'ACL added');
 	iscsi.addAclTarget = '';
 	iscsi.addAclIqn = '';
 	iscsi.addAclUser = '';
@@ -126,7 +134,7 @@ export async function iscsiAddAcl() {
 export async function iscsiRemoveAcl(targetId: string, initiatorIqn: string) {
 	if (!await confirm(`Remove ACL for ${initiatorIqn}?`)) return;
 	await withToast(
-		() => client.call('share.iscsi.remove_acl', { target_id: targetId, initiator_iqn: initiatorIqn }),
+		() => getClient().call('share.iscsi.remove_acl', { target_id: targetId, initiator_iqn: initiatorIqn }),
 		'ACL removed'
 	);
 	await iscsiRefresh();
@@ -135,7 +143,7 @@ export async function iscsiRemoveAcl(targetId: string, initiatorIqn: string) {
 export async function iscsiAddPortal() {
 	if (!iscsi.addPortalTarget || !iscsi.addPortalIp) return;
 	const ok = await withToast(
-		() => client.call('share.iscsi.add_portal', {
+		() => getClient().call('share.iscsi.add_portal', {
 			target_id: iscsi.addPortalTarget,
 			ip: iscsi.addPortalIp.trim(),
 			port: iscsi.addPortalPort,
@@ -167,7 +175,7 @@ export async function iscsiReplacePortal() {
 			: { ip: p.ip, port: p.port, iser: p.iser ?? false }
 	);
 	const ok = await withToast(
-		() => client.call('share.iscsi.set_portals', { target_id: iscsi.editPortalTarget, portals }),
+		() => getClient().call('share.iscsi.set_portals', { target_id: iscsi.editPortalTarget, portals }),
 		'Portal updated',
 	);
 	if (ok !== undefined) {
@@ -185,7 +193,7 @@ export async function iscsiReplacePortal() {
 export async function iscsiRemovePortal(targetId: string, ip: string, port: number) {
 	if (!await confirm(`Remove portal ${ip}:${port}?`)) return;
 	await withToast(
-		() => client.call('share.iscsi.remove_portal', { target_id: targetId, ip, port }),
+		() => getClient().call('share.iscsi.remove_portal', { target_id: targetId, ip, port }),
 		'Portal removed',
 	);
 	await iscsiRefresh();

--- a/webui/src/lib/sharing/nfs.svelte.ts
+++ b/webui/src/lib/sharing/nfs.svelte.ts
@@ -11,33 +11,41 @@
  * across module boundaries — bare `let nfsLoading = $state(true)`
  * inside a module wouldn't survive import. */
 
-import { getClient } from '$lib/client';
+import { getClient, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import { confirm } from '$lib/confirm.svelte';
 import type { NfsShare, Subvolume, ProtocolStatus } from '$lib/types';
 
-const client = getClient();
-
 export type NfsSortKey = 'path' | 'status';
 
-export const nfs = $state({
-	shares: [] as NfsShare[],
-	loading: true,
-	protocol: null as ProtocolStatus | null,
-	showCreate: false,
-	subvolumes: [] as Subvolume[],
-	newSubvolume: '',
-	newComment: '',
-	newHost: '',
-	newOptions: 'rw,sync,no_subtree_check',
-	expanded: {} as Record<string, boolean>,
-	addClientShare: null as string | null,
-	addClientHost: '',
-	addClientOptions: 'rw,sync,no_subtree_check',
-	search: '',
-	sortKey: null as NfsSortKey | null,
-	sortDir: 'asc' as 'asc' | 'desc',
-});
+function initialNfsState() {
+	return {
+		shares: [] as NfsShare[],
+		loading: true,
+		protocol: null as ProtocolStatus | null,
+		showCreate: false,
+		subvolumes: [] as Subvolume[],
+		newSubvolume: '',
+		newComment: '',
+		newHost: '',
+		newOptions: 'rw,sync,no_subtree_check',
+		expanded: {} as Record<string, boolean>,
+		addClientShare: null as string | null,
+		addClientHost: '',
+		addClientOptions: 'rw,sync,no_subtree_check',
+		search: '',
+		sortKey: null as NfsSortKey | null,
+		sortDir: 'asc' as 'asc' | 'desc',
+	};
+}
+
+export const nfs = $state(initialNfsState());
+
+export function resetNfsState() {
+	Object.assign(nfs, initialNfsState());
+}
+
+registerSessionReset(resetNfsState);
 
 export function nfsToggleSort(key: NfsSortKey) {
 	if (nfs.sortKey === key) {
@@ -49,19 +57,19 @@ export function nfsToggleSort(key: NfsSortKey) {
 }
 
 export async function nfsRefresh() {
-	await withToast(async () => { nfs.shares = await client.call<NfsShare[]>('share.nfs.list'); });
+	await withToast(async () => { nfs.shares = await getClient().call<NfsShare[]>('share.nfs.list'); });
 }
 
 export async function nfsLoadProtocol() {
 	try {
-		const all = await client.call<ProtocolStatus[]>('service.protocol.list');
+		const all = await getClient().call<ProtocolStatus[]>('service.protocol.list');
 		nfs.protocol = all.find(p => p.name === 'nfs') ?? null;
 	} catch { /* ignore */ }
 }
 
 export async function nfsLoadSubvolumes() {
 	await withToast(async () => {
-		const all = await client.call<Subvolume[]>('subvolume.list_all');
+		const all = await getClient().call<Subvolume[]>('subvolume.list_all');
 		nfs.subvolumes = all.filter(s => s.subvolume_type === 'filesystem');
 	});
 }
@@ -69,7 +77,7 @@ export async function nfsLoadSubvolumes() {
 export async function nfsCreate() {
 	if (!nfs.newSubvolume || !nfs.newHost) return;
 	const ok = await withToast(
-		() => client.call('share.nfs.create', {
+		() => getClient().call('share.nfs.create', {
 			path: nfs.newSubvolume,
 			comment: nfs.newComment || undefined,
 			clients: [{ host: nfs.newHost, options: nfs.newOptions }],
@@ -87,7 +95,7 @@ export async function nfsCreate() {
 
 export async function nfsToggleEnabled(share: NfsShare) {
 	await withToast(
-		() => client.call('share.nfs.update', { id: share.id, enabled: !share.enabled }),
+		() => getClient().call('share.nfs.update', { id: share.id, enabled: !share.enabled }),
 		`Share ${share.enabled ? 'disabled' : 'enabled'}`
 	);
 	await nfsRefresh();
@@ -95,13 +103,13 @@ export async function nfsToggleEnabled(share: NfsShare) {
 
 export async function nfsRemove(id: string) {
 	if (!await confirm('Delete this NFS share?')) return;
-	await withToast(() => client.call('share.nfs.delete', { id }), 'NFS share deleted');
+	await withToast(() => getClient().call('share.nfs.delete', { id }), 'NFS share deleted');
 	await nfsRefresh();
 }
 
 export async function nfsRemoveClient(share: NfsShare, host: string) {
 	const clients = share.clients.filter(c => c.host !== host);
-	await withToast(() => client.call('share.nfs.update', { id: share.id, clients }), 'Client removed');
+	await withToast(() => getClient().call('share.nfs.update', { id: share.id, clients }), 'Client removed');
 	await nfsRefresh();
 }
 
@@ -109,7 +117,7 @@ export async function nfsAddClient(share: NfsShare) {
 	if (!nfs.addClientHost) return;
 	const clients = [...share.clients, { host: nfs.addClientHost, options: nfs.addClientOptions }];
 	const ok = await withToast(
-		() => client.call('share.nfs.update', { id: share.id, clients }),
+		() => getClient().call('share.nfs.update', { id: share.id, clients }),
 		'Client added'
 	);
 	if (ok !== undefined) {

--- a/webui/src/lib/sharing/nvmeof.svelte.ts
+++ b/webui/src/lib/sharing/nvmeof.svelte.ts
@@ -5,55 +5,63 @@
  * listeners), and allowed-host NQNs — three nested collections, each
  * with add/remove handlers. */
 
-import { getClient } from '$lib/client';
+import { getClient, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import { confirm } from '$lib/confirm.svelte';
 import type { NvmeofSubsystem, Subvolume, ProtocolStatus } from '$lib/types';
 
-const client = getClient();
+function initialNvmeState() {
+	return {
+		subsystems: [] as NvmeofSubsystem[],
+		loading: true,
+		protocol: null as ProtocolStatus | null,
+		showCreate: false,
+		blockSubvolumes: [] as Subvolume[],
+		expanded: {} as Record<string, boolean>,
+		newName: '',
+		newDevice: '',
+		newAddr: '0.0.0.0',
+		newPort: 4420,
+		addNsSubsys: '',
+		addNsDevice: '',
+		addPortSubsys: '',
+		addPortTransport: 'tcp',
+		addPortAddr: '0.0.0.0',
+		addPortSvcId: 4420,
+		addPortFamily: 'ipv4' as 'ipv4' | 'ipv6',
+		addHostSubsys: '',
+		addHostNqn: '',
+		search: '',
+		sortDir: 'asc' as 'asc' | 'desc',
+	};
+}
 
-export const nvme = $state({
-	subsystems: [] as NvmeofSubsystem[],
-	loading: true,
-	protocol: null as ProtocolStatus | null,
-	showCreate: false,
-	blockSubvolumes: [] as Subvolume[],
-	expanded: {} as Record<string, boolean>,
-	newName: '',
-	newDevice: '',
-	newAddr: '0.0.0.0',
-	newPort: 4420,
-	addNsSubsys: '',
-	addNsDevice: '',
-	addPortSubsys: '',
-	addPortTransport: 'tcp',
-	addPortAddr: '0.0.0.0',
-	addPortSvcId: 4420,
-	addPortFamily: 'ipv4' as 'ipv4' | 'ipv6',
-	addHostSubsys: '',
-	addHostNqn: '',
-	search: '',
-	sortDir: 'asc' as 'asc' | 'desc',
-});
+export const nvme = $state(initialNvmeState());
+
+export function resetNvmeState() {
+	Object.assign(nvme, initialNvmeState());
+}
+
+registerSessionReset(resetNvmeState);
 
 export function nvmeToggleSort() {
 	nvme.sortDir = nvme.sortDir === 'asc' ? 'desc' : 'asc';
 }
 
 export async function nvmeRefresh() {
-	await withToast(async () => { nvme.subsystems = await client.call<NvmeofSubsystem[]>('share.nvmeof.list'); });
+	await withToast(async () => { nvme.subsystems = await getClient().call<NvmeofSubsystem[]>('share.nvmeof.list'); });
 }
 
 export async function nvmeLoadProtocol() {
 	try {
-		const all = await client.call<ProtocolStatus[]>('service.protocol.list');
+		const all = await getClient().call<ProtocolStatus[]>('service.protocol.list');
 		nvme.protocol = all.find(p => p.name === 'nvmeof') ?? null;
 	} catch { /* ignore */ }
 }
 
 export async function nvmeLoadSubvolumes() {
 	await withToast(async () => {
-		const all = await client.call<Subvolume[]>('subvolume.list_all');
+		const all = await getClient().call<Subvolume[]>('subvolume.list_all');
 		nvme.blockSubvolumes = all.filter(s => s.subvolume_type === 'block' && s.block_device);
 	});
 }
@@ -68,7 +76,7 @@ export function nvmeOnDeviceSelect() {
 export async function nvmeCreate() {
 	if (!nvme.newName || !nvme.newDevice) return;
 	const ok = await withToast(
-		() => client.call('share.nvmeof.create', {
+		() => getClient().call('share.nvmeof.create', {
 			name: nvme.newName,
 			device_path: nvme.newDevice,
 			addr: nvme.newAddr,
@@ -88,14 +96,14 @@ export async function nvmeCreate() {
 
 export async function nvmeRemove(id: string) {
 	if (!await confirm('Delete this NVMe-oF share?')) return;
-	await withToast(() => client.call('share.nvmeof.delete', { id }), 'NVMe-oF share deleted');
+	await withToast(() => getClient().call('share.nvmeof.delete', { id }), 'NVMe-oF share deleted');
 	await nvmeRefresh();
 }
 
 export async function nvmeAddNamespace() {
 	if (!nvme.addNsSubsys || !nvme.addNsDevice) return;
 	await withToast(
-		() => client.call('share.nvmeof.add_namespace', { subsystem_id: nvme.addNsSubsys, device_path: nvme.addNsDevice }),
+		() => getClient().call('share.nvmeof.add_namespace', { subsystem_id: nvme.addNsSubsys, device_path: nvme.addNsDevice }),
 		'Namespace added'
 	);
 	nvme.addNsSubsys = '';
@@ -106,7 +114,7 @@ export async function nvmeAddNamespace() {
 export async function nvmeRemoveNamespace(subsystemId: string, nsid: number) {
 	if (!await confirm(`Remove namespace ${nsid}?`)) return;
 	await withToast(
-		() => client.call('share.nvmeof.remove_namespace', { subsystem_id: subsystemId, nsid }),
+		() => getClient().call('share.nvmeof.remove_namespace', { subsystem_id: subsystemId, nsid }),
 		'Namespace removed'
 	);
 	await nvmeRefresh();
@@ -115,7 +123,7 @@ export async function nvmeRemoveNamespace(subsystemId: string, nsid: number) {
 export async function nvmeAddPort() {
 	if (!nvme.addPortSubsys) return;
 	await withToast(
-		() => client.call('share.nvmeof.add_port', {
+		() => getClient().call('share.nvmeof.add_port', {
 			subsystem_id: nvme.addPortSubsys,
 			transport: nvme.addPortTransport,
 			addr: nvme.addPortAddr,
@@ -135,7 +143,7 @@ export async function nvmeAddPort() {
 export async function nvmeRemovePort(subsystemId: string, portId: number) {
 	if (!await confirm(`Remove port ${portId}?`)) return;
 	await withToast(
-		() => client.call('share.nvmeof.remove_port', { subsystem_id: subsystemId, port_id: portId }),
+		() => getClient().call('share.nvmeof.remove_port', { subsystem_id: subsystemId, port_id: portId }),
 		'Port removed'
 	);
 	await nvmeRefresh();
@@ -144,7 +152,7 @@ export async function nvmeRemovePort(subsystemId: string, portId: number) {
 export async function nvmeAddHost() {
 	if (!nvme.addHostSubsys || !nvme.addHostNqn) return;
 	await withToast(
-		() => client.call('share.nvmeof.add_host', { subsystem_id: nvme.addHostSubsys, host_nqn: nvme.addHostNqn }),
+		() => getClient().call('share.nvmeof.add_host', { subsystem_id: nvme.addHostSubsys, host_nqn: nvme.addHostNqn }),
 		'Allowed host added'
 	);
 	nvme.addHostSubsys = '';
@@ -155,7 +163,7 @@ export async function nvmeAddHost() {
 export async function nvmeRemoveHost(subsystemId: string, hostNqn: string) {
 	if (!await confirm(`Remove access for ${hostNqn}?`)) return;
 	await withToast(
-		() => client.call('share.nvmeof.remove_host', { subsystem_id: subsystemId, host_nqn: hostNqn }),
+		() => getClient().call('share.nvmeof.remove_host', { subsystem_id: subsystemId, host_nqn: hostNqn }),
 		'Allowed host removed'
 	);
 	await nvmeRefresh();

--- a/webui/src/lib/sharing/rdma.svelte.ts
+++ b/webui/src/lib/sharing/rdma.svelte.ts
@@ -1,18 +1,23 @@
-import { getClient } from '$lib/client';
+import { getClient, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import type { RdmaStatus } from '$lib/types';
 
-const client = getClient();
+function initialRdmaState() {
+	return { status: null as RdmaStatus | null, loading: false };
+}
 
-export const rdma = $state({
-	status: null as RdmaStatus | null,
-	loading: false,
-});
+export const rdma = $state(initialRdmaState());
+
+export function resetRdmaState() {
+	Object.assign(rdma, initialRdmaState());
+}
+
+registerSessionReset(resetRdmaState);
 
 export async function rdmaLoad() {
 	rdma.loading = true;
 	try {
-		rdma.status = await client.call<RdmaStatus>('system.rdma.status');
+		rdma.status = await getClient().call<RdmaStatus>('system.rdma.status');
 	} catch {
 		// Older engine without the RPC: hide the card instead of failing
 		// the sharing page.
@@ -23,7 +28,7 @@ export async function rdmaLoad() {
 
 export async function rdmaSet(enabled: boolean) {
 	const res = await withToast(
-		() => client.call<RdmaStatus>('system.rdma.set', { enabled }),
+		() => getClient().call<RdmaStatus>('system.rdma.set', { enabled }),
 		enabled ? 'RDMA transports enabled' : 'RDMA transports disabled',
 	);
 	if (res) rdma.status = res;

--- a/webui/src/lib/sharing/smb.svelte.ts
+++ b/webui/src/lib/sharing/smb.svelte.ts
@@ -9,41 +9,49 @@
  * etc.) for that inline-create stays on the page — only the
  * "existing shares" half lives here. */
 
-import { getClient } from '$lib/client';
+import { getClient, registerSessionReset } from '$lib/client';
 import { withToast } from '$lib/toast.svelte';
 import { confirm } from '$lib/confirm.svelte';
 import type { SmbShare, SmbGroup, Subvolume, ProtocolStatus } from '$lib/types';
 
-const client = getClient();
-
 export type SmbSortKey = 'name' | 'path' | 'status';
 
-export const smb = $state({
-	shares: [] as SmbShare[],
-	loading: true,
-	protocol: null as ProtocolStatus | null,
-	showCreate: false,
-	subvolumes: [] as Subvolume[],
-	newSubvolume: '',
-	newName: '',
-	newComment: '',
-	newReadOnly: false,
-	newGuestOk: false,
-	newTimeMachine: false,
-	newTmMaxSize: null as number | null,
-	expanded: {} as Record<string, boolean>,
-	addUserShare: null as string | null,
-	addUserName: '',
-	groups: [] as SmbGroup[],
-	// Shared between the panel's "add user to share" picker and the
-	// create wizard's "valid users" picker on the page; lazy-loaded
-	// when either UI is opened to avoid a round-trip on every page
-	// load.
-	systemUsers: [] as { username: string; uid: number }[],
-	search: '',
-	sortKey: null as SmbSortKey | null,
-	sortDir: 'asc' as 'asc' | 'desc',
-});
+function initialSmbState() {
+	return {
+		shares: [] as SmbShare[],
+		loading: true,
+		protocol: null as ProtocolStatus | null,
+		showCreate: false,
+		subvolumes: [] as Subvolume[],
+		newSubvolume: '',
+		newName: '',
+		newComment: '',
+		newReadOnly: false,
+		newGuestOk: false,
+		newTimeMachine: false,
+		newTmMaxSize: null as number | null,
+		expanded: {} as Record<string, boolean>,
+		addUserShare: null as string | null,
+		addUserName: '',
+		groups: [] as SmbGroup[],
+		// Shared between the panel's "add user to share" picker and the
+		// create wizard's "valid users" picker on the page; lazy-loaded
+		// when either UI is opened to avoid a round-trip on every page
+		// load.
+		systemUsers: [] as { username: string; uid: number }[],
+		search: '',
+		sortKey: null as SmbSortKey | null,
+		sortDir: 'asc' as 'asc' | 'desc',
+	};
+}
+
+export const smb = $state(initialSmbState());
+
+export function resetSmbState() {
+	Object.assign(smb, initialSmbState());
+}
+
+registerSessionReset(resetSmbState);
 
 export function smbToggleSort(key: SmbSortKey) {
 	if (smb.sortKey === key) {
@@ -56,6 +64,7 @@ export function smbToggleSort(key: SmbSortKey) {
 
 export async function smbRefresh() {
 	await withToast(async () => {
+		const client = getClient();
 		const [shares, groups] = await Promise.all([
 			client.call<SmbShare[]>('share.smb.list'),
 			client.call<SmbGroup[]>('smb.group.list').catch(() => [] as SmbGroup[]),
@@ -67,14 +76,14 @@ export async function smbRefresh() {
 
 export async function smbLoadProtocol() {
 	try {
-		const all = await client.call<ProtocolStatus[]>('service.protocol.list');
+		const all = await getClient().call<ProtocolStatus[]>('service.protocol.list');
 		smb.protocol = all.find(p => p.name === 'smb') ?? null;
 	} catch { /* ignore */ }
 }
 
 export async function smbLoadSubvolumes() {
 	await withToast(async () => {
-		const all = await client.call<Subvolume[]>('subvolume.list_all');
+		const all = await getClient().call<Subvolume[]>('subvolume.list_all');
 		smb.subvolumes = all.filter(s => s.subvolume_type === 'filesystem');
 	});
 }
@@ -89,7 +98,7 @@ export function smbOnSubvolumeSelect() {
 export async function smbCreate() {
 	if (!smb.newName || !smb.newSubvolume) return;
 	const ok = await withToast(
-		() => client.call('share.smb.create', {
+		() => getClient().call('share.smb.create', {
 			name: smb.newName,
 			path: smb.newSubvolume,
 			comment: smb.newComment || undefined,
@@ -113,7 +122,7 @@ export async function smbCreate() {
 
 export async function smbToggleEnabled(share: SmbShare) {
 	await withToast(
-		() => client.call('share.smb.update', { id: share.id, enabled: !share.enabled }),
+		() => getClient().call('share.smb.update', { id: share.id, enabled: !share.enabled }),
 		`Share ${share.enabled ? 'disabled' : 'enabled'}`
 	);
 	await smbRefresh();
@@ -121,13 +130,13 @@ export async function smbToggleEnabled(share: SmbShare) {
 
 export async function smbRemove(id: string) {
 	if (!await confirm('Delete this SMB share?')) return;
-	await withToast(() => client.call('share.smb.delete', { id }), 'SMB share deleted');
+	await withToast(() => getClient().call('share.smb.delete', { id }), 'SMB share deleted');
 	await smbRefresh();
 }
 
 export async function smbToggleField(share: SmbShare, field: 'read_only' | 'browseable' | 'guest_ok') {
 	await withToast(
-		() => client.call('share.smb.update', { id: share.id, [field]: !share[field] }),
+		() => getClient().call('share.smb.update', { id: share.id, [field]: !share[field] }),
 		'Share updated'
 	);
 	await smbRefresh();
@@ -135,7 +144,7 @@ export async function smbToggleField(share: SmbShare, field: 'read_only' | 'brow
 
 export async function smbRemoveUser(share: SmbShare, username: string) {
 	const valid_users = share.valid_users.filter(u => u !== username);
-	await withToast(() => client.call('share.smb.update', { id: share.id, valid_users }), 'User removed');
+	await withToast(() => getClient().call('share.smb.update', { id: share.id, valid_users }), 'User removed');
 	await smbRefresh();
 }
 
@@ -144,6 +153,6 @@ export async function smbRemoveUser(share: SmbShare, username: string) {
 export async function smbEnsureSystemUsers() {
 	if (smb.systemUsers.length > 0) return;
 	try {
-		smb.systemUsers = await client.call<{ username: string; uid: number }[]>('smb.user.list');
+		smb.systemUsers = await getClient().call<{ username: string; uid: number }[]>('smb.user.list');
 	} catch { /* ignore */ }
 }

--- a/webui/src/lib/terminalStatus.svelte.ts
+++ b/webui/src/lib/terminalStatus.svelte.ts
@@ -1,7 +1,11 @@
 /** Shared reactive terminal connection status for the top bar indicator. */
+import { registerSessionReset } from './client';
+
 let _status = $state<'connecting' | 'connected' | 'disconnected' | 'idle'>('idle');
 
 export const terminalStatus = {
 	get value() { return _status; },
 	set(s: 'connecting' | 'connected' | 'disconnected' | 'idle') { _status = s; },
 };
+
+registerSessionReset(() => terminalStatus.set('idle'));

--- a/webui/src/lib/toast.svelte.test.ts
+++ b/webui/src/lib/toast.svelte.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { resetClient } from './client';
 import { dismiss, error, getToasts, info, isBusy, success, withToast } from './toast.svelte';
 
 // Toast state is module-scoped, so each test must start from an empty queue.
@@ -136,6 +137,36 @@ describe('withToast', () => {
 		expect(isBusy()).toBe(true); // b still running
 		releaseB();
 		await opB;
+		expect(isBusy()).toBe(false);
+	});
+
+	test('does not surface completion from a previous session', async () => {
+		let rejectInner!: (error: Error) => void;
+		const inner = new Promise<void>((_, reject) => {
+			rejectInner = reject;
+		});
+		const op = withToast(() => inner, 'Old session saved');
+
+		resetClient();
+		rejectInner(new Error('Old session disconnected'));
+		await op;
+
+		expect(getToasts()).toEqual([]);
+	});
+
+	test('reset clears busy state without an old operation decrementing the new session', async () => {
+		let releaseInner!: () => void;
+		const inner = new Promise<void>((resolve) => {
+			releaseInner = resolve;
+		});
+		const op = withToast(() => inner);
+		expect(isBusy()).toBe(true);
+
+		resetClient();
+		expect(isBusy()).toBe(false);
+		releaseInner();
+		await op;
+
 		expect(isBusy()).toBe(false);
 	});
 });

--- a/webui/src/lib/toast.svelte.ts
+++ b/webui/src/lib/toast.svelte.ts
@@ -1,5 +1,7 @@
 /** Toast notification store */
 
+import { getSessionGeneration, registerSessionReset } from './client';
+
 type ToastType = 'success' | 'error' | 'info';
 
 export interface Toast {
@@ -28,6 +30,10 @@ export function dismiss(id: number) {
 	toasts = toasts.filter((t) => t.id !== id);
 }
 
+export function clearToasts() {
+	toasts = [];
+}
+
 export function success(message: string) {
 	add('success', message);
 }
@@ -53,16 +59,22 @@ export async function withToast<T>(
 	fn: () => Promise<T>,
 	successMsg?: string
 ): Promise<T | undefined> {
+	const generation = getSessionGeneration();
 	_busy++;
 	try {
 		const result = await fn();
-		if (successMsg) success(successMsg);
+		if (successMsg && generation === getSessionGeneration()) success(successMsg);
 		return result;
 	} catch (e: unknown) {
 		const msg = e instanceof Error ? e.message : typeof e === 'object' && e !== null && 'message' in e ? String((e as { message: unknown }).message) : String(e);
-		error(msg);
+		if (generation === getSessionGeneration()) error(msg);
 		return undefined;
 	} finally {
-		_busy--;
+		if (generation === getSessionGeneration()) _busy--;
 	}
 }
+
+registerSessionReset(() => {
+	clearToasts();
+	_busy = 0;
+});

--- a/webui/src/lib/unlock-fs.svelte.ts
+++ b/webui/src/lib/unlock-fs.svelte.ts
@@ -14,6 +14,8 @@
  *    inline unlock without forcing the user to navigate away.
  */
 
+import { registerSessionReset } from './client';
+
 interface UnlockFsState {
 	open: boolean;
 	fsName: string;
@@ -40,3 +42,5 @@ export function unlockFsRespond(value: boolean) {
 	unlockFsState.resolve = null;
 	unlockFsState.fsName = '';
 }
+
+registerSessionReset(() => unlockFsRespond(false));

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -59,7 +59,7 @@
 	import { goto } from '$app/navigation';
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
-	import { rollbackState, confirmRollback, loadPendingRollback } from '$lib/rollbackState.svelte';
+	import { rollbackState, confirmRollback, loadPendingRollback, reconcileExpiredRollback, recoverPendingRollback } from '$lib/rollbackState.svelte';
 	import { tempUnit } from '$lib/temperature.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
@@ -321,7 +321,7 @@
 				rollbackState.pending &&
 				Math.floor(Date.now() / 1000) >= rollbackState.pending.revertAtUnix
 			) {
-				rollbackState.clear();
+				reconcileExpiredRollback();
 			}
 		}, 1000);
 		return () => clearInterval(handle);
@@ -404,7 +404,7 @@
 	// already been torn down. The txn is still alive server-side; this
 	// fetch puts the banner back so the user can confirm.
 	$effect(() => {
-		if (connected && isManagementRole(authInfo?.role)) loadPendingRollback();
+		if (connected && authInfo?.role === 'admin') loadPendingRollback();
 	});
 
 	// Clock
@@ -436,47 +436,56 @@
 		$page.url.pathname === '/portal' || $page.url.pathname.startsWith('/portal/')
 	);
 
+	const onReconnect = async () => {
+		dbg(`reconnect cb fired — clearing powering=${powering}, reconnecting=${reconnecting}, timer=${reconnectingTimer ? 'armed' : 'none'}`);
+		powering = false;
+		if (reconnectingTimer) {
+			clearTimeout(reconnectingTimer);
+			reconnectingTimer = null;
+		}
+		reconnecting = false;
+		if (authInfo?.role === 'admin') void recoverPendingRollback();
+		// Check if engine was updated while we were disconnected.
+		// If the commit changed, the WebUI bundle likely changed too — force reload.
+		try {
+			const res = await fetch('/health');
+			const health = await res.json();
+			if (initialCommit && health.commit && health.commit !== initialCommit) {
+				console.log(`Engine commit changed: ${initialCommit} → ${health.commit} — reloading`);
+				location.reload();
+				return;
+			}
+		} catch { /* health check failed, continue with stale UI */ }
+		// Engine binary is the same, but the kernel/bcachefs module may have
+		// changed underneath (e.g. a bcachefs-tools-only bump rebuilt the DKMS
+		// module without moving the engine commit). The footer reads
+		// system.info, which is fetched once on connect and cached client-side
+		// — without this trigger it shows the pre-reboot version until the
+		// user hits cmd+R.
+		sysInfoRefresh.trigger();
+	};
+	const onDisconnect = () => {
+		dbg(`disconnect cb fired — arming ${RECONNECT_OVERLAY_DELAY_MS}ms reconnect-overlay timer (powering=${powering}, prior timer=${reconnectingTimer ? 'rearming' : 'fresh'})`);
+		if (reconnectingTimer) clearTimeout(reconnectingTimer);
+		reconnectingTimer = setTimeout(() => {
+			dbg(`reconnect-overlay timer fired — reconnecting=true (powering=${powering})`);
+			reconnecting = true;
+			reconnectingTimer = null;
+		}, RECONNECT_OVERLAY_DELAY_MS);
+	};
+	let lifecycleClient: ReturnType<typeof getClient> | null = null;
+	function bindClientLifecycle(client: ReturnType<typeof getClient>) {
+		if (lifecycleClient === client) return;
+		lifecycleClient?.offReconnect(onReconnect);
+		lifecycleClient?.offDisconnect(onDisconnect);
+		lifecycleClient = client;
+		client.onReconnect(onReconnect);
+		client.onDisconnect(onDisconnect);
+	}
+
 	onMount(() => {
 		if (isPublicShare) return;
 		tryConnect();
-		const onReconnect = async () => {
-			dbg(`reconnect cb fired — clearing powering=${powering}, reconnecting=${reconnecting}, timer=${reconnectingTimer ? 'armed' : 'none'}`);
-			powering = false;
-			if (reconnectingTimer) {
-				clearTimeout(reconnectingTimer);
-				reconnectingTimer = null;
-			}
-			reconnecting = false;
-			// Check if engine was updated while we were disconnected.
-			// If the commit changed, the WebUI bundle likely changed too — force reload.
-			try {
-				const res = await fetch('/health');
-				const health = await res.json();
-				if (initialCommit && health.commit && health.commit !== initialCommit) {
-					console.log(`Engine commit changed: ${initialCommit} → ${health.commit} — reloading`);
-					location.reload();
-					return;
-				}
-			} catch { /* health check failed, continue with stale UI */ }
-			// Engine binary is the same, but the kernel/bcachefs module may have
-			// changed underneath (e.g. a bcachefs-tools-only bump rebuilt the DKMS
-			// module without moving the engine commit). The footer reads
-			// system.info, which is fetched once on connect and cached client-side
-			// — without this trigger it shows the pre-reboot version until the
-			// user hits cmd+R.
-			sysInfoRefresh.trigger();
-		};
-		const onDisconnect = () => {
-			dbg(`disconnect cb fired — arming ${RECONNECT_OVERLAY_DELAY_MS}ms reconnect-overlay timer (powering=${powering}, prior timer=${reconnectingTimer ? 'rearming' : 'fresh'})`);
-			if (reconnectingTimer) clearTimeout(reconnectingTimer);
-			reconnectingTimer = setTimeout(() => {
-				dbg(`reconnect-overlay timer fired — reconnecting=true (powering=${powering})`);
-				reconnecting = true;
-				reconnectingTimer = null;
-			}, RECONNECT_OVERLAY_DELAY_MS);
-		};
-		getClient().onReconnect(onReconnect);
-		getClient().onDisconnect(onDisconnect);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
 		const rebootPoll = setInterval(checkRebootRequired, 30_000);
 		const statusPoll = setInterval(refreshSystemStatus, 20_000);
@@ -485,9 +494,10 @@
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
-			getClient().offReconnect(onReconnect);
-			getClient().offDisconnect(onDisconnect);
-			getClient().disconnect();
+			lifecycleClient?.offReconnect(onReconnect);
+			lifecycleClient?.offDisconnect(onDisconnect);
+			lifecycleClient?.disconnect();
+			lifecycleClient = null;
 			clearInterval(sshPoll);
 			clearInterval(backupPoll);
 			clearInterval(tick);
@@ -533,6 +543,7 @@
 		}
 		try {
 			const client = getClient();
+			bindClientLifecycle(client);
 			authInfo = await client.connect();
 			const destination = redirectForRole(authInfo.role, $page.url.pathname);
 			if (destination) await goto(destination, { replaceState: true });
@@ -636,8 +647,25 @@
 		// own because JS can't clear an httpOnly cookie itself.
 		await doLogout();
 		resetClient();
+		if (reconnectingTimer) {
+			clearTimeout(reconnectingTimer);
+			reconnectingTimer = null;
+		}
+		reconnecting = false;
+		powering = false;
 		connected = false;
 		authInfo = null;
+		sysInfo = null;
+		systemStatus = null;
+		statusExpanded = false;
+		sshPasswordAuth = false;
+		configBackupMissing = false;
+		showPasswordChange = false;
+		newPassword = '';
+		confirmPassword = '';
+		passwordError = '';
+		profileOpen = false;
+		powerOpen = false;
 		showLogin = true;
 	}
 
@@ -1133,11 +1161,19 @@
 							<span class="font-medium">
 								{rollbackSecondsLeft}s to keep network change
 							</span>
+							{#if rollbackState.confirmationError}
+								<span
+									class="max-w-52 truncate text-xs text-red-300"
+									role="alert"
+									title={rollbackState.confirmationError}
+								>{rollbackState.confirmationError}</span>
+							{/if}
 							<button
 								onclick={() => confirmRollback()}
+								disabled={rollbackState.confirming}
 								class="rounded border border-amber-400/50 px-2 py-0.5 text-xs hover:bg-amber-500/10 hover:border-amber-400 active:bg-amber-500/20"
 							>
-								Keep changes
+								{rollbackState.confirming ? 'Keeping…' : 'Keep changes'}
 							</button>
 						</div>
 					{/if}

--- a/webui/src/routes/files/+page.svelte
+++ b/webui/src/routes/files/+page.svelte
@@ -9,6 +9,7 @@
 	import { getClient } from '$lib/client';
 	import { normalizeShareDownloadLimit } from '$lib/public-share';
 	import { withToast, error as toastError, success as toastSuccess } from '$lib/toast.svelte';
+	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 
 	interface FileEntry {
@@ -123,6 +124,17 @@
 	let uploading = $state(false);
 	let uploadProgress = $state(0);
 	let uploadName = $state('');
+
+	class FileUploadError extends Error {
+		status: number;
+		overwriteAllowed: boolean;
+
+		constructor(message: string, status: number, overwriteAllowed = false) {
+			super(message);
+			this.status = status;
+			this.overwriteAllowed = overwriteAllowed;
+		}
+	}
 
 	// Mkdir state
 	let showMkdir = $state(false);
@@ -472,44 +484,74 @@
 		input.multiple = true;
 		input.onchange = async () => {
 			if (!input.files?.length) return;
+			const uploadPath = currentPath;
 			for (const file of input.files) {
-				await uploadFile(file);
+				await uploadFile(file, uploadPath);
 			}
 		};
 		input.click();
 	}
 
-	async function uploadFile(file: globalThis.File) {
-		uploading = true;
+	function sendUpload(file: globalThis.File, path: string, overwrite: boolean): Promise<void> {
 		uploadProgress = 0;
-		uploadName = file.name;
-
 		const form = new FormData();
 		form.append('file', file);
+		const query = new URLSearchParams({ path });
+		if (overwrite) query.set('overwrite', 'true');
+
+		return new Promise<void>((resolve, reject) => {
+			const xhr = new XMLHttpRequest();
+			xhr.open('POST', `/api/files/upload?${query}`);
+			// Cookie auth — XHR sends same-origin cookies automatically.
+			xhr.upload.onprogress = (e) => {
+				if (e.lengthComputable) uploadProgress = Math.round((e.loaded / e.total) * 100);
+			};
+			xhr.onload = () => {
+				if (xhr.status >= 200 && xhr.status < 300) {
+					resolve();
+					return;
+				}
+				let message = 'Upload failed';
+				let overwriteAllowed = false;
+				try {
+					const body = JSON.parse(xhr.responseText);
+					if (typeof body?.error === 'string') message = body.error;
+					overwriteAllowed = body?.overwrite_allowed === true;
+				} catch {
+					if (xhr.statusText) message = xhr.statusText;
+				}
+				reject(new FileUploadError(message, xhr.status, overwriteAllowed));
+			};
+			xhr.onerror = () => reject(new FileUploadError('Network error', 0));
+			xhr.send(form);
+		});
+	}
+
+	async function uploadFile(file: globalThis.File, uploadPath: string) {
+		uploading = true;
+		uploadName = file.name;
 
 		try {
-			await new Promise<void>((resolve, reject) => {
-				const xhr = new XMLHttpRequest();
-				xhr.open('POST', `/api/files/upload?path=${encodeURIComponent(currentPath)}`);
-				// Cookie auth — XHR sends same-origin cookies automatically.
-				xhr.upload.onprogress = (e) => {
-					if (e.lengthComputable) uploadProgress = Math.round((e.loaded / e.total) * 100);
-				};
-				xhr.onload = () => {
-					if (xhr.status === 200) resolve();
-					else reject(new Error(JSON.parse(xhr.responseText)?.error || 'Upload failed'));
-				};
-				xhr.onerror = () => reject(new Error('Network error'));
-				xhr.send(form);
-			});
+			try {
+				await sendUpload(file, uploadPath, false);
+			} catch (e) {
+				if (!(e instanceof FileUploadError) || e.status !== 409 || !e.overwriteAllowed) throw e;
+				const approved = await confirm(
+					`Overwrite “${file.name}”?`,
+					'A file with this name already exists. Replacing it cannot be undone.',
+					{ confirmLabel: 'Overwrite', cancelLabel: 'Keep existing' },
+				);
+				if (!approved) return;
+				await sendUpload(file, uploadPath, true);
+			}
 		} catch (e: unknown) {
 			alert(e instanceof Error ? e.message : 'Upload failed');
+		} finally {
+			uploading = false;
+			uploadProgress = 0;
+			uploadName = '';
+			await browse(currentPath);
 		}
-
-		uploading = false;
-		uploadProgress = 0;
-		uploadName = '';
-		await browse(currentPath);
 	}
 
 	async function createDir() {

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -124,7 +124,7 @@
 			vlans: network.vlans || [],
 			bridges: network.bridges || [],
 		};
-		await applyNetworkUpdate(payload, `Removed saved config for absent device ${name}`);
+		if (!await applyNetworkUpdate(payload, `Removed saved config for absent device ${name}`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 	}
 	let savingNetwork = $state(false);
@@ -547,7 +547,10 @@
 			if (idx >= 0) payload.interfaces[idx] = entry; else payload.interfaces.push(entry);
 		}
 
-		await applyNetworkUpdate(payload, 'Network configuration applied');
+		if (!await applyNetworkUpdate(payload, 'Network configuration applied')) {
+			savingNetwork = false;
+			return;
+		}
 		networkState = await client.call<NetworkState>('system.network.get');
 		netChanged = false;
 		savingNetwork = false;
@@ -572,7 +575,7 @@
 			vlans: network.vlans || [],
 			bridges: network.bridges || [],
 		};
-		await applyNetworkUpdate(payload, `Bond ${bondName} created`);
+		if (!await applyNetworkUpdate(payload, `Bond ${bondName} created`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 		showBondForm = false; bondName = 'bond0'; bondMembers = []; bondMtu = ''; bondNoInheritMac = false;
 	}
@@ -589,7 +592,7 @@
 			vlans: [...(network.vlans || []), { parent: vlanParent, vlan_id: vlanId, ipv4: { method: 'dhcp', addresses: [], gateway: null }, ipv6: { method: 'slaac', addresses: [], gateway: null }, mtu }],
 			bridges: network.bridges || [],
 		};
-		await applyNetworkUpdate(payload, `VLAN ${vlanParent}.${vlanId} created`);
+		if (!await applyNetworkUpdate(payload, `VLAN ${vlanParent}.${vlanId} created`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 		showVlanForm = false; vlanParent = ''; vlanId = 100; vlanMtu = ''; vlanTried = false;
 	}
@@ -611,7 +614,7 @@
 			vlans: network.vlans || [],
 			bridges: network.bridges || [],
 		};
-		await applyNetworkUpdate(payload, `Bond ${name} removed`);
+		if (!await applyNetworkUpdate(payload, `Bond ${name} removed`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 	}
 
@@ -628,7 +631,7 @@
 			vlans: network.vlans || [],
 			bridges: (network.bridges || []).filter(b => b.name !== name),
 		};
-		await applyNetworkUpdate(payload, `Bridge ${name} removed`);
+		if (!await applyNetworkUpdate(payload, `Bridge ${name} removed`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 	}
 
@@ -642,7 +645,7 @@
 			vlans: (network.vlans || []).filter(v => !(v.parent === parent && v.vlan_id === vlan_id)),
 			bridges: network.bridges || [],
 		};
-		await applyNetworkUpdate(payload, `VLAN ${parent}.${vlan_id} removed`);
+		if (!await applyNetworkUpdate(payload, `VLAN ${parent}.${vlan_id} removed`)) return;
 		networkState = await client.call<NetworkState>('system.network.get');
 	}
 

--- a/webui/vitest.config.ts
+++ b/webui/vitest.config.ts
@@ -1,5 +1,6 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 // Kept separate from vite.config.ts so vitest's bundled vite copy doesn't
 // clash with the SvelteKit plugin's plugin types under svelte-check.
@@ -7,6 +8,11 @@ import { defineConfig } from 'vitest/config';
 // compile *.svelte.ts files that use $state and other runes.
 export default defineConfig({
 	plugins: [svelte()],
+	resolve: {
+		alias: {
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+		},
+	},
 	test: {
 		include: ['src/**/*.{test,spec}.ts'],
 		setupFiles: ['./vitest.setup.ts']


### PR DESCRIPTION
## Summary
- require explicit confirmation before overwriting uploads and publish completed files atomically
- preserve and serialize network rollback state across failures, reconnects, and concurrent clients
- recreate RPC clients safely on logout and reset session-scoped WebUI stores and dialogs

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- npm run check
- npm test
- npm run build