### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1788039834,
-        "narHash": "sha256-lbqQ5DT7lX+GSILC7r4xXIG2YXMGC2Hvus59HtWiP5s=",
+        "lastModified": 1788130033,
+        "narHash": "sha256-cnSlmUH+1odSO1knyrXrWUf7EjY9U4n2IlxVKMczB3Y=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "9cc4c780893928cc4f043e4c1110d58bbed28550",
+        "rev": "d997ad76e906ca9cbe1d4045d3880185e504191d",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.3",
+        "ref": "v1.39.4",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.3 release tag.
+    # Pinned to v1.39.4 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.3";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.4";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────
@@ -188,11 +188,7 @@
       base = pkgs.bcachefs-tools.overrideAttrs (old: let
         sourceVersion = (builtins.fromTOML (builtins.readFile "${bcachefs-tools}/Cargo.toml")).package.version;
       in {
-        # The v1.39.3 tag forgot to bump Cargo.toml. Scope the correction to
-        # that exact source so operator-provided input overrides stay truthful.
-        version = if (bcachefs-tools.rev or null) == "9cc4c780893928cc4f043e4c1110d58bbed28550"
-          then "1.39.3"
-          else sourceVersion;
+        version = sourceVersion;
         src = bcachefs-tools;
         cargoDeps = pkgs.rustPlatform.importCargoLock {
           lockFile = "${bcachefs-tools}/Cargo.lock";

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.3";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.4";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the

--- a/nixos/tests/bcachefs-smoke.nix
+++ b/nixos/tests/bcachefs-smoke.nix
@@ -20,7 +20,7 @@ pkgs.testers.runNixOSTest {
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
-    machine.succeed("bcachefs version | grep -F 1.39.3")
+    machine.succeed("bcachefs version | grep -F 1.39.4")
     machine.succeed("test -x /etc/systemd/system-generators/bcachefs-mount-generator")
 
     # Format the empty 1 GiB disk and mount it.


### PR DESCRIPTION
## Summary
- pin the bundled bcachefs tools and DKMS source to upstream v1.39.4
- refresh the bcachefs flake lock entry and wrapper fallback pin
- update the smoke-test version assertion
- remove the v1.39.3-specific Cargo version workaround now that upstream declares 1.39.4 correctly

## Validation
- `nix flake check --no-build`
- x86_64 and aarch64 package evaluations report `1.39.4`
- package source evaluates to upstream commit `d997ad76e906ca9cbe1d4045d3880185e504191d`
- bcachefs smoke-test derivation evaluates successfully

The Linux package and VM smoke test cannot run locally on this aarch64 Darwin host; CI will realize them on Linux.