### PR TITLE
webui: show live TLS certificate status

### DIFF
--- a/webui/src/lib/tls-status.test.ts
+++ b/webui/src/lib/tls-status.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { selectPrimaryTlsStatus, type AcmeStatus, type HostTlsStatus } from './tls-status';
+
+const staleStatus: AcmeStatus = {
+	state: 'success',
+	message: 'Certificate active for nas.0f.ee',
+	domain: 'nas.0f.ee',
+	issuer: 'E7',
+	issued: 'Wed, 20 May 2026 11:38:36 +0000',
+	expires: 'Tue, 18 Aug 2026 11:38:35 +0000'
+};
+
+const renewedHost: HostTlsStatus = {
+	host: 'nas.0f.ee',
+	state: 'active',
+	issuer: 'YE1',
+	issued: 'Wed, 19 Aug 2026 00:54:50 +0000',
+	expires: 'Tue, 17 Nov 2026 00:54:49 +0000'
+};
+
+describe('selectPrimaryTlsStatus', () => {
+	it('uses the live primary-domain certificate instead of a stale ACME snapshot', () => {
+		const selected = selectPrimaryTlsStatus('NAS.0F.EE', staleStatus, [renewedHost]);
+
+		expect(selected).toMatchObject({
+			state: 'success',
+			domain: 'nas.0f.ee',
+			issuer: 'YE1',
+			issued: renewedHost.issued,
+			expires: renewedHost.expires
+		});
+	});
+
+	it('does not use another managed hostname for the primary card', () => {
+		const selected = selectPrimaryTlsStatus('nas.0f.ee', staleStatus, [
+			{ ...renewedHost, host: 'haze.0f.ee' }
+		]);
+
+		expect(selected).toBe(staleStatus);
+	});
+
+	it('keeps provisioning errors until a primary certificate exists', () => {
+		const error: AcmeStatus = {
+			state: 'error',
+			message: 'DNS challenge failed',
+			domain: 'nas.0f.ee'
+		};
+
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', error, [
+				{ host: 'nas.0f.ee', state: 'pending' }
+			])
+		).toBe(error);
+	});
+
+	it('uses the live certificate when the operation snapshot is stale', () => {
+		const running: AcmeStatus = {
+			...staleStatus,
+			state: 'running',
+			message: 'Provisioning replacement certificate'
+		};
+
+		expect(selectPrimaryTlsStatus('nas.0f.ee', running, [renewedHost])).toMatchObject({
+			state: 'success',
+			issued: renewedHost.issued
+		});
+
+		const error: AcmeStatus = {
+			...staleStatus,
+			state: 'error',
+			message: 'Replacement failed',
+			issued: renewedHost.issued
+		};
+		expect(selectPrimaryTlsStatus('nas.0f.ee', error, [renewedHost])).toMatchObject({
+			state: 'success',
+			issued: renewedHost.issued
+		});
+	});
+
+	it('ignores an ACME snapshot for a previously configured domain', () => {
+		expect(selectPrimaryTlsStatus('new.0f.ee', staleStatus, [])).toBeNull();
+		expect(
+			selectPrimaryTlsStatus('new.0f.ee', staleStatus, [
+				{ host: 'new.0f.ee', state: 'pending' }
+			])
+		).toMatchObject({ state: 'running', domain: 'new.0f.ee' });
+	});
+
+	it('uses live operation state if the ACME status request failed', () => {
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', null, [
+				{ host: 'nas.0f.ee', state: 'failed', renewal_error: 'DNS challenge failed' }
+			])
+		).toMatchObject({ state: 'error', message: 'DNS challenge failed' });
+
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', null, [
+				{ host: 'nas.0f.ee', state: 'issuing' }
+			])
+		).toMatchObject({ state: 'running' });
+	});
+
+	it('uses a live failure instead of a stale running snapshot', () => {
+		const running: AcmeStatus = {
+			state: 'running',
+			message: 'Waiting for Caddy',
+			domain: 'nas.0f.ee'
+		};
+
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', running, [
+				{ host: 'nas.0f.ee', state: 'failed', renewal_error: 'DNS challenge failed' }
+			])
+		).toMatchObject({ state: 'error', message: 'DNS challenge failed' });
+	});
+
+	it('does not let stale success override a pending live host', () => {
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', staleStatus, [
+				{ host: 'nas.0f.ee', state: 'pending' }
+			])
+		).toMatchObject({ state: 'running', domain: 'nas.0f.ee' });
+	});
+
+	it('handles Caddy success before certificate metadata reaches disk', () => {
+		expect(
+			selectPrimaryTlsStatus('nas.0f.ee', staleStatus, [
+				{ host: 'nas.0f.ee', state: 'active', message: 'certificate obtained successfully' }
+			])
+		).toMatchObject({ state: 'success', domain: 'nas.0f.ee' });
+	});
+
+	it('surfaces an expired live primary certificate as an error', () => {
+		const selected = selectPrimaryTlsStatus('nas.0f.ee', staleStatus, [
+			{ ...renewedHost, state: 'expired' }
+		]);
+
+		expect(selected?.state).toBe('error');
+		expect(selected?.message).toContain('expired');
+		expect(selected?.expires).toBe(renewedHost.expires);
+	});
+});

