### PR TITLE
webui: preserve failed backup edits

### DIFF
--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -409,10 +409,11 @@
 			updated.repo_initialized = false;
 		}
 
-		await withToast(
-			() => client.call('backup.profile.update', updated),
+		const result = await withToast(
+			() => client.call<BackupProfile>('backup.profile.update', updated),
 			'Profile updated'
 		);
+		if (result === undefined) return;
 		editId = null;
 		await refresh();
 	}


### PR DESCRIPTION
## Summary
- keep the backup profile edit form open when an update fails
- preserve entered values and secrets after the existing error toast
- close and refresh only after the update returns a profile successfully

## Verification
- `npm run check`
- `npm test` (231 tests passed; existing `theme.svelte.ts` warning remains)
- `git diff --check`