### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1783100339,
-        "narHash": "sha256-9sDE7ua3WMCfV9ZbwQdAbpatv2IhvcwHzzPr+/l2au0=",
+        "lastModified": 1785792640,
+        "narHash": "sha256-3csE9r0g3BpQ1q9YE8GsgdettN539VH+u/uCqQR0yZU=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "dde5ecf6ad8b40c3285a6194f5a2642d0e9c6310",
+        "rev": "5ffbc8b0be7ab5e59683a8fb034e9486f074a7f9",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.38.8",
+        "ref": "v1.39.0",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.38.8 release tag.
+    # Pinned to v1.39.0 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.0";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.38.8";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.0";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the


### PR DESCRIPTION
## Summary
- update the canonical bcachefs-tools input from v1.38.8 to v1.39.0
- refresh the generated flake lock to upstream commit `5ffbc8b0`
- keep the installer wrapper fallback aligned with the root pin

## Release notes
- v1.39.0 includes an on-disk format change for per-device fragmentation LRUs
- adds failure domains, persistent damage tracking, bcachefs kvdb, and snapshot hardening
- reverts multi-device mount sources away from UUIDs; NASty already accepts both source forms

## Testing
- evaluated `packages.aarch64-linux.bcachefs-tools.version` as `1.39.0`
- built `bcachefs-tools-1.39.0` for aarch64-linux
- built `bcachefs-6.18.41-1.39.0` kernel module for aarch64-linux
- `cargo test -p nasty-system` (398 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Not run
- live mount/upgrade testing on a bcachefs pool
- full `nix flake check --all-systems --no-build`; it evaluated the changed x86_64 bcachefs derivation, then hit an unrelated transient invalid store path while evaluating `nasty-rootfs`