### PR TITLE
backup: add system recovery preset

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,11 +1,9 @@
 # Backup Restore
 
-Design for restoring rustic (restic-compatible) backups through the NASty
-WebUI. Requested in [discussion #626](https://github.com/orgs/nasty-project/discussions/626)
-(es5445): the backup system can run backups, check a repo, and list its
-snapshots, but has **no restore operation** — so disaster recovery (a dead
-box, a fresh install, appdata pulled back from S3) isn't possible without
-shelling out to Backrest.
+NASty runs and restores encrypted rustic (restic-compatible) backups through
+the WebUI. Restore was requested in
+[discussion #626](https://github.com/orgs/nasty-project/discussions/626)
+and restores a whole snapshot into a staging destination on managed storage.
 
 ## Scope
 
@@ -21,6 +19,34 @@ shelling out to Backrest.
 - Browsing and restoring individual files/folders within a snapshot.
 - In-place restore back to a snapshot's original paths (v1 always restores
   to an operator-chosen destination).
+
+## System recovery profile
+
+The Admin-only **NASty System Recovery** preset includes:
+
+- `/var/lib/nasty` — engine settings and service definitions;
+- `/etc/nixos` — the installed system wrapper and hardware configuration;
+- `/var/lib/caddy` — TLS certificates and the local CA identity;
+- `/var/lib/systemd/credential.secret` — the host key needed to decrypt
+  host-only `systemd-creds` values;
+- `/var/lib/sbctl` when Secure Boot signing keys exist.
+
+These sources contain appliance authentication state, filesystem recovery
+keys, TLS private keys, the host credential key, and potentially Secure Boot
+signing keys. Anyone with the repository password can recover this material.
+The password must be strong, unique, and stored separately. TPM-sealed
+credentials can still require the original TPM even when the host credential
+key is present.
+
+The preset deliberately excludes live Samba/AD databases. A file-level copy
+of live TDB/LDB state can be inconsistent; hosted domains must use the
+Directory panel's transaction-safe domain backup and include its `/fs`
+destination in a normal backup profile.
+
+System recovery snapshots restore under `/fs/<filesystem>/<destination>` like
+every other snapshot. They do not overwrite a running appliance in place;
+the restored tree is staged for an administrator or future recovery wizard to
+validate and import.
 
 ## Principle: operations stay on `/fs`
 

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -772,6 +772,39 @@ impl BackupError {
     }
 }
 
+fn validate_sources(sources: &[String]) -> Result<(), BackupError> {
+    if sources.is_empty() || sources.iter().any(|source| source.trim().is_empty()) {
+        return Err(BackupError::Failed("backup sources cannot be empty".into()));
+    }
+    Ok(())
+}
+
+fn backup_definition_matches(left: &BackupProfile, right: &BackupProfile) -> bool {
+    left.sources == right.sources
+        && serde_json::to_value((
+            &left.target,
+            &left.password,
+            &left.password_encrypted,
+            &left.trusted_cacert,
+        ))
+        .ok()
+            == serde_json::to_value((
+                &right.target,
+                &right.password,
+                &right.password_encrypted,
+                &right.trusted_cacert,
+            ))
+            .ok()
+}
+
+fn invalidate_last_run_if_definition_changed(update: &mut BackupProfile, existing: &BackupProfile) {
+    if !backup_definition_matches(update, existing) {
+        // A successful run only proves the old source/repository definition.
+        // Do not let UI coverage checks treat an edited profile as backed up.
+        update.last_run = None;
+    }
+}
+
 // ── Repository helpers ────────────────────────────────────────
 
 /// Build a Repository from a profile's target. The caller is expected
