### PR TITLE
network: preserve IPv4 DNS byte order

### DIFF
--- a/engine/nasty-system/src/network/nm.rs
+++ b/engine/nasty-system/src/network/nm.rs
@@ -934,7 +934,7 @@ fn ip_section_dict(ip: &NmIpSettings, family: Family) -> HashMap<String, OwnedVa
         s.insert("gateway".into(), into_value(gw.clone()));
     }
     // NM's DBus types for DNS are family-specific and not strings:
-    //   ipv4.dns  → `au`   array of u32 in network byte order
+    //   ipv4.dns  → `au`   array of in_addr_t; native u32 bytes are network order
     //   ipv6.dns  → `aay`  array of 16-byte arrays
     // Sending the string-array shape (as) gets rejected as
     //   "InvalidProperty: ipv4.dns: can't set property of type 'au'
@@ -958,7 +958,7 @@ fn ip_section_dict(ip: &NmIpSettings, family: Family) -> HashMap<String, OwnedVa
                     .dns
                     .iter()
                     .filter_map(|s| s.parse::<std::net::Ipv4Addr>().ok())
-                    .map(|a| u32::from_be_bytes(a.octets()))
+                    .map(|a| u32::from_ne_bytes(a.octets()))
                     .collect();
                 if !packed.is_empty() {
                     s.insert("dns".into(), into_value(packed));
@@ -2187,15 +2187,15 @@ mod tests {
 
     #[test]
     fn dict_emits_dns_on_ipv4_section_as_packed_uint32() {
-        // Regression test for the discussion #159 bug: NM's
+        // Regression test for discussion #159 and issue #750: NM's
         // `ipv4.dns` is type `au` (array of u32 in network byte
         // order), NOT `as`.  Sending a string array gets rejected
         // with "InvalidProperty: ipv4.dns: can't set property of
         // type 'au' from value of type 'as'" which then prevents
         // every other connection in the apply from going through.
         //
-        // 10.10.11.1 in network byte order packs to
-        //   ((10<<24) | (10<<16) | (11<<8) | 1) = 0x0A0A0B01
+        // NM stores each u32 directly as an in_addr_t, so its native-memory
+        // bytes must preserve the address octets in network order.
         let layered = LayeredConfig {
             links: vec![link_phys("eth0")],
             dns: vec!["10.10.11.1".into()],
@@ -2204,7 +2204,8 @@ mod tests {
         let dict = to_settings_dict(&to_nm_profiles(&layered)[0]);
         let ipv4 = dict.get("ipv4").expect("ipv4 section");
         let dns: Vec<u32> = ipv4["dns"].try_clone().unwrap().try_into().unwrap();
-        assert_eq!(dns, vec![0x0A_0A_0B_01]);
+        assert_eq!(dns.len(), 1);
+        assert_eq!(dns[0].to_ne_bytes(), [10, 10, 11, 1]);
         // No leakage into ipv6 (no v6 entries in input).
         let ipv6 = dict.get("ipv6").expect("ipv6 section");
         assert!(!ipv6.contains_key("dns"), "ipv6 must not carry v4 DNS");

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-XijXicrgyUOoCqHMj8d3IZIve35s9LzVLSFpSCDf8ig=";
+      npmDepsHash = "sha256-FSBvGEUu8dUD8y7bui9zmmiGw9UuSsJd9imJcFlBZQ0=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -769,9 +769,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.69.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.3.tgz",
-			"integrity": "sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+			"integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2496,9 +2496,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2556,9 +2556,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.19",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2576,7 +2576,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},


### PR DESCRIPTION
## Summary
- preserve IPv4 DNS address octets when serializing NetworkManager's legacy `au` property
- use native-endian `in_addr_t` encoding across supported architectures
- add an architecture-independent byte-order regression assertion
- refresh vulnerable WebUI transitive packages disclosed after the branch was created and update `npmDepsHash`

## Dependency audit
- Rust `cargo-deny` advisories, licenses, and sources check passes
- npm high/moderate findings are resolved by updating SvelteKit to 2.70.2, nanoid to 3.3.18, and PostCSS to 8.5.26
- npm still reports the upstream SvelteKit `cookie <0.7` advisory as low severity; npm offers only an invalid breaking downgrade, so it is not forced here

## Testing
- `cargo test -p nasty-system dict_emits_dns_on_ipv4_section_as_packed_uint32`
- `cargo test -p nasty-system`
- `cargo fmt --all -- --check`
- `cargo clippy -p nasty-system --all-targets -- -D warnings`
- `npm ci --legacy-peer-deps`
- `npm audit --audit-level=high`
- `npm run check`
- `npm test` (219 tests)
- `npm run build`
- verified `npmDepsHash` with `prefetch-npm-deps`

Fixes #750