### PR TITLE
Migrate legacy block exports safely

### DIFF
--- a/docs/version-upgrade-system.md
+++ b/docs/version-upgrade-system.md
@@ -234,6 +234,14 @@ Custom URLs are still allowed and visible, but they are not the primary UX targe
 - boot is not meant to be blocked by that absence
 - only `flake.nix` and `flake.lock` are restored
 
+## Legacy block-export migration
+
+Releases before v0.0.15 persisted managed iSCSI LUNs and NVMe-oF namespaces by their current `/dev/loopN` path. Loop numbers are not stable across reboots, so newer engines persist the filesystem UUID and bcachefs subvolume ID instead.
+
+During an in-place upgrade, the engine records the exact managed backing identity of loops that were already attached before it allocates any new loops. Legacy exports are migrated only when their saved path matches that boot-scoped evidence. The evidence survives engine-process restarts in `/run`, but is cleared by reboot. A loop path freshly assigned during cold boot is never accepted as migration evidence.
+
+If an identity cannot be proven safely, the protocol remains quiesced and the Sharing page marks the affected LUN or namespace as requiring repair. An unscoped Admin can reconnect only that entry to its original managed block subvolume. The target or subsystem name, portals, ACLs, CHAP credentials, allowed hosts, and other access settings are preserved. Cross-protocol conflicts are rejected, and a failed live activation rolls the identity change back.
+
 ## Practical summary
 
 In plain terms, the system now works like this:

