### PR TITLE
nixos: add NetWatch and SysWatch diagnostics

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -70,6 +70,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | btop | Apache-2.0 |
 | caddy | Apache-2.0 |
 | croc | MIT |
+| diskwatch | MIT |
 | docker | Apache-2.0 |
 | ethtool | GPL-2.0 |
 | fwupd | LGPL-2.1-or-later |
@@ -82,6 +83,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | lm-sensors | GPL-2.0 |
 | lsof | Zlib |
 | nfs-utils | GPL-2.0 |
+| netwatch | MIT; bundled FoxIO JA4 mapping data is BSD-3-Clause |
 | nvme-cli | GPL-2.0 |
 | openssh | BSD-2-Clause |
 | OVMF | BSD-2-Clause |
@@ -91,6 +93,37 @@ All dependencies use licenses compatible with GPL-3.0.
 | rsync | GPL-3.0 |
 | samba | GPL-3.0 |
 | smartmontools | GPL-2.0 |
+| syswatch | MIT |
 | targetcli-fb | Apache-2.0 |
 | tcpdump | BSD-3-Clause |
 | util-linux | GPL-2.0 |
+
+## NetWatch JA4 Data Notice
+
+NetWatch includes JA4 TLS client fingerprint mappings from FoxIO's JA4 mapping
+database. The bundled data is distributed under the BSD-3-Clause license:
+
+Copyright (c) 2026 FoxIO. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of FoxIO nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -529,12 +529,14 @@ in {
          bcachefs subvolume list /fs/first
          bcachefs subvolume snapshot <src> <dst>
 
-       I/O monitoring
+       diagnostics & monitoring
          iotop-c -o
          iostat -x 1
          dool -dny 1
          btop                                       interactive CPU/mem/disk/net dashboard
          diskwatch                                  read-only disk diagnostics TUI (devices, SMART, IO, hot files)
+         netwatch                                   read-only network diagnostics TUI (interfaces, connections, DNS, capture)
+         syswatch                                   read-only system diagnostics TUI (CPU, memory, processes, services)
          # → type 'debug' for perf profiling and kernel oops symbolization
          # → type 'benchmark' for fio storage tests
 
@@ -806,15 +808,55 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.3.2";
-          hash = "sha256-/wR+tUQPV6EnWcZvOdZY9di9Eu07NSnAn25du/KMlfw=";
+          rev = "v0.4.0";
+          hash = "sha256-pKo4zXyoX2OiOIwirCdzQuuFW1dMye/AA4MNVYgki3A=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.3.2";
+        version = "0.4.0";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";
+      })
+
+      # netwatch — sibling read-only network-diagnostics TUI. Packet capture
+      # uses libpcap; the TUI degrades gracefully when elevated capture/eBPF
+      # permissions are unavailable.
+      (let
+        netwatchSrc = pkgs.fetchFromGitHub {
+          owner = "matthart1983";
+          repo = "netwatch";
+          rev = "v0.29.2";
+          hash = "sha256-evfnMhLV+qxovhmBr4bGvCnY7weBGzfw6I67VJfYKJc=";
+        };
+      in pkgs.rustPlatform.buildRustPackage {
+        pname = "netwatch-tui";
+        version = "0.29.2";
+        src = netwatchSrc;
+        cargoLock.lockFile = "${netwatchSrc}/Cargo.lock";
+        nativeBuildInputs = [ pkgs.pkg-config ];
+        buildInputs = [ pkgs.libpcap ];
+        postInstall = ''
+          install -Dm644 LICENSE "$out/share/licenses/netwatch/LICENSE"
+          install -Dm644 NOTICE "$out/share/licenses/netwatch/NOTICE"
+        '';
+        meta.mainProgram = "netwatch";
+      })
+
+      # syswatch — sibling read-only host-diagnostics TUI (MIT).
+      (let
+        syswatchSrc = pkgs.fetchFromGitHub {
+          owner = "matthart1983";
+          repo = "syswatch";
+          rev = "v0.10.0";
+          hash = "sha256-EHijnB6hG3qrGteB0Q4Um9GgoIJqyZSflaMvQb2Zk8E=";
+        };
+      in pkgs.rustPlatform.buildRustPackage {
+        pname = "syswatch";
+        version = "0.10.0";
+        src = syswatchSrc;
+        cargoLock.lockFile = "${syswatchSrc}/Cargo.lock";
+        meta.mainProgram = "syswatch";
       })
 
       (writeShellScriptBin "nasty-cleanup" ''

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -367,6 +367,10 @@ pkgs.testers.runNixOSTest {
 
     machine.start()
 
+    machine.succeed("diskwatch --version | grep -Fq '0.4.0'")
+    machine.succeed("netwatch --version | grep -Fq '0.29.2'")
+    machine.succeed("syswatch --version | grep -Fq '0.10.0'")
+
     # nftables must establish a default-drop baseline independently of the
     # engine. Restart nftables as separate stop/start operations so PartOf stops
     # the engine without restarting it; inspect the baseline, then start the

--- a/webui/static/THIRD-PARTY-LICENSES.md
+++ b/webui/static/THIRD-PARTY-LICENSES.md
@@ -70,6 +70,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | btop | Apache-2.0 |
 | caddy | Apache-2.0 |
 | croc | MIT |
+| diskwatch | MIT |
 | docker | Apache-2.0 |
 | ethtool | GPL-2.0 |
 | fwupd | LGPL-2.1-or-later |
@@ -82,6 +83,7 @@ All dependencies use licenses compatible with GPL-3.0.
 | lm-sensors | GPL-2.0 |
 | lsof | Zlib |
 | nfs-utils | GPL-2.0 |
+| netwatch | MIT; bundled FoxIO JA4 mapping data is BSD-3-Clause |
 | nvme-cli | GPL-2.0 |
 | openssh | BSD-2-Clause |
 | OVMF | BSD-2-Clause |
@@ -91,6 +93,37 @@ All dependencies use licenses compatible with GPL-3.0.
 | rsync | GPL-3.0 |
 | samba | GPL-3.0 |
 | smartmontools | GPL-2.0 |
+| syswatch | MIT |
 | targetcli-fb | Apache-2.0 |
 | tcpdump | BSD-3-Clause |
 | util-linux | GPL-2.0 |
+
+## NetWatch JA4 Data Notice
+
+NetWatch includes JA4 TLS client fingerprint mappings from FoxIO's JA4 mapping
+database. The bundled data is distributed under the BSD-3-Clause license:
+
+Copyright (c) 2026 FoxIO. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of FoxIO nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary
- bump DiskWatch from 0.3.2 to 0.4.0
- package NetWatch 0.29.2 and SysWatch 0.10.0 for the appliance terminal
- document all three tools and include NetWatch/FoxIO license notices
- assert the installed versions in the appliance smoke test

## Testing
- `nix flake check --no-build`
- built all three pinned sources with the locked Nixpkgs Rust platform on `aarch64-darwin`
- verified `diskwatch 0.4.0`, `netwatch 0.29.2`, and `syswatch 0.10.0` version output
- verified the packaged NetWatch `LICENSE` and `NOTICE` files
- `git diff --check`

The exact Linux appliance build requires CI because the local host has no Linux builder.