### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786316750,
-        "narHash": "sha256-KJBzVbK5DL+ZK27Oyyn8vCWRQUHrIAelrex1oX+fWq4=",
+        "lastModified": 1786990948,
+        "narHash": "sha256-1ilzebplgFVaqiSzpTeGRgnSqYfo9W8G7xj/6KlX990=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "9dc9769fe3d4909cc86eb346514c60eb5d471411",
+        "rev": "abdbd61f320a8c82dd981b6fda189c359a82836c",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.1",
+        "ref": "v1.39.2",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.1 release tag.
+    # Pinned to v1.39.2 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.1";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.2";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.1";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.2";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the


### PR DESCRIPTION
Bumps bcachefs-tools from v1.39.1 to v1.39.2.

Changes:
- flake.nix: update pinned tag
- flake.lock: regenerate lock (abdbd61, Aug 17)
- flake.nix.template: update fallback hardcoded tag