### PR TITLE
sharing: restore block exports by immutable identity

### DIFF
--- a/engine/nasty-common/src/block_volume.rs
+++ b/engine/nasty-common/src/block_volume.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Stable identity of a block subvolume, independent of its pool name,
+/// subvolume name, mount point, and current loop-device number.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct BlockVolumeId {
+    pub filesystem_uuid: String,
+    pub subvolume_id: u32,
+}
+
+/// Runtime result of restoring block-subvolume loop devices.
+#[derive(Debug, Clone, Default)]
+pub struct BlockDeviceMappings {
+    /// Stable identity to the loop device attached during this boot.
+    pub current: HashMap<BlockVolumeId, String>,
+}
+
+impl BlockDeviceMappings {
+    pub fn is_empty(&self) -> bool {
+        self.current.is_empty()
+    }
+}

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod block_volume;
 pub mod cmd;
 pub mod jsonrpc;
 pub mod metrics_types;
@@ -6,5 +7,6 @@ pub mod secure_boot;
 pub mod state;
 pub mod tpm;
 
+pub use block_volume::{BlockDeviceMappings, BlockVolumeId};
 pub use jsonrpc::{Error as RpcError, ErrorCode, Notification, Request, Response};
 pub use state::{HasId, StateDir, load_singleton_or_recover};

--- a/engine/nasty-common/src/state.rs
+++ b/engine/nasty-common/src/state.rs
@@ -124,6 +124,35 @@ impl StateDir {
         items
     }
 
+    /// Load every JSON item or fail the whole operation. Use this for safety-
+    /// critical restoration where silently omitting one corrupt item could
+    /// leave an independent runtime configuration pointing at stale devices.
+    pub async fn load_all_strict<T: DeserializeOwned>(&self) -> std::io::Result<Vec<T>> {
+        let mut items = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&self.dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(items),
+            Err(error) => return Err(error),
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let content = tokio::fs::read_to_string(&path).await?;
+            let item = serde_json::from_str(&content).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("parse {}: {error}", path.display()),
+                )
+            })?;
+            items.push(item);
+        }
+
+        Ok(items)
+    }
+
     /// Load a single item by its ID.
     pub async fn load<T: DeserializeOwned>(&self, id: &str) -> Option<T> {
         let path = self.item_path(id);
@@ -234,5 +263,20 @@ mod tests {
             }
         }
         assert!(found_backup, "expected bad.json.corrupt.<ts> backup file");
+    }
+
+    #[tokio::test]
+    async fn strict_directory_load_rejects_partial_state() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("good.json"), br#"{"name":"ok","count":1}"#)
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("bad.json"), b"not json")
+            .await
+            .unwrap();
+
+        let result = StateDir::new(dir.path()).load_all_strict::<Sample>().await;
+
+        assert!(result.is_err());
     }
 }

--- a/engine/nasty-engine/src/fs_dependents.rs
+++ b/engine/nasty-engine/src/fs_dependents.rs
@@ -40,6 +40,7 @@ pub struct FsDependents {
     pub smb_shares: Vec<String>,
     pub iscsi_targets: Vec<String>,
     pub nvmeof_subsystems: Vec<String>,
+    pub state_errors: Vec<String>,
 }
 
 /// True if `path` falls under `/fs/<fs_name>/` (the canonical NASty
@@ -78,6 +79,10 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
     let block_devs: HashSet<String> = subvols
         .iter()
         .filter_map(|s| s.block_device.clone())
+        .collect();
+    let block_ids: HashSet<nasty_common::BlockVolumeId> = subvols
+        .iter()
+        .filter_map(|s| s.block_volume_id.clone())
         .collect();
     out.subvolumes = subvols.into_iter().map(|s| s.name).collect();
 
@@ -136,29 +141,45 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
             .map(|s| s.name)
             .collect();
     }
