### PR TITLE
fix: refresh Caddy plugin vendor hash

### DIFF
--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -2296,7 +2296,7 @@ in {
           "github.com/caddy-dns/desec@v1.1.0"
           "github.com/caddy-dns/rfc2136@v1.0.0"
         ];
-        hash = "sha256-koAljBnPgSNGZXlqVa4aab8A7EUb9xmXqEgBzZen0a0=";
+        hash = "sha256-Lw+YLl09LkIznrrRXNx7KpwIahLbAt1hyUtpnKN4SaE=";
       };
       globalConfig = ''
         # auto_https stays ON so Caddy generates the per-hostname


### PR DESCRIPTION
## Summary
- update the custom Caddy `withPlugins` fixed-output hash
- use the source hash reported by the failed v0.1.0 ISO build

## Root cause
The nixpkgs refresh changed the generated Caddy plugin source/vendor tree, but the checked-in hash remained stale. The aarch64 release build expected `sha256-koAljBnPgSNGZXlqVa4aab8A7EUb9xmXqEgBzZen0a0=` and produced `sha256-Lw+YLl09LkIznrrRXNx7KpwIahLbAt1hyUtpnKN4SaE=`.

Failed release run: https://github.com/nasty-project/nasty/actions/runs/33010028887

## Validation
- `nix flake check --no-build`
- `git diff --check`
- local Linux package build reached the expected platform boundary on macOS; the replacement hash is the value produced by the Linux release derivation