### PR TITLE
nixos: bump diskwatch to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,8 +174,9 @@
 - The Help & Community page links to `r/NAStyProject` (#714).
 - Linux moves from 6.18.38 to **6.18.40** across three weekly nixpkgs updates
   (#672, #693, #705).
-- `diskwatch` moves from 0.1.2 to **0.1.5**, adding independent-filesystem
-  attribution fixes and runtime-selectable themes (#669, #706).
+- `diskwatch` moves from 0.1.2 to **0.3.2**, adding runtime-selectable themes
+  and the Dense single-screen view, while fixing stacked-device IO accounting
+  and synchronizing live histories (#669, #706).
 - `nasty-top` moves from 0.0.8 to **0.0.9**, fixing bcachefs 1.38.8 by-UUID
   discovery and hardening monitoring (#673). bcachefs remains at 1.38.8.
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -806,12 +806,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.1.6";
-          hash = "sha256-Ugqda8QWiHlNcMFIrenoHVD2WCK9JgcfoCNNOwBuQMY=";
+          rev = "v0.3.2";
+          hash = "sha256-/wR+tUQPV6EnWcZvOdZY9di9Eu07NSnAn25du/KMlfw=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.1.6";
+        version = "0.3.2";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";


### PR DESCRIPTION
## Summary
- bump bundled DiskWatch from 0.1.6 to 0.3.2
- refresh the fixed-output source hash
- update the release notes for the Dense view and upstream accounting/history fixes

## Testing
- `nix flake check --no-build`
- native Nix `buildRustPackage` build using the pinned source and `Cargo.lock` (129 tests passed)
- built binary reports `diskwatch 0.3.2`
- Linux package derivation evaluates as `diskwatch-0.3.2`; this aarch64-darwin host has no Linux builder for local compilation
- `git diff --check`

`nix flake check --all-systems --no-build` still hits the existing root-filesystem assertions and invalid test-driver path reproduced on clean `main` at `da027fc0`.