### PR TITLE
smart: allow passthrough monitoring in VMs

### DIFF
--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -233,12 +233,24 @@ impl ProtocolService {
         let state = load_state().await;
 
         for &proto in Protocol::ALL {
-            if !state.get(proto) || excluded.contains(&proto) {
+            let enabled = state.get(proto);
+            if !enabled || excluded.contains(&proto) {
                 if excluded.contains(&proto) {
                     warn!(
                         "Skipping {} restore because its persisted backing state is unsafe",
                         proto.display_name()
                     );
+                }
+
+                // smartd used to be pulled in directly by multi-user.target.
+                // Stop an old-generation instance during a live upgrade when
+                // the persisted protocol preference says SMART is disabled.
+                if !enabled && proto == Protocol::Smart {
+                    for svc in proto.services() {
+                        if let Err(e) = systemctl("stop", svc).await {
+                            warn!("Failed to stop disabled {svc}: {e}");
+                        }
+                    }
                 }
                 continue;
             }
@@ -602,8 +614,9 @@ async fn load_state() -> ProtocolState {
             }
         },
         Err(_) => {
-            // Fresh install: disable SMART by default on VMs since smartd
-            // cannot find SMART-capable drives in virtual environments.
+            // Fresh install: disable SMART by default on VMs because virtual
+            // disks usually do not expose it. Operators with passed-through
+            // disks or controllers can explicitly enable monitoring.
             // Persist immediately — this function is called on every
             // protocol-status refresh, so without persistence the file
             // never appears, and the VM detection (plus its info!) runs

--- a/nixos/appliance-base.nix
+++ b/nixos/appliance-base.nix
@@ -159,7 +159,9 @@
     };
   };
 
-  # Enable SMART monitoring; skip silently on VMs (no SMART-capable devices)
+  # Define smartd, but let the engine own its lifecycle from protocols.json.
+  # Most VMs leave SMART disabled by default; VMs with passed-through disks or
+  # controllers can opt in and start the same service as physical appliances.
   services.smartd.enable = true;
   # smartd's default `-a` tracks attribute changes by *normalized* value, so
   # Temperature_Celsius (194) and Airflow_Temperature_Cel (190) hit the journal
@@ -174,7 +176,7 @@
   # which would *trigger* a journal line on every raw change, i.e. spam one
   # entry per 1 °C of drift.
   services.smartd.defaults.monitored = "-a -r 194 -r 190";
-  systemd.services.smartd.unitConfig.ConditionVirtualization = "no";
+  systemd.services.smartd.wantedBy = lib.mkForce [ ];
 
   # VM guest tools — QEMU/KVM half (always-on, effectively free).
   #

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -130,6 +130,11 @@ let
         # The test disk is still unformatted at this point.
         assert fs_list == [], f"fs.list expected empty, got {fs_list!r}"
 
+        smart = call(ws, "service.protocol.enable", 20, {"name": "smart"})
+        assert smart["enabled"] is True and smart["running"] is True, smart
+        smart = call(ws, "service.protocol.disable", 21, {"name": "smart"})
+        assert smart["enabled"] is False and smart["running"] is False, smart
+
         # Apps require their Docker data root on a managed bcachefs pool.
         # Create one through the public RPC so the later apps smoke exercises
         # the same supported setup path as a real appliance.
@@ -340,6 +345,14 @@ pkgs.testers.runNixOSTest {
     services.timesyncd.enable = lib.mkForce false;
     services.openssh.enable = true;
     services.avahi.enable = true;
+    services.smartd.enable = true;
+    systemd.services.smartd.wantedBy = lib.mkForce [ ];
+    # The VM's synthetic disk has no SMART support. Use a deterministic
+    # long-running stand-in so the test can exercise protocol lifecycle.
+    systemd.services.smartd.serviceConfig = {
+      Type = lib.mkForce "simple";
+      ExecStart = lib.mkForce "${pkgs.coreutils}/bin/sleep infinity";
+    };
 
     # The rpc-smoke script needs websocket-client at runtime in the guest.
     environment.systemPackages = [ pythonWithWs ];
@@ -367,11 +380,21 @@ pkgs.testers.runNixOSTest {
         f"baseline does not block DNAT forwarding: {baseline}"
     )
     assert "dport 443" not in baseline, f"baseline unexpectedly exposes WebUI: {baseline}"
+    machine.succeed("systemctl start smartd.service")
+    machine.wait_for_unit("smartd.service")
     machine.succeed(
         "systemctl start nasty-engine.service sshd.service avahi-daemon.service"
     )
     machine.wait_for_unit("nasty-engine.service")
     machine.wait_for_unit("sshd.service")
+
+    # SMART stays opt-in on ordinary VMs, but the unit must remain startable
+    # for guests with passed-through disks or controllers (#734).
+    machine.succeed("test ! -e /etc/systemd/system/multi-user.target.wants/smartd.service")
+    machine.fail("systemctl cat smartd.service | grep -q '^ConditionVirtualization='")
+    machine.fail("systemctl is-active --quiet smartd.service")
+    protocols = json.loads(machine.succeed("cat /var/lib/nasty/protocols.json"))
+    assert protocols["smart"] is False, protocols
     machine.wait_for_unit("avahi-daemon.service")
 
     dynamic_firewall = machine.succeed("nft list table inet nasty")

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -344,8 +344,8 @@
 	<!-- SMART Health tab -->
 	{:else if activeTab === 'smart'}
 		{#if isVirtual}
-			<p class="text-sm text-muted-foreground">SMART monitoring is not available on virtual machines.</p>
-		{:else}
+			<p class="mb-4 text-sm text-muted-foreground">Virtual disks usually do not expose SMART data. Monitoring can still work for disks or controllers passed through from the host.</p>
+		{/if}
 		<div class="mb-4 flex items-center gap-4">
 			{#if smartProtocol}
 				<Badge variant={smartProtocol.enabled ? 'default' : 'secondary'}>
@@ -726,7 +726,6 @@
 				</Card>
 			{/each}
 		{/if}
-		{/if}
 
 	<!-- Topology tab -->
 	{:else if activeTab === 'topology'}
@@ -825,7 +824,7 @@
 						{/each}
 					</tbody>
 				</table>
-				{#if !smartProtocol?.enabled && !isVirtual}
+				{#if !smartProtocol?.enabled}
 					<p class="mt-3 text-xs text-muted-foreground">Enable SMART monitoring for detailed topology with controller, model, serial, and health info.</p>
 				{/if}
 			{/if}


### PR DESCRIPTION
## Summary
- keep SMART disabled by default on ordinary VMs while allowing explicit opt-in for passed-through disks and controllers
- make the engine the sole owner of the smartd lifecycle and stop old-generation smartd instances when SMART is persisted disabled
- replace the WebUI VM prohibition with passthrough guidance and expose the existing SMART controls
- cover VM default-off, restore-time cleanup, and protocol enable/disable in the appliance smoke test

## Testing
- `cargo test --manifest-path engine/Cargo.toml -p nasty-system` (398 tests)
- `cargo test --manifest-path engine/Cargo.toml -p nasty-metrics` (34 tests)
- `npm test -- --run` (218 tests)
- `npm run check`
- `npm run build`
- `cargo fmt --manifest-path engine/Cargo.toml --all -- --check`
- Nix evaluation confirms smartd has no `wantedBy` target or virtualization condition
- appliance smoke expression parses locally; the x86_64-linux VM runs in integration CI

Closes #734