### PR TITLE
storage: forget unavailable filesystems

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -2589,29 +2589,27 @@ impl AppsService {
     }
 
     pub fn load_config() -> AppsConfig {
-        let content = match std::fs::read_to_string(STATE_PATH) {
-            Ok(c) => c,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return AppsConfig::default(),
-            Err(e) => {
-                // A non-NotFound read error (permissions, IO) means we
-                // *might* be silently resetting a real config. Log
-                // before returning defaults so the user can match a
-                // "my installed apps disappeared" report to the
-                // underlying cause.
-                warn!("apps.json read from {STATE_PATH} failed: {e} — using defaults");
-                return AppsConfig::default();
-            }
-        };
-        match serde_json::from_str(&content) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                warn!(
-                    "apps.json parse failed: {e} — file may be corrupt; \
-                     using defaults (any persisted config will be lost)"
-                );
+        match Self::load_config_strict() {
+            Ok(config) => config,
+            Err(error) => {
+                warn!("apps config failed to load: {error} — using defaults");
                 AppsConfig::default()
             }
         }
+    }
+
+    /// Load persisted app storage paths without silently replacing unreadable
+    /// or corrupt state. Destructive dependency checks use this to fail closed.
+    pub fn load_config_strict() -> Result<AppsConfig, AppsError> {
+        let content = match std::fs::read_to_string(STATE_PATH) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(AppsConfig::default());
+            }
+            Err(error) => return Err(AppsError::Io(error)),
+        };
+        serde_json::from_str(&content)
+            .map_err(|error| AppsError::CommandFailed(format!("parse {STATE_PATH}: {error}")))
     }
 
     async fn save_config(config: &AppsConfig) -> Result<(), AppsError> {

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -896,6 +896,15 @@ impl BackupService {
             .collect()
     }
 
+    /// Return the in-memory profiles only after verifying that persisted state
+    /// is readable and valid. Destructive dependency checks use this to avoid
+    /// treating a corrupt profile file as an empty configuration.
+    pub async fn list_profiles_strict(&self) -> Result<Vec<BackupProfile>, BackupError> {
+        let profiles = self.profiles.lock().await;
+        load_profiles_strict()?;
+        Ok(profiles.iter().map(|profile| profile.redacted()).collect())
+    }
+
     pub async fn get_profile(&self, id: &str) -> Result<BackupProfile, BackupError> {
         self.get_profile_internal(id).await.map(|p| p.redacted())
     }
@@ -1510,10 +1519,17 @@ impl BackupService {
 // ── Persistence ────────────────────────────────────────────────
 
 fn load_profiles() -> Vec<BackupProfile> {
-    std::fs::read_to_string(STATE_PATH)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
+    load_profiles_strict().unwrap_or_default()
+}
+
+fn load_profiles_strict() -> Result<Vec<BackupProfile>, BackupError> {
+    let content = match std::fs::read_to_string(STATE_PATH) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(BackupError::Io(error)),
+    };
+    serde_json::from_str(&content)
+        .map_err(|error| BackupError::Failed(format!("parse {STATE_PATH}: {error}")))
 }
 
 async fn save_profiles(profiles: &[BackupProfile]) {

--- a/engine/nasty-engine/src/fs_dependents.rs
+++ b/engine/nasty-engine/src/fs_dependents.rs
@@ -33,6 +33,7 @@ pub struct FsDependents {
     pub filesystem: String,
     pub mounted: bool,
     pub subvolumes: Vec<String>,
+    pub apps_storage: bool,
     pub apps: Vec<String>,
     pub vms: Vec<String>,
     pub backup_jobs: Vec<String>,
@@ -41,6 +42,20 @@ pub struct FsDependents {
     pub iscsi_targets: Vec<String>,
     pub nvmeof_subsystems: Vec<String>,
     pub state_errors: Vec<String>,
+}
+
+impl FsDependents {
+    pub fn has_dependents(&self) -> bool {
+        !self.subvolumes.is_empty()
+            || self.apps_storage
+            || !self.apps.is_empty()
+            || !self.vms.is_empty()
+            || !self.backup_jobs.is_empty()
+            || !self.nfs_shares.is_empty()
+            || !self.smb_shares.is_empty()
+            || !self.iscsi_targets.is_empty()
+            || !self.nvmeof_subsystems.is_empty()
+    }
 }
 
 /// True if `path` falls under `/fs/<fs_name>/` (the canonical NASty
@@ -52,9 +67,20 @@ fn path_belongs_to_fs(path: &str, fs_name: &str) -> bool {
 }
 
 /// Build the dependents view by querying every service that can hold
-/// a filesystem reference. Best-effort: a service that errors out
-/// contributes an empty list rather than failing the whole query.
+/// a filesystem reference. State read failures are reported separately so
+/// destructive callers can fail closed.
 pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
+    find_dependents_with_uuid(state, fs_name, None).await
+}
+
+/// UUID-aware variant used when the filesystem itself is unavailable. Stable
+/// block-export identities remain inspectable even when no subvolume can be
+/// discovered from the missing mount.
+pub async fn find_dependents_with_uuid(
+    state: &AppState,
+    fs_name: &str,
+    filesystem_uuid: Option<&str>,
+) -> FsDependents {
     let mut out = FsDependents {
         filesystem: fs_name.to_string(),
         ..Default::default()
@@ -68,11 +94,14 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
     }
 
     // Subvolumes are the cheapest hop: we already filter by fs.
-    let subvols = state
-        .subvolumes
-        .list_all(Some(fs_name), None)
-        .await
-        .unwrap_or_default();
+    let subvols = match state.subvolumes.list_all(Some(fs_name), None).await {
+        Ok(subvolumes) => subvolumes,
+        Err(error) => {
+            out.state_errors
+                .push(format!("subvolume state failed to load: {error}"));
+            Vec::new()
+        }
+    };
     // Block devices owned by subvolumes on this FS — used to detect
     // VM disks / iSCSI backstores / NVMe-oF namespaces that reference
     // them by `/dev/loopN` rather than path.
@@ -91,67 +120,122 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
     // all live under the apps storage path). Per-app bind mounts
     // outside that base are a refinement we can add later — they're
     // surfaced via app inspect, not the lightweight `list()`.
-    let apps_status = state.apps.status().await;
-    if apps_status
-        .storage_path
-        .as_deref()
-        .is_some_and(|p| path_belongs_to_fs(p, fs_name))
-        && let Ok(apps) = state.apps.list().await
-    {
-        out.apps = apps.into_iter().map(|a| a.name).collect();
+    match nasty_apps::AppsService::load_config_strict() {
+        Ok(config)
+            if [
+                config.storage_path.as_deref(),
+                config.appdata_path.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .any(|path| path_belongs_to_fs(path, fs_name)) =>
+        {
+            out.apps_storage = true;
+            match state.apps.list().await {
+                Ok(apps) => out.apps = apps.into_iter().map(|app| app.name).collect(),
+                Err(error) => out
+                    .state_errors
+                    .push(format!("app state failed to load: {error}")),
+            }
+        }
+        Ok(_) => {}
+        Err(error) => out
+            .state_errors
+            .push(format!("app config failed to load: {error}")),
     }
 
     // VMs: disk path either under /fs/<X>/... directly, or a loop
     // device that's the block_device of a subvolume on this FS.
-    if let Ok(vms) = state.vms.list().await {
-        for vm in vms {
-            let touches_fs = vm
-                .config
-                .disks
-                .iter()
-                .any(|d| path_belongs_to_fs(&d.path, fs_name) || block_devs.contains(&d.path));
-            if touches_fs {
-                out.vms.push(vm.config.name);
+    match state.vms.list().await {
+        Ok(vms) => {
+            for vm in vms {
+                let touches_fs = vm.config.disks.iter().any(|disk| {
+                    path_belongs_to_fs(&disk.path, fs_name)
+                        || disk
+                            .source
+                            .as_deref()
+                            .is_some_and(|source| path_belongs_to_fs(source, fs_name))
+                        || block_devs.contains(&disk.path)
+                });
+                if touches_fs {
+                    out.vms.push(vm.config.name);
+                }
             }
         }
+        Err(error) => out
+            .state_errors
+            .push(format!("VM state failed to load: {error}")),
     }
 
     // Backup jobs: any source under /fs/<X>/. A job pointing only
     // somewhere else (e.g. a subset of a different FS) is left alone.
-    let profiles = state.backups.list_profiles().await;
-    for p in profiles {
-        if p.sources.iter().any(|src| path_belongs_to_fs(src, fs_name)) {
-            out.backup_jobs.push(p.name);
+    match state.backups.list_profiles_strict().await {
+        Ok(profiles) => {
+            for profile in profiles {
+                if profile
+                    .sources
+                    .iter()
+                    .any(|source| path_belongs_to_fs(source, fs_name))
+                {
+                    out.backup_jobs.push(profile.name);
+                }
+            }
         }
+        Err(error) => out
+            .state_errors
+            .push(format!("backup state failed to load: {error}")),
     }
 
     // Shares: NFS/SMB use a single `path`; iSCSI/NVMe-oF use device
     // paths that are usually loop devices for block subvolumes.
-    if let Ok(shares) = state.nfs.list().await {
-        out.nfs_shares = shares
-            .into_iter()
-            .filter(|s| path_belongs_to_fs(&s.path, fs_name))
-            .map(|s| s.id)
-            .collect();
+    match state.nfs.list_strict().await {
+        Ok(shares) => {
+            out.nfs_shares = shares
+                .into_iter()
+                .filter(|s| path_belongs_to_fs(&s.path, fs_name))
+                .map(|s| s.id)
+                .collect();
+        }
+        Err(error) => out
+            .state_errors
+            .push(format!("NFS state failed to load: {error}")),
     }
-    if let Ok(shares) = state.smb.list().await {
-        out.smb_shares = shares
-            .into_iter()
-            .filter(|s| path_belongs_to_fs(&s.path, fs_name))
-            .map(|s| s.name)
-            .collect();
+    match state.smb.list_strict().await {
+        Ok(shares) => {
+            out.smb_shares = shares
+                .into_iter()
+                .filter(|s| path_belongs_to_fs(&s.path, fs_name))
+                .map(|s| s.name)
+                .collect();
+        }
+        Err(error) => out
+            .state_errors
+            .push(format!("SMB state failed to load: {error}")),
     }
     match state.iscsi.list().await {
         Ok(targets) => {
+            for target in &targets {
+                if target
+                    .luns
+                    .iter()
+                    .any(|lun| lun.backing_volume_unresolved && lun.backing_volume.is_none())
+                {
+                    out.state_errors.push(format!(
+                        "iSCSI target '{}' has unresolved legacy block-volume ownership",
+                        target.iqn
+                    ));
+                }
+            }
             out.iscsi_targets = targets
                 .into_iter()
                 .filter(|t| {
                     t.luns.iter().any(|l| {
                         path_belongs_to_fs(&l.backstore_path, fs_name)
                             || block_devs.contains(&l.backstore_path)
-                            || l.backing_volume
-                                .as_ref()
-                                .is_some_and(|identity| block_ids.contains(identity))
+                            || l.backing_volume.as_ref().is_some_and(|identity| {
+                                block_ids.contains(identity)
+                                    || filesystem_uuid == Some(identity.filesystem_uuid.as_str())
+                            })
                     })
                 })
                 .map(|t| t.iqn)
@@ -163,15 +247,26 @@ pub async fn find_dependents(state: &AppState, fs_name: &str) -> FsDependents {
     }
     match state.nvmeof.list().await {
         Ok(subs) => {
+            for subsystem in &subs {
+                if subsystem.namespaces.iter().any(|namespace| {
+                    namespace.backing_volume_unresolved && namespace.backing_volume.is_none()
+                }) {
+                    out.state_errors.push(format!(
+                        "NVMe-oF subsystem '{}' has unresolved legacy block-volume ownership",
+                        subsystem.nqn
+                    ));
+                }
+            }
             out.nvmeof_subsystems = subs
                 .into_iter()
                 .filter(|s| {
                     s.namespaces.iter().any(|n| {
                         path_belongs_to_fs(&n.device_path, fs_name)
                             || block_devs.contains(&n.device_path)
-                            || n.backing_volume
-                                .as_ref()
-                                .is_some_and(|identity| block_ids.contains(identity))
+                            || n.backing_volume.as_ref().is_some_and(|identity| {
+                                block_ids.contains(identity)
+                                    || filesystem_uuid == Some(identity.filesystem_uuid.as_str())
+                            })
                     })
                 })
                 .map(|s| s.nqn)
@@ -233,5 +328,17 @@ mod tests {
         // Other roots untouched.
         assert!(!path_belongs_to_fs("/var/lib/nasty", "tank"));
         assert!(!path_belongs_to_fs("", "tank"));
+    }
+
+    #[test]
+    fn dependency_presence_is_separate_from_state_errors() {
+        let mut dependents = FsDependents {
+            state_errors: vec!["unreadable".to_string()],
+            ..Default::default()
+        };
+        assert!(!dependents.has_dependents());
+
+        dependents.nvmeof_subsystems.push("nqn.test".to_string());
+        assert!(dependents.has_dependents());
     }
 }

--- a/engine/nasty-engine/src/fs_lock.rs
+++ b/engine/nasty-engine/src/fs_lock.rs
@@ -54,6 +54,12 @@ const VM_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// here in the engine layer where `AppState` is.
 pub async fn lock_with_dependents(state: &AppState, fs_name: &str) -> Result<Filesystem, String> {
     let deps = find_dependents(state, fs_name).await;
+    if !deps.state_errors.is_empty() {
+        return Err(format!(
+            "lock aborted because dependent state could not be verified: {}",
+            deps.state_errors.join("; ")
+        ));
+    }
 
     // Apps first: docker stop is blocking, runs Docker's stop-then-kill
     // timeout, returns when the container is actually stopped. Errors

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -39,8 +39,9 @@ use nasty_sharing::smb::{
 use nasty_storage::disk_type::DiskTypeUpdate;
 use nasty_storage::filesystem::{
     BlockDevice, CreateFilesystemRequest, DestroyFilesystemRequest, DeviceActionRequest,
-    DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem, FsUsage,
-    FsckStatus, ReconcileStatus, ScrubStatus, TpmBindStatus, UpdateFilesystemOptionsRequest,
+    DeviceAddRequest, DeviceSetLabelRequest, DeviceSetStateRequest, Filesystem,
+    ForgetUnavailableRequest, FsUsage, FsckStatus, ReconcileStatus, ScrubStatus, TpmBindStatus,
+    UnavailableFilesystem, UpdateFilesystemOptionsRequest,
 };
 use nasty_storage::io_scheduler::{IoSchedulerResult, IoSchedulerUpdate};
 use nasty_storage::subvolume::{
@@ -546,6 +547,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     result: Some(gen_schema::<Vec<Filesystem>>(generator)),
                 },
                 Method {
+                    name: "fs.unavailable.list",
+                    desc: "List UUID-bound host registrations whose filesystem is not currently visible. Filesystem-scoped tokens see only their assigned filesystem.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<UnavailableFilesystem>>(generator)),
+                },
+                Method {
                     name: "fs.get",
                     desc: "Get a single filesystem by name.",
                     role: MethodRole::Any,
@@ -561,9 +569,16 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "fs.destroy",
-                    desc: "Unmount and unregister a filesystem. Does not wipe the devices.",
+                    desc: "Unmount a filesystem, wipe filesystem signatures/superblocks from its member devices, and unregister it.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<DestroyFilesystemRequest>(generator)),
+                    result: None,
+                },
+                Method {
+                    name: "fs.forget",
+                    desc: "Forget an unavailable filesystem's host-side registration and operation history without modifying disks or encryption key files.",
+                    role: MethodRole::Admin,
+                    params: MethodParams::Schema(gen_schema::<ForgetUnavailableRequest>(generator)),
                     result: None,
                 },
                 Method {

--- a/engine/nasty-engine/src/registry/paths.rs
+++ b/engine/nasty-engine/src/registry/paths.rs
@@ -42,6 +42,7 @@ const ACTION_VERBS: &[(&str, HttpVerb)] = &[
     ("find", HttpVerb::Get),
     ("delete", HttpVerb::Delete),
     ("destroy", HttpVerb::Delete),
+    ("forget", HttpVerb::Delete),
     ("remove", HttpVerb::Delete),
     ("set", HttpVerb::Put),
     ("update", HttpVerb::Put),
@@ -140,6 +141,7 @@ mod tests {
         assert_eq!(translate("subvolume.find_by_property").0, HttpVerb::Get);
         assert_eq!(translate("auth.delete_user").0, HttpVerb::Delete);
         assert_eq!(translate("share.iscsi.remove_acl").0, HttpVerb::Delete);
+        assert_eq!(translate("fs.forget").0, HttpVerb::Delete);
         assert_eq!(translate("fs.options.update").0, HttpVerb::Put);
         assert_eq!(translate("fs.device.set_label").0, HttpVerb::Put);
     }

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -26,6 +26,15 @@ pub(super) async fn try_route(
             }
             Err(e) => err(req, e),
         },
+        "fs.unavailable.list" => match state.filesystems.list_unavailable().await {
+            Ok(mut filesystems) => {
+                if let Some(ref fs_name) = session.filesystem {
+                    filesystems.retain(|filesystem| &filesystem.name == fs_name);
+                }
+                ok(req, filesystems)
+            }
+            Err(error) => err(req, error),
+        },
         "fs.get" => match require_str(req, "name") {
             Ok(name) => {
                 if session.filesystem.as_deref().is_some_and(|p| p != name) {
@@ -59,6 +68,59 @@ pub(super) async fn try_route(
                     }
                 }
                 Err(e) => invalid(req, e),
+            }
+        }
+        "fs.forget" => {
+            match parse_params::<nasty_storage::filesystem::ForgetUnavailableRequest>(req) {
+                Ok(request) => {
+                    if session
+                        .filesystem
+                        .as_deref()
+                        .is_some_and(|filesystem| filesystem != request.name)
+                    {
+                        err(req, "access denied")
+                    } else {
+                        let dependents = crate::fs_dependents::find_dependents_with_uuid(
+                            state,
+                            &request.name,
+                            Some(&request.expected_uuid),
+                        )
+                        .await;
+                        if !dependents.state_errors.is_empty() {
+                            err(
+                                req,
+                                format!(
+                                    "cannot verify filesystem dependencies: {}",
+                                    dependents.state_errors.join("; ")
+                                ),
+                            )
+                        } else if dependents.has_dependents() {
+                            err(
+                                req,
+                                format!(
+                                    "filesystem '{}' still has dependent state; remove its dependents before forgetting it",
+                                    request.name
+                                ),
+                            )
+                        } else {
+                            let name = request.name.clone();
+                            match state.filesystems.forget_unavailable(request).await {
+                                Ok(()) => {
+                                    state
+                                        .mount_failures
+                                        .lock()
+                                        .await
+                                        .retain(|failed_name| failed_name != &name);
+                                    *state.alerts_cache.lock().await = None;
+                                    *state.status_cache.lock().await = None;
+                                    ok(req, "ok")
+                                }
+                                Err(error) => err(req, error),
+                            }
+                        }
+                    }
+                }
+                Err(error) => invalid(req, error),
             }
         }
         "fs.mount" => {

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -2034,6 +2034,7 @@ mod tests {
             "device.set_io_scheduler",
             "fs.create",
             "fs.destroy",
+            "fs.forget",
             "fs.mount",
             "fs.unmount",
             "fs.unlock",

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -467,6 +467,29 @@ pub struct DestroyFilesystemRequest {
     pub confirm_name: String,
 }
 
+/// A filesystem registration whose persisted UUID is not currently visible.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct UnavailableFilesystem {
+    pub name: String,
+    /// UUID persisted in the host-side registration.
+    pub uuid: String,
+    #[serde(default)]
+    pub devices: Vec<String>,
+    pub auto_mount: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_mount_error: Option<MountFailure>,
+}
+
+/// Remove an unavailable filesystem from host-side tracking only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ForgetUnavailableRequest {
+    pub name: String,
+    /// Must exactly match the UUID currently persisted for `name`.
+    pub expected_uuid: String,
+    /// Must exactly match `name`.
+    pub confirm_name: String,
+}
+
 /// Update runtime-mutable filesystem options on a mounted filesystem.
 /// Options are written directly to sysfs (/sys/fs/bcachefs/<uuid>/options/).
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -2248,6 +2271,16 @@ impl FilesystemService {
         Ok(result)
     }
 
+    /// List UUID-bound registrations that are absent from live discovery.
+    /// Legacy name-only registrations are intentionally omitted because they
+    /// cannot be forgotten with an identity-safe request.
+    pub async fn list_unavailable(&self) -> Result<Vec<UnavailableFilesystem>, FilesystemError> {
+        let state = load_fs_state_strict().await?;
+        let live = self.list().await?;
+        let failures = self.mount_state.lock().await;
+        Ok(project_unavailable_filesystems(&state, &live, &failures))
+    }
+
     /// Uncached implementation of filesystem listing.
     async fn list_uncached(&self) -> Result<Vec<Filesystem>, FilesystemError> {
         let mounts = read_bcachefs_mounts().await?;
@@ -2773,6 +2806,52 @@ impl FilesystemService {
         Ok(())
     }
 
+    /// Forget only the host-side registration for an unavailable filesystem.
+    /// This deliberately leaves device contents, encryption keys, and the
+    /// canonical mount directory untouched.
+    pub async fn forget_unavailable(
+        &self,
+        req: ForgetUnavailableRequest,
+    ) -> Result<(), FilesystemError> {
+        let _mutation_guard = self.block_mutations.lock().await;
+        let mut state = load_fs_state_strict().await?;
+        validate_forget_unavailable(&state, &req)?;
+
+        let mount_point = format!("{NASTY_MOUNT_BASE}/{}", req.name);
+        if is_mountpoint(&mount_point).await {
+            return Err(FilesystemError::CommandFailed(format!(
+                "mount point {mount_point} is occupied; refusing to forget the filesystem"
+            )));
+        }
+
+        // Safety must distinguish a genuinely absent UUID from a failed
+        // discovery command. `blkid -U` exits 2 for no match; every other
+        // failure aborts instead of being treated as evidence of absence.
+        if filesystem_uuid_is_visible(&req.expected_uuid).await? {
+            return Err(FilesystemError::CommandFailed(format!(
+                "filesystem UUID {} is visible or mounted; refusing to forget it",
+                req.expected_uuid
+            )));
+        }
+
+        state.remove(&req.name);
+        save_fs_state(&state).await?;
+
+        // Registration removal is authoritative. History cleanup is
+        // best-effort and must not turn a completed forget into a failure.
+        if self.mount_state.lock().await.remove(&req.name).is_some() {
+            persist_mount_state(&self.mount_state).await;
+        }
+        if self.scrub_state.lock().await.remove(&req.name).is_some() {
+            persist_scrub_state(&self.scrub_state).await;
+        }
+        if self.fsck_state.lock().await.remove(&req.name).is_some() {
+            persist_fsck_state(&self.fsck_state).await;
+        }
+        self.invalidate_list_cache().await;
+        Ok(())
+    }
+
     /// Mount an existing unmounted filesystem
     pub async fn mount(&self, name: &str) -> Result<Filesystem, FilesystemError> {
         self.mount_maybe_degraded(name, false).await
@@ -2821,11 +2900,30 @@ impl FilesystemService {
             Ok(filesystem) => filesystem,
             Err(error) => {
                 if let Some(expected_uuid) = expected_uuid {
-                    self.record_mount_failure(
-                        name,
-                        identity_mismatch_failure(name, expected_uuid, visible_uuid.as_deref()),
-                    )
-                    .await;
+                    let mount_point = format!("{NASTY_MOUNT_BASE}/{name}");
+                    let mount_point_occupied = is_mountpoint(&mount_point).await;
+                    let persisted_path_has_expected_uuid =
+                        if visible_uuid.is_none() && !mount_point_occupied {
+                            persisted_path_has_uuid(&opts.devices, expected_uuid).await
+                        } else {
+                            false
+                        };
+                    let reason = classify_unavailable_selection(
+                        visible_uuid.is_some(),
+                        mount_point_occupied,
+                        persisted_path_has_expected_uuid,
+                    );
+                    let failure = if reason == MountFailureReason::MissingDevice {
+                        unavailable_filesystem_failure(name, &opts.devices)
+                    } else {
+                        let actual_uuid = if mount_point_occupied {
+                            mounted_fs_uuid_at(&mount_point).await.ok().flatten()
+                        } else {
+                            visible_uuid
+                        };
+                        identity_mismatch_failure(name, expected_uuid, actual_uuid.as_deref())
+                    };
+                    self.record_mount_failure(name, failure).await;
                 }
                 return Err(error);
             }
@@ -5874,6 +5972,63 @@ struct FsMountOptions {
 /// Filesystem state: maps fs name → mount options.
 type FsState = HashMap<String, FsMountOptions>;
 
+fn project_unavailable_filesystems(
+    state: &FsState,
+    live: &[Filesystem],
+    failures: &HashMap<String, MountFailure>,
+) -> Vec<UnavailableFilesystem> {
+    let live_uuids: HashSet<&str> = live
+        .iter()
+        .map(|filesystem| filesystem.uuid.as_str())
+        .collect();
+    let mut unavailable = state
+        .iter()
+        .filter_map(|(name, options)| {
+            let uuid = options.uuid.as_deref().filter(|uuid| !uuid.is_empty())?;
+            (!live_uuids.contains(uuid)).then(|| UnavailableFilesystem {
+                name: name.clone(),
+                uuid: uuid.to_string(),
+                devices: options.devices.clone(),
+                auto_mount: options.mounted != Some(false),
+                last_mount_error: failures.get(name).cloned(),
+            })
+        })
+        .collect::<Vec<_>>();
+    unavailable.sort_by(|a, b| a.name.cmp(&b.name).then(a.uuid.cmp(&b.uuid)));
+    unavailable
+}
+
+fn validate_forget_unavailable(
+    state: &FsState,
+    req: &ForgetUnavailableRequest,
+) -> Result<(), FilesystemError> {
+    if req.confirm_name != req.name {
+        return Err(FilesystemError::InvalidInput(
+            "confirmation name does not match filesystem name".into(),
+        ));
+    }
+    let options = state
+        .get(&req.name)
+        .ok_or_else(|| FilesystemError::NotFound(req.name.clone()))?;
+    let persisted_uuid = options
+        .uuid
+        .as_deref()
+        .filter(|uuid| !uuid.is_empty())
+        .ok_or_else(|| {
+            FilesystemError::InvalidInput(format!(
+                "filesystem '{}' has legacy state without a UUID and cannot be safely forgotten",
+                req.name
+            ))
+        })?;
+    if persisted_uuid != req.expected_uuid {
+        return Err(FilesystemError::InvalidInput(format!(
+            "expected UUID does not match the persisted UUID for filesystem '{}'",
+            req.name
+        )));
+    }
+    Ok(())
+}
+
 async fn save_fs_mounted_with_opts(fs_name: &str, mut opts: FsMountOptions) {
     // Always flip mounted=true here so callers can't forget — the
     // function name promises "mounted state recorded," and the only
@@ -5928,28 +6083,28 @@ async fn forget_fs(fs_name: &str) {
 }
 
 async fn load_fs_state() -> FsState {
-    let content = match tokio::fs::read_to_string(FS_STATE_PATH).await {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return FsState::new(),
-        Err(e) => {
-            // A non-NotFound read error means we *might* be silently
-            // resetting persisted mount state — log so a "filesystems
-            // didn't auto-mount" report can be matched to the real
-            // cause (permissions, IO error, etc.).
-            warn!("read {FS_STATE_PATH} failed: {e} — using empty state");
-            return FsState::new();
-        }
-    };
-    match serde_json::from_str(&content) {
-        Ok(s) => s,
-        Err(e) => {
-            warn!(
-                "parse {FS_STATE_PATH} failed: {e} — file may be corrupt; \
-                 using empty state (mount-option overrides will be lost)"
-            );
+    match load_fs_state_strict().await {
+        Ok(state) => state,
+        Err(error) => {
+            warn!("{error} — using empty state");
             FsState::new()
         }
     }
+}
+
+async fn load_fs_state_strict() -> Result<FsState, FilesystemError> {
+    let content = match tokio::fs::read_to_string(FS_STATE_PATH).await {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(FsState::new()),
+        Err(error) => {
+            return Err(FilesystemError::CommandFailed(format!(
+                "read {FS_STATE_PATH} failed: {error}"
+            )));
+        }
+    };
+    serde_json::from_str(&content).map_err(|error| {
+        FilesystemError::CommandFailed(format!("parse {FS_STATE_PATH} failed: {error}"))
+    })
 }
 
 async fn save_fs_state(state: &FsState) -> Result<(), FilesystemError> {
@@ -6211,6 +6366,125 @@ fn identity_mismatch_failure(
         missing_devices: Vec::new(),
         raw: message,
     }
+}
+
+fn classify_unavailable_selection(
+    conflicting_visible_identity: bool,
+    canonical_mountpoint_occupied: bool,
+    persisted_path_has_expected_uuid: bool,
+) -> MountFailureReason {
+    if conflicting_visible_identity
+        || canonical_mountpoint_occupied
+        || persisted_path_has_expected_uuid
+    {
+        MountFailureReason::IdentityMismatch
+    } else {
+        MountFailureReason::MissingDevice
+    }
+}
+
+fn unavailable_filesystem_failure(name: &str, paths: &[String]) -> MountFailure {
+    let missing_devices = paths
+        .iter()
+        .map(|path| MissingDevice {
+            path: path.clone(),
+            member_index: None,
+            label: None,
+        })
+        .collect::<Vec<_>>();
+    let message = if missing_devices.is_empty() {
+        format!(
+            "Filesystem '{name}' is not visible and has no available last-known member devices."
+        )
+    } else {
+        classify_mount_failure("", &missing_devices).1
+    };
+    MountFailure {
+        attempted_at: unix_now_secs(),
+        reason: MountFailureReason::MissingDevice,
+        message: message.clone(),
+        missing_devices,
+        raw: message,
+    }
+}
+
+async fn persisted_path_has_uuid(paths: &[String], expected_uuid: &str) -> bool {
+    for path in paths {
+        if Path::new(path).exists() && get_fs_uuid(path).await.as_deref() == Some(expected_uuid) {
+            return true;
+        }
+    }
+    false
+}
+
+async fn filesystem_uuid_is_visible(uuid: &str) -> Result<bool, FilesystemError> {
+    let output = tokio::process::Command::new("blkid")
+        .args(["-U", uuid])
+        .output()
+        .await
+        .map_err(FilesystemError::Io)?;
+    if classify_blkid_uuid_probe(
+        output.status.code(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )? {
+        return Ok(true);
+    }
+
+    // bcachefs 1.38+ can make blkid miss mounted devices. A strict lsblk
+    // fallback prevents an alternate mount from being mistaken for absence.
+    let output = tokio::process::Command::new("lsblk")
+        .args(["--json", "--output", "UUID"])
+        .output()
+        .await
+        .map_err(FilesystemError::Io)?;
+    if !output.status.success() {
+        return Err(FilesystemError::CommandFailed(format!(
+            "lsblk UUID probe failed with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    lsblk_output_has_uuid(&String::from_utf8_lossy(&output.stdout), uuid)
+}
+
+fn classify_blkid_uuid_probe(
+    status_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<bool, FilesystemError> {
+    match status_code {
+        Some(0) if !stdout.trim().is_empty() => Ok(true),
+        Some(2) if stderr.trim().is_empty() => Ok(false),
+        code => Err(FilesystemError::CommandFailed(format!(
+            "blkid UUID probe failed with status {code:?}: {}",
+            stderr.trim()
+        ))),
+    }
+}
+
+fn lsblk_output_has_uuid(output: &str, expected_uuid: &str) -> Result<bool, FilesystemError> {
+    let parsed: serde_json::Value = serde_json::from_str(output).map_err(|error| {
+        FilesystemError::CommandFailed(format!("parse lsblk UUID probe: {error}"))
+    })?;
+    let roots = parsed
+        .get("blockdevices")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            FilesystemError::CommandFailed("lsblk UUID probe returned no blockdevices".into())
+        })?;
+
+    fn contains_uuid(nodes: &[serde_json::Value], expected_uuid: &str) -> bool {
+        nodes.iter().any(|node| {
+            node.get("uuid").and_then(serde_json::Value::as_str) == Some(expected_uuid)
+                || node
+                    .get("children")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|children| contains_uuid(children, expected_uuid))
+        })
+    }
+
+    Ok(contains_uuid(roots, expected_uuid))
 }
 
 /// Assemble a [`MountFailure`] from a failed mount: figure out which
@@ -7118,6 +7392,145 @@ mod tests {
         ));
         assert!(!mounted_identity_matches(Some("aaaaaaaa-main"), None));
         assert!(!mounted_identity_matches(None, Some("bbbbbbbb-usb")));
+    }
+
+    #[test]
+    fn unavailable_projection_is_uuid_based_actionable_and_sorted() {
+        let state = HashMap::from([
+            (
+                "zeta".to_string(),
+                FsMountOptions {
+                    uuid: Some("uuid-z".to_string()),
+                    devices: vec!["/dev/z-last".to_string()],
+                    mounted: Some(false),
+                    ..Default::default()
+                },
+            ),
+            (
+                "alpha".to_string(),
+                FsMountOptions {
+                    uuid: Some("uuid-a".to_string()),
+                    devices: vec!["/dev/a-last".to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "live-under-another-name".to_string(),
+                FsMountOptions {
+                    uuid: Some("uuid-live".to_string()),
+                    ..Default::default()
+                },
+            ),
+            ("legacy".to_string(), FsMountOptions::default()),
+        ]);
+        let failure = unavailable_filesystem_failure("alpha", &["/dev/a-last".to_string()]);
+        let failures = HashMap::from([("alpha".to_string(), failure.clone())]);
+        let live = vec![filesystem_fixture("renamed", "uuid-live")];
+
+        let unavailable = project_unavailable_filesystems(&state, &live, &failures);
+
+        assert_eq!(unavailable.len(), 2);
+        assert_eq!(unavailable[0].name, "alpha");
+        assert_eq!(unavailable[0].uuid, "uuid-a");
+        assert_eq!(unavailable[0].devices, vec!["/dev/a-last"]);
+        assert!(unavailable[0].auto_mount);
+        assert_eq!(unavailable[0].last_mount_error, Some(failure));
+        assert_eq!(unavailable[1].name, "zeta");
+        assert!(!unavailable[1].auto_mount);
+    }
+
+    #[test]
+    fn forget_validation_requires_confirmation_uuid_and_actionable_state() {
+        let state = HashMap::from([
+            (
+                "tank".to_string(),
+                FsMountOptions {
+                    uuid: Some("uuid-tank".to_string()),
+                    ..Default::default()
+                },
+            ),
+            ("legacy".to_string(), FsMountOptions::default()),
+        ]);
+        let mut request = ForgetUnavailableRequest {
+            name: "tank".to_string(),
+            expected_uuid: "uuid-tank".to_string(),
+            confirm_name: "tank".to_string(),
+        };
+        assert!(validate_forget_unavailable(&state, &request).is_ok());
+
+        request.confirm_name = "other".to_string();
+        assert!(matches!(
+            validate_forget_unavailable(&state, &request),
+            Err(FilesystemError::InvalidInput(_))
+        ));
+        request.confirm_name = "tank".to_string();
+        request.expected_uuid = "different".to_string();
+        assert!(matches!(
+            validate_forget_unavailable(&state, &request),
+            Err(FilesystemError::InvalidInput(_))
+        ));
+        request.name = "legacy".to_string();
+        request.confirm_name = "legacy".to_string();
+        assert!(matches!(
+            validate_forget_unavailable(&state, &request),
+            Err(FilesystemError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn unavailable_selection_classifies_only_total_absence_as_missing() {
+        assert_eq!(
+            classify_unavailable_selection(false, false, false),
+            MountFailureReason::MissingDevice
+        );
+        assert_eq!(
+            classify_unavailable_selection(true, false, false),
+            MountFailureReason::IdentityMismatch
+        );
+        assert_eq!(
+            classify_unavailable_selection(false, true, false),
+            MountFailureReason::IdentityMismatch
+        );
+        assert_eq!(
+            classify_unavailable_selection(false, false, true),
+            MountFailureReason::IdentityMismatch
+        );
+
+        let paths = vec!["/dev/old-a".to_string(), "/dev/old-b".to_string()];
+        let failure = unavailable_filesystem_failure("tank", &paths);
+        assert_eq!(failure.reason, MountFailureReason::MissingDevice);
+        assert_eq!(
+            failure
+                .missing_devices
+                .iter()
+                .map(|device| device.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/dev/old-a", "/dev/old-b"]
+        );
+    }
+
+    #[test]
+    fn blkid_uuid_probe_distinguishes_absence_from_failure() {
+        assert!(classify_blkid_uuid_probe(Some(0), "/dev/sda\n", "").unwrap());
+        assert!(!classify_blkid_uuid_probe(Some(2), "", "").unwrap());
+        assert!(classify_blkid_uuid_probe(Some(2), "", "probe error").is_err());
+        assert!(classify_blkid_uuid_probe(Some(0), "", "").is_err());
+        assert!(classify_blkid_uuid_probe(Some(1), "", "permission denied").is_err());
+        assert!(classify_blkid_uuid_probe(None, "", "terminated").is_err());
+    }
+
+    #[test]
+    fn lsblk_uuid_probe_walks_nested_devices() {
+        let output = r#"{
+            "blockdevices": [
+                {"uuid": null, "children": [{"uuid": "root"}]},
+                {"uuid": "pool", "children": []}
+            ]
+        }"#;
+        assert!(lsblk_output_has_uuid(output, "root").unwrap());
+        assert!(lsblk_output_has_uuid(output, "pool").unwrap());
+        assert!(!lsblk_output_has_uuid(output, "missing").unwrap());
+        assert!(lsblk_output_has_uuid("{}", "pool").is_err());
     }
 
     #[test]

--- a/webui/src/lib/components/ConfirmDangerousDialog.svelte
+++ b/webui/src/lib/components/ConfirmDangerousDialog.svelte
@@ -40,7 +40,7 @@
 		/>
 		<DialogFooter class="gap-2">
 			<Button variant="outline" onclick={() => confirmDangerousRespond(false)}>Cancel</Button>
-			<Button variant="destructive" disabled={!matches} onclick={() => confirmDangerousRespond(true)}>Destroy</Button>
+			<Button variant="destructive" disabled={!matches} onclick={() => confirmDangerousRespond(true)}>{confirmDangerousState.confirmLabel}</Button>
 		</DialogFooter>
 	</DialogContent>
 </Dialog>

--- a/webui/src/lib/confirm-dangerous.svelte.test.ts
+++ b/webui/src/lib/confirm-dangerous.svelte.test.ts
@@ -11,12 +11,20 @@ afterEach(() => {
 });
 
 describe('confirmDangerous', () => {
-	test('opens the dialog and populates title, message, and expectedValue', () => {
+	test('opens the dialog and populates title, message, expectedValue, and the default label', () => {
 		void confirmDangerous('Delete tank?', 'Type "tank" to confirm', 'tank');
 		expect(confirmDangerousState.open).toBe(true);
 		expect(confirmDangerousState.title).toBe('Delete tank?');
 		expect(confirmDangerousState.message).toBe('Type "tank" to confirm');
 		expect(confirmDangerousState.expectedValue).toBe('tank');
+		expect(confirmDangerousState.confirmLabel).toBe('Destroy');
+	});
+
+	test('honours a custom confirm label', () => {
+		void confirmDangerous('Forget tank?', 'Type "tank" to confirm', 'tank', {
+			confirmLabel: 'Forget filesystem'
+		});
+		expect(confirmDangerousState.confirmLabel).toBe('Forget filesystem');
 	});
 
 	test('confirmDangerousRespond(true) resolves with true and closes', async () => {
@@ -24,6 +32,7 @@ describe('confirmDangerous', () => {
 		confirmDangerousRespond(true);
 		await expect(p).resolves.toBe(true);
 		expect(confirmDangerousState.open).toBe(false);
+		expect(confirmDangerousState.confirmLabel).toBe('Destroy');
 	});
 
 	test('confirmDangerousRespond(false) resolves with false', async () => {

--- a/webui/src/lib/confirm-dangerous.svelte.ts
+++ b/webui/src/lib/confirm-dangerous.svelte.ts
@@ -11,7 +11,12 @@ interface ConfirmDangerousState {
 	title: string;
 	message: string;
 	expectedValue: string;
+	confirmLabel: string;
 	resolve: ((v: boolean) => void) | null;
+}
+
+interface ConfirmDangerousOptions {
+	confirmLabel?: string;
 }
 
 export const confirmDangerousState = $state<ConfirmDangerousState>({
@@ -19,15 +24,22 @@ export const confirmDangerousState = $state<ConfirmDangerousState>({
 	title: '',
 	message: '',
 	expectedValue: '',
+	confirmLabel: 'Destroy',
 	resolve: null,
 });
 
-export function confirmDangerous(title: string, message: string, expectedValue: string): Promise<boolean> {
+export function confirmDangerous(
+	title: string,
+	message: string,
+	expectedValue: string,
+	options?: ConfirmDangerousOptions,
+): Promise<boolean> {
 	return new Promise((resolve) => {
 		confirmDangerousState.resolve?.(false);
 		confirmDangerousState.title = title;
 		confirmDangerousState.message = message;
 		confirmDangerousState.expectedValue = expectedValue;
+		confirmDangerousState.confirmLabel = options?.confirmLabel ?? 'Destroy';
 		confirmDangerousState.resolve = resolve;
 		confirmDangerousState.open = true;
 	});
@@ -40,6 +52,7 @@ export function confirmDangerousRespond(value: boolean) {
 	confirmDangerousState.title = '';
 	confirmDangerousState.message = '';
 	confirmDangerousState.expectedValue = '';
+	confirmDangerousState.confirmLabel = 'Destroy';
 }
 
 registerSessionReset(() => confirmDangerousRespond(false));

--- a/webui/src/lib/fs-dependents.test.ts
+++ b/webui/src/lib/fs-dependents.test.ts
@@ -7,6 +7,7 @@ function deps(over: Partial<FsDependents> = {}): FsDependents {
 		filesystem: 'tank',
 		mounted: true,
 		subvolumes: [],
+		apps_storage: false,
 		apps: [],
 		vms: [],
 		backup_jobs: [],
@@ -31,6 +32,12 @@ describe('summarizeDependents', () => {
 		// pluralization is fragile but the labels are hand-curated.
 		const summary = summarizeDependents(deps({ apps: ['jellyfin'] }));
 		expect(summary).toBe('• 1 app (jellyfin)');
+	});
+
+	it('reports Apps storage without installed apps', () => {
+		expect(summarizeDependents(deps({ apps_storage: true }))).toContain(
+			'Apps storage configuration',
+		);
 	});
 
 	it('plural noun and comma-joined names when multiple items', () => {

--- a/webui/src/lib/fs-dependents.ts
+++ b/webui/src/lib/fs-dependents.ts
@@ -17,9 +17,10 @@ export function summarizeDependents(deps: FsDependents): string | null {
 		{ label: 'NVMe-oF subsystem', items: deps.nvmeof_subsystems },
 	];
 	const non_empty = groups.filter((g) => g.items.length > 0);
-	if (non_empty.length === 0 && deps.state_errors.length === 0) return null;
+	if (non_empty.length === 0 && !deps.apps_storage && deps.state_errors.length === 0) return null;
 
 	const lines = non_empty.map((g) => `• ${formatLine(g.label, g.items)}`);
+	if (deps.apps_storage) lines.push('• Apps storage configuration');
 	lines.push(...deps.state_errors.map((error) => `• Dependency state error: ${error}`));
 	return lines.join('\n');
 }

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -368,6 +368,7 @@ export interface FsDependents {
 	filesystem: string;
 	mounted: boolean;
 	subvolumes: string[];
+	apps_storage: boolean;
 	apps: string[];
 	vms: string[];
 	backup_jobs: string[];
@@ -436,6 +437,16 @@ export interface Filesystem {
 	used_bytes: number;
 	available_bytes: number;
 	options: FilesystemOptions;
+	last_mount_error?: MountFailure | null;
+}
+
+/** Persisted filesystem registration whose member disks are not currently
+ * discoverable, returned by `fs.unavailable.list`. */
+export interface UnavailableFilesystem {
+	name: string;
+	uuid: string;
+	devices: string[];
+	auto_mount: boolean;
 	last_mount_error?: MountFailure | null;
 }
 

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -17,7 +17,7 @@
 	import { confirmDangerous } from '$lib/confirm-dangerous.svelte';
 	import { unlockFs } from '$lib/unlock-fs.svelte';
 	import { summarizeDependents } from '$lib/fs-dependents';
-	import type { Filesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, FsckStatus, ReconcileStatus, TieringProfile, TieringProfileId, FsDependents, TpmBindStatus, DiskHealth } from '$lib/types';
+	import type { Filesystem, UnavailableFilesystem, FilesystemDevice, BlockDevice, DeviceState, ScrubStatus, FsckStatus, ReconcileStatus, TieringProfile, TieringProfileId, FsDependents, TpmBindStatus, DiskHealth } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import SortTh from '$lib/components/SortTh.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -27,6 +27,7 @@
 	import { RefreshCw, Pencil } from '@lucide/svelte';
 
 	let filesystems: Filesystem[] = $state([]);
+	let unavailableFilesystems: UnavailableFilesystem[] = $state([]);
 	let devices: BlockDevice[] = $state([]);
 	/** SMART health per disk (system.disks), joined by path to give an
 	 * add-device candidate its health summary before it joins an fs. */
@@ -361,10 +362,14 @@
 	});
 
 	async function refresh() {
-		await withToast(async () => {
-			filesystems = await client.call<Filesystem[]>('fs.list');
-			devices = await client.call<BlockDevice[]>('device.list');
-		});
+		const [liveResult, unavailableResult, deviceResult] = await Promise.all([
+			withToast(() => client.call<Filesystem[]>('fs.list')),
+			withToast(() => client.call<UnavailableFilesystem[]>('fs.unavailable.list')),
+			withToast(() => client.call<BlockDevice[]>('device.list')),
+		]);
+		if (liveResult) filesystems = liveResult;
+		if (unavailableResult) unavailableFilesystems = unavailableResult;
+		if (deviceResult) devices = deviceResult;
 		// Drop pending-evacuation markers once the live state confirms
 		// them (or the device vanished, or the marker went stale — an
 		// evacuation that finished instantly never shows `evacuating`).
@@ -766,6 +771,38 @@
 		await withToast(
 			() => client.call('fs.destroy', { name, confirm_name: name }),
 			`Filesystem "${name}" destroyed`
+		);
+		await refresh();
+	}
+
+	async function forgetFs(fs: UnavailableFilesystem) {
+		let dependents: string | null = null;
+		try {
+			dependents = summarizeDependents(
+				await client.call<FsDependents>('fs.dependents', { name: fs.name }),
+			);
+		} catch { /* The backend still validates dependents before forgetting. */ }
+
+		let message = `This removes only NASty's saved configuration for "${fs.name}" and stops its auto-mount attempts and alerts. It does not erase or modify any disks. If the member disks are reconnected, they retain their bcachefs data.`;
+		if (dependents) {
+			message += `\n\nNASty reports these dependents; the backend will block forgetting while they remain:\n\n${dependents}`;
+		}
+		message += `\n\nType the filesystem name to confirm.`;
+
+		if (!await confirmDangerous(
+			`Forget Filesystem "${fs.name}"`,
+			message,
+			fs.name,
+			{ confirmLabel: 'Forget filesystem' },
+		)) return;
+
+		await withToast(
+			() => client.call('fs.forget', {
+				name: fs.name,
+				expected_uuid: fs.uuid,
+				confirm_name: fs.name,
+			}),
+			`Filesystem "${fs.name}" forgotten`,
 		);
 		await refresh();
 	}
@@ -1942,12 +1979,61 @@
 
 {#if loading}
 	<p class="text-muted-foreground">Loading...</p>
-{:else if filesystems.length === 0}
+{:else if filesystems.length === 0 && unavailableFilesystems.length === 0}
 	<div class="flex flex-col items-center justify-center py-12 text-center">
 		<p class="text-muted-foreground">No filesystems configured yet.</p>
 		<p class="mt-1 text-sm text-muted-foreground">Use the <strong>Create Filesystem</strong> button above to get started.</p>
 	</div>
 {:else}
+	{#each unavailableFilesystems as fs (fs.uuid)}
+		<Card class="mb-4 border-destructive/40 bg-destructive/[0.03]">
+			<CardContent class="pt-4">
+				<div class="flex flex-wrap items-start justify-between gap-3">
+					<div class="min-w-0">
+						<div class="flex flex-wrap items-center gap-2">
+							<strong class="text-lg">{fs.name}</strong>
+							<Badge variant="destructive">Unavailable</Badge>
+						</div>
+						<p class="mt-1 text-sm text-muted-foreground">No member of this saved filesystem is currently discoverable.</p>
+					</div>
+					<Button variant="destructive" size="xs" onclick={() => forgetFs(fs)}>Forget</Button>
+				</div>
+
+				<dl class="mt-3 grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2">
+					<div class="min-w-0 sm:col-span-2">
+						<dt class="text-xs font-medium uppercase tracking-wide text-muted-foreground">UUID</dt>
+						<dd class="mt-0.5 break-all font-mono text-xs">{fs.uuid}</dd>
+					</div>
+					<div class="min-w-0">
+						<dt class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Last-known members</dt>
+						<dd class="mt-1">
+							{#if fs.devices.length}
+								<ul class="space-y-0.5">
+									{#each fs.devices as path}
+										<li class="break-all font-mono text-xs">{path}</li>
+									{/each}
+								</ul>
+							{:else}
+								<span class="text-xs text-muted-foreground">No paths recorded</span>
+							{/if}
+						</dd>
+					</div>
+					<div>
+						<dt class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Auto-mount configured</dt>
+						<dd class="mt-0.5">{fs.auto_mount ? 'Yes' : 'No'}</dd>
+					</div>
+				</dl>
+
+				{#if fs.last_mount_error?.message}
+					<div class="mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm">
+						<span class="font-medium text-destructive">Last mount failure:</span>
+						<span class="ml-1">{fs.last_mount_error.message}</span>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+	{/each}
+
 	{#each filesystems as fs (fs.uuid)}
 		<Card class="mb-4">
 			<CardContent class="pt-4">


### PR DESCRIPTION
## Summary
- list UUID-bound filesystem registrations whose member disks are entirely unavailable
- add an explicit typed-confirmation Forget action that removes only host-side registration and operation history
- refuse forgetting when the UUID is visible or mounted, dependent state exists, or dependency/discovery state cannot be verified
- classify total member absence as `missing_device` instead of `identity_mismatch`

## Safety
- does not mount, wipe, or modify member disks
- preserves encryption keys and the canonical mount directory
- requires both filesystem name confirmation and the persisted UUID
- fails closed for unreadable filesystem, app, backup, VM, share, iSCSI, or NVMe-oF state

## VM verification
- reproduced the 60-second startup wait and stale registration after logically removing every member disk
- confirmed the unavailable filesystem is projected with its persisted identity and missing-device failure
- restored the disks after reboot and successfully remounted filesystem `first`, confirming data was not modified

## Testing
- `cargo test --workspace`
- affected Rust crate tests repeated after rebase
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `npm ci --legacy-peer-deps`
- `npm run check`
- `npm test` (221 tests)
- `npm run build`
- `git diff --check origin/main...HEAD`