### PR TITLE
authz: restrict scoped share sources

### DIFF
--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused_imports, unused_variables)]
 
-use nasty_common::{ErrorCode, Request, Response};
+use nasty_common::{BlockVolumeId, ErrorCode, Request, Response};
 use serde::Deserialize;
 
 use super::*;
@@ -117,6 +117,161 @@ pub(crate) async fn sync_portal_firewall_ports(state: &AppState) -> Result<(), S
         .await
 }
 
+fn resource_matches_scope(
+    filesystem: &str,
+    owner: Option<&str>,
+    filesystem_filter: Option<&str>,
+    owner_filter: Option<&str>,
+) -> bool {
+    filesystem_filter.is_none_or(|filter| filter == filesystem)
+        && owner_filter.is_none_or(|filter| owner == Some(filter))
+}
+
+fn path_source_matches_scope(
+    requested: &std::path::Path,
+    candidates: &[(std::path::PathBuf, String, Option<String>)],
+    filesystem_filter: Option<&str>,
+    owner_filter: Option<&str>,
+) -> bool {
+    let containing_matches = candidates
+        .iter()
+        .filter(|(path, _, _)| requested.starts_with(path))
+        .max_by_key(|(path, _, _)| path.components().count())
+        .is_some_and(|(_, filesystem, owner)| {
+            resource_matches_scope(
+                filesystem,
+                owner.as_deref(),
+                filesystem_filter,
+                owner_filter,
+            )
+        });
+    let nested_matches = candidates
+        .iter()
+        .filter(|(path, _, _)| path.starts_with(requested))
+        .all(|(_, filesystem, owner)| {
+            resource_matches_scope(
+                filesystem,
+                owner.as_deref(),
+                filesystem_filter,
+                owner_filter,
+            )
+        });
+    containing_matches && nested_matches
+}
+
+async fn authorize_path_source(
+    state: &AppState,
+    session: &Session,
+    requested: &str,
+) -> Result<String, String> {
+    if session.filesystem.is_none() && session.owner.is_none() {
+        return Ok(requested.to_string());
+    }
+
+    let canonical = tokio::fs::canonicalize(requested)
+        .await
+        .map_err(|_| "access denied".to_string())?;
+    let subvolumes = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut candidates = Vec::with_capacity(subvolumes.len());
+    for subvolume in subvolumes {
+        if let Ok(path) = tokio::fs::canonicalize(&subvolume.path).await {
+            candidates.push((path, subvolume.filesystem, subvolume.owner));
+        }
+    }
+
+    if !path_source_matches_scope(
+        &canonical,
+        &candidates,
+        session.filesystem.as_deref(),
+        session.owner.as_deref(),
+    ) {
+        return Err("access denied".to_string());
+    }
+    canonical
+        .into_os_string()
+        .into_string()
+        .map_err(|_| "access denied".to_string())
+}
+
+async fn authorize_block_source(
+    state: &AppState,
+    session: &Session,
+    device_path: &str,
+) -> Result<Option<BlockVolumeId>, String> {
+    if session.filesystem.is_none() && session.owner.is_none() {
+        return state
+            .subvolumes
+            .block_volume_id_for_device(device_path)
+            .await
+            .map_err(|error| error.to_string());
+    }
+
+    let matched = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .find(|subvolume| {
+            subvolume.subvolume_type == nasty_storage::subvolume::SubvolumeType::Block
+                && subvolume.block_device.as_deref() == Some(device_path)
+        })
+        .ok_or_else(|| "access denied".to_string())?;
+    if !resource_matches_scope(
+        &matched.filesystem,
+        matched.owner.as_deref(),
+        session.filesystem.as_deref(),
+        session.owner.as_deref(),
+    ) {
+        return Err("access denied".to_string());
+    }
+    matched.block_volume_id.map(Some).ok_or_else(|| {
+        format!("managed block device {device_path} has no stable bcachefs identity")
+    })
+}
+
+async fn authorize_block_destination(
+    state: &AppState,
+    session: &Session,
+    identities: &[Option<BlockVolumeId>],
+) -> Result<(), String> {
+    if session.filesystem.is_none() && session.owner.is_none() {
+        return Ok(());
+    }
+    if identities.is_empty() || identities.iter().any(Option::is_none) {
+        return Err("access denied".to_string());
+    }
+
+    let subvolumes = state
+        .subvolumes
+        .list_all(None, None)
+        .await
+        .map_err(|error| error.to_string())?;
+    for identity in identities.iter().flatten() {
+        let subvolume = subvolumes
+            .iter()
+            .find(|subvolume| subvolume.block_volume_id.as_ref() == Some(identity))
+            .ok_or_else(|| "access denied".to_string())?;
+        if !resource_matches_scope(
+            &subvolume.filesystem,
+            subvolume.owner.as_deref(),
+            session.filesystem.as_deref(),
+            session.owner.as_deref(),
+        ) {
+            return Err("access denied".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn session_is_scoped(session: &Session) -> bool {
+    session.filesystem.is_some() || session.owner.is_some()
+}
+
 async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Option<Response> {
     Some(match req.method.as_str() {
         "share.nfs.list" => match state.nfs.list().await {
@@ -136,9 +291,15 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nfs.create(p).await {
-                    Ok(v) => ok(req, v),
+            match parse_params::<nasty_sharing::nfs::CreateNfsShareRequest>(req) {
+                Ok(mut p) => match authorize_path_source(state, session, &p.path).await {
+                    Ok(path) => {
+                        p.path = path;
+                        match state.nfs.create(p).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
+                    }
                     Err(e) => err(req, e),
                 },
                 Err(e) => invalid(req, e),
@@ -189,11 +350,28 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.smb.create(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::smb::CreateSmbShareRequest>(req) {
+                Ok(mut p) => {
+                    if session_is_scoped(session)
+                        && state.smb.list().await.is_ok_and(|shares| {
+                            shares
+                                .iter()
+                                .any(|share| share.name.eq_ignore_ascii_case(&p.name))
+                        })
+                    {
+                        return Some(err(req, "access denied"));
+                    }
+                    match authorize_path_source(state, session, &p.path).await {
+                        Ok(path) => {
+                            p.path = path;
+                            match state.smb.create(p).await {
+                                Ok(v) => ok(req, v),
+                                Err(e) => err(req, e),
+                            }
+                        }
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -244,6 +422,19 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::iscsi::CreateTargetRequest>(req) {
                 Ok(mut p) => {
+                    if session_is_scoped(session) {
+                        if p.device_path.is_none() {
+                            return Some(err(req, "access denied"));
+                        }
+                        let iqn = format!("iqn.2137-04.storage.nasty:{}", p.name);
+                        if state.iscsi.list().await.is_ok_and(|targets| {
+                            targets
+                                .iter()
+                                .any(|target| target.iqn.eq_ignore_ascii_case(&iqn))
+                        }) {
+                            return Some(err(req, "access denied"));
+                        }
+                    }
                     if p.portals
                         .as_deref()
                         .is_some_and(|ps| ps.iter().any(|portal| portal.iser))
@@ -251,21 +442,17 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                     {
                         return Some(r);
                     }
+                    if let Some(ref device_path) = p.device_path {
+                        match authorize_block_source(state, session, device_path).await {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
+                    }
                     if let Some(ref dp) = p.device_path
                         && let Some(conflict) =
                             check_block_device_conflict(state, dp, "iscsi").await
                     {
                         return Some(err(req, conflict));
-                    }
-                    if let Some(ref device_path) = p.device_path {
-                        match state
-                            .subvolumes
-                            .block_volume_id_for_device(device_path)
-                            .await
-                        {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
-                        }
                     }
                     match state.iscsi.create(p).await {
                         Ok(v) => ok(req, v),
@@ -297,19 +484,29 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::iscsi::AddLunRequest>(req) {
                 Ok(mut p) => {
+                    let target = match state.iscsi.get(&p.target_id).await {
+                        Ok(target) => target,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    let identities: Vec<_> = target
+                        .luns
+                        .iter()
+                        .map(|lun| lun.backing_volume.clone())
+                        .collect();
+                    if let Err(error) =
+                        authorize_block_destination(state, session, &identities).await
+                    {
+                        return Some(err(req, error));
+                    }
+                    match authorize_block_source(state, session, &p.backstore_path).await {
+                        Ok(identity) => p.backing_volume = identity,
+                        Err(error) => return Some(err(req, error)),
+                    }
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.backstore_path, "iscsi").await
                     {
                         err(req, conflict)
                     } else {
-                        match state
-                            .subvolumes
-                            .block_volume_id_for_device(&p.backstore_path)
-                            .await
-                        {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
-                        }
                         match state.iscsi.add_lun(p).await {
                             Ok(v) => ok(req, v),
                             Err(e) => err(req, e),
@@ -436,21 +633,28 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::nvmeof::CreateSubsystemRequest>(req) {
                 Ok(mut p) => {
+                    if session_is_scoped(session) {
+                        if p.device_path.is_none() {
+                            return Some(err(req, "access denied"));
+                        }
+                        let nqn = format!("nqn.2137-04.storage.nasty:{}", p.name);
+                        if state.nvmeof.list().await.is_ok_and(|subsystems| {
+                            subsystems.iter().any(|subsystem| subsystem.nqn == nqn)
+                        }) {
+                            return Some(err(req, "access denied"));
+                        }
+                    }
+                    if let Some(ref device_path) = p.device_path {
+                        match authorize_block_source(state, session, device_path).await {
+                            Ok(identity) => p.backing_volume = identity,
+                            Err(error) => return Some(err(req, error)),
+                        }
+                    }
                     if let Some(ref device_path) = p.device_path
                         && let Some(conflict) =
                             check_block_device_conflict(state, device_path, "nvmeof").await
                     {
                         return Some(err(req, conflict));
-                    }
-                    if let Some(ref device_path) = p.device_path {
-                        match state
-                            .subvolumes
-                            .block_volume_id_for_device(device_path)
-                            .await
-                        {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
-                        }
                     }
                     match state.nvmeof.create(p).await {
                         Ok(v) => {
@@ -506,19 +710,29 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
                 Ok(mut p) => {
+                    let subsystem = match state.nvmeof.get(&p.subsystem_id).await {
+                        Ok(subsystem) => subsystem,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    let identities: Vec<_> = subsystem
+                        .namespaces
+                        .iter()
+                        .map(|namespace| namespace.backing_volume.clone())
+                        .collect();
+                    if let Err(error) =
+                        authorize_block_destination(state, session, &identities).await
+                    {
+                        return Some(err(req, error));
+                    }
+                    match authorize_block_source(state, session, &p.device_path).await {
+                        Ok(identity) => p.backing_volume = identity,
+                        Err(error) => return Some(err(req, error)),
+                    }
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.device_path, "nvmeof").await
                     {
                         err(req, conflict)
                     } else {
-                        match state
-                            .subvolumes
-                            .block_volume_id_for_device(&p.device_path)
-                            .await
-                        {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
-                        }
                         match state.nvmeof.add_namespace(p).await {
                             Ok(v) => ok(req, v),
                             Err(e) => err(req, e),
@@ -607,4 +821,97 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn candidate(
+        path: &str,
+        filesystem: &str,
+        owner: Option<&str>,
+    ) -> (PathBuf, String, Option<String>) {
+        (
+            PathBuf::from(path),
+            filesystem.to_string(),
+            owner.map(str::to_string),
+        )
+    }
+
+    #[test]
+    fn path_scope_accepts_owned_subvolume_and_descendant() {
+        let candidates = [candidate("/fs/first/owned", "first", Some("token-a"))];
+        for path in ["/fs/first/owned", "/fs/first/owned/folder"] {
+            assert!(path_source_matches_scope(
+                Path::new(path),
+                &candidates,
+                Some("first"),
+                Some("token-a"),
+            ));
+        }
+    }
+
+    #[test]
+    fn path_scope_respects_component_boundaries() {
+        let candidates = [candidate("/fs/first/data", "first", Some("token-a"))];
+        assert!(!path_source_matches_scope(
+            Path::new("/fs/first/data2"),
+            &candidates,
+            Some("first"),
+            Some("token-a"),
+        ));
+    }
+
+    #[test]
+    fn deepest_subvolume_controls_path_ownership() {
+        let candidates = [
+            candidate("/fs/first/parent", "first", Some("token-a")),
+            candidate("/fs/first/parent/foreign", "first", Some("token-b")),
+        ];
+        assert!(!path_source_matches_scope(
+            Path::new("/fs/first/parent/foreign/file"),
+            &candidates,
+            Some("first"),
+            Some("token-a"),
+        ));
+    }
+
+    #[test]
+    fn parent_export_rejects_nested_foreign_subvolume() {
+        let candidates = [
+            candidate("/fs/first/parent", "first", Some("token-a")),
+            candidate("/fs/first/parent/foreign", "first", Some("token-b")),
+        ];
+        assert!(!path_source_matches_scope(
+            Path::new("/fs/first/parent"),
+            &candidates,
+            Some("first"),
+            Some("token-a"),
+        ));
+    }
+
+    #[test]
+    fn resource_scope_requires_filesystem_and_owner() {
+        assert!(resource_matches_scope(
+            "first",
+            Some("token-a"),
+            Some("first"),
+            Some("token-a"),
+        ));
+        assert!(!resource_matches_scope(
+            "second",
+            Some("token-a"),
+            Some("first"),
+            Some("token-a"),
+        ));
+        assert!(!resource_matches_scope(
+            "first",
+            None,
+            Some("first"),
+            Some("token-a"),
+        ));
+        assert!(resource_matches_scope("first", None, Some("first"), None));
+    }
 }


### PR DESCRIPTION
## Summary
- authorize NFS and SMB source paths against the deepest managed subvolume after canonicalization
- require scoped block exports to resolve to an owned block subvolume before conflict checks
- apply the same source and destination guards to iSCSI LUN and NVMe-oF namespace additions
- reject nested foreign subvolumes, unmanaged scoped devices, empty scoped block targets, and scoped name collisions

## Regression
The security suite in nasty-project/nasty-tests#3 currently demonstrates that scoped operator tokens can export admin-owned resources through NFS, SMB, iSCSI, and NVMe-oF.

## Validation
- `cargo test -p nasty-engine`: 219 passed
- `cargo clippy -p nasty-engine --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Scope
This closes foreign source attachment for create/add operations. Existing share records do not persist an owner, so filtering and ownership enforcement for list/get/update/delete requires a separate share-state schema change.