--- a/webui/src/lib/tls-status.ts
+++ b/webui/src/lib/tls-status.ts
@@ -1,0 +1,81 @@
+export type AcmeStatus = {
+	state: string;
+	message: string;
+	domain?: string;
+	expires?: string;
+	issued?: string;
+	issuer?: string;
+	last_attempt?: string;
+};
+
+export type HostTlsStatus = {
+	host: string;
+	state: 'active' | 'expiring' | 'expired' | 'issuing' | 'failed' | 'pending';
+	issuer?: string;
+	issued?: string;
+	expires?: string;
+	expires_in_days?: number;
+	message?: string;
+	renewal_error?: string;
+	app?: string;
+};
+
+export function selectPrimaryTlsStatus(
+	domain: string,
+	acmeStatus: AcmeStatus | null,
+	hostStatuses: HostTlsStatus[]
+): AcmeStatus | null {
+	const normalizedDomain = domain.trim().toLowerCase();
+	const scopedAcmeStatus =
+		acmeStatus?.domain && acmeStatus.domain.toLowerCase() !== normalizedDomain
+			? null
+			: acmeStatus;
+	const hostStatus = hostStatuses.find((status) => status.host.toLowerCase() === normalizedDomain);
+	if (!hostStatus) {
+		return scopedAcmeStatus;
+	}
+	const hasCertificate = Boolean(hostStatus.issued || hostStatus.expires || hostStatus.issuer);
+	if (!hasCertificate) {
+		if (hostStatus.state === 'active') {
+			return {
+				state: 'success',
+				message: hostStatus.message ?? `Certificate active for ${hostStatus.host}`,
+				domain: hostStatus.host
+			};
+		}
+		if (hostStatus.state === 'failed') {
+			return {
+				state: 'error',
+				message: hostStatus.renewal_error ?? hostStatus.message ?? 'Certificate issuance failed',
+				domain: hostStatus.host
+			};
+		}
+		if (hostStatus.state === 'issuing' || hostStatus.state === 'pending') {
+			if (
+				hostStatus.state === 'pending' &&
+				(scopedAcmeStatus?.state === 'running' || scopedAcmeStatus?.state === 'error')
+			) {
+				return scopedAcmeStatus;
+			}
+			return {
+				state: 'running',
+				message: hostStatus.message ?? 'Waiting for Caddy to obtain a certificate...',
+				domain: hostStatus.host
+			};
+		}
+		return null;
+	}
+
+	const expired = hostStatus.state === 'expired';
+	return {
+		state: expired ? 'error' : 'success',
+		message: expired
+			? `Certificate for ${hostStatus.host} expired${hostStatus.expires ? ` on ${hostStatus.expires}` : ''}`
+			: `Certificate active for ${hostStatus.host}`,
+		domain: hostStatus.host,
+		issuer: hostStatus.issuer,
+		issued: hostStatus.issued,
+		expires: hostStatus.expires,
+		last_attempt: scopedAcmeStatus?.last_attempt
+	};
+}

--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -5,16 +5,18 @@
 	import type { Settings } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import SortTh from '$lib/components/SortTh.svelte';
+	import { selectPrimaryTlsStatus, type AcmeStatus, type HostTlsStatus } from '$lib/tls-status';
 
 	const client = getClient();
 
 	let settings: Settings | null = $state(null);
 	let tlsDomain = $state('');
+	let configuredTlsDomain = $state('');
 	let filesDomain = $state('');
 	let configuredFilesDomain = $state('');
 	let tlsAcmeEmail = $state('');
 	let tlsAcmeEnabled = $state(false);
-	let acmeStatus: { state: string; message: string; domain?: string; expires?: string; issued?: string; issuer?: string; last_attempt?: string } | null = $state(null);
+	let acmeStatus: AcmeStatus | null = $state(null);
 	let tlsAcmeStaging = $state(false);
 	let tlsChallengeType = $state<'tls-alpn' | 'http' | 'dns'>('tls-alpn');
 	let tlsDnsProvider = $state('');
