### PR TITLE
subvolumes: edit inherited storage policies

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2237,7 +2237,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "subvolume.update",
-                    desc: "Update mutable subvolume attributes (compression, comments, foreground/background/promote/metadata targets, data replicas) via bcachefs `set-file-option` and xattrs.",
+                    desc: "Update mutable subvolume attributes (compression, comments, foreground/background/promote/metadata targets, data replicas, erasure coding) via bcachefs `set-file-option` and xattrs.",
                     role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<UpdateSubvolumeRequest>(generator)),
                     result: Some(gen_schema::<Subvolume>(generator)),

--- a/engine/nasty-storage/src/subvolume.rs
+++ b/engine/nasty-storage/src/subvolume.rs
@@ -92,6 +92,8 @@ pub enum SubvolumeError {
     InvalidName(String),
     #[error("invalid volsize: {0}")]
     InvalidVolsize(String),
+    #[error("invalid storage policy: {0}")]
+    InvalidStoragePolicy(String),
     #[error("cannot shrink subvolume from {current} to {requested} bytes")]
     ShrinkNotSupported { current: u64, requested: u64 },
     #[error("could not delete child subvolume(s): {0}")]
@@ -455,10 +457,15 @@ pub struct Subvolume {
     /// Whether O_DIRECT is enabled on the loop device (block subvolumes only).
     #[serde(default)]
     pub direct_io: bool,
-    /// Effective bcachefs options set on this subvolume (from bcachefs_effective.* xattrs).
-    /// Only includes options that differ from the filesystem default.
+    /// Effective bcachefs inode options (from bcachefs_effective.* xattrs).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub bcachefs_options: HashMap<String, String>,
+    /// Explicit bcachefs options set on this subvolume (from bcachefs.* xattrs).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub bcachefs_overrides: HashMap<String, String>,
+    /// Effective bcachefs options inherited from the parent directory.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub bcachefs_inherited_options: HashMap<String, String>,
     /// True only when this response came from the create operation that
     /// successfully created the underlying bcachefs subvolume.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -507,12 +514,15 @@ struct SubvolumeAttrs {
     properties: HashMap<String, String>,
     /// Effective bcachefs options (from bcachefs_effective.* xattrs).
     bcachefs_options: HashMap<String, String>,
+    /// Explicit bcachefs overrides (from bcachefs.* xattrs).
+    bcachefs_overrides: HashMap<String, String>,
 }
 
 /// Read all xattrs from a subvolume in one pass.
 /// Splits results into internal metadata (`user.nasty.*`) and user-visible properties
 /// (`user.nasty-csi:*` etc), avoiding duplicate enumeration.
 const BCACHEFS_EFFECTIVE_NS: &str = "bcachefs_effective.";
+const BCACHEFS_NS: &str = "bcachefs.";
 
 fn read_string_xattr(path: &Path, key: &str) -> Option<String> {
     xattr::get(path, key)
@@ -525,6 +535,7 @@ fn read_all_xattrs(path: &Path) -> SubvolumeAttrs {
     let mut meta_raw: HashMap<String, String> = HashMap::new();
     let mut properties: HashMap<String, String> = HashMap::new();
     let mut bcachefs_options: HashMap<String, String> = HashMap::new();
+    let mut bcachefs_overrides: HashMap<String, String> = HashMap::new();
 
     if let Ok(attrs) = xattr::list(path) {
         for name in attrs {
@@ -539,6 +550,8 @@ fn read_all_xattrs(path: &Path) -> SubvolumeAttrs {
             if let Some(key) = name_str.strip_prefix(BCACHEFS_EFFECTIVE_NS) {
                 // bcachefs effective options (bcachefs_effective.*)
                 bcachefs_options.insert(key.to_string(), value);
+            } else if let Some(key) = name_str.strip_prefix(BCACHEFS_NS) {
+                bcachefs_overrides.insert(key.to_string(), value);
             } else if let Some(key) = name_str.strip_prefix(XATTR_NS) {
                 if key.starts_with(NASTY_KEY_PREFIX) {
                     meta_raw.insert(key.to_string(), value);
@@ -584,6 +597,7 @@ fn read_all_xattrs(path: &Path) -> SubvolumeAttrs {
         },
         properties,
         bcachefs_options,
+        bcachefs_overrides,
     }
 }
 
@@ -800,7 +814,7 @@ pub struct UpdateSubvolumeRequest {
     pub filesystem: String,
     /// Name of the subvolume to update.
     pub name: String,
-    /// New compression algorithm (e.g. `lz4`, `zstd`, `none`). `none` clears compression.
+    /// New compression algorithm (e.g. `lz4`, `zstd`, `none`). Use `inherit` to remove the override.
     pub compression: Option<String>,
     /// New description for the subvolume. Empty string clears the comment.
     pub comments: Option<String>,
@@ -812,8 +826,92 @@ pub struct UpdateSubvolumeRequest {
     pub promote_target: Option<String>,
     /// Device or label for metadata/btree writes. Use `-` to remove.
     pub metadata_target: Option<String>,
-    /// Number of data replicas. Use `0` to reset to filesystem default.
+    /// Number of data replicas. Use `0` to inherit from the parent directory.
     pub data_replicas: Option<u32>,
+    /// Erasure-coding policy for this subvolume.
+    pub erasure_code: Option<SubvolumeErasureCode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SubvolumeErasureCode {
+    /// Remove the subvolume override and inherit from the parent directory.
+    Inherit,
+    /// Enable erasure coding for data in this subvolume.
+    Enabled,
+    /// Disable erasure coding for data in this subvolume.
+    Disabled,
+}
+
+impl SubvolumeErasureCode {
+    fn file_option(self) -> &'static str {
+        match self {
+            Self::Inherit => "--erasure_code=-",
+            Self::Enabled => "--erasure_code=1",
+            Self::Disabled => "--erasure_code=0",
+        }
+    }
+}
+
+fn option_enabled(value: Option<&String>) -> bool {
+    value.is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on"))
+}
+
+fn option_replicas(options: &HashMap<String, String>) -> u32 {
+    options
+        .get("data_replicas")
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1)
+}
+
+fn option_replicas_or(
+    options: &HashMap<String, String>,
+    fallback: &HashMap<String, String>,
+) -> u32 {
+    options
+        .get("data_replicas")
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| option_replicas(fallback))
+}
+
+fn option_enabled_or(
+    options: &HashMap<String, String>,
+    fallback: &HashMap<String, String>,
+) -> bool {
+    options
+        .get("erasure_code")
+        .map(|value| option_enabled(Some(value)))
+        .unwrap_or_else(|| option_enabled(fallback.get("erasure_code")))
+}
+
+fn add_storage_defaults(
+    options: &mut HashMap<String, String>,
+    data_replicas: u32,
+    erasure_code: bool,
+) {
+    options
+        .entry("data_replicas".to_string())
+        .or_insert_with(|| data_replicas.to_string());
+    options
+        .entry("erasure_code".to_string())
+        .or_insert_with(|| if erasure_code { "1" } else { "0" }.to_string());
+}
+
+fn validate_storage_policy(data_replicas: u32, erasure_code: bool) -> Result<(), SubvolumeError> {
+    if erasure_code && !(2..=3).contains(&data_replicas) {
+        return Err(SubvolumeError::InvalidStoragePolicy(format!(
+            "erasure coding requires 2 or 3 data replicas (got {data_replicas})"
+        )));
+    }
+    Ok(())
+}
+
+fn compression_file_option(value: &str) -> (&str, bool) {
+    match value {
+        "inherit" | "-" => ("-", true),
+        "none" | "" => ("none", true),
+        value => (value, false),
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1126,6 +1224,8 @@ impl SubvolumeService {
             .get(fs_name)
             .await
             .map_err(|_| SubvolumeError::FilesystemNotFound(fs_name.to_string()))?;
+        let filesystem_data_replicas = fs.options.data_replicas.unwrap_or(1);
+        let filesystem_erasure_code = fs.options.erasure_code.unwrap_or(false);
         let filesystem_uuid = fs.uuid;
         let mount_point = fs
             .mount_point
@@ -1156,6 +1256,16 @@ impl SubvolumeService {
 
             // Single-pass xattr read: meta + properties in one list+get sweep
             let attrs = read_all_xattrs(path);
+            let mut bcachefs_inherited_options = path
+                .parent()
+                .map(read_all_xattrs)
+                .map(|attrs| attrs.bcachefs_options)
+                .unwrap_or_default();
+            add_storage_defaults(
+                &mut bcachefs_inherited_options,
+                filesystem_data_replicas,
+                filesystem_erasure_code,
+            );
 
             // Apply owner filter: operators only see their own subvolumes
             if let Some(filter) = owner_filter
@@ -1253,6 +1363,8 @@ impl SubvolumeService {
                 parent,
                 direct_io: attrs.meta.direct_io,
                 bcachefs_options: attrs.bcachefs_options,
+                bcachefs_overrides: attrs.bcachefs_overrides,
+                bcachefs_inherited_options,
                 created: false,
             });
         }
@@ -1909,15 +2021,33 @@ impl SubvolumeService {
         req: UpdateSubvolumeRequest,
         owner_filter: Option<&str>,
     ) -> Result<Subvolume, SubvolumeError> {
+        let _destination_guard = self.lock_destination(&req.filesystem, &req.name).await;
         let subvol = self.get(&req.filesystem, &req.name, owner_filter).await?;
         let path = &subvol.path;
 
-        if let Some(ref comp) = req.compression {
-            let comp_value = if comp == "none" || comp.is_empty() {
-                "none"
-            } else {
-                comp.as_str()
+        if req.data_replicas.is_some() || req.erasure_code.is_some() {
+            let data_replicas = match req.data_replicas {
+                Some(0) => option_replicas(&subvol.bcachefs_inherited_options),
+                Some(replicas) => replicas,
+                None => {
+                    option_replicas_or(&subvol.bcachefs_options, &subvol.bcachefs_inherited_options)
+                }
             };
+            let erasure_code = match req.erasure_code {
+                Some(SubvolumeErasureCode::Inherit) => {
+                    option_enabled(subvol.bcachefs_inherited_options.get("erasure_code"))
+                }
+                Some(SubvolumeErasureCode::Enabled) => true,
+                Some(SubvolumeErasureCode::Disabled) => false,
+                None => {
+                    option_enabled_or(&subvol.bcachefs_options, &subvol.bcachefs_inherited_options)
+                }
+            };
+            validate_storage_policy(data_replicas, erasure_code)?;
+        }
+
+        if let Some(ref comp) = req.compression {
+            let (comp_value, clear_metadata) = compression_file_option(comp);
             info!(
                 "Setting compression={} on subvolume '{}'",
                 comp_value, req.name
@@ -1933,7 +2063,7 @@ impl SubvolumeService {
             .await
             .map_err(SubvolumeError::CommandFailed)?;
 
-            if comp_value == "none" {
+            if clear_metadata {
                 let _ = xattr::remove(path, XATTR_NASTY_COMPRESSION);
             } else {
                 xattr::set(path, XATTR_NASTY_COMPRESSION, comp_value.as_bytes()).map_err(|e| {
@@ -1969,7 +2099,13 @@ impl SubvolumeService {
             }
         }
 
-        // Update data replicas if specified (use 0 to reset to filesystem default)
+        let previous_data_replicas = subvol
+            .bcachefs_overrides
+            .get("data_replicas")
+            .map(|replicas| format!("--data_replicas={replicas}"))
+            .unwrap_or_else(|| "--data_replicas=-".to_string());
+
+        // Update data replicas if specified (use 0 to inherit from the parent)
         if let Some(replicas) = req.data_replicas {
             info!(
                 "Setting data_replicas={} on subvolume '{}'",
@@ -1983,6 +2119,32 @@ impl SubvolumeService {
             cmd::run_ok("bcachefs", &["set-file-option", &flag, path])
                 .await
                 .map_err(SubvolumeError::CommandFailed)?;
+        }
+
+        if let Some(erasure_code) = req.erasure_code {
+            info!(
+                "Setting erasure_code={:?} on subvolume '{}'",
+                erasure_code, req.name
+            );
+            if let Err(error) = cmd::run_ok(
+                "bcachefs",
+                &["set-file-option", erasure_code.file_option(), path],
+            )
+            .await
+            {
+                if req.data_replicas.is_some()
+                    && let Err(rollback_error) = cmd::run_ok(
+                        "bcachefs",
+                        &["set-file-option", &previous_data_replicas, path],
+                    )
+                    .await
+                {
+                    return Err(SubvolumeError::CommandFailed(format!(
+                        "{error}; restoring data replicas also failed: {rollback_error}"
+                    )));
+                }
+                return Err(SubvolumeError::CommandFailed(error));
+            }
         }
 
         self.get(&req.filesystem, &req.name, owner_filter).await
@@ -3611,6 +3773,62 @@ mod tests {
             "block_filesystem": "btrfs",
         }));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_request_accepts_subvolume_erasure_code_policies() {
+        for (value, expected, option) in [
+            ("inherit", SubvolumeErasureCode::Inherit, "--erasure_code=-"),
+            ("enabled", SubvolumeErasureCode::Enabled, "--erasure_code=1"),
+            (
+                "disabled",
+                SubvolumeErasureCode::Disabled,
+                "--erasure_code=0",
+            ),
+        ] {
+            let request: UpdateSubvolumeRequest = serde_json::from_value(serde_json::json!({
+                "filesystem": "tank",
+                "name": "documents",
+                "erasure_code": value,
+            }))
+            .unwrap();
+            let policy = request.erasure_code.unwrap();
+            assert_eq!(policy, expected);
+            assert_eq!(policy.file_option(), option);
+        }
+    }
+
+    #[test]
+    fn erasure_coding_requires_supported_replica_counts() {
+        assert!(validate_storage_policy(2, true).is_ok());
+        assert!(validate_storage_policy(3, true).is_ok());
+        assert!(validate_storage_policy(1, false).is_ok());
+        assert!(validate_storage_policy(4, false).is_ok());
+        assert!(matches!(
+            validate_storage_policy(1, true),
+            Err(SubvolumeError::InvalidStoragePolicy(_))
+        ));
+        assert!(matches!(
+            validate_storage_policy(4, true),
+            Err(SubvolumeError::InvalidStoragePolicy(_))
+        ));
+    }
+
+    #[test]
+    fn storage_defaults_only_fill_missing_inherited_options() {
+        let mut options = HashMap::from([("data_replicas".to_string(), "3".to_string())]);
+        add_storage_defaults(&mut options, 2, true);
+        assert_eq!(options.get("data_replicas").map(String::as_str), Some("3"));
+        assert_eq!(options.get("erasure_code").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn compression_policy_distinguishes_none_from_inheritance() {
+        assert_eq!(compression_file_option("inherit"), ("-", true));
+        assert_eq!(compression_file_option("-"), ("-", true));
+        assert_eq!(compression_file_option("none"), ("none", true));
+        assert_eq!(compression_file_option(""), ("none", true));
+        assert_eq!(compression_file_option("zstd"), ("zstd", false));
     }
 
     #[tokio::test]

--- a/webui/src/lib/subvolume-storage-policy.test.ts
+++ b/webui/src/lib/subvolume-storage-policy.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+	readSubvolumeCompressionPolicy,
+	readSubvolumeStoragePolicy,
+	storagePolicyUpdate,
+} from './subvolume-storage-policy';
+
+describe('subvolume storage policy', () => {
+	it('distinguishes inherited compression from an explicit none override', () => {
+		expect(readSubvolumeCompressionPolicy(undefined, undefined, undefined, {
+			compression: 'zstd',
+		})).toEqual({
+			compression: '',
+			effectiveCompression: 'zstd',
+			inheritedCompression: 'zstd',
+			inherited: true,
+		});
+		expect(readSubvolumeCompressionPolicy({ compression: 'none' }, { compression: 'none' }, undefined, {
+			compression: 'zstd',
+		})).toEqual({
+			compression: 'none',
+			effectiveCompression: 'none',
+			inheritedCompression: 'zstd',
+			inherited: false,
+		});
+	});
+
+	it('uses filesystem defaults when no subvolume overrides exist', () => {
+		expect(readSubvolumeStoragePolicy(undefined, undefined, undefined, {
+			data_replicas: 2,
+			erasure_code: true,
+		})).toEqual({
+			dataReplicas: '',
+			erasureCode: 'inherit',
+			effectiveDataReplicas: 2,
+			effectiveErasureCode: true,
+			inheritedDataReplicas: 2,
+			inheritedErasureCode: true,
+			configuredInheritedDataReplicas: 2,
+			configuredInheritedErasureCode: true,
+			dataReplicasInherited: true,
+			erasureCodeInherited: true,
+		});
+	});
+
+	it('recognizes explicit replica and erasure-code overrides', () => {
+		expect(readSubvolumeStoragePolicy({
+			data_replicas: '3',
+			erasure_code: '0',
+		}, {
+			data_replicas: '3',
+			erasure_code: '0',
+		}, {
+			data_replicas: '2',
+			erasure_code: '1',
+		}, {
+			data_replicas: 1,
+			erasure_code: true,
+		})).toMatchObject({
+			dataReplicas: '3',
+			erasureCode: 'disabled',
+			effectiveDataReplicas: 3,
+			effectiveErasureCode: false,
+			dataReplicasInherited: false,
+			erasureCodeInherited: false,
+		});
+	});
+
+	it('does not confuse inherited effective values with overrides', () => {
+		expect(readSubvolumeStoragePolicy({
+			data_replicas: '2',
+			erasure_code: '1',
+		}, undefined, undefined, {
+			data_replicas: 2,
+			erasure_code: true,
+		})).toMatchObject({
+			dataReplicas: '',
+			erasureCode: 'inherit',
+			effectiveDataReplicas: 2,
+			effectiveErasureCode: true,
+			dataReplicasInherited: true,
+			erasureCodeInherited: true,
+		});
+	});
+
+	it('uses the immediate parent policy as the inheritance baseline', () => {
+		expect(readSubvolumeStoragePolicy({
+			data_replicas: '3',
+			erasure_code: '1',
+		}, {
+			data_replicas: '3',
+			erasure_code: '1',
+		}, {
+			data_replicas: '2',
+			erasure_code: '0',
+		}, {
+			data_replicas: 1,
+			erasure_code: true,
+		})).toMatchObject({
+			inheritedDataReplicas: 2,
+			inheritedErasureCode: false,
+			configuredInheritedDataReplicas: 2,
+			configuredInheritedErasureCode: false,
+		});
+	});
+
+	it('applies bcachefs fixups to operationally effective values', () => {
+		expect(readSubvolumeStoragePolicy({
+			data_replicas: '1',
+			erasure_code: '1',
+		}, undefined, {
+			data_replicas: '4',
+			erasure_code: '1',
+		}, undefined)).toMatchObject({
+			effectiveDataReplicas: 1,
+			effectiveErasureCode: false,
+			inheritedDataReplicas: 3,
+			inheritedErasureCode: true,
+			configuredInheritedDataReplicas: 4,
+			configuredInheritedErasureCode: true,
+		});
+	});
+
+	it('builds updates that can restore both filesystem defaults', () => {
+		expect(storagePolicyUpdate('', 'inherit')).toEqual({
+			data_replicas: 0,
+			erasure_code: 'inherit',
+		});
+		expect(storagePolicyUpdate('2', 'enabled')).toEqual({
+			data_replicas: 2,
+			erasure_code: 'enabled',
+		});
+		expect(storagePolicyUpdate('2', 'enabled', {
+			dataReplicas: '2',
+			erasureCode: 'inherit',
+		})).toEqual({ erasure_code: 'enabled' });
+	});
+});

--- a/webui/src/lib/subvolume-storage-policy.ts
+++ b/webui/src/lib/subvolume-storage-policy.ts
@@ -1,0 +1,106 @@
+import type { FilesystemOptions } from '$lib/types';
+
+export type ErasureCodeSetting = 'inherit' | 'enabled' | 'disabled';
+
+export interface SubvolumeStoragePolicy {
+	dataReplicas: string;
+	erasureCode: ErasureCodeSetting;
+	effectiveDataReplicas: number;
+	effectiveErasureCode: boolean;
+	inheritedDataReplicas: number;
+	inheritedErasureCode: boolean;
+	configuredInheritedDataReplicas: number;
+	configuredInheritedErasureCode: boolean;
+	dataReplicasInherited: boolean;
+	erasureCodeInherited: boolean;
+}
+
+type StorageDefaults = Pick<FilesystemOptions, 'data_replicas' | 'erasure_code'>;
+type CompressionDefaults = Pick<FilesystemOptions, 'compression'>;
+
+export interface SubvolumeCompressionPolicy {
+	compression: string;
+	effectiveCompression: string;
+	inheritedCompression: string;
+	inherited: boolean;
+}
+
+function optionEnabled(value: string): boolean {
+	return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function applyBcachefsFixups(dataReplicas: number, erasureCode: boolean) {
+	if (dataReplicas === 1) erasureCode = false;
+	if (erasureCode) dataReplicas = Math.min(dataReplicas, 3);
+	return { dataReplicas, erasureCode };
+}
+
+export function readSubvolumeCompressionPolicy(
+	effectiveOptions: Record<string, string> | undefined,
+	overrides: Record<string, string> | undefined,
+	inheritedOptions: Record<string, string> | undefined,
+	defaults: CompressionDefaults | null | undefined,
+): SubvolumeCompressionPolicy {
+	const override = overrides?.compression;
+	const inheritedCompression = inheritedOptions?.compression || defaults?.compression || 'none';
+	return {
+		compression: override ?? '',
+		effectiveCompression: effectiveOptions?.compression || inheritedCompression,
+		inheritedCompression,
+		inherited: override === undefined,
+	};
+}
+
+export function readSubvolumeStoragePolicy(
+	effectiveOptions: Record<string, string> | undefined,
+	overrides: Record<string, string> | undefined,
+	inheritedOptions: Record<string, string> | undefined,
+	defaults: StorageDefaults | null | undefined,
+): SubvolumeStoragePolicy {
+	const dataReplicas = overrides?.data_replicas;
+	const erasureCode = overrides?.erasure_code;
+	const configuredInheritedDataReplicas = Number.parseInt(inheritedOptions?.data_replicas ?? '', 10)
+		|| defaults?.data_replicas || 1;
+	const configuredInheritedErasureCode = inheritedOptions?.erasure_code === undefined
+		? (defaults?.erasure_code ?? false)
+		: optionEnabled(inheritedOptions.erasure_code);
+	const effective = applyBcachefsFixups(
+		Number.parseInt(effectiveOptions?.data_replicas ?? '', 10) || configuredInheritedDataReplicas,
+		effectiveOptions?.erasure_code === undefined
+			? configuredInheritedErasureCode
+			: optionEnabled(effectiveOptions.erasure_code),
+	);
+	const inherited = applyBcachefsFixups(
+		configuredInheritedDataReplicas,
+		configuredInheritedErasureCode,
+	);
+	return {
+		dataReplicas: dataReplicas ?? '',
+		erasureCode: erasureCode === undefined
+			? 'inherit'
+			: optionEnabled(erasureCode) ? 'enabled' : 'disabled',
+		effectiveDataReplicas: effective.dataReplicas,
+		effectiveErasureCode: effective.erasureCode,
+		inheritedDataReplicas: inherited.dataReplicas,
+		inheritedErasureCode: inherited.erasureCode,
+		configuredInheritedDataReplicas,
+		configuredInheritedErasureCode,
+		dataReplicasInherited: dataReplicas === undefined,
+		erasureCodeInherited: erasureCode === undefined,
+	};
+}
+
+export function storagePolicyUpdate(
+	dataReplicas: string,
+	erasureCode: ErasureCodeSetting,
+	previous?: Pick<SubvolumeStoragePolicy, 'dataReplicas' | 'erasureCode'>,
+) {
+	const update: { data_replicas?: number; erasure_code?: ErasureCodeSetting } = {};
+	if (!previous || dataReplicas !== previous.dataReplicas) {
+		update.data_replicas = dataReplicas === '' ? 0 : Number.parseInt(dataReplicas, 10);
+	}
+	if (!previous || erasureCode !== previous.erasureCode) {
+		update.erasure_code = erasureCode;
+	}
+	return update;
+}

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -627,6 +627,8 @@ export interface Subvolume {
 	parent: string | null;
 	direct_io: boolean;
 	bcachefs_options?: Record<string, string>;
+	bcachefs_overrides?: Record<string, string>;
+	bcachefs_inherited_options?: Record<string, string>;
 }
 
 export interface Snapshot {

--- a/webui/src/routes/subvolumes/+page.svelte
+++ b/webui/src/routes/subvolumes/+page.svelte
@@ -7,6 +7,7 @@
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
+	import { readSubvolumeCompressionPolicy, readSubvolumeStoragePolicy, storagePolicyUpdate, type ErasureCodeSetting } from '$lib/subvolume-storage-policy';
 	import type { Filesystem, Subvolume, SubvolumeDependents, Snapshot, SubvolumeType, NfsShare, SmbShare, IscsiTarget, NvmeofSubsystem, App, AppsStatus, VmStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -193,11 +194,15 @@
 	// Inline editing
 	let editingField = $state<'compression' | 'comments' | null>(null);
 	let editValue = $state('');
+	let storagePolicySv = $state<Subvolume | null>(null);
+	let editDataReplicas = $state('');
+	let editErasureCode = $state<ErasureCodeSetting>('inherit');
+	let originalStoragePolicy = $state<ReturnType<typeof readSubvolumeStoragePolicy> | null>(null);
 
 	function startEdit(field: 'compression' | 'comments') {
 		editingField = field;
 		editValue = field === 'compression'
-			? (detailSv?.compression ?? '')
+			? (detailSv ? compressionPolicyFor(detailSv).compression : '')
 			: (detailSv?.comments ?? '');
 	}
 
@@ -208,7 +213,7 @@
 			filesystem: target.filesystem,
 			name: target.name,
 		};
-		params[editingField] = editValue;
+		params[editingField] = editingField === 'compression' && editValue === '' ? 'inherit' : editValue;
 		const ok = await withToast(
 			() => client.call('subvolume.update', params),
 			`${editingField === 'compression' ? 'Compression' : 'Comments'} updated`
@@ -223,6 +228,74 @@
 
 	function cancelEdit() {
 		editingField = null;
+	}
+
+	function filesystemOptionsFor(sv: Subvolume | null) {
+		return sv ? filesystems.find(fs => fs.name === sv.filesystem)?.options : undefined;
+	}
+
+	function storagePolicyFor(sv: Subvolume) {
+		return readSubvolumeStoragePolicy(
+			sv.bcachefs_options,
+			sv.bcachefs_overrides,
+			sv.bcachefs_inherited_options,
+			filesystemOptionsFor(sv),
+		);
+	}
+
+	function compressionPolicyFor(sv: Subvolume) {
+		return readSubvolumeCompressionPolicy(
+			sv.bcachefs_options,
+			sv.bcachefs_overrides,
+			sv.bcachefs_inherited_options,
+			filesystemOptionsFor(sv),
+		);
+	}
+
+	function openStoragePolicy(sv: Subvolume) {
+		const policy = storagePolicyFor(sv);
+		storagePolicySv = sv;
+		originalStoragePolicy = policy;
+		editDataReplicas = policy.dataReplicas;
+		editErasureCode = policy.erasureCode;
+	}
+
+	const editedEffectiveDataReplicas = $derived.by(() => {
+		if (editDataReplicas) return Number.parseInt(editDataReplicas, 10);
+		return storagePolicySv ? storagePolicyFor(storagePolicySv).configuredInheritedDataReplicas : 1;
+	});
+	const editedErasureCodeEnabled = $derived.by(() => {
+		if (editErasureCode === 'enabled') return true;
+		if (editErasureCode === 'disabled') return false;
+		return storagePolicySv ? storagePolicyFor(storagePolicySv).configuredInheritedErasureCode : false;
+	});
+	const invalidErasureCodePolicy = $derived(
+		editedErasureCodeEnabled && (editedEffectiveDataReplicas < 2 || editedEffectiveDataReplicas > 3)
+	);
+
+	async function saveStoragePolicy() {
+		if (!storagePolicySv) return;
+		const target = storagePolicySv;
+		const update = storagePolicyUpdate(editDataReplicas, editErasureCode, originalStoragePolicy ?? undefined);
+		if (Object.keys(update).length === 0) {
+			storagePolicySv = null;
+			return;
+		}
+		if (invalidErasureCodePolicy) return;
+		const ok = await withToast(
+			() => client.call('subvolume.update', {
+				filesystem: target.filesystem,
+				name: target.name,
+				...update,
+			}),
+			'Storage policy updated'
+		);
+		if (ok !== undefined) {
+			storagePolicySv = null;
+			await refresh();
+			const updated = subvolumes.find(sv => sv.filesystem === target.filesystem && sv.name === target.name);
+			if (updated) detailSv = updated;
+		}
 	}
 
 	// Consumers linked to the detail subvolume
@@ -978,7 +1051,8 @@
 			<div class="mb-4">
 				<Label for="sv-compression">Compression</Label>
 				<select id="sv-compression" bind:value={newCompression} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
-					<option value="">None</option>
+					<option value="">{inheritLabel(fsDefaults()?.compression)}</option>
+					<option value="none">None</option>
 					<option value="lz4">LZ4</option>
 					<option value="zstd">Zstd</option>
 					<option value="gzip">Gzip</option>
@@ -1297,6 +1371,8 @@
 								</div>
 
 								{#if detailTab === 'info'}
+									{@const storagePolicy = storagePolicyFor(detailSv)}
+									{@const compressionPolicy = compressionPolicyFor(detailSv)}
 									<div class="grid grid-cols-[auto_1fr_auto_1fr] gap-x-6 gap-y-1.5 text-sm">
 										<span class="text-muted-foreground">Type</span>
 										<span>
@@ -1310,24 +1386,35 @@
 
 										<span class="text-muted-foreground">Compression</span>
 										<span>
-											{#if editingField === 'compression'}
-												<span class="flex items-center gap-1">
-													<select bind:value={editValue} class="h-7 rounded-md border border-input bg-transparent px-2 text-xs">
-														<option value="">None</option>
-														<option value="lz4">LZ4</option>
+										{#if editingField === 'compression'}
+											<span class="flex items-center gap-1">
+												<select bind:value={editValue} class="h-7 rounded-md border border-input bg-transparent px-2 text-xs">
+													<option value="">Inherit ({compressionPolicy.inheritedCompression})</option>
+													<option value="none">None</option>
+													<option value="lz4">LZ4</option>
 														<option value="zstd">Zstd</option>
 														<option value="gzip">Gzip</option>
 													</select>
 													<button onclick={saveEdit} class="p-0.5 text-green-400 hover:text-green-300"><Check class="h-3.5 w-3.5" /></button>
 													<button onclick={cancelEdit} class="p-0.5 text-muted-foreground hover:text-foreground"><X class="h-3.5 w-3.5" /></button>
-												</span>
-											{:else}
-												<button class="group flex items-center gap-1 hover:text-blue-400 transition-colors" onclick={() => startEdit('compression')}>
-													{detailSv.compression ?? 'None'}
-													<Pencil class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+											</span>
+										{:else}
+											<button class="group flex items-center gap-1 hover:text-blue-400 transition-colors" onclick={() => startEdit('compression')}>
+												{compressionPolicy.effectiveCompression} {compressionPolicy.inherited ? '(inherited)' : '(override)'}
+												<Pencil class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
 												</button>
 											{/if}
 										</span>
+										<span class="text-muted-foreground">Data Replicas</span>
+										<button class="group flex items-center gap-1 text-left hover:text-blue-400 transition-colors" onclick={() => openStoragePolicy(detailSv!)}>
+											{storagePolicy.effectiveDataReplicas} {storagePolicy.dataReplicasInherited ? '(inherited)' : '(override)'}
+											<Pencil class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+										</button>
+										<span class="text-muted-foreground">Erasure Coding</span>
+										<button class="group flex items-center gap-1 text-left hover:text-blue-400 transition-colors" onclick={() => openStoragePolicy(detailSv!)}>
+											{storagePolicy.effectiveErasureCode ? 'Enabled' : 'Disabled'} {storagePolicy.erasureCodeInherited ? '(inherited)' : '(override)'}
+											<Pencil class="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+										</button>
 										<span class="text-muted-foreground">{detailSv.subvolume_type === 'block' ? 'Size' : 'Quota'}</span>
 										<span>
 											{#if showResize}
@@ -1655,6 +1742,43 @@
 		<Dialog.Footer>
 			<Button size="sm" onclick={createSnapshot}>Create</Button>
 			<Button variant="secondary" size="sm" onclick={() => showSnap = null}>Cancel</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root open={storagePolicySv !== null} onOpenChange={(open) => { if (!open) storagePolicySv = null; }}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Storage policy for "{storagePolicySv?.name ?? ''}"</Dialog.Title>
+		</Dialog.Header>
+		<div class="space-y-4 py-2">
+			<div>
+				<Label for="edit-data-replicas">Data Replicas</Label>
+				<select id="edit-data-replicas" bind:value={editDataReplicas} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+					<option value="">Inherit ({storagePolicySv ? storagePolicyFor(storagePolicySv).configuredInheritedDataReplicas : 1})</option>
+					<option value="1">1</option>
+					<option value="2">2</option>
+					<option value="3">3</option>
+					<option value="4">4</option>
+				</select>
+				<p class="mt-1 text-xs text-muted-foreground">Data redundancy level for this subvolume. Erasure coding supports levels 2 and 3.</p>
+			</div>
+			<div>
+				<Label for="edit-erasure-code">Erasure Coding</Label>
+				<select id="edit-erasure-code" bind:value={editErasureCode} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+					<option value="inherit">Inherit ({storagePolicySv && storagePolicyFor(storagePolicySv).configuredInheritedErasureCode ? 'enabled' : 'disabled'})</option>
+					<option value="enabled">Enabled</option>
+					<option value="disabled">Disabled</option>
+				</select>
+				<p class="mt-1 text-xs text-muted-foreground">Existing data is reconciled in the background after the policy changes.</p>
+			</div>
+			{#if invalidErasureCodePolicy}
+				<p class="text-sm text-amber-500">Erasure coding requires 2 or 3 data replicas.</p>
+			{/if}
+		</div>
+		<Dialog.Footer>
+			<Button variant="secondary" onclick={() => storagePolicySv = null}>Cancel</Button>
+			<Button onclick={saveStoragePolicy} disabled={invalidErasureCodePolicy}>Save Policy</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
## Summary
- let operators change data replicas and erasure coding on existing subvolumes
- distinguish explicit overrides, parent inheritance, and operationally effective bcachefs values
- add separate Inherit and None compression choices for new and existing subvolumes
- validate EC replica combinations, serialize concurrent updates, and roll replicas back if applying EC fails

## Testing
- `cargo test --manifest-path engine/Cargo.toml -p nasty-storage` (134 tests)
- `cargo test --manifest-path engine/Cargo.toml -p nasty-engine registry` (28 tests)
- `cargo check --manifest-path engine/Cargo.toml -p nasty-engine`
- `npm test` (218 tests)
- `npm run check`
- `npm run build`
- `cargo fmt --manifest-path engine/Cargo.toml --all -- --check`

Closes #731