### PR TITLE
metrics: expose bcachefs btree cache memory

### DIFF
--- a/engine/nasty-common/src/metrics_types.rs
+++ b/engine/nasty-common/src/metrics_types.rs
@@ -67,6 +67,9 @@ pub struct MemoryStats {
     pub swap_total_bytes: u64,
     /// Swap space currently in use.
     pub swap_used_bytes: u64,
+    /// Kernel-reported bcachefs btree-node main buffers across mounted
+    /// filesystems. This is approximate and not total bcachefs RAM.
+    pub bcachefs_btree_cache_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/engine/nasty-metrics/src/collect_bcachefs.rs
+++ b/engine/nasty-metrics/src/collect_bcachefs.rs
@@ -496,6 +496,15 @@ pub fn collect_all() -> Vec<BcachefsMetrics> {
     all
 }
 
+/// Sum the kernel-reported btree-node cache across filesystems. `None` means
+/// no mounted filesystem exposed the gauge on this kernel.
+pub fn total_btree_cache_bytes(metrics: &[BcachefsMetrics]) -> Option<u64> {
+    metrics
+        .iter()
+        .filter_map(|fs| fs.background.btree_cache_size_bytes)
+        .reduce(u64::saturating_add)
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 fn read_sysfs_str(path: &Path) -> Option<String> {
@@ -523,7 +532,8 @@ fn parse_human_bytes(s: &str) -> Option<u64> {
         return Some(v);
     }
 
-    let (num_str, multiplier) = if let Some(n) = s.strip_suffix('K') {
+    let (num_str, multiplier) = if let Some(n) = s.strip_suffix('K').or_else(|| s.strip_suffix('k'))
+    {
         (n, 1024u64)
     } else if let Some(n) = s.strip_suffix('M') {
         (n, 1024 * 1024)
@@ -538,12 +548,36 @@ fn parse_human_bytes(s: &str) -> Option<u64> {
     num_str
         .parse::<f64>()
         .ok()
+        .filter(|v| v.is_finite() && *v >= 0.0)
         .map(|v| (v * multiplier as f64) as u64)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CompressionEntry, parse_bcachefs_mount_line, parse_compression_line};
+    use super::{
+        BcachefsMetrics, CompressionEntry, parse_bcachefs_mount_line, parse_compression_line,
+        parse_human_bytes, total_btree_cache_bytes,
+    };
+
+    #[test]
+    fn parses_kernel_lowercase_kibibyte_suffix() {
+        assert_eq!(parse_human_bytes("256k"), Some(256 * 1024));
+    }
+
+    #[test]
+    fn totals_available_btree_cache_gauges() {
+        let mut first = BcachefsMetrics::default();
+        first.background.btree_cache_size_bytes = Some(1024);
+        let mut second = BcachefsMetrics::default();
+        second.background.btree_cache_size_bytes = Some(2048);
+        let missing = BcachefsMetrics::default();
+
+        assert_eq!(
+            total_btree_cache_bytes(&[first, second, missing]),
+            Some(3072)
+        );
+        assert_eq!(total_btree_cache_bytes(&[]), None);
+    }
 
     #[test]
     fn parse_compression_lz4_row() {

--- a/engine/nasty-metrics/src/collect_system.rs
+++ b/engine/nasty-metrics/src/collect_system.rs
@@ -134,6 +134,7 @@ pub fn memory_stats() -> MemoryStats {
         available_bytes: available,
         swap_total_bytes: swap_total,
         swap_used_bytes: swap_total.saturating_sub(swap_free),
+        bcachefs_btree_cache_bytes: None,
     }
 }
 

--- a/engine/nasty-metrics/src/main.rs
+++ b/engine/nasty-metrics/src/main.rs
@@ -99,8 +99,10 @@ async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoRespons
 }
 
 async fn stats_handler(State(state): State<Arc<AppState>>) -> Json<SystemStats> {
-    let stats = state.stats.read().await;
-    Json(stats.clone())
+    let mut stats = state.stats.read().await.clone();
+    let bcachefs = state.bcachefs.read().await;
+    stats.memory.bcachefs_btree_cache_bytes = collect_bcachefs::total_btree_cache_bytes(&bcachefs);
+    Json(stats)
 }
 
 async fn disks_handler(State(state): State<Arc<AppState>>) -> Json<Vec<DiskHealth>> {

--- a/engine/nasty-metrics/src/prometheus.rs
+++ b/engine/nasty-metrics/src/prometheus.rs
@@ -501,7 +501,7 @@ fn render_bcachefs_background(out: &mut String, fs: &BcachefsMetrics) {
         gauge(
             out,
             "nasty_bcachefs_btree_cache_size_bytes",
-            "Btree cache memory usage",
+            "Kernel-reported btree-node main-buffer bytes; approximate and not total bcachefs memory",
             &labels,
             bytes as f64,
         );

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -1186,6 +1186,7 @@ mod tests {
                 available_bytes: 0,
                 swap_total_bytes: 0,
                 swap_used_bytes: 0,
+                bcachefs_btree_cache_bytes: None,
             },
             network: vec![],
             disk_io: vec![],

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -857,6 +857,8 @@ export interface MemoryStats {
 	available_bytes: number;
 	swap_total_bytes: number;
 	swap_used_bytes: number;
+	/** Approximate kernel-reported bcachefs btree-node buffers, not total bcachefs RAM. */
+	bcachefs_btree_cache_bytes: number | null;
 }
 
 export interface NetIfStats {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -422,6 +422,14 @@
 						Swap: {formatBytes(stats.memory.swap_used_bytes)} / {formatBytes(stats.memory.swap_total_bytes)}
 					</div>
 				{/if}
+				{#if stats.memory.bcachefs_btree_cache_bytes != null}
+					<div
+						class="mt-1.5 text-xs text-muted-foreground"
+						title="Kernel-reported btree-node main buffers across mounted bcachefs filesystems. Approximate; included node states vary by module version, and other bcachefs and VFS allocations are excluded."
+					>
+						Btree node cache: {formatBytes(stats.memory.bcachefs_btree_cache_bytes)} ({formatPercent(stats.memory.bcachefs_btree_cache_bytes, stats.memory.total_bytes)})
+					</div>
+				{/if}
 			</CardContent>
 		</Card>
 
@@ -602,5 +610,4 @@
 		{/if}
 	</div>
 {/if}
-
 


### PR DESCRIPTION
## Summary

- aggregate the existing per-filesystem `btree_cache_size` gauges into `system.stats`
- show bcachefs btree-node cache bytes and host-RAM percentage on the dashboard Memory card
- accept the lowercase `k` suffix emitted by bcachefs sysfs and reject non-finite values
- clarify the Prometheus metric description so it is not presented as total bcachefs memory

## Measurement scope

`btree_cache_size` is a kernel-reported estimate of btree-node main buffers. Included node states vary by bcachefs module version, and the value excludes other bcachefs allocations, VFS caches, slabs, and transient work buffers. The UI exposes it as a useful lower-bound component, not an ARC-equivalent total.

Companion nasty-top TUI PR: nasty-project/nasty-top#24

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `npm run check`
- `npm test -- --run`
- `npm run build`
- `git diff --check origin/main...HEAD`

Live appliance validation against populated bcachefs sysfs remains pending.