### PR TITLE
storage: manage I/O schedulers per device

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -249,6 +249,8 @@ async fn main() -> anyhow::Result<()> {
         // Ok/Failed in place, no popping-into-existence reflow.
         // Keep this list in sync with the `run_phase` calls below.
         boot_status: boot_status::BootStatusTracker::new(&[
+            "io_scheduler.migrate_legacy",
+            "io_scheduler.restore",
             "filesystems.restore_mounts",
             "subvolumes.restore_block_devices",
             "nvmeof.remap_device_paths",
@@ -278,10 +280,11 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Restore state from previous session:
-    // 1. Mount filesystems tracked in fs-state.json
-    // 2. Re-attach loop devices for block subvolumes
-    // 3. Start enabled protocols (services + kernel modules)
-    // 4. Restore NVMe-oF configfs (volatile, needs modules from step 3)
+    // 1. Migrate and restore physical-device I/O scheduler overrides
+    // 2. Mount filesystems tracked in fs-state.json
+    // 3. Re-attach loop devices for block subvolumes
+    // 4. Start enabled protocols (services + kernel modules)
+    // 5. Restore NVMe-oF configfs (volatile, needs modules from step 4)
     //
     // Every restoration step gets a wall-clock budget via `run_phase`
     // so a single misbehaving subsystem (a hung mount, a slow Tailscale
@@ -298,6 +301,23 @@ async fn main() -> anyhow::Result<()> {
     // seconds and the ceilings are never reached.
     use std::time::Duration;
     let secs = Duration::from_secs;
+
+    state
+        .boot_status
+        .run_phase(
+            "io_scheduler.migrate_legacy",
+            secs(45),
+            nasty_storage::io_scheduler::migrate_legacy(),
+        )
+        .await;
+    state
+        .boot_status
+        .run_phase(
+            "io_scheduler.restore",
+            secs(30),
+            nasty_storage::io_scheduler::restore(),
+        )
+        .await;
 
     let mount_failures = state
         .boot_status

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -42,6 +42,7 @@ use nasty_storage::filesystem::{
     DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem, FsUsage,
     FsckStatus, ReconcileStatus, ScrubStatus, TpmBindStatus, UpdateFilesystemOptionsRequest,
 };
+use nasty_storage::io_scheduler::{IoSchedulerResult, IoSchedulerUpdate};
 use nasty_storage::subvolume::{
     CloneSnapshotRequest, CloneSubvolumeRequest, CreateSnapshotRequest, CreateSubvolumeRequest,
     DeleteSnapshotRequest, DeleteSubvolumeRequest, FindByPropertyRequest, RemovePropertiesRequest,
@@ -514,6 +515,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<DiskTypeUpdate>(generator)),
                     result: None,
+                },
+                Method {
+                    name: "device.set_io_scheduler",
+                    desc: "Set and persist the I/O scheduler on the physical whole disk owning a queue, or stop managing it without changing the active scheduler. Device aliases and partitions are resolved through sysfs.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<IoSchedulerUpdate>(generator)),
+                    result: Some(gen_schema::<IoSchedulerResult>(generator)),
                 },
             ],
         ),

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -173,6 +173,15 @@ pub(super) async fn try_route(
             },
             Err(e) => invalid(req, e),
         },
