### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786990948,
-        "narHash": "sha256-1ilzebplgFVaqiSzpTeGRgnSqYfo9W8G7xj/6KlX990=",
+        "lastModified": 1788039834,
+        "narHash": "sha256-lbqQ5DT7lX+GSILC7r4xXIG2YXMGC2Hvus59HtWiP5s=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "abdbd61f320a8c82dd981b6fda189c359a82836c",
+        "rev": "9cc4c780893928cc4f043e4c1110d58bbed28550",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.2",
+        "ref": "v1.39.3",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.2 release tag.
+    # Pinned to v1.39.3 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.2";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.3";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────
@@ -185,8 +185,14 @@
       # its own Kconfig is never processed by the host kernel's build system.
       # We patch the DKMS Makefile to inject -DCONFIG_BCACHEFS_QUOTA directly,
       # enabling the VFS quotactl_ops (sb->s_qcop) that setquota/repquota need.
-      base = pkgs.bcachefs-tools.overrideAttrs (old: {
-        version = (builtins.fromTOML (builtins.readFile "${bcachefs-tools}/Cargo.toml")).package.version;
+      base = pkgs.bcachefs-tools.overrideAttrs (old: let
+        sourceVersion = (builtins.fromTOML (builtins.readFile "${bcachefs-tools}/Cargo.toml")).package.version;
+      in {
+        # The v1.39.3 tag forgot to bump Cargo.toml. Scope the correction to
+        # that exact source so operator-provided input overrides stay truthful.
+        version = if (bcachefs-tools.rev or null) == "9cc4c780893928cc4f043e4c1110d58bbed28550"
+          then "1.39.3"
+          else sourceVersion;
         src = bcachefs-tools;
         cargoDeps = pkgs.rustPlatform.importCargoLock {
           lockFile = "${bcachefs-tools}/Cargo.lock";
@@ -201,6 +207,11 @@
         # a build-dependency library. rust-bindgen is the wrapped binary
         # with its libclang plumbing included.
         nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ pkgs.rust-bindgen ];
+        # v1.39.3 adds a mount generator. Keep it in this derivation's output
+        # instead of the read-only systemd package returned by pkg-config.
+        makeFlags = (old.makeFlags or []) ++ [
+          "PKGCONFIG_GENERATORDIR=$(out)/lib/systemd/system-generators"
+        ];
       });
     in base.overrideAttrs (old: {
       passthru = old.passthru // {

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.2";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.3";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the

--- a/nixos/tests/bcachefs-smoke.nix
+++ b/nixos/tests/bcachefs-smoke.nix
@@ -20,6 +20,9 @@ pkgs.testers.runNixOSTest {
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
+    machine.succeed("bcachefs version | grep -F 1.39.3")
+    machine.succeed("test -x /etc/systemd/system-generators/bcachefs-mount-generator")
+
     # Format the empty 1 GiB disk and mount it.
     machine.succeed("bcachefs format /dev/vdb")
     machine.succeed("mkdir -p /mnt/test")


### PR DESCRIPTION
## Summary

- bump the bundled bcachefs-tools source and DKMS module from v1.39.2 to v1.39.3
- update the installed-wrapper fallback pin to the same release
- correct the exact v1.39.3 tag reporting 1.39.2 in its unchanged `Cargo.toml`, without changing versions for operator-provided input overrides
- install the release new systemd mount generator into the package output rather than systemd read-only Nix store path
- assert the reported version and generator presence in the bcachefs appliance smoke test

## Upstream packaging notes

The signed v1.39.3 tag resolves to `9cc4c780893928cc4f043e4c1110d58bbed28550`. That tag still declares version 1.39.2 in `Cargo.toml`, so the override is intentionally scoped to this exact revision. The release also adds `bcachefs-mount-generator`; its destination must be overridden for Nix builds, matching upstream own flake fix.

## Verification

- `nix flake check --no-build`
- x86_64 and aarch64 package/config evaluations report `1.39.3`
- a v1.39.2 input override still reports `1.39.2`
- `nix build .#checks.x86_64-linux.bcachefs-smoke --dry-run`
- `nix-instantiate --parse flake.nix`
- `git diff --check`

The actual Linux package/VM build was not run locally because the development host is `aarch64-darwin` and has no Linux builder. CI exercises the Linux package, DKMS module, generator installation, and VM smoke assertions.