### PR TITLE
alerts: acknowledge active occurrences

### DIFF
--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -4588,7 +4588,7 @@ enum AlertLifecycle {
 /// systems can close the same incident they opened).
 async fn dispatch_alert_event(
     config: &nasty_system::notifications::NotificationConfig,
-    alert: &nasty_system::alerts::ActiveAlert,
+    alert: &nasty_system::alerts::AlertOccurrence,
     lifecycle: AlertLifecycle,
 ) {
     use nasty_system::notifications;
@@ -4609,14 +4609,9 @@ async fn dispatch_alert_event(
         "{}\n\nSource: {}\nValue: {:.1}\nThreshold: {:.1}{}",
         alert.message, alert.source, alert.current_value, alert.threshold, body_suffix
     );
-    // Stable event id derived from rule + source + the value the
-    // alert had when it fired. Crucially the resolved event reuses
-    // the same id (we use the original alert's current_value, not
-    // whatever the metric reads now) so receivers can pair the two.
-    let event_id = format!(
-        "alert-{}-{}-{}",
-        alert.rule_id, alert.source, alert.current_value as i64
-    );
+    // The persisted occurrence ID remains stable as values change and is
+    // replaced when a resolved condition later fires again.
+    let event_id = format!("alert-{}", alert.instance_id);
     let mut data = serde_json::to_value(alert).unwrap_or(serde_json::Value::Null);
     // Embed lifecycle in `data.lifecycle` too — some receivers route
     // on a single nested field rather than the top-level event_type.
@@ -4644,11 +4639,11 @@ async fn dispatch_alert_event(
 
 fn spawn_alert_notifier(state: Arc<AppState>) {
     let h = tokio::spawn(async move {
-        use nasty_system::alerts::ActiveAlert;
+        use nasty_system::alerts::AlertOccurrence;
         use nasty_system::notifications;
         use std::collections::HashMap;
 
-        // Keyed map (rule_id, source) → the ActiveAlert as it was when
+        // Keyed map instance ID → the alert occurrence as it was when
         // we first dispatched the alert.fired event. We keep the whole
         // alert (not just the key) so when the alert resolves we can
         // emit alert.resolved carrying the same payload — receivers
@@ -4659,7 +4654,7 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
         // event. Persisting outbox state across restarts is out of
         // scope; the same limitation already applies to fired events
         // (currently-active alerts re-fire after a restart).
-        let mut previously_active: HashMap<(String, String), ActiveAlert> = HashMap::new();
+        let mut notified_active: HashMap<String, AlertOccurrence> = HashMap::new();
 
         // Wait for the metrics service and the rest of the system to come up
         // before the first evaluation; first-boot stats are noisy.
@@ -4673,51 +4668,70 @@ fn spawn_alert_notifier(state: Arc<AppState>) {
             // the notifier silently skipped every cycle when no admin had a
             // browser open. A drive failing at 3am went unalerted until someone
             // opened the dashboard the next morning.
-            let active = crate::router::evaluate_active_alerts(&state).await;
+            let (active, alert_revision) = crate::router::evaluate_active_alerts(&state).await;
 
             // Refresh the RPC cache as a side effect so the next WebUI poll
             // returns instantly with up-to-date data.
-            if let Ok(value) = serde_json::to_value(&active) {
-                *state.alerts_cache.lock().await = Some((std::time::Instant::now(), value));
+            let visible: Vec<_> = active.iter().filter(|alert| !alert.acknowledged).collect();
+            if let Ok(value) = serde_json::to_value(&visible) {
+                let mut cache = state.alerts_cache.lock().await;
+                if alert_revision == state.alerts.revision() {
+                    *cache = Some((std::time::Instant::now(), value));
+                }
             }
 
-            let current: HashMap<(String, String), ActiveAlert> = active
+            let current: HashMap<String, AlertOccurrence> = active
                 .iter()
-                .map(|a| ((a.rule_id.clone(), a.source.clone()), a.clone()))
+                .map(|alert| (alert.instance_id.clone(), alert.clone()))
                 .collect();
 
-            // Newly-fired = in `current` but not in `previously_active`.
-            let new_alerts: Vec<&ActiveAlert> = current
-                .iter()
-                .filter(|(k, _)| !previously_active.contains_key(k))
-                .map(|(_, a)| a)
+            // Only track incidents for which alert.fired was actually sent.
+            // Acknowledged occurrences and cycles with no enabled channel must
+            // not later emit an orphan alert.resolved event.
+            let new_alerts: Vec<AlertOccurrence> = current
+                .values()
+                .filter(|alert| {
+                    !alert.acknowledged && !notified_active.contains_key(&alert.instance_id)
+                })
+                .cloned()
                 .collect();
 
-            // Resolved = in `previously_active` but not in `current`.
+            // Resolved = previously notified but no longer active.
             // Emit with the original alert payload so the receiver
             // sees the same `source`, `rule_id`, etc. it opened the
             // incident with — typical pattern for monitoring systems
             // (PagerDuty / Opsgenie / Alertmanager) that key incident
             // close events on the original payload.
-            let resolved_alerts: Vec<&ActiveAlert> = previously_active
-                .iter()
-                .filter(|(k, _)| !current.contains_key(k))
-                .map(|(_, a)| a)
+            let resolved_alerts: Vec<AlertOccurrence> = notified_active
+                .values()
+                .filter(|alert| !current.contains_key(&alert.instance_id))
+                .cloned()
                 .collect();
 
             if !new_alerts.is_empty() || !resolved_alerts.is_empty() {
                 let config = notifications::NotificationConfig::load();
-                if config.channels.iter().any(|ch| ch.enabled) {
+                let notifications_enabled = config.channels.iter().any(|ch| ch.enabled);
+                let mut fired = Vec::new();
+                if notifications_enabled {
                     for alert in &new_alerts {
-                        dispatch_alert_event(&config, alert, AlertLifecycle::Fired).await;
+                        if state
+                            .alerts
+                            .is_active_unacknowledged(&alert.instance_id)
+                            .await
+                        {
+                            dispatch_alert_event(&config, alert, AlertLifecycle::Fired).await;
+                            fired.push(alert.clone());
+                        }
                     }
                     for alert in &resolved_alerts {
                         dispatch_alert_event(&config, alert, AlertLifecycle::Resolved).await;
                     }
                 }
+                notified_active.retain(|id, _| current.contains_key(id));
+                for alert in fired {
+                    notified_active.insert(alert.instance_id.clone(), alert);
+                }
             }
-
-            previously_active = current;
         }
     });
     // Observer spawn — alert evaluation is supposed to run forever; if

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -49,7 +49,7 @@ use nasty_storage::subvolume::{
     ResizeSubvolumeRequest, RollbackResult, RollbackSnapshotRequest, SetPropertiesRequest,
     Snapshot, Subvolume, UpdateSubvolumeRequest,
 };
-use nasty_system::alerts::{ActiveAlert, AlertRule, AlertRuleUpdate};
+use nasty_system::alerts::{AlertAcknowledgement, AlertOccurrence, AlertRule, AlertRuleUpdate};
 use nasty_system::dc::{DcPrincipal, DcStatus, DemoteRequest, ProvisionRequest};
 use nasty_system::domain::{DomainPrincipal, DomainStatus, JoinDomainRequest, LeaveDomainRequest};
 use nasty_system::firewall::FirewallStatus;
@@ -273,7 +273,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     desc: "Evaluate alert rules against current system state and return any active alerts.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
-                    result: Some(gen_schema::<Vec<ActiveAlert>>(generator)),
+                    result: Some(gen_schema::<Vec<AlertOccurrence>>(generator)),
                 },
                 Method {
                     name: "system.reboot",
@@ -459,6 +459,16 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
         (
             "Alert Rules",
             vec![
+                Method {
+                    name: "alert.acknowledge",
+                    desc: "Acknowledge one active alert occurrence until its condition resolves.",
+                    role: MethodRole::Operator,
+                    params: MethodParams::AdHoc(ad_hoc_one(
+                        "instance_id",
+                        "Opaque active alert occurrence identifier.",
+                    )),
+                    result: Some(gen_schema::<AlertAcknowledgement>(generator)),
+                },
                 Method {
                     name: "alert.rules.list",
                     desc: "List all alert rules.",

--- a/engine/nasty-engine/src/registry/paths.rs
+++ b/engine/nasty-engine/src/registry/paths.rs
@@ -186,6 +186,7 @@ mod tests {
         assert_eq!(translate("auth.logout").0, HttpVerb::Post);
         assert_eq!(translate("system.update.apply").0, HttpVerb::Post);
         assert_eq!(translate("system.update.rollback").0, HttpVerb::Post);
+        assert_eq!(translate("alert.acknowledge").0, HttpVerb::Post);
         assert_eq!(
             translate("system.version.upgrade_tagged_release").0,
             HttpVerb::Post

--- a/engine/nasty-engine/src/router/alerts.rs
+++ b/engine/nasty-engine/src/router/alerts.rs
@@ -35,12 +35,32 @@ pub(super) async fn try_route(
                 }
             }
 
-            let alerts = evaluate_active_alerts(state).await;
+            let (evaluated, revision) = evaluate_active_alerts(state).await;
+            let alerts: Vec<_> = evaluated
+                .into_iter()
+                .filter(|alert| !alert.acknowledged)
+                .collect();
             let value = serde_json::to_value(&alerts).unwrap_or_default();
-            *state.alerts_cache.lock().await = Some((std::time::Instant::now(), value));
+            let mut cache = state.alerts_cache.lock().await;
+            if revision == state.alerts.revision() {
+                *cache = Some((std::time::Instant::now(), value));
+            }
 
             ok(req, alerts)
         }
+        "alert.acknowledge" => match require_str(req, "instance_id") {
+            Ok(instance_id) => {
+                match acknowledge_active_alert(state, instance_id, &session.username).await {
+                    Ok(acknowledgement) => {
+                        *state.alerts_cache.lock().await = None;
+                        *state.status_cache.lock().await = None;
+                        ok(req, acknowledgement)
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
+            Err(r) => r,
+        },
         "alert.rules.list" => ok(req, state.alerts.list_rules().await),
         "alert.rules.create" => match parse_params(req) {
             Ok(rule) => match state.alerts.create_rule(rule).await {

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -185,6 +185,7 @@ fn is_operator_allowed(method: &str) -> bool {
                 // was listening. Same coupling as share CRUD.
                 | "service.protocol.enable"
                 | "service.protocol.disable"
+                | "alert.acknowledge"
                 // VM disk-image import. Operator already has
                 // `vm.create` etc.; without import they can't
                 // populate the disk to boot from.
@@ -382,7 +383,7 @@ fn collection_for_method(method: &str) -> Option<&'static str> {
         m if m.starts_with("system.tuning.") && !is_read_only(m) => Some("tuning"),
         m if m.starts_with("system.nut.") && !is_read_only(m) => Some("nut"),
         m if m.starts_with("system.tailscale.") && !is_read_only(m) => Some("tailscale"),
-        m if m.starts_with("alert.rules.") && !is_read_only(m) => Some("alert"),
+        m if m.starts_with("alert.") && !is_read_only(m) => Some("alert"),
         _ => None,
     }
 }
@@ -1175,7 +1176,88 @@ pub(super) async fn vm_clone(
 /// silence everything else.
 pub(crate) async fn evaluate_active_alerts(
     state: &AppState,
-) -> Vec<nasty_system::alerts::ActiveAlert> {
+) -> (Vec<nasty_system::alerts::AlertOccurrence>, u64) {
+    let _guard = state.alerts.lock_evaluation().await;
+    let alerts = evaluate_active_alerts_inner(state).await;
+    (alerts, state.alerts.revision())
+}
+
+pub(crate) async fn acknowledge_active_alert(
+    state: &AppState,
+    instance_id: &str,
+    username: &str,
+) -> Result<nasty_system::alerts::AlertAcknowledgement, String> {
+    let _guard = state.alerts.lock_evaluation().await;
+    let active = evaluate_active_alerts_inner(state).await;
+    if !active.iter().any(|alert| alert.instance_id == instance_id) {
+        return Err("alert is no longer active".into());
+    }
+    state.alerts.acknowledge(instance_id, username).await
+}
+
+#[derive(Default)]
+struct AlertCoverage {
+    unavailable_metrics: std::collections::HashSet<nasty_system::alerts::AlertMetric>,
+    unavailable_sources: std::collections::HashSet<(nasty_system::alerts::AlertMetric, String)>,
+    observed_smart_attributes: std::collections::HashMap<String, std::collections::HashSet<u32>>,
+}
+
+impl AlertCoverage {
+    fn mark_metric(&mut self, metric: nasty_system::alerts::AlertMetric) {
+        self.unavailable_metrics.insert(metric);
+    }
+
+    fn mark_source(
+        &mut self,
+        metric: nasty_system::alerts::AlertMetric,
+        source: impl Into<String>,
+    ) {
+        self.unavailable_sources.insert((metric, source.into()));
+    }
+
+    fn observe_smart_attributes(
+        &mut self,
+        source: String,
+        attribute_ids: impl Iterator<Item = u32>,
+    ) {
+        self.observed_smart_attributes
+            .insert(source, attribute_ids.collect());
+    }
+
+    fn is_observed(&self, alert: &nasty_system::alerts::ActiveAlert) -> bool {
+        if self.unavailable_metrics.contains(&alert.metric) {
+            return false;
+        }
+        let source = if alert.metric == nasty_system::alerts::AlertMetric::SmartAttribute {
+            alert
+                .source
+                .rsplit_once('#')
+                .map_or(alert.source.as_str(), |(device, _)| device)
+        } else {
+            &alert.source
+        };
+        if self
+            .unavailable_sources
+            .contains(&(alert.metric.clone(), source.to_string()))
+        {
+            return false;
+        }
+        if alert.metric == nasty_system::alerts::AlertMetric::SmartAttribute
+            && let Some(observed) = self.observed_smart_attributes.get(source)
+        {
+            return alert
+                .source
+                .rsplit_once('#')
+                .and_then(|(_, id)| id.parse().ok())
+                .is_some_and(|id| observed.contains(&id));
+        }
+        true
+    }
+}
+
+pub(crate) async fn evaluate_active_alerts_inner(
+    state: &AppState,
+) -> Vec<nasty_system::alerts::AlertOccurrence> {
     use nasty_system::alerts;
 
     // System stats — required for CPU/memory/temp rules. If the metrics
@@ -1188,13 +1270,26 @@ pub(crate) async fn evaluate_active_alerts(
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("alert evaluation: stats fetch failed: {e}");
-                return Vec::new();
+                return state.alerts.reconcile_active(Vec::new(), |_| false).await;
             }
         };
+
+    let mut coverage = AlertCoverage::default();
 
     let filesystems = match state.filesystems.list().await {
         Ok(v) => v,
         Err(e) => {
+            for metric in [
+                alerts::AlertMetric::FsUsagePercent,
+                alerts::AlertMetric::BcachefsDegraded,
+                alerts::AlertMetric::BcachefsDeviceError,
+                alerts::AlertMetric::BcachefsDeviceState,
+                alerts::AlertMetric::BcachefsIOErrors,
+                alerts::AlertMetric::BcachefsScrubErrors,
+                alerts::AlertMetric::BcachefsReconcileStalled,
+            ] {
+                coverage.mark_metric(metric);
+            }
             tracing::warn!(
                 "alert evaluation: filesystems.list() failed: {e} — \
                  fs-level alerts will be skipped this cycle"
@@ -1207,12 +1302,49 @@ pub(crate) async fn evaluate_active_alerts(
         .is_enabled(nasty_system::protocol::Protocol::Smart)
         .await
     {
-        fetch_metrics_json(&state.metrics_client, "/api/disks")
-            .await
-            .unwrap_or_default()
+        match fetch_metrics_json(&state.metrics_client, "/api/disks").await {
+            Ok(disks) => disks,
+            Err(e) => {
+                for metric in [
+                    alerts::AlertMetric::DiskTemperature,
+                    alerts::AlertMetric::SmartHealth,
+                    alerts::AlertMetric::SmartAttribute,
+                ] {
+                    coverage.mark_metric(metric);
+                }
+                tracing::warn!(
+                    "alert evaluation: disk metrics fetch failed: {e} — \
+                     SMART alerts will retain their last known state"
+                );
+                Vec::new()
+            }
+        }
     } else {
         Vec::new()
     };
+
+    for disk in &disk_health {
+        let label = match &disk.transport {
+            Some(transport) => format!("{} [{}]", disk.device, transport),
+            None => disk.device.clone(),
+        };
+        if disk.temperature_c.is_none() {
+            coverage.mark_source(alerts::AlertMetric::DiskTemperature, label.clone());
+        }
+        if disk.smart_status == "UNAVAILABLE" {
+            coverage.mark_source(alerts::AlertMetric::SmartHealth, label.clone());
+            coverage.mark_source(alerts::AlertMetric::SmartAttribute, label);
+        } else if disk.rotational.is_none()
+            || (disk.rotational == Some(true) && disk.attributes.is_empty())
+        {
+            coverage.mark_source(alerts::AlertMetric::SmartAttribute, label);
+        } else if disk.rotational == Some(true) {
+            coverage.observe_smart_attributes(
+                label,
+                disk.attributes.iter().map(|attribute| attribute.id),
+            );
+        }
+    }
 
     let fs_usage_list: Vec<alerts::FsUsage> = filesystems
         .iter()
@@ -1271,6 +1403,13 @@ pub(crate) async fn evaluate_active_alerts(
                 fs_service.scrub_status(&fs.name),
                 fs_service.reconcile_status(&fs.name),
             );
+            let mut unavailable = Vec::new();
+            if !io_error_count.1 {
+                unavailable.push(alerts::AlertMetric::BcachefsIOErrors);
+            }
+            if scrub_result.is_err() {
+                unavailable.push(alerts::AlertMetric::BcachefsScrubErrors);
+            }
 
             let scrub_errors = match scrub_result {
                 Ok(s) => s.raw.to_lowercase().contains("error"),
@@ -1287,36 +1426,72 @@ pub(crate) async fn evaluate_active_alerts(
                     } else {
                         ReconcileProgressSample::Unavailable
                     };
+                    if sample.pending.is_some()
+                        && !sample.active
+                        && progress == ReconcileProgressSample::Unavailable
+                    {
+                        unavailable.push(alerts::AlertMetric::BcachefsReconcileStalled);
+                    }
                     reconcile_stall_check(&fs.name, &sample, progress)
                 }
-                Ok(_) | Err(_) => {
+                Ok(_) => {
+                    clear_reconcile_tracker(&fs.name);
+                    false
+                }
+                Err(_) => {
+                    unavailable.push(alerts::AlertMetric::BcachefsReconcileStalled);
                     clear_reconcile_tracker(&fs.name);
                     false
                 }
             };
 
-            alerts::BcachefsHealth {
-                fs_name: fs.name.clone(),
-                degraded,
-                devices,
-                io_error_count,
-                scrub_errors,
-                reconcile_stalled,
-            }
+            (
+                alerts::BcachefsHealth {
+                    fs_name: fs.name.clone(),
+                    degraded,
+                    devices,
+                    io_error_count: io_error_count.0,
+                    scrub_errors,
+                    reconcile_stalled,
+                },
+                unavailable,
+            )
         });
     }
     let mut bcachefs_health = Vec::new();
     while let Some(result) = health_tasks.join_next().await {
-        if let Ok(health) = result {
+        if let Ok((health, unavailable)) = result {
+            for metric in unavailable {
+                coverage.mark_source(metric, health.fs_name.clone());
+            }
             bcachefs_health.push(health);
+        } else {
+            for metric in [
+                alerts::AlertMetric::BcachefsDegraded,
+                alerts::AlertMetric::BcachefsDeviceError,
+                alerts::AlertMetric::BcachefsDeviceState,
+                alerts::AlertMetric::BcachefsIOErrors,
+                alerts::AlertMetric::BcachefsScrubErrors,
+                alerts::AlertMetric::BcachefsReconcileStalled,
+            ] {
+                coverage.mark_metric(metric);
+            }
         }
     }
 
     // Kernel error counters from the metrics service.
     let kernel_summary: nasty_common::metrics_types::KernelErrorSummary =
-        fetch_metrics_json(&state.metrics_client, "/api/kernel_errors")
-            .await
-            .unwrap_or_default();
+        match fetch_metrics_json(&state.metrics_client, "/api/kernel_errors").await {
+            Ok(summary) => summary,
+            Err(e) => {
+                coverage.mark_metric(alerts::AlertMetric::KernelErrors);
+                tracing::warn!(
+                    "alert evaluation: kernel metrics fetch failed: {e} — \
+                     kernel alerts will retain their last known state"
+                );
+                Default::default()
+            }
+        };
     let kernel_alert = alerts::KernelErrorAlert {
         total_count: kernel_summary.total_count,
         categories: kernel_summary
@@ -1326,7 +1501,7 @@ pub(crate) async fn evaluate_active_alerts(
             .collect(),
     };
 
-    let mut active = state
+    let (mut active, unavailable_disk_metrics) = state
         .alerts
         .evaluate(
             &stats,
@@ -1336,6 +1511,9 @@ pub(crate) async fn evaluate_active_alerts(
             &kernel_alert,
         )
         .await;
+    for metric in unavailable_disk_metrics {
+        coverage.mark_metric(metric);
+    }
 
     // Mount failures recorded at boot stay live until the engine is
     // restarted. Enrich the alert with current state: a locked
@@ -1349,6 +1527,9 @@ pub(crate) async fn evaluate_active_alerts(
         let current_fses = match state.filesystems.list().await {
             Ok(v) => v,
             Err(e) => {
+                for name in mount_failures.iter() {
+                    coverage.mark_source(alerts::AlertMetric::BcachefsDegraded, name.clone());
+                }
                 tracing::warn!(
                     "mount-failure alert enrichment: filesystems.list() failed: {e} — \
                      using empty fs set, alerts may show stale state"
@@ -1388,8 +1569,12 @@ pub(crate) async fn evaluate_active_alerts(
             });
         }
     }
+    drop(mount_failures);
 
-    active
+    state
+        .alerts
+        .reconcile_active(active, |alert| coverage.is_observed(alert))
+        .await
 }
 
 /// How long reconcile must have pending work with no pending-counter or
@@ -1556,28 +1741,55 @@ fn clear_reconcile_tracker(fs_name: &str) {
     RECONCILE_STALL_TRACKER.lock().unwrap().remove(fs_name);
 }
 
-/// Read bcachefs error counters from sysfs. Returns total read+write error count.
-pub(super) async fn read_bcachefs_error_count(uuid: &str) -> u64 {
+/// Read bcachefs error counters from sysfs. The completeness flag prevents a
+/// partial zero from resolving an alert while retaining any confirmed errors.
+pub(super) async fn read_bcachefs_error_count(uuid: &str) -> (u64, bool) {
     let counters_dir = format!("/sys/fs/bcachefs/{uuid}/counters");
     let mut total = 0u64;
+    let mut complete = true;
     for name in ["io_read_errors", "io_write_errors", "io_checksum_errors"] {
         let path = format!("{counters_dir}/{name}");
-        if let Ok(val) = tokio::fs::read_to_string(&path).await
-            && let Ok(n) = val.trim().parse::<u64>()
-        {
-            total += n;
+        match tokio::fs::read_to_string(&path).await {
+            Ok(value) => match value.trim().parse::<u64>() {
+                Ok(value) => total += value,
+                Err(_) => complete = false,
+            },
+            Err(_) => complete = false,
         }
     }
-    total
+    (total, complete)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ReconcileProgress, ReconcileProgressSample, clear_reconcile_tracker, is_operator_allowed,
-        is_read_only, is_universally_allowed, is_user_allowed, reconcile_progress,
-        reconcile_stall_check_at,
+        AlertCoverage, ReconcileProgress, ReconcileProgressSample, clear_reconcile_tracker,
+        is_operator_allowed, is_read_only, is_universally_allowed, is_user_allowed,
+        reconcile_progress, reconcile_stall_check_at,
     };
+
+    fn smart_attribute_alert(source: &str) -> nasty_system::alerts::ActiveAlert {
+        nasty_system::alerts::ActiveAlert {
+            rule_id: "smart-attribute".into(),
+            rule_name: "SMART attribute warning".into(),
+            severity: nasty_system::alerts::AlertSeverity::Warning,
+            metric: nasty_system::alerts::AlertMetric::SmartAttribute,
+            message: "SMART attribute is non-zero".into(),
+            current_value: 1.0,
+            threshold: 0.0,
+            source: source.into(),
+        }
+    }
+
+    #[test]
+    fn smart_attribute_resolution_requires_the_specific_attribute() {
+        let mut coverage = AlertCoverage::default();
+        coverage.observe_smart_attributes("/dev/sda".into(), [5, 197].into_iter());
+
+        assert!(coverage.is_observed(&smart_attribute_alert("/dev/sda#5")));
+        assert!(!coverage.is_observed(&smart_attribute_alert("/dev/sda#198")));
+        assert!(coverage.is_observed(&smart_attribute_alert("/dev/sdb#198")));
+    }
 
     #[test]
     fn reconcile_progress_uses_only_reconcile_movement_counters() {

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -82,8 +82,11 @@ pub(super) async fn try_route(
                     return Some(ok(req, cached.clone()));
                 }
             }
-            let status = build_system_status(state).await;
-            *state.status_cache.lock().await = Some((std::time::Instant::now(), status.clone()));
+            let (status, revision) = build_system_status(state).await;
+            let mut cache = state.status_cache.lock().await;
+            if revision == state.alerts.revision() {
+                *cache = Some((std::time::Instant::now(), status.clone()));
+            }
             ok(req, status)
         }
         "system.operations.list" => ok(req, build_operations(state).await),
@@ -937,16 +940,16 @@ pub(super) async fn try_route(
 /// Aggregate the sidebar status band (#528): current alert counts (reusing the
 /// shared alert evaluation) plus a scan of every filesystem for in-progress
 /// array operations (device evacuation, running scrub, active reconcile).
-async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
+async fn build_system_status(state: &AppState) -> (nasty_system::SystemStatus, u64) {
     use nasty_system::alerts::AlertSeverity;
 
     // Alert side: reuse the canonical evaluation, then split by severity.
-    let alerts = super::evaluate_active_alerts(state).await;
+    let (alerts, alert_revision) = super::evaluate_active_alerts(state).await;
     let mut critical_count = 0u32;
     let mut warning_count = 0u32;
     let mut top_critical: Option<String> = None;
     let mut top_warning: Option<String> = None;
-    for a in &alerts {
+    for a in alerts.iter().filter(|alert| !alert.acknowledged) {
         match a.severity {
             AlertSeverity::Critical => {
                 critical_count += 1;
@@ -1008,12 +1011,15 @@ async fn build_system_status(state: &AppState) -> nasty_system::SystemStatus {
         }
     }
 
-    nasty_system::SystemStatus::from_parts(
-        critical_count,
-        warning_count,
-        top_critical,
-        top_warning,
-        operations,
+    (
+        nasty_system::SystemStatus::from_parts(
+            critical_count,
+            warning_count,
+            top_critical,
+            top_warning,
+            operations,
+        ),
+        alert_revision,
     )
 }
 

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -1,7 +1,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 
 const STATE_PATH: &str = "/var/lib/nasty/alerts.json";
 const STATE_DIR: &str = "/var/lib/nasty";
@@ -24,7 +26,7 @@ pub struct AlertRule {
     pub severity: AlertSeverity,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AlertMetric {
     FsUsagePercent,
@@ -76,7 +78,7 @@ pub enum AlertSeverity {
     Critical,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ActiveAlert {
     /// ID of the rule that triggered this alert.
     pub rule_id: String,
@@ -96,13 +98,55 @@ pub struct ActiveAlert {
     pub source: String,
 }
 
+/// One continuous occurrence of an alert condition. A condition that resolves
+/// and later fires again receives a new instance ID and must be acknowledged
+/// separately.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AlertOccurrence {
+    #[serde(flatten)]
+    pub alert: ActiveAlert,
+    pub instance_id: String,
+    pub acknowledged: bool,
+    pub acknowledged_at: Option<String>,
+    pub acknowledged_by: Option<String>,
+}
+
+impl Deref for AlertOccurrence {
+    type Target = ActiveAlert;
+
+    fn deref(&self) -> &Self::Target {
+        &self.alert
+    }
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AlertAcknowledgement {
+    pub instance_id: String,
+    pub acknowledged_at: String,
+    pub acknowledged_by: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct AlertInstanceState {
+    instance_id: String,
+    alert: ActiveAlert,
+    acknowledged_at: Option<String>,
+    acknowledged_by: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct AlertState {
     rules: Vec<AlertRule>,
+    #[serde(default)]
+    active_instances: Vec<AlertInstanceState>,
+    #[serde(skip)]
+    dirty: bool,
 }
 
 pub struct AlertService {
     state: Arc<RwLock<AlertState>>,
+    evaluation_lock: Arc<Mutex<()>>,
+    revision: Arc<AtomicU64>,
 }
 
 impl AlertService {
@@ -130,6 +174,8 @@ impl AlertService {
 
         Self {
             state: Arc::new(RwLock::new(state)),
+            evaluation_lock: Arc::new(Mutex::new(())),
+            revision: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -152,6 +198,8 @@ impl AlertService {
         };
         state.rules.push(rule.clone());
         save_state(&state).await.map_err(|e| e.to_string())?;
+        state.dirty = false;
+        self.revision.fetch_add(1, Ordering::AcqRel);
         Ok(rule)
     }
 
@@ -182,6 +230,8 @@ impl AlertService {
 
         let rule = rule.clone();
         save_state(&state).await.map_err(|e| e.to_string())?;
+        state.dirty = false;
+        self.revision.fetch_add(1, Ordering::AcqRel);
         Ok(rule)
     }
 
@@ -193,6 +243,8 @@ impl AlertService {
             return Err("rule not found".into());
         }
         save_state(&state).await.map_err(|e| e.to_string())?;
+        state.dirty = false;
+        self.revision.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 
@@ -206,21 +258,204 @@ impl AlertService {
         disk_health: &[DiskHealthSummary],
         bcachefs_health: &[BcachefsHealth],
         kernel_errors: &KernelErrorAlert,
-    ) -> Vec<ActiveAlert> {
+    ) -> (Vec<ActiveAlert>, Vec<AlertMetric>) {
         let state = self.state.read().await;
-        evaluate_rules(
+        let disk_free = DiskFreeSpace {
+            root_free_gb: root_free_gb(),
+            boot_free_mb: boot_free_mb(),
+        };
+        let mut unavailable = Vec::new();
+        if disk_free.root_free_gb.is_none() {
+            unavailable.push(AlertMetric::RootDiskFreeGb);
+        }
+        if disk_free.boot_free_mb.is_none() {
+            unavailable.push(AlertMetric::BootDiskFreeMb);
+        }
+        let alerts = evaluate_rules(
             &state.rules,
             stats,
             filesystems,
             disk_health,
             bcachefs_health,
             kernel_errors,
-            DiskFreeSpace {
-                root_free_gb: root_free_gb(),
-                boot_free_mb: boot_free_mb(),
-            },
-        )
+            disk_free,
+        );
+        (alerts, unavailable)
     }
+
+    /// Serialize evaluation and acknowledgement so neither can overwrite the
+    /// other's occurrence state.
+    pub async fn lock_evaluation(&self) -> OwnedMutexGuard<()> {
+        self.evaluation_lock.clone().lock_owned().await
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision.load(Ordering::Acquire)
+    }
+
+    pub async fn is_active_unacknowledged(&self, instance_id: &str) -> bool {
+        self.state
+            .read()
+            .await
+            .active_instances
+            .iter()
+            .any(|instance| {
+                instance.instance_id == instance_id && instance.acknowledged_at.is_none()
+            })
+    }
+
+    pub async fn reconcile_active(
+        &self,
+        alerts: Vec<ActiveAlert>,
+        is_observed: impl Fn(&ActiveAlert) -> bool,
+    ) -> Vec<AlertOccurrence> {
+        let mut state = self.state.write().await;
+        let enabled_rule_ids: std::collections::HashSet<_> = state
+            .rules
+            .iter()
+            .filter(|rule| rule.enabled)
+            .map(|rule| rule.id.as_str())
+            .collect();
+        let is_enabled =
+            |rule_id: &str| rule_id == "mount-failure" || enabled_rule_ids.contains(rule_id);
+        let existing: Vec<_> = state
+            .active_instances
+            .iter()
+            .filter(|instance| is_enabled(&instance.alert.rule_id))
+            .cloned()
+            .collect();
+        let alerts = alerts
+            .into_iter()
+            .filter(|alert| is_enabled(&alert.rule_id))
+            .collect();
+        let (instances, occurrences) = reconcile_instances(&existing, alerts, is_observed);
+        let lifecycle_changed = !same_instance_lifecycle(&instances, &state.active_instances);
+        state.active_instances = instances;
+        self.revision.fetch_add(1, Ordering::AcqRel);
+        if lifecycle_changed {
+            state.dirty = true;
+        }
+        if state.dirty {
+            if let Err(e) = save_state(&state).await {
+                tracing::warn!("failed to persist alert occurrence state: {e}");
+            } else {
+                state.dirty = false;
+            }
+        }
+        occurrences
+    }
+
+    pub async fn acknowledge(
+        &self,
+        instance_id: &str,
+        username: &str,
+    ) -> Result<AlertAcknowledgement, String> {
+        let mut state = self.state.write().await;
+        let mut candidate = state.clone();
+        let acknowledgement = mark_acknowledged(
+            &mut candidate.active_instances,
+            instance_id,
+            username,
+            &chrono::Utc::now().to_rfc3339(),
+        )?;
+        save_state(&candidate).await.map_err(|e| e.to_string())?;
+        candidate.dirty = false;
+        *state = candidate;
+        self.revision.fetch_add(1, Ordering::AcqRel);
+        Ok(acknowledgement)
+    }
+}
+
+fn reconcile_instances(
+    existing: &[AlertInstanceState],
+    alerts: Vec<ActiveAlert>,
+    is_observed: impl Fn(&ActiveAlert) -> bool,
+) -> (Vec<AlertInstanceState>, Vec<AlertOccurrence>) {
+    let mut instances = Vec::with_capacity(alerts.len());
+    let mut occurrences = Vec::with_capacity(alerts.len());
+    let mut remaining = existing.to_vec();
+
+    for alert in alerts {
+        let mut instance = remaining
+            .iter()
+            .position(|instance| {
+                instance.alert.rule_id == alert.rule_id && instance.alert.source == alert.source
+            })
+            .map(|position| remaining.remove(position))
+            .unwrap_or_else(|| AlertInstanceState {
+                instance_id: uuid_v4(),
+                alert: alert.clone(),
+                acknowledged_at: None,
+                acknowledged_by: None,
+            });
+        instance.alert = alert.clone();
+        occurrences.push(occurrence_with_alert(&instance, alert));
+        instances.push(instance);
+    }
+
+    // Absence only proves resolution when this occurrence's own signal was
+    // observed. Keep unrelated or per-resource telemetry gaps last-known-good.
+    for instance in remaining {
+        if !is_observed(&instance.alert) {
+            occurrences.push(occurrence_from(&instance));
+            instances.push(instance);
+        }
+    }
+
+    (instances, occurrences)
+}
+
+fn same_instance_lifecycle(left: &[AlertInstanceState], right: &[AlertInstanceState]) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|left| {
+            right.iter().any(|right| {
+                left.instance_id == right.instance_id
+                    && left.alert.rule_id == right.alert.rule_id
+                    && left.alert.source == right.alert.source
+                    && left.acknowledged_at == right.acknowledged_at
+                    && left.acknowledged_by == right.acknowledged_by
+            })
+        })
+}
+
+fn occurrence_from(instance: &AlertInstanceState) -> AlertOccurrence {
+    occurrence_with_alert(instance, instance.alert.clone())
+}
+
+fn occurrence_with_alert(instance: &AlertInstanceState, alert: ActiveAlert) -> AlertOccurrence {
+    AlertOccurrence {
+        alert,
+        instance_id: instance.instance_id.clone(),
+        acknowledged: instance.acknowledged_at.is_some(),
+        acknowledged_at: instance.acknowledged_at.clone(),
+        acknowledged_by: instance.acknowledged_by.clone(),
+    }
+}
+
+fn mark_acknowledged(
+    instances: &mut [AlertInstanceState],
+    instance_id: &str,
+    username: &str,
+    acknowledged_at: &str,
+) -> Result<AlertAcknowledgement, String> {
+    let instance = instances
+        .iter_mut()
+        .find(|instance| instance.instance_id == instance_id)
+        .ok_or_else(|| "alert is no longer active".to_string())?;
+
+    let at = instance
+        .acknowledged_at
+        .get_or_insert_with(|| acknowledged_at.to_string())
+        .clone();
+    let by = instance
+        .acknowledged_by
+        .get_or_insert_with(|| username.to_string())
+        .clone();
+    Ok(AlertAcknowledgement {
+        instance_id: instance.instance_id.clone(),
+        acknowledged_at: at,
+        acknowledged_by: by,
+    })
 }
 
 /// Free-space readings for the alert metrics that need them. Bundled
@@ -1066,35 +1301,7 @@ fn default_rules() -> Vec<AlertRule> {
 }
 
 fn uuid_v4() -> String {
-    let mut bytes = [0u8; 16];
-    // Use /dev/urandom for random bytes
-    if let Ok(data) = std::fs::read("/dev/urandom") {
-        for (i, b) in data.iter().take(16).enumerate() {
-            bytes[i] = *b;
-        }
-    }
-    // Set version and variant bits
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    format!(
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        bytes[0],
-        bytes[1],
-        bytes[2],
-        bytes[3],
-        bytes[4],
-        bytes[5],
-        bytes[6],
-        bytes[7],
-        bytes[8],
-        bytes[9],
-        bytes[10],
-        bytes[11],
-        bytes[12],
-        bytes[13],
-        bytes[14],
-        bytes[15],
-    )
+    uuid::Uuid::new_v4().to_string()
 }
 
 async fn load_state() -> AlertState {
@@ -1102,9 +1309,16 @@ async fn load_state() -> AlertState {
 }
 
 async fn save_state(state: &AlertState) -> Result<(), std::io::Error> {
+    use tokio::io::AsyncWriteExt;
+
     tokio::fs::create_dir_all(STATE_DIR).await?;
-    let json = serde_json::to_string_pretty(state).unwrap();
-    tokio::fs::write(STATE_PATH, json).await?;
+    let json = serde_json::to_vec_pretty(state).map_err(std::io::Error::other)?;
+    let tmp_path = format!("{STATE_PATH}.tmp");
+    let mut file = tokio::fs::File::create(&tmp_path).await?;
+    file.write_all(&json).await?;
+    file.sync_all().await?;
+    drop(file);
+    tokio::fs::rename(tmp_path, STATE_PATH).await?;
     Ok(())
 }
 
@@ -1113,6 +1327,129 @@ mod tests {
     use super::*;
     use crate::SystemStats;
     use nasty_common::metrics_types::{CpuStats, MemoryStats};
+
+    fn test_alert(value: f64) -> ActiveAlert {
+        ActiveAlert {
+            rule_id: "smart-attribute".into(),
+            rule_name: "SMART attribute warning".into(),
+            severity: AlertSeverity::Warning,
+            metric: AlertMetric::SmartAttribute,
+            message: "SMART attribute is non-zero".into(),
+            current_value: value,
+            threshold: 0.0,
+            source: "/dev/sda#5".into(),
+        }
+    }
+
+    #[test]
+    fn legacy_alert_state_deserializes_without_occurrences() {
+        let state: AlertState = serde_json::from_str(r#"{"rules":[]}"#).unwrap();
+        assert!(state.active_instances.is_empty());
+    }
+
+    #[test]
+    fn acknowledgement_survives_value_changes_and_resets_after_resolution() {
+        let (mut instances, first) = reconcile_instances(&[], vec![test_alert(1.0)], |_| true);
+        let first_id = first[0].instance_id.clone();
+        mark_acknowledged(
+            &mut instances,
+            &first_id,
+            "operator",
+            "2026-08-05T00:00:00Z",
+        )
+        .unwrap();
+
+        let (instances, continuing) =
+            reconcile_instances(&instances, vec![test_alert(2.0)], |_| true);
+        assert_eq!(continuing[0].instance_id, first_id);
+        assert!(continuing[0].acknowledged);
+        assert_eq!(continuing[0].acknowledged_by.as_deref(), Some("operator"));
+        assert_eq!(continuing[0].current_value, 2.0);
+
+        let (instances, resolved) = reconcile_instances(&instances, Vec::new(), |_| true);
+        assert!(instances.is_empty());
+        assert!(resolved.is_empty());
+
+        let (_, recurrence) = reconcile_instances(&instances, vec![test_alert(3.0)], |_| true);
+        assert_ne!(recurrence[0].instance_id, first_id);
+        assert!(!recurrence[0].acknowledged);
+    }
+
+    #[test]
+    fn acknowledgement_is_idempotent_and_rejects_stale_ids() {
+        let (mut instances, occurrences) =
+            reconcile_instances(&[], vec![test_alert(1.0)], |_| true);
+        let id = &occurrences[0].instance_id;
+        let first = mark_acknowledged(&mut instances, id, "alice", "first").unwrap();
+        let second = mark_acknowledged(&mut instances, id, "bob", "second").unwrap();
+        assert_eq!(first.acknowledged_at, "first");
+        assert_eq!(second.acknowledged_at, "first");
+        assert_eq!(second.acknowledged_by, "alice");
+        assert!(mark_acknowledged(&mut instances, "stale", "alice", "now").is_err());
+    }
+
+    #[test]
+    fn incomplete_evaluation_preserves_missing_occurrences() {
+        let (mut instances, occurrences) =
+            reconcile_instances(&[], vec![test_alert(1.0)], |_| true);
+        let id = occurrences[0].instance_id.clone();
+        mark_acknowledged(&mut instances, &id, "alice", "now").unwrap();
+
+        let (preserved, visible) = reconcile_instances(&instances, Vec::new(), |_| false);
+        assert_eq!(preserved.len(), 1);
+        assert_eq!(visible[0].instance_id, id);
+        assert!(visible[0].acknowledged);
+    }
+
+    #[test]
+    fn incomplete_family_does_not_prevent_unrelated_resolution() {
+        let mut cpu = test_alert(90.0);
+        cpu.rule_id = "cpu-high".into();
+        cpu.metric = AlertMetric::CpuLoadPercent;
+        cpu.source = "system".into();
+        let (instances, _) = reconcile_instances(&[], vec![test_alert(1.0), cpu], |_| true);
+
+        let (preserved, visible) = reconcile_instances(&instances, Vec::new(), |alert| {
+            alert.metric != AlertMetric::SmartAttribute
+        });
+
+        assert_eq!(preserved.len(), 1);
+        assert_eq!(visible[0].source, "/dev/sda#5");
+    }
+
+    #[test]
+    fn incomplete_resource_does_not_prevent_peer_resolution() {
+        let mut other_disk = test_alert(2.0);
+        other_disk.source = "/dev/sdb#5".into();
+        let (instances, _) = reconcile_instances(&[], vec![test_alert(1.0), other_disk], |_| true);
+
+        let (preserved, visible) = reconcile_instances(&instances, Vec::new(), |alert| {
+            !alert.source.starts_with("/dev/sda#")
+        });
+
+        assert_eq!(preserved.len(), 1);
+        assert_eq!(visible[0].source, "/dev/sda#5");
+    }
+
+    #[test]
+    fn persisted_acknowledgement_survives_reload() {
+        let (mut instances, occurrences) =
+            reconcile_instances(&[], vec![test_alert(1.0)], |_| true);
+        mark_acknowledged(&mut instances, &occurrences[0].instance_id, "alice", "now").unwrap();
+        let state = AlertState {
+            rules: Vec::new(),
+            active_instances: instances,
+            dirty: false,
+        };
+
+        let loaded: AlertState =
+            serde_json::from_str(&serde_json::to_string(&state).unwrap()).unwrap();
+        let (_, visible) =
+            reconcile_instances(&loaded.active_instances, vec![test_alert(2.0)], |_| true);
+
+        assert!(visible[0].acknowledged);
+        assert_eq!(visible[0].acknowledged_by.as_deref(), Some("alice"));
+    }
 
     // ── reconcile stall sampling (#487) ────────────────────────
 

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1464,7 +1464,7 @@ export interface AlertRule {
 	severity: AlertSeverity;
 }
 
-export type AlertMetric = 'fs_usage_percent' | 'cpu_load_percent' | 'memory_usage_percent' | 'disk_temperature' | 'smart_health' | 'swap_usage_percent' | 'bcachefs_degraded' | 'bcachefs_device_error' | 'bcachefs_device_state' | 'bcachefs_io_errors' | 'bcachefs_scrub_errors' | 'bcachefs_reconcile_stalled' | 'root_disk_free_gb' | 'boot_disk_free_mb' | 'kernel_errors';
+export type AlertMetric = 'fs_usage_percent' | 'cpu_load_percent' | 'memory_usage_percent' | 'disk_temperature' | 'smart_health' | 'smart_attribute' | 'swap_usage_percent' | 'bcachefs_degraded' | 'bcachefs_device_error' | 'bcachefs_device_state' | 'bcachefs_io_errors' | 'bcachefs_scrub_errors' | 'bcachefs_reconcile_stalled' | 'root_disk_free_gb' | 'boot_disk_free_mb' | 'kernel_errors';
 export type AlertCondition = 'above' | 'below' | 'equals';
 export type AlertSeverity = 'warning' | 'critical';
 
@@ -1477,6 +1477,16 @@ export interface ActiveAlert {
 	current_value: number;
 	threshold: number;
 	source: string;
+	instance_id: string;
+	acknowledged: boolean;
+	acknowledged_at: string | null;
+	acknowledged_by: string | null;
+}
+
+export interface AlertAcknowledgement {
+	instance_id: string;
+	acknowledged_at: string;
+	acknowledged_by: string;
 }
 
 // ── Backups ────────────────────────────────────────────────

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -5,7 +5,7 @@
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
 	import { tempUnit, cToF, tempUnitLabel } from '$lib/temperature.svelte';
-	import type { AlertRule, ActiveAlert, AlertMetric, AlertCondition, AlertSeverity } from '$lib/types';
+	import type { AlertRule, ActiveAlert, AlertAcknowledgement, AlertMetric, AlertCondition, AlertSeverity, AuthMe, UserRole } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
@@ -17,6 +17,11 @@
 	let activeAlerts: ActiveAlert[] = $state([]);
 	let loading = $state(true);
 	let showCreate = $state(false);
+	let role = $state<UserRole>('readonly');
+	let acknowledging = $state<string | null>(null);
+	let refreshTimer: ReturnType<typeof setInterval> | undefined;
+	const canAcknowledge = $derived(role === 'admin' || role === 'operator');
+	const canManageRules = $derived(role === 'admin');
 
 	let newName = $state('');
 	let createTried = $state(false);
@@ -37,6 +42,7 @@
 		memory_usage_percent: 'Memory Usage (%)',
 		disk_temperature: `Disk Temperature (${tempUnitLabel(tempUnit.current)})`,
 		smart_health: 'SMART Health Failure',
+		smart_attribute: 'SMART Critical Attribute',
 		swap_usage_percent: 'Swap Usage (%)',
 		bcachefs_degraded: 'bcachefs Degraded Mode',
 		bcachefs_device_error: 'bcachefs Device Errors',
@@ -88,17 +94,58 @@
 		client.onEvent(handleEvent);
 		await refresh();
 		loading = false;
+		refreshTimer = setInterval(refreshActiveAlerts, 15_000);
 	});
 
-	onDestroy(() => client.offEvent(handleEvent));
+	onDestroy(() => {
+		client.offEvent(handleEvent);
+		if (refreshTimer) clearInterval(refreshTimer);
+	});
 
 	async function refresh() {
 		await withToast(async () => {
-			[rules, activeAlerts] = await Promise.all([
+			const [nextRules, nextAlerts, me] = await Promise.all([
 				client.call<AlertRule[]>('alert.rules.list'),
 				client.call<ActiveAlert[]>('system.alerts'),
+				client.call<AuthMe>('auth.me'),
 			]);
+			rules = nextRules;
+			activeAlerts = nextAlerts;
+			role = me.role;
 		});
+	}
+
+	async function refreshActiveAlerts() {
+		try {
+			activeAlerts = await client.call<ActiveAlert[]>('system.alerts');
+		} catch {
+			// Keep the last known rows during a transient polling failure.
+		}
+	}
+
+	async function acknowledgeAlert(alert: ActiveAlert) {
+		if (!await confirm(
+			'Acknowledge this alert?',
+			'This occurrence will be hidden until its condition clears. A later recurrence will alert again.',
+			{ confirmLabel: 'Acknowledge' }
+		)) return;
+
+		acknowledging = alert.instance_id;
+		try {
+			const acknowledged = await withToast(
+				() => client.call<AlertAcknowledgement>('alert.acknowledge', {
+					instance_id: alert.instance_id,
+				}),
+				'Alert acknowledged'
+			);
+			if (acknowledged !== undefined) {
+				activeAlerts = activeAlerts.filter((item) => item.instance_id !== alert.instance_id);
+			} else {
+				await refreshActiveAlerts();
+			}
+		} finally {
+			acknowledging = null;
+		}
 	}
 
 	async function createRule() {
@@ -154,7 +201,10 @@
 {#if activeAlerts.length > 0}
 	<div class="mb-6">
 		<h2 class="mb-3 text-base font-semibold">Active Alerts ({activeAlerts.length})</h2>
-		{#each activeAlerts as alert}
+		<p class="mb-3 text-sm text-muted-foreground">
+			Active alerts are conditions that currently match and have not been acknowledged.
+		</p>
+		{#each activeAlerts as alert (alert.instance_id)}
 			<div class="mb-2 flex items-center gap-3 rounded-lg border px-4 py-2.5 text-sm {
 				alert.severity === 'critical' ? 'border-red-800 bg-red-950 text-red-200' : 'border-amber-800 bg-amber-950 text-amber-200'
 			}">
@@ -163,6 +213,16 @@
 				}">{alert.severity}</span>
 				<span class="flex-1">{alert.message}</span>
 				<span class="font-mono text-xs opacity-70">{alert.source}</span>
+				{#if canAcknowledge}
+					<Button
+						variant="secondary"
+						size="xs"
+						disabled={acknowledging === alert.instance_id}
+						onclick={() => acknowledgeAlert(alert)}
+					>
+						{acknowledging === alert.instance_id ? 'Acknowledging...' : 'Acknowledge'}
+					</Button>
+				{/if}
 			</div>
 		{/each}
 	</div>
@@ -172,11 +232,13 @@
 	</div>
 {/if}
 
-<div class="mb-4 flex items-center gap-3">
-	<Button size="sm" onclick={() => showCreate = !showCreate}>
-		{showCreate ? 'Cancel' : 'Create Rule'}
-	</Button>
-</div>
+{#if canManageRules}
+	<div class="mb-4 flex items-center gap-3">
+		<Button size="sm" onclick={() => showCreate = !showCreate}>
+			{showCreate ? 'Cancel' : 'Create Rule'}
+		</Button>
+	</div>
+{/if}
 
 {#if showCreate}
 	<Card class="mb-6 max-w-lg">
@@ -258,12 +320,16 @@
 						</Badge>
 					</td>
 					<td class="p-3">
-						<div class="flex gap-2">
-							<Button variant="secondary" size="xs" onclick={() => toggleRule(rule)}>
-								{rule.enabled ? 'Disable' : 'Enable'}
-							</Button>
-							<Button variant="destructive" size="xs" onclick={() => deleteRule(rule.id)}>Delete</Button>
-						</div>
+						{#if canManageRules}
+							<div class="flex gap-2">
+								<Button variant="secondary" size="xs" onclick={() => toggleRule(rule)}>
+									{rule.enabled ? 'Disable' : 'Enable'}
+								</Button>
+								<Button variant="destructive" size="xs" onclick={() => deleteRule(rule.id)}>Delete</Button>
+							</div>
+						{:else}
+							<span class="text-muted-foreground">—</span>
+						{/if}
 					</td>
 				</tr>
 			{/each}


### PR DESCRIPTION
## Summary
- persist stable IDs for continuous alert occurrences and keep acknowledgements across restarts
- add operator/admin acknowledgement through RPC and the Alerts UI, with acknowledged alerts removed from status counts and caches
- preserve occurrence identity across partial telemetry, correlate notification lifecycle events, and issue new IDs after resolution and recurrence

## Verification
- `cargo test -p nasty-system` (405 passed)
- `cargo test -p nasty-engine` (230 passed)
- `cargo clippy -p nasty-system -p nasty-engine --all-targets -- -D warnings`
- `npm run check`
- `npm test -- --run` (219 passed)
- `npm run build`
- `git diff --check`

Closes #737