### PR TITLE
Disclose telemetry payload accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [FAQ.md](FAQ.md) for common questions about bcachefs, NixOS, and project sta
 
 ## Telemetry
 
-NASty collects anonymous usage data (drive count and storage capacity). Disable anytime from **Settings → Telemetry**. Details: [nasty-telemetry](https://github.com/nasty-project/nasty-telemetry).
+NASty sends a random installation ID and daily aggregate usage data for mounted storage, configured VMs and apps, software version/build, and CPU architecture. The report does not include names, paths, file contents, hostnames, or hardware identifiers. Disable anytime from **Settings → Telemetry**. Details: [nasty-telemetry](https://github.com/nasty-project/nasty-telemetry).
 
 ## License
 

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -765,7 +765,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Start daily anonymous telemetry (if not opted out)
+    // Start daily pseudonymous usage telemetry (if not opted out)
     telemetry::spawn_daily(state.clone());
 
     // Background alert evaluation + notifications

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1985,7 +1985,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             "Telemetry",
             vec![Method {
                 name: "telemetry.send",
-                desc: "Trigger an immediate anonymous telemetry report (drive/VM/app counts, version, arch) to the NASty telemetry endpoint. No-op when telemetry is disabled in settings.",
+                desc: "Trigger an immediate usage telemetry report (random installation ID; mounted drive, capacity, and used-space totals; VM/app counts; version/build; architecture). No-op when telemetry is disabled in settings.",
                 role: MethodRole::Admin,
                 params: MethodParams::None,
                 result: Some(serde_json::json!({

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -296,7 +296,7 @@ pub struct Settings {
     /// TTL on the parent zone).
     #[serde(default)]
     pub tls_dns_propagation_wait: Option<u32>,
-    /// Whether anonymous telemetry is enabled (drive count, storage capacity).
+    /// Whether pseudonymous usage telemetry is enabled.
     #[serde(default = "default_telemetry_enabled")]
     pub telemetry_enabled: bool,
     /// OpenID Connect single-sign-on configuration. Disabled by default.
@@ -563,7 +563,7 @@ pub struct SettingsUpdate {
     pub tls_dns_resolver: Option<String>,
     /// Propagation wait in seconds. 0 clears (engine treats as default).
     pub tls_dns_propagation_wait: Option<u32>,
-    /// Enable/disable anonymous telemetry.
+    /// Enable/disable pseudonymous usage telemetry.
     pub telemetry_enabled: Option<bool>,
 }
 

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -979,12 +979,14 @@
 				</Button>
 			</section>
 
-			<!-- Telemetry -->
+			<!-- Usage telemetry -->
 			<section class="rounded-lg border border-border p-5">
-				<h2 class="mb-2 text-base font-semibold">Anonymous Telemetry</h2>
+				<h2 class="mb-2 text-base font-semibold">Usage Telemetry</h2>
 				<p class="mb-4 text-sm text-muted-foreground">
-					Help improve NASty by sharing anonymous usage data: number of drives and storage capacity.
-					No personal information is collected.
+					Help improve NASty by sending a random installation ID and daily totals for mounted storage,
+					configured VMs and apps, software version, build, and CPU architecture. The report does not
+					include names, paths, file contents, hostnames, or hardware identifiers.
+					<a href="https://github.com/nasty-project/nasty-telemetry#what-is-collected" target="_blank" rel="noreferrer" class="text-blue-400 hover:underline">See exactly what is collected.</a>
 				</p>
 
 				<div class="mb-4">


### PR DESCRIPTION
## Summary
- replace anonymous wording with accurate usage/pseudonymous terminology
- list the existing installation ID, storage, workload, build, and architecture fields
- scope exclusions to the report payload and link to the now-updated telemetry documentation
- align internal comments and generated API method text

## Verification
- `npm run check --prefix webui`
- `npm test --prefix webui` (205 tests)
- `npm run build --prefix webui`
- `cargo fmt --manifest-path engine/Cargo.toml --all --check`
- `git diff --check`