### PR TITLE
ad: wait for LDAP readiness before join

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,9 @@ on:
       # test validates. Watch all of nixos/ so build-affecting config
       # can't merge unvalidated.
       - 'nixos/**'
+      # Engine behavior is exercised by appliance-smoke and the AD DC/member
+      # test; engine-only changes must not skip those integration checks.
+      - 'engine/**'
       - 'flake.nix'
       - 'flake.lock'
 
@@ -78,19 +81,10 @@ jobs:
             .#checks.x86_64-linux.appliance-smoke \
             -L --print-build-logs
 
-      - name: AD DC VM test (non-gating while stabilizing)
-        # ad-dc (#20): NASty provisions a real domain via
-        # samba-dc.service + dc.provision, and a second NASty joins it
-        # with the shipped member-join flow. This is
-        # the test's first live CI run, and a brand-new two-VM AD test is
-        # exactly the kind of thing that finds a harness or
-        # readiness-signal issue the first time it runs for real (see
-        # nixos/tests/ad-dc.nix's header for the two named fallbacks).
-        # Non-gating until it has built up a green track record, then
-        # promote to gating. continue-on-error masks the step's
-        # conclusion in the GitHub UI, so its logs — not the checkmark —
-        # are the source of truth while it stabilizes.
-        continue-on-error: true
+      - name: AD DC VM test
+        # Full two-node interoperability check: one NASty provisions a real
+        # domain and another joins it, resolves a domain user, and authenticates
+        # to SMB. Keep this gating so a green workflow means AD actually passed.
         run: |
           nix build \
             .#checks.x86_64-linux.ad-dc \

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -13,6 +13,7 @@
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,8 @@ const FS_ROOT: &str = "/fs";
 /// NASty's own network config — consulted (read-only) by the static-IP
 /// precondition. Path mirrors `network.rs`'s private `JSON_PATH`.
 const NETWORKING_JSON_PATH: &str = "/var/lib/nasty/networking.json";
+const LDAP_READY_TIMEOUT: Duration = Duration::from_secs(60);
+const LDAP_READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug, thiserror::Error)]
 pub enum DcError {
@@ -141,6 +144,58 @@ fn strip_dns_forwarder_lines(conf: &str) -> String {
         })
         .map(|l| format!("{l}\n"))
         .collect()
+}
+
+fn ldap_ready_args(workgroup: &str) -> Vec<String> {
+    vec![
+        "--kill-after=1s".into(),
+        "5s".into(),
+        "ldbsearch".into(),
+        "--configfile".into(),
+        DC_CONF_PATH.into(),
+        "-H".into(),
+        "ldap://127.0.0.1".into(),
+        "-s".into(),
+        "base".into(),
+        "-b".into(),
+        String::new(),
+        "-U".into(),
+        format!(r"{workgroup}\Administrator"),
+        "--use-kerberos=off".into(),
+        "defaultNamingContext".into(),
+    ]
+}
+
+fn ldap_rootdse_ready(output: &str) -> bool {
+    output.lines().any(|line| {
+        line.split_once(':')
+            .is_some_and(|(name, value)| name == "defaultNamingContext" && !value.trim().is_empty())
+    })
+}
+
+async fn wait_for_ldap_ready(workgroup: &str, admin_password: &str) -> Result<(), DcError> {
+    let args = ldap_ready_args(workgroup);
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let deadline = Instant::now() + LDAP_READY_TIMEOUT;
+
+    loop {
+        let last_error = match run_cmd_stdin("timeout", &args, &[], admin_password).await {
+            Ok(output) if ldap_rootdse_ready(&output) => {
+                info!("dc: authenticated LDAP is ready");
+                return Ok(());
+            }
+            Ok(_) => "LDAP RootDSE did not return defaultNamingContext".to_string(),
+            Err(error) => error.to_string(),
+        };
+
+        if Instant::now() >= deadline {
+            return Err(DcError::CommandFailed(format!(
+                "samba-dc became active but authenticated LDAP was not ready within {}s: {last_error}",
+                LDAP_READY_TIMEOUT.as_secs()
+            )));
+        }
+        tokio::time::sleep(LDAP_READY_POLL_INTERVAL).await;
+    }
 }
 
 /// Insert `extra` immediately after the `[global]` section header. A blind
@@ -520,6 +575,11 @@ impl DcService {
             // samba-dc conflicts with smbd/nmbd/winbindd — systemd swaps
             // them atomically.
             run_cmd("systemctl", &["start", "samba-dc.service"], &[]).await?;
+            // Samba sends READY=1 before asynchronous TLS generation and
+            // authenticated LDAP initialization finish. Do not expose a DC
+            // as provisioned until the same remote-auth path used by domain
+            // joins can query RootDSE successfully.
+            wait_for_ldap_ready(&workgroup, &req.admin_password).await?;
 
             Self::save_config(&DcConfig {
                 realm: realm.clone(),
@@ -869,6 +929,26 @@ mod tests {
             1,
             "expected exactly one dns forwarder line, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn ldap_readiness_probe_uses_stdin_credentials_and_requires_rootdse() {
+        let secret = "Sup3r.Secret!";
+        let args = ldap_ready_args("ADEXAMPLE");
+        assert_eq!(args[0], "--kill-after=1s");
+        assert_eq!(args[1], "5s");
+        assert_eq!(args[2], "ldbsearch");
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "-U" && w[1] == r"ADEXAMPLE\Administrator")
+        );
+        assert!(!args.iter().any(|arg| arg.contains(secret)));
+
+        assert!(ldap_rootdse_ready(
+            "# record 1\ndn:\ndefaultNamingContext: DC=ad,DC=example,DC=com\n"
+        ));
+        assert!(!ldap_rootdse_ready("# record 1\ndn:\n"));
+        assert!(!ldap_rootdse_ready("defaultNamingContext:\n"));
     }
 
     // ── looks_provisioned ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- wait for an authenticated LDAP RootDSE query before `dc.provision` reports success
- keep the Administrator password on stdin and bound each readiness probe with a forced timeout
- make engine-only changes trigger Integration on pull requests
- promote the two-node AD DC/member VM test from masked to gating

## Root cause
`samba-dc.service` sends `READY=1` before asynchronous TLS generation and authenticated LDAP initialization finish. CI then starts the member join as soon as systemd reports the DC active. In failing runs, `domain.join` begins before Samba logs `TLS self-signed keys generated OK`, and `net ads join` exits 255 with `failed to connect to AD: Operations error`. Identical code passes when TLS initialization wins the race.

The DC now proves the same authenticated LDAP path needed by a member join can query RootDSE before it persists `dc.json` or returns success. A timeout enters the existing provision unwind rather than exposing a half-ready DC.

## Verification
- `cargo test -p nasty-system` (398 passed)
- `cargo test -p nasty-system dc::tests` (13 passed)
- `cargo clippy -p nasty-system --all-targets -- -D warnings`
- `nix flake check --no-build`
- `nix eval --raw .#checks.x86_64-linux.ad-dc.name`
- `git diff --check`

The full `x86_64-linux` two-VM test is intentionally gating in this PR because the local host is `aarch64-darwin`.