### PR TITLE
firewall: allow WSD metadata traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@
 
 ### Sharing & block exports
 
+- SMB discovery now permits WSD metadata exchange on TCP 5357 in addition to
+  UDP 3702, allowing GNOME Files and other WSD clients to finish discovery
+  (#778).
 - iSCSI LUNs and NVMe-oF namespaces persist immutable block-volume identities
   and remap each export independently. Unresolved identities quiesce the
   affected protocol instead of risking the wrong volume (#698).

--- a/engine/nasty-system/src/firewall.rs
+++ b/engine/nasty-system/src/firewall.rs
@@ -318,9 +318,9 @@ fn tcp_range(from: u16, to: u16) -> PortSpec {
 pub fn ports_for_protocol(proto: Protocol) -> Vec<PortSpec> {
     match proto {
         Protocol::Nfs => vec![tcp(2049)],
-        // 445/139: Samba serving. 3702/udp: WSDD announcements for
-        // Windows 10/11 Explorer discovery (samba-wsdd.service).
-        Protocol::Smb => vec![tcp(445), tcp(139), udp(3702)],
+        // 445/139: Samba serving. WSDD uses 3702/udp for discovery and
+        // 5357/tcp for the metadata exchange that completes discovery.
+        Protocol::Smb => vec![tcp(445), tcp(139), udp(3702), tcp(5357)],
         Protocol::Iscsi => vec![tcp(3260)],
         Protocol::Nvmeof => vec![tcp(4420)],
         Protocol::Nut => vec![tcp(3493)],
@@ -1392,11 +1392,9 @@ mod tests {
 
     #[test]
     fn smb_opens_serving_and_wsdd_discovery_ports() {
-        // 445 + 139 are Samba's serving ports; 3702/udp is WSDD's
-        // multicast WS-Discovery port — without it Windows 10/11
-        // Explorer can't browse the host. Pin them so a refactor
-        // doesn't silently drop discovery and turn NASty invisible
-        // to Windows file managers again (issue #70).
+        // 445 + 139 are Samba's serving ports. WSDD discovers over
+        // 3702/udp, then serves device metadata over 5357/tcp. Pin the
+        // complete exchange so NASty remains visible to network browsers.
         let ports = ports_for_protocol(Protocol::Smb);
         assert!(
             ports
@@ -1412,6 +1410,11 @@ mod tests {
             ports
                 .iter()
                 .any(|p| p.port == 3702 && p.transport == Transport::Udp)
+        );
+        assert!(
+            ports
+                .iter()
+                .any(|p| p.port == 5357 && p.transport == Transport::Tcp)
         );
     }
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -1971,7 +1971,7 @@ in {
     #
     # - mDNS `_smb._tcp` via Avahi  → macOS Finder, GNOME Files, KDE
     # - mDNS `_device-info._tcp`    → Finder shows the rack-server icon
-    # - WS-Discovery (UDP 3702)     → Windows 10/11 Explorer
+    # - WS-Discovery (UDP 3702 + TCP 5357) → Windows Explorer and GNOME Files
     #
     # All gated on the build-time SMB switch. The engine starts/stops
     # samba-wsdd alongside samba-smbd/nmbd via the protocol service


### PR DESCRIPTION
## Summary
- open TCP 5357 with the existing SMB dynamic firewall service for WSD metadata exchange
- retain the same SMB source and interface restrictions for the new port
- extend the SMB/WSD regression test and update discovery documentation

Fixes #778.

## Testing
- `cargo test -p nasty-system` (417 tests)
- `cargo clippy -p nasty-system --all-targets -- -D warnings`
- `git diff --check`