### PR TITLE
authz: enforce Operator root boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   Terminals and sensitive deployment/import endpoints require an unscoped
   Admin; file mutations require Operator/Admin authority within any filesystem
   scope, while VM consoles require an unscoped Operator/Admin (#663).
+- Root-equivalent workload and block-device operations now require an unscoped
+  Admin. Operators retain safe simple-app, VM, iSCSI, and NVMe-oF workflows but
+  cannot activate Compose stacks, unsafe mounts, passthrough devices, raw QEMU
+  options, or unmanaged block exports.
 - Existing `auth.json` must be a regular, non-symlinked, initialized JSON file
   owned by root with no group/other permission bits. Invalid state stops the
   engine instead of silently recreating `admin/admin`; only a genuinely absent

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use bollard::Docker;
@@ -472,6 +472,37 @@ async fn save_networks(f: &ManagedNetworksFile) -> Result<(), AppsError> {
 /// `..`, and any path under `/var/lib/nasty/` (except the app's own dir) are
 /// rejected outright. In strict mode (allow_unsafe == false), bind mounts
 /// must additionally fall under the app's data dir or `/fs/`.
+fn projected_canonical_path(path: &str) -> PathBuf {
+    let original = PathBuf::from(path);
+    if !original.is_absolute() {
+        return original;
+    }
+
+    let mut existing = original.as_path();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            break;
+        };
+        missing.push(name.to_os_string());
+        let Some(parent) = existing.parent() else {
+            break;
+        };
+        existing = parent;
+    }
+
+    let mut resolved = std::fs::canonicalize(existing).unwrap_or_else(|_| existing.to_path_buf());
+    for component in missing.into_iter().rev() {
+        resolved.push(component);
+    }
+    resolved
+}
+
+fn path_within(path: &Path, root: &str) -> bool {
+    let root = projected_canonical_path(root);
+    root != Path::new("/") && path.starts_with(root)
+}
+
 pub fn validate_simple_volumes(
     app_name: &str,
     storage_base: &str,
@@ -492,15 +523,16 @@ pub fn validate_simple_volumes(
                 "'{src}' escapes via '..'"
             )));
         }
