### PR TITLE
ci: bump official Actions to v7

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-tags: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: engine
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Version must match rust-toolchain.toml at the repo root.
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -47,9 +47,9 @@ jobs:
       run:
         working-directory: webui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -76,7 +76,7 @@ jobs:
     name: npmDepsHash freshness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:
@@ -138,7 +138,7 @@ jobs:
     name: Installer template canonical shape and effective bcachefs pin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Assert template uses follows for nixpkgs
         run: |
@@ -223,7 +223,7 @@ jobs:
     name: Installer wrapper-lock shape stable (nix flake lock idempotent)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
     name: bcachefs smoke (NixOS test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/nix-engine-build.yml
+++ b/.github/workflows/nix-engine-build.yml
@@ -39,7 +39,7 @@ jobs:
     name: Nix engine build (sandbox-visibility gate)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -38,7 +38,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
     name: cargo-deny (advisories, licenses, sources)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Official action: pins cargo-deny version, downloads a prebuilt
       # binary (no `cargo install` compile penalty), and runs `check`.
@@ -55,9 +55,9 @@ jobs:
       run:
         working-directory: webui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -84,7 +84,7 @@ jobs:
       run:
         working-directory: engine
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.95.0
 
@@ -102,7 +102,7 @@ jobs:
       - name: Run geiger
         run: cargo geiger --workspace --output-format Ascii > /tmp/geiger.txt 2>&1 || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cargo-geiger-report
           path: /tmp/geiger.txt


### PR DESCRIPTION
## Summary
- bump `actions/checkout` from v6 to v7
- bump `actions/setup-node` from v6 to v7
- bump `actions/upload-artifact` from v4 to v7

## Compatibility
- every workflow uses GitHub-hosted `ubuntu-latest` or `ubuntu-24.04-arm` runners
- the Node 24 / Actions Runner 2.327.1+ requirement is therefore satisfied
- existing setup-node cache inputs and upload-artifact inputs remain supported
- this repository has no `pull_request_target` or `workflow_run` checkout affected by checkout v7 fork restrictions

## Verification
- `actionlint .github/workflows/*`
- stale action-version search
- `git diff --check`