@@ -31,7 +33,11 @@
 	let savingTls = $state(false);
 	let tlsChanged = $state(false);
 	let editing = $state(false);
-	const certActive = $derived.by(() => Boolean(acmeStatus && acmeStatus.state === 'success' && tlsAcmeEnabled));
+	let hostStatuses: HostTlsStatus[] = $state([]);
+	const displayAcmeStatus = $derived.by(() =>
+		selectPrimaryTlsStatus(configuredTlsDomain, acmeStatus, hostStatuses)
+	);
+	const certActive = $derived.by(() => Boolean(displayAcmeStatus?.state === 'success' && tlsAcmeEnabled));
 	const configuredFilesPortalUrl = $derived(configuredFilesDomain ? `https://${configuredFilesDomain}/portal` : '');
 	const filesDomainError = $derived(validateOptionalFilesDomain(filesDomain, tlsDomain));
 
@@ -71,6 +77,7 @@
 	onMount(async () => {
 		settings = await client.call<Settings>('system.settings.get');
 		tlsDomain = settings?.tls_domain ?? '';
+		configuredTlsDomain = tlsDomain;
 		filesDomain = settings?.files_domain ?? '';
 		configuredFilesDomain = filesDomain;
 		tlsAcmeEmail = settings?.tls_acme_email ?? '';
@@ -99,19 +106,6 @@
 		hostStatusPollHandle = setInterval(refreshHostStatuses, 10_000) as unknown as number;
 	});
 
-	type HostTlsStatus = {
-		host: string;
-		state: 'active' | 'expiring' | 'expired' | 'issuing' | 'failed' | 'pending';
-		issuer?: string;
-		issued?: string;
-		expires?: string;
-		expires_in_days?: number;
-		message?: string;
-		renewal_error?: string;
-		app?: string;
-	};
-
-	let hostStatuses: HostTlsStatus[] = $state([]);
 	let hostStatusPollHandle: number | null = $state(null);
 
 	// ── Column sorting ──────────────────────────────────────────────────
