### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785792640,
-        "narHash": "sha256-3csE9r0g3BpQ1q9YE8GsgdettN539VH+u/uCqQR0yZU=",
+        "lastModified": 1786316750,
+        "narHash": "sha256-KJBzVbK5DL+ZK27Oyyn8vCWRQUHrIAelrex1oX+fWq4=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "5ffbc8b0be7ab5e59683a8fb034e9486f074a7f9",
+        "rev": "9dc9769fe3d4909cc86eb346514c60eb5d471411",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.0",
+        "ref": "v1.39.1",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.0 release tag.
+    # Pinned to v1.39.1 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.0";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.1";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.0";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.1";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the


### PR DESCRIPTION
## Summary
- bump the canonical bcachefs-tools input from v1.39.0 to v1.39.1
- refresh the locked upstream revision and NAR hash
- keep the installer wrapper fallback pin aligned with the bundled release

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p nasty-system update::tests` (64 passed)
- `nix flake check --no-build`
- x86_64 `bcachefs-tools` package build; binary reports `1.39.1`
- x86_64 DKMS module build; `modinfo` reports version `1.39.1` and kernel vermagic `6.18.42`
- x86_64 and aarch64 package/module evaluation

`nix flake check --no-build --all-systems` also evaluated both bcachefs package outputs and the bcachefs smoke derivation; its aggregate failures reproduce unchanged on the base commit (bare configurations without a root filesystem and Darwin evaluation of Linux VM checks).