### PR TITLE
engine: prioritize control plane over bulk work

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2920,6 +2920,7 @@ name = "nasty-common"
 version = "0.0.15"
 dependencies = [
  "base64 0.22.1",
+ "libc",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -5014,7 +5014,11 @@ impl AppsService {
                 })?;
         }
         let owner = format!("{}:{}", req.uid, req.gid);
-        let mut cmd = Command::new("chown");
+        let mut cmd = if req.recursive {
+            nasty_common::priority::bulk_command("chown")
+        } else {
+            Command::new("chown")
+        };
         if req.recursive {
             cmd.arg("-R");
         }
@@ -5733,6 +5737,20 @@ async fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), AppsError> {
     Ok(())
 }
 
+async fn run_bulk_cmd(cmd: &str, args: &[&str]) -> Result<(), AppsError> {
+    let output = nasty_common::priority::bulk_command(cmd)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| AppsError::CommandFailed(format!("{cmd}: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AppsError::CommandFailed(format!("{cmd}: {stderr}")));
+    }
+    Ok(())
+}
+
 /// Probe a running container for an available shell.
 /// Returns None if the container has no shell (scratch/distroless images).
 async fn find_container_shell(container: &str) -> Option<&'static str> {
@@ -6155,7 +6173,7 @@ async fn run_appdata_relocation(
     }
     // `cp -a` preserves ownership/modes/xattrs — container uids must
     // survive the move or every app hits permission errors on restart.
-    if let Err(e) = run_cmd("cp", &["-a", &format!("{current}/."), &target_path]).await {
+    if let Err(e) = run_bulk_cmd("cp", &["-a", &format!("{current}/."), &target_path]).await {
         // Drop the partial copy so a retry doesn't hit the no-merge guard.
         let _ = run_cmd("bcachefs", &["subvolume", "delete", &target_path]).await;
         fail(&status, &stopped, format!("copy failed: {e}")).await;

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -152,7 +152,7 @@ pub enum BackupTarget {
 /// file we materialize from `profile.trusted_cacert`). Ready to be
 /// combined with the target shape to build rustic-compatible backend
 /// options. Decryption + cacert file writes are async; target
-/// construction must run sync inside `spawn_blocking`, so we resolve
+/// construction must run synchronously on a bulk worker, so we resolve
 /// once outside and pass this struct in.
 #[derive(Debug, Default)]
 struct ResolvedTargetSecrets {
@@ -164,7 +164,7 @@ struct ResolvedTargetSecrets {
     rest_password: Option<String>,
     /// Absolute path of a PEM file containing the operator-supplied
     /// trusted CA cert (`profile.trusted_cacert`). Materialized by
-    /// [`BackupProfile::resolve_runtime`] before the spawn_blocking
+    /// [`BackupProfile::resolve_runtime`] before the bulk-worker
     /// boundary so the sync `to_backend_options` only needs to pass
     /// the path through to rustic_backend's `cacert` option.
     cacert_path: Option<String>,
@@ -587,7 +587,7 @@ impl BackupProfile {
     /// Resolve secrets AND materialize the runtime cacert file (if
     /// the profile has one). Single async entry point that the
     /// init/run/check/snapshots/prune paths call before the
-    /// `spawn_blocking` boundary.
+    /// bulk-worker boundary.
     async fn resolve_runtime(&self) -> Result<ResolvedTargetSecrets, BackupError> {
         let mut resolved = self.target.resolve_secrets(&self.id).await?;
         if let Some(pem) = self
@@ -811,7 +811,7 @@ fn invalidate_last_run_if_definition_changed(update: &mut BackupProfile, existin
 /// to have already resolved target-side secrets via
 /// `target.resolve_secrets(profile_id).await` and passed them in —
 /// rustic's Repository construction is sync, so the decryption has to
-/// happen outside this function before `spawn_blocking`.
+/// happen outside this function before entering the bulk worker.
 fn make_repo(
     profile: &BackupProfile,
     resolved: &ResolvedTargetSecrets,
@@ -1215,7 +1215,7 @@ impl BackupService {
         let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.resolve_runtime().await?;
-        tokio::task::spawn_blocking(move || {
+        nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo(&profile, &resolved)?;
             repo.init(
                 &creds(&password),
@@ -1258,7 +1258,7 @@ impl BackupService {
 
         let run_profile = profile.clone();
         let sources = profile.sources.clone();
-        let backup_result = tokio::task::spawn_blocking(move || {
+        let backup_result = nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo(&profile, &resolved)?;
             let repo = repo
                 .open(&creds(&password))
@@ -1282,10 +1282,11 @@ impl BackupService {
                 result.summary.as_ref().map(|s| s.files_changed),
             ))
         })
-        .await
-        .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?;
+        .await;
 
         *self.running.lock().await = None;
+        let backup_result =
+            backup_result.map_err(|e| BackupError::Failed(format!("spawn: {e}")))?;
         let duration = start.elapsed().as_secs();
 
         let result = match backup_result {
@@ -1342,7 +1343,7 @@ impl BackupService {
         let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.resolve_runtime().await?;
-        tokio::task::spawn_blocking(move || {
+        nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo(&profile, &resolved)?;
             let repo = repo
                 .open(&creds(&password))
@@ -1383,7 +1384,7 @@ impl BackupService {
         let snapshot_id = snapshot_id.to_string();
         let dest_str = dest.to_string_lossy().to_string();
 
-        tokio::task::spawn_blocking(move || {
+        nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo_with_progress(&profile, &resolved, progress)?;
             let repo = repo
                 .open(&creds(&password))
@@ -1442,7 +1443,7 @@ impl BackupService {
         let resolved = profile.resolve_runtime().await?;
         let r = profile.retention.clone();
 
-        tokio::task::spawn_blocking(move || {
+        nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo(&profile, &resolved)?;
             let repo = repo
                 .open(&creds(&password))
@@ -1492,7 +1493,7 @@ impl BackupService {
         let profile = self.get_profile_internal(id).await?;
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.resolve_runtime().await?;
-        tokio::task::spawn_blocking(move || {
+        nasty_common::priority::spawn_bulk(move || {
             let repo = make_repo(&profile, &resolved)?;
             let repo = repo
                 .open(&creds(&password))

--- a/engine/nasty-common/Cargo.toml
+++ b/engine/nasty-common/Cargo.toml
@@ -14,6 +14,7 @@ tracing.workspace = true
 uuid.workspace = true
 schemars.workspace = true
 base64.workspace = true
+libc.workspace = true
 tempfile = "3"
 
 [dev-dependencies]

--- a/engine/nasty-common/src/lib.rs
+++ b/engine/nasty-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod block_volume;
 pub mod cmd;
 pub mod jsonrpc;
 pub mod metrics_types;
+pub mod priority;
 pub mod secrets;
 pub mod secure_boot;
 pub mod state;

--- a/engine/nasty-common/src/priority.rs
+++ b/engine/nasty-common/src/priority.rs
@@ -1,0 +1,169 @@
+//! Scheduling helpers that keep bulk work below the engine control plane.
+
+use tokio::process::Command;
+
+#[cfg(target_os = "linux")]
+const BULK_NICE: i32 = 10;
+const MAX_BULK_WORKERS: usize = 4;
+static BULK_WORKERS: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(MAX_BULK_WORKERS);
+#[cfg(target_os = "linux")]
+const IOPRIO_WHO_PROCESS: libc::c_int = 1;
+#[cfg(target_os = "linux")]
+const IOPRIO_CLASS_SHIFT: libc::c_int = 13;
+#[cfg(target_os = "linux")]
+const IOPRIO_CLASS_BE: libc::c_int = 2;
+#[cfg(target_os = "linux")]
+const BULK_IO_PRIORITY: libc::c_int = 7;
+
+/// Properties for bulk work launched as a transient systemd service.
+pub const BULK_SYSTEMD_PROPERTIES: [&str; 3] = [
+    "--property=Nice=10",
+    "--property=IOSchedulingClass=best-effort",
+    "--property=IOSchedulingPriority=7",
+];
+
+/// Build a subprocess command that runs at low CPU and best-effort-low IO
+/// priority. On non-Linux development hosts this is a normal command.
+pub fn bulk_command(program: &str) -> Command {
+    let command = Command::new(program);
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+        let mut command = command;
+
+        // Runs in the child after fork and before exec. Only async-signal-safe
+        // syscalls are used here.
+        unsafe {
+            command
+                .as_std_mut()
+                .pre_exec(set_current_thread_bulk_priority);
+        }
+        return command;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        command
+    }
+}
+
+/// Run in-process bulk work on a dedicated OS thread. A dedicated thread is
+/// intentional: lowering a Tokio blocking-pool thread would affect unrelated
+/// control-plane work when that reusable thread handles its next task.
+pub async fn spawn_bulk<T, F>(work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let permit = BULK_WORKERS
+        .acquire()
+        .await
+        .map_err(|_| "bulk worker queue closed".to_string())?;
+    spawn_bulk_inner(work, Some(permit)).await
+}
+
+/// Run bulk work outside the shared queue when the caller already owns a
+/// separate concurrency permit for the full lifetime of the work.
+pub async fn spawn_bounded_bulk<T, F>(work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    spawn_bulk_inner(work, None).await
+}
+
+async fn spawn_bulk_inner<T, F>(
+    work: F,
+    permit: Option<tokio::sync::SemaphorePermit<'static>>,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("nasty-bulk-worker".into())
+        .spawn(move || {
+            let _permit = permit;
+            #[cfg(target_os = "linux")]
+            if let Err(error) = set_current_thread_bulk_priority() {
+                let _ = tx.send(Err(format!("set bulk worker priority: {error}")));
+                return;
+            }
+            let _ = tx.send(Ok(work()));
+        })
+        .map_err(|error| format!("spawn bulk worker: {error}"))?;
+    rx.await
+        .map_err(|_| "bulk worker exited without a result".to_string())?
+}
+
+#[cfg(target_os = "linux")]
+fn set_current_thread_bulk_priority() -> std::io::Result<()> {
+    if unsafe { libc::setpriority(libc::PRIO_PROCESS, 0, BULK_NICE) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let ioprio = (IOPRIO_CLASS_BE << IOPRIO_CLASS_SHIFT) | BULK_IO_PRIORITY;
+    if unsafe { libc::syscall(libc::SYS_ioprio_set, IOPRIO_WHO_PROCESS, 0, ioprio) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bulk_worker_returns_result() {
+        assert_eq!(spawn_bulk(|| 42).await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn bulk_command_executes_child() {
+        let status = bulk_command("true").status().await.unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn bulk_worker_limit_is_bounded() {
+        assert_eq!(MAX_BULK_WORKERS, 4);
+    }
+
+    #[test]
+    fn transient_service_properties_match_bulk_process_priorities() {
+        assert_eq!(
+            BULK_SYSTEMD_PROPERTIES,
+            [
+                "--property=Nice=10",
+                "--property=IOSchedulingClass=best-effort",
+                "--property=IOSchedulingPriority=7",
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn bulk_command_has_expected_linux_nice_value() {
+        let output = bulk_command("sh")
+            .args(["-c", "ps -o ni= -p $$"])
+            .output()
+            .await
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "10");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn bulk_worker_has_expected_linux_priorities() {
+        let (nice, ioprio) = spawn_bulk(|| {
+            let nice = unsafe { libc::getpriority(libc::PRIO_PROCESS, 0) };
+            let ioprio = unsafe { libc::syscall(libc::SYS_ioprio_get, IOPRIO_WHO_PROCESS, 0) };
+            (nice, ioprio as libc::c_int)
+        })
+        .await
+        .unwrap();
+        assert_eq!(nice, BULK_NICE);
+        assert_eq!(ioprio >> IOPRIO_CLASS_SHIFT, IOPRIO_CLASS_BE);
+        assert_eq!(ioprio & ((1 << IOPRIO_CLASS_SHIFT) - 1), BULK_IO_PRIORITY);
+    }
+}

--- a/engine/nasty-common/src/priority.rs
+++ b/engine/nasty-common/src/priority.rs
@@ -38,7 +38,7 @@ pub fn bulk_command(program: &str) -> Command {
                 .as_std_mut()
                 .pre_exec(set_current_thread_bulk_priority);
         }
-        return command;
+        command
     }
     #[cfg(not(target_os = "linux"))]
     {

--- a/engine/nasty-engine/src/guestshare.rs
+++ b/engine/nasty-engine/src/guestshare.rs
@@ -295,19 +295,26 @@ impl OpenedGuestArchive {
         let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let producer_cancelled = Arc::clone(&cancelled);
         let runtime = tokio::runtime::Handle::current();
-        tokio::task::spawn_blocking(move || {
-            let result = runtime.block_on(tokio::time::timeout(
-                std::time::Duration::from_secs(MAX_ARCHIVE_DURATION_SECS),
-                write_share_zip(writer, self.roots, self.permit, producer_cancelled),
-            ));
+        tokio::spawn(async move {
+            let result = nasty_common::priority::spawn_bounded_bulk(move || {
+                runtime.block_on(async {
+                    tokio::time::timeout(
+                        std::time::Duration::from_secs(MAX_ARCHIVE_DURATION_SECS),
+                        write_share_zip(writer, self.roots, self.permit, producer_cancelled),
+                    )
+                    .await
+                })
+            })
+            .await;
             match result {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(error))) => {
                     // The client gets a truncated archive; nothing else we can
                     // do once the response body has started streaming.
                     tracing::warn!("guest share zip stream aborted: {error}");
                 }
-                Err(_) => tracing::warn!("guest share zip stream reached its time limit"),
+                Ok(Err(_)) => tracing::warn!("guest share zip stream reached its time limit"),
+                Err(error) => tracing::warn!("guest share zip worker failed: {error}"),
             }
         });
         GuestArchiveReader { reader, cancelled }
@@ -361,7 +368,6 @@ async fn write_share_zip(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use async_zip::{Compression, ZipEntryBuilder};
     use futures_util::io::AsyncReadExt;
-    use tokio_util::compat::TokioAsyncReadCompatExt;
 
     let mut zip = async_zip::tokio::write::ZipFileWriter::with_tokio(writer);
     let mut entry_count = 0usize;
@@ -404,7 +410,9 @@ async fn write_share_zip(
                         .ok_or_else(|| archive_limit("archive byte limit exceeded"))?;
                     let builder = ZipEntryBuilder::new(name.into(), Compression::Deflate);
                     let mut entry = zip.write_entry_stream(builder).await?;
-                    let mut file = tokio::fs::File::from_std(file).compat().take(size);
+                    // The archive worker is already a dedicated demoted thread;
+                    // keep reads there instead of Tokio's control-plane pool.
+                    let mut file = futures_util::io::AllowStdIo::new(file).take(size);
                     futures_util::io::copy(&mut file, &mut entry).await?;
                     entry.close().await?;
                 }

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -1646,7 +1646,7 @@ async fn files_size_handler(
     // sizes the browser already shows. `du` doesn't follow symlinks, `safe_path`
     // confined `dir` to FILES_ROOT, and `--` guards the canonical path from being
     // read as an option. Timeout-bounded so a huge tree can't wedge the request.
-    let du = tokio::process::Command::new("du")
+    let du = nasty_common::priority::bulk_command("du")
         .arg("-sb")
         .arg("--")
         .arg(dir.as_os_str())
@@ -2719,10 +2719,7 @@ async fn files_copy_handler(
     let result = if from_meta.is_dir() {
         copy_dir_recursive(&from, &to).await
     } else {
-        tokio::fs::copy(&from, &to)
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+        copy_file(&from, &to).await
     };
 
     match result {
@@ -2768,38 +2765,49 @@ async fn files_copy_handler(
 /// is treated by users as "new copy made now," not "snapshot of
 /// the original at this point in time."
 async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    let src = src.to_path_buf();
+    let dst = dst.to_path_buf();
+    nasty_common::priority::spawn_bulk(move || copy_dir_recursive_sync(&src, &dst))
+        .await
+        .map_err(|error| format!("spawn bulk copy worker: {error}"))?
+}
+
+async fn copy_file(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    let src = src.to_path_buf();
+    let dst = dst.to_path_buf();
+    nasty_common::priority::spawn_bulk(move || {
+        std::fs::copy(&src, &dst)
+            .map(|_| ())
+            .map_err(|error| format!("copy {} -> {}: {error}", src.display(), dst.display()))
+    })
+    .await
+    .map_err(|error| format!("spawn bulk copy worker: {error}"))?
+}
+
+fn copy_dir_recursive_sync(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
     // (current source path, current destination path) tuples.
     let mut stack: Vec<(std::path::PathBuf, std::path::PathBuf)> =
         vec![(src.to_path_buf(), dst.to_path_buf())];
     while let Some((src_dir, dst_dir)) = stack.pop() {
-        tokio::fs::create_dir(&dst_dir)
-            .await
-            .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?;
-        let mut entries = tokio::fs::read_dir(&src_dir)
-            .await
+        std::fs::create_dir(&dst_dir).map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?;
+        let entries = std::fs::read_dir(&src_dir)
             .map_err(|e| format!("read_dir {}: {e}", src_dir.display()))?;
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?
-        {
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?;
             let entry_src = entry.path();
             let entry_dst = dst_dir.join(entry.file_name());
             let meta = entry
                 .metadata()
-                .await
                 .map_err(|e| format!("metadata {}: {e}", entry_src.display()))?;
             if meta.is_dir() {
                 stack.push((entry_src, entry_dst));
             } else if meta.file_type().is_symlink() {
-                let target = tokio::fs::read_link(&entry_src)
-                    .await
+                let target = std::fs::read_link(&entry_src)
                     .map_err(|e| format!("read_link {}: {e}", entry_src.display()))?;
-                tokio::fs::symlink(&target, &entry_dst)
-                    .await
+                std::os::unix::fs::symlink(&target, &entry_dst)
                     .map_err(|e| format!("symlink {}: {e}", entry_dst.display()))?;
             } else {
-                tokio::fs::copy(&entry_src, &entry_dst).await.map_err(|e| {
+                std::fs::copy(&entry_src, &entry_dst).map_err(|e| {
                     format!(
                         "copy {} -> {}: {e}",
                         entry_src.display(),
@@ -2849,14 +2857,12 @@ fn derive_restore_dest(rel: &str) -> Result<String, String> {
 
 /// Remove whatever currently exists at `p` (file, symlink, or directory)
 /// so a restore can overwrite it. No-op when `p` doesn't exist.
-async fn remove_existing(p: &std::path::Path) -> Result<(), String> {
-    match tokio::fs::symlink_metadata(p).await {
-        Ok(m) if m.is_dir() => tokio::fs::remove_dir_all(p)
-            .await
-            .map_err(|e| format!("rm -r {}: {e}", p.display())),
-        Ok(_) => tokio::fs::remove_file(p)
-            .await
-            .map_err(|e| format!("rm {}: {e}", p.display())),
+fn remove_existing(p: &std::path::Path) -> Result<(), String> {
+    match std::fs::symlink_metadata(p) {
+        Ok(m) if m.is_dir() => {
+            std::fs::remove_dir_all(p).map_err(|e| format!("rm -r {}: {e}", p.display()))
+        }
+        Ok(_) => std::fs::remove_file(p).map_err(|e| format!("rm {}: {e}", p.display())),
         Err(_) => Ok(()),
     }
 }
@@ -2867,40 +2873,41 @@ async fn remove_existing(p: &std::path::Path) -> Result<(), String> {
 /// in the live tree but not the snapshot are left untouched (additive —
 /// no `--delete`).
 async fn restore_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    let src = src.to_path_buf();
+    let dst = dst.to_path_buf();
+    nasty_common::priority::spawn_bulk(move || restore_dir_recursive_sync(&src, &dst))
+        .await
+        .map_err(|error| format!("spawn bulk restore worker: {error}"))?
+}
+
+fn restore_dir_recursive_sync(src: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
     let mut stack: Vec<(std::path::PathBuf, std::path::PathBuf)> =
         vec![(src.to_path_buf(), dst.to_path_buf())];
     while let Some((src_dir, dst_dir)) = stack.pop() {
-        match tokio::fs::symlink_metadata(&dst_dir).await {
+        match std::fs::symlink_metadata(&dst_dir) {
             Ok(m) if m.is_dir() => {} // merge into the existing directory
             Ok(_) => {
                 // A non-directory is in the way — replace it with a dir.
-                remove_existing(&dst_dir).await?;
-                tokio::fs::create_dir(&dst_dir)
-                    .await
+                remove_existing(&dst_dir)?;
+                std::fs::create_dir(&dst_dir)
                     .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?;
             }
-            Err(_) => tokio::fs::create_dir_all(&dst_dir)
-                .await
+            Err(_) => std::fs::create_dir_all(&dst_dir)
                 .map_err(|e| format!("mkdir {}: {e}", dst_dir.display()))?,
         }
-        let mut entries = tokio::fs::read_dir(&src_dir)
-            .await
+        let entries = std::fs::read_dir(&src_dir)
             .map_err(|e| format!("read_dir {}: {e}", src_dir.display()))?;
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?
-        {
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("next_entry {}: {e}", src_dir.display()))?;
             let entry_src = entry.path();
             let entry_dst = dst_dir.join(entry.file_name());
             let meta = entry
                 .metadata()
-                .await
                 .map_err(|e| format!("metadata {}: {e}", entry_src.display()))?;
             if meta.is_dir() {
                 stack.push((entry_src, entry_dst));
             } else {
-                restore_leaf(&entry_src, &entry_dst, &meta).await?;
+                restore_leaf_sync(&entry_src, &entry_dst, &meta)?;
             }
         }
     }
@@ -2914,24 +2921,34 @@ async fn restore_leaf(
     dst: &std::path::Path,
     meta: &std::fs::Metadata,
 ) -> Result<(), String> {
+    let src = src.to_path_buf();
+    let dst = dst.to_path_buf();
+    let meta = meta.clone();
+    nasty_common::priority::spawn_bulk(move || restore_leaf_sync(&src, &dst, &meta))
+        .await
+        .map_err(|error| format!("spawn bulk restore worker: {error}"))?
+}
+
+fn restore_leaf_sync(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    meta: &std::fs::Metadata,
+) -> Result<(), String> {
     if meta.file_type().is_symlink() {
-        remove_existing(dst).await?;
-        let target = tokio::fs::read_link(src)
-            .await
-            .map_err(|e| format!("read_link {}: {e}", src.display()))?;
-        tokio::fs::symlink(&target, dst)
-            .await
+        remove_existing(dst)?;
+        let target =
+            std::fs::read_link(src).map_err(|e| format!("read_link {}: {e}", src.display()))?;
+        std::os::unix::fs::symlink(&target, dst)
             .map_err(|e| format!("symlink {}: {e}", dst.display()))
     } else {
-        // `tokio::fs::copy` overwrites a regular file, but not a dir/symlink
+        // `std::fs::copy` overwrites a regular file, but not a dir/symlink
         // sitting at the destination — clear those first.
-        if let Ok(m) = tokio::fs::symlink_metadata(dst).await
+        if let Ok(m) = std::fs::symlink_metadata(dst)
             && (m.is_dir() || m.file_type().is_symlink())
         {
-            remove_existing(dst).await?;
+            remove_existing(dst)?;
         }
-        tokio::fs::copy(src, dst)
-            .await
+        std::fs::copy(src, dst)
             .map(|_| ())
             .map_err(|e| format!("copy {} -> {}: {e}", src.display(), dst.display()))
     }

--- a/engine/nasty-engine/src/terminal.rs
+++ b/engine/nasty-engine/src/terminal.rs
@@ -93,15 +93,20 @@ async fn handle_terminal(
         }
     };
 
-    let mut cmd = if let Some(ref argv) = auth.cmd {
-        let mut c = CommandBuilder::new(&argv[0]);
-        c.args(&argv[1..]);
-        c
+    // Terminal sessions can launch arbitrary sustained work. Demote the shell
+    // before exec so those processes cannot inherit the engine's priority.
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.args([
+        "-c",
+        "env -u POSIXLY_CORRECT renice -n 10 -p $$ >/dev/null && \
+         ionice -c2 -n7 -p $$ && exec \"$@\"",
+        "nasty-terminal",
+    ]);
+    if let Some(ref argv) = auth.cmd {
+        cmd.args(argv);
     } else {
-        let mut c = CommandBuilder::new("bash");
-        c.args(["--rcfile", "/etc/nasty/terminal-rc"]);
-        c
-    };
+        cmd.args(["bash", "--rcfile", "/etc/nasty/terminal-rc"]);
+    }
     cmd.env("TERM", "xterm-256color");
     cmd.env("HOME", "/root");
     // Marker for any in-PTY script to detect "this shell is hosted

--- a/engine/nasty-engine/src/vm_disk_import.rs
+++ b/engine/nasty-engine/src/vm_disk_import.rs
@@ -438,7 +438,7 @@ async fn decompress_to_tmp(
     // stdin: the source file; stdout: the tmp file. Using -dc keeps
     // the original around so the user's upload isn't consumed.
     let tmp_file = std::fs::File::create(&tmp).map_err(|e| format!("create tmp: {e}"))?;
-    let mut child = Command::new(bin)
+    let mut child = nasty_common::priority::bulk_command(bin)
         .args(["-dc"])
         .arg(source)
         .stdout(std::process::Stdio::from(tmp_file))
@@ -683,7 +683,7 @@ async fn qemu_img_info(path: &Path) -> Result<ImageInfo, String> {
 /// by `\r` (in-place updates) — we read raw bytes and split on either
 /// `\r` or `\n` so each progress tick gets surfaced.
 async fn run_convert(socket: &mut WebSocket, input: &Path, output_dev: &str) -> Result<(), String> {
-    let mut child = Command::new("qemu-img")
+    let mut child = nasty_common::priority::bulk_command("qemu-img")
         .args(["convert", "-p", "-O", "raw"])
         .arg(input)
         .arg(output_dev)

--- a/engine/nasty-storage/src/cmd.rs
+++ b/engine/nasty-storage/src/cmd.rs
@@ -10,6 +10,15 @@ pub async fn run(program: &str, args: &[&str]) -> std::io::Result<Output> {
     Command::new(program).args(args).output().await
 }
 
+/// Execute a CPU/IO-heavy command below control-plane priority.
+pub async fn run_bulk(program: &str, args: &[&str]) -> std::io::Result<Output> {
+    debug!("exec (bulk): {} {}", program, args.join(" "));
+    nasty_common::priority::bulk_command(program)
+        .args(args)
+        .output()
+        .await
+}
+
 /// Execute a command with data piped to stdin.
 pub async fn run_stdin(program: &str, args: &[&str], stdin_data: &[u8]) -> std::io::Result<Output> {
     debug!("exec (stdin): {} {}", program, args.join(" "));
@@ -49,6 +58,20 @@ pub async fn run_ok_stdin(
 /// Execute a command, returning stdout as String on success or an error message on failure.
 pub async fn run_ok(program: &str, args: &[&str]) -> Result<String, String> {
     let output = run(program, args)
+        .await
+        .map_err(|e| format!("failed to execute {program}: {e}"))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("{program} exited with {}: {stderr}", output.status))
+    }
+}
+
+/// Execute a bulk command, returning stdout on success or stderr on failure.
+pub async fn run_ok_bulk(program: &str, args: &[&str]) -> Result<String, String> {
+    let output = run_bulk(program, args)
         .await
         .map_err(|e| format!("failed to execute {program}: {e}"))?;
 

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -3784,7 +3784,7 @@ impl FilesystemService {
         }
         args.push(&req.device);
         args.push(mount_point);
-        cmd::run_ok("bcachefs", &args)
+        cmd::run_ok_bulk("bcachefs", &args)
             .await
             .map_err(FilesystemError::CommandFailed)?;
 
@@ -3835,7 +3835,7 @@ impl FilesystemService {
         // Spawn evacuation in background — this can take hours for large devices.
         // bcachefs sets the device state to "evacuating" automatically.
         tokio::spawn(async move {
-            match cmd::run_ok("bcachefs", &["device", "evacuate", &device]).await {
+            match cmd::run_ok_bulk("bcachefs", &["device", "evacuate", &device]).await {
                 Ok(_) => info!("Evacuation of {} in '{}' completed", device, fs_name),
                 Err(e) => warn!("Evacuation of {} in '{}' failed: {}", device, fs_name, e),
             }
@@ -6442,9 +6442,7 @@ async fn stream_scrub_and_collect(
     store: &ScrubStateMap,
 ) -> (ScrubOutcome, String) {
     use tokio::io::AsyncReadExt;
-    use tokio::process::Command;
-
-    let mut child = match Command::new("bcachefs")
+    let mut child = match nasty_common::priority::bulk_command("bcachefs")
         .args(["scrub", mount])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -6652,8 +6650,6 @@ async fn stream_fsck_and_collect(
     repair: bool,
 ) -> (FsckOutcome, String) {
     use tokio::io::AsyncReadExt;
-    use tokio::process::Command;
-
     // `-n` = dry run (report only, change nothing); `-y` = assume yes
     // (auto-repair). `-f` forces a full check even if the superblock
     // looks clean — without it bcachefs may skip a clean-marked fs.
@@ -6661,7 +6657,7 @@ async fn stream_fsck_and_collect(
     let mut args: Vec<&str> = vec!["fsck", mode, "-f"];
     args.extend(devices.iter().map(|d| d.as_str()));
 
-    let mut child = match Command::new("bcachefs")
+    let mut child = match nasty_common::priority::bulk_command("bcachefs")
         .args(&args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/engine/nasty-system/src/dc.rs
+++ b/engine/nasty-system/src/dc.rs
@@ -19,7 +19,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use crate::domain::{run_cmd, run_cmd_stdin};
+use crate::domain::{run_cmd, run_cmd_bulk, run_cmd_stdin};
 
 pub const DC_CONF_PATH: &str = "/etc/samba/smb.dc.conf";
 pub const DC_STATE_PATH: &str = "/var/lib/nasty/dc.json";
@@ -682,7 +682,7 @@ impl DcService {
         let resolved = validate_backup_dest(Path::new(dest), Path::new(FS_ROOT))?;
         tokio::fs::create_dir_all(&resolved).await?;
         let target = resolved.to_string_lossy().to_string();
-        samba_tool(&with_conf(vec![
+        samba_tool_bulk(&with_conf(vec![
             "domain".into(),
             "backup".into(),
             "offline".into(),
@@ -826,6 +826,11 @@ impl DcService {
 async fn samba_tool(argv: &[String]) -> Result<String, DcError> {
     let args: Vec<&str> = argv.iter().map(String::as_str).collect();
     Ok(run_cmd("samba-tool", &args, &[]).await?)
+}
+
+async fn samba_tool_bulk(argv: &[String]) -> Result<String, DcError> {
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    Ok(run_cmd_bulk("samba-tool", &args, &[]).await?)
 }
 
 /// Run samba-tool feeding `stdin_input` (the only way secrets travel).

--- a/engine/nasty-system/src/domain.rs
+++ b/engine/nasty-system/src/domain.rs
@@ -344,6 +344,24 @@ pub(crate) async fn run_cmd(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Run a long CPU/IO-heavy command below control-plane priority.
+pub(crate) async fn run_cmd_bulk(
+    program: &str,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> Result<String, DomainError> {
+    let output = nasty_common::priority::bulk_command(program)
+        .args(args)
+        .envs(envs.iter().copied())
+        .output()
+        .await
+        .map_err(|e| DomainError::CommandFailed(format!("failed to run {program}: {e}")))?;
+    if !output.status.success() {
+        return Err(command_error(program, &output));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 /// Run a command, writing `stdin_input` (plus a trailing newline) to its
 /// stdin — used to hand credentials to `net ads join`/`net ads leave`
 /// without ever putting the password in argv (visible via `/proc/*/cmdline`).

--- a/engine/nasty-system/src/guest_tools.rs
+++ b/engine/nasty-system/src/guest_tools.rs
@@ -234,6 +234,9 @@ echo "==> VM guest tools applied."
             "--property=Type=oneshot",
             "--property=StandardOutput=journal",
             "--property=StandardError=journal",
+            "--property=Nice=10",
+            "--property=IOSchedulingClass=best-effort",
+            "--property=IOSchedulingPriority=7",
             "--setenv",
         ])
         .arg(format!("PATH={path}"))

--- a/engine/nasty-system/src/secure_boot_enrollment.rs
+++ b/engine/nasty-system/src/secure_boot_enrollment.rs
@@ -412,6 +412,9 @@ impl SecureBootEnrollmentService {
                 "--collect",
                 "--no-block",
                 "--description=NASty Secure Boot enrollment rebuild",
+                "--property=Nice=10",
+                "--property=IOSchedulingClass=best-effort",
+                "--property=IOSchedulingPriority=7",
                 "/run/current-system/sw/bin/nasty-rebuild",
             ])
             .output()
@@ -525,7 +528,7 @@ async fn remove_overlay_file() -> Result<(), EnrollmentError> {
 /// `/etc/nixos/flake.lock`. Network-bound — fails when the box is
 /// offline; the caller surfaces the failure to the operator.
 async fn run_nix_flake_lock() -> Result<(), EnrollmentError> {
-    let out = Command::new("nix")
+    let out = nasty_common::priority::bulk_command("nix")
         .args([
             "--extra-experimental-features",
             "nix-command flakes",

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -395,6 +395,9 @@ SIGNAL_ROLLBACK_EOF
                     --property=Type=oneshot \
                     --property=StandardOutput=journal \
                     --property=StandardError=journal \
+                    --property=Nice=10 \
+                    --property=IOSchedulingClass=best-effort \
+                    --property=IOSchedulingPriority=7 \
                     --setenv "PATH=$PATH" \
                     --setenv "OLD_SYSTEM=$OLD_SYSTEM" \
                     --setenv "MARKER=$MARKER" \
@@ -584,6 +587,7 @@ async fn start_update_transaction(
         "--setenv",
         &format!("PATH={path}"),
     ]);
+    cmd.args(nasty_common::priority::BULK_SYSTEMD_PROPERTIES);
     if let Some(config) = nix_config.filter(|config| !config.is_empty()) {
         cmd.args(["--setenv", &format!("NIX_CONFIG={config}")]);
     }
@@ -1494,6 +1498,9 @@ impl UpdateService {
                 "--property=Type=oneshot",
                 "--property=StandardOutput=journal",
                 "--property=StandardError=journal",
+                "--property=Nice=10",
+                "--property=IOSchedulingClass=best-effort",
+                "--property=IOSchedulingPriority=7",
                 "--setenv",
                 &format!("PATH={path}"),
                 "--",
@@ -1675,6 +1682,9 @@ echo "==> Switch to generation {gen_id} complete!"
                 "--property=Type=oneshot",
                 "--property=StandardOutput=journal",
                 "--property=StandardError=journal",
+                "--property=Nice=10",
+                "--property=IOSchedulingClass=best-effort",
+                "--property=IOSchedulingPriority=7",
                 "--setenv",
                 &format!("PATH={path}"),
                 "--",
@@ -4203,6 +4213,9 @@ proc /proc proc rw 0 0\n\
         assert!(script.contains("Previous-generation activation continues in $ROLLBACK_UNIT"));
         assert!(script.contains("if $MARKER_SET && $rollback_ok && ! $detached_started; then"));
         assert!(script.contains("Recovery remains suppressed; backups are in $BACKUP"));
+        assert!(script.contains("--property=Nice=10"));
+        assert!(script.contains("--property=IOSchedulingClass=best-effort"));
+        assert!(script.contains("--property=IOSchedulingPriority=7"));
     }
 
     #[test]

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -987,7 +987,7 @@ impl VmService {
         // real error the operator sees — instead of "Started VM" for a guest
         // that never launched.
         let qemu_bin = format!("qemu-system-{}", std::env::consts::ARCH);
-        let output = Command::new(&qemu_bin)
+        let output = nasty_common::priority::bulk_command(&qemu_bin)
             .args(&args)
             .stdin(Stdio::null())
             .stdout(Stdio::null())

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -808,6 +808,9 @@ in {
 
       (writeShellScriptBin "nasty-cleanup" ''
         set -euo pipefail
+        ${pkgs.coreutils}/bin/env -u POSIXLY_CORRECT \
+          ${pkgs.util-linux}/bin/renice -n 10 -p $$ >/dev/null
+        ${pkgs.util-linux}/bin/ionice -c2 -n7 -p $$
         echo "==> Removing old NixOS generations (keeping last 3)..."
         nix-env --delete-generations +3 -p /nix/var/nix/profiles/system 2>/dev/null || true
         echo "==> Running garbage collection..."
@@ -826,6 +829,12 @@ in {
       (writeShellScriptBin "nasty-rebuild" ''
         set -euo pipefail
 
+        # Absolute priorities keep direct and already-demoted transient-unit
+        # invocations at the same level instead of applying nice twice.
+        ${pkgs.coreutils}/bin/env -u POSIXLY_CORRECT \
+          ${pkgs.util-linux}/bin/renice -n 10 -p $$ >/dev/null
+        ${pkgs.util-linux}/bin/ionice -c2 -n7 -p $$
+
         # The WebUI terminal's PTY belongs to nasty-engine. Activation stops
         # the engine, so keeping switch-to-configuration attached to that PTY
         # makes its next stderr write fail and the Rust binary panic (exit 101).
@@ -843,6 +852,9 @@ in {
             --description "NASty manual rebuild" \
             --property StandardOutput=journal \
             --property StandardError=journal \
+            --property Nice=10 \
+            --property IOSchedulingClass=best-effort \
+            --property IOSchedulingPriority=7 \
             --setenv "PATH=$PATH" \
             -- /run/current-system/sw/bin/nasty-rebuild
           echo "==> Rebuild detached from the WebUI terminal. Follow it with:"
@@ -1003,6 +1015,13 @@ in {
           sed -i -E "s#^(\s*nasty\.url\s*=\s*\")github:nasty-project/nasty/[^\"]+(\")#\1github:nasty-project/nasty/$nasty_ref\2#" /etc/nixos/flake.nix
         fi
 
+        run_bulk() (
+          ${pkgs.coreutils}/bin/env -u POSIXLY_CORRECT \
+            ${pkgs.util-linux}/bin/renice -n 10 -p $BASHPID >/dev/null
+          ${pkgs.util-linux}/bin/ionice -c2 -n7 -p $BASHPID
+          exec "$@"
+        )
+
         # Run the actual rebuild work — either inline (from a real SSH
         # session) or detached as a systemd transient unit (from the
         # WebUI terminal, so the rebuild survives the engine restart
@@ -1033,11 +1052,14 @@ in {
               --collect \
               --no-block \
               --description "nasty-sync detached rebuild" \
+              --property Nice=10 \
+              --property IOSchedulingClass=best-effort \
+              --property IOSchedulingPriority=7 \
               --setenv "PATH=$PATH" \
               -- bash -c "$script"
             echo "==> Started. Detaching."
           else
-            bash -c "$script"
+            run_bulk bash -c "$script"
           fi
         }
 
@@ -1085,7 +1107,7 @@ in {
           update)
             echo "==> Bumping nasty input to current main HEAD..."
             cd /etc/nixos
-            nix flake update nasty
+            run_bulk nix flake update nasty
             run_rebuild "set -euo pipefail; cd /etc/nixos; echo '==> Rebuilding system...'; nixos-rebuild switch --flake /etc/nixos; systemctl is-active --quiet nasty-engine || systemctl start nasty-engine; echo '==> Done.'" "nasty-sync-rebuild"
             # Inline-path bookkeeping. Detached path can't update this
             # in real time; the engine startup hook will reconcile.
@@ -1099,7 +1121,7 @@ in {
           update-with-bcachefs)
             cd /etc/nixos
             echo "==> Bumping nasty input to current main HEAD..."
-            nix flake update nasty
+            run_bulk nix flake update nasty
             # If a positional <ref> was passed, use it. Otherwise pull
             # the bcachefs ref the new nasty HEAD declares — read it
             # directly out of the freshly-fetched nasty source in the
@@ -1135,7 +1157,7 @@ in {
               exit 1
             fi
             echo "==> Re-resolving lock for bcachefs-tools..."
-            nix flake lock
+            run_bulk nix flake lock
             run_rebuild "set -euo pipefail; cd /etc/nixos; echo '==> Rebuilding system...'; nixos-rebuild switch --flake /etc/nixos; systemctl is-active --quiet nasty-engine || systemctl start nasty-engine; echo '==> Done.'" "nasty-sync-rebuild"
             if [ -z "''${NASTY_WEBUI_TERMINAL:-}" ]; then
               stamp_nasty_version
@@ -1168,7 +1190,7 @@ in {
               exit 1
             fi
             echo "==> Bumping nasty input to current main HEAD..."
-            nix flake update nasty
+            run_bulk nix flake update nasty
             run_rebuild "set -euo pipefail; cd /etc/nixos; echo '==> Rebuilding system...'; nixos-rebuild switch --flake /etc/nixos; systemctl is-active --quiet nasty-engine || systemctl start nasty-engine; echo '==> Done.'" "nasty-sync-rebuild"
             if [ -z "''${NASTY_WEBUI_TERMINAL:-}" ]; then
               stamp_nasty_version
@@ -1740,6 +1762,11 @@ in {
         Restart = "always";
         RestartSec = 5;
         StateDirectory = "nasty";
+
+        # Keep authentication, RPC dispatch, and status polling responsive
+        # during CPU-saturating migrations. Reset-on-fork also resets pthreads,
+        # including Tokio workers, so known bulk work is demoted explicitly.
+        Nice = -5;
 
         # The engine is a privileged system manager and cannot run under a
         # private mount namespace — that would hide its mounts from

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -387,6 +387,14 @@ pkgs.testers.runNixOSTest {
     )
     machine.wait_for_unit("nasty-engine.service")
     machine.wait_for_unit("sshd.service")
+    machine.succeed("test \"$(systemctl show nasty-engine.service -p Nice --value)\" = -5")
+    machine.succeed(
+        "test \"$(systemctl show nasty-engine.service -p CPUSchedulingResetOnFork --value)\" = no"
+    )
+    machine.succeed(
+        "pid=$(systemctl show nasty-engine.service -p MainPID --value); "
+        "test \"$(ps -L -o ni= -p \"$pid\" | tr -d ' ' | grep -cx -- '-5')\" -gt 1"
+    )
 
     # SMART stays opt-in on ordinary VMs, but the unit must remain startable
     # for guests with passed-through disks or controllers (#734).


### PR DESCRIPTION
## Summary

- run `nasty-engine` at nice `-5` so authentication, RPC dispatch, and status polling retain CPU priority under saturation
- explicitly demote known CPU- and IO-heavy subprocesses, terminal process trees, QEMU guests, rebuilds, maintenance work, and filesystem operations to nice `10` with best-effort IO priority `7`
- move in-process bulk work onto dedicated demoted threads behind a four-worker limit, without contaminating reusable Tokio worker threads
- add Linux priority tests and appliance smoke assertions for the service and its live worker threads

`CPUSchedulingResetOnFork` remains disabled because Linux also applies the reset to pthread creation, which would drop Tokio worker threads back to nice `0`. Bulk work is instead demoted at each known execution boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `nix-instantiate --parse nixos/modules/nasty.nix`
- `nix-instantiate --parse nixos/tests/appliance-smoke.nix`
- `git diff --check origin/main...HEAD`
- ARM64 NixOS appliance boot under QEMU TCG: engine startup and priority-specific smoke assertions passed, including multiple live engine threads at nice `-5`

## Limitations

A complete appliance smoke run under ARM64 TCG exceeded the existing 10-second WebSocket timeout after the priority assertions passed. Ordinary streaming uploads and downloads also remain on Tokio filesystem workers; isolating those streams requires a larger worker redesign and is outside this change.

The reconcile-stalled alert finding from the issue was addressed separately by #739.

Fixes #735