### PR TITLE
deps: update Rust to 1.98.0

### DIFF
--- a/engine/nasty-engine/src/router/share.rs
+++ b/engine/nasty-engine/src/router/share.rs
@@ -378,6 +378,7 @@ async fn authorize_block_destination(
     Ok(())
 }
 
+#[allow(clippy::result_large_err)]
 async fn authorized_iscsi_target(
     req: &Request,
     state: &AppState,
@@ -434,6 +435,7 @@ async fn authorized_iscsi_target(
     Ok(target)
 }
 
+#[allow(clippy::result_large_err)]
 async fn authorized_nvmeof_subsystem(
     req: &Request,
     state: &AppState,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- update the development and CI Rust toolchain from 1.97.1 to 1.98.0
- acknowledge the new `result_large_err` lint at the two authorization helpers that intentionally return Axum responses directly
- leave Cargo dependencies and the lockfile unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --all-targets --no-fail-fast`
- `nix flake check --no-build`
- `git diff --check`