### PR TITLE
fix: reclaim boot space after failed updates

### DIFF
--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -847,11 +847,11 @@ fn evaluate_rules(
                         // Mention the actionable remedy in the message
                         // so the user doesn't have to dig — the typical
                         // path is "trim old generations" not "resize ESP".
-                        // `nasty-cleanup` is the one-shot helper that
+                        // `nasty-cleanup all` is the one-shot helper that
                         // does delete-old-generations + nix-gc +
                         // switch-to-configuration boot in order.
                         message: format!(
-                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nasty-cleanup` to reclaim space.",
+                            "/boot has {:.0} MB free (threshold: {:.0} MB). The next system update may fail to install its initrd. Run `nasty-cleanup all` to reclaim space.",
                             free_mb, rule.threshold
                         ),
                         current_value: free_mb,
@@ -2289,6 +2289,7 @@ mod tests {
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0].source, "/boot");
         assert!((alerts[0].current_value - 20.0).abs() < 0.001);
+        assert!(alerts[0].message.contains("nasty-cleanup all"));
         // None means "/boot not statvfs'able" (e.g. not a separate
         // mount) — no fire, silence is correct.
         let alerts = evaluate_rules(

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -658,14 +658,15 @@ in {
        nasty — built-in tools
          nasty-top                                  live IO, latency, tuning advisor
          nasty-report                               dump diagnostic info for bug reports
-         nasty-cleanup                              remove old generations + garbage collect
+         nasty-cleanup                              keep 3 generations + garbage collect
+         nasty-cleanup all                          keep current generation only
          nasty-rebuild                              force rebuild from current /etc/nixos
 
        NixOS — system management
          nixos-rebuild switch --flake /etc/nixos#nasty     rebuild and activate
          nixos-rebuild boot --flake /etc/nixos#nasty       rebuild, activate on next boot
          nix-env --list-generations -p /nix/var/nix/profiles/system   list generations
-         nix-env --delete-generations old -p /nix/var/nix/profiles/system   keep current only
+         nix-env --delete-generations +3 -p /nix/var/nix/profiles/system   keep last 3
 
        NixOS — flake management
          nix flake update nasty --flake /etc/nixos         pull latest NASty
@@ -864,10 +865,26 @@ in {
         ${pkgs.coreutils}/bin/env -u POSIXLY_CORRECT \
           ${pkgs.util-linux}/bin/renice -n 10 -p $$ >/dev/null
         ${pkgs.util-linux}/bin/ionice -c2 -n7 -p $$
-        echo "==> Removing non-current NixOS generations..."
-        # `old` also removes generations newer than current, which failed
-        # updates can leave behind after rolling the profile back.
-        nix-env --delete-generations old -p /nix/var/nix/profiles/system 2>/dev/null || true
+        if [ "$#" -gt 1 ]; then
+          echo "Usage: nasty-cleanup [all]" >&2
+          exit 2
+        fi
+        case "''${1:-}" in
+          "")
+            echo "==> Removing old NixOS generations (keeping last 3)..."
+            nix-env --delete-generations +3 -p /nix/var/nix/profiles/system 2>/dev/null || true
+            ;;
+          all)
+            echo "==> Removing all non-current NixOS generations..."
+            # `old` also removes generations newer than current, which failed
+            # updates can leave behind after rolling the profile back.
+            nix-env --delete-generations old -p /nix/var/nix/profiles/system 2>/dev/null || true
+            ;;
+          *)
+            echo "Usage: nasty-cleanup [all]" >&2
+            exit 2
+            ;;
+        esac
         echo "==> Running garbage collection..."
         nix-collect-garbage 2>&1
         # Re-sync /boot to match the surviving generations: GC removed

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -665,7 +665,7 @@ in {
          nixos-rebuild switch --flake /etc/nixos#nasty     rebuild and activate
          nixos-rebuild boot --flake /etc/nixos#nasty       rebuild, activate on next boot
          nix-env --list-generations -p /nix/var/nix/profiles/system   list generations
-         nix-env --delete-generations +3 -p /nix/var/nix/profiles/system   keep last 3
+         nix-env --delete-generations old -p /nix/var/nix/profiles/system   keep current only
 
        NixOS — flake management
          nix flake update nasty --flake /etc/nixos         pull latest NASty
@@ -864,8 +864,10 @@ in {
         ${pkgs.coreutils}/bin/env -u POSIXLY_CORRECT \
           ${pkgs.util-linux}/bin/renice -n 10 -p $$ >/dev/null
         ${pkgs.util-linux}/bin/ionice -c2 -n7 -p $$
-        echo "==> Removing old NixOS generations (keeping last 3)..."
-        nix-env --delete-generations +3 -p /nix/var/nix/profiles/system 2>/dev/null || true
+        echo "==> Removing non-current NixOS generations..."
+        # `old` also removes generations newer than current, which failed
+        # updates can leave behind after rolling the profile back.
+        nix-env --delete-generations old -p /nix/var/nix/profiles/system 2>/dev/null || true
         echo "==> Running garbage collection..."
         nix-collect-garbage 2>&1
         # Re-sync /boot to match the surviving generations: GC removed

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -686,7 +686,7 @@
 						<div class="flex-1">
 							<div class="font-medium text-amber-200">Last update attempt failed</div>
 							<p class="mt-1 text-muted-foreground">
-								The most recent update didn't complete — the system kept running the previous generation. If disk space ran out, use <code class="font-mono text-xs">nasty-cleanup</code> to reclaim old generations and re-sync <code class="font-mono text-xs">/boot</code>. Then start the same action again: check and upgrade a development build, use Upgrade for a tagged release, or resubmit the selected Upstream inputs. The log below has the failed attempt's journal output.
+								The most recent update didn't complete — the system kept running the previous generation. If disk space ran out, use <code class="font-mono text-xs">nasty-cleanup all</code> to reclaim old generations and re-sync <code class="font-mono text-xs">/boot</code>. Then start the same action again: check and upgrade a development build, use Upgrade for a tagged release, or resubmit the selected Upstream inputs. The log below has the failed attempt's journal output.
 							</p>
 						</div>
 					</div>
@@ -1013,7 +1013,7 @@
 
 					{#if status?.state === 'failed'}
 						<p class="mt-4 text-xs text-muted-foreground">
-							Resolve the cause, then start the same action again above. For disk-space failures, run <code class="font-mono">nasty-cleanup</code> first.
+							Resolve the cause, then start the same action again above. For disk-space failures, run <code class="font-mono">nasty-cleanup all</code> first.
 						</p>
 						<div class="mt-3 flex gap-2">
 							<Button variant="secondary" size="sm" onclick={() => status = { state: 'idle', log: '', reboot_required: false, webui_changed: false }}>Dismiss</Button>


### PR DESCRIPTION
## Summary

- keep the existing `nasty-cleanup` default of retaining three generations
- add `nasty-cleanup all` to retain only the current generation, including deleting newer failed attempts
- direct low-`/boot` alerts and failed-update guidance to the explicit recovery mode
- reject unsupported arguments with a usage error

## Root cause

`nix-env --delete-generations +3` keeps the last three generations up to the current one **and every generation newer than current**. After a bootloader installation fails and the profile rolls back, default cleanup can therefore preserve four profiles and attempt to copy the failed generation kernel/initrd back to an already-full ESP.

On a legacy 249 MiB ESP, each observed kernel/initrd set consumes about 94 MiB. Retaining two sets leaves only about 63 MiB, but systemd-boot needs to copy the next roughly 94 MiB set before it prunes stale files. The explicit `all` mode uses `--delete-generations old`, which removes both older rollback generations and newer failed generations while Nix protects the current generation.

After the next successful update, the previous current generation is available as the rollback generation again.

## Validation

- `nix flake check --no-build`
- `cargo fmt --all -- --check`
- `cargo test -p nasty-system evaluate_rules_boot_disk_free_mb_fires_when_below_threshold`
- `npm run check` (0 errors, 0 warnings)
- `git diff --check`
- reproduced and recovered the original failure on a 249 MiB ESP