### PR TITLE
nixos: fix nasty-sync module version probe

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1067,7 +1067,8 @@ in {
             fi
             ENGINE_VER=$(cat /etc/nasty-version 2>/dev/null || echo "?")
             printf "  engine:         %s\n" "$ENGINE_VER"
-            RUNNING_BCACHEFS=$(bcachefs --field version 2>/dev/null | head -1 || echo "?")
+            RUNNING_BCACHEFS=$(modinfo --field version bcachefs 2>/dev/null | head -1 || true)
+            RUNNING_BCACHEFS=''${RUNNING_BCACHEFS:-?}
             printf "  bcachefs kernel module: %s\n" "$RUNNING_BCACHEFS"
             if [ "$RUNNING_BCACHEFS" != "?" ] && [ "$BCACHEFS_TAG" != "?" ]; then
               BCACHEFS_TAG_BARE=''${BCACHEFS_TAG#v}


### PR DESCRIPTION
## Summary
- query the loaded bcachefs kernel module with `modinfo` instead of passing `--field` to the `bcachefs` CLI
- normalize a missing or failed probe to a single `?`

## Root cause
`nasty-sync -s` ran `bcachefs --field version`. The bcachefs CLI printed `Unknown command --field` to stdout, which the script then treated as the running module version and reported as a false mismatch.

The live host confirms `modinfo --field version bcachefs` returns `1.38.8`, matching the pinned tools.

## Verification
- `nix-instantiate --parse nixos/modules/nasty.nix`
- `nix flake check --no-build`
- `git diff --check`