@@ -232,6 +226,7 @@
 		);
 		if (result !== undefined) {
 			settings = result;
+			configuredTlsDomain = result.tls_domain ?? '';
 			filesDomain = result.files_domain ?? '';
 			configuredFilesDomain = filesDomain;
 			tlsChanged = false;
@@ -495,7 +490,7 @@
 			<Button size="sm" onclick={saveTls} disabled={savingTls || !tlsChanged || !!filesDomainError}>
 				{savingTls ? 'Saving…' : 'Save'}
 			</Button>
-			{#if tlsAcmeEnabled && acmeStatus?.state !== 'running'}
+			{#if tlsAcmeEnabled && displayAcmeStatus?.state !== 'running'}
 				<Button size="sm" variant="secondary" onclick={async () => {
 					await withToast(() => client.call('system.acme.retry'), 'Provisioning started');
 					startAcmePolling();
@@ -510,65 +505,69 @@
 	<!-- Status panel (right column) -->
 	<section class="rounded-lg border border-border p-5 self-start">
 		<h3 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Certificate Status</h3>
-		{#if !acmeStatus || acmeStatus.state === 'idle'}
+		{#if !displayAcmeStatus || displayAcmeStatus.state === 'idle'}
 			<div class="flex items-center gap-2 text-sm">
 				<span class="h-2 w-2 rounded-full bg-muted-foreground"></span>
 				<span class="text-muted-foreground">Self-signed (default)</span>
 			</div>
 			<p class="mt-2 text-xs text-muted-foreground">Browsers will show a security warning. Enable Let's Encrypt for a trusted certificate.</p>
-		{:else if acmeStatus.state === 'running'}
+		{:else if displayAcmeStatus.state === 'running'}
 			<div class="flex items-center gap-2 text-sm">
 				<span class="h-2 w-2 rounded-full bg-yellow-500 animate-pulse"></span>
 				<span class="text-yellow-500 font-medium">Provisioning</span>
 			</div>
-			{#if acmeStatus.domain}
-				<p class="mt-1 text-xs text-muted-foreground">{acmeStatus.domain}</p>
+			{#if displayAcmeStatus.domain}
+				<p class="mt-1 text-xs text-muted-foreground">{displayAcmeStatus.domain}</p>
 			{/if}
 			<div class="mt-3 rounded bg-muted/30 p-3">
-				<p class="text-xs text-muted-foreground whitespace-pre-wrap break-words">{acmeStatus.message}</p>
+				<p class="text-xs text-muted-foreground whitespace-pre-wrap break-words">{displayAcmeStatus.message}</p>
 			</div>
 			<div class="mt-3 h-1 overflow-hidden rounded-full bg-secondary">
 				<div class="h-full w-1/3 bg-yellow-500 animate-[indeterminate_1.5s_ease-in-out_infinite]"></div>
 			</div>
-			<Button size="xs" variant="secondary" class="mt-3" onclick={async () => { await client.call('system.acme.reset'); acmeStatus = await client.call('system.acme.status'); }}>
-				Dismiss
-			</Button>
-		{:else if acmeStatus.state === 'success'}
+			{#if displayAcmeStatus === acmeStatus}
+				<Button size="xs" variant="secondary" class="mt-3" onclick={async () => { await client.call('system.acme.reset'); acmeStatus = await client.call('system.acme.status'); }}>
+					Dismiss
+				</Button>
+			{/if}
+		{:else if displayAcmeStatus.state === 'success'}
 			<div class="flex items-center gap-2 text-sm">
 				<span class="h-2 w-2 rounded-full bg-green-500"></span>
 				<span class="text-green-500 font-medium">Certificate active</span>
 			</div>
-			{#if acmeStatus.domain}
-				<p class="mt-1 text-xs font-mono">{acmeStatus.domain}</p>
+			{#if displayAcmeStatus.domain}
+				<p class="mt-1 text-xs font-mono">{displayAcmeStatus.domain}</p>
 			{/if}
 			<div class="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
-				{#if acmeStatus.issuer}
+				{#if displayAcmeStatus.issuer}
 					<span class="text-muted-foreground">Issuer</span>
-					<span>{acmeStatus.issuer}</span>
+					<span>{displayAcmeStatus.issuer}</span>
 				{/if}
-				{#if acmeStatus.issued}
+				{#if displayAcmeStatus.issued}
 					<span class="text-muted-foreground">Issued</span>
-					<span>{acmeStatus.issued}</span>
+					<span>{displayAcmeStatus.issued}</span>
 				{/if}
-				{#if acmeStatus.expires}
+				{#if displayAcmeStatus.expires}
 					<span class="text-muted-foreground">Expires</span>
-					<span>{acmeStatus.expires}</span>
+					<span>{displayAcmeStatus.expires}</span>
 				{/if}
 			</div>
-		{:else if acmeStatus.state === 'error'}
+		{:else if displayAcmeStatus.state === 'error'}
 			<div class="flex items-center gap-2 text-sm">
 				<span class="h-2 w-2 rounded-full bg-red-500"></span>
 				<span class="text-red-500 font-medium">Error</span>
 			</div>
-			{#if acmeStatus.domain}
-				<p class="mt-1 text-xs font-mono">{acmeStatus.domain}</p>
+			{#if displayAcmeStatus.domain}
+				<p class="mt-1 text-xs font-mono">{displayAcmeStatus.domain}</p>
 			{/if}
-			{#if acmeStatus.message}
-				<pre class="mt-2 max-h-48 overflow-auto rounded bg-red-950/30 p-3 text-xs text-red-300 whitespace-pre-wrap break-words">{acmeStatus.message}</pre>
+			{#if displayAcmeStatus.message}
+				<pre class="mt-2 max-h-48 overflow-auto rounded bg-red-950/30 p-3 text-xs text-red-300 whitespace-pre-wrap break-words">{displayAcmeStatus.message}</pre>
 			{/if}
-			<Button size="xs" variant="secondary" class="mt-3" onclick={async () => { await client.call('system.acme.reset'); acmeStatus = await client.call('system.acme.status'); }}>
-				Dismiss
-			</Button>
+			{#if displayAcmeStatus === acmeStatus}
+				<Button size="xs" variant="secondary" class="mt-3" onclick={async () => { await client.call('system.acme.reset'); acmeStatus = await client.call('system.acme.status'); }}>
+					Dismiss
+				</Button>
+			{/if}
 		{/if}
 	</section>
 


### PR DESCRIPTION
## Summary
- make the primary Certificate Status card use the same live per-host inventory as the managed-certificate table
- scope fallback ACME state to the configured domain and handle pending, failed, active, renewed, and expired transitions
- keep Retry and Dismiss behavior aligned with the displayed live state
- add focused status-selection regression tests

Follow-up to #776.

## Testing
- `npm run check`
- `npm test` (231 tests)
- `cargo test -p nasty-system` (416 tests)
- `git diff --check`