### PR TITLE
Fix mounted filesystem browsing in guest links and portal

### DIFF
--- a/engine/nasty-engine/src/file_boundary.rs
+++ b/engine/nasty-engine/src/file_boundary.rs
@@ -185,7 +185,10 @@ fn classify_node(fd: OwnedFd, expected_device: Option<u64>) -> io::Result<Bounda
         return readable_regular_file(fd, expected_device).map(BoundaryNode::File);
     }
     if metadata.is_dir() {
-        let fd = readable_directory(fd, &metadata)?;
+        // Keep the O_PATH descriptor returned by openat2. It is already a
+        // stable directory handle and is valid as a dirfd for the guarded
+        // openat/openat2 calls below; reopening it through /proc/self/fd adds
+        // a filesystem-specific failure point without strengthening the jail.
         return Ok(BoundaryNode::Directory(BoundaryDirectory {
             fd: Arc::new(fd),
             device: metadata.dev(),
@@ -221,28 +224,6 @@ fn readable_regular_file(fd: OwnedFd, expected_device: Option<u64>) -> io::Resul
     #[cfg(not(target_os = "linux"))]
     {
         Ok(File::from(fd))
-    }
-}
-
-fn readable_directory(fd: OwnedFd, metadata: &std::fs::Metadata) -> io::Result<OwnedFd> {
-    #[cfg(target_os = "linux")]
-    {
-        let path = format!("/proc/self/fd/{}", fd.as_raw_fd());
-        let file = OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY)
-            .open(path)?;
-        let reopened = file.metadata()?;
-        if reopened.dev() != metadata.dev() || reopened.ino() != metadata.ino() {
-            return Err(invalid_path("reopened directory identity changed"));
-        }
-        Ok(file.into())
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = metadata;
-        Ok(fd)
     }
 }
 

--- a/engine/nasty-engine/src/file_boundary.rs
+++ b/engine/nasty-engine/src/file_boundary.rs
@@ -317,15 +317,23 @@ fn open_relative(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<O
         )
     };
     if fd < 0 {
-        return Err(io::Error::last_os_error());
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ENOSYS) {
+            return open_relative_components(base, relative, no_xdev);
+        }
+        return Err(error);
     }
     Ok(unsafe { OwnedFd::from_raw_fd(fd as libc::c_int) })
 }
 
