### PR TITLE
ci: bump Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       # Version must match rust-toolchain.toml at the repo root.
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/engine/nasty-metrics/src/collect_bcachefs.rs
+++ b/engine/nasty-metrics/src/collect_bcachefs.rs
@@ -539,10 +539,9 @@ fn parse_human_bytes(s: &str) -> Option<u64> {
         (n, 1024 * 1024)
     } else if let Some(n) = s.strip_suffix('G') {
         (n, 1024 * 1024 * 1024)
-    } else if let Some(n) = s.strip_suffix('T') {
-        (n, 1024 * 1024 * 1024 * 1024)
     } else {
-        return None;
+        let n = s.strip_suffix('T')?;
+        (n, 1024 * 1024 * 1024 * 1024)
     };
 
     num_str

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- bump the repository and CI Rust toolchain from 1.95.0 to 1.97.1
- keep the duplicated CI pins aligned with `rust-toolchain.toml`
- satisfy the new `clippy::question_mark` lint with a behavior-preserving suffix parse cleanup

## Verification
- `rustc 1.97.1 (8bab26f4f 2026-07-14)`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --no-fail-fast` (1,213 passed, 1 ignored)
- `actionlint`
- toolchain pin consistency check
- `git diff --check`