### PR TITLE
nixos: bump diskwatch to 0.1.5

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -795,12 +795,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.1.3";
-          hash = "sha256-CGt9954nwgVMcNJg6QjRLjhN8N9rQ6+bRuCzqQAUXGc=";
+          rev = "v0.1.5";
+          hash = "sha256-5EGNfMn//b38mhTK8rJfPJdk1rIPeijreDBkgoDmjBs=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.1.3";
+        version = "0.1.5";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";


### PR DESCRIPTION
## Summary
- bump the bundled diskwatch TUI from v0.1.3 to v0.1.5
- include the v0.1.4 independent-filesystem attribution fix
- add the v0.1.5 runtime-selectable color themes

Upstream comparison: https://github.com/matthart1983/diskwatch/compare/v0.1.3...v0.1.5

## Testing
- `nix flake check --no-build`
- native Nix build of the pinned `diskwatch-0.1.5` derivation
- verified packaged binary reports `diskwatch 0.1.5`
- verified the NixOS system package set resolves `diskwatch-0.1.5`
- `git diff --check`