### PR TITLE
csi: recover orphan snapshots and harden iSCSI creation

### DIFF
--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -525,9 +525,16 @@ impl IscsiService {
             }
         };
 
-        // Create target and TPG in configfs
+        // Create the IQN and TPG separately. Apart from allowing cleanup of a
+        // half-created target, this keeps configfs errors tied to the component
+        // that actually failed instead of create_dir_all reporting only the leaf.
+        let target_path = format!("{ISCSI_BASE}/{iqn}");
         let tpg_path = format!("{ISCSI_BASE}/{iqn}/tpgt_1");
-        configfs_mkdir(&tpg_path).await?;
+        configfs_mkdir_new(&target_path).await?;
+        if let Err(error) = configfs_mkdir(&tpg_path).await {
+            let _ = configfs_rmdir(&target_path).await;
+            return Err(error);
+        }
 
         // Create mandatory portals first — any failure aborts the
         // whole create, but we've only created the TPG dir so far,
@@ -535,11 +542,7 @@ impl IscsiService {
         let mut created_portals = Vec::with_capacity(mandatory_portals.len() + 1);
         for portal in &mandatory_portals {
             if let Err(e) = create_np(&tpg_path, portal).await {
-                // Best-effort cleanup of what we created so far so the
-                // next attempt doesn't trip the idempotency check with
-                // a stale half-target.
-                let _ = configfs_rmdir(&tpg_path).await;
-                let _ = configfs_rmdir(&format!("{ISCSI_BASE}/{iqn}")).await;
+                cleanup_unpersisted_target(&target_path, &tpg_path, &created_portals).await;
                 return Err(e);
             }
             created_portals.push(portal.clone());
@@ -566,17 +569,23 @@ impl IscsiService {
             }
         }
 
-        // Explicit ACL targets start deny-by-default and never enter demo mode.
-        configfs_write(&format!("{tpg_path}/attrib/authentication"), "0").await?;
-        configfs_write(
-            &format!("{tpg_path}/attrib/generate_node_acls"),
-            if has_explicit_acls { "0" } else { "1" },
-        )
-        .await?;
-        configfs_write(&format!("{tpg_path}/attrib/demo_mode_write_protect"), "0").await?;
-
-        // Enable the TPG
-        configfs_write(&format!("{tpg_path}/enable"), "1").await?;
+        let configure = async {
+            // Explicit ACL targets start deny-by-default and never enter demo mode.
+            configfs_write(&format!("{tpg_path}/attrib/authentication"), "0").await?;
+            configfs_write(
+                &format!("{tpg_path}/attrib/generate_node_acls"),
+                if has_explicit_acls { "0" } else { "1" },
+            )
+            .await?;
+            configfs_write(&format!("{tpg_path}/attrib/demo_mode_write_protect"), "0").await?;
+            configfs_write(&format!("{tpg_path}/enable"), "1").await?;
+            Ok::<(), IscsiError>(())
+        }
+        .await;
+        if let Err(error) = configure {
+            cleanup_unpersisted_target(&target_path, &tpg_path, &created_portals).await;
+            return Err(error);
+        }
 
         let target = IscsiTarget {
             id: Uuid::new_v4().to_string(),
@@ -591,7 +600,10 @@ impl IscsiService {
             enabled: true,
         };
 
-        state_dir().save(&target.id, &target).await?;
+        if let Err(error) = state_dir().save(&target.id, &target).await {
+            cleanup_unpersisted_target(&target_path, &tpg_path, &target.portals).await;
+            return Err(error.into());
+        }
         save_lio_config().await;
 
         // Optional: add LUN if device_path was provided
@@ -1296,8 +1308,23 @@ async fn create_np(tpg_path: &str, portal: &Portal) -> Result<(), IscsiError> {
     Ok(())
 }
 
+async fn cleanup_unpersisted_target(target_path: &str, tpg_path: &str, portals: &[Portal]) {
+    let _ = configfs_write(&format!("{tpg_path}/enable"), "0").await;
+    for portal in portals.iter().rev() {
+        let _ = configfs_rmdir(&np_path_for(tpg_path, &portal.ip, portal.port)).await;
+    }
+    let _ = configfs_rmdir(tpg_path).await;
+    let _ = configfs_rmdir(target_path).await;
+}
+
 async fn configfs_mkdir(path: &str) -> Result<(), IscsiError> {
     tokio::fs::create_dir_all(path)
+        .await
+        .map_err(|e| IscsiError::ConfigFs(format!("mkdir {path}: {e}")))
+}
+
+async fn configfs_mkdir_new(path: &str) -> Result<(), IscsiError> {
+    tokio::fs::create_dir(path)
         .await
         .map_err(|e| IscsiError::ConfigFs(format!("mkdir {path}: {e}")))
 }

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -221,19 +221,16 @@ fn authorize_snapshot_provenance(
     Ok(())
 }
 
-fn authorize_snapshot_delete(
-    orphaned: bool,
-    snapshot_exists: bool,
-    allow_orphan_cleanup: bool,
-    snapshot_name: &str,
+fn authorize_orphan_snapshot(
+    snapshot_owner: Option<&str>,
+    owner_filter: Option<&str>,
+    allow_admin_override: bool,
 ) -> Result<(), SubvolumeError> {
-    if orphaned && !allow_orphan_cleanup {
-        return Err(SubvolumeError::AccessDenied);
+    if allow_admin_override {
+        return Ok(());
     }
-    if !snapshot_exists {
-        return Err(SubvolumeError::NotFound(snapshot_name.to_string()));
-    }
-    Ok(())
+    let owner = owner_filter.ok_or(SubvolumeError::AccessDenied)?;
+    require_owner(snapshot_owner, Some(owner))
 }
 
 fn validate_volsize_bytes(bytes: u64) -> Result<(), SubvolumeError> {
@@ -2000,7 +1997,8 @@ impl SubvolumeService {
     }
 
     /// Delete a snapshot.
-    /// `owner_filter`: if Some, verifies the caller owns the parent subvolume.
+    /// `owner_filter`: if Some, verifies the caller owns the parent subvolume or
+    /// a retained orphan snapshot.
     pub async fn delete_snapshot(
         &self,
         req: DeleteSnapshotRequest,
@@ -2017,24 +2015,26 @@ impl SubvolumeService {
             Err(SubvolumeError::NotFound(_)) => None,
             Err(error) => return Err(error),
         };
-        let orphaned = parent.is_none();
-        if orphaned && !allow_orphan_cleanup {
+        if parent.is_none() && owner_filter.is_none() && !allow_orphan_cleanup {
             return Err(SubvolumeError::AccessDenied);
         }
 
         let mount_point = self.fs_mount_point(&req.filesystem).await?;
         let snap_path = snap_path(&mount_point, &req.subvolume, &req.name);
-        authorize_snapshot_delete(
-            orphaned,
-            Path::new(&snap_path).exists(),
-            allow_orphan_cleanup,
-            &req.name,
-        )?;
+        if !Path::new(&snap_path).exists() {
+            return Err(SubvolumeError::NotFound(req.name.clone()));
+        }
         let snapshot_meta = read_meta_xattrs(Path::new(&snap_path));
         if let Some(parent) = parent.as_ref() {
             authorize_snapshot_provenance(
                 snapshot_meta.owner.as_deref(),
                 parent.owner.as_deref(),
+                owner_filter,
+                allow_orphan_cleanup,
+            )?;
+        } else {
+            authorize_orphan_snapshot(
+                snapshot_meta.owner.as_deref(),
                 owner_filter,
                 allow_orphan_cleanup,
             )?;
@@ -2147,7 +2147,8 @@ impl SubvolumeService {
     }
 
     /// Clone a snapshot into a new writable subvolume.
-    /// `owner_filter`: if Some, verifies the caller owns the parent subvolume.
+    /// `owner_filter`: if Some, verifies the caller owns the parent subvolume or
+    /// a retained orphan snapshot.
     pub async fn clone_snapshot(
         &self,
         req: CloneSnapshotRequest,
@@ -2164,10 +2165,12 @@ impl SubvolumeService {
             .await
         {
             Ok(parent) => Some(parent),
-            Err(SubvolumeError::NotFound(_)) if allow_admin_override => None,
-            Err(SubvolumeError::NotFound(_)) => return Err(SubvolumeError::AccessDenied),
+            Err(SubvolumeError::NotFound(_)) => None,
             Err(error) => return Err(error),
         };
+        if parent.is_none() && owner_filter.is_none() && !allow_admin_override {
+            return Err(SubvolumeError::AccessDenied);
+        }
 
         let mount_point = self.fs_mount_point(&req.filesystem).await?;
         let snap_path = snap_path(&mount_point, &req.subvolume, &req.snapshot);
@@ -2184,6 +2187,12 @@ impl SubvolumeService {
             authorize_snapshot_provenance(
                 snapshot_meta.owner.as_deref(),
                 parent.owner.as_deref(),
+                owner_filter,
+                allow_admin_override,
+            )?;
+        } else {
+            authorize_orphan_snapshot(
+                snapshot_meta.owner.as_deref(),
                 owner_filter,
                 allow_admin_override,
             )?;
@@ -3419,21 +3428,22 @@ mod tests {
     }
 
     #[test]
-    fn orphan_snapshot_cleanup_requires_explicit_authority() {
-        assert!(authorize_snapshot_delete(false, true, false, "snap").is_ok());
+    fn orphan_snapshot_requires_matching_owner_or_admin() {
+        assert!(authorize_orphan_snapshot(Some("token-a"), Some("token-a"), false).is_ok());
         assert!(matches!(
-            authorize_snapshot_delete(true, true, false, "snap"),
-            Err(SubvolumeError::AccessDenied)
-        ));
-        assert!(authorize_snapshot_delete(true, true, true, "snap").is_ok());
-        assert!(matches!(
-            authorize_snapshot_delete(true, false, false, "snap"),
+            authorize_orphan_snapshot(Some("token-b"), Some("token-a"), false),
             Err(SubvolumeError::AccessDenied)
         ));
         assert!(matches!(
-            authorize_snapshot_delete(true, false, true, "snap"),
-            Err(SubvolumeError::NotFound(name)) if name == "snap"
+            authorize_orphan_snapshot(None, Some("token-a"), false),
+            Err(SubvolumeError::AccessDenied)
         ));
+        assert!(matches!(
+            authorize_orphan_snapshot(Some("token-a"), None, false),
+            Err(SubvolumeError::AccessDenied)
+        ));
+        assert!(authorize_orphan_snapshot(Some("token-b"), None, true).is_ok());
+        assert!(authorize_orphan_snapshot(None, None, true).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- authorize scoped callers to clone and delete retained orphan snapshots when the snapshot owner matches
- preserve admin recovery while denying foreign, ownerless, and recreated-parent ownership conflicts
- create iSCSI IQNs and TPGs transactionally with precise configfs errors and rollback before persistence

## Validation

- `cargo test -p nasty-storage -p nasty-sharing -p nasty-snapshot -p nasty-engine`
- `cargo clippy -p nasty-storage -p nasty-sharing -p nasty-snapshot -p nasty-engine --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- deployed commit `46d86a9` to test appliance `10.10.10.17`
- RBAC integration suite: 32/32 passed
- iSCSI lifecycle suite: 95/95 passed
- final cleanup audit: zero iSCSI targets and no tagged resources

## Context

Addresses the SMB detached-snapshot and iSCSI creation regressions observed in nasty-csi run 30336614150.