### PR TITLE
iso: keep x86 release image below asset limit

### DIFF
--- a/nixos/iso.nix
+++ b/nixos/iso.nix
@@ -127,7 +127,12 @@ in
   # image — well over 100 MB of headroom — at the cost of a slightly
   # slower installer live-boot. The *installed* appliance runs from
   # bcachefs, not this squashfs, so runtime performance is unaffected.
-  isoImage.squashfsCompression = lib.mkForce "xz -Xdict-size 100%";
+  # The x86 BCJ filter keeps machine-code-heavy x86_64 images below the limit
+  # without removing anything from the installer closure.
+  isoImage.squashfsCompression = lib.mkForce (
+    "xz -Xdict-size 100%"
+    + lib.optionalString pkgs.stdenv.hostPlatform.isx86_64 " -Xbcj x86"
+  );
 
   environment.systemPackages = with pkgs; [
     bcachefs-tools


### PR DESCRIPTION
## Summary
- enable the x86 BCJ filter for the x86_64 installer squashfs
- preserve the full installer closure while improving compression of executable machine code
- leave aarch64 compression unchanged

## Root cause
The v0.1.0 x86_64 ISO built successfully but was exactly 2,147,483,648 bytes (1,048,576 ISO sectors). GitHub release assets must be strictly smaller than 2 GiB, so upload failed with HTTP 422.

Failed upload: https://github.com/nasty-project/nasty/actions/runs/33013527348/job/98325691558

## Validation
- x86_64 evaluates to `xz -Xdict-size 100% -Xbcj x86`
- aarch64 remains `xz -Xdict-size 100%`
- pinned SquashFS 4.7.5 reports x86 BCJ support
- `nix flake check --no-build`
- `git diff --check`