+        "device.set_io_scheduler" => {
+            match parse_params::<nasty_storage::io_scheduler::IoSchedulerUpdate>(req) {
+                Ok(update) => match nasty_storage::io_scheduler::set(update).await {
+                    Ok(result) => ok(req, result),
+                    Err(error) => err(req, error),
+                },
+                Err(error) => invalid(req, error),
+            }
+        }
         "device.wipe" => match parse_params::<serde_json::Value>(req) {
             Ok(p) => {
                 let path = p

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1819,6 +1819,7 @@ mod tests {
         for m in [
             "fs.tpm.bind",
             "fs.tpm.unbind",
+            "device.set_io_scheduler",
             "fs.create",
             "fs.destroy",
             "fs.mount",

--- a/engine/nasty-storage/src/disk_type.rs
+++ b/engine/nasty-storage/src/disk_type.rs
@@ -79,7 +79,8 @@ pub fn choose_stable_id(
     // because VMware reuses a constant serial across SATA disks.
     let hardware = by_id_names
         .iter()
-        .find(|n| n.starts_with("wwn-") || n.starts_with("nvme-eui.") || n.starts_with("scsi-3"));
+        .filter(|n| n.starts_with("wwn-") || n.starts_with("nvme-eui.") || n.starts_with("scsi-3"))
+        .min();
     if let Some(id) = hardware {
         return (id.clone(), "hardware");
     }
@@ -227,6 +228,21 @@ mod tests {
         let (key, kind) = choose_stable_id(&by_id, Some("pci-0000:00:10.0-scsi-0:0:0:0"), "sdd");
         assert_eq!(key, "wwn-0x5000c291082e5f93");
         assert_eq!(kind, "hardware");
+    }
+
+    #[test]
+    fn hardware_identity_is_independent_of_directory_order() {
+        let first = vec![
+            "wwn-0x5000c291082e5f93".to_string(),
+            "scsi-35000c291082e5f93".to_string(),
+        ];
+        let mut reversed = first.clone();
+        reversed.reverse();
+
+        assert_eq!(
+            choose_stable_id(&first, None, "sdd"),
+            choose_stable_id(&reversed, None, "sdd")
+        );
     }
 
     #[test]

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use crate::cmd;
+use crate::io_scheduler::IoSchedulerState;
 
 const NASTY_MOUNT_BASE: &str = "/fs";
 const FS_STATE_PATH: &str = "/var/lib/nasty/fs-state.json";
@@ -320,9 +321,6 @@ pub struct FilesystemOptions {
     /// Journal flush delay in microseconds. Higher values batch more journal writes,
     /// improving throughput under sync-heavy workloads (e.g. NFS commits).
     pub journal_flush_delay: Option<u32>,
-    /// I/O scheduler for member block devices (e.g. `none`, `mq-deadline`, `kyber`).
-    /// `none` is recommended for SSDs; `mq-deadline` is the kernel default.
-    pub io_scheduler: Option<String>,
     /// Maximum concurrent background mover IOs.
     pub move_ios_in_flight: Option<u32>,
     /// Maximum bytes in flight for background mover (e.g. `"8.0M"`).
@@ -452,9 +450,6 @@ pub struct CreateFilesystemRequest {
     /// Journal flush delay in microseconds (default: 1000). Higher values batch
     /// more journal writes, improving throughput under sync-heavy workloads.
     pub journal_flush_delay: Option<u32>,
-    /// I/O scheduler for member block devices (`none`, `mq-deadline`, `kyber`).
-    /// `none` is recommended for SSDs.
-    pub io_scheduler: Option<String>,
 }
 
 fn default_replicas() -> u32 {
@@ -507,8 +502,6 @@ pub struct UpdateFilesystemOptionsRequest {
     pub journal_flush_disabled: Option<bool>,
     /// Journal flush delay in microseconds. Higher values batch more journal writes.
     pub journal_flush_delay: Option<u32>,
-    /// I/O scheduler for member block devices (`none`, `mq-deadline`, `kyber`).
-    pub io_scheduler: Option<String>,
     /// Data checksum algorithm (`none`, `crc32c`, `crc64`, `xxhash`).
     pub data_checksum: Option<String>,
     /// Metadata checksum algorithm (`none`, `crc32c`, `crc64`, `xxhash`).
@@ -1284,13 +1277,6 @@ fn validate_create_request(req: &CreateFilesystemRequest) -> Result<(), Filesyst
     {
         return Err(FilesystemError::InvalidInput(format!(
             "invalid version_upgrade value '{value}'"
-        )));
-    }
-    if let Some(value) = req.io_scheduler.as_deref()
-        && !matches!(value, "none" | "mq-deadline" | "kyber")
-    {
-        return Err(FilesystemError::InvalidInput(format!(
-            "invalid io_scheduler value '{value}'"
         )));
     }
     Ok(())
@@ -2256,8 +2242,7 @@ impl FilesystemService {
 
             // Read per-device labels and fs options for mounted filesystems
             let fs_devices = read_fs_devices(&uuid, devices).await;
-            let mut options = read_fs_options_sysfs(&uuid).await;
-            options.io_scheduler = read_io_scheduler(&fs_devices).await;
+            let options = read_fs_options_sysfs(&uuid).await;
 
             filesystems.push(Filesystem {
                 name,
@@ -2569,7 +2554,6 @@ impl FilesystemService {
             encrypted: if is_encrypted { Some(true) } else { None },
             version_upgrade: req.version_upgrade.clone(),
             journal_flush_delay: req.journal_flush_delay,
-            io_scheduler: req.io_scheduler.clone(),
             ..FsMountOptions::default()
         };
         let mount_opt_str = build_mount_opts(&mount_opts);
@@ -2594,33 +2578,6 @@ impl FilesystemService {
             return Err(FilesystemError::CommandFailed(format!(
                 "mounted filesystem UUID did not match expected UUID {uuid}{suffix}"
             )));
-        }
-
-        // Apply I/O scheduler to member block devices
-        let dev_list: Vec<FilesystemDevice> = req
-            .devices
-            .iter()
-            .map(|d| FilesystemDevice {
-                path: d.path.clone(),
-                label: d.label.clone(),
-                durability: d.durability,
-                state: None,
-                data_allowed: None,
-                has_data: None,
-                discard: None,
-                rotational: None,
-                read_errors: None,
-                write_errors: None,
-                checksum_errors: None,
-                member_index: None,
-                uuid: None,
-                missing: None,
-            })
-            .collect();
-        if let Some(ref sched) = req.io_scheduler
-            && let Err(e) = apply_io_scheduler(&dev_list, sched).await
-        {
-            warn!("Failed to set I/O scheduler: {e}");
         }
 
         // Track mount state with identity info for boot reconciliation
@@ -2932,13 +2889,6 @@ impl FilesystemService {
             return Err(FilesystemError::CommandFailed(message));
         }
 
-        // Apply I/O scheduler to member block devices
-        if let Some(ref sched) = opts.io_scheduler
-            && let Err(e) = apply_io_scheduler(&fs.devices, sched).await
-        {
-            warn!("Failed to set I/O scheduler: {e}");
-        }
-
         // Track mount state with identity info for boot reconciliation.
         // If we successfully unlocked via a stored key, force the
         // persisted `encrypted` flag to true: opts.encrypted may have
@@ -3201,11 +3151,6 @@ impl FilesystemService {
             write_opt(&base, "journal_flush_delay", &v.to_string()).await?;
         }
 
-        // Apply I/O scheduler to member block devices
-        if let Some(ref sched) = req.io_scheduler {
-            apply_io_scheduler(&fs.devices, sched).await?;
-        }
-
         // Mount options require a remount to take effect — but only if they actually changed.
         let state = load_fs_state().await;
         let current = state.get(&req.name).cloned().unwrap_or_default();
@@ -3220,11 +3165,7 @@ impl FilesystemService {
                 && req.journal_flush_delay != current.journal_flush_delay);
         drop(state);
 
-        // Persist state changes (mount opts + io_scheduler)
-        let state_changed = mount_changed
-            || (req.io_scheduler.is_some() && req.io_scheduler != current.io_scheduler);
-
-        if state_changed {
+        if mount_changed {
             let mut state = load_fs_state().await;
             {
                 let opts = state.entry(req.name.clone()).or_default();
@@ -3251,9 +3192,6 @@ impl FilesystemService {
                 }
                 if let Some(v) = req.journal_flush_delay {
                     opts.journal_flush_delay = Some(v);
-                }
-                if let Some(ref v) = req.io_scheduler {
-                    opts.io_scheduler = Some(v.clone());
                 }
             }
             if let Err(e) = save_fs_state(&state).await {
@@ -3353,6 +3291,7 @@ impl FilesystemService {
             serde_json::from_str(&output).unwrap_or(serde_json::Value::Null);
 
         let mut devices = Vec::new();
+        let mut partition_parents = std::collections::HashMap::new();
         if let Some(blockdevices) = parsed.get("blockdevices").and_then(|v| v.as_array()) {
             fn classify(name: &str, rota: bool, transport: Option<&str>) -> (bool, String) {
                 if name.starts_with("nvme") {
@@ -3405,6 +3344,9 @@ impl FilesystemService {
                 out: &mut Vec<BlockDevice>,
                 resolver: &crate::disk_type::IdentityResolver,
                 overrides: &std::collections::HashMap<String, String>,
+                scheduler_states: &std::collections::HashMap<String, IoSchedulerState>,
+                parent_disk: Option<&str>,
+                partition_parents: &mut std::collections::HashMap<String, String>,
             ) {
                 for dev in devs {
                     let name = dev.get("name").and_then(|v| v.as_str()).unwrap_or("");
@@ -3452,6 +3394,11 @@ impl FilesystemService {
 
                     if dev_type == "disk" || dev_type == "part" {
                         let path = format!("/dev/{name}");
+                        if dev_type == "part"
+                            && let Some(parent) = parent_disk
+                        {
+                            partition_parents.insert(path.clone(), format!("/dev/{parent}"));
+                        }
                         let in_fs = fs_devices.contains(&path);
                         let actually_mounted = mounted_devices.contains(&path);
 
@@ -3459,6 +3406,7 @@ impl FilesystemService {
                         // disks only — partitions inherit nothing here.
                         let (mut stable_id, mut id_kind) = (None, None);
                         let mut type_source = "detected".to_string();
+                        let mut io_scheduler = None;
                         if dev_type == "disk" {
                             let (key, kind) = resolver.resolve(name);
                             if let Some(class) = overrides.get(&key)
@@ -3471,6 +3419,7 @@ impl FilesystemService {
                             }
                             stable_id = Some(key);
                             id_kind = Some(kind.to_string());
+                            io_scheduler = scheduler_states.get(name).cloned();
                         }
 
                         out.push(BlockDevice {
@@ -3490,10 +3439,16 @@ impl FilesystemService {
                             stable_id,
                             id_kind,
                             type_source,
+                            io_scheduler,
                         });
                     }
 
                     if let Some(children) = dev.get("children").and_then(|v| v.as_array()) {
+                        let child_parent = if dev_type == "disk" {
+                            Some(name)
+                        } else {
+                            parent_disk
+                        };
                         collect_devices(
                             children,
                             fs_devices,
@@ -3501,6 +3456,9 @@ impl FilesystemService {
                             out,
                             resolver,
                             overrides,
+                            scheduler_states,
+                            child_parent,
+                            partition_parents,
                         );
                     }
                 }
@@ -3508,6 +3466,22 @@ impl FilesystemService {
             // Identity (by-id/by-path) + persisted type overrides are read
             // once per listing, then applied per whole-disk inside the walk.
             let resolver = crate::disk_type::IdentityResolver::new().await;
+            fn disk_names(devs: &[serde_json::Value], names: &mut Vec<String>) {
+                for dev in devs {
+                    if dev.get("type").and_then(|value| value.as_str()) == Some("disk")
+                        && let Some(name) = dev.get("name").and_then(|value| value.as_str())
+                    {
+                        names.push(name.to_string());
+                    }
+                    if let Some(children) = dev.get("children").and_then(|value| value.as_array()) {
+                        disk_names(children, names);
+                    }
+                }
+            }
+            let mut whole_disk_names = Vec::new();
+            disk_names(blockdevices, &mut whole_disk_names);
+            let scheduler_states =
+                crate::io_scheduler::states_for_device_names(&resolver, &whole_disk_names).await;
             let overrides = crate::disk_type::load().await;
             collect_devices(
                 blockdevices,
@@ -3516,50 +3490,39 @@ impl FilesystemService {
                 &mut devices,
                 &resolver,
                 &overrides,
+                &scheduler_states,
+                None,
+                &mut partition_parents,
             );
-        }
 
-        // Mark parent disks as in_use if any of their partitions are in_use.
-        let in_use_paths: std::collections::HashSet<String> = devices
-            .iter()
-            .filter(|d| d.in_use && d.dev_type == "part")
-            .map(|d| d.path.clone())
-            .collect();
-        for dev in &mut devices {
-            if dev.dev_type == "disk"
-                && !dev.in_use
-                && in_use_paths.iter().any(|p| p.starts_with(&dev.path))
-            {
-                dev.in_use = true;
+            // Parentage comes from lsblk's device tree. Device names may end
+            // in digits, so prefix trimming is not a valid partition parser.
+            let in_use_parents: std::collections::HashSet<&str> = devices
+                .iter()
+                .filter(|device| device.in_use && device.dev_type == "part")
+                .filter_map(|device| partition_parents.get(&device.path).map(String::as_str))
+                .collect();
+            for device in &mut devices {
+                if device.dev_type == "disk" && in_use_parents.contains(device.path.as_str()) {
+                    device.in_use = true;
+                }
             }
         }
 
         // Detect unpartitioned free space on disks with existing partitions.
         // Use sgdisk to find the largest free gap; if > 1 GiB, add a virtual "free" entry.
         // Skip boot devices (mmcblk/eMMC) — they should never be offered as storage.
-        let partitioned_disks: Vec<String> = devices
-            .iter()
-            .filter(|d| d.dev_type == "part")
-            .filter(|d| !d.path.contains("mmcblk"))
-            .filter_map(|d| {
-                // /dev/sda1 -> /dev/sda, /dev/nvme0n1p1 -> /dev/nvme0n1
-                let name = d.path.trim_start_matches("/dev/");
-                // Strip trailing partition number
-                if name.contains("nvme") || name.contains("loop") || name.contains("mmcblk") {
-                    name.rsplit_once('p')
-                        .map(|(base, _)| format!("/dev/{base}"))
-                } else {
-                    let base = name.trim_end_matches(|c: char| c.is_ascii_digit());
-                    Some(format!("/dev/{base}"))
-                }
-            })
+        let partitioned_disks: Vec<String> = partition_parents
+            .values()
+            .filter(|path| !path.contains("mmcblk"))
             // A disk that is itself a filesystem member (whole-disk
             // bcachefs) can't host a new partition, and probing it with
             // sgdisk only produces GPT lectures — the member superblock
             // sits where a partition table would be. Partition nodes on
             // such a disk are stale kernel state from a pre-wipe table
             // (#488).
-            .filter(|parent| !used_devices.contains(parent))
+            .filter(|parent| !used_devices.contains(*parent))
+            .cloned()
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
             .collect();
@@ -3624,6 +3587,7 @@ impl FilesystemService {
                             stable_id: None,
                             id_kind: None,
                             type_source,
+                            io_scheduler: None,
                         });
                     }
                 }
@@ -4903,6 +4867,10 @@ pub struct BlockDevice {
     /// when an operator override is in effect (#552).
     #[serde(default = "default_type_source")]
     pub type_source: String,
+    /// Kernel I/O scheduler state for physical whole disks. Partitions and
+    /// synthetic free-space rows do not own a queue and return `None`.
+    #[serde(default)]
+    pub io_scheduler: Option<IoSchedulerState>,
 }
 
 fn default_type_source() -> String {
@@ -5407,7 +5375,6 @@ async fn read_fs_options_sysfs(uuid: &str) -> FilesystemOptions {
         fsck: None,
         journal_flush_disabled: None,
         journal_flush_delay: read_opt_u32(&base, "journal_flush_delay").await,
-        io_scheduler: None, // read per-device, not from bcachefs sysfs
         move_ios_in_flight: read_opt_u32(&base, "move_ios_in_flight").await,
         move_bytes_in_flight: read_opt(&base, "move_bytes_in_flight").await,
     }
@@ -5793,8 +5760,14 @@ struct FsMountOptions {
     journal_flush_disabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     journal_flush_delay: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    io_scheduler: Option<String>,
+    /// Retained only so unresolved scheduler migration data survives an
+    /// unrelated filesystem-state rewrite.
+    #[serde(
+        default,
+        rename = "io_scheduler",
+        skip_serializing_if = "Option::is_none"
+    )]
+    legacy_io_scheduler: Option<String>,
 }
 
 /// Filesystem state: maps fs name → mount options.
@@ -5820,7 +5793,7 @@ async fn save_fs_mounted_with_opts(fs_name: &str, mut opts: FsMountOptions) {
 /// Mark a filesystem as unmounted without losing its tuned mount
 /// options. Sets `mounted: Some(false)` so `restore_mounts` skips it
 /// at next boot; preserves `encrypted`, `compression`, `journal_*`,
-/// `io_scheduler`, etc. so the next manual `mount` doesn't start
+/// etc. so the next manual `mount` doesn't start
 /// from defaults. Pre-fix this function removed the entry entirely,
 /// which silently wiped the operator's config (and produced the
 /// "encrypted=None at boot → systemd-ask-password deadlock" reported
@@ -6841,45 +6814,6 @@ fn build_mount_opts(opts: &FsMountOptions) -> String {
     parts.join(",")
 }
 
-/// Extract the short device name from a path (e.g. `/dev/sda` → `sda`).
-fn block_dev_name(path: &str) -> Option<&str> {
-    path.rsplit('/').next()
-}
-
-/// Apply an I/O scheduler to all member block devices of a filesystem.
-async fn apply_io_scheduler(
-    devices: &[FilesystemDevice],
-    scheduler: &str,
-) -> Result<(), FilesystemError> {
-    for dev in devices {
-        let Some(name) = block_dev_name(&dev.path) else {
-            continue;
-        };
-        let sysfs_path = format!("/sys/block/{name}/queue/scheduler");
-        if let Err(e) = tokio::fs::write(&sysfs_path, scheduler).await {
-            // Not fatal — device may be a partition or missing sysfs entry
-            warn!("Failed to set I/O scheduler on {name}: {e}");
-        } else {
-            info!("Set I/O scheduler to '{scheduler}' on {name}");
-        }
-    }
-    Ok(())
-}
-
-/// Read the active I/O scheduler from the first member device.
-/// Returns the bracketed value from `/sys/block/{dev}/queue/scheduler`.
-async fn read_io_scheduler(devices: &[FilesystemDevice]) -> Option<String> {
-    let dev = devices.first()?;
-    let name = block_dev_name(&dev.path)?;
-    let sysfs_path = format!("/sys/block/{name}/queue/scheduler");
-    let content = tokio::fs::read_to_string(&sysfs_path).await.ok()?;
-    // Format: "none [mq-deadline] kyber" — extract the bracketed one
-    content
-        .split_whitespace()
-        .find(|s| s.starts_with('['))
-        .map(|s| s.trim_matches(|c| c == '[' || c == ']').to_string())
-}
-
 async fn is_mountpoint(path: &str) -> bool {
     use std::os::unix::fs::MetadataExt;
     if tokio::fs::read_to_string("/proc/self/mountinfo")
@@ -7012,7 +6946,6 @@ mod tests {
             encoded_extent_max: None,
             version_upgrade: None,
             journal_flush_delay: None,
-            io_scheduler: None,
         }
     }
 
@@ -7469,11 +7402,27 @@ mod tests {
         assert_eq!(opts.devices.len(), 3);
     }
 
+    #[test]
+    fn unresolved_legacy_scheduler_survives_state_roundtrip() {
+        let legacy = r#"{
+            "devices": ["/dev/missing"],
+            "io_scheduler": "bfq"
+        }"#;
+        let opts: FsMountOptions = serde_json::from_str(legacy).expect("legacy state parses");
+        assert_eq!(opts.legacy_io_scheduler.as_deref(), Some("bfq"));
+
+        let json = serde_json::to_string(&opts).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&json).unwrap()["io_scheduler"],
+            "bfq"
+        );
+    }
+
     /// Round-trip an unmount→mount cycle in pure data form: an FS
     /// with tuned options must keep them across a `mounted = false`
     /// pause and survive serde re-serialization. Regression for
-    /// "unmount silently wiped my compression/journal_flush_delay/
-    /// io_scheduler config" — pre-fix `save_fs_unmounted` did a
+    /// "unmount silently wiped my compression/journal_flush_delay config" —
+    /// pre-fix `save_fs_unmounted` did a
     /// flat `state.remove(name)`.
     #[test]
     fn unmount_preserves_tuned_options_across_state_roundtrip() {
@@ -7483,7 +7432,6 @@ mod tests {
             mounted: Some(true),
             encrypted: Some(true),
             journal_flush_delay: Some(1000),
-            io_scheduler: Some("none".into()),
             ..FsMountOptions::default()
         };
 
@@ -7500,7 +7448,6 @@ mod tests {
         assert_eq!(restored.mounted, Some(false));
         assert_eq!(restored.encrypted, Some(true)); // the regression we're fencing
         assert_eq!(restored.journal_flush_delay, Some(1000));
-        assert_eq!(restored.io_scheduler.as_deref(), Some("none"));
         assert_eq!(restored.devices, vec!["/dev/sda", "/dev/sdb"]);
     }
 

--- a/engine/nasty-storage/src/io_scheduler.rs
+++ b/engine/nasty-storage/src/io_scheduler.rs
@@ -1,0 +1,694 @@
+//! Physical block-device I/O scheduler management.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use crate::disk_type::IdentityResolver;
+
+const STATE_PATH: &str = "/var/lib/nasty/io-scheduler-overrides.json";
+const LEGACY_FS_STATE_PATH: &str = "/var/lib/nasty/fs-state.json";
+const SYS_CLASS_BLOCK: &str = "/sys/class/block";
+
+/// Serializes scheduler mutations and state-file migration.
+static MUTATION_LOCK: Mutex<()> = Mutex::const_new(());
+
+type Overrides = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct IoSchedulerState {
+    /// Scheduler currently selected by the kernel.
+    pub active: String,
+    /// Schedulers advertised by this device's queue.
+    pub available: Vec<String>,
+    /// Scheduler NASty will restore at startup, if managed.
+    pub configured: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct IoSchedulerUpdate {
+    /// A whole-disk path, partition path, or `/dev/disk/*` alias.
+    pub path: String,
+    /// Scheduler to manage, or `None` to stop managing without changing it.
+    pub scheduler: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IoSchedulerResult {
+    /// Canonical whole-device path that owns the queue.
+    pub path: String,
+    /// Stable identity used for persistence.
+    pub stable_id: String,
+    /// Durability of `stable_id`: `hardware`, `slot`, or `volatile`.
+    pub id_kind: String,
+    pub io_scheduler: IoSchedulerState,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedDevice {
+    name: String,
+    path: String,
+    scheduler_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LegacyClaim {
+    stable_id: String,
+    scheduler: String,
+}
+
+/// Set or clear management for a physical device queue.
+pub async fn set(update: IoSchedulerUpdate) -> Result<IoSchedulerResult, String> {
+    let _guard = MUTATION_LOCK.lock().await;
+    let device = resolve_device(&update.path).await?;
+    let resolver = IdentityResolver::new().await;
+    let (stable_id, id_kind) = resolver.resolve(&device.name);
+    let mut overrides = load_overrides().await;
+
+    let io_scheduler = match update.scheduler {
+        None => {
+            let mut state = read_state(&device, None).await?;
+            if overrides.remove(&stable_id).is_some() {
+                save_overrides(&overrides).await?;
+            }
+            state.configured = None;
+            info!(
+                "Stopped managing I/O scheduler for {} (stable id '{}')",
+                device.path, stable_id
+            );
+            state
+        }
+        Some(scheduler) => {
+            let advertised = read_state(&device, overrides.get(&stable_id).cloned()).await?;
+            if !advertised.available.iter().any(|value| value == &scheduler) {
+                return Err(format!(
+                    "I/O scheduler '{scheduler}' is not available for {}; advertised values: {}",
+                    device.path,
+                    advertised.available.join(", ")
+                ));
+            }
+
+            let previous_active = advertised.active;
+            let mut state = write_and_confirm(&device, &scheduler).await?;
+            overrides.insert(stable_id.clone(), scheduler.clone());
+            if let Err(save_error) = save_overrides(&overrides).await {
+                let rollback = write_and_confirm(&device, &previous_active).await;
+                return Err(match rollback {
+                    Ok(_) => format!(
+                        "persist I/O scheduler override: {save_error}; restored active scheduler '{previous_active}'"
+                    ),
+                    Err(rollback_error) => format!(
+                        "persist I/O scheduler override: {save_error}; additionally failed to restore active scheduler '{previous_active}': {rollback_error}"
+                    ),
+                });
+            }
+
+            state.configured = Some(scheduler.clone());
+            info!(
+                "Set I/O scheduler for {} (stable id '{}') to '{}'",
+                device.path, stable_id, scheduler
+            );
+            state
+        }
+    };
+
+    Ok(IoSchedulerResult {
+        path: device.path,
+        stable_id,
+        id_kind: id_kind.to_string(),
+        io_scheduler,
+    })
+}
+
+/// Read scheduler state for the whole devices in an `lsblk` listing pass.
+pub(crate) async fn states_for_device_names(
+    resolver: &IdentityResolver,
+    names: &[String],
+) -> HashMap<String, IoSchedulerState> {
+    let overrides = load_overrides().await;
+    let mut states = HashMap::new();
+    for name in names {
+        let configured = overrides.get(&resolver.resolve(name).0).cloned();
+        let device = ResolvedDevice {
+            name: name.clone(),
+            path: format!("/dev/{name}"),
+            scheduler_path: Path::new(SYS_CLASS_BLOCK)
+                .join(name)
+                .join("queue/scheduler"),
+        };
+        if let Ok(state) = read_state(&device, configured).await {
+            states.insert(name.clone(), state);
+        }
+    }
+    states
+}
+
+/// Restore every currently resolvable persisted override. Failures are isolated
+/// per disk so one missing or changed device never blocks engine startup.
+pub async fn restore() {
+    let _guard = MUTATION_LOCK.lock().await;
+    let overrides = load_overrides().await;
+    if overrides.is_empty() {
+        return;
+    }
+
+    let resolver = IdentityResolver::new().await;
+    let devices = match enumerate_queue_owners().await {
+        Ok(devices) => devices,
+        Err(error) => {
+            warn!("Cannot enumerate block devices for I/O scheduler restore: {error}");
+            return;
+        }
+    };
+    let mut matched = BTreeSet::new();
+
+    for device in devices.values() {
+        let (stable_id, _) = resolver.resolve(&device.name);
+        let Some(scheduler) = overrides.get(&stable_id) else {
+            continue;
+        };
+        matched.insert(stable_id.clone());
+        match write_and_confirm(device, scheduler).await {
+            Ok(_) => info!(
+                "Restored I/O scheduler '{}' on {} (stable id '{}')",
+                scheduler, device.path, stable_id
+            ),
+            Err(error) => warn!("I/O scheduler restore failed for {}: {error}", device.path),
+        }
+    }
+
+    for stable_id in overrides.keys() {
+        if !matched.contains(stable_id) {
+            warn!("No usable block device found for I/O scheduler override '{stable_id}'");
+        }
+    }
+}
+
+/// Migrate concrete filesystem-level scheduler settings to physical stable IDs.
+/// The new state is durably renamed into place before legacy fields are removed.
+pub async fn migrate_legacy() {
+    let _guard = MUTATION_LOCK.lock().await;
+    if let Err(error) = migrate_legacy_inner().await {
+        warn!("Legacy I/O scheduler migration failed: {error}");
+    }
+}
+
+async fn migrate_legacy_inner() -> Result<(), String> {
+    let content = match tokio::fs::read_to_string(LEGACY_FS_STATE_PATH).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("read {LEGACY_FS_STATE_PATH}: {error}")),
+    };
+    let mut state: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|error| format!("parse {LEGACY_FS_STATE_PATH}: {error}"))?;
+    let entries = state
+        .as_object()
+        .ok_or_else(|| format!("{LEGACY_FS_STATE_PATH} is not a JSON object"))?;
+    if !entries.values().any(|options| {
+        options
+            .get("io_scheduler")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.is_empty())
+    }) {
+        return Ok(());
+    }
+
+    match tokio::process::Command::new("udevadm")
+        .args(["settle", "--timeout=30"])
+        .status()
+        .await
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => warn!(
+            "udevadm settle exited {status} before legacy I/O scheduler migration; continuing"
+        ),
+        Err(error) => warn!(
+            "udevadm settle failed before legacy I/O scheduler migration: {error}; continuing"
+        ),
+    }
+
+    let resolver = IdentityResolver::new().await;
+    let mut claims = Vec::new();
+    let mut claims_by_entry = BTreeMap::new();
+    let mut fully_resolved_entries = BTreeSet::new();
+
+    for (name, options) in entries {
+        let Some(scheduler) = options
+            .get("io_scheduler")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let mut entry_claims = Vec::new();
+        let mut fully_resolved = false;
+        if let Some(devices) = options.get("devices").and_then(serde_json::Value::as_array) {
+            fully_resolved = !devices.is_empty();
+            for value in devices {
+                let Some(path) = value.as_str() else {
+                    fully_resolved = false;
+                    continue;
+                };
+                let Ok(device) = resolve_device(path).await else {
+                    fully_resolved = false;
+                    continue;
+                };
+                entry_claims.push(LegacyClaim {
+                    stable_id: resolver.resolve(&device.name).0,
+                    scheduler: scheduler.to_string(),
+                });
+            }
+        }
+        if fully_resolved {
+            fully_resolved_entries.insert(name.clone());
+        }
+        claims.extend(entry_claims.iter().cloned());
+        claims_by_entry.insert(name.clone(), entry_claims);
+    }
+
+    if claims.is_empty() {
+        return Ok(());
+    }
+
+    let existing = load_overrides().await;
+    let (merged, conflicts) = merge_legacy_claims(&existing, &claims);
+    if merged != existing {
+        save_overrides(&merged).await?;
+    }
+
+    let migrated_entries =
+        completed_legacy_entries(fully_resolved_entries, &claims_by_entry, &conflicts);
+    if migrated_entries.is_empty() {
+        return Ok(());
+    }
+
+    remove_migrated_fields(&mut state, &migrated_entries);
+    atomic_write_json(LEGACY_FS_STATE_PATH, &state).await?;
+    info!(
+        "Migrated legacy I/O scheduler settings from {} filesystem entries",
+        migrated_entries.len()
+    );
+    Ok(())
+}
+
+fn remove_migrated_fields(state: &mut serde_json::Value, migrated_entries: &[String]) {
+    let Some(entries) = state.as_object_mut() else {
+        return;
+    };
+    for name in migrated_entries {
+        if let Some(options) = entries
+            .get_mut(name)
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            options.remove("io_scheduler");
+        }
+    }
+}
+
+fn completed_legacy_entries(
+    fully_resolved_entries: BTreeSet<String>,
+    claims_by_entry: &BTreeMap<String, Vec<LegacyClaim>>,
+    conflicts: &BTreeSet<String>,
+) -> Vec<String> {
+    fully_resolved_entries
+        .into_iter()
+        .filter(|name| {
+            claims_by_entry.get(name).is_some_and(|entry_claims| {
+                entry_claims
+                    .iter()
+                    .all(|claim| !conflicts.contains(&claim.stable_id))
+            })
+        })
+        .collect()
+}
+
+fn merge_legacy_claims(
+    existing: &Overrides,
+    claims: &[LegacyClaim],
+) -> (Overrides, BTreeSet<String>) {
+    let mut merged = existing.clone();
+    let mut conflicts = BTreeSet::new();
+    let mut by_disk: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for claim in claims {
+        by_disk
+            .entry(&claim.stable_id)
+            .or_default()
+            .insert(&claim.scheduler);
+    }
+
+    for (stable_id, schedulers) in by_disk {
+        if existing.contains_key(stable_id) {
+            continue;
+        }
+        if schedulers.len() == 1 {
+            merged.insert(
+                stable_id.to_string(),
+                schedulers.into_iter().next().unwrap().to_string(),
+            );
+        } else {
+            merged.remove(stable_id);
+            conflicts.insert(stable_id.to_string());
+            warn!(
+                "Conflicting legacy I/O scheduler claims for stable disk '{}'; leaving it unmanaged",
+                stable_id
+            );
+        }
+    }
+    (merged, conflicts)
+}
+
+async fn resolve_device(path: &str) -> Result<ResolvedDevice, String> {
+    let canonical = tokio::fs::canonicalize(path)
+        .await
+        .map_err(|error| format!("resolve block device path '{path}': {error}"))?;
+    let metadata = tokio::fs::metadata(&canonical).await.map_err(|error| {
+        format!(
+            "inspect block device path '{}': {error}",
+            canonical.display()
+        )
+    })?;
+    if !metadata.file_type().is_block_device() {
+        return Err(format!("path '{path}' is not a block device"));
+    }
+    let name = canonical
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("block device path '{path}' has no valid device name"))?;
+    resolve_sysfs_name(name).await
+}
+
+async fn resolve_sysfs_name(name: &str) -> Result<ResolvedDevice, String> {
+    let class_path = Path::new(SYS_CLASS_BLOCK).join(name);
+    let target = tokio::fs::canonicalize(&class_path)
+        .await
+        .map_err(|error| format!("resolve {}: {error}", class_path.display()))?;
+    let is_partition = tokio::fs::metadata(target.join("partition")).await.is_ok();
+    let owner_target = queue_owner_target(&target, is_partition)?;
+    let owner_name = owner_target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("cannot determine queue owner for /dev/{name}"))?
+        .to_string();
+    let scheduler_path = Path::new(SYS_CLASS_BLOCK)
+        .join(&owner_name)
+        .join("queue/scheduler");
+    tokio::fs::metadata(&scheduler_path)
+        .await
+        .map_err(|error| {
+            format!(
+                "{} has no scheduler queue: {error}",
+                scheduler_path.display()
+            )
+        })?;
+
+    Ok(ResolvedDevice {
+        path: format!("/dev/{owner_name}"),
+        name: owner_name,
+        scheduler_path,
+    })
+}
+
+fn queue_owner_target(target: &Path, is_partition: bool) -> Result<&Path, String> {
+    if is_partition {
+        target
+            .parent()
+            .ok_or_else(|| format!("partition sysfs path {} has no parent", target.display()))
+    } else {
+        Ok(target)
+    }
+}
+
+async fn enumerate_queue_owners() -> Result<BTreeMap<String, ResolvedDevice>, String> {
+    let mut entries = tokio::fs::read_dir(SYS_CLASS_BLOCK)
+        .await
+        .map_err(|error| format!("read {SYS_CLASS_BLOCK}: {error}"))?;
+    let mut devices = BTreeMap::new();
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|error| format!("read {SYS_CLASS_BLOCK}: {error}"))?
+    {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if let Ok(device) = resolve_sysfs_name(&name).await {
+            devices.entry(device.name.clone()).or_insert(device);
+        }
+    }
+    Ok(devices)
+}
+
+async fn read_state(
+    device: &ResolvedDevice,
+    configured: Option<String>,
+) -> Result<IoSchedulerState, String> {
+    let content = tokio::fs::read_to_string(&device.scheduler_path)
+        .await
+        .map_err(|error| format!("read {}: {error}", device.scheduler_path.display()))?;
+    let (active, available) = parse_scheduler_content(&content)?;
+    Ok(IoSchedulerState {
+        active,
+        available,
+        configured,
+    })
+}
+
+fn parse_scheduler_content(content: &str) -> Result<(String, Vec<String>), String> {
+    let mut active = None;
+    let mut available = Vec::new();
+    for token in content.split_whitespace() {
+        let bracketed = token.starts_with('[') && token.ends_with(']');
+        let value = if bracketed {
+            &token[1..token.len() - 1]
+        } else {
+            token
+        };
+        if value.is_empty() || token.starts_with('[') != token.ends_with(']') {
+            return Err(format!("invalid scheduler queue content: {content:?}"));
+        }
+        if bracketed && active.replace(value.to_string()).is_some() {
+            return Err(format!(
+                "multiple active schedulers in queue content: {content:?}"
+            ));
+        }
+        if !available.iter().any(|candidate| candidate == value) {
+            available.push(value.to_string());
+        }
+    }
+    let active =
+        active.ok_or_else(|| format!("no active scheduler in queue content: {content:?}"))?;
+    Ok((active, available))
+}
+
+async fn write_and_confirm(
+    device: &ResolvedDevice,
+    scheduler: &str,
+) -> Result<IoSchedulerState, String> {
+    tokio::fs::write(&device.scheduler_path, scheduler)
+        .await
+        .map_err(|error| format!("write {}: {error}", device.scheduler_path.display()))?;
+    let state = read_state(device, None).await?;
+    if state.active != scheduler {
+        return Err(format!(
+            "kernel did not activate I/O scheduler '{scheduler}' on {}; active scheduler is '{}'",
+            device.path, state.active
+        ));
+    }
+    Ok(state)
+}
+
+async fn load_overrides() -> Overrides {
+    nasty_common::load_singleton_or_recover(STATE_PATH).await
+}
+
+async fn save_overrides(overrides: &Overrides) -> Result<(), String> {
+    atomic_write_json(STATE_PATH, overrides).await
+}
+
+async fn atomic_write_json<T: Serialize + ?Sized>(path: &str, value: &T) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("serialize state for {path}: {error}"))?;
+    if let Some(parent) = Path::new(path).parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    }
+    let temporary = format!("{path}.tmp");
+    let mut file = tokio::fs::File::create(&temporary)
+        .await
+        .map_err(|error| format!("create {temporary}: {error}"))?;
+    file.write_all(&bytes)
+        .await
+        .map_err(|error| format!("write {temporary}: {error}"))?;
+    file.sync_all()
+        .await
+        .map_err(|error| format!("sync {temporary}: {error}"))?;
+    drop(file);
+    tokio::fs::rename(&temporary, path)
+        .await
+        .map_err(|error| format!("rename {temporary} to {path}: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dynamic_scheduler_names_and_active_value() {
+        let (active, available) =
+            parse_scheduler_content("none mq-deadline [bfq] custom-scheduler\n").unwrap();
+        assert_eq!(active, "bfq");
+        assert_eq!(
+            available,
+            vec!["none", "mq-deadline", "bfq", "custom-scheduler"]
+        );
+    }
+
+    #[test]
+    fn rejects_scheduler_content_without_an_active_value() {
+        assert!(parse_scheduler_content("none mq-deadline bfq").is_err());
+    }
+
+    #[test]
+    fn partition_queue_owner_uses_sysfs_parent_without_name_heuristics() {
+        let nvme = Path::new("/sys/devices/pci/block/nvme12n34/nvme12n34p56");
+        assert_eq!(
+            queue_owner_target(nvme, true).unwrap(),
+            Path::new("/sys/devices/pci/block/nvme12n34")
+        );
+        let digit_ending_disk = Path::new("/sys/devices/virtual/block/md127");
+        assert_eq!(
+            queue_owner_target(digit_ending_disk, false).unwrap(),
+            digit_ending_disk
+        );
+    }
+
+    #[test]
+    fn migration_deduplicates_identical_claims() {
+        let claims = vec![
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "bfq".into(),
+            },
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "bfq".into(),
+            },
+        ];
+        assert_eq!(
+            merge_legacy_claims(&Overrides::new(), &claims),
+            (
+                Overrides::from([("disk-a".into(), "bfq".into())]),
+                BTreeSet::new()
+            )
+        );
+    }
+
+    #[test]
+    fn migration_leaves_conflicting_disk_unmanaged() {
+        let claims = vec![
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "none".into(),
+            },
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "bfq".into(),
+            },
+        ];
+        assert_eq!(
+            merge_legacy_claims(&Overrides::new(), &claims),
+            (Overrides::new(), BTreeSet::from(["disk-a".into()]))
+        );
+    }
+
+    #[test]
+    fn existing_override_wins_over_legacy_claims() {
+        let existing = Overrides::from([("disk-a".into(), "kyber".into())]);
+        let claims = vec![
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "none".into(),
+            },
+            LegacyClaim {
+                stable_id: "disk-a".into(),
+                scheduler: "bfq".into(),
+            },
+        ];
+        assert_eq!(
+            merge_legacy_claims(&existing, &claims),
+            (existing, BTreeSet::new())
+        );
+    }
+
+    #[test]
+    fn migration_only_completes_fully_resolved_nonconflicting_entries() {
+        let claims_by_entry = BTreeMap::from([
+            (
+                "complete".into(),
+                vec![LegacyClaim {
+                    stable_id: "disk-a".into(),
+                    scheduler: "bfq".into(),
+                }],
+            ),
+            (
+                "conflicting".into(),
+                vec![LegacyClaim {
+                    stable_id: "disk-b".into(),
+                    scheduler: "none".into(),
+                }],
+            ),
+            (
+                "partial".into(),
+                vec![LegacyClaim {
+                    stable_id: "disk-c".into(),
+                    scheduler: "bfq".into(),
+                }],
+            ),
+        ]);
+
+        assert_eq!(
+            completed_legacy_entries(
+                BTreeSet::from(["complete".into(), "conflicting".into()]),
+                &claims_by_entry,
+                &BTreeSet::from(["disk-b".into()]),
+            ),
+            vec!["complete"]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_non_block_device_paths() {
+        let error = resolve_device("/dev/null").await.unwrap_err();
+        assert!(error.contains("is not a block device"));
+    }
+
+    #[test]
+    fn migration_removes_only_selected_legacy_fields() {
+        let mut state = serde_json::json!({
+            "tank": {
+                "uuid": "uuid-a",
+                "devices": ["/dev/sda1"],
+                "io_scheduler": "bfq",
+                "future_option": {"nested": true}
+            },
+            "offline": {
+                "devices": ["/dev/missing"],
+                "io_scheduler": "none"
+            },
+            "top_level_future": [1, 2, 3]
+        });
+
+        remove_migrated_fields(&mut state, &["tank".to_string()]);
+
+        assert!(state["tank"].get("io_scheduler").is_none());
+        assert_eq!(state["tank"]["future_option"]["nested"], true);
+        assert_eq!(state["offline"]["io_scheduler"], "none");
+        assert_eq!(state["top_level_future"], serde_json::json!([1, 2, 3]));
+    }
+}

--- a/engine/nasty-storage/src/lib.rs
+++ b/engine/nasty-storage/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod cmd;
 pub mod disk_type;
 pub mod filesystem;
+pub mod io_scheduler;
 pub mod subvolume;
 
 pub use filesystem::{FilesystemError, FilesystemService};

--- a/webui/src/lib/navigation.test.ts
+++ b/webui/src/lib/navigation.test.ts
@@ -69,6 +69,12 @@ describe('navigation model', () => {
 		]));
 	});
 
+	test('finds Disks by I/O scheduler terminology', () => {
+		const entries = resolveNavigation({ kvmAvailable: true });
+		expect(searchNavigation(entries, 'scheduler')).toEqual(new Set(['/disks']));
+		expect(searchNavigation(entries, 'elevator')).toEqual(new Set(['/disks']));
+	});
+
 	test('search cannot expose capability-gated entries', () => {
 		const entries = resolveNavigation({ kvmAvailable: false });
 		expect(searchNavigation(entries, 'virtual machine')).toEqual(new Set());

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -78,7 +78,7 @@ const NAVIGATION: NavEntry[] = [
 		children: [
 			item('filesystems', '/filesystems', 'Filesystems', Database, ['filesystem', 'pool', 'bcachefs', 'format', 'mount', 'unmount', 'create', 'encryption', 'replicas', 'erasure', 'tiering', 'compression', 'scrub', 'fsck', 'check', 'repair', 'balance', 'rebuild', 'defrag', 'add disk', 'remove disk', 'tpm', 'tpm2', 'seal', 'unlock', 'key', 'quota'], { commonRank: 1 }),
 			item('subvolumes', '/subvolumes', 'Subvolumes', Layers, ['subvolume', 'snapshot', 'quota', 'block device', 'dataset', 'clone', 'send', 'receive', 'replication', 'volume', 'zvol', 'lun', 'namespace'], { commonRank: 2 }),
-			item('disks', '/disks', 'Disks', HardDrive, ['disk', 'drive', 'smart', 'health', 'temperature', 'ssd', 'hdd', 'sas', 'nvme', 'topology', 'device', 'wipe', 'format', 'partition', 'serial', 'model', 'firmware', 'pcie', 'endurance', 'wear', 'scan'], { commonRank: 3 }),
+			item('disks', '/disks', 'Disks', HardDrive, ['disk', 'drive', 'smart', 'health', 'temperature', 'ssd', 'hdd', 'sas', 'nvme', 'topology', 'device', 'wipe', 'format', 'partition', 'serial', 'model', 'firmware', 'pcie', 'endurance', 'wear', 'scan', 'scheduler', 'elevator'], { commonRank: 3 }),
 			item('operations', '/operations', 'Operations', Activity, ['operation', 'scrub', 'reconcile', 'balance', 'copygc', 'evacuate', 'progress', 'activity', 'job']),
 			item('files', '/files', 'Files', FolderOpen, ['file', 'browser', 'folder', 'directory', 'upload', 'download', 'rename', 'move', 'copy', 'permissions'], { commonRank: 4 })
 		]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -488,7 +488,6 @@ export interface FilesystemOptions {
 	fsck: boolean | null;
 	journal_flush_disabled: boolean | null;
 	journal_flush_delay: number | null;
-	io_scheduler: string | null;
 	move_ios_in_flight: number | null;
 	move_bytes_in_flight: string | null;
 }
@@ -552,6 +551,12 @@ export interface FsckStatus {
 	last_output?: string | null;
 }
 
+export interface DeviceIoScheduler {
+	active: string;
+	available: string[];
+	configured: string | null;
+}
+
 export interface BlockDevice {
 	path: string;
 	size_bytes: number;
@@ -582,6 +587,7 @@ export interface BlockDevice {
 	id_kind?: string;
 	/** "detected" (from lsblk/sysfs) | "manual" (operator override). */
 	type_source: string;
+	io_scheduler: DeviceIoScheduler | null;
 }
 
 export type TieringProfileId = 'single' | 'write_cache' | 'full_tiering' | 'none' | 'manual';

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -21,11 +21,14 @@
 	let expandedDisk = $state<string | null>(null);
 	let isVirtual = $state(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	let schedulerValues = $state<Record<string, string>>({});
+	let schedulerPending = $state<Record<string, boolean>>({});
+	let isAdmin = $state(false);
 
 	const client = getClient();
 
 	onMount(async () => {
-		await Promise.all([loadBlockDevices(), loadSmartProtocol(), loadVmStatus()]);
+		await Promise.all([loadBlockDevices(), loadSmartProtocol(), loadVmStatus(), loadIdentity()]);
 		loading = false;
 		pollInterval = setInterval(refresh, 30000);
 	});
@@ -36,8 +39,29 @@
 
 	async function loadBlockDevices() {
 		await withToast(async () => {
-			blockDevices = await client.call<BlockDevice[]>('device.list');
+			const fresh = await client.call<BlockDevice[]>('device.list');
+			blockDevices = fresh;
+			const nextValues = Object.fromEntries(
+				fresh
+					.filter((dev) => dev.io_scheduler)
+					.map((dev) => [dev.path, dev.io_scheduler?.configured ?? ''])
+			);
+			for (const dev of fresh) {
+				if (dev.io_scheduler && schedulerPending[dev.path]) {
+					nextValues[dev.path] = schedulerValues[dev.path] ?? '';
+				}
+			}
+			schedulerValues = nextValues;
 		});
+	}
+
+	async function loadIdentity() {
+		try {
+			const identity = await client.call<{ role: string }>('auth.me');
+			isAdmin = identity.role === 'admin';
+		} catch {
+			isAdmin = false;
+		}
 	}
 
 	async function loadVmStatus() {
@@ -98,6 +122,29 @@
 				: `${dev.path} type set to ${deviceClass.toUpperCase()}`
 		);
 		if (ok !== undefined) await loadBlockDevices();
+	}
+
+	async function setIoScheduler(dev: BlockDevice, scheduler: string) {
+		const previous = schedulerValues[dev.path] ?? dev.io_scheduler?.configured ?? '';
+		schedulerValues[dev.path] = scheduler;
+		schedulerPending[dev.path] = true;
+		try {
+			const ok = await withToast(
+				() => client.call('device.set_io_scheduler', {
+					path: dev.path,
+					scheduler: scheduler || null,
+				}),
+				scheduler
+					? `${dev.path} I/O scheduler set to ${scheduler}`
+					: `${dev.path} I/O scheduler is no longer managed; the active scheduler was left unchanged`
+			);
+			if (ok === undefined) {
+				schedulerValues[dev.path] = previous;
+			}
+		} finally {
+			delete schedulerPending[dev.path];
+			await loadBlockDevices();
+		}
 	}
 
 	// Human note about how durable an override on this disk is.
@@ -279,12 +326,14 @@
 
 	<!-- Devices tab -->
 	{#if activeTab === 'devices'}
-		<table class="w-full text-sm">
+		<div class="overflow-x-auto">
+		<table class="min-w-[900px] w-full text-sm">
 			<thead>
 				<tr>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Device</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Size</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Type</th>
+					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Scheduler</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Filesystem</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground">Status</th>
 					<th class="border-b-2 border-border p-3 text-left text-xs uppercase text-muted-foreground w-px whitespace-nowrap">Actions</th>
@@ -292,7 +341,10 @@
 			</thead>
 			<tbody>
 				{#each blockDevices as dev}
-					<tr class="border-b border-border {dev.dev_type === 'part' ? 'bg-muted/10' : ''}">
+					<tr
+						class="border-b border-border {dev.dev_type === 'part' ? 'bg-muted/10' : ''} {schedulerPending[dev.path] ? 'pointer-events-none opacity-50' : ''}"
+						aria-busy={schedulerPending[dev.path] || undefined}
+					>
 						<td class="p-3 font-mono text-sm {dev.dev_type === 'part' ? 'pl-8' : ''}">{dev.path}</td>
 						<td class="p-3">{formatBytes(dev.size_bytes)}</td>
 						<td class="p-3">
@@ -306,6 +358,7 @@
 										value={dev.type_source === 'manual' ? dev.device_class : 'auto'}
 										title="Override the detected disk type (for VMs where it's wrong)"
 										onchange={(e) => setDiskType(dev, e.currentTarget.value)}
+										disabled={schedulerPending[dev.path]}
 									>
 										<option value="auto">Auto</option>
 										<option value="ssd">SSD</option>
@@ -320,6 +373,29 @@
 								{/if}
 							</div>
 						</td>
+						<td class="min-w-48 p-3">
+							{#if dev.dev_type === 'disk' && dev.io_scheduler}
+								<select
+									class="w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
+									value={schedulerValues[dev.path] ?? dev.io_scheduler.configured ?? ''}
+									onchange={(e) => setIoScheduler(dev, e.currentTarget.value)}
+									disabled={schedulerPending[dev.path] || !isAdmin}
+									aria-label={`I/O scheduler for ${dev.path}`}
+									title={isAdmin ? 'Persist an I/O scheduler for this disk' : 'Administrator access is required to change the I/O scheduler'}
+								>
+									<option value="">Unmanaged (leave active unchanged)</option>
+									{#if dev.io_scheduler.configured && !dev.io_scheduler.available.includes(dev.io_scheduler.configured)}
+										<option value={dev.io_scheduler.configured} disabled>{dev.io_scheduler.configured} (unavailable)</option>
+									{/if}
+									{#each dev.io_scheduler.available as scheduler (scheduler)}
+										<option value={scheduler}>{scheduler}</option>
+									{/each}
+								</select>
+								<div class="mt-1 text-xs text-muted-foreground">Active: {dev.io_scheduler.active}</div>
+							{:else}
+								<span class="text-muted-foreground">—</span>
+							{/if}
+						</td>
 						<td class="p-3 font-mono text-xs text-muted-foreground">{dev.fs_type ?? '—'}</td>
 						<td class="p-3">
 							{#if dev.in_use}
@@ -333,13 +409,14 @@
 						</td>
 						<td class="p-3 w-px whitespace-nowrap">
 							{#if !dev.in_use && dev.fs_type}
-								<Button variant="destructive" size="xs" onclick={() => wipe(dev)}>Wipe</Button>
+								<Button variant="destructive" size="xs" onclick={() => wipe(dev)} disabled={schedulerPending[dev.path]}>Wipe</Button>
 							{/if}
 						</td>
 					</tr>
 				{/each}
 			</tbody>
 		</table>
+		</div>
 
 	<!-- SMART Health tab -->
 	{:else if activeTab === 'smart'}

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -77,7 +77,6 @@
 	let mountFsck = $state(false);
 	let journalFlushDisabled = $state(false);
 	let journalFlushDelay = $state('');
-	let ioScheduler = $state('');
 
 	// Manual tiering state
 	let manualLabels: Record<string, string> = $state({});
@@ -115,7 +114,6 @@
 	let editFsck = $state(false);
 	let editJournalFlushDisabled = $state(false);
 	let editJournalFlushDelay = $state('');
-	let editIoScheduler = $state('');
 
 	let showCreateAdvanced = $state(false);
 	let showCreateCommands = $state(false);
@@ -696,7 +694,6 @@
 				encoded_extent_max: encodedExtentMax || undefined,
 				version_upgrade: versionUpgrade || undefined,
 				journal_flush_delay: journalFlushDelay ? parseInt(journalFlushDelay) : undefined,
-				io_scheduler: ioScheduler || undefined,
 			}),
 			`Filesystem "${newName}" created`
 		);
@@ -726,7 +723,6 @@
 			mountFsck = false;
 			journalFlushDisabled = false;
 			journalFlushDelay = '';
-			ioScheduler = '';
 			await refresh();
 		}
 	}
@@ -982,7 +978,6 @@
 		editFsck = fs.options.fsck ?? false;
 		editJournalFlushDisabled = fs.options.journal_flush_disabled ?? false;
 		editJournalFlushDelay = fs.options.journal_flush_delay?.toString() ?? '';
-		editIoScheduler = fs.options.io_scheduler ?? '';
 		showEditAdvanced = false;
 	}
 
@@ -1057,7 +1052,6 @@
 				fsck: editFsck || undefined,
 				journal_flush_disabled: editJournalFlushDisabled || undefined,
 				journal_flush_delay: editJournalFlushDelay ? parseInt(editJournalFlushDelay) : undefined,
-				io_scheduler: editIoScheduler || undefined,
 			}, 60_000),
 			`Options updated for "${fsName}"`
 		);
@@ -1911,19 +1905,10 @@
 							Disable journal flush
 						</label>
 					</div>
-					<div class="mt-3 grid grid-cols-2 gap-3">
+					<div class="mt-3 max-w-xs">
 						<div>
 							<Label class="text-xs">Journal flush delay (µs)</Label>
 							<Input type="number" bind:value={journalFlushDelay} placeholder="1000" class="mt-1 h-8 text-xs" />
-						</div>
-						<div>
-							<Label class="text-xs">I/O scheduler</Label>
-							<select bind:value={ioScheduler} class="mt-1 h-8 w-full rounded-md border border-input bg-background px-2 text-xs">
-								<option value="">Default</option>
-								<option value="none">none (recommended for SSDs)</option>
-								<option value="mq-deadline">mq-deadline</option>
-								<option value="kyber">kyber</option>
-							</select>
 						</div>
 					</div>
 					<p class="mt-2 text-xs text-muted-foreground">Checksum and bucket size are set at format time. Mount options can be changed later via Edit Options.</p>
@@ -2334,22 +2319,13 @@
 											<span class="text-xs">Disable journal flush</span>
 										</label>
 									</div>
-									<div class="mt-2 grid grid-cols-2 gap-2">
+									<div class="mt-2 max-w-xs">
 										<div>
 											<Label class="text-[0.65rem]">Journal flush delay (µs)</Label>
 											<Input type="number" bind:value={editJournalFlushDelay} placeholder="1000" class="mt-0.5 h-7 text-xs" />
 										</div>
-										<div>
-											<Label class="text-[0.65rem]">I/O scheduler</Label>
-											<select bind:value={editIoScheduler} class="mt-0.5 h-7 w-full rounded-md border border-input bg-background px-2 text-xs">
-												<option value="">Default</option>
-												<option value="none">none (recommended for SSDs)</option>
-												<option value="mq-deadline">mq-deadline</option>
-												<option value="kyber">kyber</option>
-											</select>
-										</div>
 									</div>
-									<p class="mt-1.5 text-[0.6rem] text-muted-foreground">These require a remount to take effect.</p>
+									<p class="mt-1.5 text-[0.6rem] text-muted-foreground">This requires a remount to take effect.</p>
 								</fieldset>
 							</div>
 						{/if}
@@ -2398,10 +2374,6 @@
 								{#if fs.options.journal_flush_delay}
 									<span class="text-muted-foreground">Journal Flush Delay</span>
 									<span>{fs.options.journal_flush_delay} µs</span>
-								{/if}
-								{#if fs.options.io_scheduler}
-									<span class="text-muted-foreground">I/O Scheduler</span>
-									<span>{fs.options.io_scheduler}</span>
 								{/if}
 							</div>
 


### PR DESCRIPTION
## Summary
- move I/O scheduler management from filesystem options to physical disks, resolving aliases and partitions to their queue owner
- validate kernel-advertised schedulers, persist overrides by stable identity, and restore them during startup
- migrate legacy filesystem scheduler settings without discarding partial or conflicting migration data
- add admin-only scheduler controls and active scheduler state to the Disks page

## Safety
- confirm the active scheduler after every kernel write
- roll back the runtime scheduler if persistence fails
- reject non-block-device paths and preserve unresolved legacy settings across filesystem-state rewrites
- derive partition parentage from the `lsblk` tree instead of device-name heuristics

## Verification
- `cargo test --workspace`
- `cargo clippy -p nasty-storage -p nasty-engine --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check`
- `npm test -- --run` (23 files, 219 tests)
- `npm run build`
- `git diff --check`

## Runtime limitation
Live scheduler writes, startup restoration, and migration against Linux `/sys/class/block` could not be exercised from the macOS development environment.