### PR TITLE
engine: avoid Docker readiness race during activation

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -11,7 +11,9 @@
 //! docker-compose.yml files and using Docker's `com.docker.compose.project` label.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
+use std::time::Duration;
 
 use bollard::Docker;
 use bollard::models::{
@@ -37,6 +39,8 @@ pub use caddy::{CaddyRouteSummary, HostCert};
 const STATE_PATH: &str = "/var/lib/nasty/apps-enabled";
 const COMPOSE_DIR: &str = "/var/lib/nasty/apps";
 const DOCKER_SERVICE: &str = "docker.service";
+const DOCKER_PING_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Stable, relocation-proof home for container persistent data (#436).
 /// A symlink whose target is the real appdata subvolume on some
 /// bcachefs filesystem — compose files reference `/appdata/<app>/…`,
@@ -5353,7 +5357,7 @@ impl AppsService {
 
     async fn is_docker_ready(&self) -> bool {
         match self.docker() {
-            Ok(d) => d.ping().await.is_ok(),
+            Ok(d) => completes_ok_within(DOCKER_PING_TIMEOUT, d.ping()).await,
             Err(_) => false,
         }
     }
@@ -5828,6 +5832,13 @@ impl AppsService {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
+
+async fn completes_ok_within<F, T, E>(limit: Duration, operation: F) -> bool
+where
+    F: Future<Output = Result<T, E>>,
+{
+    matches!(tokio::time::timeout(limit, operation).await, Ok(Ok(_)))
+}
 
 /// Container name for simple apps: "nasty-{name}"
 fn container_name(app_name: &str) -> String {
@@ -6810,12 +6821,22 @@ async fn fetch_manifest_json(
 #[cfg(test)]
 mod tests {
     use super::{
-        AppVolume, InstallAppRequest, StartupConfig, compose_file_args, docker_data_root_status,
-        extract_user_env, render_env_file, render_startup_override, validate_app_name,
-        validate_new_app_name, validate_new_app_request, validate_simple_volumes,
-        validate_volume_name,
+        AppVolume, InstallAppRequest, StartupConfig, completes_ok_within, compose_file_args,
+        docker_data_root_status, extract_user_env, render_env_file, render_startup_override,
+        validate_app_name, validate_new_app_name, validate_new_app_request,
+        validate_simple_volumes, validate_volume_name,
     };
     use std::path::PathBuf;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn bounded_operation_distinguishes_success_error_and_stall() {
+        assert!(completes_ok_within(Duration::ZERO, async { Ok::<_, ()>(()) }).await);
+        assert!(!completes_ok_within(Duration::ZERO, async { Err::<(), _>(()) }).await);
+        assert!(
+            !completes_ok_within(Duration::ZERO, std::future::pending::<Result<(), ()>>(),).await
+        );
+    }
 
     #[test]
     fn new_app_name_accepts_conservative_grammar() {

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, reload};
 
 mod app_deploy;
@@ -431,7 +431,21 @@ async fn main() -> anyhow::Result<()> {
                     let dc_enabled = nasty_system::dc::DcService::load_config().await.is_some();
                     let (iscsi_ports, nvmeof_ports) =
                         router::share::portal_firewall_ports(&state).await?;
-                    let published = router::apps::published_firewall_ports(&state).await?;
+                    let published = match tokio::time::timeout(
+                        secs(5),
+                        router::apps::published_firewall_ports(&state),
+                    )
+                    .await
+                    {
+                        Ok(result) => result?,
+                        Err(_) => {
+                            warn!(
+                                "Docker app-port discovery exceeded 5s during firewall initialization; \
+                                 starting fail-closed with app ports blocked until app restoration reconciles them"
+                            );
+                            Vec::new()
+                        }
+                    };
                     state
                         .firewall
                         .init(

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -336,6 +336,7 @@ PROFILE_MUTATED=false
 MARKER_SET=false
 TAILSCALE_REQUIRED=false
 TAILSCALE_IP_BEFORE=""
+TRANSACTION_STARTED_AT=$(date '+%Y-%m-%d %H:%M:%S')
 
 _proxy_conf() {
     readlink -f /run/current-system/etc/caddy/Caddyfile 2>/dev/null || true
@@ -361,6 +362,24 @@ wait_for_previous_tailscale() {
     return 1
 }
 
+dump_failure_diagnostics() {
+    local phase="$1"
+    echo "--- $phase: failed services ---"
+    systemctl --failed --no-pager --full || true
+    echo "--- $phase: relevant service status ---"
+    systemctl status --no-pager --full --lines=30 \
+        nasty-engine.service caddy.service nasty-tailscale.service \
+        docker.service containerd.service nftables.service || true
+    echo "--- $phase: nasty-engine journal ---"
+    journalctl --since "$TRANSACTION_STARTED_AT" --no-pager -n 160 \
+        -u nasty-engine.service || true
+    echo "--- $phase: supporting service journal ---"
+    journalctl --since "$TRANSACTION_STARTED_AT" --no-pager -n 160 \
+        -u caddy.service -u nasty-tailscale.service -u docker.service \
+        -u containerd.service -u nftables.service || true
+    echo "--- end $phase diagnostics ---"
+}
+
 cleanup() {
 @BD_CLEANUP@
     rm -rf "$WORK_DIR"
@@ -383,6 +402,9 @@ rollback_transaction() {
     trap - ERR TERM INT HUP
     set +e
     echo "==> Update transaction failed (exit $rc); restoring the previous system..."
+    if $PROFILE_MUTATED; then
+        dump_failure_diagnostics "candidate activation failure"
+    fi
     if $PROFILE_MUTATED && ! $MARKER_SET; then
         if install -m 0600 /dev/null "$MARKER"; then
             MARKER_SET=true
@@ -464,15 +486,13 @@ SIGNAL_ROLLBACK_EOF
         rm -f "$MARKER" || rollback_ok=false
     fi
     rm -f "$LIVE_DIR/.flake.nix.nasty-new" "$LIVE_DIR/.flake.lock.nasty-new"
-    echo "--- journalctl -u nixos-rebuild-switch-to-configuration -n 60 ---"
-    journalctl -u nixos-rebuild-switch-to-configuration --no-pager -n 60 || true
-    echo "--- end journal dump ---"
     if $detached_started; then
         echo "==> Previous-generation activation continues in $ROLLBACK_UNIT.service"
 @BD_CLEANUP@
     elif $rollback_ok; then
         cleanup
     else
+        dump_failure_diagnostics "rollback failure"
         echo "==> CRITICAL: automatic rollback failed."
         echo "==> Recovery remains suppressed; backups are in $BACKUP"
 @BD_CLEANUP@
@@ -4372,6 +4392,27 @@ proc /proc proc rw 0 0\n\
         assert!(script.contains("--property=Nice=10"));
         assert!(script.contains("--property=IOSchedulingClass=best-effort"));
         assert!(script.contains("--property=IOSchedulingPriority=7"));
+    }
+
+    #[test]
+    fn wrapper_transaction_captures_actionable_failure_diagnostics() {
+        let script = rendered_transaction();
+        let candidate_dump = script
+            .find("dump_failure_diagnostics \"candidate activation failure\"")
+            .unwrap();
+        let rollback_activation = script
+            .find("\"$OLD_SYSTEM/bin/switch-to-configuration\" switch")
+            .unwrap();
+
+        assert!(candidate_dump < rollback_activation);
+        assert!(script.contains("TRANSACTION_STARTED_AT=$(date"));
+        assert!(script.contains("systemctl --failed --no-pager --full"));
+        assert!(script.contains("nasty-engine.service caddy.service nasty-tailscale.service"));
+        assert!(script.contains("docker.service containerd.service nftables.service"));
+        assert!(script.contains("journalctl --since \"$TRANSACTION_STARTED_AT\""));
+        assert!(script.contains("-u nasty-engine.service"));
+        assert!(script.contains("dump_failure_diagnostics \"rollback failure\""));
+        assert!(!script.contains("nixos-rebuild-switch-to-configuration"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #774.

An app-heavy system could fail an otherwise successful upgrade while Docker/containerd restarted. Early firewall initialization waited on an unbounded Docker ping and app-port inventory until its 15-second phase budget expired, causing activation and rollback to report failure.

Changes:
- bound Docker readiness probes to 3 seconds
- bound early app-port discovery to 5 seconds and retain fail-closed firewall behavior until normal app restoration reconciles ports
- capture failed units, service status, and relevant journals before rollback starts
- capture a separate diagnostic snapshot if rollback also fails
- remove the ineffective journal query for a nonexistent switch-to-configuration unit

Verification:
- cargo test --workspace
- cargo test -p nasty-engine
- cargo test -p nasty-system
- cargo clippy --workspace --all-targets -- -D warnings
- generated update transaction passes bash syntax validation