-    if let Ok(targets) = state.iscsi.list().await {
-        out.iscsi_targets = targets
-            .into_iter()
-            .filter(|t| {
-                t.luns.iter().any(|l| {
-                    path_belongs_to_fs(&l.backstore_path, fs_name)
-                        || block_devs.contains(&l.backstore_path)
+    match state.iscsi.list().await {
+        Ok(targets) => {
+            out.iscsi_targets = targets
+                .into_iter()
+                .filter(|t| {
+                    t.luns.iter().any(|l| {
+                        path_belongs_to_fs(&l.backstore_path, fs_name)
+                            || block_devs.contains(&l.backstore_path)
+                            || l.backing_volume
+                                .as_ref()
+                                .is_some_and(|identity| block_ids.contains(identity))
+                    })
                 })
-            })
-            .map(|t| t.iqn)
-            .collect();
+                .map(|t| t.iqn)
+                .collect();
+        }
+        Err(error) => out
+            .state_errors
+            .push(format!("iSCSI state failed to load: {error}")),
     }
-    if let Ok(subs) = state.nvmeof.list().await {
-        out.nvmeof_subsystems = subs
-            .into_iter()
-            .filter(|s| {
-                s.namespaces.iter().any(|n| {
-                    path_belongs_to_fs(&n.device_path, fs_name)
-                        || block_devs.contains(&n.device_path)
+    match state.nvmeof.list().await {
+        Ok(subs) => {
+            out.nvmeof_subsystems = subs
+                .into_iter()
+                .filter(|s| {
+                    s.namespaces.iter().any(|n| {
+                        path_belongs_to_fs(&n.device_path, fs_name)
+                            || block_devs.contains(&n.device_path)
+                            || n.backing_volume
+                                .as_ref()
+                                .is_some_and(|identity| block_ids.contains(identity))
+                    })
                 })
-            })
-            .map(|s| s.nqn)
-            .collect();
+                .map(|s| s.nqn)
+                .collect();
+        }
+        Err(error) => out
+            .state_errors
+            .push(format!("NVMe-oF state failed to load: {error}")),
     }
 
     out

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -313,10 +313,9 @@ async fn main() -> anyhow::Result<()> {
         );
         *state.mount_failures.lock().await = mount_failures;
     }
-    // Re-attach loop devices and get the current name→device mapping.
-    // Loop device numbers change across reboots, so NVMe-oF and iSCSI state
-    // files must be patched before their respective restore steps run.
-    let dev_map = state
+    // Re-attach loop devices and resolve persisted sharing state by immutable
+    // filesystem UUID + bcachefs subvolume ID before protocols start.
+    let block_devices = state
         .boot_status
         .run_phase(
             "subvolumes.restore_block_devices",
@@ -324,27 +323,56 @@ async fn main() -> anyhow::Result<()> {
             state.subvolumes.restore_block_devices(),
         )
         .await;
-    if !dev_map.is_empty() {
-        state
-            .boot_status
-            .run_phase(
-                "nvmeof.remap_device_paths",
-                secs(15), // string substitution + state-file save
-                state.nvmeof.remap_device_paths(&dev_map),
-            )
+    let nvmeof_remap = state
+        .boot_status
+        .run_phase(
+            "nvmeof.remap_device_paths",
+            secs(15),
+            state.nvmeof.remap_device_paths(&block_devices),
+        )
+        .await;
+    let iscsi_remap = state
+        .boot_status
+        .run_phase(
+            "iscsi.remap_device_paths",
+            secs(15),
+            state.iscsi.remap_device_paths(&block_devices),
+        )
+        .await;
+    let reload_iscsi = !iscsi_remap.safe_to_restore
+        || state
+            .protocols
+            .is_enabled(nasty_system::protocol::Protocol::Iscsi)
             .await;
-        state
-            .boot_status
-            .run_phase(
-                "iscsi.remap_device_paths",
-                secs(15),
-                state.iscsi.remap_device_paths(&dev_map),
-            )
-            .await;
+    if reload_iscsi {
+        tokio::time::timeout(
+            secs(30),
+            state
+                .protocols
+                .quiesce(nasty_system::protocol::Protocol::Iscsi),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out quiescing iSCSI before protocol restore"))?
+        .map_err(|error| {
+            anyhow::anyhow!("failed to quiesce iSCSI before protocol restore: {error}")
+        })?;
+    }
+    if !nvmeof_remap.safe_to_restore {
+        tokio::time::timeout(secs(30), state.nvmeof.quiesce())
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out quiescing unsafe NVMe-oF state"))?
+            .map_err(|error| anyhow::anyhow!("failed to quiesce unsafe NVMe-oF state: {error}"))?;
     }
 
     // Settle any interrupted network transaction and remove orphaned profiles
     // before rendering interface-restricted firewall rules.
+    let mut excluded_protocols = std::collections::HashSet::new();
+    if !iscsi_remap.safe_to_restore {
+        excluded_protocols.insert(nasty_system::protocol::Protocol::Iscsi);
+    }
+    if !nvmeof_remap.safe_to_restore {
+        excluded_protocols.insert(nasty_system::protocol::Protocol::Nvmeof);
+    }
     state
         .boot_status
         .run_phase(
@@ -411,7 +439,7 @@ async fn main() -> anyhow::Result<()> {
         .run_phase(
             "protocols.restore",
             secs(90), // 9 systemd services × up to ~10s each on a bursty box
-            state.protocols.restore(),
+            state.protocols.restore_excluding(&excluded_protocols),
         )
         .await;
     // Protocol restore disables persisted entries whose daemons fail to start.
@@ -421,7 +449,10 @@ async fn main() -> anyhow::Result<()> {
         use nasty_system::protocol::Protocol;
         let mut actual_states = Vec::new();
         for proto in Protocol::ALL {
-            actual_states.push((*proto, state.protocols.is_enabled(*proto).await));
+            actual_states.push((
+                *proto,
+                !excluded_protocols.contains(proto) && state.protocols.is_enabled(*proto).await,
+            ));
         }
         state
             .firewall
@@ -489,15 +520,29 @@ async fn main() -> anyhow::Result<()> {
 
     state
         .boot_status
-        .run_phase(
-            "nvmeof.restore",
-            // configfs writes are fast, but restore first waits (up to 45s)
-            // for specific port addresses to come up so binds don't race the
-            // network and fail with EADDRNOTAVAIL (#625). Budget covers the
-            // wait plus the writes.
-            secs(75),
-            state.nvmeof.restore(),
-        )
+        .run_phase("nvmeof.restore", secs(75), async {
+            if nvmeof_remap.safe_to_restore {
+                if let Err(error) = state.nvmeof.restore().await {
+                    tracing::error!("Failed to restore NVMe-oF safely: {error}");
+                    if let Err(error) = state.nvmeof.quiesce().await {
+                        tracing::error!("Failed to quiesce partial NVMe-oF restore: {error}");
+                    }
+                    if let Err(error) = state
+                        .firewall
+                        .close(nasty_system::protocol::Protocol::Nvmeof)
+                        .await
+                    {
+                        tracing::error!(
+                            "Failed to close NVMe-oF firewall after restore failure: {error}"
+                        );
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    "Skipping NVMe-oF configfs restore because block identity resolution failed"
+                );
+            }
+        })
         .await;
     state
         .boot_status

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -77,8 +77,7 @@ pub(super) async fn try_route(
                     .await
                 {
                     Ok(v) => {
-                        // Cascade: restore block devices on this filesystem
-                        let _ = state.subvolumes.restore_block_devices().await;
+                        reconcile_block_shares(state).await;
                         ok(req, v)
                     }
                     Err(e) => err(req, e),
@@ -98,7 +97,10 @@ pub(super) async fn try_route(
                 let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let passphrase = p.get("passphrase").and_then(|v| v.as_str()).unwrap_or("");
                 match state.filesystems.unlock(name, passphrase).await {
-                    Ok(fs) => ok(req, fs),
+                    Ok(fs) => {
+                        reconcile_block_shares(state).await;
+                        ok(req, fs)
+                    }
                     Err(e) => err(req, e),
                 }
             }
@@ -365,4 +367,88 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+async fn reconcile_block_shares(state: &AppState) {
+    let mappings = state.subvolumes.restore_block_devices().await;
+    let nvmeof = state.nvmeof.remap_device_paths(&mappings).await;
+    let iscsi = state.iscsi.remap_device_paths(&mappings).await;
+    if !iscsi.safe_to_restore {
+        if let Err(error) = state
+            .protocols
+            .quiesce(nasty_system::protocol::Protocol::Iscsi)
+            .await
+        {
+            tracing::error!("Failed to quiesce unsafe iSCSI state: {error}");
+        }
+        let _ = state
+            .firewall
+            .close(nasty_system::protocol::Protocol::Iscsi)
+            .await;
+    } else if state
+        .protocols
+        .is_enabled(nasty_system::protocol::Protocol::Iscsi)
+        .await
+        && (iscsi.changed
+            || !state
+                .protocols
+                .is_running(nasty_system::protocol::Protocol::Iscsi)
+                .await)
+    {
+        let result = match state
+            .protocols
+            .quiesce(nasty_system::protocol::Protocol::Iscsi)
+            .await
+        {
+            Ok(()) => match state
+                .firewall
+                .open(nasty_system::protocol::Protocol::Iscsi)
+                .await
+            {
+                Ok(()) => state.protocols.enable("iscsi").await.map(|_| ()),
+                Err(error) => Err(error),
+            },
+            Err(error) => Err(error),
+        };
+        if let Err(error) = result {
+            tracing::warn!("Failed to reactivate iSCSI after mount: {error}");
+            let _ = state
+                .firewall
+                .close(nasty_system::protocol::Protocol::Iscsi)
+                .await;
+        }
+    }
+    if !nvmeof.safe_to_restore {
+        if let Err(error) = state.nvmeof.quiesce().await {
+            tracing::error!("Failed to quiesce unsafe NVMe-oF state: {error}");
+        }
+        let _ = state
+            .firewall
+            .close(nasty_system::protocol::Protocol::Nvmeof)
+            .await;
+    } else if state
+        .protocols
+        .is_enabled(nasty_system::protocol::Protocol::Nvmeof)
+        .await
+        && (nvmeof.changed || !state.nvmeof.is_active().await.unwrap_or(false))
+    {
+        if let Err(error) = state
+            .firewall
+            .open(nasty_system::protocol::Protocol::Nvmeof)
+            .await
+        {
+            tracing::warn!("Failed to reopen NVMe-oF firewall after mount: {error}");
+        } else if let Err(error) = state.protocols.enable("nvmeof").await {
+            tracing::warn!("Failed to reactivate NVMe-oF after mount: {error}");
+        } else if let Err(error) = state.nvmeof.restore().await {
+            tracing::warn!("Failed to restore NVMe-oF after mount: {error}");
+            if let Err(error) = state.nvmeof.quiesce().await {
+                tracing::error!("Failed to quiesce partial NVMe-oF restore: {error}");
+            }
+            let _ = state
+                .firewall
+                .close(nasty_system::protocol::Protocol::Nvmeof)
+                .await;
+        }
+    }
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -653,32 +653,62 @@ pub(super) async fn check_block_device_conflict(
     device_path: &str,
     exclude_protocol: &str,
 ) -> Option<String> {
-    if exclude_protocol != "iscsi"
-        && let Ok(targets) = state.iscsi.list().await
+    let identity = match state
+        .subvolumes
+        .block_volume_id_for_device(device_path)
+        .await
     {
-        for target in &targets {
-            for lun in &target.luns {
-                if lun.backstore_path == device_path {
-                    return Some(format!(
-                        "device {} is already exported via iSCSI (target '{}')",
-                        device_path, target.iqn
-                    ));
+        Ok(identity) => identity,
+        Err(error) => return Some(error.to_string()),
+    };
+    if exclude_protocol != "iscsi" {
+        match state.iscsi.list().await {
+            Ok(targets) => {
+                for target in &targets {
+                    for lun in &target.luns {
+                        if lun.backstore_path == device_path
+                            || identity.as_ref().is_some_and(|identity| {
+                                lun.backing_volume.as_ref() == Some(identity)
+                            })
+                        {
+                            return Some(format!(
+                                "device {} is already exported via iSCSI (target '{}')",
+                                device_path, target.iqn
+                            ));
+                        }
+                    }
                 }
+            }
+            Err(error) => {
+                return Some(format!(
+                    "cannot verify iSCSI device conflicts because state failed to load: {error}"
+                ));
             }
         }
     }
 
-    if exclude_protocol != "nvmeof"
-        && let Ok(subsystems) = state.nvmeof.list().await
-    {
-        for sub in &subsystems {
-            for ns in &sub.namespaces {
-                if ns.device_path == device_path {
-                    return Some(format!(
-                        "device {} is already exported via NVMe-oF (subsystem '{}')",
-                        device_path, sub.nqn
-                    ));
+    if exclude_protocol != "nvmeof" {
+        match state.nvmeof.list().await {
+            Ok(subsystems) => {
+                for sub in &subsystems {
+                    for ns in &sub.namespaces {
+                        if ns.device_path == device_path
+                            || identity.as_ref().is_some_and(|identity| {
+                                ns.backing_volume.as_ref() == Some(identity)
+                            })
+                        {
+                            return Some(format!(
+                                "device {} is already exported via NVMe-oF (subsystem '{}')",
+                                device_path, sub.nqn
+                            ));
+                        }
+                    }
                 }
+            }
+            Err(error) => {
+                return Some(format!(
+                    "cannot verify NVMe-oF device conflicts because state failed to load: {error}"
+                ));
             }
         }
     }
@@ -811,6 +841,7 @@ pub(super) async fn check_subvolume_in_use(
         None => return None,
     };
     let block_device = sv.block_device.as_deref();
+    let block_volume_id = sv.block_volume_id.as_ref();
     let subvol_path = &sv.path;
 
     // ── Block device checks (VMs, iSCSI, NVMe-oF) ──
@@ -829,12 +860,18 @@ pub(super) async fn check_subvolume_in_use(
                 }
             }
         }
+    }
 
-        // Check iSCSI targets
-        if let Ok(targets) = state.iscsi.list().await {
+    // Sharing state persists immutable block identities, so these checks remain
+    // valid even while the backing volume is detached or loop numbers changed.
+    match state.iscsi.list().await {
+        Ok(targets) => {
             for target in &targets {
                 for lun in &target.luns {
-                    if lun.backstore_path == bd {
+                    if block_device.is_some_and(|device| lun.backstore_path == device)
+                        || block_volume_id
+                            .is_some_and(|identity| lun.backing_volume.as_ref() == Some(identity))
+                    {
                         return Some(format!(
                             "subvolume is in use by iSCSI target '{}'. Delete the target first.",
                             target.iqn
@@ -843,12 +880,21 @@ pub(super) async fn check_subvolume_in_use(
                 }
             }
         }
+        Err(error) => {
+            return Some(format!(
+                "cannot verify iSCSI dependencies because state failed to load: {error}"
+            ));
+        }
+    }
 
-        // Check NVMe-oF subsystems
-        if let Ok(subsystems) = state.nvmeof.list().await {
+    match state.nvmeof.list().await {
+        Ok(subsystems) => {
             for subsys in &subsystems {
                 for ns in &subsys.namespaces {
-                    if ns.device_path == bd {
+                    if block_device.is_some_and(|device| ns.device_path == device)
+                        || block_volume_id
+                            .is_some_and(|identity| ns.backing_volume.as_ref() == Some(identity))
+                    {
                         return Some(format!(
                             "subvolume is in use by NVMe-oF subsystem '{}'. Delete the subsystem first.",
                             subsys.nqn
@@ -856,6 +902,11 @@ pub(super) async fn check_subvolume_in_use(
                     }
                 }
             }
+        }
+        Err(error) => {
+            return Some(format!(
+                "cannot verify NVMe-oF dependencies because state failed to load: {error}"
+            ));
         }
     }
 

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -21,10 +21,92 @@ pub(super) async fn try_route(
         "service.protocol.enable" => match require_str(req, "name") {
             Ok(name) => {
                 if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
+                    if matches!(
+                        proto,
+                        nasty_system::protocol::Protocol::Iscsi
+                            | nasty_system::protocol::Protocol::Nvmeof
+                    ) {
+                        let mappings = state.subvolumes.restore_block_devices().await;
+                        let safe = match proto {
+                            nasty_system::protocol::Protocol::Iscsi => {
+                                let outcome = state.iscsi.remap_device_paths(&mappings).await;
+                                outcome.safe_to_restore
+                            }
+                            nasty_system::protocol::Protocol::Nvmeof => {
+                                let outcome = state.nvmeof.remap_device_paths(&mappings).await;
+                                outcome.safe_to_restore
+                            }
+                            _ => true,
+                        };
+                        if !safe {
+                            let quiesce_error = match proto {
+                                nasty_system::protocol::Protocol::Iscsi => {
+                                    state.protocols.quiesce(proto).await.err()
+                                }
+                                nasty_system::protocol::Protocol::Nvmeof => state
+                                    .nvmeof
+                                    .quiesce()
+                                    .await
+                                    .err()
+                                    .map(|error| error.to_string()),
+                                _ => None,
+                            };
+                            let _ = state.firewall.close(proto).await;
+                            return Some(err(
+                                req,
+                                if let Some(quiesce_error) = quiesce_error {
+                                    format!(
+                                        "{} backing volumes could not be resolved safely; live export quiescing also failed: {quiesce_error}",
+                                        proto.display_name()
+                                    )
+                                } else {
+                                    format!(
+                                        "{} backing volumes could not be resolved safely",
+                                        proto.display_name()
+                                    )
+                                },
+                            ));
+                        }
+                        if proto == nasty_system::protocol::Protocol::Iscsi
+                            && let Err(error) = state.protocols.quiesce(proto).await
+                        {
+                            return Some(err(
+                                req,
+                                format!("failed to reload remapped iSCSI state: {error}"),
+                            ));
+                        }
+                    }
                     match state.firewall.open(proto).await {
                         Err(e) => err(req, format!("firewall update failed: {e}")),
                         Ok(()) => match state.protocols.enable(name).await {
-                            Ok(v) => ok(req, v),
+                            Ok(v) => {
+                                if proto == nasty_system::protocol::Protocol::Nvmeof
+                                    && let Err(error) = state.nvmeof.restore().await
+                                {
+                                    let quiesce = state.nvmeof.quiesce().await.err();
+                                    let disable = state.protocols.disable(name).await.err();
+                                    let close = state.firewall.close(proto).await.err();
+                                    let mut message =
+                                        format!("failed to restore NVMe-oF safely: {error}");
+                                    if let Some(error) = quiesce {
+                                        message.push_str(&format!(
+                                            "; live namespace quiescing also failed: {error}"
+                                        ));
+                                    }
+                                    if let Some(error) = disable {
+                                        message.push_str(&format!(
+                                            "; protocol rollback also failed: {error}"
+                                        ));
+                                    }
+                                    if let Some(error) = close {
+                                        message.push_str(&format!(
+                                            "; firewall rollback also failed: {error}"
+                                        ));
+                                    }
+                                    return Some(err(req, message));
+                                }
+                                ok(req, v)
+                            }
                             Err(service_error) => {
                                 let rollback = state.firewall.close(proto).await;
                                 match rollback {

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -243,7 +243,7 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                 return Some(r);
             }
             match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
-                Ok(p) => {
+                Ok(mut p) => {
                     if p.portals
                         .as_deref()
                         .is_some_and(|ps| ps.iter().any(|portal| portal.iser))
@@ -256,6 +256,16 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                             check_block_device_conflict(state, dp, "iscsi").await
                     {
                         return Some(err(req, conflict));
+                    }
+                    if let Some(ref device_path) = p.device_path {
+                        match state
+                            .subvolumes
+                            .block_volume_id_for_device(device_path)
+                            .await
+                        {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
                     }
                     match state.iscsi.create(p).await {
                         Ok(v) => ok(req, v),
@@ -286,12 +296,20 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                 return Some(r);
             }
             match parse_params::<nasty_sharing::iscsi::AddLunRequest>(req) {
-                Ok(p) => {
+                Ok(mut p) => {
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.backstore_path, "iscsi").await
                     {
                         err(req, conflict)
                     } else {
+                        match state
+                            .subvolumes
+                            .block_volume_id_for_device(&p.backstore_path)
+                            .await
+                        {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
                         match state.iscsi.add_lun(p).await {
                             Ok(v) => ok(req, v),
                             Err(e) => err(req, e),
@@ -417,12 +435,22 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                 return Some(r);
             }
             match parse_params::<nasty_sharing::nvmeof::CreateSubsystemRequest>(req) {
-                Ok(p) => {
+                Ok(mut p) => {
                     if let Some(ref device_path) = p.device_path
                         && let Some(conflict) =
                             check_block_device_conflict(state, device_path, "nvmeof").await
                     {
                         return Some(err(req, conflict));
+                    }
+                    if let Some(ref device_path) = p.device_path {
+                        match state
+                            .subvolumes
+                            .block_volume_id_for_device(device_path)
+                            .await
+                        {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
                     }
                     match state.nvmeof.create(p).await {
                         Ok(v) => {
@@ -477,12 +505,20 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                 return Some(r);
             }
             match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
-                Ok(p) => {
+                Ok(mut p) => {
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.device_path, "nvmeof").await
                     {
                         err(req, conflict)
                     } else {
+                        match state
+                            .subvolumes
+                            .block_volume_id_for_device(&p.device_path)
+                            .await
+                        {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
                         match state.nvmeof.add_namespace(p).await {
                             Ok(v) => ok(req, v),
                             Err(e) => err(req, e),

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -152,18 +152,39 @@ pub(super) async fn try_route(
                     // disabling under live consumers would strand them
                     // (nvmet-rdma port writes fail, iSER portals die).
                     let mut consumers: Vec<String> = Vec::new();
-                    if let Ok(subsystems) = state.nvmeof.list().await {
-                        for s in subsystems {
-                            if s.ports.iter().any(|port| port.transport == "rdma") {
-                                consumers.push(format!("NVMe-oF subsystem '{}'", s.nqn));
+                    match state.nvmeof.list().await {
+                        Ok(subsystems) => {
+                            for s in subsystems {
+                                if s.ports.iter().any(|port| port.transport == "rdma") {
+                                    consumers.push(format!("NVMe-oF subsystem '{}'", s.nqn));
+                                }
                             }
                         }
+                        Err(error) => {
+                            return Some(err(
+                                req,
+                                format!(
+                                    "cannot safely disable RDMA because NVMe-oF state failed to load: {error}"
+                                ),
+                            ));
+                        }
                     }
-                    if let Ok(targets) = state.iscsi.list().await {
-                        for t in targets {
-                            if t.portals.iter().any(|portal| portal.iser) {
-                                consumers.push(format!("iSCSI target '{}' (iSER portal)", t.iqn));
+                    match state.iscsi.list().await {
+                        Ok(targets) => {
+                            for t in targets {
+                                if t.portals.iter().any(|portal| portal.iser) {
+                                    consumers
+                                        .push(format!("iSCSI target '{}' (iSER portal)", t.iqn));
+                                }
                             }
+                        }
+                        Err(error) => {
+                            return Some(err(
+                                req,
+                                format!(
+                                    "cannot safely disable RDMA because iSCSI state failed to load: {error}"
+                                ),
+                            ));
                         }
                     }
                     if !consumers.is_empty() {

--- a/engine/nasty-engine/src/subvolume_dependents.rs
+++ b/engine/nasty-engine/src/subvolume_dependents.rs
@@ -39,6 +39,7 @@ pub struct SubvolumeDependents {
     pub smb_shares: Vec<String>,
     pub iscsi_targets: Vec<String>,
     pub nvmeof_subsystems: Vec<String>,
+    pub state_errors: Vec<String>,
 }
 
 /// Find the subvolume (by path) that owns `target`. Returns `None`
@@ -76,6 +77,8 @@ pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDep
     let mut by_path: HashMap<String, SubvolumeDependents> = HashMap::new();
     // Index of block-device → subvolume path, for the loop-backed case.
     let mut by_block_dev: HashMap<String, String> = HashMap::new();
+    // Stable block identity → subvolume path, valid while detached too.
+    let mut by_block_id: HashMap<nasty_common::BlockVolumeId, String> = HashMap::new();
     // Subvolume paths sorted longest-first so the prefix match picks
     // the most-specific subvolume — `/fs/tank/apps/grafana/data`
     // attributes to `/fs/tank/apps/grafana` rather than `/fs/tank` if
@@ -94,6 +97,9 @@ pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDep
         );
         if let Some(bd) = sv.block_device.clone() {
             by_block_dev.insert(bd, sv.path.clone());
+        }
+        if let Some(identity) = sv.block_volume_id.clone() {
+            by_block_id.insert(identity, sv.path.clone());
         }
         paths_desc.push(sv.path.clone());
     }
@@ -175,41 +181,73 @@ pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDep
 
     // iSCSI targets. Each LUN's backstore_path is either a file path
     // (image-backed) or a block device (loop-backed).
-    if let Ok(targets) = state.iscsi.list().await {
-        for t in targets {
-            let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
-            for l in &t.luns {
-                if let Some(p) = owning_subvol(&paths_desc, &l.backstore_path) {
-                    owners.insert(p.to_string());
+    match state.iscsi.list().await {
+        Ok(targets) => {
+            for t in targets {
+                let mut owners: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for l in &t.luns {
+                    if let Some(p) = owning_subvol(&paths_desc, &l.backstore_path) {
+                        owners.insert(p.to_string());
+                    }
+                    if let Some(p) = by_block_dev.get(&l.backstore_path) {
+                        owners.insert(p.clone());
+                    }
+                    if let Some(p) = l
+                        .backing_volume
+                        .as_ref()
+                        .and_then(|identity| by_block_id.get(identity))
+                    {
+                        owners.insert(p.clone());
+                    }
                 }
-                if let Some(p) = by_block_dev.get(&l.backstore_path) {
-                    owners.insert(p.clone());
+                for path in owners {
+                    if let Some(deps) = by_path.get_mut(&path) {
+                        deps.iscsi_targets.push(t.iqn.clone());
+                    }
                 }
             }
-            for path in owners {
-                if let Some(deps) = by_path.get_mut(&path) {
-                    deps.iscsi_targets.push(t.iqn.clone());
-                }
+        }
+        Err(error) => {
+            let message = format!("iSCSI state failed to load: {error}");
+            for deps in by_path.values_mut() {
+                deps.state_errors.push(message.clone());
             }
         }
     }
 
     // NVMe-oF subsystems.
-    if let Ok(subs) = state.nvmeof.list().await {
-        for s in subs {
-            let mut owners: std::collections::HashSet<String> = std::collections::HashSet::new();
-            for n in &s.namespaces {
-                if let Some(p) = owning_subvol(&paths_desc, &n.device_path) {
-                    owners.insert(p.to_string());
+    match state.nvmeof.list().await {
+        Ok(subs) => {
+            for s in subs {
+                let mut owners: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for n in &s.namespaces {
+                    if let Some(p) = owning_subvol(&paths_desc, &n.device_path) {
+                        owners.insert(p.to_string());
+                    }
+                    if let Some(p) = by_block_dev.get(&n.device_path) {
+                        owners.insert(p.clone());
+                    }
+                    if let Some(p) = n
+                        .backing_volume
+                        .as_ref()
+                        .and_then(|identity| by_block_id.get(identity))
+                    {
+                        owners.insert(p.clone());
+                    }
                 }
-                if let Some(p) = by_block_dev.get(&n.device_path) {
-                    owners.insert(p.clone());
+                for path in owners {
+                    if let Some(deps) = by_path.get_mut(&path) {
+                        deps.nvmeof_subsystems.push(s.nqn.clone());
+                    }
                 }
             }
-            for path in owners {
-                if let Some(deps) = by_path.get_mut(&path) {
-                    deps.nvmeof_subsystems.push(s.nqn.clone());
-                }
+        }
+        Err(error) => {
+            let message = format!("NVMe-oF state failed to load: {error}");
+            for deps in by_path.values_mut() {
+                deps.state_errors.push(message.clone());
             }
         }
     }

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use nasty_common::secrets::{self, EncryptedBlob};
-use nasty_common::{HasId, StateDir};
+use nasty_common::{BlockDeviceMappings, BlockVolumeId, HasId, StateDir};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -12,6 +12,8 @@ const STATE_DIR: &str = "/var/lib/nasty/shares/iscsi";
 const DEFAULT_IQN_PREFIX: &str = "iqn.2137-04.storage.nasty";
 const ISCSI_BASE: &str = "/sys/kernel/config/target/iscsi";
 const CORE_BASE: &str = "/sys/kernel/config/target/core";
+const UNRESOLVED_BACKSTORE: &str = "/dev/nasty-unresolved-block-volume";
+const SAVECONFIG: &str = "/etc/target/saveconfig.json";
 
 #[derive(Debug, Error)]
 pub enum IscsiError {
@@ -73,6 +75,12 @@ pub struct Lun {
     /// "block" or "fileio"
     pub backstore_type: String,
     pub size_bytes: Option<u64>,
+    /// Stable identity of a NASty-managed block subvolume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backing_volume: Option<BlockVolumeId>,
+    /// Prevents startup from trusting a stale legacy loop path.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub backing_volume_unresolved: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -166,6 +174,10 @@ pub struct CreateTargetRequest {
     /// Block device path (e.g. /dev/loop0). When provided, a LUN is
     /// automatically created and the target is ready for connections.
     pub device_path: Option<String>,
+    /// Filled authoritatively by the engine router; not accepted from clients.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub backing_volume: Option<BlockVolumeId>,
     /// Initiator ACLs to set up. When provided, `generate_node_acls` is
     /// disabled and only these initiators are allowed.
     pub acls: Option<Vec<AclEntry>>,
@@ -197,6 +209,16 @@ pub struct AddLunRequest {
     pub backstore_type: Option<String>,
     /// Required for fileio if file doesn't exist yet
     pub size_bytes: Option<u64>,
+    /// Filled authoritatively by the engine router; not accepted from clients.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub backing_volume: Option<BlockVolumeId>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DeviceRemapOutcome {
+    pub safe_to_restore: bool,
+    pub changed: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -283,33 +305,79 @@ impl IscsiService {
         Self
     }
 
-    /// Update persisted device paths after a reboot where loop device numbers changed.
-    /// `dev_map` maps subvolume_name → current loop device (e.g. "vol1" → "/dev/loop0").
-    /// The subvolume name is extracted from the IQN suffix after the last ':'.
-    /// Also patches /etc/target/saveconfig.json so target.service loads with correct paths.
-    pub async fn remap_device_paths(&self, dev_map: &std::collections::HashMap<String, String>) {
-        let mut targets: Vec<IscsiTarget> = state_dir().load_all().await;
-        for target in &mut targets {
-            let name = target.iqn.rsplit(':').next().unwrap_or("").to_string();
-            let Some(new_dev) = dev_map.get(&name) else {
-                continue;
+    /// Resolve every managed LUN independently by immutable backing identity.
+    /// Legacy loop paths without an identity are never trusted.
+    pub async fn remap_device_paths(&self, mappings: &BlockDeviceMappings) -> DeviceRemapOutcome {
+        let mut targets: Vec<IscsiTarget> = match state_dir().load_all_strict().await {
+            Ok(targets) => targets,
+            Err(error) => {
+                warn!("Cannot safely load all iSCSI state: {error}");
+                return DeviceRemapOutcome::default();
+            }
+        };
+        if targets.is_empty() {
+            let safe_to_restore = match validate_no_saved_exports().await {
+                Ok(()) => true,
+                Err(error) => {
+                    warn!("Cannot safely restore empty iSCSI state: {error}");
+                    false
+                }
             };
-            let mut changed = false;
-            for lun in &mut target.luns {
-                if &lun.backstore_path != new_dev {
-                    info!(
-                        "Remapping iSCSI '{}' lun{} {} → {}",
-                        target.iqn, lun.lun_id, lun.backstore_path, new_dev
-                    );
-                    lun.backstore_path = new_dev.clone();
-                    changed = true;
+            return DeviceRemapOutcome {
+                safe_to_restore,
+                changed: false,
+            };
+        }
+        let mut patches = std::collections::HashMap::new();
+        let mut safe_to_restore = true;
+        let mut any_changed = false;
+        for target in &mut targets {
+            let (changed, target_safe, target_patches) = remap_target(target, mappings);
+            any_changed |= changed;
+            let persisted = if changed {
+                match state_dir().save(&target.id, target).await {
+                    Ok(()) => true,
+                    Err(error) => {
+                        warn!(
+                            "Failed to persist iSCSI block identities for '{}': {error}",
+                            target.iqn
+                        );
+                        safe_to_restore = false;
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            safe_to_restore &= target_safe;
+            if persisted {
+                for (name, path) in target_patches {
+                    insert_backstore_patch(&mut patches, name, path, &mut safe_to_restore);
                 }
             }
-            if changed {
-                let _ = state_dir().save(&target.id, target).await;
+            for lun in &target.luns {
+                let path = if persisted || !is_managed_lun(lun) {
+                    lun.backstore_path.clone()
+                } else {
+                    UNRESOLVED_BACKSTORE.to_string()
+                };
+                insert_backstore_patch(
+                    &mut patches,
+                    lun.backstore_name.clone(),
+                    path,
+                    &mut safe_to_restore,
+                );
             }
         }
-        patch_saveconfig(dev_map).await;
+        let expected_targets = targets.iter().map(|target| target.iqn.clone()).collect();
+        if let Err(error) = patch_saveconfig(&patches, &expected_targets).await {
+            warn!("Failed to patch iSCSI saveconfig safely: {error}");
+            safe_to_restore = false;
+        }
+        DeviceRemapOutcome {
+            safe_to_restore,
+            changed: any_changed,
+        }
     }
 
     /// Eagerly seal plaintext CHAP passwords left in state files from
@@ -351,7 +419,7 @@ impl IscsiService {
     }
 
     pub async fn list(&self) -> Result<Vec<IscsiTarget>, IscsiError> {
-        let targets: Vec<IscsiTarget> = state_dir().load_all().await;
+        let targets: Vec<IscsiTarget> = state_dir().load_all_strict().await?;
         Ok(targets.into_iter().map(|t| t.redacted()).collect())
     }
 
@@ -365,7 +433,7 @@ impl IscsiService {
 
     pub async fn create(&self, req: CreateTargetRequest) -> Result<IscsiTarget, IscsiError> {
         validate_target_name(&req.name)?;
-        let targets: Vec<IscsiTarget> = state_dir().load_all().await;
+        let targets: Vec<IscsiTarget> = state_dir().load_all_strict().await?;
         let iqn = format!("{DEFAULT_IQN_PREFIX}:{}", req.name);
 
         if let Some(existing) = targets.into_iter().find(|t| t.iqn == iqn) {
@@ -472,6 +540,7 @@ impl IscsiService {
                         backstore_path: device_path,
                         backstore_type: Some("block".to_string()),
                         size_bytes: None,
+                        backing_volume: req.backing_volume,
                     })
                     .await?;
             } else {
@@ -662,6 +731,8 @@ impl IscsiService {
             backstore_name,
             backstore_type,
             size_bytes: req.size_bytes,
+            backing_volume: req.backing_volume,
+            backing_volume_unresolved: false,
         };
 
         target.luns.push(lun);
@@ -931,6 +1002,87 @@ impl IscsiService {
     }
 }
 
+fn is_managed_lun(lun: &Lun) -> bool {
+    lun.backstore_type == "block"
+        && (lun.backing_volume.is_some()
+            || lun.backing_volume_unresolved
+            || lun.backstore_path.starts_with("/dev/loop"))
+}
+
+fn remap_target(
+    target: &mut IscsiTarget,
+    mappings: &BlockDeviceMappings,
+) -> (bool, bool, Vec<(String, String)>) {
+    let mut changed = false;
+    let mut safe = true;
+    let mut patches = Vec::new();
+
+    for lun in &mut target.luns {
+        if !is_managed_lun(lun) {
+            continue;
+        }
+        let identity = lun.backing_volume.clone();
+        let resolved = identity
+            .as_ref()
+            .and_then(|identity| mappings.current.get(identity))
+            .cloned();
+
+        match (identity, resolved) {
+            (Some(identity), Some(device_path)) => {
+                if lun.backing_volume.as_ref() != Some(&identity) {
+                    lun.backing_volume = Some(identity);
+                    changed = true;
+                }
+                if lun.backstore_path != device_path {
+                    info!(
+                        "Remapping iSCSI '{}' lun{} {} → {}",
+                        target.iqn, lun.lun_id, lun.backstore_path, device_path
+                    );
+                    lun.backstore_path = device_path.clone();
+                    changed = true;
+                }
+                if lun.backing_volume_unresolved {
+                    lun.backing_volume_unresolved = false;
+                    changed = true;
+                }
+                patches.push((lun.backstore_name.clone(), device_path.clone()));
+            }
+            _ => {
+                warn!(
+                    "Cannot safely resolve iSCSI '{}' lun{} backing volume; blocking iSCSI restore",
+                    target.iqn, lun.lun_id
+                );
+                if !lun.backing_volume_unresolved {
+                    lun.backing_volume_unresolved = true;
+                    changed = true;
+                }
+                patches.push((lun.backstore_name.clone(), UNRESOLVED_BACKSTORE.to_string()));
+                safe = false;
+            }
+        }
+    }
+
+    (changed, safe, patches)
+}
+
+fn insert_backstore_patch(
+    patches: &mut std::collections::HashMap<String, String>,
+    name: String,
+    path: String,
+    safe_to_restore: &mut bool,
+) {
+    match patches.entry(name.clone()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(path);
+        }
+        std::collections::hash_map::Entry::Occupied(entry) if entry.get() != &path => {
+            warn!("Duplicate iSCSI backstore name '{name}' has conflicting devices");
+            *safe_to_restore = false;
+        }
+        std::collections::hash_map::Entry::Occupied(_) => {}
+    }
+}
+
 // ── configfs helpers ────────────────────────────────────────────
 
 /// Create a network portal (np) directory, flipping it to iSER when
@@ -1091,39 +1243,81 @@ async fn wait_for_target_ready(iqn: &str) {
     warn!("iSCSI target {iqn} readiness check timed out — proceeding anyway");
 }
 
-/// Patch /etc/target/saveconfig.json to fix stale loop device paths.
-async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
-    const SAVECONFIG: &str = "/etc/target/saveconfig.json";
+/// Patch /etc/target/saveconfig.json by exact persisted backstore name.
+async fn patch_saveconfig(
+    backstores: &std::collections::HashMap<String, String>,
+    targets: &std::collections::HashSet<String>,
+) -> Result<(), String> {
+    let text = tokio::fs::read_to_string(SAVECONFIG)
+        .await
+        .map_err(|e| format!("read {SAVECONFIG}: {e}"))?;
+    let mut json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("parse {SAVECONFIG}: {e}"))?;
+    let changed = patch_saveconfig_value(&mut json, backstores, targets)?;
+    if changed {
+        let out = serde_json::to_string_pretty(&json)
+            .map_err(|e| format!("serialize {SAVECONFIG}: {e}"))?;
+        tokio::fs::write(SAVECONFIG, out)
+            .await
+            .map_err(|e| format!("write {SAVECONFIG}: {e}"))?;
+    }
+    Ok(())
+}
+
+async fn validate_no_saved_exports() -> Result<(), String> {
     let text = match tokio::fs::read_to_string(SAVECONFIG).await {
-        Ok(t) => t,
-        Err(_) => return,
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("read {SAVECONFIG}: {error}")),
     };
-    let mut json: serde_json::Value = match serde_json::from_str(&text) {
-        Ok(v) => v,
-        Err(e) => {
-            warn!("Failed to parse {SAVECONFIG}: {e}");
-            return;
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|error| format!("parse {SAVECONFIG}: {error}"))?;
+    validate_empty_saveconfig_value(&json)
+}
+
+fn validate_empty_saveconfig_value(json: &serde_json::Value) -> Result<(), String> {
+    for key in ["storage_objects", "targets"] {
+        let values = json
+            .get(key)
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| format!("saveconfig has no {key} array"))?;
+        if !values.is_empty() {
+            return Err(format!(
+                "saveconfig contains {} stale {key} entries but iSCSI state is empty",
+                values.len()
+            ));
         }
-    };
+    }
+    Ok(())
+}
+
+fn patch_saveconfig_value(
+    json: &mut serde_json::Value,
+    backstores: &std::collections::HashMap<String, String>,
+    targets: &std::collections::HashSet<String>,
+) -> Result<bool, String> {
     let Some(objects) = json
         .get_mut("storage_objects")
         .and_then(|v| v.as_array_mut())
     else {
-        return;
+        return Err("saveconfig has no storage_objects array".to_string());
     };
     let mut changed = false;
+    let mut matched = std::collections::HashMap::<String, usize>::new();
     for obj in objects.iter_mut() {
         let name = obj
             .get("name")
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        for (subvol_name, new_dev) in dev_map {
-            let expected_prefix = format!("nasty_{subvol_name}_");
-            if name.starts_with(&expected_prefix)
-                && let Some(dev_field) = obj.get("dev").and_then(|v| v.as_str())
-                && dev_field != new_dev
-            {
+        if !backstores.contains_key(&name) {
+            return Err(format!("saveconfig contains unexpected backstore '{name}'"));
+        }
+        if let Some(new_dev) = backstores.get(&name)
+            && let Some(dev_field) = obj.get("dev").and_then(|v| v.as_str())
+        {
+            *matched.entry(name.clone()).or_default() += 1;
+            if dev_field != new_dev {
                 info!(
                     "Patching saveconfig.json backstore '{name}' {} → {new_dev}",
                     dev_field
@@ -1133,19 +1327,47 @@ async fn patch_saveconfig(dev_map: &std::collections::HashMap<String, String>) {
             }
         }
     }
-    if changed {
-        match serde_json::to_string_pretty(&json) {
-            Ok(out) => {
-                if let Err(e) = tokio::fs::write(SAVECONFIG, out).await {
-                    // The patched config exists in memory but won't survive
-                    // a restart — log so a "iSCSI config keeps reverting"
-                    // bug is debuggable from a single message.
-                    warn!("write patched saveconfig to {SAVECONFIG} failed: {e}");
-                }
+    if objects.len() != backstores.len() {
+        return Err(format!(
+            "saveconfig contains {} backstores but persisted state expects {}",
+            objects.len(),
+            backstores.len()
+        ));
+    }
+    for name in backstores.keys() {
+        match matched.get(name).copied().unwrap_or(0) {
+            1 => {}
+            0 => return Err(format!("saveconfig is missing backstore '{name}'")),
+            count => {
+                return Err(format!(
+                    "saveconfig contains {count} backstores named '{name}'"
+                ));
             }
-            Err(e) => warn!("Failed to serialize patched saveconfig.json: {e}"),
         }
     }
+    let saved_targets = json
+        .get("targets")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "saveconfig has no targets array".to_string())?;
+    let mut matched_targets = std::collections::HashMap::<String, usize>::new();
+    for target in saved_targets {
+        let wwn = target
+            .get("wwn")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "saveconfig target has no wwn".to_string())?;
+        if !targets.contains(wwn) {
+            return Err(format!("saveconfig contains unexpected target '{wwn}'"));
+        }
+        *matched_targets.entry(wwn.to_string()).or_default() += 1;
+    }
+    for wwn in targets {
+        match matched_targets.get(wwn).copied().unwrap_or(0) {
+            1 => {}
+            0 => return Err(format!("saveconfig is missing target '{wwn}'")),
+            count => return Err(format!("saveconfig contains target '{wwn}' {count} times")),
+        }
+    }
+    Ok(changed)
 }
 
 /// Build the configfs `np/<addr>` path for a portal. LIO's configfs
@@ -1292,6 +1514,200 @@ fn validate_portal_ip(ip: &str) -> Result<String, IscsiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn volume(pool: &str, id: u32) -> BlockVolumeId {
+        BlockVolumeId {
+            filesystem_uuid: pool.to_string(),
+            subvolume_id: id,
+        }
+    }
+
+    fn lun(lun_id: u32, path: &str, identity: Option<BlockVolumeId>) -> Lun {
+        Lun {
+            lun_id,
+            backstore_path: path.to_string(),
+            backstore_name: format!("backstore-{lun_id}"),
+            backstore_type: "block".to_string(),
+            size_bytes: None,
+            backing_volume: identity,
+            backing_volume_unresolved: false,
+        }
+    }
+
+    fn target(name: &str, luns: Vec<Lun>) -> IscsiTarget {
+        IscsiTarget {
+            id: "target-id".to_string(),
+            iqn: format!("iqn.test:{name}"),
+            alias: None,
+            portals: vec![],
+            luns,
+            acls: vec![],
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn remaps_each_lun_by_immutable_identity() {
+        let first = volume("pool-a", 10);
+        let second = volume("pool-b", 20);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(first.clone(), "/dev/loop9".into());
+        mappings.current.insert(second.clone(), "/dev/loop4".into());
+        let mut target = target(
+            "custom-name",
+            vec![
+                lun(0, "/dev/loop0", Some(first.clone())),
+                lun(1, "/dev/loop1", Some(second.clone())),
+            ],
+        );
+
+        let (changed, safe, patches) = remap_target(&mut target, &mappings);
+
+        assert!(changed);
+        assert!(safe);
+        assert_eq!(target.luns[0].backstore_path, "/dev/loop9");
+        assert_eq!(target.luns[1].backstore_path, "/dev/loop4");
+        assert_eq!(patches[0], ("backstore-0".into(), "/dev/loop9".into()));
+        assert_eq!(patches[1], ("backstore-1".into(), "/dev/loop4".into()));
+    }
+
+    #[test]
+    fn ambiguous_legacy_multi_lun_state_fails_closed() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        let mut target = target(
+            "volume",
+            vec![lun(0, "/dev/loop0", None), lun(1, "/dev/loop1", None)],
+        );
+
+        let (_, safe, patches) = remap_target(&mut target, &mappings);
+
+        assert!(!safe);
+        assert!(target.luns.iter().all(|lun| lun.backing_volume_unresolved));
+        assert!(patches.iter().all(|(_, path)| path == UNRESOLVED_BACKSTORE));
+    }
+
+    #[test]
+    fn duplicate_names_do_not_enable_legacy_fallback() {
+        let first = volume("pool-a", 10);
+        let second = volume("pool-b", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(first.clone(), "/dev/loop7".into());
+        mappings.current.insert(second.clone(), "/dev/loop8".into());
+        let mut target = target("volume", vec![lun(0, "/dev/loop0", None)]);
+
+        let (_, safe, _) = remap_target(&mut target, &mappings);
+
+        assert!(!safe);
+        assert!(target.luns[0].backing_volume_unresolved);
+    }
+
+    #[test]
+    fn custom_target_name_never_migrates_legacy_lun() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        let mut target = target("volume", vec![lun(0, "/dev/loop0", None)]);
+
+        let (_, safe, _) = remap_target(&mut target, &mappings);
+
+        assert!(!safe);
+        assert!(target.luns[0].backing_volume.is_none());
+        assert!(target.luns[0].backing_volume_unresolved);
+        assert_eq!(target.luns[0].backstore_path, "/dev/loop0");
+    }
+
+    #[test]
+    fn raw_block_device_is_not_remapped() {
+        let mut target = target("raw", vec![lun(0, "/dev/sda", None)]);
+
+        let (changed, safe, patches) = remap_target(&mut target, &BlockDeviceMappings::default());
+
+        assert!(!changed);
+        assert!(safe);
+        assert!(patches.is_empty());
+        assert_eq!(target.luns[0].backstore_path, "/dev/sda");
+    }
+
+    #[test]
+    fn lun_loads_legacy_state_without_identity() {
+        let lun: Lun = serde_json::from_str(
+            r#"{"lun_id":0,"backstore_path":"/dev/loop0","backstore_name":"old","backstore_type":"block","size_bytes":null}"#,
+        )
+        .unwrap();
+        assert!(lun.backing_volume.is_none());
+        assert!(!lun.backing_volume_unresolved);
+    }
+
+    #[test]
+    fn saveconfig_patch_is_exact_per_backstore() {
+        let mut json = serde_json::json!({
+            "storage_objects": [
+                {"name": "backstore-0", "dev": "/dev/loop0"},
+                {"name": "backstore-1", "dev": "/dev/loop1"}
+            ],
+            "targets": [{"wwn": "iqn.test:target"}]
+        });
+        let patches = std::collections::HashMap::from([
+            ("backstore-0".to_string(), "/dev/loop9".to_string()),
+            ("backstore-1".to_string(), "/dev/loop4".to_string()),
+        ]);
+        let targets = std::collections::HashSet::from(["iqn.test:target".to_string()]);
+
+        assert!(patch_saveconfig_value(&mut json, &patches, &targets).unwrap());
+        assert_eq!(json["storage_objects"][0]["dev"], "/dev/loop9");
+        assert_eq!(json["storage_objects"][1]["dev"], "/dev/loop4");
+    }
+
+    #[test]
+    fn saveconfig_patch_rejects_missing_backstore() {
+        let mut json = serde_json::json!({ "storage_objects": [], "targets": [] });
+        let patches =
+            std::collections::HashMap::from([("missing".to_string(), "/dev/loop9".to_string())]);
+
+        assert!(patch_saveconfig_value(&mut json, &patches, &Default::default()).is_err());
+    }
+
+    #[test]
+    fn saveconfig_patch_rejects_unpersisted_exports() {
+        let mut json = serde_json::json!({
+            "storage_objects": [
+                {"name": "expected", "dev": "/dev/loop0"},
+                {"name": "stale", "dev": "/dev/loop1"}
+            ],
+            "targets": [
+                {"wwn": "iqn.test:expected"},
+                {"wwn": "iqn.test:stale"}
+            ]
+        });
+        let patches =
+            std::collections::HashMap::from([("expected".to_string(), "/dev/loop0".to_string())]);
+        let targets = std::collections::HashSet::from(["iqn.test:expected".to_string()]);
+
+        assert!(patch_saveconfig_value(&mut json, &patches, &targets).is_err());
+    }
+
+    #[test]
+    fn empty_state_rejects_stale_saveconfig_exports() {
+        let json = serde_json::json!({
+            "storage_objects": [{"name": "stale", "dev": "/dev/loop0"}],
+            "targets": [{"wwn": "iqn.test:stale"}]
+        });
+
+        assert!(validate_empty_saveconfig_value(&json).is_err());
+        assert!(
+            validate_empty_saveconfig_value(&serde_json::json!({
+                "storage_objects": [],
+                "targets": []
+            }))
+            .is_ok()
+        );
+    }
 
     fn fake_blob() -> EncryptedBlob {
         serde_json::from_str("\"c2VhbGVkLWJsb2I=\"").unwrap()

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use nasty_common::{HasId, StateDir};
+use nasty_common::{BlockDeviceMappings, BlockVolumeId, HasId, StateDir};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -59,6 +59,12 @@ pub struct Namespace {
     pub device_path: String,
     /// Whether the namespace is enabled in configfs.
     pub enabled: bool,
+    /// Stable identity of a NASty-managed block subvolume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backing_volume: Option<BlockVolumeId>,
+    /// Prevents startup from trusting a stale legacy loop path.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub backing_volume_unresolved: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -86,6 +92,10 @@ pub struct CreateSubsystemRequest {
     /// Block device path (e.g. /dev/loop0). When provided, a namespace is
     /// automatically created.
     pub device_path: Option<String>,
+    /// Filled authoritatively by the engine router; not accepted from clients.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub backing_volume: Option<BlockVolumeId>,
     /// Listen address (default 0.0.0.0). Only used when `device_path` is set.
     pub addr: Option<String>,
     /// Port number (default 4420). Only used when `device_path` is set.
@@ -107,6 +117,16 @@ pub struct AddNamespaceRequest {
     pub subsystem_id: String,
     /// Block device path (e.g. /dev/sdc)
     pub device_path: String,
+    /// Filled authoritatively by the engine router; not accepted from clients.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub backing_volume: Option<BlockVolumeId>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DeviceRemapOutcome {
+    pub safe_to_restore: bool,
+    pub changed: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -198,7 +218,7 @@ impl NvmeofService {
 
     /// Restore NVMe-oF configfs state from persisted JSON files.
     /// Called at startup — configfs is volatile and lost on reboot.
-    pub async fn restore(&self) {
+    pub async fn restore(&self) -> Result<(), NvmeofError> {
         // Only restore if the nvmeof protocol is enabled
         let proto_state: serde_json::Value =
             tokio::fs::read_to_string("/var/lib/nasty/protocols.json")
@@ -209,14 +229,15 @@ impl NvmeofService {
 
         if proto_state.get("nvmeof").and_then(|v| v.as_bool()) != Some(true) {
             info!("NVMe-oF protocol disabled, skipping restore");
-            return;
+            return Ok(());
         }
 
-        let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
+        let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all_strict().await?;
         if subsystems.is_empty() {
             info!("No NVMe-oF subsystems to restore");
-            return;
+            return Ok(());
         }
+        let mut failures = Vec::new();
 
         // Boot restore races the network coming up: a port bound to a
         // specific address whose interface isn't configured yet fails to
@@ -234,34 +255,37 @@ impl NvmeofService {
 
             // Create subsystem
             let subsys_path = format!("{NVMET_BASE}/subsystems/{}", subsys.nqn);
-            if let Err(e) = configfs_mkdir(&subsys_path).await {
+            if let Err(e) = configfs_ensure_dir(&subsys_path).await {
                 warn!("Failed to create subsystem {}: {e}", subsys.nqn);
+                failures.push(format!("{} subsystem: {e}", subsys.nqn));
                 continue;
             }
-            let _ = configfs_write(
+            if let Err(error) = configfs_write(
                 &format!("{subsys_path}/attr_allow_any_host"),
                 if subsys.allow_any_host { "1" } else { "0" },
             )
-            .await;
+            .await
+            {
+                warn!(
+                    "Failed to restore access policy for {}: {error}",
+                    subsys.nqn
+                );
+                failures.push(format!("{} access policy: {error}", subsys.nqn));
+                continue;
+            }
 
             // Restore namespaces
             for ns in &subsys.namespaces {
-                if !Path::new(&ns.device_path).exists() {
-                    warn!(
-                        "  Device {} not found, skipping namespace {}",
-                        ns.device_path, ns.nsid
-                    );
-                    continue;
-                }
                 let ns_path = format!("{subsys_path}/namespaces/{}", ns.nsid);
-                if let Err(e) = configfs_mkdir(&ns_path).await {
+                if let Err(e) = configfs_ensure_dir(&ns_path).await {
                     warn!("  Failed to create namespace {}: {e}", ns.nsid);
+                    failures.push(format!("{} namespace {}: {e}", subsys.nqn, ns.nsid));
                     continue;
                 }
-                let _ = configfs_write(&format!("{ns_path}/device_path"), &ns.device_path).await;
-                let _ = configfs_write(&format!("{ns_path}/buffered_io"), "0").await;
-                if ns.enabled {
-                    let _ = configfs_write(&format!("{ns_path}/enable"), "1").await;
+                if let Err(error) = restore_namespace(&ns_path, ns).await {
+                    warn!("  Failed to restore namespace {} safely: {error}", ns.nsid);
+                    failures.push(format!("{} namespace {}: {error}", subsys.nqn, ns.nsid));
+                    continue;
                 }
                 info!("  Restored namespace {} -> {}", ns.nsid, ns.device_path);
             }
@@ -269,9 +293,16 @@ impl NvmeofService {
             // Restore allowed hosts
             for host_nqn in &subsys.allowed_hosts {
                 let host_path = format!("{NVMET_BASE}/hosts/{host_nqn}");
-                let _ = configfs_mkdir(&host_path).await;
+                if let Err(error) = configfs_ensure_dir(&host_path).await {
+                    warn!("  Failed to restore allowed host {host_nqn}: {error}");
+                    failures.push(format!("{} host {host_nqn}: {error}", subsys.nqn));
+                    continue;
+                }
                 let link = format!("{subsys_path}/allowed_hosts/{host_nqn}");
-                let _ = configfs_symlink(&host_path, &link).await;
+                if let Err(error) = configfs_ensure_symlink(&host_path, &link).await {
+                    warn!("  Failed to link allowed host {host_nqn}: {error}");
+                    failures.push(format!("{} host {host_nqn}: {error}", subsys.nqn));
+                }
             }
 
             // Restore ports — reuse existing port if one already binds to the same address
@@ -283,17 +314,27 @@ impl NvmeofService {
                     existing
                 } else {
                     let port_path = format!("{NVMET_BASE}/ports/{}", port.port_id);
-                    if let Err(e) = configfs_mkdir(&port_path).await {
+                    if let Err(e) = configfs_ensure_dir(&port_path).await {
                         warn!("  Failed to create port {}: {e}", port.port_id);
+                        failures.push(format!("{} port {}: {e}", subsys.nqn, port.port_id));
                         continue;
                     }
-                    let _ =
-                        configfs_write(&format!("{port_path}/addr_trtype"), &port.transport).await;
-                    let _ = configfs_write(&format!("{port_path}/addr_traddr"), &port.addr).await;
-                    let _ = configfs_write(&format!("{port_path}/addr_trsvcid"), &port.service_id)
-                        .await;
-                    let _ = configfs_write(&format!("{port_path}/addr_adrfam"), &port.addr_family)
-                        .await;
+                    let configured = async {
+                        configfs_write(&format!("{port_path}/addr_trtype"), &port.transport)
+                            .await?;
+                        configfs_write(&format!("{port_path}/addr_traddr"), &port.addr).await?;
+                        configfs_write(&format!("{port_path}/addr_trsvcid"), &port.service_id)
+                            .await?;
+                        configfs_write(&format!("{port_path}/addr_adrfam"), &port.addr_family)
+                            .await?;
+                        Ok::<(), NvmeofError>(())
+                    }
+                    .await;
+                    if let Err(error) = configured {
+                        warn!("  Failed to configure port {}: {error}", port.port_id);
+                        failures.push(format!("{} port {}: {error}", subsys.nqn, port.port_id));
+                        continue;
+                    }
                     port.port_id
                 };
 
@@ -303,54 +344,133 @@ impl NvmeofService {
                 // bind, so this is where EADDRNOTAVAIL surfaces. Report it
                 // instead of swallowing it (#625) — a silent failure left the
                 // target dead with no clue in the logs.
-                match configfs_symlink(&format!("{NVMET_BASE}/subsystems/{}", subsys.nqn), &link)
-                    .await
+                match configfs_ensure_symlink(
+                    &format!("{NVMET_BASE}/subsystems/{}", subsys.nqn),
+                    &link,
+                )
+                .await
                 {
                     Ok(()) => info!(
                         "  Restored port {} ({}:{})",
                         actual_port_id, port.addr, port.service_id
                     ),
-                    Err(e) => warn!(
-                        "  NVMe-oF port {} bind to {}:{} failed ({e}) — the address may not \
-                         be up yet; re-add the portal once its interface is active",
-                        actual_port_id, port.addr, port.service_id
-                    ),
+                    Err(e) => {
+                        warn!(
+                            "  NVMe-oF port {} bind to {}:{} failed ({e}) — the address may not \
+                             be up yet; re-add the portal once its interface is active",
+                            actual_port_id, port.addr, port.service_id
+                        );
+                        failures.push(format!("{} port {} bind: {e}", subsys.nqn, actual_port_id));
+                    }
                 }
             }
         }
 
         info!("NVMe-oF restore complete");
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(NvmeofError::ConfigFs(failures.join("; ")))
+        }
     }
 
-    /// Update persisted device paths after a reboot where loop device numbers changed.
-    /// `dev_map` maps subvolume_name → current loop device (e.g. "tank-vol" → "/dev/loop0").
-    /// The subvolume name is extracted from the NQN suffix after the last ':'.
-    pub async fn remap_device_paths(&self, dev_map: &std::collections::HashMap<String, String>) {
-        let mut subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
-        for subsys in &mut subsystems {
-            let name = subsys.nqn.rsplit(':').next().unwrap_or("").to_string();
-            let Some(new_dev) = dev_map.get(&name) else {
+    /// Disable every NASty-managed live namespace without changing persisted
+    /// state. nvmet configfs survives an engine-process restart, so merely
+    /// skipping restore is not sufficient when backing identity is unsafe.
+    pub async fn quiesce(&self) -> Result<(), NvmeofError> {
+        let subsystem_dir = format!("{NVMET_BASE}/subsystems");
+        let mut subsystems = match tokio::fs::read_dir(&subsystem_dir).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(NvmeofError::Io(error)),
+        };
+        while let Some(subsystem) = subsystems.next_entry().await? {
+            let nqn = subsystem.file_name();
+            let nqn = nqn.to_string_lossy();
+            if !nqn.starts_with(DEFAULT_NQN_PREFIX) {
                 continue;
+            }
+            let namespace_dir = subsystem.path().join("namespaces");
+            let mut namespaces = match tokio::fs::read_dir(&namespace_dir).await {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(NvmeofError::Io(error)),
             };
-            let mut changed = false;
-            for ns in &mut subsys.namespaces {
-                if &ns.device_path != new_dev {
-                    info!(
-                        "Remapping NVMe-oF '{}' ns{} {} → {}",
-                        subsys.nqn, ns.nsid, ns.device_path, new_dev
-                    );
-                    ns.device_path = new_dev.clone();
-                    changed = true;
+            while let Some(namespace) = namespaces.next_entry().await? {
+                let enable = namespace.path().join("enable");
+                tokio::fs::write(&enable, "0").await.map_err(|error| {
+                    NvmeofError::ConfigFs(format!("disable {}: {error}", enable.display()))
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether every persisted enabled namespace is currently enabled in
+    /// configfs. Used to avoid disrupting healthy initiators on unrelated
+    /// filesystem mounts while still recovering a previously quiesced export.
+    pub async fn is_active(&self) -> Result<bool, NvmeofError> {
+        let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all_strict().await?;
+        for subsystem in subsystems {
+            for namespace in subsystem.namespaces.into_iter().filter(|ns| ns.enabled) {
+                let enable = format!(
+                    "{NVMET_BASE}/subsystems/{}/namespaces/{}/enable",
+                    subsystem.nqn, namespace.nsid
+                );
+                match tokio::fs::read_to_string(&enable).await {
+                    Ok(value) if value.trim() == "1" => {}
+                    Ok(_) => return Ok(false),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                    Err(error) => return Err(NvmeofError::Io(error)),
                 }
             }
-            if changed {
-                let _ = state_dir().save(&subsys.id, subsys).await;
+        }
+        Ok(true)
+    }
+
+    /// Resolve every namespace independently by immutable backing identity.
+    pub async fn remap_device_paths(&self, mappings: &BlockDeviceMappings) -> DeviceRemapOutcome {
+        let mut subsystems: Vec<NvmeofSubsystem> = match state_dir().load_all_strict().await {
+            Ok(subsystems) => subsystems,
+            Err(error) => {
+                warn!("Cannot safely load all NVMe-oF state: {error}");
+                return DeviceRemapOutcome::default();
             }
+        };
+        let mut safe_to_restore = match validate_managed_configfs_inventory(&subsystems).await {
+            Ok(()) => true,
+            Err(error) => {
+                warn!("Cannot validate live NVMe-oF inventory safely: {error}");
+                false
+            }
+        };
+        if subsystems.is_empty() {
+            return DeviceRemapOutcome {
+                safe_to_restore,
+                changed: false,
+            };
+        }
+        let mut any_changed = false;
+        for subsys in &mut subsystems {
+            let (changed, subsystem_safe) = remap_subsystem(subsys, mappings);
+            any_changed |= changed;
+            safe_to_restore &= subsystem_safe;
+            if changed && let Err(error) = state_dir().save(&subsys.id, subsys).await {
+                warn!(
+                    "Failed to persist NVMe-oF block identities for '{}': {error}",
+                    subsys.nqn
+                );
+                safe_to_restore = false;
+            }
+        }
+        DeviceRemapOutcome {
+            safe_to_restore,
+            changed: any_changed,
         }
     }
 
     pub async fn list(&self) -> Result<Vec<NvmeofSubsystem>, NvmeofError> {
-        Ok(state_dir().load_all().await)
+        Ok(state_dir().load_all_strict().await?)
     }
 
     pub async fn get(&self, id: &str) -> Result<NvmeofSubsystem, NvmeofError> {
@@ -370,7 +490,7 @@ impl NvmeofService {
                 validate_host_nqn(host_nqn)?;
             }
         }
-        let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all().await;
+        let subsystems: Vec<NvmeofSubsystem> = state_dir().load_all_strict().await?;
         let nqn = format!("{DEFAULT_NQN_PREFIX}:{}", req.name);
 
         if let Some(existing) = subsystems.into_iter().find(|s| s.nqn == nqn) {
@@ -411,6 +531,7 @@ impl NvmeofService {
                     .add_namespace(AddNamespaceRequest {
                         subsystem_id: subsystem.id.clone(),
                         device_path,
+                        backing_volume: req.backing_volume,
                     })
                     .await?;
             } else {
@@ -601,6 +722,8 @@ impl NvmeofService {
             nsid,
             device_path: req.device_path,
             enabled: true,
+            backing_volume: req.backing_volume,
+            backing_volume_unresolved: false,
         });
 
         state_dir()
@@ -1002,6 +1125,17 @@ async fn configfs_mkdir(path: &str) -> Result<(), NvmeofError> {
         .map_err(|e| NvmeofError::ConfigFs(format!("mkdir {path}: {e}")))
 }
 
+async fn configfs_ensure_dir(path: &str) -> Result<(), NvmeofError> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(NvmeofError::ConfigFs(format!(
+            "{path} exists and is not a directory"
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => configfs_mkdir(path).await,
+        Err(error) => Err(NvmeofError::ConfigFs(format!("stat {path}: {error}"))),
+    }
+}
+
 async fn configfs_rmdir(path: &str) -> Result<(), NvmeofError> {
     tokio::fs::remove_dir(path)
         .await
@@ -1025,6 +1159,20 @@ async fn configfs_symlink(target: &str, link: &str) -> Result<(), NvmeofError> {
     tokio::fs::symlink(target, link)
         .await
         .map_err(|e| NvmeofError::ConfigFs(format!("symlink {link} -> {target}: {e}")))
+}
+
+async fn configfs_ensure_symlink(target: &str, link: &str) -> Result<(), NvmeofError> {
+    match tokio::fs::read_link(link).await {
+        Ok(existing) if existing == Path::new(target) => Ok(()),
+        Ok(existing) => Err(NvmeofError::ConfigFs(format!(
+            "symlink {link} points to {} instead of {target}",
+            existing.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            configfs_symlink(target, link).await
+        }
+        Err(error) => Err(NvmeofError::ConfigFs(format!("readlink {link}: {error}"))),
+    }
 }
 
 async fn dir_is_empty(path: &str) -> bool {
@@ -1069,6 +1217,136 @@ async fn detect_primary_ip() -> Option<String> {
         }
     }
     None
+}
+
+fn is_managed_namespace(namespace: &Namespace) -> bool {
+    namespace.backing_volume.is_some()
+        || namespace.backing_volume_unresolved
+        || namespace.device_path.starts_with("/dev/loop")
+}
+
+async fn restore_namespace(ns_path: &str, namespace: &Namespace) -> Result<(), NvmeofError> {
+    configfs_write(&format!("{ns_path}/enable"), "0").await?;
+    if !Path::new(&namespace.device_path).exists() {
+        return Err(NvmeofError::DeviceNotFound(namespace.device_path.clone()));
+    }
+    configfs_write(&format!("{ns_path}/device_path"), &namespace.device_path).await?;
+    configfs_write(&format!("{ns_path}/buffered_io"), "0").await?;
+    if namespace.enabled {
+        configfs_write(&format!("{ns_path}/enable"), "1").await?;
+    }
+    Ok(())
+}
+
+async fn validate_managed_configfs_inventory(
+    expected: &[NvmeofSubsystem],
+) -> Result<(), NvmeofError> {
+    let expected: std::collections::HashMap<&str, std::collections::HashSet<u32>> = expected
+        .iter()
+        .map(|subsystem| {
+            (
+                subsystem.nqn.as_str(),
+                subsystem
+                    .namespaces
+                    .iter()
+                    .map(|namespace| namespace.nsid)
+                    .collect(),
+            )
+        })
+        .collect();
+    let subsystem_dir = format!("{NVMET_BASE}/subsystems");
+    let mut subsystems = match tokio::fs::read_dir(&subsystem_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(NvmeofError::Io(error)),
+    };
+    while let Some(subsystem) = subsystems.next_entry().await? {
+        let nqn = subsystem.file_name().to_string_lossy().to_string();
+        if !nqn.starts_with(DEFAULT_NQN_PREFIX) {
+            continue;
+        }
+        let Some(expected_namespaces) = expected.get(nqn.as_str()) else {
+            return Err(NvmeofError::ConfigFs(format!(
+                "live subsystem '{nqn}' has no persisted state"
+            )));
+        };
+        let mut namespaces = match tokio::fs::read_dir(subsystem.path().join("namespaces")).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(NvmeofError::Io(error)),
+        };
+        while let Some(namespace) = namespaces.next_entry().await? {
+            let nsid = namespace
+                .file_name()
+                .to_string_lossy()
+                .parse::<u32>()
+                .map_err(|_| {
+                    NvmeofError::ConfigFs(format!(
+                        "live subsystem '{nqn}' has invalid namespace entry '{}'",
+                        namespace.file_name().to_string_lossy()
+                    ))
+                })?;
+            if !expected_namespaces.contains(&nsid) {
+                return Err(NvmeofError::ConfigFs(format!(
+                    "live subsystem '{nqn}' namespace {nsid} has no persisted state"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn remap_subsystem(
+    subsystem: &mut NvmeofSubsystem,
+    mappings: &BlockDeviceMappings,
+) -> (bool, bool) {
+    let mut changed = false;
+    let mut safe = true;
+
+    for namespace in &mut subsystem.namespaces {
+        if !is_managed_namespace(namespace) {
+            continue;
+        }
+        let identity = namespace.backing_volume.clone();
+        let resolved = identity
+            .as_ref()
+            .and_then(|identity| mappings.current.get(identity))
+            .cloned();
+
+        match (identity, resolved) {
+            (Some(identity), Some(device_path)) => {
+                if namespace.backing_volume.as_ref() != Some(&identity) {
+                    namespace.backing_volume = Some(identity);
+                    changed = true;
+                }
+                if namespace.device_path != device_path {
+                    info!(
+                        "Remapping NVMe-oF '{}' ns{} {} → {}",
+                        subsystem.nqn, namespace.nsid, namespace.device_path, device_path
+                    );
+                    namespace.device_path = device_path;
+                    changed = true;
+                }
+                if namespace.backing_volume_unresolved {
+                    namespace.backing_volume_unresolved = false;
+                    changed = true;
+                }
+            }
+            _ => {
+                warn!(
+                    "Cannot safely resolve NVMe-oF '{}' ns{} backing volume; blocking NVMe-oF restore",
+                    subsystem.nqn, namespace.nsid
+                );
+                if !namespace.backing_volume_unresolved {
+                    namespace.backing_volume_unresolved = true;
+                    changed = true;
+                }
+                safe = false;
+            }
+        }
+    }
+
+    (changed, safe)
 }
 
 /// Validate the user-supplied portion of an NVMe-oF subsystem name.
@@ -1146,6 +1424,202 @@ fn validate_transport(t: &str) -> Result<(), NvmeofError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn volume(pool: &str, id: u32) -> BlockVolumeId {
+        BlockVolumeId {
+            filesystem_uuid: pool.to_string(),
+            subvolume_id: id,
+        }
+    }
+
+    fn namespace(nsid: u32, path: &str, identity: Option<BlockVolumeId>) -> Namespace {
+        Namespace {
+            nsid,
+            device_path: path.to_string(),
+            enabled: true,
+            backing_volume: identity,
+            backing_volume_unresolved: false,
+        }
+    }
+
+    fn subsystem(name: &str, namespaces: Vec<Namespace>) -> NvmeofSubsystem {
+        NvmeofSubsystem {
+            id: "subsystem-id".to_string(),
+            nqn: format!("nqn.test:{name}"),
+            namespaces,
+            ports: vec![],
+            allowed_hosts: vec![],
+            allow_any_host: true,
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn remaps_each_namespace_by_immutable_identity() {
+        let first = volume("pool-a", 10);
+        let second = volume("pool-b", 20);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(first.clone(), "/dev/loop9".into());
+        mappings.current.insert(second.clone(), "/dev/loop4".into());
+        let mut subsystem = subsystem(
+            "custom-name",
+            vec![
+                namespace(1, "/dev/loop0", Some(first)),
+                namespace(2, "/dev/loop1", Some(second)),
+            ],
+        );
+
+        let (changed, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(changed);
+        assert!(safe);
+        assert_eq!(subsystem.namespaces[0].device_path, "/dev/loop9");
+        assert_eq!(subsystem.namespaces[1].device_path, "/dev/loop4");
+    }
+
+    #[test]
+    fn ambiguous_legacy_multi_namespace_state_fails_closed() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        let mut subsystem = subsystem(
+            "volume",
+            vec![
+                namespace(1, "/dev/loop0", None),
+                namespace(2, "/dev/loop1", None),
+            ],
+        );
+
+        let (_, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(!safe);
+        assert!(
+            subsystem
+                .namespaces
+                .iter()
+                .all(|namespace| namespace.backing_volume_unresolved)
+        );
+    }
+
+    #[test]
+    fn duplicate_names_do_not_enable_legacy_fallback() {
+        let first = volume("pool-a", 10);
+        let second = volume("pool-b", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(first.clone(), "/dev/loop7".into());
+        mappings.current.insert(second.clone(), "/dev/loop8".into());
+        let mut subsystem = subsystem("volume", vec![namespace(1, "/dev/loop0", None)]);
+
+        let (_, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(!safe);
+        assert!(subsystem.namespaces[0].backing_volume_unresolved);
+    }
+
+    #[test]
+    fn custom_subsystem_name_never_migrates_legacy_namespace() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        let mut subsystem = subsystem("volume", vec![namespace(1, "/dev/loop0", None)]);
+
+        let (_, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(!safe);
+        assert!(subsystem.namespaces[0].backing_volume.is_none());
+        assert!(subsystem.namespaces[0].backing_volume_unresolved);
+        assert_eq!(subsystem.namespaces[0].device_path, "/dev/loop0");
+    }
+
+    #[test]
+    fn raw_block_device_is_not_remapped() {
+        let mut subsystem = subsystem("raw", vec![namespace(1, "/dev/sda", None)]);
+
+        let (changed, safe) = remap_subsystem(&mut subsystem, &BlockDeviceMappings::default());
+
+        assert!(!changed);
+        assert!(safe);
+        assert_eq!(subsystem.namespaces[0].device_path, "/dev/sda");
+    }
+
+    #[test]
+    fn namespace_loads_legacy_state_without_identity() {
+        let namespace: Namespace =
+            serde_json::from_str(r#"{"nsid":1,"device_path":"/dev/loop0","enabled":true}"#)
+                .unwrap();
+        assert!(namespace.backing_volume.is_none());
+        assert!(!namespace.backing_volume_unresolved);
+    }
+
+    #[tokio::test]
+    async fn failed_namespace_rewrite_leaves_existing_namespace_disabled() {
+        let dir = std::env::temp_dir().join(format!("nasty-nvmeof-test-{}", Uuid::new_v4()));
+        let ns_path = dir.join("namespace");
+        tokio::fs::create_dir_all(&ns_path).await.unwrap();
+        tokio::fs::write(ns_path.join("enable"), "1").await.unwrap();
+        tokio::fs::write(ns_path.join("device_path"), "/dev/old")
+            .await
+            .unwrap();
+        tokio::fs::write(ns_path.join("buffered_io"), "0")
+            .await
+            .unwrap();
+        let namespace = namespace(1, "/path/that/does/not/exist", None);
+
+        let result = restore_namespace(ns_path.to_str().unwrap(), &namespace).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            tokio::fs::read_to_string(ns_path.join("enable"))
+                .await
+                .unwrap(),
+            "0"
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(ns_path.join("device_path"))
+                .await
+                .unwrap(),
+            "/dev/old"
+        );
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn namespace_rewrite_enables_only_after_new_path_is_written() {
+        let dir = std::env::temp_dir().join(format!("nasty-nvmeof-test-{}", Uuid::new_v4()));
+        tokio::fs::create_dir(&dir).await.unwrap();
+        let backing = dir.join("backing");
+        tokio::fs::write(&backing, []).await.unwrap();
+        let ns_path = dir.join("namespace");
+        tokio::fs::create_dir(&ns_path).await.unwrap();
+        for attribute in ["enable", "device_path", "buffered_io"] {
+            tokio::fs::write(ns_path.join(attribute), "old")
+                .await
+                .unwrap();
+        }
+        let namespace = namespace(1, backing.to_str().unwrap(), None);
+
+        restore_namespace(ns_path.to_str().unwrap(), &namespace)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(ns_path.join("device_path"))
+                .await
+                .unwrap(),
+            backing.to_str().unwrap()
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(ns_path.join("enable"))
+                .await
+                .unwrap(),
+            "1"
+        );
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
 
     // ── port-address readiness (reboot restore race, #625) ────────
 

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::sync::{Arc, Weak};
 
+use nasty_common::{BlockDeviceMappings, BlockVolumeId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -409,6 +410,9 @@ pub struct Subvolume {
     pub volsize_bytes: Option<u64>,
     /// Loop device path currently attached to the backing image (block subvolumes only).
     pub block_device: Option<String>,
+    /// Stable backing identity for sharing and reboot restoration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_volume_id: Option<BlockVolumeId>,
     /// Filesystem initialized inside the block image by the backend.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_filesystem: Option<BlockFilesystem>,
@@ -865,14 +869,13 @@ impl SubvolumeService {
     }
 
     /// Re-attach loop devices for block subvolumes after filesystems are mounted.
-    /// Returns a map of subvolume_name → current loop device path so callers
-    /// can patch NVMe-oF / iSCSI state files before those services start.
-    pub async fn restore_block_devices(&self) -> std::collections::HashMap<String, String> {
+    /// Returns stable identities and current loop paths for sharing restoration.
+    pub async fn restore_block_devices(&self) -> BlockDeviceMappings {
         let all = match self.list_all(None, None).await {
             Ok(v) => v,
             Err(e) => {
                 warn!("restore_block_devices: failed to list subvolumes: {e}");
-                return std::collections::HashMap::new();
+                return BlockDeviceMappings::default();
             }
         };
 
@@ -881,14 +884,21 @@ impl SubvolumeService {
             .filter(|s| s.subvolume_type == SubvolumeType::Block)
             .collect();
 
-        let mut dev_map = std::collections::HashMap::new();
+        let mut mappings = BlockDeviceMappings::default();
 
         if block_subvols.is_empty() {
             info!("No block subvolumes to restore");
-            return dev_map;
+            return mappings;
         }
 
         for subvol in block_subvols {
+            let Some(identity) = subvol.block_volume_id.clone() else {
+                warn!(
+                    "Block subvolume {}/{} has no bcachefs subvolume ID; refusing to use it for share restoration",
+                    subvol.filesystem, subvol.name
+                );
+                continue;
+            };
             let img_path = format!("{}/{BLOCK_FILE_NAME}", subvol.path);
             if !Path::new(&img_path).exists() {
                 warn!(
@@ -930,10 +940,10 @@ impl SubvolumeService {
                 }
             };
 
-            dev_map.insert(subvol.name.clone(), loop_dev);
+            mappings.current.insert(identity, loop_dev);
         }
 
-        dev_map
+        mappings
     }
 
     /// One-shot migration: assign a project quota ID to every
@@ -1042,11 +1052,19 @@ impl SubvolumeService {
         fs_name: &str,
         owner_filter: Option<&str>,
     ) -> Result<Vec<Subvolume>, SubvolumeError> {
-        let mount_point = self.fs_mount_point(fs_name).await?;
+        let fs = self
+            .filesystems
+            .get(fs_name)
+            .await
+            .map_err(|_| SubvolumeError::FilesystemNotFound(fs_name.to_string()))?;
+        let filesystem_uuid = fs.uuid;
+        let mount_point = fs
+            .mount_point
+            .ok_or_else(|| SubvolumeError::FilesystemNotMounted(fs_name.to_string()))?;
         let mut subvolumes = Vec::new();
 
         // Ask bcachefs which paths are real subvolumes (filters out plain dirs)
-        let info = bcachefs_list_all(&mount_point).await;
+        let info = bcachefs_list_all_strict(&mount_point).await?;
 
         // Batch queries: run repquota + losetup once instead of du/losetup per subvolume
         let (project_usages, losetup_map) =
@@ -1134,6 +1152,17 @@ impl SubvolumeService {
             };
 
             let parent = info.snapshot_parents.get(name.as_str()).cloned();
+            let block_volume_id = if attrs.meta.subvolume_type == SubvolumeType::Block {
+                info.subvolume_ids
+                    .get(name.as_str())
+                    .copied()
+                    .map(|subvolume_id| BlockVolumeId {
+                        filesystem_uuid: filesystem_uuid.clone(),
+                        subvolume_id,
+                    })
+            } else {
+                None
+            };
 
             subvolumes.push(Subvolume {
                 name: name.to_string(),
@@ -1146,6 +1175,7 @@ impl SubvolumeService {
                 comments: attrs.meta.comments,
                 volsize_bytes: attrs.meta.volsize_bytes,
                 block_device,
+                block_volume_id,
                 block_filesystem: attrs.meta.block_filesystem,
                 block_filesystem_uuid: attrs.meta.block_filesystem_uuid,
                 snapshots: snapshots.iter().map(|s| s.name.clone()).collect(),
@@ -1159,6 +1189,26 @@ impl SubvolumeService {
         }
 
         Ok(subvolumes)
+    }
+
+    /// Resolve a currently attached managed block subvolume by its loop path.
+    /// `None` means the path is not a NASty-managed block subvolume.
+    pub async fn block_volume_id_for_device(
+        &self,
+        device_path: &str,
+    ) -> Result<Option<BlockVolumeId>, SubvolumeError> {
+        let matched = self.list_all(None, None).await?.into_iter().find(|subvol| {
+            subvol.subvolume_type == SubvolumeType::Block
+                && subvol.block_device.as_deref() == Some(device_path)
+        });
+        match matched {
+            Some(subvol) => subvol.block_volume_id.map(Some).ok_or_else(|| {
+                SubvolumeError::CommandFailed(format!(
+                    "managed block device {device_path} has no stable bcachefs identity"
+                ))
+            }),
+            None => Ok(None),
+        }
     }
 
     /// List subvolumes across all mounted filesystems.
@@ -1185,10 +1235,8 @@ impl SubvolumeService {
             {
                 continue;
             }
-            match self.list(&fs.name, owner_filter).await {
-                Ok(mut subvols) => all.append(&mut subvols),
-                Err(_) => continue,
-            }
+            let mut subvols = self.list(&fs.name, owner_filter).await?;
+            all.append(&mut subvols);
         }
         Ok(all)
     }
@@ -2493,9 +2541,12 @@ impl SubvolumeService {
 }
 
 /// Parsed result from `bcachefs subvolume list --snapshots --json`.
+#[derive(Default)]
 struct BcachefsInfo {
     /// Relative paths of non-snapshot subvolumes (e.g. "foo").
     subvol_paths: std::collections::HashSet<String>,
+    /// Relative subvolume path to stable bcachefs subvolume ID.
+    subvolume_ids: std::collections::HashMap<String, u32>,
     /// Relative path of each snapshot → read_only flag (e.g. "foo@snap" → true).
     snapshot_flags: std::collections::HashMap<String, bool>,
     /// Relative path of each snapshot → parent path (from bcachefs snapshot_parent).
@@ -2508,6 +2559,8 @@ struct BcachefsInfo {
 struct BcachefsListEntry {
     path: String,
     #[serde(default)]
+    subvolid: Option<u32>,
+    #[serde(default)]
     flags: Option<String>,
     snapshot_parent: Option<String>,
     #[serde(default)]
@@ -2518,24 +2571,43 @@ struct BcachefsListEntry {
 /// return both the subvolume paths and per-snapshot read_only flags.
 /// On any error returns empty collections so callers degrade gracefully.
 async fn bcachefs_list_all(mount_point: &str) -> BcachefsInfo {
+    bcachefs_list_all_strict(mount_point)
+        .await
+        .unwrap_or_default()
+}
+
+async fn bcachefs_list_all_strict(mount_point: &str) -> Result<BcachefsInfo, SubvolumeError> {
     let output = cmd::run_ok(
         "bcachefs",
         &["subvolume", "list", "--snapshots", "--json", mount_point],
     )
     .await
-    .unwrap_or_default();
-    parse_bcachefs_list(&output)
+    .map_err(|error| SubvolumeError::CommandFailed(error.to_string()))?;
+    let entries: Vec<BcachefsListEntry> = serde_json::from_str(&output).map_err(|error| {
+        SubvolumeError::CommandFailed(format!(
+            "parse bcachefs subvolume list for {mount_point}: {error}"
+        ))
+    })?;
+    Ok(build_bcachefs_info(entries))
 }
 
+#[cfg(test)]
 fn parse_bcachefs_list(output: &str) -> BcachefsInfo {
     let entries: Vec<BcachefsListEntry> = serde_json::from_str(output).unwrap_or_default();
+    build_bcachefs_info(entries)
+}
 
+fn build_bcachefs_info(entries: Vec<BcachefsListEntry>) -> BcachefsInfo {
     let mut subvol_paths = std::collections::HashSet::new();
+    let mut subvolume_ids = std::collections::HashMap::new();
     let mut snapshot_flags = std::collections::HashMap::new();
     let mut snapshot_parents = std::collections::HashMap::new();
     let mut snapshot_created_at = std::collections::HashMap::new();
 
     for entry in entries {
+        if let Some(subvolume_id) = entry.subvolid {
+            subvolume_ids.insert(entry.path.clone(), subvolume_id);
+        }
         let is_ro = entry.flags.as_deref() == Some("ro");
         if let Some(ref parent) = entry.snapshot_parent {
             if is_ro {
@@ -2559,6 +2631,7 @@ fn parse_bcachefs_list(output: &str) -> BcachefsInfo {
 
     BcachefsInfo {
         subvol_paths,
+        subvolume_ids,
         snapshot_flags,
         snapshot_parents,
         snapshot_created_at,
@@ -3074,6 +3147,19 @@ async fn materialize_subvol_from_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bcachefs_subvolume_id_is_preserved() {
+        let info = parse_bcachefs_list(
+            r#"[
+                {"path":"volume","subvolid":41,"flags":null,"snapshot_parent":null},
+                {"path":"volume@snap","subvolid":42,"flags":"ro","snapshot_parent":"/volume"}
+            ]"#,
+        );
+
+        assert_eq!(info.subvolume_ids.get("volume"), Some(&41));
+        assert_eq!(info.subvolume_ids.get("volume@snap"), Some(&42));
+    }
 
     #[test]
     fn bcachefs_snapshot_creation_time_is_preserved() {

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 const STATE_PATH: &str = "/var/lib/nasty/protocols.json";
 const SMB_NASTY_CONF: &str = "/etc/samba/smb.nasty.conf";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Protocol {
     Nfs,
@@ -223,10 +223,23 @@ impl ProtocolService {
     /// Restore enabled protocol services on startup.
     /// Starts daemons and loads kernel modules for protocols the user enabled.
     pub async fn restore(&self) {
+        self.restore_excluding(&std::collections::HashSet::new())
+            .await;
+    }
+
+    /// Restore enabled protocols except entries whose backing state failed
+    /// safety validation during boot.
+    pub async fn restore_excluding(&self, excluded: &std::collections::HashSet<Protocol>) {
         let state = load_state().await;
 
         for &proto in Protocol::ALL {
-            if !state.get(proto) {
+            if !state.get(proto) || excluded.contains(&proto) {
+                if excluded.contains(&proto) {
+                    warn!(
+                        "Skipping {} restore because its persisted backing state is unsafe",
+                        proto.display_name()
+                    );
+                }
                 continue;
             }
 
@@ -284,9 +297,23 @@ impl ProtocolService {
         }
     }
 
+    /// Stop a protocol's live services without changing the operator's
+    /// persisted enabled preference. Used when boot-time safety validation
+    /// fails and the protocol may have survived an engine-only restart.
+    pub async fn quiesce(&self, proto: Protocol) -> Result<(), String> {
+        for service in proto.services().iter().rev() {
+            systemctl("stop", service).await?;
+        }
+        Ok(())
+    }
+
     /// List all protocols with their enabled/running status
     pub async fn is_enabled(&self, proto: Protocol) -> bool {
         load_state().await.get(proto)
+    }
+
+    pub async fn is_running(&self, proto: Protocol) -> bool {
+        is_protocol_running(proto).await
     }
 
     pub async fn list(&self) -> Vec<ProtocolStatus> {
@@ -442,7 +469,7 @@ async fn is_protocol_running(proto: Protocol) -> bool {
     match proto {
         Protocol::Nfs => systemctl_is_active("nfs-server.service").await,
         Protocol::Smb => systemctl_is_active("samba-smbd.service").await,
-        Protocol::Iscsi => std::path::Path::new("/sys/module/iscsi_target_mod").exists(),
+        Protocol::Iscsi => systemctl_is_active("target.service").await,
         Protocol::Nvmeof => {
             // NVMe-oF is "running" if nvmet configfs is available
             std::path::Path::new("/sys/kernel/config/nvmet").exists()
@@ -518,10 +545,11 @@ async fn protocol_modules(proto: Protocol) -> Vec<&'static str> {
 }
 
 pub(crate) async fn systemctl(action: &str, service: &str) -> Result<(), String> {
-    let output = tokio::process::Command::new("systemctl")
-        .args([action, service])
-        .output()
+    let mut command = tokio::process::Command::new("systemctl");
+    command.args([action, service]).kill_on_drop(true);
+    let output = tokio::time::timeout(std::time::Duration::from_secs(30), command.output())
         .await
+        .map_err(|_| format!("systemctl {action} {service} timed out after 30 seconds"))?
         .map_err(|e| format!("failed to run systemctl: {e}"))?;
 
     if output.status.success() {

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1959,7 +1959,7 @@ in {
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "${pkgs.bash}/bin/bash -c 'test -f /etc/target/saveconfig.json && ${targetcli-fixed}/bin/targetcli restoreconfig /etc/target/saveconfig.json || true'";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'if test -f /etc/target/saveconfig.json; then exec ${targetcli-fixed}/bin/targetcli restoreconfig /etc/target/saveconfig.json; fi'";
         ExecStop = "${targetcli-fixed}/bin/targetcli clearconfig confirm=True";
       };
     };

--- a/webui/src/lib/fs-dependents.test.ts
+++ b/webui/src/lib/fs-dependents.test.ts
@@ -14,6 +14,7 @@ function deps(over: Partial<FsDependents> = {}): FsDependents {
 		smb_shares: [],
 		iscsi_targets: [],
 		nvmeof_subsystems: [],
+		state_errors: [],
 		...over,
 	};
 }

--- a/webui/src/lib/fs-dependents.ts
+++ b/webui/src/lib/fs-dependents.ts
@@ -17,9 +17,10 @@ export function summarizeDependents(deps: FsDependents): string | null {
 		{ label: 'NVMe-oF subsystem', items: deps.nvmeof_subsystems },
 	];
 	const non_empty = groups.filter((g) => g.items.length > 0);
-	if (non_empty.length === 0) return null;
+	if (non_empty.length === 0 && deps.state_errors.length === 0) return null;
 
 	const lines = non_empty.map((g) => `• ${formatLine(g.label, g.items)}`);
+	lines.push(...deps.state_errors.map((error) => `• Dependency state error: ${error}`));
 	return lines.join('\n');
 }
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -361,6 +361,7 @@ export interface SubvolumeDependents {
 	smb_shares: string[];
 	iscsi_targets: string[];
 	nvmeof_subsystems: string[];
+	state_errors: string[];
 }
 
 export interface FsDependents {
@@ -374,6 +375,7 @@ export interface FsDependents {
 	smb_shares: string[];
 	iscsi_targets: string[];
 	nvmeof_subsystems: string[];
+	state_errors: string[];
 }
 
 export interface ServiceStatus {
@@ -600,6 +602,11 @@ export interface TieringProfile {
 
 export type SubvolumeType = 'filesystem' | 'block';
 
+export interface BlockVolumeId {
+	filesystem_uuid: string;
+	subvolume_id: number;
+}
+
 export interface Subvolume {
 	name: string;
 	filesystem: string;
@@ -612,6 +619,7 @@ export interface Subvolume {
 	comments: string | null;
 	volsize_bytes: number | null;
 	block_device: string | null;
+	block_volume_id?: BlockVolumeId | null;
 	snapshots: string[];
 	owner: string | null;
 	properties: Record<string, string>;
@@ -720,6 +728,8 @@ export interface Lun {
 	backstore_name: string;
 	backstore_type: string;
 	size_bytes: number | null;
+	backing_volume?: BlockVolumeId | null;
+	backing_volume_unresolved?: boolean;
 }
 
 export interface Acl {
@@ -742,6 +752,8 @@ export interface Namespace {
 	nsid: number;
 	device_path: string;
 	enabled: boolean;
+	backing_volume?: BlockVolumeId | null;
+	backing_volume_unresolved?: boolean;
 }
 
 export interface NvmeofPort {

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -508,12 +508,13 @@
 	 * subvolume can go. Apps/VMs/backups all imply non-trivial
 	 * lifecycles we shouldn't tear down implicitly from a Delete
 	 * Subvolume click. */
-	const blockingDeps = $derived.by((): { label: string; route: string }[] => {
+	const blockingDeps = $derived.by((): { label: string; route?: string }[] => {
 		if (!deleteDeps) return [];
-		const out: { label: string; route: string }[] = [];
+		const out: { label: string; route?: string }[] = [];
 		for (const v of deleteDeps.vms) out.push({ label: `VM '${v}'`, route: '/vms' });
 		for (const a of deleteDeps.apps) out.push({ label: `app '${a}'`, route: '/apps' });
 		for (const b of deleteDeps.backup_jobs) out.push({ label: `backup job '${b}'`, route: '/backups' });
+		for (const error of deleteDeps.state_errors) out.push({ label: `Dependency state error: ${error}` });
 		return out;
 	});
 
@@ -1691,7 +1692,7 @@
 						{#each blockingDeps as b}
 							<li>
 								{b.label}
-								<a href={b.route} class="ml-1 text-xs text-primary underline">go to {b.route}</a>
+								{#if b.route}<a href={b.route} class="ml-1 text-xs text-primary underline">go to {b.route}</a>{/if}
 							</li>
 						{/each}
 					</ul>
@@ -1738,4 +1739,3 @@
 		{/if}
 	</Dialog.Content>
 </Dialog.Root>
-


### PR DESCRIPTION
## Summary
- persist managed block exports by filesystem UUID and bcachefs subvolume ID instead of loop-device path
- remap each iSCSI LUN and NVMe-oF namespace independently, with strict state/inventory validation and fail-closed quiescing
- reconcile exports after startup, mount, unlock, and protocol enable while surfacing dependency-state errors to destructive workflows

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run check`
- `npm test` (193 passed)
- `npm run build`
- `nix-instantiate --parse nixos/modules/nasty.nix`
- independent final correctness review: no high/medium findings