-        if src == "/" {
+        let resolved = projected_canonical_path(src);
+        if resolved == Path::new("/") {
             return Err(AppsError::ForbiddenBind(
                 "host root '/' is never allowed as a bind mount".to_string(),
             ));
         }
-        let in_app_dir = src == &app_data_dir || src.starts_with(&format!("{app_data_dir}/"));
+        let in_app_dir = path_within(&resolved, &app_data_dir);
         // Engine state dir is off-limits even with allow_unsafe — that's where
         // auth.json, settings.json, audit.log, OIDC client secrets live.
-        let in_engine_state = src == "/var/lib/nasty" || src.starts_with("/var/lib/nasty/");
+        let in_engine_state = path_within(&resolved, "/var/lib/nasty");
         if in_engine_state && !in_app_dir {
             return Err(AppsError::ForbiddenBind(format!(
                 "'{src}' targets engine state — not allowed even with allow_unsafe"
@@ -510,8 +542,8 @@ pub fn validate_simple_volumes(
         if !allow_unsafe {
             // `/appdata` is the stable symlink onto the appdata
             // subvolume (#436) — inside the sandbox by definition.
-            let in_appdata = src == APPDATA_LINK || src.starts_with(&format!("{APPDATA_LINK}/"));
-            let allowed = in_app_dir || src == "/fs" || src.starts_with("/fs/") || in_appdata;
+            let allowed =
+                in_app_dir || path_within(&resolved, APPDATA_LINK) || path_within(&resolved, "/fs");
             if !allowed {
                 return Err(AppsError::ForbiddenBind(format!(
                     "'{src}' is outside '{app_data_dir}/', '/appdata/' and '/fs/'. Set allow_unsafe to override."
@@ -7256,6 +7288,30 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(e.contains("/home/user/data"), "{e}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_rejects_symlink_that_escapes_the_app_data_dir() {
+        use std::os::unix::fs::symlink;
+
+        let base = unique_tmp("simple-bind-symlink");
+        let storage = base.join("storage");
+        let app_dir = storage.join("myapp");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let link = app_dir.join("escape");
+        symlink(&outside, &link).unwrap();
+
+        validate_simple_volumes(
+            "myapp",
+            storage.to_str().unwrap(),
+            &[vol(link.to_str().unwrap())],
+            false,
+        )
+        .unwrap_err();
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/engine/nasty-engine/src/app_deploy.rs
+++ b/engine/nasty-engine/src/app_deploy.rs
@@ -1006,7 +1006,10 @@ enum BindReject {
 }
 
 fn always_forbidden_bind(source: &str) -> Option<BindReject> {
-    if source.contains("..") {
+    if std::path::Path::new(source)
+        .components()
+        .any(|component| component == std::path::Component::ParentDir)
+    {
         return Some(BindReject::Hard(
             "'..' traversal is never allowed in bind sources",
         ));
@@ -1016,10 +1019,105 @@ fn always_forbidden_bind(source: &str) -> Option<BindReject> {
             "'/' (host root) is never allowed as a bind source",
         ));
     }
-    if source == "/var/lib/nasty" || source.starts_with("/var/lib/nasty/") {
+    let engine_state = projected_canonical_path("/var/lib/nasty");
+    let source_path = std::path::Path::new(source);
+    if source == "/var/lib/nasty"
+        || source.starts_with("/var/lib/nasty/")
+        || (source_path.is_absolute() && projected_canonical_path(source).starts_with(engine_state))
+    {
         return Some(BindReject::EngineState);
     }
     None
+}
+
+fn projected_canonical_path(path: &str) -> std::path::PathBuf {
+    let original = std::path::PathBuf::from(path);
+    if !original.is_absolute() {
+        return original;
+    }
+
+    let mut existing = original.as_path();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            break;
+        };
+        missing.push(name.to_os_string());
+        let Some(parent) = existing.parent() else {
+            break;
+        };
+        existing = parent;
+    }
+
+    let mut resolved = std::fs::canonicalize(existing).unwrap_or_else(|_| existing.to_path_buf());
+    for component in missing.into_iter().rev() {
+        resolved.push(component);
+    }
+    resolved
+}
+
+fn projected_compose_path(path: &str, project_dir: &str) -> std::path::PathBuf {
+    if std::path::Path::new(path).is_absolute() {
+        projected_canonical_path(path)
+    } else {
+        projected_canonical_path(
+            std::path::Path::new(project_dir)
+                .join(path)
+                .to_string_lossy()
+                .as_ref(),
+        )
+    }
+}
+
+fn operator_bind_allowed(source: &str, allowed_app_dir: &str) -> bool {
+    if !source.starts_with('/') && !source.starts_with('.') {
+        return false;
+    }
+
+    let source = projected_compose_path(source, allowed_app_dir);
+    [allowed_app_dir, "/appdata", "/fs"]
+        .iter()
+        .map(|root| projected_canonical_path(root))
+        .any(|root| root != std::path::Path::new("/") && source.starts_with(root))
+}
+
+fn value_has_unsafe_host_reference(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(value) => {
+            value.starts_with('/')
+                || value.starts_with('~')
+                || value.contains('$')
+                || value.contains("..")
+        }
+        serde_json::Value::Array(values) => values.iter().any(value_has_unsafe_host_reference),
+        _ => false,
+    }
+}
+
+fn value_has_protected_host_reference(value: &serde_json::Value, allowed_app_dir: &str) -> bool {
+    match value {
+        serde_json::Value::String(path) => {
+            if path.contains('$') {
+                return true;
+            }
+            let resolved = projected_compose_path(path, allowed_app_dir);
+            let resolved_app_dir = projected_canonical_path(allowed_app_dir);
+            let in_app_dir = resolved.starts_with(&resolved_app_dir);
+            matches!(always_forbidden_bind(path), Some(BindReject::Hard(_)))
+                || match always_forbidden_bind(&resolved.to_string_lossy()) {
+                    Some(BindReject::Hard(_)) => true,
+                    Some(BindReject::EngineState) => !in_app_dir,
+                    None => false,
+                }
+        }
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| value_has_protected_host_reference(value, allowed_app_dir)),
+        serde_json::Value::Object(values) => values
+            .values()
+            .any(|value| value_has_protected_host_reference(value, allowed_app_dir)),
+        _ => false,
+    }
 }
 
 /// Validate a docker-compose YAML before it's written to disk and handed to
@@ -1035,7 +1133,11 @@ fn always_forbidden_bind(source: &str) -> Option<BindReject> {
 /// transcoding (/dev/dri), Frigate (USB cameras), etc. A small core of checks
 /// stays on either way: nothing may bind-mount the engine's state dir, the
 /// root filesystem, or use `..` to escape.
-fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<(), String> {
+pub(crate) fn validate_compose(
+    yaml: &str,
+    app_name: &str,
+    allow_unsafe: bool,
+) -> Result<(), String> {
     let parsed: serde_json::Value =
         serde_yaml_ng::from_str(yaml).map_err(|e| format!("compose YAML failed to parse: {e}"))?;
 
@@ -1050,17 +1152,28 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
         let scope = |field: &str| format!("services.{svc_name}.{field}");
 
         if !allow_unsafe {
-            if svc.get("privileged").and_then(|v| v.as_bool()) == Some(true) {
+            if svc.get("privileged").is_some_and(|value| {
+                value.as_bool() == Some(true)
+                    || value.as_str().is_some_and(|value| value.contains('$'))
+            }) {
                 return Err(format!(
                     "{} sets privileged: true (host-root equivalent). Set allow_unsafe to override.",
                     scope("privileged")
                 ));
             }
 
-            for field in ["pid", "ipc", "uts", "userns_mode", "cgroup", "network_mode"] {
+            for field in [
+                "pid",
+                "ipc",
+                "uts",
+                "userns_mode",
+                "cgroup",
+                "cgroupns_mode",
+                "network_mode",
+            ] {
                 if let Some(v) = svc.get(field).and_then(|v| v.as_str()) {
                     let v_lower = v.to_ascii_lowercase();
-                    if v_lower == "host" || v_lower.starts_with("host:") {
+                    if v.contains('$') || v_lower == "host" || v_lower.starts_with("host:") {
                         return Err(format!(
                             "{} = '{}' shares the host namespace. Set allow_unsafe to override.",
                             scope(field),
@@ -1082,7 +1195,7 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 for c in caps {
                     if let Some(s) = c.as_str() {
                         let bare = s.strip_prefix("CAP_").unwrap_or(s).to_ascii_uppercase();
-                        if FORBIDDEN_CAPS.contains(&bare.as_str()) {
+                        if s.contains('$') || FORBIDDEN_CAPS.contains(&bare.as_str()) {
                             return Err(format!(
                                 "{} includes '{}' — grants host-equivalent privilege. Set allow_unsafe to override.",
                                 scope("cap_add"),
@@ -1097,7 +1210,9 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 for o in opts {
                     if let Some(s) = o.as_str() {
                         let normalized = s.replace(' ', "").to_ascii_lowercase();
-                        if FORBIDDEN_SECURITY_OPTS.iter().any(|f| normalized == *f) {
+                        if s.contains('$')
+                            || FORBIDDEN_SECURITY_OPTS.iter().any(|f| normalized == *f)
+                        {
                             return Err(format!(
                                 "{} includes '{}' — disables container sandbox. Set allow_unsafe to override.",
                                 scope("security_opt"),
@@ -1123,6 +1238,44 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     scope("device_cgroup_rules")
                 ));
             }
+
+            if svc.get("use_api_socket").is_some_and(|value| {
+                value.as_bool() == Some(true)
+                    || value.as_str().is_some_and(|value| value.contains('$'))
+            }) {
+                return Err(format!(
+                    "{} exposes the Docker API socket. Set allow_unsafe to override.",
+                    scope("use_api_socket")
+                ));
+            }
+
+            for field in ["env_file", "label_file"] {
+                if svc.get(field).is_some_and(value_has_unsafe_host_reference) {
+                    return Err(format!(
+                        "{} reads an absolute, escaping, or interpolated host path. Set allow_unsafe to override.",
+                        scope(field)
+                    ));
+                }
+            }
+        }
+
+        for field in ["env_file", "label_file"] {
+            if svc
+                .get(field)
+                .is_some_and(|value| value_has_protected_host_reference(value, &allowed_app_dir))
+            {
+                return Err(format!(
+                    "{} reads an interpolated or protected host path",
+                    scope(field)
+                ));
+            }
+        }
+
+        if svc.get("extends").is_some() || svc.get("volumes_from").is_some() {
+            return Err(format!(
+                "{} imports content that cannot be checked against the protected host-path policy",
+                scope("extends/volumes_from")
+            ));
         }
 
         if let Some(volumes) = svc.get("volumes").and_then(|v| v.as_array()) {
@@ -1134,6 +1287,12 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     }
                     serde_json::Value::Object(map) => {
                         let kind = map.get("type").and_then(|v| v.as_str()).unwrap_or("volume");
+                        if kind.contains('$') {
+                            return Err(format!(
+                                "{} has an interpolated mount type, which cannot be safety-checked",
+                                scope("volumes")
+                            ));
+                        }
                         if kind != "bind" {
                             // Named volumes, tmpfs, npipe — host filesystem isn't directly exposed.
                             continue;
@@ -1150,16 +1309,32 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     continue;
                 }
 
+                // Compose expands these after parsing, so this validator cannot
+                // prove an interpolated source avoids protected host state.
+                if source.contains('$') {
+                    return Err(format!(
+                        "{} bind source '{}' is interpolated and cannot be safety-checked",
+                        scope("volumes"),
+                        source
+                    ));
+                }
+
                 // Named volume short-form ("data:/var/lib/foo") — no host path.
                 if !source.starts_with('/') && !source.starts_with('.') && !source.starts_with('~')
                 {
                     continue;
                 }
 
-                let in_app_dir =
-                    source.starts_with(&format!("{allowed_app_dir}/")) || source == allowed_app_dir;
+                let resolved_source = projected_compose_path(&source, &allowed_app_dir);
+                let policy_source = resolved_source.to_string_lossy();
+                let resolved_app_dir = projected_canonical_path(&allowed_app_dir);
+                let in_app_dir = source.starts_with(&format!("{allowed_app_dir}/"))
+                    || source == allowed_app_dir
+                    || resolved_source.starts_with(&resolved_app_dir);
 
-                match always_forbidden_bind(&source) {
+                match always_forbidden_bind(&source)
+                    .or_else(|| always_forbidden_bind(&policy_source))
+                {
                     Some(BindReject::Hard(why)) => {
                         return Err(format!(
                             "{} bind-mounts '{}' — {} (off-limits even with allow_unsafe)",
@@ -1209,9 +1384,7 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 if !allow_unsafe {
                     // `/appdata` is the stable symlink onto the appdata
                     // subvolume (#436) — sandbox territory by definition.
-                    let in_appdata = source == "/appdata" || source.starts_with("/appdata/");
-                    let allowed =
-                        in_app_dir || source.starts_with("/fs/") || source == "/fs" || in_appdata;
+                    let allowed = operator_bind_allowed(&source, &allowed_app_dir);
                     if !allowed {
                         return Err(format!(
                             "{} bind-mounts '{}' — only paths under '{}/', '/appdata/' or '/fs/' are allowed. Set allow_unsafe to override.",
@@ -1239,6 +1412,15 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                     .and_then(|v| v.as_str())
                     .map(|s| s.contains("bind"))
                     .unwrap_or(false);
+            if ["type", "o", "device"].iter().any(|key| {
+                opts.get(*key)
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|value| value.contains('$'))
+            }) {
+                return Err(format!(
+                    "volumes.{vol_name}.driver_opts contains interpolation that cannot be safety-checked"
+                ));
+            }
             if !is_bind {
                 continue;
             }
@@ -1247,10 +1429,14 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
                 continue;
             }
 
-            let in_app_dir =
-                device.starts_with(&format!("{allowed_app_dir}/")) || device == allowed_app_dir;
+            let resolved_device = projected_compose_path(device, &allowed_app_dir);
+            let policy_device = resolved_device.to_string_lossy();
+            let resolved_app_dir = projected_canonical_path(&allowed_app_dir);
+            let in_app_dir = device.starts_with(&format!("{allowed_app_dir}/"))
+                || device == allowed_app_dir
+                || resolved_device.starts_with(&resolved_app_dir);
 
-            match always_forbidden_bind(device) {
+            match always_forbidden_bind(device).or_else(|| always_forbidden_bind(&policy_device)) {
                 Some(BindReject::Hard(why)) => {
                     return Err(format!(
                         "volumes.{vol_name} bind-mounts '{device}' — {why} (off-limits even with allow_unsafe)"
@@ -1265,13 +1451,37 @@ fn validate_compose(yaml: &str, app_name: &str, allow_unsafe: bool) -> Result<()
             }
 
             if !allow_unsafe {
-                let in_appdata = device == "/appdata" || device.starts_with("/appdata/");
-                let allowed =
-                    in_app_dir || device.starts_with("/fs/") || device == "/fs" || in_appdata;
+                let allowed = operator_bind_allowed(device, &allowed_app_dir);
                 if !allowed {
                     return Err(format!(
                         "volumes.{vol_name} bind-mounts '{device}' — only paths under '{allowed_app_dir}/', '/appdata/' or '/fs/' are allowed. Set allow_unsafe to override."
                     ));
+                }
+            }
+        }
+    }
+
+    if parsed.get("include").is_some() {
+        return Err(
+            "top-level include imports content that cannot be checked against the protected host-path policy"
+                .to_string(),
+        );
+    }
+
+    for section in ["configs", "secrets"] {
+        if let Some(entries) = parsed.get(section).and_then(|value| value.as_object()) {
+            for (name, entry) in entries {
+                if let Some(file) = entry.get("file") {
+                    if value_has_protected_host_reference(file, &allowed_app_dir) {
+                        return Err(format!(
+                            "{section}.{name}.file reads an interpolated or protected host path"
+                        ));
+                    }
+                    if !allow_unsafe && value_has_unsafe_host_reference(file) {
+                        return Err(format!(
+                            "{section}.{name}.file reads an absolute or escaping host path and requires Admin access"
+                        ));
+                    }
                 }
             }
         }
@@ -1377,7 +1587,10 @@ async fn pull_image_with_progress(
 
 #[cfg(test)]
 mod tests {
-    use super::{external_network_name, validate_compose};
+    use super::{
+        BindReject, always_forbidden_bind, external_network_name, operator_bind_allowed,
+        projected_canonical_path, projected_compose_path, validate_compose,
+    };
 
     #[test]
     fn external_network_name_parses_docker_error() {
@@ -1448,6 +1661,57 @@ mod tests {
             "services:\n  bad:\n    image: alpine\n    privileged: true\n",
             "privileged",
         );
+    }
+
+    #[test]
+    fn strict_rejects_interpolated_privilege_fields() {
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    privileged: ${PRIVILEGED:-true}\n",
+            "privileged",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    network_mode: ${MODE:-host}\n",
+            "network_mode",
+        );
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    cap_add: [\"${CAPABILITY:-SYS_ADMIN}\"]\n",
+            "cap_add",
+        );
+    }
+
+    #[test]
+    fn strict_rejects_compose_indirection_and_api_socket() {
+        err_strict(
+            "services:\n  bad:\n    image: alpine\n    use_api_socket: true\n",
+            "Docker API socket",
+        );
+        err_strict(
+            "include:\n  - privileged.yml\nservices:\n  app:\n    image: alpine\n",
+            "include",
+        );
+        err_strict(
+            "services:\n  app:\n    image: alpine\nsecrets:\n  passwd:\n    file: /etc/passwd\n",
+            "secrets.passwd.file",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_bind_policy_resolves_symlinks_before_allowing_paths() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let allowed = temp.path().join("allowed");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let link = allowed.join("escape");
+        symlink(&outside, &link).unwrap();
+
+        assert!(!operator_bind_allowed(
+            link.to_str().unwrap(),
+            allowed.to_str().unwrap()
+        ));
     }
 
     #[test]
@@ -1662,6 +1926,65 @@ mod tests {
         err_unsafe(
             "services:\n  s:\n    image: alpine\n    volumes: [evil:/x]\nvolumes:\n  evil:\n    driver_opts:\n      type: none\n      o: bind\n      device: /\n",
             "off-limits",
+        );
+    }
+
+    #[test]
+    fn unsafe_rejects_unvalidated_compose_indirection() {
+        err_unsafe(
+            "include:\n  - imported.yml\nservices:\n  app:\n    image: alpine\n",
+            "include",
+        );
+        err_unsafe(
+            "services:\n  app:\n    extends:\n      file: imported.yml\n      service: base\n",
+            "extends",
+        );
+        err_unsafe(
+            "services:\n  app:\n    image: alpine\n    volumes_from: [base]\n",
+            "volumes_from",
+        );
+    }
+
+    #[test]
+    fn unsafe_rejects_protected_host_file_references() {
+        err_unsafe(
+            "services:\n  app:\n    image: alpine\n    env_file: /var/lib/nasty/auth.json\n",
+            "protected host path",
+        );
+        err_unsafe(
+            "services:\n  app:\n    image: alpine\nsecrets:\n  auth:\n    file: /var/lib/nasty/auth.json\n",
+            "protected host path",
+        );
+        err_unsafe(
+            "services:\n  app:\n    image: alpine\nconfigs:\n  auth:\n    file: ${AUTH_FILE}\n",
+            "interpolated",
+        );
+    }
+
+    #[test]
+    fn dotdot_policy_checks_path_components() {
+        assert!(always_forbidden_bind("/fs/tank/archive..old").is_none());
+        assert!(matches!(
+            always_forbidden_bind("/fs/tank/../private"),
+            Some(BindReject::Hard(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_compose_paths_resolve_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, project.join("escape")).unwrap();
+
+        assert_eq!(
+            projected_compose_path("./escape/data", project.to_str().unwrap()),
+            projected_canonical_path(outside.to_str().unwrap()).join("data")
         );
     }
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -875,7 +875,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "snapshot.rollback",
                     desc: "Roll a subvolume back to a snapshot: quiesce its apps/VMs/shares, take a safety snapshot of the current state, swap the subvolume to the snapshot, and resume. Destructive; filesystem subvolumes only.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<RollbackSnapshotRequest>(generator)),
                     result: Some(gen_schema::<RollbackResult>(generator)),
                 },
@@ -2980,7 +2980,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "apps.appdata.relocate",
                     desc: "Move the appdata subvolume to another filesystem and flip the stable /appdata symlink: stops apps that bind /appdata, copies with ownership preserved, switches, restarts them. The old copy is left in place for the operator to delete after verifying.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "filesystem",
                         "Target filesystem name (the <X> of /fs/<X>).",
@@ -2990,14 +2990,14 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "apps.enable",
                     desc: "Enable the apps runtime on this box (optionally pinning the storage filesystem) and start Docker.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<EnableAppsRequest>(generator)),
                     result: None,
                 },
                 Method {
                     name: "apps.disable",
                     desc: "Disable the apps runtime on this box (stop Docker and clear the persisted enabled flag in AppsConfig).",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::None,
                     result: None,
                 },
@@ -3103,28 +3103,28 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "apps.compose.install",
                     desc: "Deploy a new compose-based app by writing its docker-compose.yml to disk, pre-creating bind-mount dirs with the right ownership, running `docker compose up -d`, and auto-creating an ingress for the first exposed TCP port.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<InstallComposeRequest>(generator)),
                     result: Some(gen_schema::<App>(generator)),
                 },
                 Method {
                     name: "apps.compose.update",
                     desc: "Overwrite a compose app's docker-compose.yml, pre-create any newly added bind-mount sources, and run `docker compose up -d --no-build --pull missing --remove-orphans` to apply the new config.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<InstallComposeRequest>(generator)),
                     result: Some(gen_schema::<App>(generator)),
                 },
                 Method {
                     name: "apps.compose.remove",
                     desc: "Tear down a compose app via `docker compose down -v --remove-orphans`, delete its project directory, and remove its Caddy ingress.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Compose app name.")),
                     result: None,
                 },
                 Method {
                     name: "apps.compose.set_startup",
                     desc: "Set NASty-managed startup ordering for a compose stack (#437): when managed, the engine forces `restart: \"no\"` and brings the stack up at boot in the configured order with a settle delay; when unmanaged, the stack reverts to its compose file's own restart policy.",
-                    role: MethodRole::Operator,
+                    role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<SetComposeStartupRequest>(generator)),
                     result: None,
                 },

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -11,6 +11,72 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn simple_requires_admin(req: &nasty_apps::InstallAppRequest) -> bool {
+    req.allow_unsafe || req.network.as_deref() == Some("host")
+}
+
+async fn existing_app_requires_admin(state: &AppState, name: &str) -> Result<bool, String> {
+    let app = state
+        .apps
+        .get(name)
+        .await
+        .map_err(|error| error.to_string())?;
+    if app.kind == "compose" || app.unsafe_mode || app.network.as_deref() == Some("host") {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+async fn existing_app_access_error(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+    name: &str,
+) -> Option<Response> {
+    match existing_app_requires_admin(state, name).await {
+        Ok(false) => {
+            if session.filesystem.is_some() || session.owner.is_some() {
+                let config = match state.apps.get_config(name).await {
+                    Ok(config) => config,
+                    Err(error) => return Some(err(req, error)),
+                };
+                if let Err(error) = authorize_app_paths(
+                    state,
+                    session,
+                    config
+                        .volumes
+                        .into_iter()
+                        .map(|volume| volume.host_path)
+                        .collect(),
+                )
+                .await
+                {
+                    return Some(err(req, error));
+                }
+            }
+            None
+        }
+        Ok(true) => require_root_equivalent(req, session, "unsafe_existing_app"),
+        Err(error) => Some(invalid(req, error)),
+    }
+}
+
+async fn authorize_app_paths(
+    state: &AppState,
+    session: &Session,
+    paths: Vec<String>,
+) -> Result<(), String> {
+    if session.filesystem.is_none() && session.owner.is_none() {
+        return Ok(());
+    }
+    for path in &paths {
+        if path.starts_with('/') {
+            super::share::authorize_path_source(state, session, path).await?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) async fn published_firewall_ports(
     state: &AppState,
 ) -> Result<Vec<nasty_system::firewall::PublishedAppPort>, String> {
@@ -54,16 +120,24 @@ pub(super) async fn try_route(
     let response = match req.method.as_str() {
         "apps.status" => ok(req, state.apps.status().await),
         "apps.enable" => {
+            if let Some(response) = require_root_equivalent(req, session, "apps_runtime_enable") {
+                return Some(response);
+            }
             let p: nasty_apps::EnableAppsRequest = parse_params(req).unwrap_or_default();
             match state.apps.enable(p).await {
                 Ok(()) => ok(req, "ok"),
                 Err(e) => err(req, e),
             }
         }
-        "apps.disable" => match state.apps.disable().await {
-            Ok(()) => ok(req, "ok"),
-            Err(e) => err(req, e),
-        },
+        "apps.disable" => {
+            if let Some(response) = require_root_equivalent(req, session, "apps_runtime_disable") {
+                return Some(response);
+            }
+            match state.apps.disable().await {
+                Ok(()) => ok(req, "ok"),
+                Err(e) => err(req, e),
+            }
+        }
         "apps.list" => match state.apps.list().await {
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
@@ -88,6 +162,24 @@ pub(super) async fn try_route(
         },
         "apps.install" => match parse_params::<nasty_apps::InstallAppRequest>(req) {
             Ok(p) => {
+                if simple_requires_admin(&p)
+                    && let Some(response) =
+                        require_root_equivalent(req, session, "unsafe_app_payload")
+                {
+                    return Some(response);
+                }
+                if let Err(error) = authorize_app_paths(
+                    state,
+                    session,
+                    p.volumes
+                        .iter()
+                        .map(|volume| volume.host_path.clone())
+                        .collect(),
+                )
+                .await
+                {
+                    return Some(err(req, error));
+                }
                 // Refresh Caddy TLS automation when the install opts into
                 // a subdomain ingress — install() wires the route but the
                 // TLS layer is reached from here (see the matching note in
@@ -109,11 +201,31 @@ pub(super) async fn try_route(
             }
             Err(e) => invalid(req, e),
         },
-        "apps.update" => match parse_params(req) {
-            Ok(p) => match state.apps.update(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "apps.update" => match parse_params::<nasty_apps::InstallAppRequest>(req) {
+            Ok(p) => {
+                if simple_requires_admin(&p)
+                    && let Some(response) =
+                        require_root_equivalent(req, session, "unsafe_app_payload")
+                {
+                    return Some(response);
+                }
+                if let Err(error) = authorize_app_paths(
+                    state,
+                    session,
+                    p.volumes
+                        .iter()
+                        .map(|volume| volume.host_path.clone())
+                        .collect(),
+                )
+                .await
+                {
+                    return Some(err(req, error));
+                }
+                match state.apps.update(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
         "apps.inspect_image" => match require_str(req, "image") {
@@ -140,13 +252,18 @@ pub(super) async fn try_route(
             Err(e) => invalid(req, e),
         },
         "apps.appdata.status" => ok(req, state.apps.appdata_relocate_status().await),
-        "apps.appdata.relocate" => match require_str(req, "filesystem") {
-            Ok(fs) => match state.apps.appdata_relocate(fs).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
-            Err(r) => r,
-        },
+        "apps.appdata.relocate" => {
+            if let Some(response) = require_root_equivalent(req, session, "appdata_relocation") {
+                return Some(response);
+            }
+            match require_str(req, "filesystem") {
+                Ok(fs) => match state.apps.appdata_relocate(fs).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
+                Err(r) => r,
+            }
+        }
         "apps.fix_volume_perms" => match parse_params(req) {
             Ok(p) => match state.apps.fix_volume_perms(p).await {
                 Ok(()) => ok(req, serde_json::json!({"ok": true})),
@@ -162,52 +279,82 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "apps.remove" => match require_str(req, "name") {
-            Ok(name) => match state.apps.remove(name).await {
-                Ok(()) => {
-                    // Cover the case where the removed app had a
-                    // subdomain ingress — Caddy stops trying to renew
-                    // the now-orphaned cert. The internal remove path
-                    // in nasty-apps clears the route via the admin API
-                    // but doesn't know about the TLS-automation layer.
-                    tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
-                    ok(req, "ok")
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
                 }
-                Err(e) => err(req, e),
-            },
+                match state.apps.remove(name).await {
+                    Ok(()) => {
+                        // Cover the case where the removed app had a
+                        // subdomain ingress — Caddy stops trying to renew
+                        // the now-orphaned cert. The internal remove path
+                        // in nasty-apps clears the route via the admin API
+                        // but doesn't know about the TLS-automation layer.
+                        tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                        ok(req, "ok")
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.stop" => match require_str(req, "name") {
-            Ok(name) => match state.apps.stop(name).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.stop(name).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.start" => match require_str(req, "name") {
-            Ok(name) => match state.apps.start(name).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.start(name).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.restart" => match require_str(req, "name") {
-            Ok(name) => match state.apps.restart(name).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.restart(name).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.pull" => match require_str(req, "name") {
-            Ok(name) => match state.apps.pull(name).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.pull(name).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
-        "apps.prune" => match state.apps.prune().await {
-            Ok(v) => ok(req, v),
-            Err(e) => err(req, e),
-        },
+        "apps.prune" => {
+            if let Some(response) = require_unscoped_mutation(req, session, "global_apps_prune") {
+                return Some(response);
+            }
+            match state.apps.prune().await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            }
+        }
         "apps.exec_command" => match require_str(req, "name") {
             Ok(name) => match state.apps.exec_command(name).await {
                 Ok(v) => ok(req, v),
@@ -247,25 +394,50 @@ pub(super) async fn try_route(
                 Err(e) => err(req, e),
             }
         }
-        "apps.compose.install" => match parse_params(req) {
-            Ok(p) => match state.apps.compose_install(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "apps.compose.install" => match parse_params::<nasty_apps::InstallComposeRequest>(req) {
+            Ok(p) => {
+                if let Some(response) = require_root_equivalent(req, session, "compose_lifecycle") {
+                    return Some(response);
+                }
+                if let Err(error) =
+                    crate::app_deploy::validate_compose(&p.compose_file, &p.name, true)
+                {
+                    return Some(invalid(req, error));
+                }
+                match state.apps.compose_install(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
-        "apps.compose.update" => match parse_params(req) {
-            Ok(p) => match state.apps.compose_update(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "apps.compose.update" => match parse_params::<nasty_apps::InstallComposeRequest>(req) {
+            Ok(p) => {
+                if let Some(response) = require_root_equivalent(req, session, "compose_lifecycle") {
+                    return Some(response);
+                }
+                if let Err(error) =
+                    crate::app_deploy::validate_compose(&p.compose_file, &p.name, true)
+                {
+                    return Some(invalid(req, error));
+                }
+                match state.apps.compose_update(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
         "apps.compose.remove" => match require_str(req, "name") {
-            Ok(name) => match state.apps.compose_remove(name).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = require_root_equivalent(req, session, "compose_lifecycle") {
+                    return Some(response);
+                }
+                match state.apps.compose_remove(name).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.compose.get" => match require_str(req, "name") {
@@ -293,14 +465,21 @@ pub(super) async fn try_route(
         }
         "apps.compose.set_startup" => {
             match parse_params::<nasty_apps::SetComposeStartupRequest>(req) {
-                Ok(p) => match state
-                    .apps
-                    .compose_set_startup(&p.name, p.managed, p.order, p.delay_secs)
-                    .await
-                {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
+                Ok(p) => {
+                    if let Some(response) =
+                        existing_app_access_error(req, state, session, &p.name).await
+                    {
+                        return Some(response);
+                    }
+                    match state
+                        .apps
+                        .compose_set_startup(&p.name, p.managed, p.order, p.delay_secs)
+                        .await
+                    {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -343,6 +522,11 @@ pub(super) async fn try_route(
         },
         "apps.ingress.set" => match parse_params::<nasty_apps::SetIngressRequest>(req) {
             Ok(p) => {
+                if let Some(response) =
+                    existing_app_access_error(req, state, session, &p.name).await
+                {
+                    return Some(response);
+                }
                 let _reservation = crate::ingress_conflict::lock_hostname_reservations().await;
                 // Gate the set on a subdomain-conflict check — catches the
                 // "two apps claim the same hostname" / "app subdomain ==
@@ -392,16 +576,21 @@ pub(super) async fn try_route(
             ok(req, reason)
         }
         "apps.ingress.remove" => match require_str(req, "name") {
-            Ok(name) => match state.apps.ingress_remove(name).await {
-                Ok(()) => {
-                    // Reapply so Caddy stops trying to renew the cert
-                    // for the now-orphaned subdomain. Same fire-and-
-                    // forget pattern as the set arm above.
-                    tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
-                    ok(req, "ok")
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
                 }
-                Err(e) => err(req, e),
-            },
+                match state.apps.ingress_remove(name).await {
+                    Ok(()) => {
+                        // Reapply so Caddy stops trying to renew the cert
+                        // for the now-orphaned subdomain. Same fire-and-
+                        // forget pattern as the set arm above.
+                        tokio::spawn(nasty_system::settings::reapply_tls_from_disk());
+                        ok(req, "ok")
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
 
@@ -412,6 +601,11 @@ pub(super) async fn try_route(
         },
         "apps.networks.create" => match parse_params::<nasty_apps::ManagedNetwork>(req) {
             Ok(spec) => {
+                if let Some(response) =
+                    require_unscoped_mutation(req, session, "global_apps_network_create")
+                {
+                    return Some(response);
+                }
                 let ifaces = crate::system_network_ifaces(state).await;
                 // Resolve the management interface from the caller's peer so we
                 // can refuse a host shim on it (lockout guard, #448).
@@ -449,16 +643,23 @@ pub(super) async fn try_route(
             Err(e) => invalid(req, e),
         },
         "apps.networks.remove" => match require_str(req, "name") {
-            Ok(name) => match state.apps.network_remove(name).await {
-                Ok(()) => {
-                    // Tear down the host shim too (best-effort).
-                    if let Err(e) = crate::remove_macvlan_shim(state, name).await {
-                        tracing::warn!("apps: failed to remove macvlan shim for '{name}': {e}");
-                    }
-                    ok(req, "ok")
+            Ok(name) => {
+                if let Some(response) =
+                    require_unscoped_mutation(req, session, "global_apps_network_remove")
+                {
+                    return Some(response);
                 }
-                Err(e) => err(req, e),
-            },
+                match state.apps.network_remove(name).await {
+                    Ok(()) => {
+                        // Tear down the host shim too (best-effort).
+                        if let Err(e) = crate::remove_macvlan_shim(state, name).await {
+                            tracing::warn!("apps: failed to remove macvlan shim for '{name}': {e}");
+                        }
+                        ok(req, "ok")
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         _ => return None,
@@ -486,4 +687,36 @@ pub(super) async fn try_route(
         tracing::warn!("app firewall reconciliation after failed request also failed: {e}");
     }
     Some(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn simple_request(extra: serde_json::Value) -> nasty_apps::InstallAppRequest {
+        let mut value = serde_json::json!({
+            "name": "safe-app",
+            "image": "example/app:latest"
+        });
+        value.as_object_mut().unwrap().extend(
+            extra
+                .as_object()
+                .expect("test request extension must be an object")
+                .clone(),
+        );
+        serde_json::from_value(value).expect("valid test request")
+    }
+
+    #[test]
+    fn simple_admin_gate_covers_unsafe_mounts_and_host_networking() {
+        assert!(!simple_requires_admin(&simple_request(serde_json::json!(
+            {}
+        ))));
+        assert!(simple_requires_admin(&simple_request(serde_json::json!({
+            "allow_unsafe": true
+        }))));
+        assert!(simple_requires_admin(&simple_request(serde_json::json!({
+            "network": "host"
+        }))));
+    }
 }

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -11,6 +11,29 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+async fn require_block_share_recovery_access(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+) -> Option<Response> {
+    for protocol in [
+        nasty_system::protocol::Protocol::Iscsi,
+        nasty_system::protocol::Protocol::Nvmeof,
+    ] {
+        if !state.protocols.is_enabled(protocol).await {
+            continue;
+        }
+        match super::service::protocol_has_admin_only_sources(state, protocol).await {
+            Ok(true) => {
+                return require_root_equivalent(req, session, "raw_block_share_recovery");
+            }
+            Ok(false) => {}
+            Err(error) => return Some(err(req, error)),
+        }
+    }
+    None
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
@@ -132,6 +155,9 @@ pub(super) async fn try_route(
                 #[serde(default)]
                 degraded: bool,
             }
+            if let Some(response) = require_block_share_recovery_access(req, state, session).await {
+                return Some(response);
+            }
             match parse_params::<MountParams>(req) {
                 Ok(p) => match state
                     .filesystems
@@ -159,6 +185,11 @@ pub(super) async fn try_route(
         },
         "fs.unlock" => match parse_params::<serde_json::Value>(req) {
             Ok(p) => {
+                if let Some(response) =
+                    require_block_share_recovery_access(req, state, session).await
+                {
+                    return Some(response);
+                }
                 let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let passphrase = p.get("passphrase").and_then(|v| v.as_str()).unwrap_or("");
                 match state.filesystems.unlock(name, passphrase).await {

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -84,7 +84,6 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "snapshot.create"
                 | "snapshot.delete"
                 | "snapshot.clone"
-                | "snapshot.rollback"
                 | "share.nfs.create"
                 | "share.nfs.update"
                 | "share.nfs.delete"
@@ -136,10 +135,6 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "vm.kill"
                 | "vm.snapshot"
                 | "vm.clone"
-                | "apps.enable"
-                // `apps.disable` was admin-only — same asymmetry: an
-                // operator could turn the apps runtime on but not off.
-                | "apps.disable"
                 | "apps.install"
                 | "apps.update"
                 | "apps.remove"
@@ -148,13 +143,6 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "apps.restart"
                 | "apps.pull"
                 | "apps.prune"
-                | "apps.compose.install"
-                | "apps.compose.update"
-                | "apps.compose.remove"
-                | "apps.compose.set_startup"
-                // Appdata relocation (#436) — same altitude as the
-                // rest of app lifecycle management.
-                | "apps.appdata.relocate"
                 | "apps.ingress.set"
                 | "apps.ingress.remove"
                 // Docker network management (#435, #438). Registered as
@@ -576,6 +564,71 @@ pub(super) fn invalid(req: &Request, msg: impl std::fmt::Display) -> Response {
         req.id.clone(),
         ErrorCode::InvalidParams,
         format!("Invalid params: {msg}"),
+    )
+}
+
+fn require_endpoint_access(
+    req: &Request,
+    session: &Session,
+    access: crate::auth::EndpointAccess,
+    reason: &str,
+    audit_allowed: bool,
+) -> Option<Response> {
+    match crate::auth::authorize_session(session, access) {
+        Ok(()) => {
+            if audit_allowed {
+                crate::auth::audit(
+                    "root_equivalent_requested",
+                    &session.username,
+                    session.client_ip.as_deref().unwrap_or("unknown"),
+                    &format!("method={} reason={reason}", req.method),
+                );
+            }
+            None
+        }
+        Err(denied) => {
+            crate::auth::audit(
+                "permission_denied",
+                &session.username,
+                session.client_ip.as_deref().unwrap_or("unknown"),
+                &format!(
+                    "method={} role={:?} reason={reason}",
+                    req.method, session.role
+                ),
+            );
+            Some(err(req, denied.message()))
+        }
+    }
+}
+
+/// Gate payloads that turn an otherwise Operator-level method into a
+/// root-equivalent operation. Keep this check beside dispatch so every caller
+/// gets the same scope enforcement and audit trail.
+pub(super) fn require_root_equivalent(
+    req: &Request,
+    session: &Session,
+    reason: &str,
+) -> Option<Response> {
+    require_endpoint_access(
+        req,
+        session,
+        crate::auth::EndpointAccess::RootEquivalent,
+        reason,
+        true,
+    )
+}
+
+pub(super) fn require_unscoped_mutation(
+    req: &Request,
+    session: &Session,
+    reason: &str,
+) -> Option<Response> {
+    require_endpoint_access(
+        req,
+        session,
+        crate::auth::EndpointAccess::UnscopedMutation,
+        reason,
+        false,
     )
 }
 

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -11,6 +11,50 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+pub(super) async fn protocol_has_admin_only_sources(
+    state: &AppState,
+    protocol: nasty_system::protocol::Protocol,
+) -> Result<bool, String> {
+    match protocol {
+        nasty_system::protocol::Protocol::Iscsi => {
+            let targets = state
+                .iscsi
+                .list()
+                .await
+                .map_err(|error| error.to_string())?;
+            for lun in targets.iter().flat_map(|target| &target.luns) {
+                match lun.backstore_type.as_str() {
+                    "block" if lun.backing_volume.is_none() || lun.backing_volume_unresolved => {
+                        return Ok(true);
+                    }
+                    "fileio"
+                        if !super::share::fileio_source_is_managed(&lun.backstore_path).await =>
+                    {
+                        return Ok(true);
+                    }
+                    "block" | "fileio" => {}
+                    _ => return Ok(true),
+                }
+            }
+            Ok(false)
+        }
+        nasty_system::protocol::Protocol::Nvmeof => state
+            .nvmeof
+            .list()
+            .await
+            .map(|subsystems| {
+                subsystems
+                    .iter()
+                    .flat_map(|subsystem| &subsystem.namespaces)
+                    .any(|namespace| {
+                        namespace.backing_volume.is_none() || namespace.backing_volume_unresolved
+                    })
+            })
+            .map_err(|error| error.to_string()),
+        _ => Ok(false),
+    }
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
@@ -36,11 +80,29 @@ pub(super) async fn try_route(
         "service.protocol.enable" => match require_str(req, "name") {
             Ok(name) => {
                 if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
+                    if let Some(response) =
+                        require_unscoped_mutation(req, session, "global_protocol_enable")
+                    {
+                        return Some(response);
+                    }
                     if matches!(
                         proto,
                         nasty_system::protocol::Protocol::Iscsi
                             | nasty_system::protocol::Protocol::Nvmeof
                     ) {
+                        match protocol_has_admin_only_sources(state, proto).await {
+                            Ok(true) => {
+                                if let Some(response) = require_root_equivalent(
+                                    req,
+                                    session,
+                                    "raw_block_protocol_restore",
+                                ) {
+                                    return Some(response);
+                                }
+                            }
+                            Ok(false) => {}
+                            Err(error) => return Some(err(req, error)),
+                        }
                         let mappings = state.subvolumes.restore_block_devices().await;
                         let safe = match proto {
                             nasty_system::protocol::Protocol::Iscsi => {
@@ -146,22 +208,29 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "service.protocol.disable" => match require_str(req, "name") {
-            Ok(name) => match state.protocols.disable(name).await {
-                Ok(v) => {
-                    if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
-                        match state.firewall.close(proto).await {
-                            Ok(()) => ok(req, v),
-                            Err(e) => err(
-                                req,
-                                format!("protocol disabled but firewall update failed: {e}"),
-                            ),
-                        }
-                    } else {
-                        ok(req, v)
-                    }
+            Ok(name) => {
+                if let Some(response) =
+                    require_unscoped_mutation(req, session, "global_protocol_disable")
+                {
+                    return Some(response);
                 }
-                Err(e) => err(req, e),
-            },
+                match state.protocols.disable(name).await {
+                    Ok(v) => {
+                        if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
+                            match state.firewall.close(proto).await {
+                                Ok(()) => ok(req, v),
+                                Err(e) => err(
+                                    req,
+                                    format!("protocol disabled but firewall update failed: {e}"),
+                                ),
+                            }
+                        } else {
+                            ok(req, v)
+                        }
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "service.base_names.get" => {

--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -127,6 +127,29 @@ fn resource_matches_scope(
         && owner_filter.is_none_or(|filter| owner == Some(filter))
 }
 
+fn session_allows_raw_block_sources(session: &Session) -> bool {
+    session.role == Role::Admin && !session_is_scoped(session)
+}
+
+fn session_allows_empty_block_destination(session: &Session) -> bool {
+    session.role == Role::Operator && !session_is_scoped(session)
+}
+
+fn block_authorization_error(req: &Request, session: &Session, error: String) -> Response {
+    if error == "access denied" {
+        crate::auth::audit(
+            "permission_denied",
+            &session.username,
+            session.client_ip.as_deref().unwrap_or("unknown"),
+            &format!(
+                "method={} role={:?} reason=block_source_policy",
+                req.method, session.role
+            ),
+        );
+    }
+    err(req, error)
+}
+
 fn path_source_matches_scope(
     requested: &std::path::Path,
     candidates: &[(std::path::PathBuf, String, Option<String>)],
@@ -159,7 +182,7 @@ fn path_source_matches_scope(
     containing_matches && nested_matches
 }
 
-async fn authorize_path_source(
+pub(super) async fn authorize_path_source(
     state: &AppState,
     session: &Session,
     requested: &str,
@@ -202,7 +225,7 @@ async fn authorize_block_source(
     session: &Session,
     device_path: &str,
 ) -> Result<Option<BlockVolumeId>, String> {
-    if session.filesystem.is_none() && session.owner.is_none() {
+    if session_allows_raw_block_sources(session) {
         return state
             .subvolumes
             .block_volume_id_for_device(device_path)
@@ -234,15 +257,102 @@ async fn authorize_block_source(
     })
 }
 
+async fn authorize_fileio_source(
+    state: &AppState,
+    session: &Session,
+    requested: &str,
+) -> Result<String, String> {
+    if session_allows_raw_block_sources(session) {
+        return Ok(requested.to_string());
+    }
+
+    let canonical = canonical_fileio_source(requested).await?;
+    if !canonical.starts_with("/fs") {
+        return Err("access denied".to_string());
+    }
+
+    if session_is_scoped(session) {
+        let subvolumes = state
+            .subvolumes
+            .list_all(None, None)
+            .await
+            .map_err(|error| error.to_string())?;
+        let mut candidates = Vec::with_capacity(subvolumes.len());
+        for subvolume in subvolumes {
+            if let Ok(path) = tokio::fs::canonicalize(&subvolume.path).await {
+                candidates.push((path, subvolume.filesystem, subvolume.owner));
+            }
+        }
+        if !path_source_matches_scope(
+            &canonical,
+            &candidates,
+            session.filesystem.as_deref(),
+            session.owner.as_deref(),
+        ) {
+            return Err("access denied".to_string());
+        }
+    }
+
+    canonical
+        .into_os_string()
+        .into_string()
+        .map_err(|_| "access denied".to_string())
+}
+
+async fn canonical_fileio_source(requested: &str) -> Result<std::path::PathBuf, String> {
+    let requested_path = std::path::Path::new(requested);
+    let canonical = if requested_path.exists() {
+        tokio::fs::canonicalize(requested_path)
+            .await
+            .map_err(|_| "access denied".to_string())?
+    } else {
+        let name = requested_path
+            .file_name()
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| "access denied".to_string())?;
+        let parent = requested_path
+            .parent()
+            .ok_or_else(|| "access denied".to_string())?;
+        tokio::fs::canonicalize(parent)
+            .await
+            .map_err(|_| "access denied".to_string())?
+            .join(name)
+    };
+    Ok(canonical)
+}
+
+pub(super) async fn fileio_source_is_managed(requested: &str) -> bool {
+    match canonical_fileio_source(requested).await {
+        Ok(path) => path.starts_with("/fs"),
+        Err(_) => fileio_source_is_lexically_managed(requested),
+    }
+}
+
+fn fileio_source_is_lexically_managed(requested: &str) -> bool {
+    let path = std::path::Path::new(requested);
+    path.is_absolute()
+        && path.starts_with("/fs")
+        && !path
+            .components()
+            .any(|component| component == std::path::Component::ParentDir)
+}
+
 async fn authorize_block_destination(
     state: &AppState,
     session: &Session,
     identities: &[Option<BlockVolumeId>],
 ) -> Result<(), String> {
-    if session.filesystem.is_none() && session.owner.is_none() {
+    if session_allows_raw_block_sources(session) {
         return Ok(());
     }
-    if identities.is_empty() || identities.iter().any(Option::is_none) {
+    if identities.is_empty() {
+        return if session_allows_empty_block_destination(session) {
+            Ok(())
+        } else {
+            Err("access denied".to_string())
+        };
+    }
+    if identities.iter().any(Option::is_none) {
         return Err("access denied".to_string());
     }
 
@@ -268,8 +378,105 @@ async fn authorize_block_destination(
     Ok(())
 }
 
+async fn authorized_iscsi_target(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+    target_id: &str,
+) -> Result<nasty_sharing::iscsi::IscsiTarget, Response> {
+    let target = state
+        .iscsi
+        .get(target_id)
+        .await
+        .map_err(|error| err(req, error))?;
+
+    let mut root_reason = None;
+    for lun in &target.luns {
+        match lun.backstore_type.as_str() {
+            "block" if lun.backing_volume.is_none() || lun.backing_volume_unresolved => {
+                root_reason = Some("raw_iscsi_destination");
+            }
+            "fileio" if !fileio_source_is_managed(&lun.backstore_path).await => {
+                root_reason = Some("unmanaged_iscsi_fileio_destination");
+            }
+            "block" | "fileio" => {}
+            _ => root_reason = Some("unknown_iscsi_backstore"),
+        }
+    }
+    if let Some(reason) = root_reason
+        && let Some(response) = require_root_equivalent(req, session, reason)
+    {
+        return Err(response);
+    }
+
+    if session_is_scoped(session) {
+        for lun in target
+            .luns
+            .iter()
+            .filter(|lun| lun.backstore_type == "fileio")
+        {
+            authorize_fileio_source(state, session, &lun.backstore_path)
+                .await
+                .map_err(|error| block_authorization_error(req, session, error))?;
+        }
+        let identities: Vec<_> = target
+            .luns
+            .iter()
+            .filter(|lun| lun.backstore_type == "block")
+            .map(|lun| lun.backing_volume.clone())
+            .collect();
+        if target.luns.is_empty() || !identities.is_empty() {
+            authorize_block_destination(state, session, &identities)
+                .await
+                .map_err(|error| block_authorization_error(req, session, error))?;
+        }
+    }
+    Ok(target)
+}
+
+async fn authorized_nvmeof_subsystem(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+    subsystem_id: &str,
+) -> Result<nasty_sharing::nvmeof::NvmeofSubsystem, Response> {
+    let subsystem = state
+        .nvmeof
+        .get(subsystem_id)
+        .await
+        .map_err(|error| err(req, error))?;
+    if subsystem
+        .namespaces
+        .iter()
+        .any(|namespace| namespace.backing_volume.is_none() || namespace.backing_volume_unresolved)
+        && let Some(response) = require_root_equivalent(req, session, "raw_nvmeof_destination")
+    {
+        return Err(response);
+    }
+    if session_is_scoped(session) {
+        let identities: Vec<_> = subsystem
+            .namespaces
+            .iter()
+            .map(|namespace| namespace.backing_volume.clone())
+            .collect();
+        authorize_block_destination(state, session, &identities)
+            .await
+            .map_err(|error| block_authorization_error(req, session, error))?;
+    }
+    Ok(subsystem)
+}
+
 fn session_is_scoped(session: &Session) -> bool {
     session.filesystem.is_some() || session.owner.is_some()
+}
+
+fn smb_extra_params_require_admin(
+    existing: Option<&std::collections::HashMap<String, String>>,
+    requested: Option<&std::collections::HashMap<String, String>>,
+) -> bool {
+    requested
+        .or(existing)
+        .is_some_and(|params| !params.is_empty())
 }
 
 async fn quiesce_iscsi_after_failed_repair(state: &AppState) -> Option<String> {
@@ -355,11 +562,20 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nfs.update(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nfs::UpdateNfsShareRequest>(req) {
+                Ok(p) => {
+                    let share = match state.nfs.get(&p.id).await {
+                        Ok(share) => share,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    if let Err(error) = authorize_path_source(state, session, &share.path).await {
+                        return Some(err(req, error));
+                    }
+                    match state.nfs.update(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -369,11 +585,20 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nfs.delete(p).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nfs::DeleteNfsShareRequest>(req) {
+                Ok(p) => {
+                    let share = match state.nfs.get(&p.id).await {
+                        Ok(share) => share,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    if let Err(error) = authorize_path_source(state, session, &share.path).await {
+                        return Some(err(req, error));
+                    }
+                    match state.nfs.delete(p).await {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -396,6 +621,12 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::smb::CreateSmbShareRequest>(req) {
                 Ok(mut p) => {
+                    if smb_extra_params_require_admin(None, p.extra_params.as_ref())
+                        && let Some(response) =
+                            require_root_equivalent(req, session, "raw_samba_parameters")
+                    {
+                        return Some(response);
+                    }
                     if session_is_scoped(session)
                         && state.smb.list().await.is_ok_and(|shares| {
                             shares
@@ -425,11 +656,28 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.smb.update(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::smb::UpdateSmbShareRequest>(req) {
+                Ok(p) => {
+                    let share = match state.smb.get(&p.id).await {
+                        Ok(share) => share,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    if smb_extra_params_require_admin(
+                        Some(&share.extra_params),
+                        p.extra_params.as_ref(),
+                    ) && let Some(response) =
+                        require_root_equivalent(req, session, "raw_samba_parameters")
+                    {
+                        return Some(response);
+                    }
+                    if let Err(error) = authorize_path_source(state, session, &share.path).await {
+                        return Some(err(req, error));
+                    }
+                    match state.smb.update(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -439,11 +687,20 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.smb.delete(p).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::smb::DeleteSmbShareRequest>(req) {
+                Ok(p) => {
+                    let share = match state.smb.get(&p.id).await {
+                        Ok(share) => share,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    if let Err(error) = authorize_path_source(state, session, &share.path).await {
+                        return Some(err(req, error));
+                    }
+                    match state.smb.delete(p).await {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -488,8 +745,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                     }
                     if let Some(ref device_path) = p.device_path {
                         match authorize_block_source(state, session, device_path).await {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
+                            Ok(identity) => {
+                                if identity.is_none()
+                                    && let Some(response) =
+                                        require_root_equivalent(req, session, "raw_iscsi_source")
+                                {
+                                    return Some(response);
+                                }
+                                p.backing_volume = identity;
+                            }
+                            Err(error) => {
+                                return Some(block_authorization_error(req, session, error));
+                            }
                         }
                     }
                     if let Some(ref dp) = p.device_path
@@ -512,11 +779,17 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.delete(p).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::DeleteTargetRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) = authorized_iscsi_target(req, state, session, &p.id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.iscsi.delete(p).await {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -528,23 +801,38 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::iscsi::AddLunRequest>(req) {
                 Ok(mut p) => {
-                    let target = match state.iscsi.get(&p.target_id).await {
-                        Ok(target) => target,
-                        Err(error) => return Some(err(req, error)),
-                    };
-                    let identities: Vec<_> = target
-                        .luns
-                        .iter()
-                        .map(|lun| lun.backing_volume.clone())
-                        .collect();
-                    if let Err(error) =
-                        authorize_block_destination(state, session, &identities).await
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
                     {
-                        return Some(err(req, error));
+                        return Some(response);
                     }
-                    match authorize_block_source(state, session, &p.backstore_path).await {
-                        Ok(identity) => p.backing_volume = identity,
-                        Err(error) => return Some(err(req, error)),
+                    let fileio = p.backstore_type.as_deref() == Some("fileio")
+                        || (p.backstore_type.is_none()
+                            && std::path::Path::new(&p.backstore_path)
+                                .metadata()
+                                .is_ok_and(|metadata| metadata.is_file()));
+                    if fileio {
+                        match authorize_fileio_source(state, session, &p.backstore_path).await {
+                            Ok(path) => p.backstore_path = path,
+                            Err(error) => {
+                                return Some(block_authorization_error(req, session, error));
+                            }
+                        }
+                    } else {
+                        match authorize_block_source(state, session, &p.backstore_path).await {
+                            Ok(identity) => {
+                                if identity.is_none()
+                                    && let Some(response) =
+                                        require_root_equivalent(req, session, "raw_iscsi_source")
+                                {
+                                    return Some(response);
+                                }
+                                p.backing_volume = identity;
+                            }
+                            Err(error) => {
+                                return Some(block_authorization_error(req, session, error));
+                            }
+                        }
                     }
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.backstore_path, "iscsi").await
@@ -566,11 +854,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.remove_lun(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::RemoveLunRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.iscsi.remove_lun(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -645,11 +940,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.add_acl(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::AddAclRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.iscsi.add_acl(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -659,11 +961,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.remove_acl(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::RemoveAclRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.iscsi.remove_acl(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -675,6 +984,11 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::iscsi::AddPortalRequest>(req) {
                 Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
                     if p.iser
                         && let Some(r) = require_rdma(req, "ib_isert").await
                     {
@@ -696,6 +1010,11 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::iscsi::SetPortalsRequest>(req) {
                 Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
                     if p.portals.iter().any(|portal| portal.iser)
                         && let Some(r) = require_rdma(req, "ib_isert").await
                     {
@@ -715,11 +1034,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.iscsi.remove_portal(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::iscsi::RemovePortalRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_iscsi_target(req, state, session, &p.target_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.iscsi.remove_portal(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -755,8 +1081,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
                     }
                     if let Some(ref device_path) = p.device_path {
                         match authorize_block_source(state, session, device_path).await {
-                            Ok(identity) => p.backing_volume = identity,
-                            Err(error) => return Some(err(req, error)),
+                            Ok(identity) => {
+                                if identity.is_none()
+                                    && let Some(response) =
+                                        require_root_equivalent(req, session, "raw_nvmeof_source")
+                                {
+                                    return Some(response);
+                                }
+                                p.backing_volume = identity;
+                            }
+                            Err(error) => {
+                                return Some(block_authorization_error(req, session, error));
+                            }
                         }
                     }
                     if let Some(ref device_path) = p.device_path
@@ -803,11 +1139,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.delete(p).await {
-                    Ok(()) => ok(req, "ok"),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::DeleteSubsystemRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.nvmeof.delete(p).await {
+                        Ok(()) => ok(req, "ok"),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -819,23 +1162,24 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::nvmeof::AddNamespaceRequest>(req) {
                 Ok(mut p) => {
-                    let subsystem = match state.nvmeof.get(&p.subsystem_id).await {
-                        Ok(subsystem) => subsystem,
-                        Err(error) => return Some(err(req, error)),
-                    };
-                    let identities: Vec<_> = subsystem
-                        .namespaces
-                        .iter()
-                        .map(|namespace| namespace.backing_volume.clone())
-                        .collect();
-                    if let Err(error) =
-                        authorize_block_destination(state, session, &identities).await
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
                     {
-                        return Some(err(req, error));
+                        return Some(response);
                     }
                     match authorize_block_source(state, session, &p.device_path).await {
-                        Ok(identity) => p.backing_volume = identity,
-                        Err(error) => return Some(err(req, error)),
+                        Ok(identity) => {
+                            if identity.is_none()
+                                && let Some(response) =
+                                    require_root_equivalent(req, session, "raw_nvmeof_source")
+                            {
+                                return Some(response);
+                            }
+                            p.backing_volume = identity;
+                        }
+                        Err(error) => {
+                            return Some(block_authorization_error(req, session, error));
+                        }
                     }
                     if let Some(conflict) =
                         check_block_device_conflict(state, &p.device_path, "nvmeof").await
@@ -857,11 +1201,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.remove_namespace(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::RemoveNamespaceRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.nvmeof.remove_namespace(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -941,6 +1292,11 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             }
             match parse_params::<nasty_sharing::nvmeof::AddPortRequest>(req) {
                 Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
+                    {
+                        return Some(response);
+                    }
                     if p.transport.as_deref() == Some("rdma")
                         && let Some(r) = require_rdma(req, "nvmet-rdma").await
                     {
@@ -960,11 +1316,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.remove_port(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::RemovePortRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.nvmeof.remove_port(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -974,11 +1337,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.add_host(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::AddHostRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.nvmeof.add_host(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -988,11 +1358,18 @@ async fn route_inner(req: &Request, state: &AppState, session: &Session) -> Opti
             {
                 return Some(r);
             }
-            match parse_params(req) {
-                Ok(p) => match state.nvmeof.remove_host(p).await {
-                    Ok(v) => ok(req, v),
-                    Err(e) => err(req, e),
-                },
+            match parse_params::<nasty_sharing::nvmeof::RemoveHostRequest>(req) {
+                Ok(p) => {
+                    if let Err(response) =
+                        authorized_nvmeof_subsystem(req, state, session, &p.subsystem_id).await
+                    {
+                        return Some(response);
+                    }
+                    match state.nvmeof.remove_host(p).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
+                }
                 Err(e) => invalid(req, e),
             }
         }
@@ -1015,6 +1392,93 @@ mod tests {
             filesystem.to_string(),
             owner.map(str::to_string),
         )
+    }
+
+    fn session(role: Role, filesystem: Option<&str>, owner: Option<&str>) -> Session {
+        Session {
+            token: "token".to_string(),
+            username: "tester".to_string(),
+            role,
+            file_principal: None,
+            filesystem: filesystem.map(str::to_string),
+            owner: owner.map(str::to_string),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: Some("127.0.0.1".to_string()),
+        }
+    }
+
+    #[test]
+    fn raw_block_sources_require_unscoped_admin() {
+        assert!(session_allows_raw_block_sources(&session(
+            Role::Admin,
+            None,
+            None
+        )));
+        assert!(!session_allows_raw_block_sources(&session(
+            Role::Operator,
+            None,
+            None
+        )));
+        assert!(!session_allows_raw_block_sources(&session(
+            Role::Admin,
+            Some("tank"),
+            None
+        )));
+        assert!(!session_allows_raw_block_sources(&session(
+            Role::Admin,
+            None,
+            Some("token-a")
+        )));
+    }
+
+    #[test]
+    fn samba_raw_parameters_use_the_effective_update_value() {
+        let existing = std::collections::HashMap::from([(
+            "root preexec".to_string(),
+            "/bin/true".to_string(),
+        )]);
+        let cleared = std::collections::HashMap::new();
+
+        assert!(smb_extra_params_require_admin(Some(&existing), None));
+        assert!(smb_extra_params_require_admin(None, Some(&existing)));
+        assert!(!smb_extra_params_require_admin(
+            Some(&existing),
+            Some(&cleared)
+        ));
+    }
+
+    #[test]
+    fn offline_fileio_sources_use_a_component_safe_fs_fallback() {
+        assert!(fileio_source_is_lexically_managed(
+            "/fs/offline/subvolume/disk.img"
+        ));
+        assert!(!fileio_source_is_lexically_managed(
+            "/fs/offline/../etc/passwd"
+        ));
+        assert!(!fileio_source_is_lexically_managed(
+            "/filesystem/offline/disk.img"
+        ));
+        assert!(!fileio_source_is_lexically_managed("relative/disk.img"));
+    }
+
+    #[test]
+    fn unscoped_operator_can_seed_an_empty_target_with_a_managed_source() {
+        assert!(session_allows_empty_block_destination(&session(
+            Role::Operator,
+            None,
+            None
+        )));
+        assert!(!session_allows_empty_block_destination(&session(
+            Role::Operator,
+            Some("tank"),
+            None
+        )));
+        assert!(!session_allows_empty_block_destination(&session(
+            Role::ReadOnly,
+            None,
+            None
+        )));
     }
 
     #[test]

--- a/engine/nasty-engine/src/router/snapshot.rs
+++ b/engine/nasty-engine/src/router/snapshot.rs
@@ -93,6 +93,11 @@ pub(super) async fn try_route(
         // swap the subvolume to the snapshot, resume. Destructive — takes a
         // safety snapshot first. Orchestrated in the engine layer.
         "snapshot.rollback" => {
+            if let Some(response) =
+                require_root_equivalent(req, session, "dependent_resource_restart")
+            {
+                return Some(response);
+            }
             match parse_params::<nasty_storage::subvolume::RollbackSnapshotRequest>(req) {
                 Ok(p) => {
                     if filesystem_scope_denied(session.filesystem.as_deref(), &p.filesystem) {

--- a/engine/nasty-engine/src/router/vm.rs
+++ b/engine/nasty-engine/src/router/vm.rs
@@ -4,12 +4,206 @@
 
 #![allow(unused_imports, unused_variables)]
 
+use std::path::{Path, PathBuf};
+
 use nasty_common::{ErrorCode, Request, Response};
 use serde::Deserialize;
 
 use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
+
+#[derive(Debug)]
+struct ManagedVmDisk {
+    device: Option<String>,
+    source: String,
+}
+
+#[derive(Clone, Copy)]
+struct VmSecurityFields<'a> {
+    disks: &'a [nasty_vm::VmDisk],
+    cdroms: &'a [String],
+    legacy_boot_iso: Option<&'a str>,
+    passthrough_devices: &'a [nasty_vm::PassthroughDevice],
+    usb_devices: &'a [nasty_vm::UsbPassthrough],
+    extra_args: Option<&'a [String]>,
+    cpu_model: Option<&'a str>,
+    machine_type: Option<&'a str>,
+    vga: Option<&'a str>,
+}
+
+fn paths_match(left: &str, right: &str) -> bool {
+    let left = std::fs::canonicalize(left).unwrap_or_else(|_| PathBuf::from(left));
+    let right = std::fs::canonicalize(right).unwrap_or_else(|_| PathBuf::from(right));
+    left == right
+}
+
+fn path_resolves_under_dev(path: &str) -> bool {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| PathBuf::from(path))
+        .starts_with("/dev")
+}
+
+fn operator_disk_is_safe(disk: &nasty_vm::VmDisk, managed: &[ManagedVmDisk]) -> bool {
+    if let Some(source) = disk.source.as_deref() {
+        return managed
+            .iter()
+            .any(|candidate| paths_match(source, &candidate.source));
+    }
+
+    if !path_resolves_under_dev(&disk.path) {
+        return true;
+    }
+
+    managed.iter().any(|candidate| {
+        candidate
+            .device
+            .as_deref()
+            .is_some_and(|device| paths_match(&disk.path, device))
+    })
+}
+
+fn vm_security_reason(
+    fields: VmSecurityFields<'_>,
+    managed: &[ManagedVmDisk],
+) -> Option<&'static str> {
+    if !fields.passthrough_devices.is_empty() {
+        return Some("pci_passthrough");
+    }
+    if !fields.usb_devices.is_empty() {
+        return Some("usb_passthrough");
+    }
+    if fields.extra_args.is_some_and(|args| !args.is_empty()) {
+        return Some("raw_qemu_arguments");
+    }
+    if fields
+        .cpu_model
+        .is_some_and(|value| !matches!(value, "" | "host" | "max" | "qemu64"))
+        || fields
+            .machine_type
+            .is_some_and(|value| !matches!(value, "" | "q35" | "i440fx"))
+        || fields
+            .vga
+            .is_some_and(|value| !matches!(value, "" | "virtio" | "qxl" | "std" | "none"))
+    {
+        return Some("custom_qemu_hardware");
+    }
+    if fields
+        .cdroms
+        .iter()
+        .any(|path| path_resolves_under_dev(path))
+        || fields.legacy_boot_iso.is_some_and(path_resolves_under_dev)
+    {
+        return Some("raw_vm_cdrom");
+    }
+    if fields
+        .disks
+        .iter()
+        .any(|disk| !operator_disk_is_safe(disk, managed))
+    {
+        return Some("unmanaged_vm_disk");
+    }
+    None
+}
+
+async fn managed_vm_disks(
+    state: &AppState,
+    session: &Session,
+) -> Result<Vec<ManagedVmDisk>, String> {
+    let subvolumes = state
+        .subvolumes
+        .list_all(session.filesystem.as_deref(), session.owner.as_deref())
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(subvolumes
+        .into_iter()
+        .filter(|subvolume| {
+            subvolume.subvolume_type == nasty_storage::subvolume::SubvolumeType::Block
+                && subvolume.block_volume_id.is_some()
+        })
+        .map(|subvolume| ManagedVmDisk {
+            device: subvolume.block_device,
+            source: Path::new(&subvolume.path)
+                .join("vol.img")
+                .to_string_lossy()
+                .into_owned(),
+        })
+        .collect())
+}
+
+async fn require_vm_payload_access(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+    fields: VmSecurityFields<'_>,
+) -> Option<Response> {
+    if session.filesystem.is_some() || session.owner.is_some() {
+        if fields.disks.is_empty() {
+            return require_unscoped_mutation(req, session, "vm_without_scoped_backing_disk");
+        }
+        for path in fields
+            .disks
+            .iter()
+            .filter(|disk| disk.source.is_none() && !path_resolves_under_dev(&disk.path))
+            .map(|disk| disk.path.as_str())
+            .chain(fields.cdroms.iter().map(String::as_str))
+            .chain(fields.legacy_boot_iso)
+        {
+            if let Err(error) = super::share::authorize_path_source(state, session, path).await {
+                return Some(err(req, error));
+            }
+        }
+    }
+
+    let preliminary_reason = vm_security_reason(fields, &[])?;
+
+    // Only raw-looking block disks need inventory resolution. The other
+    // privileged fields are unconditionally Admin-only.
+    if preliminary_reason != "unmanaged_vm_disk"
+        || (session.role == Role::Admin && session.filesystem.is_none() && session.owner.is_none())
+    {
+        return require_root_equivalent(req, session, preliminary_reason);
+    }
+
+    let managed = match managed_vm_disks(state, session).await {
+        Ok(managed) => managed,
+        Err(error) => return Some(err(req, error)),
+    };
+    vm_security_reason(fields, &managed)
+        .and_then(|reason| require_root_equivalent(req, session, reason))
+}
+
+async fn existing_vm_access_error(
+    req: &Request,
+    state: &AppState,
+    session: &Session,
+    id: &str,
+) -> Option<Response> {
+    if session.filesystem.is_none() && session.owner.is_none() {
+        return None;
+    }
+    let config = match state.vms.get(id).await {
+        Ok(status) => status.config,
+        Err(error) => return Some(err(req, error)),
+    };
+    require_vm_payload_access(
+        req,
+        state,
+        session,
+        VmSecurityFields {
+            disks: &config.disks,
+            cdroms: &config.cdroms,
+            legacy_boot_iso: config.boot_iso.as_deref(),
+            passthrough_devices: &config.passthrough_devices,
+            usb_devices: &config.usb_devices,
+            extra_args: config.extra_args.as_deref(),
+            cpu_model: config.cpu_model.as_deref(),
+            machine_type: config.machine_type.as_deref(),
+            vga: config.vga.as_deref(),
+        },
+    )
+    .await
+}
 
 pub(super) async fn try_route(
     req: &Request,
@@ -35,46 +229,172 @@ pub(super) async fn try_route(
             },
             Err(r) => r,
         },
-        "vm.create" => match parse_params(req) {
-            Ok(p) => match state.vms.create(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "vm.create" => match parse_params::<nasty_vm::CreateVmRequest>(req) {
+            Ok(p) => {
+                let _guard = state.block_share_mutation.lock().await;
+                if let Some(response) = require_vm_payload_access(
+                    req,
+                    state,
+                    session,
+                    VmSecurityFields {
+                        disks: p.disks.as_deref().unwrap_or_default(),
+                        cdroms: p.cdroms.as_deref().unwrap_or_default(),
+                        legacy_boot_iso: p.boot_iso.as_deref(),
+                        passthrough_devices: p.passthrough_devices.as_deref().unwrap_or_default(),
+                        usb_devices: p.usb_devices.as_deref().unwrap_or_default(),
+                        extra_args: None,
+                        cpu_model: None,
+                        machine_type: None,
+                        vga: None,
+                    },
+                )
+                .await
+                {
+                    return Some(response);
+                }
+                match state.vms.create(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
-        "vm.update" => match parse_params(req) {
-            Ok(p) => match state.vms.update(p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+        "vm.update" => match parse_params::<nasty_vm::UpdateVmRequest>(req) {
+            Ok(p) => {
+                let _guard = state.block_share_mutation.lock().await;
+                if let Some(response) = existing_vm_access_error(req, state, session, &p.id).await {
+                    return Some(response);
+                }
+                let changes_security = p.disks.is_some()
+                    || p.passthrough_devices.is_some()
+                    || p.usb_devices.is_some()
+                    || p.cdroms.is_some()
+                    || p.boot_iso.is_some()
+                    || p.extra_args.is_some()
+                    || p.cpu_model.is_some()
+                    || p.machine_type.is_some()
+                    || p.vga.is_some()
+                    || p.autostart == Some(true);
+                if changes_security {
+                    let existing = match state.vms.get(&p.id).await {
+                        Ok(status) => status.config,
+                        Err(error) => return Some(err(req, error)),
+                    };
+                    let replacing_cdroms = p.cdroms.is_some() || p.boot_iso.is_some();
+                    let effective_cdroms: &[String] = if let Some(cdroms) = p.cdroms.as_deref() {
+                        cdroms
+                    } else if p.boot_iso.is_some() {
+                        &[]
+                    } else {
+                        &existing.cdroms
+                    };
+                    if let Some(response) = require_vm_payload_access(
+                        req,
+                        state,
+                        session,
+                        VmSecurityFields {
+                            disks: p.disks.as_deref().unwrap_or(&existing.disks),
+                            cdroms: effective_cdroms,
+                            legacy_boot_iso: if replacing_cdroms {
+                                p.boot_iso.as_deref()
+                            } else {
+                                existing.boot_iso.as_deref()
+                            },
+                            passthrough_devices: p
+                                .passthrough_devices
+                                .as_deref()
+                                .unwrap_or(&existing.passthrough_devices),
+                            usb_devices: p.usb_devices.as_deref().unwrap_or(&existing.usb_devices),
+                            extra_args: p.extra_args.as_deref().or(existing.extra_args.as_deref()),
+                            cpu_model: p.cpu_model.as_deref().or(existing.cpu_model.as_deref()),
+                            machine_type: p
+                                .machine_type
+                                .as_deref()
+                                .or(existing.machine_type.as_deref()),
+                            vga: p.vga.as_deref().or(existing.vga.as_deref()),
+                        },
+                    )
+                    .await
+                    {
+                        return Some(response);
+                    }
+                }
+                match state.vms.update(p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
         "vm.delete" => match require_str(req, "id") {
-            Ok(id) => match state.vms.delete(id).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(id) => {
+                if let Some(response) = existing_vm_access_error(req, state, session, id).await {
+                    return Some(response);
+                }
+                match state.vms.delete(id).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "vm.start" => match require_str(req, "id") {
-            Ok(id) => match state.vms.start(id).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            Ok(id) => {
+                let _guard = state.block_share_mutation.lock().await;
+                match state.vms.get(id).await {
+                    Ok(status) => {
+                        if let Some(response) = require_vm_payload_access(
+                            req,
+                            state,
+                            session,
+                            VmSecurityFields {
+                                disks: &status.config.disks,
+                                cdroms: &status.config.cdroms,
+                                legacy_boot_iso: status.config.boot_iso.as_deref(),
+                                passthrough_devices: &status.config.passthrough_devices,
+                                usb_devices: &status.config.usb_devices,
+                                extra_args: status.config.extra_args.as_deref(),
+                                cpu_model: status.config.cpu_model.as_deref(),
+                                machine_type: status.config.machine_type.as_deref(),
+                                vga: status.config.vga.as_deref(),
+                            },
+                        )
+                        .await
+                        {
+                            return Some(response);
+                        }
+                        match state.vms.start(id).await {
+                            Ok(v) => ok(req, v),
+                            Err(e) => err(req, e),
+                        }
+                    }
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "vm.stop" => match require_str(req, "id") {
-            Ok(id) => match state.vms.stop(id).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(id) => {
+                if let Some(response) = existing_vm_access_error(req, state, session, id).await {
+                    return Some(response);
+                }
+                match state.vms.stop(id).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "vm.kill" => match require_str(req, "id") {
-            Ok(id) => match state.vms.kill(id).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
+            Ok(id) => {
+                if let Some(response) = existing_vm_access_error(req, state, session, id).await {
+                    return Some(response);
+                }
+                match state.vms.kill(id).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "vm.snapshot" => match parse_params::<nasty_vm::SnapshotVmRequest>(req) {
@@ -92,10 +412,17 @@ pub(super) async fn try_route(
             Err(e) => invalid(req, e),
         },
         "vm.clone" => match parse_params::<nasty_vm::CloneVmRequest>(req) {
-            Ok(p) => match vm_clone(state, &p).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            Ok(p) => {
+                if let Some(response) =
+                    require_unscoped_mutation(req, session, "global_vm_clone_inventory")
+                {
+                    return Some(response);
+                }
+                match vm_clone(state, &p).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(e) => invalid(req, e),
         },
         "vm.images.list" => ok(req, list_vm_images(state).await),
@@ -126,4 +453,153 @@ pub(super) async fn try_route(
         },
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disk(path: &str, source: Option<&str>) -> nasty_vm::VmDisk {
+        nasty_vm::VmDisk {
+            path: path.to_string(),
+            source: source.map(str::to_string),
+            interface: "virtio".to_string(),
+            readonly: false,
+            cache: None,
+            aio: None,
+            discard: None,
+            iops_rd: None,
+            iops_wr: None,
+        }
+    }
+
+    fn managed() -> Vec<ManagedVmDisk> {
+        vec![ManagedVmDisk {
+            device: Some("/dev/loop7".to_string()),
+            source: "/fs/tank/vms/managed/vol.img".to_string(),
+        }]
+    }
+
+    fn fields<'a>(disks: &'a [nasty_vm::VmDisk]) -> VmSecurityFields<'a> {
+        VmSecurityFields {
+            disks,
+            cdroms: &[],
+            legacy_boot_iso: None,
+            passthrough_devices: &[],
+            usb_devices: &[],
+            extra_args: None,
+            cpu_model: None,
+            machine_type: None,
+            vga: None,
+        }
+    }
+
+    #[test]
+    fn operator_allows_image_and_managed_block_disks() {
+        let managed = managed();
+        assert!(operator_disk_is_safe(
+            &disk("/fs/tank/vms/image.qcow2", None),
+            &managed
+        ));
+        assert!(operator_disk_is_safe(&disk("/dev/loop7", None), &managed));
+        assert!(operator_disk_is_safe(
+            &disk("/dev/loop99", Some("/fs/tank/vms/managed/vol.img")),
+            &managed
+        ));
+    }
+
+    #[test]
+    fn operator_rejects_raw_devices_and_forged_sources() {
+        let managed = managed();
+        assert!(!operator_disk_is_safe(&disk("/dev/sda", None), &managed));
+        assert!(!operator_disk_is_safe(&disk("/dev/loop8", None), &managed));
+        assert!(!operator_disk_is_safe(
+            &disk(
+                "/fs/tank/vms/image.qcow2",
+                Some("/fs/tank/vms/unknown/vol.img")
+            ),
+            &managed
+        ));
+    }
+
+    #[test]
+    fn operator_vm_policy_rejects_passthrough_and_raw_qemu_args() {
+        let pci = nasty_vm::PassthroughDevice {
+            address: "0000:03:00.0".to_string(),
+            label: None,
+        };
+        let usb = nasty_vm::UsbPassthrough {
+            vendor_id: "1234".to_string(),
+            product_id: "5678".to_string(),
+            label: None,
+        };
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    passthrough_devices: &[pci],
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            Some("pci_passthrough")
+        );
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    usb_devices: &[usb],
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            Some("usb_passthrough")
+        );
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    extra_args: Some(&["-nodefaults".to_string()]),
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            Some("raw_qemu_arguments")
+        );
+    }
+
+    #[test]
+    fn empty_privileged_fields_are_operator_safe() {
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    extra_args: Some(&[]),
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn operator_rejects_raw_device_cdroms() {
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    cdroms: &["/dev/sr0".to_string()],
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            Some("raw_vm_cdrom")
+        );
+        assert_eq!(
+            vm_security_reason(
+                VmSecurityFields {
+                    legacy_boot_iso: Some("/dev/sda"),
+                    ..fields(&[])
+                },
+                &managed()
+            ),
+            Some("raw_vm_cdrom")
+        );
+    }
 }

--- a/engine/nasty-vm/src/lib.rs
+++ b/engine/nasty-vm/src/lib.rs
@@ -425,6 +425,87 @@ fn validate_vm_path(path: &str) -> Result<(), VmError> {
     Ok(())
 }
 
+fn validate_qemu_drive_value(field: &str, value: &str) -> Result<(), VmError> {
+    if value.contains([',', '\n', '\r', '\0']) {
+        return Err(VmError::InvalidDiskPath(format!(
+            "{field} contains characters that alter QEMU drive options"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_vm_disk(disk: &VmDisk) -> Result<(), VmError> {
+    validate_qemu_drive_value("disk path", &disk.path)?;
+    if !matches!(disk.interface.as_str(), "" | "virtio" | "scsi" | "ide") {
+        return Err(VmError::InvalidDiskPath(format!(
+            "unsupported disk interface '{}'",
+            disk.interface
+        )));
+    }
+    if disk
+        .cache
+        .as_deref()
+        .is_some_and(|value| !matches!(value, "writeback" | "writethrough" | "none" | "unsafe"))
+    {
+        return Err(VmError::InvalidDiskPath(
+            "unsupported cache mode".to_string(),
+        ));
+    }
+    if disk
+        .aio
+        .as_deref()
+        .is_some_and(|value| !matches!(value, "threads" | "native"))
+    {
+        return Err(VmError::InvalidDiskPath("unsupported I/O mode".to_string()));
+    }
+    if disk
+        .discard
+        .as_deref()
+        .is_some_and(|value| !matches!(value, "unmap" | "ignore"))
+    {
+        return Err(VmError::InvalidDiskPath(
+            "unsupported discard mode".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_vm_network_values(networks: &[VmNetwork]) -> Result<(), VmError> {
+    for network in networks {
+        if !matches!(network.mode.as_str(), "user" | "bridge") {
+            return Err(VmError::InvalidNetwork(format!(
+                "unsupported network mode '{}'",
+                network.mode
+            )));
+        }
+        if let Some(bridge) = network.bridge.as_deref()
+            && (bridge.is_empty()
+                || bridge.len() > 15
+                || !bridge.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || "._-".contains(character)
+                }))
+        {
+            return Err(VmError::InvalidNetwork(
+                "bridge name contains unsupported characters".to_string(),
+            ));
+        }
+        if let Some(mac) = network.mac.as_deref() {
+            let mut octets = mac.split(':');
+            let valid = (0..6).all(|_| {
+                octets.next().is_some_and(|octet| {
+                    octet.len() == 2 && octet.chars().all(|character| character.is_ascii_hexdigit())
+                })
+            }) && octets.next().is_none();
+            if !valid {
+                return Err(VmError::InvalidNetwork(
+                    "MAC address must contain six hexadecimal octets".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Path to the QMP unix socket for a given VM.
 fn qmp_socket_path(vm_id: &str) -> String {
     format!("{QMP_DIR}/{vm_id}.qmp")
@@ -671,6 +752,7 @@ impl VmService {
         // Validate disk paths exist and are within allowed locations
         if let Some(ref disks) = req.disks {
             for disk in disks {
+                validate_vm_disk(disk)?;
                 if !Path::new(&disk.path).exists() {
                     return Err(VmError::InvalidDiskPath(format!(
                         "disk path {} does not exist",
@@ -696,6 +778,7 @@ impl VmService {
         .filter(|iso| !iso.trim().is_empty())
         .collect();
         for iso in &cdroms {
+            validate_qemu_drive_value("CD-ROM path", iso)?;
             if !Path::new(iso).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
                     "CD-ROM ISO {iso} does not exist"
@@ -705,6 +788,9 @@ impl VmService {
         }
         if let Some(ref usb) = req.usb_devices {
             validate_usb_passthroughs(usb)?;
+        }
+        if let Some(ref networks) = req.networks {
+            validate_vm_network_values(networks)?;
         }
 
         let id = Uuid::new_v4().to_string();
@@ -799,12 +885,16 @@ impl VmService {
                 config.memory_mib = mem;
             }
             if let Some(mut disks) = req.disks {
+                for disk in &disks {
+                    validate_vm_disk(disk)?;
+                }
                 // Capture the stable backing file for new block-device
                 // disks while the loop mapping is still valid (#592).
                 backfill_disk_sources(&mut disks, &losetup_pairs().await);
                 config.disks = disks;
             }
             if let Some(nets) = req.networks {
+                validate_vm_network_values(&nets)?;
                 config.networks = nets;
             }
             if let Some(pt) = req.passthrough_devices {
@@ -830,6 +920,7 @@ impl VmService {
                     .filter(|iso| !iso.trim().is_empty())
                     .collect();
                 for iso in &list {
+                    validate_qemu_drive_value("CD-ROM path", iso)?;
                     if !Path::new(iso).exists() {
                         return Err(VmError::InvalidDiskPath(format!(
                             "CD-ROM ISO {iso} does not exist"
@@ -921,6 +1012,7 @@ impl VmService {
 
         // Validate all disk paths exist and are within allowed locations before starting
         for disk in &config.disks {
+            validate_vm_disk(disk)?;
             if !Path::new(&disk.path).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
                     "disk path {} does not exist",
@@ -930,6 +1022,7 @@ impl VmService {
             validate_vm_path(&disk.path)?;
         }
         for iso in &config.cdroms {
+            validate_qemu_drive_value("CD-ROM path", iso)?;
             if !Path::new(iso).exists() {
                 return Err(VmError::InvalidDiskPath(format!(
                     "CD-ROM ISO {iso} does not exist"
@@ -942,6 +1035,7 @@ impl VmService {
         // VM never launches) if the target bridge doesn't exist. Catching it here
         // gives the operator a clear reason instead of a daemon that silently
         // never came up.
+        validate_vm_network_values(&config.networks)?;
         validate_bridge_networks(&config.networks)?;
 
         // Ensure runtime directory exists with restrictive permissions (owner-only)
@@ -1479,6 +1573,26 @@ mod tests {
         assert!(validate_bridge_networks(&nets).is_ok());
     }
 
+    #[test]
+    fn network_validation_rejects_qemu_suboption_injection() {
+        let networks = vec![VmNetwork {
+            mode: "bridge".to_string(),
+            bridge: Some("br0,helper=/tmp/x".to_string()),
+            mac: Some("52:54:00:12:34:56,romfile=/etc/shadow".to_string()),
+        }];
+        assert!(validate_vm_network_values(&networks).is_err());
+    }
+
+    #[test]
+    fn network_validation_accepts_documented_values() {
+        let networks = vec![VmNetwork {
+            mode: "bridge".to_string(),
+            bridge: Some("br0".to_string()),
+            mac: Some("52:54:00:12:34:56".to_string()),
+        }];
+        assert!(validate_vm_network_values(&networks).is_ok());
+    }
+
     fn base_config() -> VmConfig {
         VmConfig {
             id: "test-id".to_string(),
@@ -1514,6 +1628,26 @@ mod tests {
             iops_rd: None,
             iops_wr: None,
         }
+    }
+
+    #[test]
+    fn disk_validation_rejects_qemu_option_injection() {
+        let mut value = disk("/fs/tank/vm.img", None);
+        value.cache = Some("none,file=/dev/sda".to_string());
+        assert!(validate_vm_disk(&value).is_err());
+
+        let value = disk("/fs/tank/vm.img,format=qcow2", None);
+        assert!(validate_vm_disk(&value).is_err());
+        assert!(validate_qemu_drive_value("CD-ROM path", "/fs/install.iso,if=none").is_err());
+    }
+
+    #[test]
+    fn disk_validation_accepts_documented_options() {
+        let mut value = disk("/fs/tank/vm.img", None);
+        value.cache = Some("none".to_string());
+        value.aio = Some("native".to_string());
+        value.discard = Some("unmap".to_string());
+        assert!(validate_vm_disk(&value).is_ok());
     }
 
     fn pairs(items: &[(&str, &str)]) -> Vec<(String, String)> {


### PR DESCRIPTION
## Summary
- add shared audited gates for root-equivalent and unscoped mutations
- require Admin for Compose lifecycle, unsafe app settings, raw VM/QEMU capabilities, and unmanaged block exports
- authorize existing share, app, and VM state before lifecycle or exposure mutations
- harden Compose host-path validation, Samba raw parameters, and QEMU drive/network option handling
- align method registry roles with enforced Admin-only operations

## Boundary
Operators retain managed simple-app, VM, iSCSI, NVMe-oF, NFS, and SMB workflows. Unresolved Compose host-path interpolation fails closed because protected host paths cannot be proven safe before rendering.

Path-replacement TOCTOU/capability work remains explicitly deferred to Stage 2.

## Verification
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `nix flake check --no-build`
- `git diff --check`