### PR TITLE
Add recognizable logos to installed apps

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -51,6 +51,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | clsx | MIT |
 | layerchart | MIT |
 | lightningcss | MPL-2.0 |
+| simple-icons | CC0-1.0 |
 | svelte | MIT |
 | svelte-check | MIT |
 | tailwind-merge | MIT |

--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-TJa5HTd8PRWodgiNQ7N0uRkZ30HBOROFnOwj7HggWfE=";
+      npmDepsHash = "sha256-XijXicrgyUOoCqHMj8d3IZIve35s9LzVLSFpSCDf8ig=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -20,7 +20,8 @@
 				"@xterm/addon-fit": "^0.11.0",
 				"@xterm/addon-web-links": "^0.12.0",
 				"@xterm/xterm": "^6.0.0",
-				"codemirror": "^6.0.2"
+				"codemirror": "^6.0.2",
+				"simple-icons": "^16.27.1"
 			},
 			"devDependencies": {
 				"@internationalized/date": "^3.12.1",
@@ -2703,6 +2704,25 @@
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-icons": {
+			"version": "16.27.1",
+			"resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.27.1.tgz",
+			"integrity": "sha512-slZF8iKxkv7Lb9SF3L1AcIl5iYLNvDrKKm8yV69cG66XvxJ12SX+bYTgxRwCY4bXSmklGXoXaKEyVmEypOCeqw==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/simple-icons"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/simple-icons"
+				}
+			],
+			"license": "CC0-1.0",
+			"engines": {
+				"node": ">=0.12.18"
+			}
 		},
 		"node_modules/sirv": {
 			"version": "3.0.2",

--- a/webui/package.json
+++ b/webui/package.json
@@ -47,6 +47,7 @@
 		"@xterm/addon-fit": "^0.11.0",
 		"@xterm/addon-web-links": "^0.12.0",
 		"@xterm/xterm": "^6.0.0",
-		"codemirror": "^6.0.2"
+		"codemirror": "^6.0.2",
+		"simple-icons": "^16.27.1"
 	}
 }

--- a/webui/src/lib/app-icons.test.ts
+++ b/webui/src/lib/app-icons.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import { appMonogram, normalizeImageRepository, resolveAppIcon } from './app-icons';
+
+describe('app icons', () => {
+	test('normalizes registries, tags, digests, and the Docker Hub library namespace', () => {
+		expect(normalizeImageRepository('lscr.io/linuxserver/jellyfin:latest')).toBe('linuxserver/jellyfin');
+		expect(normalizeImageRepository('docker.io/library/postgres@sha256:abc')).toBe('postgres');
+		expect(normalizeImageRepository('registry.example:5000/team/My_App:v2')).toBe('team/my-app');
+		expect(normalizeImageRepository('https://example.test/not-an-image')).toBe('');
+	});
+
+	test('matches known images without depending on the user-selected app name', () => {
+		const icon = resolveAppIcon({
+			name: 'media',
+			image: 'lscr.io/linuxserver/jellyfin:latest',
+			kind: 'simple',
+			containers: []
+		});
+		expect(icon?.title).toBe('Jellyfin');
+	});
+
+	test('uses a compose project name before an arbitrary primary service image', () => {
+		const icon = resolveAppIcon({
+			name: 'immich',
+			image: 'docker.io/library/redis:latest',
+			kind: 'compose',
+			containers: [{ name: 'cache', container_id: 'abc', image: 'redis:latest', status: 'running' }]
+		});
+		expect(icon?.title).toBe('Immich');
+	});
+
+	test('checks compose service images when the project and primary image are unknown', () => {
+		const icon = resolveAppIcon({
+			name: 'photos-stack',
+			image: 'example/worker:latest',
+			kind: 'compose',
+			containers: [
+				{ name: 'worker', container_id: 'abc', image: 'example/worker:latest', status: 'running' },
+				{ name: 'web', container_id: 'def', image: 'ghcr.io/immich-app/immich-server:v2', status: 'running' }
+			]
+		});
+		expect(icon?.title).toBe('Immich');
+	});
+
+	test('does not identify an ambiguous compose stack as one of its dependencies', () => {
+		const icon = resolveAppIcon({
+			name: 'photos-stack',
+			image: 'redis:latest',
+			kind: 'compose',
+			containers: [
+				{ name: 'cache', container_id: 'abc', image: 'redis:latest', status: 'running' },
+				{ name: 'web', container_id: 'def', image: 'ghcr.io/immich-app/immich-server:v2', status: 'running' }
+			]
+		});
+		expect(icon).toBeNull();
+	});
+
+	test('returns no brand for unknown apps and gives them a stable monogram', () => {
+		expect(resolveAppIcon({ name: 'my-service', image: 'example/custom:1', kind: 'simple', containers: [] })).toBeNull();
+		expect(appMonogram('my-service')).toEqual(appMonogram('my-service'));
+		expect(appMonogram('my-service').initials).toBe('MS');
+		expect(appMonogram('my-service').hue).toBeGreaterThanOrEqual(0);
+		expect(appMonogram('my-service').hue).toBeLessThan(360);
+	});
+});