--- a/engine/nasty-common/src/block_volume.rs
+++ b/engine/nasty-common/src/block_volume.rs
@@ -16,10 +16,54 @@ pub struct BlockVolumeId {
 pub struct BlockDeviceMappings {
     /// Stable identity to the loop device attached during this boot.
     pub current: HashMap<BlockVolumeId, String>,
+    /// Exact loop paths that were already attached to their managed backing
+    /// files before this engine start. These are safe evidence for upgrading
+    /// legacy export state; freshly allocated cold-boot paths are not.
+    pub preexisting: HashMap<String, BlockVolumeId>,
 }
 
 impl BlockDeviceMappings {
     pub fn is_empty(&self) -> bool {
         self.current.is_empty()
+    }
+
+    pub fn legacy_identity_for_exact_path(&self, path: &str) -> Option<&BlockVolumeId> {
+        self.preexisting.get(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_lookup_requires_an_exact_preexisting_path() {
+        let identity = BlockVolumeId {
+            filesystem_uuid: "pool".into(),
+            subvolume_id: 7,
+        };
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop1".into());
+
+        assert!(
+            mappings
+                .legacy_identity_for_exact_path("/dev/loop1")
+                .is_none()
+        );
+
+        mappings
+            .preexisting
+            .insert("/dev/loop1".into(), identity.clone());
+        assert_eq!(
+            mappings.legacy_identity_for_exact_path("/dev/loop1"),
+            Some(&identity)
+        );
+        assert!(
+            mappings
+                .legacy_identity_for_exact_path("/dev/loop10")
+                .is_none()
+        );
     }
 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -89,6 +89,7 @@ pub struct AppState {
     pub apps: nasty_apps::AppsService,
     pub app_firewall_sync: tokio::sync::Mutex<()>,
     pub portal_firewall_sync: tokio::sync::Mutex<()>,
+    pub block_share_mutation: Arc<tokio::sync::Mutex<()>>,
     pub backups: nasty_backup::BackupService,
     pub firmware: nasty_system::firmware::FirmwareService,
     /// Cached alerts result (timestamp, json value). Avoids re-evaluating
@@ -236,6 +237,7 @@ async fn main() -> anyhow::Result<()> {
         apps: nasty_apps::AppsService::new(),
         app_firewall_sync: tokio::sync::Mutex::new(()),
         portal_firewall_sync: tokio::sync::Mutex::new(()),
+        block_share_mutation: Arc::new(tokio::sync::Mutex::new(())),
         backups: nasty_backup::BackupService::new(),
         firmware: nasty_system::firmware::FirmwareService::new(),
         alerts_cache: tokio::sync::Mutex::new(None),

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -21,7 +21,8 @@ use nasty_apps::{
 use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
     AddAclRequest, AddLunRequest, AddPortalRequest, CreateTargetRequest, DeleteTargetRequest,
-    IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest, SetPortalsRequest,
+    IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest, RepairLunRequest,
+    SetPortalsRequest,
 };
 use nasty_sharing::nfs::{
     CreateNfsShareRequest, DeleteNfsShareRequest, NfsShare, UpdateNfsShareRequest,
@@ -29,7 +30,7 @@ use nasty_sharing::nfs::{
 use nasty_sharing::nvmeof::{
     AddHostRequest, AddNamespaceRequest, AddPortRequest, CreateSubsystemRequest,
     DeleteSubsystemRequest, NvmeofSubsystem, RemoveHostRequest, RemoveNamespaceRequest,
-    RemovePortRequest,
+    RemovePortRequest, RepairNamespaceRequest,
 };
 use nasty_sharing::smb::{
     CreateSmbShareRequest, CreateSmbUserRequest, DeleteSmbShareRequest, SmbGroup, SmbShare,
@@ -973,6 +974,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     result: Some(gen_schema::<IscsiTarget>(generator)),
                 },
                 Method {
+                    name: "share.iscsi.repair_lun",
+                    desc: "Reconnect an unresolved legacy LUN to a managed block subvolume without changing target, portal, or ACL settings.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<RepairLunRequest>(generator)),
+                    result: Some(gen_schema::<IscsiTarget>(generator)),
+                },
+                Method {
                     name: "share.iscsi.add_acl",
                     desc: "Allow an iSCSI initiator IQN to connect.",
                     role: MethodRole::Operator,
@@ -1052,6 +1060,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     desc: "Remove a namespace from a subsystem.",
                     role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<RemoveNamespaceRequest>(generator)),
+                    result: Some(gen_schema::<NvmeofSubsystem>(generator)),
+                },
+                Method {
+                    name: "share.nvmeof.repair_namespace",
+                    desc: "Reconnect an unresolved legacy namespace to a managed block subvolume without changing subsystem, port, or host settings.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<RepairNamespaceRequest>(generator)),
                     result: Some(gen_schema::<NvmeofSubsystem>(generator)),
                 },
                 Method {

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -76,10 +76,13 @@ pub(super) async fn try_route(
                     .mount_maybe_degraded(&p.name, p.degraded)
                     .await
                 {
-                    Ok(v) => {
-                        reconcile_block_shares(state).await;
-                        ok(req, v)
-                    }
+                    Ok(v) => match reconcile_block_shares(state).await {
+                        Ok(()) => ok(req, v),
+                        Err(error) => err(
+                            req,
+                            format!("filesystem mounted but block-share recovery failed: {error}"),
+                        ),
+                    },
                     Err(e) => err(req, e),
                 },
                 Err(e) => invalid(req, e),
@@ -97,10 +100,13 @@ pub(super) async fn try_route(
                 let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let passphrase = p.get("passphrase").and_then(|v| v.as_str()).unwrap_or("");
                 match state.filesystems.unlock(name, passphrase).await {
-                    Ok(fs) => {
-                        reconcile_block_shares(state).await;
-                        ok(req, fs)
-                    }
+                    Ok(fs) => match reconcile_block_shares(state).await {
+                        Ok(()) => ok(req, fs),
+                        Err(error) => err(
+                            req,
+                            format!("filesystem unlocked but block-share recovery failed: {error}"),
+                        ),
+                    },
                     Err(e) => err(req, e),
                 }
             }
@@ -369,7 +375,13 @@ pub(super) async fn try_route(
     })
 }
 
-async fn reconcile_block_shares(state: &AppState) {
+pub(crate) async fn reconcile_block_shares(state: &AppState) -> Result<(), String> {
+    let _guard = state.block_share_mutation.lock().await;
+    reconcile_block_shares_under_lock(state).await
+}
+
+pub(crate) async fn reconcile_block_shares_under_lock(state: &AppState) -> Result<(), String> {
+    let mut failures = Vec::new();
     let mappings = state.subvolumes.restore_block_devices().await;
     let nvmeof = state.nvmeof.remap_device_paths(&mappings).await;
     let iscsi = state.iscsi.remap_device_paths(&mappings).await;
@@ -380,6 +392,7 @@ async fn reconcile_block_shares(state: &AppState) {
             .await
         {
             tracing::error!("Failed to quiesce unsafe iSCSI state: {error}");
+            failures.push(format!("quiesce unsafe iSCSI state: {error}"));
         }
         let _ = state
             .firewall
@@ -412,6 +425,7 @@ async fn reconcile_block_shares(state: &AppState) {
         };
         if let Err(error) = result {
             tracing::warn!("Failed to reactivate iSCSI after mount: {error}");
+            failures.push(format!("reactivate iSCSI: {error}"));
             let _ = state
                 .firewall
                 .close(nasty_system::protocol::Protocol::Iscsi)
@@ -421,6 +435,7 @@ async fn reconcile_block_shares(state: &AppState) {
     if !nvmeof.safe_to_restore {
         if let Err(error) = state.nvmeof.quiesce().await {
             tracing::error!("Failed to quiesce unsafe NVMe-oF state: {error}");
+            failures.push(format!("quiesce unsafe NVMe-oF state: {error}"));
         }
         let _ = state
             .firewall
@@ -438,10 +453,13 @@ async fn reconcile_block_shares(state: &AppState) {
             .await
         {
             tracing::warn!("Failed to reopen NVMe-oF firewall after mount: {error}");
+            failures.push(format!("reopen NVMe-oF firewall: {error}"));
         } else if let Err(error) = state.protocols.enable("nvmeof").await {
             tracing::warn!("Failed to reactivate NVMe-oF after mount: {error}");
+            failures.push(format!("reactivate NVMe-oF: {error}"));
         } else if let Err(error) = state.nvmeof.restore().await {
             tracing::warn!("Failed to restore NVMe-oF after mount: {error}");
+            failures.push(format!("restore NVMe-oF: {error}"));
             if let Err(error) = state.nvmeof.quiesce().await {
                 tracing::error!("Failed to quiesce partial NVMe-oF restore: {error}");
             }
@@ -450,5 +468,10 @@ async fn reconcile_block_shares(state: &AppState) {
                 .close(nasty_system::protocol::Protocol::Nvmeof)
                 .await;
         }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
     }
 }

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -16,6 +16,21 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    let block_protocol_mutation = matches!(
+        req.method.as_str(),
+        "service.protocol.enable" | "service.protocol.disable"
+    ) && req.params.as_ref().is_some_and(|params| {
+        matches!(
+            params.get("name").and_then(serde_json::Value::as_str),
+            Some("iscsi" | "nvmeof")
+        )
+    });
+    let _block_share_guard = if block_protocol_mutation {
+        Some(state.block_share_mutation.lock().await)
+    } else {
+        None
+    };
+
     Some(match req.method.as_str() {
         "service.protocol.list" => ok(req, state.protocols.list().await),
         "service.protocol.enable" => match require_str(req, "name") {

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -272,7 +272,51 @@ fn session_is_scoped(session: &Session) -> bool {
     session.filesystem.is_some() || session.owner.is_some()
 }
 
+async fn quiesce_iscsi_after_failed_repair(state: &AppState) -> Option<String> {
+    let mut failures = Vec::new();
+    if let Err(error) = state
+        .protocols
+        .quiesce(nasty_system::protocol::Protocol::Iscsi)
+        .await
+    {
+        failures.push(error);
+    }
+    if let Err(error) = state
+        .firewall
+        .close(nasty_system::protocol::Protocol::Iscsi)
+        .await
+    {
+        failures.push(error);
+    }
+    (!failures.is_empty()).then(|| failures.join("; "))
+}
+
+async fn quiesce_nvmeof_after_failed_repair(state: &AppState) -> Option<String> {
+    let mut failures = Vec::new();
+    if let Err(error) = state.nvmeof.quiesce().await {
+        failures.push(error.to_string());
+    }
+    if let Err(error) = state
+        .firewall
+        .close(nasty_system::protocol::Protocol::Nvmeof)
+        .await
+    {
+        failures.push(error);
+    }
+    (!failures.is_empty()).then(|| failures.join("; "))
+}
+
 async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Option<Response> {
+    let is_block_share_mutation = (req.method.starts_with("share.iscsi.")
+        || req.method.starts_with("share.nvmeof."))
+        && !req.method.ends_with(".list")
+        && !req.method.ends_with(".get");
+    let _block_share_guard = if is_block_share_mutation {
+        Some(state.block_share_mutation.lock().await)
+    } else {
+        None
+    };
+
     Some(match req.method.as_str() {
         "share.nfs.list" => match state.nfs.list().await {
             Ok(v) => ok(req, v),
@@ -530,6 +574,71 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                 Err(e) => invalid(req, e),
             }
         }
+        "share.iscsi.repair_lun" => {
+            if session.role != Role::Admin || session_is_scoped(session) {
+                return Some(err(req, "unscoped Admin session required"));
+            }
+            match parse_params::<nasty_sharing::iscsi::RepairLunRequest>(req) {
+                Ok(p) => {
+                    if let Some(conflict) =
+                        check_block_device_conflict(state, &p.device_path, "iscsi").await
+                    {
+                        return Some(err(req, conflict));
+                    }
+                    match state
+                        .subvolumes
+                        .block_volume_id_for_device(&p.device_path)
+                        .await
+                    {
+                        Ok(Some(identity)) => match state.iscsi.repair_lun(p, identity).await {
+                            Ok((repaired, previous)) => {
+                                let activation = match state
+                                    .protocols
+                                    .quiesce(nasty_system::protocol::Protocol::Iscsi)
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        super::fs::reconcile_block_shares_under_lock(state).await
+                                    }
+                                    Err(error) => Err(format!(
+                                        "failed to stop the existing iSCSI export: {error}"
+                                    )),
+                                };
+                                match activation {
+                                    Ok(()) => ok(req, repaired.redacted()),
+                                    Err(activation_error) => {
+                                        let rollback_error =
+                                            state.iscsi.restore_target_state(&previous).await.err();
+                                        let cleanup_error =
+                                            quiesce_iscsi_after_failed_repair(state).await;
+                                        let mut message = format!(
+                                            "LUN repair could not be activated: {activation_error}"
+                                        );
+                                        if let Some(error) = rollback_error {
+                                            message.push_str(&format!(
+                                                "; persisted-state rollback failed: {error}"
+                                            ));
+                                        } else {
+                                            message.push_str("; persisted state was rolled back");
+                                        }
+                                        if let Some(error) = cleanup_error {
+                                            message.push_str(&format!(
+                                                "; safe export cleanup failed: {error}"
+                                            ));
+                                        }
+                                        err(req, message)
+                                    }
+                                }
+                            }
+                            Err(e) => err(req, e),
+                        },
+                        Ok(None) => err(req, "selected device is not a managed block subvolume"),
+                        Err(e) => err(req, e),
+                    }
+                }
+                Err(e) => invalid(req, e),
+            }
+        }
         "share.iscsi.add_acl" => {
             if let Some(r) =
                 require_protocol(state, req, nasty_system::protocol::Protocol::Iscsi).await
@@ -753,6 +862,74 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                     Ok(v) => ok(req, v),
                     Err(e) => err(req, e),
                 },
+                Err(e) => invalid(req, e),
+            }
+        }
+        "share.nvmeof.repair_namespace" => {
+            if session.role != Role::Admin || session_is_scoped(session) {
+                return Some(err(req, "unscoped Admin session required"));
+            }
+            match parse_params::<nasty_sharing::nvmeof::RepairNamespaceRequest>(req) {
+                Ok(p) => {
+                    if let Some(conflict) =
+                        check_block_device_conflict(state, &p.device_path, "nvmeof").await
+                    {
+                        return Some(err(req, conflict));
+                    }
+                    match state
+                        .subvolumes
+                        .block_volume_id_for_device(&p.device_path)
+                        .await
+                    {
+                        Ok(Some(identity)) => {
+                            match state.nvmeof.repair_namespace(p, identity).await {
+                                Ok((repaired, previous)) => {
+                                    let activation = match state.nvmeof.quiesce().await {
+                                        Ok(()) => {
+                                            super::fs::reconcile_block_shares_under_lock(state)
+                                                .await
+                                        }
+                                        Err(error) => Err(format!(
+                                            "failed to stop the existing NVMe-oF export: {error}"
+                                        )),
+                                    };
+                                    match activation {
+                                        Ok(()) => ok(req, repaired),
+                                        Err(activation_error) => {
+                                            let rollback_error = state
+                                                .nvmeof
+                                                .restore_subsystem_state(&previous)
+                                                .await
+                                                .err();
+                                            let cleanup_error =
+                                                quiesce_nvmeof_after_failed_repair(state).await;
+                                            let mut message = format!(
+                                                "namespace repair could not be activated: {activation_error}"
+                                            );
+                                            if let Some(error) = rollback_error {
+                                                message.push_str(&format!(
+                                                    "; persisted-state rollback failed: {error}"
+                                                ));
+                                            } else {
+                                                message
+                                                    .push_str("; persisted state was rolled back");
+                                            }
+                                            if let Some(error) = cleanup_error {
+                                                message.push_str(&format!(
+                                                    "; safe export cleanup failed: {error}"
+                                                ));
+                                            }
+                                            err(req, message)
+                                        }
+                                    }
+                                }
+                                Err(e) => err(req, e),
+                            }
+                        }
+                        Ok(None) => err(req, "selected device is not a managed block subvolume"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }

--- a/engine/nasty-engine/src/router/snapshot.rs
+++ b/engine/nasty-engine/src/router/snapshot.rs
@@ -20,6 +20,13 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    let _block_share_guard =
+        if matches!(req.method.as_str(), "snapshot.clone" | "snapshot.rollback") {
+            Some(state.block_share_mutation.lock().await)
+        } else {
+            None
+        };
+
     Some(match req.method.as_str() {
         "snapshot.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {

--- a/engine/nasty-engine/src/router/subvolume.rs
+++ b/engine/nasty-engine/src/router/subvolume.rs
@@ -16,6 +16,20 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    let mutates_block_attachment = matches!(
+        req.method.as_str(),
+        "subvolume.create"
+            | "subvolume.delete"
+            | "subvolume.attach"
+            | "subvolume.detach"
+            | "subvolume.clone"
+    );
+    let _block_share_guard = if mutates_block_attachment {
+        Some(state.block_share_mutation.lock().await)
+    } else {
+        None
+    };
+
     Some(match req.method.as_str() {
         "subvolume.list_all" => {
             let fs_filter = session.filesystem.as_deref();

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -640,8 +640,10 @@ pub(super) async fn try_route(
                     // port-sync isn't completely silent.
                     if let Some(ref ip) = v.ip {
                         let nvmeof = state.nvmeof.clone();
+                        let block_share_mutation = state.block_share_mutation.clone();
                         let ip = ip.clone();
                         let h = tokio::spawn(async move {
+                            let _guard = block_share_mutation.lock().await;
                             nvmeof.ensure_tailscale_ports(&ip).await;
                         });
                         tokio::spawn(async move {
@@ -663,7 +665,9 @@ pub(super) async fn try_route(
                 // Clean up NVMe-oF ports that were on the Tailscale IP
                 // (Tailscale IPs are in the 100.x.y.z range)
                 let nvmeof = state.nvmeof.clone();
+                let block_share_mutation = state.block_share_mutation.clone();
                 tokio::spawn(async move {
+                    let _guard = block_share_mutation.lock().await;
                     let subsystems = match nvmeof.list().await {
                         Ok(s) => s,
                         Err(e) => {

--- a/engine/nasty-engine/src/router/vm.rs
+++ b/engine/nasty-engine/src/router/vm.rs
@@ -16,6 +16,12 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    let _block_share_guard = if req.method == "vm.clone" {
+        Some(state.block_share_mutation.lock().await)
+    } else {
+        None
+    };
+
     Some(match req.method.as_str() {
         "vm.capabilities" => ok(req, state.vms.capabilities().await),
         "vm.list" => match state.vms.list().await {

--- a/engine/nasty-sharing/src/iscsi.rs
+++ b/engine/nasty-sharing/src/iscsi.rs
@@ -25,6 +25,8 @@ pub enum IscsiError {
     BackstoreNotFound(String),
     #[error("path is not within a NASty filesystem: {0}")]
     PathNotInPool(String),
+    #[error("LUN backing volume cannot be repaired: {0}")]
+    InvalidBackingVolume(String),
     #[error("configfs error: {0}")]
     ConfigFs(String),
     #[error("command failed: {0}")]
@@ -227,6 +229,16 @@ pub struct RemoveLunRequest {
     pub target_id: String,
     /// LUN ID to remove.
     pub lun_id: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RepairLunRequest {
+    /// ID of the target containing the unresolved LUN.
+    pub target_id: String,
+    /// LUN whose managed backing identity should be repaired.
+    pub lun_id: u32,
+    /// Currently attached managed block-subvolume device.
+    pub device_path: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -476,6 +488,26 @@ impl IscsiService {
             .await
             .map(|t| t.redacted())
             .ok_or_else(|| IscsiError::NotFound(id.to_string()))
+    }
+
+    pub async fn repair_lun(
+        &self,
+        req: RepairLunRequest,
+        identity: BlockVolumeId,
+    ) -> Result<(IscsiTarget, IscsiTarget), IscsiError> {
+        let mut target = state_dir()
+            .load::<IscsiTarget>(&req.target_id)
+            .await
+            .ok_or_else(|| IscsiError::NotFound(req.target_id.clone()))?;
+        let previous = target.clone();
+        repair_target_lun(&mut target, req.lun_id, req.device_path, identity)?;
+        state_dir().save(&target.id, &target).await?;
+        Ok((target, previous))
+    }
+
+    pub async fn restore_target_state(&self, target: &IscsiTarget) -> Result<(), IscsiError> {
+        state_dir().save(&target.id, target).await?;
+        Ok(())
     }
 
     pub async fn create(&self, req: CreateTargetRequest) -> Result<IscsiTarget, IscsiError> {
@@ -1207,6 +1239,33 @@ fn is_managed_lun(lun: &Lun) -> bool {
             || lun.backstore_path.starts_with("/dev/loop"))
 }
 
+fn repair_target_lun(
+    target: &mut IscsiTarget,
+    lun_id: u32,
+    device_path: String,
+    identity: BlockVolumeId,
+) -> Result<(), IscsiError> {
+    let lun = target
+        .luns
+        .iter_mut()
+        .find(|lun| lun.lun_id == lun_id)
+        .ok_or_else(|| IscsiError::NotFound(format!("LUN {lun_id}")))?;
+    if !lun.backing_volume_unresolved && lun.backing_volume.is_some() {
+        return Err(IscsiError::InvalidBackingVolume(format!(
+            "LUN {lun_id} is already resolved"
+        )));
+    }
+    if lun.backstore_type != "block" || !lun.backstore_path.starts_with("/dev/loop") {
+        return Err(IscsiError::InvalidBackingVolume(format!(
+            "LUN {lun_id} is not an unresolved managed block volume"
+        )));
+    }
+    lun.backstore_path = device_path;
+    lun.backing_volume = Some(identity);
+    lun.backing_volume_unresolved = false;
+    Ok(())
+}
+
 fn remap_target(
     target: &mut IscsiTarget,
     mappings: &BlockDeviceMappings,
@@ -1219,7 +1278,11 @@ fn remap_target(
         if !is_managed_lun(lun) {
             continue;
         }
-        let identity = lun.backing_volume.clone();
+        let identity = lun.backing_volume.clone().or_else(|| {
+            mappings
+                .legacy_identity_for_exact_path(&lun.backstore_path)
+                .cloned()
+        });
         let resolved = identity
             .as_ref()
             .and_then(|identity| mappings.current.get(identity))
@@ -1819,6 +1882,85 @@ mod tests {
         assert_eq!(target.luns[1].backstore_path, "/dev/loop4");
         assert_eq!(patches[0], ("backstore-0".into(), "/dev/loop9".into()));
         assert_eq!(patches[1], ("backstore-1".into(), "/dev/loop4".into()));
+    }
+
+    #[test]
+    fn migrates_legacy_lun_from_exact_preexisting_attachment() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        mappings
+            .preexisting
+            .insert("/dev/loop7".into(), identity.clone());
+        let mut target = target("custom-name", vec![lun(0, "/dev/loop7", None)]);
+        target.alias = Some("preserved alias".into());
+        target.portals = vec![Portal {
+            ip: "10.0.0.1".into(),
+            port: 3260,
+            iser: false,
+        }];
+
+        let (changed, safe, _) = remap_target(&mut target, &mappings);
+
+        assert!(changed);
+        assert!(safe);
+        assert_eq!(target.luns[0].backing_volume, Some(identity));
+        assert!(!target.luns[0].backing_volume_unresolved);
+        assert_eq!(target.alias.as_deref(), Some("preserved alias"));
+        assert_eq!(target.portals[0].ip, "10.0.0.1");
+    }
+
+    #[test]
+    fn freshly_allocated_loop_path_is_not_legacy_migration_evidence() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(identity, "/dev/loop0".into());
+        let mut target = target("volume", vec![lun(0, "/dev/loop0", None)]);
+
+        let (_, safe, patches) = remap_target(&mut target, &mappings);
+
+        assert!(!safe);
+        assert!(target.luns[0].backing_volume.is_none());
+        assert!(target.luns[0].backing_volume_unresolved);
+        assert_eq!(patches[0].1, UNRESOLVED_BACKSTORE);
+    }
+
+    #[test]
+    fn repair_changes_only_selected_unresolved_lun() {
+        let identity = volume("pool-a", 10);
+        let preserved = volume("pool-b", 20);
+        let mut unresolved = lun(0, "/dev/loop0", None);
+        unresolved.backing_volume_unresolved = true;
+        let mut target = target(
+            "repair",
+            vec![unresolved, lun(1, "/dev/loop4", Some(preserved.clone()))],
+        );
+        target.alias = Some("keep me".into());
+
+        repair_target_lun(&mut target, 0, "/dev/loop7".into(), identity.clone()).unwrap();
+
+        assert_eq!(target.luns[0].backstore_path, "/dev/loop7");
+        assert_eq!(target.luns[0].backing_volume, Some(identity));
+        assert!(!target.luns[0].backing_volume_unresolved);
+        assert_eq!(target.luns[1].backing_volume, Some(preserved));
+        assert_eq!(target.alias.as_deref(), Some("keep me"));
+    }
+
+    #[test]
+    fn repair_rejects_resolved_or_raw_luns() {
+        let identity = volume("pool-a", 10);
+        let mut resolved = target(
+            "resolved",
+            vec![lun(0, "/dev/loop0", Some(identity.clone()))],
+        );
+        assert!(
+            repair_target_lun(&mut resolved, 0, "/dev/loop1".into(), identity.clone()).is_err()
+        );
+
+        let mut raw = target("raw", vec![lun(0, "/dev/sda", None)]);
+        assert!(repair_target_lun(&mut raw, 0, "/dev/loop1".into(), identity).is_err());
     }
 
     #[test]

--- a/engine/nasty-sharing/src/nvmeof.rs
+++ b/engine/nasty-sharing/src/nvmeof.rs
@@ -19,6 +19,8 @@ pub enum NvmeofError {
     AlreadyExists(String),
     #[error("device not found: {0}")]
     DeviceNotFound(String),
+    #[error("namespace backing volume cannot be repaired: {0}")]
+    InvalidBackingVolume(String),
     #[error("namespace not found: nsid {0}")]
     NamespaceNotFound(u32),
     #[error("port not found: {0}")]
@@ -138,6 +140,16 @@ pub struct RemoveNamespaceRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct RepairNamespaceRequest {
+    /// ID of the subsystem containing the unresolved namespace.
+    pub subsystem_id: String,
+    /// Namespace whose managed backing identity should be repaired.
+    pub nsid: u32,
+    /// Currently attached managed block-subvolume device.
+    pub device_path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AddPortRequest {
     /// ID of the subsystem to add the port to.
     pub subsystem_id: String,
@@ -214,6 +226,29 @@ impl Default for NvmeofService {
 impl NvmeofService {
     pub fn new() -> Self {
         Self
+    }
+
+    pub async fn repair_namespace(
+        &self,
+        req: RepairNamespaceRequest,
+        identity: BlockVolumeId,
+    ) -> Result<(NvmeofSubsystem, NvmeofSubsystem), NvmeofError> {
+        let mut subsystem = state_dir()
+            .load::<NvmeofSubsystem>(&req.subsystem_id)
+            .await
+            .ok_or_else(|| NvmeofError::NotFound(req.subsystem_id.clone()))?;
+        let previous = subsystem.clone();
+        repair_subsystem_namespace(&mut subsystem, req.nsid, req.device_path, identity)?;
+        state_dir().save(&subsystem.id, &subsystem).await?;
+        Ok((subsystem, previous))
+    }
+
+    pub async fn restore_subsystem_state(
+        &self,
+        subsystem: &NvmeofSubsystem,
+    ) -> Result<(), NvmeofError> {
+        state_dir().save(&subsystem.id, subsystem).await?;
+        Ok(())
     }
 
     /// Restore NVMe-oF configfs state from persisted JSON files.
@@ -1234,6 +1269,33 @@ fn is_managed_namespace(namespace: &Namespace) -> bool {
         || namespace.device_path.starts_with("/dev/loop")
 }
 
+fn repair_subsystem_namespace(
+    subsystem: &mut NvmeofSubsystem,
+    nsid: u32,
+    device_path: String,
+    identity: BlockVolumeId,
+) -> Result<(), NvmeofError> {
+    let namespace = subsystem
+        .namespaces
+        .iter_mut()
+        .find(|namespace| namespace.nsid == nsid)
+        .ok_or(NvmeofError::NamespaceNotFound(nsid))?;
+    if !namespace.backing_volume_unresolved && namespace.backing_volume.is_some() {
+        return Err(NvmeofError::InvalidBackingVolume(format!(
+            "namespace {nsid} is already resolved"
+        )));
+    }
+    if !namespace.device_path.starts_with("/dev/loop") {
+        return Err(NvmeofError::InvalidBackingVolume(format!(
+            "namespace {nsid} is not an unresolved managed block volume"
+        )));
+    }
+    namespace.device_path = device_path;
+    namespace.backing_volume = Some(identity);
+    namespace.backing_volume_unresolved = false;
+    Ok(())
+}
+
 async fn restore_namespace(ns_path: &str, namespace: &Namespace) -> Result<(), NvmeofError> {
     configfs_write(&format!("{ns_path}/enable"), "0").await?;
     if !Path::new(&namespace.device_path).exists() {
@@ -1316,7 +1378,11 @@ fn remap_subsystem(
         if !is_managed_namespace(namespace) {
             continue;
         }
-        let identity = namespace.backing_volume.clone();
+        let identity = namespace.backing_volume.clone().or_else(|| {
+            mappings
+                .legacy_identity_for_exact_path(&namespace.device_path)
+                .cloned()
+        });
         let resolved = identity
             .as_ref()
             .and_then(|identity| mappings.current.get(identity))
@@ -1484,6 +1550,85 @@ mod tests {
         assert!(safe);
         assert_eq!(subsystem.namespaces[0].device_path, "/dev/loop9");
         assert_eq!(subsystem.namespaces[1].device_path, "/dev/loop4");
+    }
+
+    #[test]
+    fn migrates_legacy_namespace_from_exact_preexisting_attachment() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings
+            .current
+            .insert(identity.clone(), "/dev/loop7".into());
+        mappings
+            .preexisting
+            .insert("/dev/loop7".into(), identity.clone());
+        let mut subsystem = subsystem("custom-name", vec![namespace(1, "/dev/loop7", None)]);
+        subsystem.allowed_hosts = vec!["nqn.test:host".into()];
+        subsystem.allow_any_host = false;
+
+        let (changed, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(changed);
+        assert!(safe);
+        assert_eq!(subsystem.namespaces[0].backing_volume, Some(identity));
+        assert!(!subsystem.namespaces[0].backing_volume_unresolved);
+        assert_eq!(subsystem.allowed_hosts, ["nqn.test:host"]);
+        assert!(!subsystem.allow_any_host);
+    }
+
+    #[test]
+    fn freshly_allocated_loop_path_is_not_legacy_namespace_evidence() {
+        let identity = volume("pool-a", 10);
+        let mut mappings = BlockDeviceMappings::default();
+        mappings.current.insert(identity, "/dev/loop0".into());
+        let mut subsystem = subsystem("volume", vec![namespace(1, "/dev/loop0", None)]);
+
+        let (_, safe) = remap_subsystem(&mut subsystem, &mappings);
+
+        assert!(!safe);
+        assert!(subsystem.namespaces[0].backing_volume.is_none());
+        assert!(subsystem.namespaces[0].backing_volume_unresolved);
+    }
+
+    #[test]
+    fn repair_changes_only_selected_unresolved_namespace() {
+        let identity = volume("pool-a", 10);
+        let preserved = volume("pool-b", 20);
+        let mut unresolved = namespace(1, "/dev/loop0", None);
+        unresolved.backing_volume_unresolved = true;
+        let mut subsystem = subsystem(
+            "repair",
+            vec![
+                unresolved,
+                namespace(2, "/dev/loop4", Some(preserved.clone())),
+            ],
+        );
+        subsystem.allowed_hosts = vec!["nqn.test:host".into()];
+
+        repair_subsystem_namespace(&mut subsystem, 1, "/dev/loop7".into(), identity.clone())
+            .unwrap();
+
+        assert_eq!(subsystem.namespaces[0].device_path, "/dev/loop7");
+        assert_eq!(subsystem.namespaces[0].backing_volume, Some(identity));
+        assert!(!subsystem.namespaces[0].backing_volume_unresolved);
+        assert_eq!(subsystem.namespaces[1].backing_volume, Some(preserved));
+        assert_eq!(subsystem.allowed_hosts, ["nqn.test:host"]);
+    }
+
+    #[test]
+    fn repair_rejects_resolved_or_raw_namespaces() {
+        let identity = volume("pool-a", 10);
+        let mut resolved = subsystem(
+            "resolved",
+            vec![namespace(1, "/dev/loop0", Some(identity.clone()))],
+        );
+        assert!(
+            repair_subsystem_namespace(&mut resolved, 1, "/dev/loop1".into(), identity.clone())
+                .is_err()
+        );
+
+        let mut raw = subsystem("raw", vec![namespace(1, "/dev/sda", None)]);
+        assert!(repair_subsystem_namespace(&mut raw, 1, "/dev/loop1".into(), identity).is_err());
     }
 
     #[test]

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -15,6 +15,31 @@ use crate::cmd;
 use crate::filesystem::FilesystemService;
 
 const BLOCK_FILE_NAME: &str = "vol.img";
+const LEGACY_EXPORT_EVIDENCE: &str = "/run/nasty-block-export-legacy-evidence.json";
+
+async fn load_or_initialize_legacy_evidence(
+    path: &Path,
+    observed: &HashMap<String, BlockVolumeId>,
+) -> Result<HashMap<String, BlockVolumeId>, String> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(contents) => serde_json::from_str(&contents)
+            .map_err(|error| format!("parse {}: {error}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let temporary = path.with_extension(format!("{}.tmp", std::process::id()));
+            let contents = serde_json::to_vec(observed)
+                .map_err(|error| format!("serialize legacy export evidence: {error}"))?;
+            tokio::fs::write(&temporary, contents)
+                .await
+                .map_err(|error| format!("write {}: {error}", temporary.display()))?;
+            if let Err(error) = tokio::fs::rename(&temporary, path).await {
+                let _ = tokio::fs::remove_file(&temporary).await;
+                return Err(format!("publish {}: {error}", path.display()));
+            }
+            Ok(observed.clone())
+        }
+        Err(error) => Err(format!("read {}: {error}", path.display())),
+    }
+}
 
 fn subvol_path(mount_point: &str, name: &str) -> String {
     format!("{mount_point}/{name}")
@@ -824,6 +849,8 @@ pub struct FindByPropertyRequest {
 pub struct SubvolumeService {
     filesystems: FilesystemService,
     destination_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
+    restore_block_devices_lock: Mutex<()>,
+    legacy_export_evidence: Mutex<Option<HashMap<String, BlockVolumeId>>>,
 }
 
 impl SubvolumeService {
@@ -831,7 +858,24 @@ impl SubvolumeService {
         Self {
             filesystems,
             destination_locks: Mutex::new(HashMap::new()),
+            restore_block_devices_lock: Mutex::new(()),
+            legacy_export_evidence: Mutex::new(None),
         }
+    }
+
+    async fn legacy_export_evidence(
+        &self,
+        observed: &HashMap<String, BlockVolumeId>,
+    ) -> Result<HashMap<String, BlockVolumeId>, String> {
+        let mut cached = self.legacy_export_evidence.lock().await;
+        if let Some(evidence) = cached.as_ref() {
+            return Ok(evidence.clone());
+        }
+
+        let evidence =
+            load_or_initialize_legacy_evidence(Path::new(LEGACY_EXPORT_EVIDENCE), observed).await?;
+        *cached = Some(evidence.clone());
+        Ok(evidence)
     }
 
     async fn lock_destination(&self, filesystem: &str, name: &str) -> OwnedMutexGuard<()> {
@@ -868,6 +912,7 @@ impl SubvolumeService {
     /// Re-attach loop devices for block subvolumes after filesystems are mounted.
     /// Returns stable identities and current loop paths for sharing restoration.
     pub async fn restore_block_devices(&self) -> BlockDeviceMappings {
+        let _restore_guard = self.restore_block_devices_lock.lock().await;
         let all = match self.list_all(None, None).await {
             Ok(v) => v,
             Err(e) => {
@@ -882,6 +927,30 @@ impl SubvolumeService {
             .collect();
 
         let mut mappings = BlockDeviceMappings::default();
+
+        // Capture exact path-to-identity evidence before this engine allocates
+        // any loops. The /run manifest survives process restarts but not a
+        // reboot, preventing a fresh cold-boot assignment from becoming
+        // migration evidence on a later refresh.
+        let mut observed_existing = HashMap::new();
+        let mut existing_by_identity = HashMap::new();
+        for subvol in &block_subvols {
+            let Some(identity) = subvol.block_volume_id.as_ref() else {
+                continue;
+            };
+            let img_path = format!("{}/{}", subvol.path, BLOCK_FILE_NAME);
+            if let Some(device) = find_loop_device(&img_path).await {
+                observed_existing.insert(device.clone(), identity.clone());
+                existing_by_identity.insert(identity.clone(), device);
+            }
+        }
+        let evidence = match self.legacy_export_evidence(&observed_existing).await {
+            Ok(evidence) => evidence,
+            Err(error) => {
+                warn!("Cannot establish safe legacy block-export evidence: {error}");
+                return mappings;
+            }
+        };
 
         if block_subvols.is_empty() {
             info!("No block subvolumes to restore");
@@ -906,7 +975,7 @@ impl SubvolumeService {
             }
 
             // Use existing loop device if already attached (engine restart, not reboot)
-            let loop_dev = if let Some(existing) = find_loop_device(&img_path).await {
+            let loop_dev = if let Some(existing) = existing_by_identity.remove(&identity) {
                 info!(
                     "Loop device already attached for {}/{}",
                     subvol.filesystem, subvol.name
@@ -937,7 +1006,10 @@ impl SubvolumeService {
                 }
             };
 
-            mappings.current.insert(identity, loop_dev);
+            mappings.current.insert(identity.clone(), loop_dev.clone());
+            if evidence.get(&loop_dev) == Some(&identity) {
+                mappings.preexisting.insert(loop_dev, identity);
+            }
         }
 
         mappings
@@ -3156,6 +3228,46 @@ async fn materialize_subvol_from_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn legacy_evidence_survives_process_restart_without_accepting_new_loops() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nasty-legacy-export-evidence-{}-{unique}.json",
+            std::process::id()
+        ));
+        let original = BlockVolumeId {
+            filesystem_uuid: "pool-a".into(),
+            subvolume_id: 10,
+        };
+        let replacement = BlockVolumeId {
+            filesystem_uuid: "pool-b".into(),
+            subvolume_id: 20,
+        };
+        let first = HashMap::from([("/dev/loop0".into(), original.clone())]);
+        assert_eq!(
+            load_or_initialize_legacy_evidence(&path, &first)
+                .await
+                .unwrap(),
+            first
+        );
+
+        let after_restart = HashMap::from([
+            ("/dev/loop0".into(), replacement),
+            ("/dev/loop1".into(), original),
+        ]);
+        assert_eq!(
+            load_or_initialize_legacy_evidence(&path, &after_restart)
+                .await
+                .unwrap(),
+            first
+        );
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
 
     #[test]
     fn bcachefs_subvolume_id_is_preserved() {

--- a/webui/src/lib/sharing/iscsi.svelte.ts
+++ b/webui/src/lib/sharing/iscsi.svelte.ts
@@ -24,6 +24,9 @@ function initialIscsiState() {
 		addLunTarget: '',
 		addLunPath: '',
 		addLunType: '',
+		repairLunTarget: '',
+		repairLunId: 0,
+		repairLunDevice: '',
 		addAclTarget: '',
 		addAclIqn: '',
 		addAclUser: '',
@@ -116,6 +119,27 @@ export async function iscsiRemoveLun(targetId: string, lunId: number) {
 	if (!await confirm(`Remove LUN ${lunId}?`)) return;
 	await withToast(() => getClient().call('share.iscsi.remove_lun', { target_id: targetId, lun_id: lunId }), 'LUN removed');
 	await iscsiRefresh();
+}
+
+export async function iscsiRepairLun() {
+	if (!iscsi.repairLunTarget || !iscsi.repairLunDevice) return;
+	if (!await confirm(
+		'Reconnect this LUN?',
+		'Only select the original block subvolume. Choosing a different volume would expose its data through this target.',
+	)) return;
+	const repaired = await withToast(
+		() => getClient().call('share.iscsi.repair_lun', {
+			target_id: iscsi.repairLunTarget,
+			lun_id: iscsi.repairLunId,
+			device_path: iscsi.repairLunDevice,
+		}),
+		'LUN backing volume reconnected',
+	);
+	if (repaired !== undefined) {
+		iscsi.repairLunTarget = '';
+		iscsi.repairLunDevice = '';
+		await Promise.all([iscsiRefresh(), iscsiLoadProtocol()]);
+	}
 }
 
 export async function iscsiAddAcl() {

--- a/webui/src/lib/sharing/nvmeof.svelte.ts
+++ b/webui/src/lib/sharing/nvmeof.svelte.ts
@@ -24,6 +24,9 @@ function initialNvmeState() {
 		newPort: 4420,
 		addNsSubsys: '',
 		addNsDevice: '',
+		repairNsSubsys: '',
+		repairNsId: 0,
+		repairNsDevice: '',
 		addPortSubsys: '',
 		addPortTransport: 'tcp',
 		addPortAddr: '0.0.0.0',
@@ -118,6 +121,27 @@ export async function nvmeRemoveNamespace(subsystemId: string, nsid: number) {
 		'Namespace removed'
 	);
 	await nvmeRefresh();
+}
+
+export async function nvmeRepairNamespace() {
+	if (!nvme.repairNsSubsys || !nvme.repairNsDevice) return;
+	if (!await confirm(
+		'Reconnect this namespace?',
+		'Only select the original block subvolume. Choosing a different volume would expose its data through this subsystem.',
+	)) return;
+	const repaired = await withToast(
+		() => getClient().call('share.nvmeof.repair_namespace', {
+			subsystem_id: nvme.repairNsSubsys,
+			nsid: nvme.repairNsId,
+			device_path: nvme.repairNsDevice,
+		}),
+		'Namespace backing volume reconnected',
+	);
+	if (repaired !== undefined) {
+		nvme.repairNsSubsys = '';
+		nvme.repairNsDevice = '';
+		await Promise.all([nvmeRefresh(), nvmeLoadProtocol()]);
+	}
 }
 
 export async function nvmeAddPort() {

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -78,6 +78,7 @@
 	let shareNvmeofPort = $state('4420');
 
 	let shareSubvolumes: Subvolume[] = $state([]);
+	let isAdmin = $state(false);
 
 	// Inline subvolume creation within share wizard
 	let showInlineCreate = $state(false);
@@ -303,6 +304,9 @@
 	onMount(async () => {
 		client.onEvent(handleEvent);
 		await Promise.all([
+			client.call<{ role: string; scoped: boolean }>('auth.me').then(identity => {
+				isAdmin = identity.role === 'admin' && !identity.scoped;
+			}).catch(() => { isAdmin = false; }),
 			nfsRefresh().then(() => { nfs.loading = false; }),
 			smbRefresh().then(() => { smb.loading = false; }),
 			iscsiRefresh().then(() => { iscsi.loading = false; }),
@@ -551,12 +555,12 @@
 
 <!-- ════════════════════════════════════════════════════ iSCSI ════════════════════════════════════════════════════ -->
 {:else if activeTab === 'iscsi'}
-	<IscsiPanel />
+	<IscsiPanel {isAdmin} />
 
 
 <!-- ════════════════════════════════════════════════════ NVMe-oF ════════════════════════════════════════════════════ -->
 {:else if activeTab === 'nvmeof'}
-	<NvmeofPanel />
+	<NvmeofPanel {isAdmin} />
 
 
 <!-- ════════════════════════════════════════════════════ Guest Shares ════════════════════════════════════════════════════ -->

--- a/webui/src/routes/sharing/IscsiPanel.svelte
+++ b/webui/src/routes/sharing/IscsiPanel.svelte
@@ -17,6 +17,7 @@
 		iscsiRemove,
 		iscsiAddLun,
 		iscsiRemoveLun,
+		iscsiRepairLun,
 		iscsiAddAcl,
 		iscsiRemoveAcl,
 		iscsiAddPortal,
@@ -25,7 +26,9 @@
 		iscsiLoadSubvolumes,
 	} from '$lib/sharing/iscsi.svelte';
 
-	$effect(() => { if (iscsi.showCreate || iscsi.addLunTarget) iscsiLoadSubvolumes(); });
+	let { isAdmin = false }: { isAdmin?: boolean } = $props();
+
+	$effect(() => { if (iscsi.showCreate || iscsi.addLunTarget || iscsi.repairLunTarget) iscsiLoadSubvolumes(); });
 
 	// Per-form "tried" flags — defer amber required-field decoration
 	// until each submit button is clicked at least once.
@@ -43,6 +46,11 @@
 		if (!iscsi.addLunPath) { addLunTried = true; return; }
 		addLunTried = false;
 		await iscsiAddLun();
+	}
+	function startRepairLun(targetId: string, lunId: number) {
+		iscsi.repairLunTarget = targetId;
+		iscsi.repairLunId = lunId;
+		iscsi.repairLunDevice = '';
 	}
 	async function iscsiAddAclGuarded() {
 		if (!iscsi.addAclIqn) { addAclTried = true; return; }
@@ -150,6 +158,7 @@
 						{target.luns.length} LUN{target.luns.length !== 1 ? 's' : ''}
 						&middot; {target.portals.length} portal{target.portals.length !== 1 ? 's' : ''}
 						&middot; {target.acls.length === 0 ? 'open (any initiator)' : `${target.acls.length} ACL${target.acls.length !== 1 ? 's' : ''}`}
+						{#if target.luns.some(lun => lun.backing_volume_unresolved)}<Badge variant="secondary" class="ml-2 border-amber-500/50 text-amber-500">Repair required</Badge>{/if}
 					</td>
 					<td class="p-3" onclick={(e) => e.stopPropagation()}>
 						<div class="flex gap-2">
@@ -229,13 +238,31 @@
 									{:else}
 										<div class="space-y-1">
 											{#each target.luns as lun}
-												<div class="flex items-center gap-3 rounded bg-secondary/50 px-2 py-1.5">
+												<div class="rounded bg-secondary/50 px-2 py-1.5">
+													<div class="flex items-center gap-3">
 													<div class="text-sm">
 														<span class="font-mono text-xs font-semibold">LUN {lun.lun_id}</span>
 														<span class="ml-2 text-muted-foreground">{lun.backstore_path}</span>
 														<span class="ml-1 text-xs text-muted-foreground">({lun.backstore_type})</span>
 													</div>
+													{#if lun.backing_volume_unresolved}
+														<Badge variant="secondary" class="border-amber-500/50 text-amber-500">Backing unresolved</Badge>
+														{#if isAdmin}<Button variant="outline" size="xs" onclick={() => startRepairLun(target.id, lun.lun_id)}>Reconnect</Button>{/if}
+													{/if}
 													<Button variant="destructive" size="xs" onclick={() => iscsiRemoveLun(target.id, lun.lun_id)}>Remove</Button>
+													</div>
+													{#if lun.backing_volume_unresolved && !isAdmin}
+														<p class="mt-2 text-xs text-amber-500">An unscoped Admin must reconnect this LUN to its original block subvolume.</p>
+													{:else if iscsi.repairLunTarget === target.id && iscsi.repairLunId === lun.lun_id}
+														<div class="mt-2 flex items-center gap-2 border-t border-border pt-2">
+															<select bind:value={iscsi.repairLunDevice} class="h-8 min-w-72 rounded-md border border-input bg-background px-2 text-xs">
+																<option value="">Select the original block subvolume...</option>
+																{#each iscsi.blockSubvolumes as sv}<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>{/each}
+															</select>
+															<Button size="xs" disabled={!iscsi.repairLunDevice} onclick={iscsiRepairLun}>Reconnect</Button>
+															<Button size="xs" variant="ghost" onclick={() => { iscsi.repairLunTarget = ''; iscsi.repairLunDevice = ''; }}>Cancel</Button>
+														</div>
+													{/if}
 												</div>
 											{/each}
 										</div>

--- a/webui/src/routes/sharing/NvmeofPanel.svelte
+++ b/webui/src/routes/sharing/NvmeofPanel.svelte
@@ -17,6 +17,7 @@
 		nvmeRemove,
 		nvmeAddNamespace,
 		nvmeRemoveNamespace,
+		nvmeRepairNamespace,
 		nvmeAddPort,
 		nvmeRemovePort,
 		nvmeAddHost,
@@ -24,7 +25,9 @@
 		nvmeLoadSubvolumes,
 	} from '$lib/sharing/nvmeof.svelte';
 
-	$effect(() => { if (nvme.showCreate || nvme.addNsSubsys) nvmeLoadSubvolumes(); });
+	let { isAdmin = false }: { isAdmin?: boolean } = $props();
+
+	$effect(() => { if (nvme.showCreate || nvme.addNsSubsys || nvme.repairNsSubsys) nvmeLoadSubvolumes(); });
 
 	// Per-form "tried" flags — defer amber required-field decoration
 	// until each submit button is clicked at least once.
@@ -41,6 +44,11 @@
 		if (!nvme.addNsDevice) { addNsTried = true; return; }
 		addNsTried = false;
 		await nvmeAddNamespace();
+	}
+	function startRepairNamespace(subsystemId: string, nsid: number) {
+		nvme.repairNsSubsys = subsystemId;
+		nvme.repairNsId = nsid;
+		nvme.repairNsDevice = '';
 	}
 	async function nvmeAddHostGuarded() {
 		if (!nvme.addHostNqn) { addHostTried = true; return; }
@@ -143,6 +151,7 @@
 						{subsys.namespaces.length} namespace{subsys.namespaces.length !== 1 ? 's' : ''}
 						&middot; {subsys.ports.length} port{subsys.ports.length !== 1 ? 's' : ''}
 						&middot; {subsys.allow_any_host ? 'any host' : `${subsys.allowed_hosts.length} allowed host${subsys.allowed_hosts.length !== 1 ? 's' : ''}`}
+						{#if subsys.namespaces.some(ns => ns.backing_volume_unresolved)}<Badge variant="secondary" class="ml-2 border-amber-500/50 text-amber-500">Repair required</Badge>{/if}
 					</td>
 					<td class="p-3" onclick={(e) => e.stopPropagation()}>
 						<div class="flex gap-2">
@@ -165,13 +174,31 @@
 									{:else}
 										<div class="space-y-1">
 											{#each subsys.namespaces as ns}
-												<div class="flex items-center gap-3 rounded bg-secondary/50 px-2 py-1.5">
+												<div class="rounded bg-secondary/50 px-2 py-1.5">
+													<div class="flex items-center gap-3">
 													<div class="text-sm">
 														<span class="font-mono text-xs font-semibold">NSID {ns.nsid}</span>
 														<span class="ml-2 text-muted-foreground">{ns.device_path}</span>
 														<Badge variant={ns.enabled ? 'default' : 'secondary'} class="ml-2 text-[0.6rem]">{ns.enabled ? 'Active' : 'Off'}</Badge>
 													</div>
+													{#if ns.backing_volume_unresolved}
+														<Badge variant="secondary" class="border-amber-500/50 text-amber-500">Backing unresolved</Badge>
+														{#if isAdmin}<Button variant="outline" size="xs" onclick={() => startRepairNamespace(subsys.id, ns.nsid)}>Reconnect</Button>{/if}
+													{/if}
 													<Button variant="destructive" size="xs" onclick={() => nvmeRemoveNamespace(subsys.id, ns.nsid)}>Remove</Button>
+													</div>
+													{#if ns.backing_volume_unresolved && !isAdmin}
+														<p class="mt-2 text-xs text-amber-500">An unscoped Admin must reconnect this namespace to its original block subvolume.</p>
+													{:else if nvme.repairNsSubsys === subsys.id && nvme.repairNsId === ns.nsid}
+														<div class="mt-2 flex items-center gap-2 border-t border-border pt-2">
+															<select bind:value={nvme.repairNsDevice} class="h-8 min-w-72 rounded-md border border-input bg-background px-2 text-xs">
+																<option value="">Select the original block subvolume...</option>
+																{#each nvme.blockSubvolumes as sv}<option value={sv.block_device}>{sv.filesystem}/{sv.name} ({sv.block_device})</option>{/each}
+															</select>
+															<Button size="xs" disabled={!nvme.repairNsDevice} onclick={nvmeRepairNamespace}>Reconnect</Button>
+															<Button size="xs" variant="ghost" onclick={() => { nvme.repairNsSubsys = ''; nvme.repairNsDevice = ''; }}>Cancel</Button>
+														</div>
+													{/if}
 												</div>
 											{/each}
 										</div>


### PR DESCRIPTION
## Summary
- migrate legacy iSCSI LUNs and NVMe-oF namespaces from loop paths to immutable block-volume identities only when exact boot-scoped evidence exists
- fail closed on ambiguous mappings and add Admin repair actions for unresolved exports
- serialize block attachment and share mutations to prevent loop-device reassignment races
- document the upgrade and repair behavior

## Verification
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `npm test -- --run` (205 tests)
- `npm run check`
- `npm run build`
- `git diff --check`