### PR TITLE
tailscale: refresh package to 1.102.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -280,11 +280,11 @@
     },
     "tailscale-nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- refresh only the independent `tailscale-nixpkgs` input
- update the appliance Tailscale package from 1.102.1 to 1.102.2
- leave primary nixpkgs, bcachefs-tools, and Lanzaboote pins unchanged

## Verification
- x86_64-linux package evaluation: `1.102.2`
- aarch64-linux package evaluation: `1.102.2`
- both NixOS service package evaluations report `1.102.2`
- `nix flake check --no-build`
- `checks.x86_64-linux.tailscale-independent-package`
- built x86_64 Tailscale package
- `git diff --check`