### PR TITLE
nixos: bump diskwatch to 0.1.6

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -806,12 +806,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.1.5";
-          hash = "sha256-5EGNfMn//b38mhTK8rJfPJdk1rIPeijreDBkgoDmjBs=";
+          rev = "v0.1.6";
+          hash = "sha256-Ugqda8QWiHlNcMFIrenoHVD2WCK9JgcfoCNNOwBuQMY=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.1.5";
+        version = "0.1.6";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";


### PR DESCRIPTION
## Summary
- bump the bundled diskwatch diagnostics TUI from 0.1.5 to 0.1.6
- refresh the fixed-output source hash

Upstream adds a compact 80x24 view, graph and capacity-projection improvements, and fixes the initial IO sample treating since-boot totals as one second of throughput.

## Verification
- evaluated configured package as `diskwatch-0.1.6`
- built the actual x86_64-linux Nix package
- upstream package tests: 77 passed
- built binary reports `diskwatch 0.1.6`
- `git diff --check`