--- a/webui/src/lib/app-icons.ts
+++ b/webui/src/lib/app-icons.ts
@@ -1,0 +1,146 @@
+import {
+	siAdguard,
+	siCaddy,
+	siEmby,
+	siGitea,
+	siGrafana,
+	siHomeassistant,
+	siImmich,
+	siInfluxdb,
+	siJellyfin,
+	siMariadb,
+	siMinio,
+	siMysql,
+	siNextcloud,
+	siNginx,
+	siPaperlessngx,
+	siPihole,
+	siPlex,
+	siPortainer,
+	siPostgresql,
+	siPrometheus,
+	siQbittorrent,
+	siRadarr,
+	siRedis,
+	siSonarr,
+	siTraefikproxy,
+	siVaultwarden,
+	type SimpleIcon
+} from 'simple-icons';
+import type { App } from './types';
+
+const iconAliases = new Map<string, SimpleIcon>([
+	['adguard', siAdguard],
+	['adguardhome', siAdguard],
+	['adguard/adguardhome', siAdguard],
+	['caddy', siCaddy],
+	['emby', siEmby],
+	['emby/embyserver', siEmby],
+	['gitea', siGitea],
+	['gitea/gitea', siGitea],
+	['grafana', siGrafana],
+	['grafana/grafana', siGrafana],
+	['grafana/grafana-enterprise', siGrafana],
+	['grafana/grafana-oss', siGrafana],
+	['home-assistant', siHomeassistant],
+	['homeassistant', siHomeassistant],
+	['home-assistant/home-assistant', siHomeassistant],
+	['immich', siImmich],
+	['immich-server', siImmich],
+	['immich-app/immich-server', siImmich],
+	['influxdb', siInfluxdb],
+	['influxdata/influxdb', siInfluxdb],
+	['jellyfin', siJellyfin],
+	['jellyfin/jellyfin', siJellyfin],
+	['linuxserver/jellyfin', siJellyfin],
+	['mariadb', siMariadb],
+	['minio', siMinio],
+	['minio/minio', siMinio],
+	['mysql', siMysql],
+	['nextcloud', siNextcloud],
+	['nginx', siNginx],
+	['nginxinc/nginx-unprivileged', siNginx],
+	['paperless', siPaperlessngx],
+	['paperless-ngx', siPaperlessngx],
+	['paperless-ngx/paperless-ngx', siPaperlessngx],
+	['pihole', siPihole],
+	['pihole/pihole', siPihole],
+	['plex', siPlex],
+	['plexinc/pms-docker', siPlex],
+	['linuxserver/plex', siPlex],
+	['pms-docker', siPlex],
+	['portainer', siPortainer],
+	['portainer/portainer-ce', siPortainer],
+	['postgres', siPostgresql],
+	['postgresql', siPostgresql],
+	['prometheus', siPrometheus],
+	['prom/prometheus', siPrometheus],
+	['qbittorrent', siQbittorrent],
+	['linuxserver/qbittorrent', siQbittorrent],
+	['radarr', siRadarr],
+	['linuxserver/radarr', siRadarr],
+	['redis', siRedis],
+	['redis/redis-stack', siRedis],
+	['redis/redis-stack-server', siRedis],
+	['sonarr', siSonarr],
+	['linuxserver/sonarr', siSonarr],
+	['traefik', siTraefikproxy],
+	['traefikproxy/traefik', siTraefikproxy],
+	['vaultwarden', siVaultwarden],
+	['vaultwarden/server', siVaultwarden]
+]);
+
+function normalizeAlias(value: string): string {
+	return value.trim().toLowerCase().replace(/[_\s]+/g, '-');
+}
+
+/** Strip registry, tag, and digest while retaining the repository namespace. */
+export function normalizeImageRepository(image: string): string {
+	let value = image.trim().toLowerCase();
+	if (!value || value.includes('://')) return '';
+
+	value = value.split('@', 1)[0];
+	const slash = value.lastIndexOf('/');
+	const colon = value.lastIndexOf(':');
+	if (colon > slash) value = value.slice(0, colon);
+
+	const parts = value.split('/').filter(Boolean);
+	if (parts.length > 1 && (parts[0].includes('.') || parts[0].includes(':') || parts[0] === 'localhost')) {
+		parts.shift();
+	}
+	if (parts[0] === 'library') parts.shift();
+	return parts.map(normalizeAlias).join('/');
+}
+
+function iconForImage(image: string): SimpleIcon | null {
+	const repository = normalizeImageRepository(image);
+	if (!repository) return null;
+	return iconAliases.get(repository) ?? iconAliases.get(repository.split('/').at(-1) ?? '') ?? null;
+}
+
+export function resolveAppIcon(app: Pick<App, 'name' | 'image' | 'kind' | 'containers'>): SimpleIcon | null {
+	const byName = iconAliases.get(normalizeAlias(app.name));
+	if (app.kind === 'compose' && byName) return byName;
+
+	const byPrimaryImage = iconForImage(app.image);
+	if (app.kind !== 'compose') return byPrimaryImage ?? byName ?? null;
+
+	const composeIcons = new Map<string, SimpleIcon>();
+	if (byPrimaryImage) composeIcons.set(byPrimaryImage.slug, byPrimaryImage);
+	for (const container of app.containers ?? []) {
+		const icon = iconForImage(container.image);
+		if (icon) composeIcons.set(icon.slug, icon);
+	}
+	return composeIcons.size === 1 ? composeIcons.values().next().value ?? null : null;
+}
+
+export function appMonogram(name: string): { initials: string; hue: number } {
+	const normalized = name.trim();
+	const parts = normalized.split(/[^a-z0-9]+/i).filter(Boolean);
+	const initials = parts.length > 1
+		? `${parts[0][0]}${parts[1][0]}`.toUpperCase()
+		: (parts[0] || '?').slice(0, 2).toUpperCase();
+	let hash = 0;
+	for (const character of normalized) hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+	return { initials, hue: hash % 360 };
+}

