### PR TITLE
telemetry: report sharing configuration counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [FAQ.md](FAQ.md) for common questions about bcachefs, NixOS, and project sta
 
 ## Telemetry
 
-NASty sends a random installation ID and daily aggregate usage data for mounted storage, configured VMs and apps, software version/build, and CPU architecture. The report does not include names, paths, file contents, hostnames, or hardware identifiers. Disable anytime from **Settings → Telemetry**. Details: [nasty-telemetry](https://github.com/nasty-project/nasty-telemetry).
+NASty sends a random installation ID and daily aggregate usage data for mounted storage, configured VMs, apps, and sharing exports, software version/build, and CPU architecture. The report does not include names, paths, file contents, hostnames, or hardware identifiers. Disable anytime from **Settings → Telemetry**. Details: [nasty-telemetry](https://github.com/nasty-project/nasty-telemetry).
 
 ## License
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1985,7 +1985,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             "Telemetry",
             vec![Method {
                 name: "telemetry.send",
-                desc: "Trigger an immediate usage telemetry report (random installation ID; mounted drive, capacity, and used-space totals; VM/app counts; version/build; architecture). No-op when telemetry is disabled in settings.",
+                desc: "Trigger an immediate usage telemetry report (random installation ID; mounted drive, capacity, and used-space totals; VM/app and configured sharing export counts; version/build; architecture). No-op when telemetry is disabled in settings.",
                 role: MethodRole::Admin,
                 params: MethodParams::None,
                 result: Some(serde_json::json!({

--- a/engine/nasty-engine/src/telemetry.rs
+++ b/engine/nasty-engine/src/telemetry.rs
@@ -23,6 +23,14 @@ struct Report {
     commit: Option<String>,
     vms: usize,
     apps: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    smb_shares: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nfs_exports: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iscsi_luns: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nvmeof_namespaces: Option<usize>,
     arch: &'static str,
 }
 
@@ -87,6 +95,33 @@ async fn collect_report(state: &AppState) -> Option<Report> {
 
     let vms = state.vms.list().await.map(|v| v.len()).unwrap_or(0);
     let apps = state.apps.list().await.map(|a| a.len()).unwrap_or(0);
+    let (smb, nfs, iscsi, nvmeof) = tokio::join!(
+        state.smb.list_strict(),
+        state.nfs.list_strict(),
+        state.iscsi.list(),
+        state.nvmeof.list(),
+    );
+    let smb_shares = smb
+        .inspect_err(|e| debug!("Failed to count SMB shares for telemetry: {e}"))
+        .ok()
+        .map(|shares| shares.len());
+    let nfs_exports = nfs
+        .inspect_err(|e| debug!("Failed to count NFS exports for telemetry: {e}"))
+        .ok()
+        .map(|exports| exports.len());
+    let iscsi_luns = iscsi
+        .inspect_err(|e| debug!("Failed to count iSCSI LUNs for telemetry: {e}"))
+        .ok()
+        .map(|targets| targets.iter().map(|target| target.luns.len()).sum());
+    let nvmeof_namespaces = nvmeof
+        .inspect_err(|e| debug!("Failed to count NVMe-oF namespaces for telemetry: {e}"))
+        .ok()
+        .map(|subsystems| {
+            subsystems
+                .iter()
+                .map(|subsystem| subsystem.namespaces.len())
+                .sum()
+        });
 
     Some(Report {
         instance_id: id,
@@ -97,6 +132,10 @@ async fn collect_report(state: &AppState) -> Option<Report> {
         commit: build_commit(),
         vms,
         apps,
+        smb_shares,
+        nfs_exports,
+        iscsi_luns,
+        nvmeof_namespaces,
         arch: std::env::consts::ARCH,
     })
 }
@@ -114,12 +153,16 @@ pub async fn send_report(state: &AppState) -> bool {
     };
 
     debug!(
-        "Sending telemetry: drives={}, total={}B, used={}B, vms={}, apps={}, arch={}, version={}, commit={:?}",
+        "Sending telemetry: drives={}, total={}B, used={}B, vms={}, apps={}, smb={:?}, nfs={:?}, iscsi={:?}, nvmeof={:?}, arch={}, version={}, commit={:?}",
         report.drives,
         report.total_bytes,
         report.used_bytes,
         report.vms,
         report.apps,
+        report.smb_shares,
+        report.nfs_exports,
+        report.iscsi_luns,
+        report.nvmeof_namespaces,
         report.arch,
         report.version,
         report.commit
@@ -145,6 +188,62 @@ pub async fn send_report(state: &AppState) -> bool {
             debug!("Telemetry report failed: {e}");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_serializes_protocol_export_counts() {
+        let value = serde_json::to_value(Report {
+            instance_id: "instance".to_string(),
+            drives: 2,
+            total_bytes: 100,
+            used_bytes: 50,
+            version: "1.2.3",
+            commit: None,
+            vms: 1,
+            apps: 2,
+            smb_shares: Some(3),
+            nfs_exports: Some(4),
+            iscsi_luns: Some(5),
+            nvmeof_namespaces: Some(6),
+            arch: "x86_64",
+        })
+        .unwrap();
+
+        assert_eq!(value["smb_shares"], 3);
+        assert_eq!(value["nfs_exports"], 4);
+        assert_eq!(value["iscsi_luns"], 5);
+        assert_eq!(value["nvmeof_namespaces"], 6);
+        assert!(value.get("commit").is_none());
+    }
+
+    #[test]
+    fn report_omits_unobserved_protocol_counts() {
+        let value = serde_json::to_value(Report {
+            instance_id: "instance".to_string(),
+            drives: 2,
+            total_bytes: 100,
+            used_bytes: 50,
+            version: "1.2.3",
+            commit: None,
+            vms: 1,
+            apps: 2,
+            smb_shares: None,
+            nfs_exports: None,
+            iscsi_luns: None,
+            nvmeof_namespaces: None,
+            arch: "x86_64",
+        })
+        .unwrap();
+
+        assert!(value.get("smb_shares").is_none());
+        assert!(value.get("nfs_exports").is_none());
+        assert!(value.get("iscsi_luns").is_none());
+        assert!(value.get("nvmeof_namespaces").is_none());
     }
 }
 

--- a/engine/nasty-engine/src/telemetry.rs
+++ b/engine/nasty-engine/src/telemetry.rs
@@ -191,6 +191,31 @@ pub async fn send_report(state: &AppState) -> bool {
     }
 }
 
+/// Spawn the daily telemetry background task.
+pub fn spawn_daily(state: Arc<AppState>) {
+    let h = tokio::spawn(async move {
+        // Random initial delay (0-24h) to spread load across instances
+        let jitter = rand::rng().random_range(0..TELEMETRY_INTERVAL.as_secs());
+        debug!("Telemetry: first report in {}s", jitter);
+        tokio::time::sleep(Duration::from_secs(jitter)).await;
+
+        let mut ticker = interval(TELEMETRY_INTERVAL);
+        loop {
+            ticker.tick().await;
+            send_report(&state).await;
+        }
+    });
+    // Observer spawn — telemetry loop is supposed to run forever; if
+    // it exits (cleanly or by panic) we want a single log line so the
+    // user can see why telemetry stopped reporting.
+    tokio::spawn(async move {
+        match h.await {
+            Ok(()) => tracing::warn!("telemetry loop exited unexpectedly"),
+            Err(e) => tracing::warn!("telemetry loop panicked / cancelled: {e}"),
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,29 +270,4 @@ mod tests {
         assert!(value.get("iscsi_luns").is_none());
         assert!(value.get("nvmeof_namespaces").is_none());
     }
-}
-
-/// Spawn the daily telemetry background task.
-pub fn spawn_daily(state: Arc<AppState>) {
-    let h = tokio::spawn(async move {
-        // Random initial delay (0-24h) to spread load across instances
-        let jitter = rand::rng().random_range(0..TELEMETRY_INTERVAL.as_secs());
-        debug!("Telemetry: first report in {}s", jitter);
-        tokio::time::sleep(Duration::from_secs(jitter)).await;
-
-        let mut ticker = interval(TELEMETRY_INTERVAL);
-        loop {
-            ticker.tick().await;
-            send_report(&state).await;
-        }
-    });
-    // Observer spawn — telemetry loop is supposed to run forever; if
-    // it exits (cleanly or by panic) we want a single log line so the
-    // user can see why telemetry stopped reporting.
-    tokio::spawn(async move {
-        match h.await {
-            Ok(()) => tracing::warn!("telemetry loop exited unexpectedly"),
-            Err(e) => tracing::warn!("telemetry loop panicked / cancelled: {e}"),
-        }
-    });
 }

--- a/engine/nasty-sharing/src/nfs.rs
+++ b/engine/nasty-sharing/src/nfs.rs
@@ -160,6 +160,11 @@ impl NfsService {
         Ok(state_dir().load_all().await)
     }
 
+    /// List all exports, failing instead of silently omitting unreadable state.
+    pub async fn list_strict(&self) -> Result<Vec<NfsShare>, NfsError> {
+        Ok(state_dir().load_all_strict().await?)
+    }
+
     /// Get a single share by ID
     pub async fn get(&self, id: &str) -> Result<NfsShare, NfsError> {
         state_dir()

--- a/engine/nasty-sharing/src/smb.rs
+++ b/engine/nasty-sharing/src/smb.rs
@@ -181,6 +181,11 @@ impl SmbService {
         Ok(state_dir().load_all().await)
     }
 
+    /// List all shares, failing instead of silently omitting unreadable state.
+    pub async fn list_strict(&self) -> Result<Vec<SmbShare>, SmbError> {
+        Ok(state_dir().load_all_strict().await?)
+    }
+
     pub async fn get(&self, id: &str) -> Result<SmbShare, SmbError> {
         state_dir()
             .load::<SmbShare>(id)

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -984,7 +984,7 @@
 				<h2 class="mb-2 text-base font-semibold">Usage Telemetry</h2>
 				<p class="mb-4 text-sm text-muted-foreground">
 					Help improve NASty by sending a random installation ID and daily totals for mounted storage,
-					configured VMs and apps, software version, build, and CPU architecture. The report does not
+					configured VMs, apps, and sharing exports, software version, build, and CPU architecture. The report does not
 					include names, paths, file contents, hostnames, or hardware identifiers.
 					<a href="https://github.com/nasty-project/nasty-telemetry#what-is-collected" target="_blank" rel="noreferrer" class="text-blue-400 hover:underline">See exactly what is collected.</a>
 				</p>


### PR DESCRIPTION
## Summary
- report configured SMB shares, NFS exports, iSCSI LUNs, and NVMe-oF namespaces
- omit protocol fields when configuration state cannot be read reliably
- update telemetry disclosures in the README, RPC registry, and settings UI

## Verification
- cargo fmt --manifest-path engine/Cargo.toml --all --check
- cargo test --manifest-path engine/Cargo.toml -p nasty-engine telemetry::tests
- full engine/sharing test suite
- WebUI checks, tests, and build
- git diff --check

Receiver support is already deployed via nasty-project/nasty-telemetry#10.