-/// macOS development/tests use component-at-a-time `openat`. The appliance
-/// uses the Linux implementation above; unsupported Linux kernels fail closed.
+/// macOS uses component-at-a-time `openat`. Linux uses the same guarded walk
+/// only when `openat2` is unavailable (including seccomp returning ENOSYS).
 #[cfg(not(target_os = "linux"))]
 fn open_relative(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<OwnedFd> {
+    open_relative_components(base, relative, no_xdev)
+}
+
+fn open_relative_components(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<OwnedFd> {
     let components: Vec<&OsStr> = relative
         .components()
         .map(|component| match component {
@@ -343,6 +351,9 @@ fn open_relative(base: &OwnedFd, relative: &Path, no_xdev: bool) -> io::Result<O
     for (index, component) in components.iter().enumerate() {
         let parent = current.as_ref().unwrap_or(base).as_raw_fd();
         let name = c_string(component)?;
+        #[cfg(target_os = "linux")]
+        let mut flags = libc::O_PATH | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+        #[cfg(not(target_os = "linux"))]
         let mut flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK;
         if index + 1 < components.len() {
             flags |= libc::O_DIRECTORY;
@@ -486,6 +497,38 @@ mod tests {
         report.read_to_end(&mut bytes).unwrap();
         assert_eq!(bytes, b"original");
         assert!(opened.open_child(OsStr::new("../docs/report.txt")).is_err());
+    }
+
+    #[test]
+    fn component_fallback_walks_from_stable_descriptors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path().join("fs");
+        let shared = files.join("pool/docs");
+        std::fs::create_dir_all(shared.join("nested")).unwrap();
+        std::fs::write(shared.join("nested/report.txt"), b"report").unwrap();
+
+        let files_fd = open_directory(&files).unwrap();
+        let shared_fd = open_relative_components(&files_fd, Path::new("pool/docs"), false).unwrap();
+        let root = classify_node(shared_fd, None).unwrap();
+        let BoundaryNode::Directory(directory) = root else {
+            panic!("shared root should be a directory");
+        };
+        assert!(
+            directory
+                .entry_names(10)
+                .unwrap()
+                .iter()
+                .any(|name| name == "nested")
+        );
+
+        let mut report = open_regular_from_root(
+            BoundaryNode::Directory(directory),
+            Path::new("nested/report.txt"),
+        )
+        .unwrap();
+        let mut bytes = Vec::new();
+        report.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"report");
     }
 
     #[cfg(unix)]

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -909,8 +909,23 @@ impl GuestShareService {
                 .enumerate()
                 .filter_map(|(root, path)| {
                     let path = PathBuf::from(path);
-                    let node = crate::file_boundary::open_root_beneath(&files_root, &path).ok()?;
-                    let metadata = node.metadata().ok()?;
+                    let node = crate::file_boundary::open_root_beneath(&files_root, &path)
+                        .map_err(|error| {
+                            tracing::warn!(
+                                "Guest share root {} could not be opened: {error}",
+                                path.display()
+                            );
+                        })
+                        .ok()?;
+                    let metadata = node
+                        .metadata()
+                        .map_err(|error| {
+                            tracing::warn!(
+                                "Guest share root {} metadata failed: {error}",
+                                path.display()
+                            );
+                        })
+                        .ok()?;
                     Some(PublicEntry {
                         root,
                         name: path

--- a/engine/nasty-engine/src/user_files.rs
+++ b/engine/nasty-engine/src/user_files.rs
@@ -121,10 +121,20 @@ pub(crate) async fn browse_handler(
         Err(()) => return unavailable(StatusCode::NOT_FOUND),
     };
     let display_path = query.path.clone();
+    let share_id = share.id.clone();
     let result = tokio::task::spawn_blocking(move || browse_share(&share, &relative, display_path))
         .await
+        .map_err(|error| {
+            tracing::warn!("Portal browse task failed for share {share_id}: {error}");
+        })
         .ok()
-        .and_then(Result::ok);
+        .and_then(|result| {
+            result
+                .map_err(|error| {
+                    tracing::warn!("Portal browse failed for share {share_id}: {error}");
+                })
+                .ok()
+        });
     match result {
         Some(result) => Json(result).into_response(),
         None => unavailable(StatusCode::NOT_FOUND),

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -19,6 +19,7 @@ let
     import ssl
     import subprocess
     import sys
+    import urllib.parse
     import urllib.request
     import websocket
 
@@ -81,6 +82,11 @@ let
             return json.loads(resp.read())["token"]
 
 
+    def http_json(url):
+        with urllib.request.urlopen(url) as resp:
+            return json.loads(resp.read())
+
+
     # ── Session 1: change the default admin password ──────────────
     # Default admin/admin has must_change_password set, which gates
     # most RPC methods. Change it, then re-login so subsequent calls
@@ -139,10 +145,44 @@ let
             f"created filesystem missing from fs.list: {fs_list!r}"
         )
 
+        # Public folder links and the standard-user portal both walk paths
+        # through file_boundary. Exercise a real /fs/<name> mount here: unit
+        # tests use ordinary temp directories and cannot catch mount-crossing
+        # regressions in the descriptor opener.
+        subprocess.run(
+            ["mkdir", "-p", "/fs/smoke-pool/media/movies"],
+            check=True,
+        )
+        with open("/fs/smoke-pool/media/movies/readme.txt", "w") as marker:
+            marker.write("portal-boundary-ok")
+        guest = call(ws, "guestshare.create", 5, {
+            "paths": ["/fs/smoke-pool/media"],
+            "expires_at": None,
+            "password": None,
+            "max_downloads": None,
+            "note": "appliance smoke",
+        })
+        public_base = (
+            "http://127.0.0.1:2137/api/public/share/"
+            + urllib.parse.quote(guest["token"], safe="")
+        )
+        public_meta = http_json(public_base)
+        assert public_meta["entries"] == [{
+            "root": 0,
+            "name": "media",
+            "is_dir": True,
+            "size": 0,
+        }], f"mounted guest folder missing from metadata: {public_meta!r}"
+        public_listing = http_json(public_base + "/browse?root=0")
+        assert any(
+            entry["name"] == "movies" and entry["is_dir"]
+            for entry in public_listing["entries"]
+        ), f"mounted guest folder cannot be browsed: {public_listing!r}"
+
         # Unknown method must come back as a JSON-RPC error envelope,
         # not a silent drop.
-        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 5}))
-        bad = recv_response(ws, 5)
+        ws.send(json.dumps({"jsonrpc": "2.0", "method": "no.such.method", "id": 6}))
+        bad = recv_response(ws, 6)
         assert bad.get("error"), f"unknown method should error: {bad!r}"
         print("unknown method error:", bad["error"], file=sys.stderr)
     finally:


### PR DESCRIPTION
## Summary
- fall back to a descriptor-by-descriptor `openat` walk when Linux reports `openat2` as unavailable
- retain stable `O_PATH` directory handles instead of reopening mounted share roots through `/proc/self/fd`
- preserve normal-component validation, `O_NOFOLLOW`, descriptor-relative traversal, and descendant mount checks in both paths
- log guest-root and portal-browse failures while keeping generic client responses
- exercise guest metadata and browsing on a real bcachefs pool in the appliance smoke test

The first appliance run exposed the production failure directly: `openat2` returned `ENOSYS` inside `nasty-engine`, matching the empty guest metadata and portal browse failures. The fallback handles that environment without relaxing the path boundary.

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine file_boundary`
- `cargo test -p nasty-engine` (224 passed)
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `nix flake check --no-build`
- `git diff --check`
- Linux ARM64 focused harness: all seven boundary tests passed, including the component fallback

The x86_64 Linux bcachefs appliance test is rerunning in CI.

Fixes #724
Fixes #725