@@ -933,6 +966,7 @@ impl BackupService {
         &self,
         mut profile: BackupProfile,
     ) -> Result<BackupProfile, BackupError> {
+        validate_sources(&profile.sources)?;
         // Encrypt plaintext secrets before persisting. If the secrets
         // backend is unavailable on this host (no systemd-creds, broken
         // TPM enrollment, etc.) we keep the legacy plaintext field
@@ -969,11 +1003,14 @@ impl BackupService {
         id: &str,
         mut update: BackupProfile,
     ) -> Result<BackupProfile, BackupError> {
+        validate_sources(&update.sources)?;
         // Same encryption-on-save invariant as create. The operator
         // can submit a plaintext password (rotate) or omit it (keep
         // existing); we carry the existing encrypted value forward
         // when the update doesn't supply a new one.
-        carry_forward_existing_secrets(&mut update, &self.get_profile_internal(id).await?);
+        let existing = self.get_profile_internal(id).await?;
+        carry_forward_existing_secrets(&mut update, &existing);
+        invalidate_last_run_if_definition_changed(&mut update, &existing);
         if let Some(pem) = &update.trusted_cacert {
             validate_pem_cert(pem)?;
         }
@@ -1202,6 +1239,7 @@ impl BackupService {
 
     pub async fn run_backup(&self, id: &str) -> Result<BackupRunResult, BackupError> {
         let profile = self.get_profile_internal(id).await?;
+        validate_sources(&profile.sources)?;
 
         // Auto-init repo if not yet initialized
         if !profile.repo_initialized {
@@ -1218,6 +1256,7 @@ impl BackupService {
         let start = std::time::Instant::now();
         *self.running.lock().await = Some(id.to_string());
 
+        let run_profile = profile.clone();
         let sources = profile.sources.clone();
         let backup_result = tokio::task::spawn_blocking(move || {
             let repo = make_repo(&profile, &resolved)?;
@@ -1270,17 +1309,27 @@ impl BackupService {
             },
         };
 
-        {
+        let result_recorded = {
             let mut profiles = self.profiles.lock().await;
-            if let Some(p) = profiles.iter_mut().find(|p| p.id == id) {
+            let unchanged = profiles
+                .iter_mut()
+                .find(|profile| profile.id == id)
+                .filter(|profile| backup_definition_matches(profile, &run_profile));
+            if let Some(p) = unchanged {
                 p.last_run = Some(result.clone());
+                save_profiles(&profiles).await;
+                true
+            } else {
+                warn!(
+                    "Backup profile '{id}' changed while its job was running; not recording the stale result"
+                );
+                false
             }
-            save_profiles(&profiles).await;
-        }
+        };
 
         if result.success {
             info!("Backup completed in {}s", duration);
-            if let Err(e) = self.prune(id).await {
+            if result_recorded && let Err(e) = self.prune(run_profile).await {
                 warn!("Auto-prune failed: {e}");
             }
         } else {
@@ -1388,8 +1437,7 @@ impl BackupService {
         .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
     }
 
-    async fn prune(&self, id: &str) -> Result<(), BackupError> {
-        let profile = self.get_profile_internal(id).await?;
+    async fn prune(&self, profile: BackupProfile) -> Result<(), BackupError> {
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.resolve_runtime().await?;
         let r = profile.retention.clone();
@@ -1493,6 +1541,15 @@ async fn save_profiles(profiles: &[BackupProfile]) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn backup_sources_must_not_be_empty() {
+        assert!(validate_sources(&["/var/lib/nasty".into(), "/etc/nixos".into()]).is_ok());
+        assert!(validate_sources(&[]).is_err());
+        assert!(validate_sources(&["".into()]).is_err());
+        assert!(validate_sources(&["relative/path".into()]).is_ok());
+        assert!(validate_sources(&["/".into()]).is_ok());
+    }
+
     /// Construct an `EncryptedBlob` without going through systemd-creds.
     /// The blob isn't decryptable — that's fine for tests that just
     /// need to assert "an encrypted value is present" or that resolve
@@ -1519,6 +1576,38 @@ mod tests {
             last_run: None,
             trusted_cacert: None,
         }
+    }
+
+    #[test]
+    fn backup_definition_changes_invalidate_previous_success() {
+        let mut existing = baseline_profile(BackupTarget::Local {
+            path: "/backup".into(),
+        });
+        existing.last_run = Some(BackupRunResult {
+            timestamp: "2026-07-28T00:00:00Z".into(),
+            success: true,
+            message: "ok".into(),
+            duration_secs: 1,
+            bytes_added: Some(1),
+            files_new: Some(1),
+            files_changed: Some(0),
+        });
+
+        let mut unchanged = existing.clone();
+        invalidate_last_run_if_definition_changed(&mut unchanged, &existing);
+        assert!(unchanged.last_run.is_some());
+
+        let mut changed = existing.clone();
+        changed.sources.push("/etc/nixos".into());
+        invalidate_last_run_if_definition_changed(&mut changed, &existing);
+        assert!(changed.last_run.is_none());
+
+        let mut retargeted = existing.clone();
+        retargeted.target = BackupTarget::Local {
+            path: "/different-backup".into(),
+        };
+        invalidate_last_run_if_definition_changed(&mut retargeted, &existing);
+        assert!(retargeted.last_run.is_none());
     }
 
     fn s3_with_plaintext(secret: &str, region: Option<&str>) -> BackupTarget {

--- a/engine/nasty-engine/src/router/backup.rs
+++ b/engine/nasty-engine/src/router/backup.rs
@@ -11,6 +11,45 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn is_data_source(source: &str) -> bool {
+    let Ok(relative) = std::path::Path::new(source).strip_prefix("/fs") else {
+        return false;
+    };
+    let mut components = relative.components();
+    matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
+fn profile_requires_admin(profile: &nasty_backup::BackupProfile) -> bool {
+    profile.sources.iter().any(|source| !is_data_source(source))
+}
+
+fn profile_access_error(
+    session: &Session,
+    profile: &nasty_backup::BackupProfile,
+) -> Option<&'static str> {
+    if session.filesystem.is_some() || session.owner.is_some() {
+        return Some("backup management requires an unscoped session");
+    }
+    if profile_requires_admin(profile) && session.role != Role::Admin {
+        return Some("an admin session is required for system-state backup profiles");
+    }
+    None
+}
+
+async fn require_profile_access(
+    state: &AppState,
+    session: &Session,
+    id: &str,
+) -> Result<(), String> {
+    let profile = state
+        .backups
+        .get_profile(id)
+        .await
+        .map_err(|error| error.to_rpc_error())?;
+    profile_access_error(session, &profile).map_or(Ok(()), |message| Err(message.to_string()))
+}
+
 #[derive(Deserialize)]
 struct RestoreParams {
     id: String,
@@ -35,9 +74,12 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "backup.profile.create" => match parse_params::<nasty_backup::BackupProfile>(req) {
-            Ok(p) => match state.backups.create_profile(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e.to_rpc_error()),
+            Ok(p) => match profile_access_error(session, &p) {
+                Some(message) => err(req, message),
+                None => match state.backups.create_profile(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e.to_rpc_error()),
+                },
             },
             Err(e) => err(req, e),
         },
@@ -47,17 +89,26 @@ pub(super) async fn try_route(
                 Err(r) => return Some(r),
             };
             match parse_params::<nasty_backup::BackupProfile>(req) {
-                Ok(p) => match state.backups.update_profile(&id, p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e.to_rpc_error()),
+                Ok(p) => match require_profile_access(state, session, &id).await {
+                    Err(e) => err(req, e),
+                    Ok(()) => match profile_access_error(session, &p) {
+                        Some(message) => err(req, message),
+                        None => match state.backups.update_profile(&id, p).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e.to_rpc_error()),
+                        },
+                    },
                 },
                 Err(e) => err(req, e),
             }
         }
         "backup.profile.delete" => match require_str(req, "id") {
-            Ok(id) => match state.backups.delete_profile(id).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e.to_rpc_error()),
+            Ok(id) => match require_profile_access(state, session, id).await {
+                Ok(()) => match state.backups.delete_profile(id).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e.to_rpc_error()),
+                },
+                Err(e) => err(req, e),
             },
             Err(r) => r,
         },
@@ -69,16 +120,22 @@ pub(super) async fn try_route(
         // taking 32 s. Clients poll backup.jobs.get / backup.jobs.list
         // to watch the Pending → Running → Succeeded|Failed transition.
         "backup.repo.init" => match require_str(req, "id") {
-            Ok(id) => match state.backups.start_init_repo(id).await {
-                Ok(job) => ok(req, job),
-                Err(e) => err(req, e.to_string()),
+            Ok(id) => match require_profile_access(state, session, id).await {
+                Ok(()) => match state.backups.start_init_repo(id).await {
+                    Ok(job) => ok(req, job),
+                    Err(e) => err(req, e.to_string()),
+                },
+                Err(e) => err(req, e),
             },
             Err(r) => r,
         },
         "backup.run" => match require_str(req, "id") {
-            Ok(id) => match state.backups.start_run_backup(id).await {
-                Ok(job) => ok(req, job),
-                Err(e) => err(req, e.to_string()),
+            Ok(id) => match require_profile_access(state, session, id).await {
+                Ok(()) => match state.backups.start_run_backup(id).await {
+                    Ok(job) => ok(req, job),
+                    Err(e) => err(req, e.to_string()),
+                },
+                Err(e) => err(req, e),
             },
             Err(r) => r,
         },
@@ -90,20 +147,26 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "backup.restore" => match parse_params::<RestoreParams>(req) {
-            Ok(p) => match state
-                .backups
-                .start_restore(&p.id, &p.snapshot_id, &p.dest, p.allow_overwrite)
-                .await
-            {
-                Ok(job) => ok(req, job),
-                Err(e) => err(req, e.to_rpc_error()),
+            Ok(p) => match require_profile_access(state, session, &p.id).await {
+                Ok(()) => match state
+                    .backups
+                    .start_restore(&p.id, &p.snapshot_id, &p.dest, p.allow_overwrite)
+                    .await
+                {
+                    Ok(job) => ok(req, job),
+                    Err(e) => err(req, e.to_rpc_error()),
+                },
+                Err(e) => err(req, e),
             },
             Err(e) => err(req, e),
         },
         "backup.repo.check" => match require_str(req, "id") {
-            Ok(id) => match state.backups.start_check_repo(id).await {
-                Ok(job) => ok(req, job),
-                Err(e) => err(req, e.to_string()),
+            Ok(id) => match require_profile_access(state, session, id).await {
+                Ok(()) => match state.backups.start_check_repo(id).await {
+                    Ok(job) => ok(req, job),
+                    Err(e) => err(req, e.to_string()),
+                },
+                Err(e) => err(req, e),
             },
             Err(r) => r,
         },
@@ -127,4 +190,56 @@ pub(super) async fn try_route(
         "backup.secrets_status" => ok(req, state.backups.secrets_status().await),
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_data_source, profile_access_error};
+    use crate::auth::{Role, Session};
+
+    fn profile(sources: &[&str]) -> nasty_backup::BackupProfile {
+        serde_json::from_value(serde_json::json!({
+            "id": "profile",
+            "name": "Profile",
+            "enabled": true,
+            "sources": sources,
+            "target": { "type": "local", "path": "/fs/tank/backups" }
+        }))
+        .unwrap()
+    }
+
+    fn session(role: Role, scoped: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role,
+            file_principal: None,
+            filesystem: scoped.then(|| "tank".into()),
+            owner: None,
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn data_sources_are_absolute_children_of_fs() {
+        assert!(is_data_source("/fs/tank"));
+        assert!(is_data_source("/fs/tank/appdata"));
+        assert!(!is_data_source("/fs"));
+        assert!(!is_data_source("/fs/../etc"));
+        assert!(!is_data_source("/var/lib/nasty"));
+        assert!(!is_data_source("relative/path"));
+    }
+
+    #[test]
+    fn system_profiles_require_an_unscoped_admin() {
+        let data = profile(&["/fs/tank/appdata"]);
+        let system = profile(&["/var/lib/nasty", "/etc/nixos"]);
+
+        assert!(profile_access_error(&session(Role::Operator, false), &data).is_none());
+        assert!(profile_access_error(&session(Role::Operator, false), &system).is_some());
+        assert!(profile_access_error(&session(Role::Admin, false), &system).is_none());
+        assert!(profile_access_error(&session(Role::Admin, true), &system).is_some());
+    }
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -165,14 +165,12 @@ fn is_operator_allowed(method: &str) -> bool {
                 // fixing here because the guard test now enforces it.
                 | "apps.networks.create"
                 | "apps.networks.remove"
-                // Backup lifecycle is operator territory in a NAS
-                // appliance — same role that manages shares + apps
-                // typically manages where the data is copied. The
-                // read paths (`backup.profile.get`/`list`,
-                // `backup.status`, `backup.snapshots`) are already
-                // in `is_read_only`, so credentials in profiles are
-                // already visible to operators; admitting the write
-                // paths doesn't widen secrets exposure.
+                // Data backup lifecycle is operator territory in a NAS
+                // appliance — the same role manages shares and apps.
+                // `router::backup` adds a content-aware Admin gate when a
+                // profile reads system state outside `/fs`; otherwise an
+                // Operator could send arbitrary root-readable files to a
+                // repository they control.
                 | "backup.profile.create"
                 | "backup.profile.update"
                 | "backup.profile.delete"

--- a/webui/src/lib/recoveryBackup.ts
+++ b/webui/src/lib/recoveryBackup.ts
@@ -1,0 +1,15 @@
+export const CORE_RECOVERY_SOURCES = [
+	{ path: '/var/lib/nasty', label: 'NASty settings and service definitions' },
+	{ path: '/etc/nixos', label: 'installed system and hardware configuration' },
+	{ path: '/var/lib/caddy', label: 'TLS certificates and local CA identity' },
+	{ path: '/var/lib/systemd/credential.secret', label: 'host key for encrypted credentials' },
+] as const;
+
+export const CORE_RECOVERY_PATHS = CORE_RECOVERY_SOURCES.map(source => source.path);
+
+export const SECURE_BOOT_RECOVERY_SOURCE = {
+	path: '/var/lib/sbctl',
+	label: 'Secure Boot private signing keys',
+} as const;
+
+export const RECOVERY_BACKUP_CHANGED_EVENT = 'nasty:recovery-backup-changed';

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	import LauncherSidebarNav from '$lib/components/LauncherSidebarNav.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
-	import type { BootStatus, BootPhase, SystemStatus } from '$lib/types';
+	import type { BackupProfile, BootStatus, BootPhase, SecureBootReadinessReport, SystemStatus } from '$lib/types';
 	import favicon from '$lib/assets/favicon.svg';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
@@ -65,6 +65,7 @@
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
 	import { isManagementRole, isStandardUser, redirectForRole } from '$lib/access';
+	import { CORE_RECOVERY_PATHS, RECOVERY_BACKUP_CHANGED_EVENT, SECURE_BOOT_RECOVERY_SOURCE } from '$lib/recoveryBackup';
 
 	let { children } = $props();
 	let connected = $state(false);
@@ -249,16 +250,28 @@
 	}
 
 	// Config backup warning
-	const BACKUP_DISMISSED_KEY = 'nasty:config_backup_dismissed';
+	const BACKUP_DISMISSED_KEY = 'nasty:system_recovery_backup_dismissed:v1';
 	let configBackupMissing = $state(false);
 	let configBackupDismissed = $state(
 		typeof localStorage !== 'undefined' && localStorage.getItem(BACKUP_DISMISSED_KEY) === '1'
 	);
 	async function checkConfigBackup() {
-		if (!connected || !isManagementRole(authInfo?.role) || configBackupDismissed) return;
+		if (!connected || authInfo?.role !== 'admin' || configBackupDismissed) return;
 		try {
-			const profiles = await getClient().call<{ sources: string[] }[]>('backup.profile.list');
-			configBackupMissing = !profiles.some(p => p.sources.some(s => s.includes('/var/lib/nasty')));
+			const requiredSources: string[] = [...CORE_RECOVERY_PATHS];
+			try {
+				const readiness = await getClient().call<SecureBootReadinessReport>('system.secure_boot.readiness');
+				if (readiness.sbctl_keys_already_generated) {
+					requiredSources.push(SECURE_BOOT_RECOVERY_SOURCE.path);
+				}
+			} catch { /* Secure Boot is optional. */ }
+			const profiles = await getClient().call<BackupProfile[]>('backup.profile.list');
+			configBackupMissing = !profiles.some(profile =>
+				profile.enabled
+				&& profile.repo_initialized
+				&& profile.last_run?.success === true
+				&& requiredSources.every(source => profile.sources.includes(source))
+			);
 		} catch { /* ignore */ }
 	}
 	function dismissConfigBackup() {
@@ -486,6 +499,7 @@
 	onMount(() => {
 		if (isPublicShare) return;
 		tryConnect();
+		window.addEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
 		const rebootPoll = setInterval(checkRebootRequired, 30_000);
 		const statusPoll = setInterval(refreshSystemStatus, 20_000);
@@ -504,6 +518,7 @@
 			clearInterval(rebootPoll);
 			clearInterval(statusPoll);
 			clearInterval(authPoll);
+			window.removeEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
 		};
 	});
 
@@ -1330,8 +1345,8 @@
 				{/if}
 				{#if configBackupMissing}
 					<div class="mb-4 flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
-						<span class="flex-1">NASty configuration is not backed up.</span>
-						<Button size="sm" onclick={() => goto('/backups?create=config')}>Create Backup</Button>
+						<span class="flex-1">No successful system recovery backup covers NASty state, system configuration, TLS identity, and the host credential key.</span>
+						<Button size="sm" onclick={() => goto('/backups?create=config')}>Create Recovery Backup</Button>
 						<button onclick={dismissConfigBackup} class="text-xs text-amber-400/60 hover:text-amber-400 shrink-0">dismiss</button>
 					</div>
 				{/if}

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -6,19 +6,29 @@
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 	import { formatBytes } from '$lib/format';
-	import type { BackupProfile, BackupSnapshot, BackupStatus, BackupJob, SecretsStatus, Subvolume, Filesystem } from '$lib/types';
+	import type { BackupProfile, BackupSnapshot, BackupStatus, BackupJob, SecretsStatus, Subvolume, Filesystem, SecureBootReadinessReport } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Badge } from '$lib/components/ui/badge';
 	import PathPicker from '$lib/components/PathPicker.svelte';
+	import { CORE_RECOVERY_SOURCES, RECOVERY_BACKUP_CHANGED_EVENT, SECURE_BOOT_RECOVERY_SOURCE } from '$lib/recoveryBackup';
 	import { FolderOpen } from '@lucide/svelte';
 
 	const client = getClient();
 	let profiles: BackupProfile[] = $state([]);
 	let loading = $state(true);
 	let showCreate = $state(false);
+	let isAdmin = $state(false);
+	let canOperateBackups = $state(false);
+	let secureBootKeysAvailable = $state(false);
+	const recoverySources = $derived([
+		...CORE_RECOVERY_SOURCES,
+		...(secureBootKeysAvailable
+			? [SECURE_BOOT_RECOVERY_SOURCE]
+			: []),
+	]);
 	let backupStatus: BackupStatus | null = $state(null);
 	/** Loaded once on mount from backup.secrets_status — drives the
 	 * small status pill near the page header. `null` means the
@@ -111,6 +121,23 @@
 		} catch { /* ignore */ }
 	}
 
+	async function loadRecoveryContext() {
+		try {
+			const identity = await client.call<{ role: string; scoped: boolean }>('auth.me');
+			isAdmin = identity.role === 'admin' && !identity.scoped;
+			canOperateBackups = !identity.scoped && (identity.role === 'admin' || identity.role === 'operator');
+		} catch {
+			isAdmin = false;
+			canOperateBackups = false;
+			return;
+		}
+		if (!isAdmin) return;
+		try {
+			const readiness = await client.call<SecureBootReadinessReport>('system.secure_boot.readiness');
+			secureBootKeysAvailable = readiness.sbctl_keys_already_generated;
+		} catch { /* Secure Boot is optional. */ }
+	}
+
 	function toggleSource(path: string) {
 		const s = new Set(selectedSources);
 		if (s.has(path)) s.delete(path); else s.add(path);
@@ -118,7 +145,7 @@
 		// Preserve any typed-in or browse-added paths that aren't part
 		// of a checkbox row, so toggling a checkbox doesn't wipe them.
 		const knownPaths = new Set<string>([
-			'/var/lib/nasty',
+			...recoverySources.map(source => source.path),
 			...filesystems.filter(f => f.mounted).map(f => `/fs/${f.name}`),
 			...subvolumes.map(sv => `/fs/${sv.filesystem}/${sv.name}`),
 		]);
@@ -520,7 +547,7 @@
 	}
 
 	onMount(async () => {
-		await refresh();
+		await Promise.all([refresh(), loadRecoveryContext()]);
 		loading = false;
 		// Load filesystems (and subvolumes) up front rather than only when
 		// the create form is opened — the restore dialog's destination
@@ -552,12 +579,12 @@
 		} catch { /* engine didn't expose jobs.list; ignore */ }
 
 		// Auto-open create form with config preset from ?create=config
-		if ($page.url.searchParams.get('create') === 'config') {
+		if ($page.url.searchParams.get('create') === 'config' && isAdmin) {
 			showCreate = true;
-			newName = 'NASty Config';
-			newSources = '/var/lib/nasty';
+			newName = 'NASty System Recovery';
+			newSources = recoverySources.map(source => source.path).join(', ');
 			newSchedule = '0 3 * * *';
-			selectedSources = new Set(['/var/lib/nasty']);
+			selectedSources = new Set(recoverySources.map(source => source.path));
 		}
 	});
 
@@ -580,6 +607,7 @@
 	async function refresh() {
 		try {
 			profiles = await client.call<BackupProfile[]>('backup.profile.list');
+			window.dispatchEvent(new Event(RECOVERY_BACKUP_CHANGED_EVENT));
 			backupStatus = await client.call<BackupStatus>('backup.status');
 			// Fetch snapshot counts for initialized repos
 			for (const p of profiles.filter(p => p.repo_initialized)) {
@@ -720,6 +748,21 @@
 		if (t.type === 'b2') return `b2:${t.bucket}`;
 		return '?';
 	}
+
+	function profileHasSystemSources(profile: BackupProfile): boolean {
+		return profile.sources.some(source => {
+			const components = source.split('/').filter(component => component && component !== '.');
+			return !source.startsWith('/')
+				|| components.length < 2
+				|| components[0] !== 'fs'
+				|| components.slice(1).some(component => component === '.' || component === '..');
+		});
+	}
+
+	function hasRecoverySource(rawSources: string): boolean {
+		const sources = new Set(rawSources.split(',').map(source => source.trim()).filter(Boolean));
+		return recoverySources.some(source => sources.has(source.path));
+	}
 </script>
 
 <div class="space-y-4">
@@ -728,9 +771,11 @@
 	</div>
 
 	<div class="mb-4 flex items-center gap-3">
+		{#if canOperateBackups}
 		<Button size="sm" onclick={() => { showCreate = !showCreate; if (showCreate) loadSourceData(); }}>
 			{showCreate ? 'Cancel' : 'Create Backup'}
 		</Button>
+		{/if}
 		{#if secretsStatus}
 			{#if secretsStatus.status === 'available' && secretsStatus.backend === 'tpm-and-host'}
 				<Badge variant="default" class="text-[0.65rem]"
@@ -772,12 +817,17 @@
 				<div>
 					<Label>Sources {#if !newSources && createTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 					<div class="mt-1 space-y-1">
-						<!-- System config -->
-						<label class="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/30 {selectedSources.has('/var/lib/nasty') ? 'bg-muted/20' : ''}">
-							<input type="checkbox" checked={selectedSources.has('/var/lib/nasty')} onchange={() => toggleSource('/var/lib/nasty')} class="rounded border-input" />
-							<span class="font-mono text-xs">/var/lib/nasty</span>
-							<span class="text-xs text-muted-foreground">NASty configuration</span>
-						</label>
+						{#if isAdmin}
+							<!-- Recovery-sensitive host state is Admin-only. The backend
+							     enforces the same boundary for direct RPC callers. -->
+							{#each recoverySources as source}
+								<label class="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/30 {selectedSources.has(source.path) ? 'bg-muted/20' : ''}">
+									<input type="checkbox" checked={selectedSources.has(source.path)} onchange={() => toggleSource(source.path)} class="rounded border-input" />
+									<span class="font-mono text-xs">{source.path}</span>
+									<span class="text-xs text-muted-foreground">{source.label}</span>
+								</label>
+							{/each}
+						{/if}
 						<!-- Whole-filesystem sources. Useful when the user wants
 						     everything under a pool without picking subvolumes
 						     individually. -->
@@ -799,11 +849,16 @@
 						{/each}
 					</div>
 					<div class="mt-2 flex gap-2">
-						<Input bind:value={newSources} placeholder="Additional paths (comma-separated)" class="font-mono text-xs" />
+						<Input bind:value={newSources} placeholder={isAdmin ? 'Additional paths (comma-separated)' : 'Additional /fs paths (comma-separated)'} class="font-mono text-xs" />
 						<Button variant="outline" size="sm" onclick={() => { createPickerOpen = true; }} title="Browse for a folder under /fs">
 							<FolderOpen size={14} class="mr-1" /> Browse
 						</Button>
 					</div>
+					{#if hasRecoverySource(newSources)}
+						<div class="mt-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+							This recovery snapshot contains appliance authentication state, filesystem recovery keys, TLS private keys, the host credential key, and possibly Secure Boot signing keys. Anyone with the repository password can recover this material. Use a strong, separately stored password. TPM-sealed credentials can still require the original TPM. Samba/AD databases are not included because they require a transaction-safe domain backup.
+						</div>
+					{/if}
 				</div>
 
 				<div>
@@ -940,6 +995,7 @@
 	{:else}
 		<div class="space-y-3">
 			{#each profiles as profile}
+				{@const canManageProfile = canOperateBackups && (isAdmin || !profileHasSystemSources(profile))}
 				<Card>
 					<CardContent class="pt-4 pb-4">
 						<div class="flex items-start justify-between">
@@ -990,6 +1046,7 @@
 								{/if}
 							</div>
 							<div class="flex gap-2">
+								{#if canManageProfile}
 								{#if !profile.repo_initialized}
 									<Button size="xs" onclick={() => initRepo(profile.id)} disabled={activeJobs[profile.id] !== undefined}>
 										{activeJobs[profile.id] ? 'Init Repo…' : 'Init Repo'}
@@ -1006,6 +1063,9 @@
 								{/if}
 								<Button size="xs" variant="secondary" onclick={() => startEdit(profile)}>Edit</Button>
 								<Button size="xs" variant="destructive" onclick={() => deleteProfile(profile.id)}>Delete</Button>
+								{:else if profileHasSystemSources(profile)}
+									<Badge variant="secondary" class="text-[0.6rem]">Admin required</Badge>
+								{/if}
 							</div>
 						</div>
 						{#if editId === profile.id}


### PR DESCRIPTION
## Summary

- replace the single-path config preset with an Admin-only system recovery preset covering `/var/lib/nasty`, `/etc/nixos`, Caddy TLS state, the systemd host credential key, and Secure Boot keys when present
- require an unscoped Admin for system-state profiles while retaining Operator access to `/fs` data backups
- report recovery coverage only after the current source/repository definition succeeds, including concurrent-edit-safe result recording and pruning
- document key-material exposure, staged restore behavior, and the transaction-safe Samba/AD backup requirement

Context: https://github.com/orgs/nasty-project/discussions/710

## Security

Recovery repositories contain appliance authentication state, filesystem recovery keys, TLS private keys, the host credential key, and potentially Secure Boot signing keys. The UI warns administrators to use a strong, separately stored repository password. Live Samba/AD databases remain excluded because a file-level copy is not transaction-safe.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `npm run check`
- `npm test` (195 tests)
- `npm run build`
- final focused code review: no findings