### PR TITLE
docs: correct API connection guidance

### DIFF
--- a/engine/nasty-engine/src/registry/markdown.rs
+++ b/engine/nasty-engine/src/registry/markdown.rs
@@ -20,22 +20,25 @@ pub fn render_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     let mut out = String::new();
 
     out.push_str("# NASty JSON-RPC API\n\n");
-    out.push_str("NASty exposes a **JSON-RPC 2.0** API over **WebSocket** at `/ws`.\n\n");
+    out.push_str("NASty exposes a **JSON-RPC 2.0** API over **WebSocket** at `/ws` and a REST gateway for the same registered methods under `/api/v1`.\n\n");
     out.push_str("## Transport\n\n");
-    out.push_str("Connect to `ws://<host>/ws` with a valid session cookie or `Authorization: Bearer <token>` header.\n\n");
-    out.push_str("**Request:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"pool.list\", \"params\": {}}\n```\n\n");
+    out.push_str("Connect to `wss://<host>/ws` when the appliance is served over HTTPS. Use `ws://<host>/ws` only for deliberate direct plain-HTTP access. Authenticate with the `nasty_session` cookie or an `Authorization: Bearer <token>` header.\n\n");
+    out.push_str("**Request:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"fs.list\", \"params\": {}}\n```\n\n");
     out.push_str(
         "**Response:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"result\": [...]}\n```\n\n",
     );
     out.push_str("**Error:**\n```json\n{\"jsonrpc\": \"2.0\", \"id\": 1, \"error\": {\"code\": -32603, \"message\": \"filesystem not found: mypool\"}}\n```\n\n");
     out.push_str("## Authentication\n\n");
     out.push_str("Send `POST /api/login` with `{\"username\": \"...\", \"password\": \"...\"}` to receive a session token. ");
-    out.push_str("Pass it as a cookie (`session=<token>`) or `Authorization: Bearer <token>` header on the WebSocket upgrade.\n\n");
+    out.push_str("Pass it as a cookie (`nasty_session=<token>`) or `Authorization: Bearer <token>` header.\n\n");
+    out.push_str("## REST and OpenAPI\n\n");
+    out.push_str("Registered methods are also available through the REST gateway; for example, `fs.list` maps to `GET /api/v1/fs/list`. GET parameters use the query string and other methods accept a JSON body. Interactive Swagger UI is available at `/api/docs`, backed by the OpenAPI 3.1 document at `/api/openapi.json`. Streaming endpoints and real-time events remain WebSocket-only.\n\n");
     out.push_str("## Roles\n\n");
     out.push_str("| Role | Description |\n|------|-------------|\n");
     out.push_str("| `admin` | Full access to all methods |\n");
-    out.push_str("| `operator` | Create/delete subvolumes and snapshots; read pools. Cannot manage users, destroy pools, or change system settings. |\n");
-    out.push_str("| `readonly` | Read-only access to all list/get methods |\n\n");
+    out.push_str("| `operator` | Day-to-day storage, sharing, app, and VM operations without Admin-only system or root-equivalent access |\n");
+    out.push_str("| `readonly` | Non-privileged read-only API access |\n");
+    out.push_str("| `user` | Self-service account methods and authorized file-portal access |\n\n");
     out.push_str(
         "API tokens can additionally be scoped to a single **filesystem** (restricts visibility) ",
     );
@@ -44,7 +47,7 @@ pub fn render_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     out.push_str(
         "After any successful mutation the server broadcasts an event on the same WebSocket:\n",
     );
-    out.push_str("```json\n{\"event\": \"pool\"}\n```\n");
+    out.push_str("```json\n{\"event\": \"filesystem\"}\n```\n");
     out.push_str("Clients should re-fetch the relevant resource when they receive an event. ");
     out.push_str("Event types: `filesystem`, `subvolume`, `snapshot`, `share.nfs`, `share.smb`, `share.iscsi`, `share.nvmeof`, `protocol`, `settings`, `alert`.\n\n");
     out.push_str("---\n\n");

--- a/engine/nasty-engine/src/registry/tests.rs
+++ b/engine/nasty-engine/src/registry/tests.rs
@@ -1,7 +1,9 @@
 //! Markdown emitter unit tests. Pin the small schema-shape converters so a
 //! refactor that breaks how oneOf / $ref / nullables render fails fast.
 
-use super::markdown::{render_properties, render_result_summary, type_str_from_schema};
+use super::markdown::{
+    render_markdown, render_properties, render_result_summary, type_str_from_schema,
+};
 use serde_json::json;
 
 #[test]
@@ -185,4 +187,29 @@ fn registry_builds_without_panic() {
     assert!(!groups.is_empty(), "registry returned no groups");
     let total: usize = groups.iter().map(|(_, ms)| ms.len()).sum();
     assert!(total > 100, "expected >100 methods, got {total}");
+}
+
+#[test]
+fn markdown_introduction_matches_current_transports_and_names() {
+    let (_generator, groups) = super::build_full_registry();
+    let rendered = render_markdown(&groups);
+
+    for expected in [
+        "`wss://<host>/ws`",
+        "`nasty_session=<token>`",
+        "\"method\": \"fs.list\"",
+        "`GET /api/v1/fs/list`",
+        "`/api/docs`",
+        "`/api/openapi.json`",
+        "\"event\": \"filesystem\"",
+    ] {
+        assert!(rendered.contains(expected), "missing `{expected}`");
+    }
+    for stale in [
+        "`session=<token>`",
+        "\"method\": \"pool.list\"",
+        "\"event\": \"pool\"",
+    ] {
+        assert!(!rendered.contains(stale), "found stale `{stale}`");
+    }
 }

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -306,7 +306,7 @@
 				{
 					term: 'API',
 					summary: 'Application Programming Interface — how software talks to NASty.',
-					detail: 'NASty\'s engine exposes a JSON-RPC 2.0 API over WebSocket. Everything the web UI does goes through this API, and you can use it directly for scripting and automation. Connect to ws://<nasty-ip>/ws/api with a valid token.',
+					detail: 'NASty\'s engine exposes JSON-RPC 2.0 over WebSocket at wss://<nasty-host>/ws and the same registered methods through REST under /api/v1. Use the nasty_session cookie or a Bearer token to authenticate. Interactive REST documentation is available at /api/docs.',
 				},
 				{
 					term: 'SSO / OIDC',


### PR DESCRIPTION
## Summary
- document secure WebSocket and REST API endpoints accurately
- use the current `nasty_session` cookie, `fs.list` method, and `filesystem` event names
- describe Swagger UI and OpenAPI locations
- align the WebUI Help entry with the generated API introduction
- add regression coverage for current transport and naming contracts

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine registry::`
- `npm run check`
- `git diff --check`