### PR TITLE
nixos: support Tailscale with legacy wrappers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -438,9 +438,11 @@
       tailscale-independent-package = let
         config = (mkNixosConfigs "x86_64-linux").nasty.config;
         expected = tailscale-nixpkgs.legacyPackages.x86_64-linux.tailscale;
+        moduleArgs = builtins.functionArgs (import ./nixos/modules/nasty.nix);
       in pkgs.runCommand "tailscale-independent-package" {} ''
         test "${config.services.nasty.tailscale.package}" = "${expected}"
         test "${nixpkgs.lib.boolToString config.systemd.services.nasty-tailscale.stopIfChanged}" = false
+        test "${nixpkgs.lib.boolToString (moduleArgs ? nasty-tailscale)}" = false
         touch "$out"
       '';
       bcachefs-smoke = import ./nixos/tests/bcachefs-smoke.nix {

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1,9 +1,12 @@
-args@{ config, lib, pkgs, nasty-engine ? null, nasty-webui ? null, nasty-version ? "dev", nasty-bcachefs-tools ? pkgs.bcachefs-tools, nasty-tailscale ? pkgs.tailscale, ... }:
+args@{ config, lib, pkgs, nasty-engine ? null, nasty-webui ? null, nasty-version ? "dev", nasty-bcachefs-tools ? pkgs.bcachefs-tools, ... }:
 
 let
   cfg = config.services.nasty;
   inherit (lib) mkEnableOption mkOption mkIf types;
   nastySystemFlakeSnapshot = args.nastySystemFlakeSnapshot or null;
+  # Old wrapper flakes do not pass this specialArg. Keep the fallback out of
+  # the module argument list so NixOS does not require it before defaults run.
+  nasty-tailscale = args.nasty-tailscale or pkgs.tailscale;
 
   # Boot-time fail-closed policy. The engine atomically replaces this table
   # with its complete dynamic rules before restoring network-facing services.


### PR DESCRIPTION
## Summary
- avoid declaring `nasty-tailscale` as a named NixOS module argument, which old installed wrapper flakes cannot provide
- read the optional special argument through the captured argument set and fall back to the system `pkgs.tailscale`
- assert that the module remains evaluable without a `nasty-tailscale` argument

## Context
A production `nasty-sync` after #747 advanced the `nasty` input while retaining the old wrapper shape. NixOS attempted to resolve the newly named module argument before its default and failed with `attribute 'nasty-tailscale' missing`.

## Testing
- evaluated `checks.x86_64-linux.tailscale-independent-package.drvPath` successfully
- verified `builtins.functionArgs` no longer exposes `nasty-tailscale`
- recovered and successfully updated the affected appliance

Follow-up to #747.