--- a/webui/src/lib/components/AppIcon.svelte
+++ b/webui/src/lib/components/AppIcon.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { appMonogram, resolveAppIcon } from '$lib/app-icons';
+	import type { App } from '$lib/types';
+
+	let { app, size = 32 }: { app: App; size?: number } = $props();
+	const icon = $derived(resolveAppIcon(app));
+	const fallback = $derived(appMonogram(app.name));
+</script>
+
+{#if icon}
+	<span
+		class="inline-flex shrink-0 items-center justify-center rounded-lg border border-border/70 bg-white shadow-sm"
+		style={`width: ${size}px; height: ${size}px`}
+		title={icon.title}
+	>
+		<svg
+			viewBox="0 0 24 24"
+			width={Math.round(size * 0.58)}
+			height={Math.round(size * 0.58)}
+			style={`color: #${icon.hex}`}
+			aria-hidden="true"
+		>
+			<path fill="currentColor" d={icon.path}></path>
+		</svg>
+	</span>
+{:else}
+	<span
+		class="inline-flex shrink-0 items-center justify-center rounded-lg border border-white/10 text-[0.65rem] font-bold tracking-wide text-white shadow-sm"
+		style={`width: ${size}px; height: ${size}px; background-color: hsl(${fallback.hue} 52% 42%)`}
+		aria-hidden="true"
+	>
+		{fallback.initials}
+	</span>
+{/if}

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -15,6 +15,7 @@
 	import SortTh from '$lib/components/SortTh.svelte';
 	import CodeEditor from '$lib/components/CodeEditor.svelte';
 	import PathPicker from '$lib/components/PathPicker.svelte';
+	import AppIcon from '$lib/components/AppIcon.svelte';
 	import { CircleCheck, Circle, FolderOpen } from '@lucide/svelte';
 	import type { Filesystem, FsDependents } from '$lib/types';
 	import { unlockFs } from '$lib/unlock-fs.svelte';
@@ -2552,6 +2553,7 @@
 					<tr class="border-b border-border hover:bg-muted/30 transition-colors">
 						<td class="p-3">
 							<div class="flex items-center gap-2">
+								<AppIcon {app} />
 								<span class="font-semibold">{app.name}</span>
 								<Badge variant="outline" class="text-[0.6rem]">{app.kind}</Badge>
 								{#if app.unsafe_mode}

--- a/webui/static/THIRD-PARTY-LICENSES.md
+++ b/webui/static/THIRD-PARTY-LICENSES.md
@@ -51,6 +51,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | clsx | MIT |
 | layerchart | MIT |
 | lightningcss | MPL-2.0 |
+| simple-icons | CC0-1.0 |
 | svelte | MIT |
 | svelte-check | MIT |
 | tailwind-merge | MIT |


### PR DESCRIPTION
## Summary
- show compact brand icons beside recognized apps in the installed-apps table
- normalize registry prefixes, tags, digests, and common image aliases for 26 self-hosted services
- resolve Compose projects by project name or one unambiguous recognized service image
- render deterministic colored monograms for arbitrary and unknown images
- bundle selected Simple Icons locally so the feature works offline and respects the existing CSP
- record the CC0 dependency and refresh the Nix npm dependency hash

## Testing
- `npm run check`
- `npm test` (211 passed)
- `npm run build`
- `nix flake check --no-build`
- npm dependency hash freshness check
- `git diff --check`

Fixes #726