### PR TITLE
caddy: bump Hetzner DNS plugin to 2.0.1

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2224,7 +2224,7 @@ in {
           "github.com/caddy-dns/duckdns@v0.5.0"
           # Cloud / hosting providers commonly running NASty boxes.
           "github.com/caddy-dns/route53@v1.6.2"
-          "github.com/caddy-dns/hetzner/v2@v2.0.0"
+          "github.com/caddy-dns/hetzner/v2@v2.0.1"
           "github.com/caddy-dns/linode@v0.8.0"
           # Indie domain registrars with first-class API support.
           "github.com/caddy-dns/porkbun@v0.3.1"
@@ -2235,7 +2235,7 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-Pws8IAyp2Iui5YrUIGswVBb/OiUeGz1mUyhJvjfn0Zo=";
+        hash = "sha256-koAljBnPgSNGZXlqVa4aab8A7EUb9xmXqEgBzZen0a0=";
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
## Summary
- bump `caddy-dns/hetzner` from 2.0.0 to 2.0.1
- refresh the aggregate `caddy.withPlugins` vendor hash

The upstream code change modernizes module registration; its module path, dependencies, API, and configuration remain unchanged.

## Verification
- built the actual customized Caddy 2.11.4 package on x86_64-linux
- Caddy build and check phases passed
- module list contains `dns.providers.hetzner`
- build metadata reports `github.com/caddy-dns/hetzner/v2 v2.0.1`
- `git diff --check`