### PR TITLE
webui: default new browsers to icon navigation

### DIFF
--- a/webui/src/lib/uiPrefs.svelte.test.ts
+++ b/webui/src/lib/uiPrefs.svelte.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from 'vitest';
-import { uiPrefs } from './uiPrefs.svelte';
+import { parseMenuStyle, uiPrefs } from './uiPrefs.svelte';
 
 beforeEach(() => {
 	uiPrefs.setLogoHidden(false);
@@ -9,6 +9,17 @@ beforeEach(() => {
 });
 
 describe('uiPrefs', () => {
+	test('defaults fresh and invalid preferences to icons', () => {
+		expect(parseMenuStyle(null)).toBe('icons');
+		expect(parseMenuStyle('unknown')).toBe('icons');
+	});
+
+	test('preserves every explicit menu preference', () => {
+		expect(parseMenuStyle('classic')).toBe('classic');
+		expect(parseMenuStyle('icons')).toBe('icons');
+		expect(parseMenuStyle('launcher')).toBe('launcher');
+	});
+
 	test('persists the selected menu presentation', () => {
 		uiPrefs.setMenuStyle('icons');
 		expect(uiPrefs.menuStyle).toBe('icons');

--- a/webui/src/lib/uiPrefs.svelte.ts
+++ b/webui/src/lib/uiPrefs.svelte.ts
@@ -7,12 +7,16 @@ const ICON_GROUP_KEY = 'nasty:icon_nav_group';
 
 export type MenuStyle = 'classic' | 'icons' | 'launcher';
 
+export function parseMenuStyle(value: string | null): MenuStyle {
+	return value === 'classic' || value === 'icons' || value === 'launcher' ? value : 'icons';
+}
+
 function createUiPrefs() {
 	let logoHidden = $state<boolean>(
 		typeof localStorage !== 'undefined' && localStorage.getItem(LOGO_HIDDEN_KEY) === '1'
 	);
 	const storedMenuStyle = typeof localStorage !== 'undefined' ? localStorage.getItem(MENU_STYLE_KEY) : null;
-	let menuStyle = $state<MenuStyle>(storedMenuStyle === 'icons' || storedMenuStyle === 'launcher' ? storedMenuStyle : 'classic');
+	let menuStyle = $state<MenuStyle>(parseMenuStyle(storedMenuStyle));
 	let iconGroupId = $state<string | null>(
 		typeof localStorage !== 'undefined' ? localStorage.getItem(ICON_GROUP_KEY) : null
 	);


### PR DESCRIPTION
## Summary
- default fresh browsers to the icon/category navigation style
- preserve every explicit stored choice, including `classic`
- normalize unknown preference values to the new icon default
- add regression coverage for defaults and stored-value compatibility

Existing users with a saved navigation style are unaffected. Preferences remain per-browser through localStorage.

## Verification
- `npm test -- --run src/lib/uiPrefs.svelte.test.ts`
- `npm run check`
- `npm run build`
- `git diff --check`

The production build completed with one pre-existing `theme.svelte.ts` warning unrelated to this change.