### PR TITLE
nixos: prevent iSCSI restore activation race

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Run integration tests
         run: |
           nix build \
+            .#checks.x86_64-linux.iscsi-engine-owned-lifecycle \
             .#checks.x86_64-linux.bcachefs-smoke \
             .#checks.x86_64-linux.appliance-smoke \
             -L --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -417,6 +417,16 @@
       nasty-webui = mkWebui "x86_64-linux";
       nasty-bcachefs-tools = mkBcachefsTools "x86_64-linux";
     in {
+      # target.service is restored only after the engine has remapped persisted
+      # LUN identities. NixOS must not independently restart an active changed
+      # unit during a generation switch or it races the engine's quiesce step.
+      iscsi-engine-owned-lifecycle = let
+        restartIfChanged =
+          (mkNixosConfigs "x86_64-linux").nasty.config.systemd.services.target.restartIfChanged;
+      in pkgs.runCommand "iscsi-engine-owned-lifecycle" {} ''
+        test "${nixpkgs.lib.boolToString restartIfChanged}" = false
+        touch "$out"
+      '';
       bcachefs-smoke = import ./nixos/tests/bcachefs-smoke.nix {
         inherit pkgs nasty-bcachefs-tools;
       };

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1955,6 +1955,11 @@ in {
     # loading kernel modules and patching device paths.
     systemd.services.target = mkIf cfg.iscsi.enable {
       description = "LIO iSCSI target restore";
+      # The engine owns this unit's lifecycle so it can patch persisted
+      # backstore paths before restoring LIO. If NixOS restarts an active,
+      # changed unit during a generation switch, it races engine startup's
+      # mandatory quiesce and the switch fails when targetcli receives SIGTERM.
+      restartIfChanged = false;
       path = [ targetcli-fixed ];
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
## Summary
- keep NixOS activation from independently restarting the engine-managed `target.service`
- let engine startup remain the sole owner of quiescing, immutable LUN remapping, and LIO restoration
- add a flake check for the lifecycle invariant and run it in integration CI

## Incident
Updating nas.0f.ee from `189fecb5` to `7209f417` started the changed `target.service` and `nasty-engine.service` concurrently. Engine startup then quiesced iSCSI for DATA-1 remapping, sending SIGTERM to the in-progress `targetcli restoreconfig`; `switch-to-configuration` returned status 4 and the transactional updater correctly rolled back.

NixOS reads `restartIfChanged` from the new unit definition, so this also protects the first update crossing #698.

## Verification
- `nix eval --json .#nixosConfigurations.nasty.config.systemd.services.target.restartIfChanged` => `false`
- `nix eval --raw .#checks.x86_64-linux.iscsi-engine-owned-lifecycle.drvPath`
- `nix flake check --no-build`
- `git diff --check`

Full x86_64 generation-switch realization is left to integration CI because the local host is aarch64-darwin.