### PR TITLE
webui: add configurable dashboard

### DIFF
--- a/webui/src/lib/components/dashboard/alerts-widget.svelte
+++ b/webui/src/lib/components/dashboard/alerts-widget.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { ActiveAlert } from '$lib/types';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { CheckCircle2, TriangleAlert } from '@lucide/svelte';
+
+	let { alerts, loaded, density }: { alerts: ActiveAlert[]; loaded: boolean; density: DashboardDensity } = $props();
+</script>
+
+<Card aria-live="polite" class={alerts.some((alert) => alert.severity === 'critical') ? 'border-red-800/80' : ''}>
+	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
+		<CardTitle class="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+			{#if !loaded}
+				<TriangleAlert class="h-4 w-4 text-muted-foreground" /> Alert status unavailable
+			{:else if alerts.length === 0}
+				<CheckCircle2 class="h-4 w-4 text-emerald-400" /> No active alerts
+			{:else}
+				<TriangleAlert class="h-4 w-4 text-amber-400" /> {alerts.length} active alert{alerts.length === 1 ? '' : 's'}
+			{/if}
+		</CardTitle>
+	</CardHeader>
+	{#if loaded && alerts.length > 0}
+		<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+			<div class="space-y-2">
+				{#each alerts as alert}
+					<div class="flex items-start gap-3 rounded-md border px-3 py-2 text-sm {alert.severity === 'critical' ? 'border-red-800 bg-red-950/70 text-red-200' : 'border-amber-800 bg-amber-950/60 text-amber-200'}">
+						<span class="mt-1 h-2 w-2 shrink-0 rounded-full {alert.severity === 'critical' ? 'bg-red-400' : 'bg-amber-400'}"></span>
+						<span class="text-[0.65rem] font-bold uppercase tracking-wide">{alert.severity}</span>
+						<span class="min-w-0 flex-1">{alert.message}</span>
+					</div>
+				{/each}
+			</div>
+		</CardContent>
+	{/if}
+</Card>

--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import {
+		dashboardPresets,
+		dashboardWidgetMeta,
+		defaultDashboardPreferences,
+		type DashboardPreferences,
+		type DashboardPreset,
+	} from '$lib/dashboard.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { ArrowDown, ArrowUp, LayoutDashboard, RotateCcw } from '@lucide/svelte';
+
+	let { open = $bindable(false), preferences, onSave }: {
+		open: boolean;
+		preferences: DashboardPreferences;
+		onSave: (preferences: DashboardPreferences) => void;
+	} = $props();
+
+	let draft = $state<DashboardPreferences>(defaultDashboardPreferences());
+	let wasOpen = false;
+
+	$effect(() => {
+		if (open && !wasOpen) draft = clone(preferences);
+		wasOpen = open;
+	});
+
+	function clone(value: DashboardPreferences): DashboardPreferences {
+		return { ...value, widgets: value.widgets.map((widget) => ({ ...widget })) };
+	}
+
+	function selectPreset(preset: DashboardPreset) {
+		draft = { ...draft, preset };
+	}
+
+	function updateWidget(index: number, patch: Partial<DashboardPreferences['widgets'][number]>) {
+		draft = {
+			...draft,
+			widgets: draft.widgets.map((widget, position) => position === index ? { ...widget, ...patch } : widget),
+		};
+	}
+
+	function moveWidget(index: number, direction: -1 | 1) {
+		const target = index + direction;
+		if (target < 0 || target >= draft.widgets.length) return;
+		const widgets = [...draft.widgets];
+		[widgets[index], widgets[target]] = [widgets[target], widgets[index]];
+		draft = { ...draft, widgets };
+	}
+
+	function resetCustom() {
+		draft = { ...defaultDashboardPreferences(), preset: 'custom' };
+	}
+
+	function save() {
+		onSave(clone(draft));
+		open = false;
+	}
+
+	let canSave = $derived(draft.preset !== 'custom' || draft.widgets.some((widget) => widget.visible));
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="flex max-h-[85vh] w-[94vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+		<Dialog.Header class="border-b border-border px-6 py-5">
+			<Dialog.Title class="flex items-center gap-2"><LayoutDashboard class="h-5 w-5" /> Customize dashboard</Dialog.Title>
+			<Dialog.Description>Choose a focused preset or build a responsive dashboard from predefined widgets.</Dialog.Description>
+		</Dialog.Header>
+
+		<div class="overflow-y-auto px-6 py-5">
+			<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				{#each (Object.entries(dashboardPresets) as [Exclude<DashboardPreset, 'custom'>, (typeof dashboardPresets)[Exclude<DashboardPreset, 'custom'>]][]) as [id, preset]}
+					<button type="button" onclick={() => selectPreset(id)} aria-pressed={draft.preset === id} class="rounded-lg border p-3 text-left transition-colors {draft.preset === id ? 'border-primary bg-primary/10' : 'border-border hover:bg-accent'}">
+						<div class="text-sm font-semibold">{preset.label}</div>
+						<p class="mt-1 text-xs leading-relaxed text-muted-foreground">{preset.description}</p>
+					</button>
+				{/each}
+				<button type="button" onclick={() => selectPreset('custom')} aria-pressed={draft.preset === 'custom'} class="rounded-lg border p-3 text-left transition-colors {draft.preset === 'custom' ? 'border-primary bg-primary/10' : 'border-border hover:bg-accent'}">
+					<div class="text-sm font-semibold">Custom</div>
+					<p class="mt-1 text-xs leading-relaxed text-muted-foreground">Choose visibility, order, width, and density.</p>
+				</button>
+			</div>
+
+			{#if draft.preset === 'custom'}
+				<div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
+					<div><h3 class="text-sm font-semibold">Custom widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets share a row on wide screens and stack on mobile.</p></div>
+					<div class="flex items-center gap-2">
+						<label for="dashboard-density" class="text-xs font-medium text-muted-foreground">Density</label>
+						<select id="dashboard-density" value={draft.density} onchange={(event) => draft = { ...draft, density: (event.currentTarget as HTMLSelectElement).value === 'compact' ? 'compact' : 'comfortable' }} class="h-8 rounded-md border border-border bg-background px-2 text-xs">
+							<option value="comfortable">Comfortable</option><option value="compact">Compact</option>
+						</select>
+					</div>
+				</div>
+
+				<div class="mt-3 divide-y divide-border rounded-lg border border-border">
+					{#each draft.widgets as widget, index (widget.id)}
+						<div class="flex items-center gap-3 px-3 py-2.5">
+							<input type="checkbox" checked={widget.visible} onchange={(event) => updateWidget(index, { visible: (event.currentTarget as HTMLInputElement).checked })} aria-label={`Show ${dashboardWidgetMeta[widget.id].label}`} class="h-4 w-4 accent-primary" />
+							<div class="min-w-0 flex-1"><div class="text-sm font-medium">{dashboardWidgetMeta[widget.id].label}</div><div class="truncate text-xs text-muted-foreground">{dashboardWidgetMeta[widget.id].description}</div></div>
+							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: (event.currentTarget as HTMLSelectElement).value === 'half' ? 'half' : 'full' })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">Half</option></select>
+							<div class="flex">
+								<Button variant="ghost" size="icon-sm" disabled={index === 0} onclick={() => moveWidget(index, -1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp /></Button>
+								<Button variant="ghost" size="icon-sm" disabled={index === draft.widgets.length - 1} onclick={() => moveWidget(index, 1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown /></Button>
+							</div>
+						</div>
+					{/each}
+				</div>
+				{#if !canSave}<p class="mt-2 text-xs text-red-400">Select at least one widget.</p>{/if}
+			{/if}
+		</div>
+
+		<Dialog.Footer class="border-t border-border px-6 py-4">
+			{#if draft.preset === 'custom'}<Button variant="ghost" onclick={resetCustom} class="mr-auto"><RotateCcw /> Reset custom</Button>{/if}
+			<Button variant="outline" onclick={() => open = false}>Cancel</Button>
+			<Button disabled={!canSave} onclick={save}>Apply dashboard</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -82,7 +82,7 @@
 
 			{#if draft.preset === 'custom'}
 				<div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-					<div><h3 class="text-sm font-semibold">Custom widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets share a row on wide screens and stack on mobile.</p></div>
+					<div><h3 class="text-sm font-semibold">Custom widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets pack into open column space on wide screens. Full-width widgets start a new row.</p></div>
 					<div class="flex items-center gap-2">
 						<label for="dashboard-density" class="text-xs font-medium text-muted-foreground">Density</label>
 						<select id="dashboard-density" value={draft.density} onchange={(event) => draft = { ...draft, density: (event.currentTarget as HTMLSelectElement).value === 'compact' ? 'compact' : 'comfortable' }} class="h-8 rounded-md border border-border bg-background px-2 text-xs">

--- a/webui/src/lib/components/dashboard/disk-io-widget.svelte
+++ b/webui/src/lib/components/dashboard/disk-io-widget.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DiskIoStats } from '$lib/types';
+	import { formatBytes } from '$lib/format';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import IoChart from '$lib/components/io-chart.svelte';
+
+	type Rate = { readRate: number; writeRate: number };
+	type Sample = { time: Date; in: number; out: number };
+	let { devices, rates, samples, density }: {
+		devices: DiskIoStats[];
+		rates: Map<string, Rate>;
+		samples: Map<string, Sample[]>;
+		density: DashboardDensity;
+	} = $props();
+</script>
+
+<Card class="h-full">
+	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}><CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Disk I/O</CardTitle></CardHeader>
+	<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+		{#if devices.length === 0}
+			<p class="text-sm text-muted-foreground">No disk activity reported.</p>
+		{:else}
+			<div class="divide-y divide-border">
+				{#each devices as device}
+					{@const rate = rates.get(device.name)}
+					<div class={density === 'compact' ? 'py-2 first:pt-0 last:pb-0' : 'py-2.5 first:pt-0 last:pb-0'}>
+						<div class="mb-1.5 flex items-center gap-2"><span class="text-sm font-semibold">{device.name}</span>{#if device.io_in_progress > 0}<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[0.65rem] font-medium text-amber-500">{device.io_in_progress} active</span>{/if}<span class="ml-auto text-xs tabular-nums text-muted-foreground">{formatBytes(device.read_bytes + device.write_bytes)}</span></div>
+						<div class="mb-2 flex gap-5 text-xs"><span><b class="text-muted-foreground">R</b> <span class="tabular-nums font-semibold">{rate ? `${formatBytes(rate.readRate)}/s` : '-'}</span></span><span><b class="text-muted-foreground">W</b> <span class="tabular-nums font-semibold">{rate ? `${formatBytes(rate.writeRate)}/s` : '-'}</span></span></div>
+						<IoChart samples={samples.get(device.name) ?? []} inLabel="Read" outLabel="Write" inColor="var(--chart-2)" outColor="var(--chart-4)" ariaLabel={`${device.name} disk throughput history`} />
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/history-widget.svelte
+++ b/webui/src/lib/components/dashboard/history-widget.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import IoChart from '$lib/components/io-chart.svelte';
+
+	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
+	type Sample = { time: Date; in: number; out: number };
+
+	let {
+		cpuSamples,
+		memorySamples,
+		range,
+		offset,
+		rangeDuration,
+		density,
+		width,
+		loading,
+		onRange,
+		onBack,
+		onForward,
+		onLive,
+	}: {
+		cpuSamples: Sample[];
+		memorySamples: Sample[];
+		range: MetricsRange;
+		offset: number;
+		rangeDuration: number;
+		density: DashboardDensity;
+		width: DashboardWidgetWidth;
+		loading: boolean;
+		onRange: (range: MetricsRange) => void;
+		onBack: () => void;
+		onForward: () => void;
+		onLive: () => void;
+	} = $props();
+</script>
+
+<div>
+	<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+		<div class="flex items-center gap-2">
+			<span class="text-sm font-semibold">History{loading ? ' - loading' : ''}</span>
+			{#if offset > 0}
+				<span class="text-xs text-muted-foreground">{new Date(Date.now() - offset - rangeDuration).toLocaleString()} - {new Date(Date.now() - offset).toLocaleString()}</span>
+			{/if}
+		</div>
+		<div class="flex max-w-full items-center gap-1 overflow-x-auto pb-1">
+			{#if offset > 0}<button type="button" onclick={onLive} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs font-medium text-primary hover:bg-accent disabled:opacity-40">Live</button>{/if}
+			<button type="button" onclick={onBack} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-40" aria-label="Earlier history">&larr;</button>
+			<div class="flex rounded-md border border-border">
+				{#each (['5m', '1h', '1d', '7d', '30d'] as const) as option}
+					<button type="button" onclick={() => onRange(option)} disabled={loading} aria-pressed={range === option} class="px-2.5 py-1 text-xs font-medium first:rounded-l-md last:rounded-r-md disabled:opacity-40 {range === option ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">{option}</button>
+				{/each}
+			</div>
+			<button type="button" onclick={onForward} disabled={offset === 0 || loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:cursor-default disabled:opacity-30" aria-label="Later history">&rarr;</button>
+		</div>
+	</div>
+	<div class="grid grid-cols-1 gap-3 {width === 'full' ? 'sm:grid-cols-2' : ''}">
+		<Card>
+			<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}><CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle></CardHeader>
+			<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}><IoChart samples={cpuSamples} inLabel="Usage" inColor="var(--chart-3)" yFormat={(value) => value.toFixed(0) + '%'} tooltipFormat={(value) => value.toFixed(1) + '%'} ariaLabel="CPU usage history" emptyMessage={loading ? 'Loading data...' : 'No data for selected interval.'} /></CardContent>
+		</Card>
+		<Card>
+			<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}><CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Memory usage</CardTitle></CardHeader>
+			<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}><IoChart samples={memorySamples} inLabel="Used" inColor="var(--chart-5)" yFormat={(value) => value.toFixed(0) + '%'} tooltipFormat={(value) => value.toFixed(1) + '%'} ariaLabel="Memory usage history" emptyMessage={loading ? 'Loading data...' : 'No data for selected interval.'} /></CardContent>
+		</Card>
+	</div>
+</div>

--- a/webui/src/lib/components/dashboard/network-widget.svelte
+++ b/webui/src/lib/components/dashboard/network-widget.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { NetIfStats } from '$lib/types';
+	import { formatBytes } from '$lib/format';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import IoChart from '$lib/components/io-chart.svelte';
+
+	type Rate = { rxRate: number; txRate: number };
+	type Sample = { time: Date; in: number; out: number };
+	let { interfaces, rates, samples, density }: {
+		interfaces: NetIfStats[];
+		rates: Map<string, Rate>;
+		samples: Map<string, Sample[]>;
+		density: DashboardDensity;
+	} = $props();
+
+	function ipv4(addresses: string[]): string[] {
+		return addresses.filter((address) => !address.includes(':'));
+	}
+</script>
+
+<Card class="h-full">
+	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}><CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Network</CardTitle></CardHeader>
+	<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+		{#if interfaces.length === 0}
+			<p class="text-sm text-muted-foreground">No network interfaces reported.</p>
+		{:else}
+			<div class="divide-y divide-border">
+				{#each interfaces as iface}
+					{@const rate = rates.get(iface.name)}
+					{@const addresses = ipv4(iface.addresses)}
+					<div class={density === 'compact' ? 'py-2 first:pt-0 last:pb-0' : 'py-2.5 first:pt-0 last:pb-0'}>
+						<div class="mb-1.5 flex flex-wrap items-center gap-2"><span class="text-sm font-semibold">{iface.name}</span><span class="h-2 w-2 rounded-full {iface.up ? 'bg-emerald-400' : 'bg-red-400'}"></span><span class="sr-only">{iface.up ? 'up' : 'down'}</span>{#if iface.speed_mbps}<span class="text-xs text-muted-foreground">{iface.speed_mbps >= 1000 ? `${iface.speed_mbps / 1000}G` : `${iface.speed_mbps}M`}</span>{/if}{#if addresses.length > 0}<span class="ml-auto font-mono text-xs">{addresses.join(', ')}</span>{/if}</div>
+						<div class="mb-2 flex gap-5 text-xs"><span><b class="text-muted-foreground">RX</b> <span class="tabular-nums font-semibold">{rate ? `${formatBytes(rate.rxRate)}/s` : '-'}</span></span><span><b class="text-muted-foreground">TX</b> <span class="tabular-nums font-semibold">{rate ? `${formatBytes(rate.txRate)}/s` : '-'}</span></span><span class="ml-auto tabular-nums text-muted-foreground">{formatBytes(iface.rx_bytes + iface.tx_bytes)} total</span></div>
+						<IoChart samples={samples.get(iface.name) ?? []} inLabel="RX" outLabel="TX" inColor="var(--chart-2)" outColor="var(--chart-1)" ariaLabel={`${iface.name} network throughput history`} />
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/operations-widget.svelte
+++ b/webui/src/lib/components/dashboard/operations-widget.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { ActiveOperation } from '$lib/types';
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Activity, CheckCircle2, TriangleAlert } from '@lucide/svelte';
+
+	let { operations, loaded, density }: { operations: ActiveOperation[]; loaded: boolean; density: DashboardDensity } = $props();
+
+	function kindLabel(kind: string): string {
+		return ({ scrub: 'Scrub', evacuate: 'Evacuate', reconcile: 'Reconcile', copygc: 'Copy-GC' } as Record<string, string>)[kind] ?? kind;
+	}
+</script>
+
+<Card>
+	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
+		<CardTitle class="flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-muted-foreground">
+			<span class="flex items-center gap-2">{#if !loaded}<TriangleAlert class="h-4 w-4 text-muted-foreground" />{:else if operations.length > 0}<Activity class="h-4 w-4 text-amber-400" />{:else}<CheckCircle2 class="h-4 w-4 text-emerald-400" />{/if} Active operations</span>
+			<a href="/operations" class="normal-case tracking-normal text-primary hover:underline">Open operations</a>
+		</CardTitle>
+	</CardHeader>
+	<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+		{#if !loaded}
+			<p class="text-sm text-muted-foreground">Operation status is unavailable.</p>
+		{:else if operations.length === 0}
+			<p class="text-sm text-muted-foreground">No scrub, evacuation, or reconciliation work is active.</p>
+		{:else}
+			<div class="grid gap-2 md:grid-cols-2">
+				{#each operations as operation}
+					<div class="rounded-md border border-border px-3 py-2">
+						<div class="flex items-center gap-2"><span class="text-sm font-semibold">{kindLabel(operation.kind)}</span><span class="font-mono text-xs text-muted-foreground">{operation.fs}</span>{#if operation.progress_percent != null}<span class="ml-auto text-xs tabular-nums text-amber-400">{operation.progress_percent.toFixed(0)}%</span>{/if}</div>
+						<p class="mt-1 truncate text-xs text-muted-foreground" title={operation.detail}>{operation.detail}</p>
+						{#if operation.progress_percent != null}<div class="mt-2 h-1.5 overflow-hidden rounded bg-muted"><div class="h-full bg-amber-500" style="width: {Math.max(0, Math.min(100, operation.progress_percent))}%"></div></div>{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/storage-widget.svelte
+++ b/webui/src/lib/components/dashboard/storage-widget.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DiskHealth, Filesystem, FilesystemDevice, FsDeviceUsage, FsUsage } from '$lib/types';
+	import { formatBytes, formatPercent } from '$lib/format';
+	import { formatTemp } from '$lib/temperature.svelte';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Database, TriangleAlert } from '@lucide/svelte';
+
+	type DiskRate = { readRate: number; writeRate: number };
+	let { filesystems, usages, health, rates, density }: {
+		filesystems: Filesystem[];
+		usages: Record<string, FsUsage>;
+		health: DiskHealth[];
+		rates: Map<string, DiskRate>;
+		density: DashboardDensity;
+	} = $props();
+
+	function deviceName(path: string): string {
+		return path.split('/').filter(Boolean).at(-1) ?? path;
+	}
+
+	function usageFor(filesystem: Filesystem, device: FilesystemDevice): FsDeviceUsage | undefined {
+		return usages[filesystem.name]?.devices.find((usage) =>
+			usage.path === device.path || deviceName(usage.path) === deviceName(device.path)
+		);
+	}
+
+	function healthEntriesFor(device: FilesystemDevice): DiskHealth[] {
+		return health.filter((disk) => disk.device === device.path || deviceName(disk.device) === deviceName(device.path));
+	}
+
+	function healthFor(device: FilesystemDevice): DiskHealth | undefined {
+		const matches = healthEntriesFor(device);
+		return matches.length === 1 ? matches[0] : undefined;
+	}
+
+	function smartFailed(device: FilesystemDevice): boolean {
+		return healthEntriesFor(device).some((disk) => disk.smart_status !== 'UNAVAILABLE' && !disk.health_passed);
+	}
+
+	function smartUnavailable(device: FilesystemDevice): boolean {
+		const matches = healthEntriesFor(device);
+		return matches.length > 0 && matches.every((disk) => disk.smart_status === 'UNAVAILABLE');
+	}
+
+	function rateFor(device: FilesystemDevice): DiskRate | undefined {
+		return rates.get(deviceName(device.path));
+	}
+
+	function filesystemState(filesystem: Filesystem): { label: string; className: string } {
+		if (filesystem.devices.some((device) => device.missing)) return { label: 'Missing member', className: 'text-red-400' };
+		if (!filesystem.mounted) return { label: 'Unmounted', className: 'text-amber-400' };
+		if (filesystem.devices.some((device) => device.state === 'failed' || smartFailed(device))) return { label: 'Failed member', className: 'text-red-400' };
+		if (filesystem.devices.some((device) => device.state === 'ro')) return { label: 'Read-only member', className: 'text-amber-400' };
+		if (filesystem.devices.some((device) => device.state === 'evacuating')) return { label: 'Evacuating', className: 'text-amber-400' };
+		if (filesystem.devices.some((device) => (device.read_errors ?? 0) + (device.write_errors ?? 0) + (device.checksum_errors ?? 0) > 0)) return { label: 'Errors recorded', className: 'text-amber-400' };
+		if (filesystem.used_bytes + filesystem.available_bytes <= 0) return { label: 'Capacity unavailable', className: 'text-amber-400' };
+		return { label: 'Healthy', className: 'text-emerald-400' };
+	}
+
+	function deviceState(device: FilesystemDevice): { label: string; className: string } {
+		if (device.missing) return { label: 'missing', className: 'border-red-800 bg-red-950 text-red-300' };
+		if (smartFailed(device)) return { label: 'SMART fail', className: 'border-red-800 bg-red-950 text-red-300' };
+		if (device.state === 'failed') return { label: 'failed', className: 'border-red-800 bg-red-950 text-red-300' };
+		if (device.state === 'evacuating') return { label: 'evacuating', className: 'border-amber-700 bg-amber-950 text-amber-300' };
+		if (device.state === 'ro') return { label: 'ro', className: 'border-amber-700 bg-amber-950 text-amber-300' };
+		if (smartUnavailable(device)) return { label: 'SMART unavailable', className: 'border-border bg-muted text-muted-foreground' };
+		return { label: device.state ?? 'online', className: 'border-emerald-800 bg-emerald-950 text-emerald-300' };
+	}
+
+	function policy(filesystem: Filesystem): string {
+		const data = filesystem.options.erasure_code ? 'EC data' : `Data x${filesystem.options.data_replicas ?? 1}`;
+		return `${data} - Metadata x${filesystem.options.metadata_replicas ?? 1}`;
+	}
+
+	function barColor(percent: number): string {
+		if (percent > 90) return 'bg-red-500';
+		if (percent > 75) return 'bg-amber-500';
+		return 'bg-emerald-500';
+	}
+</script>
+
+<Card class="overflow-hidden">
+	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
+		<CardTitle class="flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-muted-foreground">
+			<span class="flex items-center gap-2"><Database class="h-4 w-4" /> Compact storage</span>
+			<a href="/filesystems" class="normal-case tracking-normal text-primary hover:underline">Manage filesystems</a>
+		</CardTitle>
+	</CardHeader>
+	<CardContent class="p-0">
+		{#if filesystems.length === 0}
+			<div class="px-4 pb-4 text-sm text-muted-foreground">No filesystems configured.</div>
+		{:else}
+			<div class="divide-y divide-border">
+				{#each filesystems as filesystem (filesystem.uuid)}
+					{@const state = filesystemState(filesystem)}
+					{@const userCapacity = filesystem.used_bytes + filesystem.available_bytes}
+					{@const usedPercent = userCapacity > 0 ? filesystem.used_bytes / userCapacity * 100 : 0}
+					<section>
+						<div class="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-muted/35 px-4 py-2.5">
+							<div class="min-w-36"><div class="flex items-center gap-2"><a href="/filesystems" class="font-semibold hover:text-primary">{filesystem.name}</a>{#if state.label !== 'Healthy'}<TriangleAlert class="h-3.5 w-3.5 text-amber-400" />{/if}</div><div class="text-[0.68rem] text-muted-foreground">{policy(filesystem)}</div></div>
+							<div class="min-w-48 flex-1">
+								{#if userCapacity > 0}
+									<div class="mb-1 flex justify-between text-xs tabular-nums"><span>{formatBytes(filesystem.used_bytes)} used</span><span class="text-muted-foreground">{formatBytes(filesystem.available_bytes)} available - {formatPercent(filesystem.used_bytes, userCapacity)}</span></div><div class="h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(usedPercent)}" style="width: {Math.min(100, usedPercent)}%"></div></div>
+								{:else}
+									<div class="text-xs text-muted-foreground">Capacity data unavailable</div>
+								{/if}
+							</div>
+							<span class="text-xs font-medium {state.className}">{state.label}</span>
+						</div>
+						<div class="overflow-x-auto">
+							<table class="w-full min-w-[760px] text-left text-xs">
+								<caption class="sr-only">Storage members for {filesystem.name}</caption>
+								<thead class="text-[0.65rem] uppercase tracking-wide text-muted-foreground"><tr><th class="px-4 py-1.5 font-medium">Device</th><th class="px-3 py-1.5 font-medium">State</th><th class="px-3 py-1.5 text-right font-medium">Raw size</th><th class="px-3 py-1.5 text-right font-medium">Physical allocation</th><th class="px-3 py-1.5 text-right font-medium">Unallocated</th><th class="px-3 py-1.5 text-right font-medium">Read / Write</th><th class="px-4 py-1.5 text-right font-medium">Temp</th></tr></thead>
+								<tbody class="divide-y divide-border/70">
+									{#each filesystem.devices as device (device.uuid ?? device.path)}
+										{@const usage = usageFor(filesystem, device)}
+										{@const disk = healthFor(device)}
+										{@const rate = rateFor(device)}
+										{@const memberState = deviceState(device)}
+										{@const allocationPercent = usage && usage.total_bytes > 0 ? usage.used_bytes / usage.total_bytes * 100 : 0}
+										<tr class="hover:bg-muted/20">
+											<td class={density === 'compact' ? 'px-4 py-1.5' : 'px-4 py-2.5'}><div class="flex items-center gap-2"><span class="font-mono font-semibold">{device.path}</span>{#if device.label}<span class="rounded bg-primary/10 px-1.5 py-0.5 text-[0.65rem] text-primary">{device.label}</span>{/if}</div><div class="mt-0.5 text-[0.65rem] text-muted-foreground">member {device.member_index ?? '-'}{device.durability === 0 ? ' - cache durability' : ''}</div></td>
+											<td class="px-3"><span class="rounded border px-1.5 py-0.5 text-[0.65rem] {memberState.className}">{memberState.label}</span></td>
+											<td class="px-3 text-right tabular-nums">{usage ? formatBytes(usage.total_bytes) : disk ? formatBytes(disk.capacity_bytes) : '-'}</td>
+											<td class="px-3 text-right"><div class="tabular-nums">{usage ? formatBytes(usage.used_bytes) : '-'}</div>{#if usage}<div class="ml-auto mt-1 h-1 w-20 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(allocationPercent)}" style="width: {Math.min(100, allocationPercent)}%"></div></div>{/if}</td>
+											<td class="px-3 text-right tabular-nums text-muted-foreground">{usage ? formatBytes(usage.free_bytes) : '-'}</td>
+											<td class="px-3 text-right tabular-nums"><span class="text-cyan-400">{rate ? formatBytes(rate.readRate) + '/s' : '-'}</span><span class="mx-1 text-muted-foreground">/</span><span class="text-violet-400">{rate ? formatBytes(rate.writeRate) + '/s' : '-'}</span></td>
+											<td class="px-4 text-right font-medium {smartFailed(device) ? 'text-red-400' : disk?.temperature_c != null && disk.temperature_c >= 50 ? 'text-amber-400' : disk?.temperature_c != null ? 'text-emerald-400' : 'text-muted-foreground'}">{formatTemp(disk?.temperature_c ?? null) ?? '-'}</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					</section>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/summary-widget.svelte
+++ b/webui/src/lib/components/dashboard/summary-widget.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import type { Filesystem, SystemStats } from '$lib/types';
+	import { formatBytes, formatPercent } from '$lib/format';
+	import { formatTemp } from '$lib/temperature.svelte';
+	import { Card, CardContent } from '$lib/components/ui/card';
+
+	let { stats, filesystems, density, width }: {
+		stats: SystemStats;
+		filesystems: Filesystem[];
+		density: DashboardDensity;
+		width: DashboardWidgetWidth;
+	} = $props();
+
+	function cpuPercent(): number {
+		return Math.min(100, (stats.cpu.load_1 / stats.cpu.count) * 100);
+	}
+
+	function memoryPercent(): number {
+		return stats.memory.total_bytes > 0 ? (stats.memory.used_bytes / stats.memory.total_bytes) * 100 : 0;
+	}
+
+	function totalStorage(): { used: number; total: number; unknown: number } {
+		return filesystems.reduce((total, filesystem) => {
+			const capacity = Math.max(0, filesystem.used_bytes + filesystem.available_bytes);
+			const known = filesystem.mounted && capacity > 0;
+			return {
+				used: total.used + (known ? Math.max(0, filesystem.used_bytes) : 0),
+				total: total.total + (known ? capacity : 0),
+				unknown: total.unknown + (known ? 0 : 1),
+			};
+		}, { used: 0, total: 0, unknown: 0 });
+	}
+
+	function barColor(percent: number): string {
+		if (percent > 90) return 'bg-red-500';
+		if (percent > 75) return 'bg-amber-500';
+		return 'bg-primary';
+	}
+
+	let storage = $derived(totalStorage());
+</script>
+
+<div class="grid grid-cols-2 gap-3 {width === 'full' ? 'lg:grid-cols-4' : ''}">
+	<Card>
+		<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU load</div>
+			<div class="mt-1 flex items-baseline gap-2"><span class="text-2xl font-bold">{stats.cpu.load_1.toFixed(2)}</span><span class="text-xs text-muted-foreground">/ {stats.cpu.count} cores</span></div>
+			<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(cpuPercent())}" style="width: {cpuPercent()}%"></div></div>
+			<div class="mt-1.5 flex justify-between text-xs tabular-nums text-muted-foreground"><span>5m {stats.cpu.load_5.toFixed(2)}</span><span>15m {stats.cpu.load_15.toFixed(2)}</span></div>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+			<div class="text-xs uppercase tracking-wide text-muted-foreground">Memory</div>
+			<div class="mt-1 flex flex-wrap items-baseline gap-x-2"><span class="text-2xl font-bold">{formatPercent(stats.memory.used_bytes, stats.memory.total_bytes)}</span><span class="text-xs text-muted-foreground">{formatBytes(stats.memory.used_bytes)} / {formatBytes(stats.memory.total_bytes)}</span></div>
+			<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(memoryPercent())}" style="width: {memoryPercent()}%"></div></div>
+			{#if stats.memory.bcachefs_btree_cache_bytes != null}<div class="mt-1.5 truncate text-xs text-muted-foreground" title="Approximate kernel-reported bcachefs btree-node buffers">Btree cache {formatBytes(stats.memory.bcachefs_btree_cache_bytes)}</div>{/if}
+		</CardContent>
+	</Card>
+
+	{#if stats.cpu.temp_c != null || stats.cpu.freq_mhz != null}
+		<Card>
+			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+				<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU</div>
+				<div class="mt-1 text-2xl font-bold">{formatTemp(stats.cpu.temp_c) ?? '-'}</div>
+				<div class="mt-2 text-xs text-muted-foreground">{stats.cpu.freq_mhz != null ? (stats.cpu.freq_mhz >= 1000 ? (stats.cpu.freq_mhz / 1000).toFixed(1) + ' GHz' : stats.cpu.freq_mhz + ' MHz') : ''}{stats.cpu.governor ? ` - ${stats.cpu.governor}` : ''}</div>
+			</CardContent>
+		</Card>
+	{/if}
+
+	{#if filesystems.length > 0}
+		<Card>
+			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+				<div class="text-xs uppercase tracking-wide text-muted-foreground">Storage</div>
+				{#if storage.total > 0}
+					<div class="mt-1 flex flex-wrap items-baseline gap-x-2"><span class="text-2xl font-bold">{formatPercent(storage.used, storage.total)}</span><span class="text-xs text-muted-foreground">{formatBytes(storage.used)} / {formatBytes(storage.total)}</span></div>
+					<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(storage.used / storage.total * 100)}" style="width: {storage.used / storage.total * 100}%"></div></div>
+				{:else}
+					<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
+				{/if}
+				<div class="mt-1.5 text-xs text-muted-foreground">{filesystems.length} filesystem{filesystems.length === 1 ? '' : 's'}{storage.unknown > 0 ? ` - ${storage.unknown} unavailable` : ''}</div>
+			</CardContent>
+		</Card>
+	{/if}
+</div>

--- a/webui/src/lib/components/dashboard/system-widget.svelte
+++ b/webui/src/lib/components/dashboard/system-widget.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { SystemHealth, SystemInfo } from '$lib/types';
+	import { formatBytes, formatUptime } from '$lib/format';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { ChevronDown, ChevronRight } from '@lucide/svelte';
+
+	let {
+		info,
+		health,
+		loaded,
+		density,
+	}: { info: SystemInfo | null; health: SystemHealth | null; loaded: boolean; density: DashboardDensity } = $props();
+	let expanded = $state(false);
+</script>
+
+<Card>
+	<CardContent class={density === 'compact' ? 'py-3' : 'py-4'}>
+		{#if !loaded}
+			<p class="text-sm text-muted-foreground">System status is unavailable.</p>
+		{/if}
+		<div class="flex flex-wrap items-center gap-x-8 gap-y-2">
+			{#if info}
+				<div class="flex items-center gap-2">
+					<span class="text-lg font-bold">{info.hostname}</span>
+					<span class="text-xs text-muted-foreground">v{info.version}</span>
+				</div>
+				<div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+					<span>Kernel {info.kernel}</span>
+					<span>Up {formatUptime(info.uptime_seconds)}</span>
+				</div>
+			{/if}
+			{#if health}
+				<button
+					type="button"
+					onclick={() => expanded = !expanded}
+					class="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-3 transition-opacity hover:opacity-80"
+					aria-expanded={expanded}
+				>
+					<span class="text-sm font-semibold {health.status === 'ok' ? 'text-emerald-400' : 'text-red-400'}">
+						{health.status.toUpperCase()}
+					</span>
+					{#each health.services as service}
+						<span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+							<span class="h-1.5 w-1.5 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
+							{service.name}<span class="sr-only">{service.running ? 'running' : 'down'}</span>
+						</span>
+					{/each}
+					{#if expanded}<ChevronDown class="h-4 w-4" />{:else}<ChevronRight class="h-4 w-4" />{/if}
+				</button>
+			{/if}
+		</div>
+
+		{#if expanded && health}
+			<div class="mt-4 grid grid-cols-1 gap-3 border-t border-border pt-4 sm:grid-cols-2">
+				{#each health.services as service}
+					<div class="rounded-md border border-border p-3">
+						<div class="mb-2 flex items-center justify-between">
+							<div class="flex items-center gap-2">
+								<span class="h-2 w-2 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
+								<span class="text-sm font-medium">{service.name}</span>
+							</div>
+							<span class="rounded-md border px-2 py-0.5 text-xs font-medium {service.running ? 'border-emerald-700 bg-emerald-950 text-emerald-400' : 'border-red-700 bg-red-950 text-red-400'}">
+								{service.running ? 'Running' : 'Down'}
+							</span>
+						</div>
+						{#if service.running && service.pid}
+							<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+								<span class="text-muted-foreground">PID</span><span class="text-right font-mono">{service.pid}</span>
+								<span class="text-muted-foreground">Memory</span><span class="text-right font-mono">{service.memory_bytes != null ? formatBytes(service.memory_bytes) : '-'}</span>
+								<span class="text-muted-foreground">CPU Time</span><span class="text-right font-mono">{service.cpu_seconds != null ? service.cpu_seconds.toFixed(1) + 's' : '-'}</span>
+								<span class="text-muted-foreground">Uptime</span><span class="text-right font-mono">{service.uptime_seconds != null ? formatUptime(service.uptime_seconds) : '-'}</span>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/io-chart.svelte
+++ b/webui/src/lib/components/io-chart.svelte
@@ -13,6 +13,8 @@
 		outColor?: string;
 		yFormat?: (v: number) => string;
 		tooltipFormat?: (v: number) => string;
+		ariaLabel?: string;
+		emptyMessage?: string;
 	}
 
 	let {
@@ -23,6 +25,8 @@
 		outColor = 'var(--chart-2)',
 		yFormat,
 		tooltipFormat = (v: number) => formatBytes(v) + '/s',
+		ariaLabel,
+		emptyMessage = 'Collecting data...',
 	}: Props = $props();
 
 	// Derive the Y-axis formatter from the peak value so all ticks share one unit.
@@ -48,45 +52,60 @@
 					{ key: 'out', label: outLabel!, color: outColor },
 				]
 	);
+
+	const accessibleSummary = $derived.by(() => {
+		const subject = ariaLabel ?? `${inLabel}${outLabel ? ` and ${outLabel}` : ''} history`;
+		if (samples.length === 0) return `${subject}. ${emptyMessage}`;
+		const first = samples[0];
+		const latest = samples.at(-1)!;
+		const peakIn = Math.max(...samples.map((sample) => sample.in));
+		const peakOut = Math.max(...samples.map((sample) => sample.out));
+		const timeRange = `${first.time.toLocaleString()} to ${latest.time.toLocaleString()}`;
+		const values = `${inLabel} latest ${tooltipFormat(latest.in)}, peak ${tooltipFormat(peakIn)}`;
+		const outgoing = outLabel ? `; ${outLabel} latest ${tooltipFormat(latest.out)}, peak ${tooltipFormat(peakOut)}` : '';
+		return `${subject}. ${samples.length} samples from ${timeRange}. ${values}${outgoing}.`;
+	});
 </script>
 
 {#if samples.length >= 2}
-	<Chart.Container config={chartConfig} class="aspect-[4/1] w-full pl-20">
-		<AreaChart
-			data={samples}
-			x="time"
-			xScale={scaleUtc()}
-			{series}
-			props={{
-				area: {
-					curve: curveMonotoneX,
-					'fill-opacity': 0.3,
-					line: { class: 'stroke-1' },
-				},
-				xAxis: {
-					format: (v: Date) => v.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
-					ticks: 4,
-				},
-				yAxis: {
-					format: yFormatDerived,
-					ticks: 3,
-				},
-			}}
-		>
-			{#snippet tooltip()}
-				<Chart.Tooltip
-					labelFormatter={(v: Date) => v.toLocaleTimeString()}
-					indicator="line"
-				>
-					{#snippet formatter({ value })}
-						<span class="text-foreground font-mono font-medium tabular-nums">{tooltipFormat(value as number)}</span>
-					{/snippet}
-				</Chart.Tooltip>
-			{/snippet}
-		</AreaChart>
-	</Chart.Container>
+	<div role="img" aria-label={accessibleSummary}>
+		<Chart.Container config={chartConfig} class="aspect-[4/1] w-full pl-20">
+			<AreaChart
+				data={samples}
+				x="time"
+				xScale={scaleUtc()}
+				{series}
+				props={{
+					area: {
+						curve: curveMonotoneX,
+						'fill-opacity': 0.3,
+						line: { class: 'stroke-1' },
+					},
+					xAxis: {
+						format: (v: Date) => v.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+						ticks: 4,
+					},
+					yAxis: {
+						format: yFormatDerived,
+						ticks: 3,
+					},
+				}}
+			>
+				{#snippet tooltip()}
+					<Chart.Tooltip
+						labelFormatter={(v: Date) => v.toLocaleTimeString()}
+						indicator="line"
+					>
+						{#snippet formatter({ value })}
+							<span class="text-foreground font-mono font-medium tabular-nums">{tooltipFormat(value as number)}</span>
+						{/snippet}
+					</Chart.Tooltip>
+				{/snippet}
+			</AreaChart>
+		</Chart.Container>
+	</div>
 {:else}
-	<div class="flex h-16 items-center justify-center text-xs text-muted-foreground">
-		Collecting data...
+	<div class="flex h-16 items-center justify-center text-xs text-muted-foreground" role="status">
+		{emptyMessage}
 	</div>
 {/if}

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import {
+	DASHBOARD_PREFERENCES_KEY,
+	dashboardPrefs,
+	defaultDashboardPreferences,
+	parseDashboardPreferences,
+	resolveDashboardDensity,
+	resolveDashboardWidgets,
+} from './dashboard.svelte';
+
+beforeEach(() => {
+	localStorage.clear();
+	dashboardPrefs.reset();
+});
+
+describe('dashboard preferences', () => {
+	test('defaults missing, malformed, and unknown versions to overview', () => {
+		expect(parseDashboardPreferences(null).preset).toBe('overview');
+		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":2,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+	});
+
+	test('normalizes custom widgets without losing newly added widget ids', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 1,
+			preset: 'custom',
+			density: 'compact',
+			widgets: [
+				{ id: 'storage', visible: false, width: 'half' },
+				{ id: 'storage', visible: true, width: 'full' },
+				{ id: 'unknown', visible: true, width: 'full' },
+			],
+		}));
+
+		expect(parsed.widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half' });
+		expect(new Set(parsed.widgets.map((widget) => widget.id)).size).toBe(8);
+		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
+		expect(resolveDashboardDensity(parsed)).toBe('compact');
+	});
+
+	test('resolves fixed presets independently from custom widget choices', () => {
+		const preferences = defaultDashboardPreferences();
+		preferences.preset = 'storage';
+		preferences.widgets = preferences.widgets.map((widget) => ({ ...widget, visible: false }));
+
+		expect(resolveDashboardWidgets(preferences).map((widget) => widget.id)).toEqual([
+			'alerts', 'system', 'operations', 'storage',
+		]);
+		expect(resolveDashboardDensity(preferences)).toBe('compact');
+	});
+
+	test('persists a versioned custom layout', () => {
+		const preferences = defaultDashboardPreferences();
+		preferences.preset = 'custom';
+		preferences.density = 'compact';
+		preferences.widgets[0].visible = false;
+		dashboardPrefs.set(preferences);
+
+		expect(dashboardPrefs.value.preset).toBe('custom');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 1,
+			preset: 'custom',
+			density: 'compact',
+		});
+	});
+});

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	parseDashboardPreferences,
 	resolveDashboardDensity,
 	resolveDashboardWidgets,
+	swapDashboardWidgets,
 } from './dashboard.svelte';
 
 beforeEach(() => {
@@ -62,5 +63,16 @@ describe('dashboard preferences', () => {
 			preset: 'custom',
 			density: 'compact',
 		});
+	});
+
+	test('swaps custom widgets without mutating the saved layout', () => {
+		const preferences = defaultDashboardPreferences();
+		const swapped = swapDashboardWidgets(preferences.widgets, 'alerts', 'storage');
+
+		expect(swapped.map((widget) => widget.id)).toEqual([
+			'storage', 'system', 'summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
+		]);
+		expect(preferences.widgets[0].id).toBe('alerts');
+		expect(swapDashboardWidgets(preferences.widgets, 'alerts', 'alerts')).not.toBe(preferences.widgets);
 	});
 });

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,0 +1,177 @@
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
+export const DASHBOARD_PREFERENCES_VERSION = 1;
+
+export const dashboardWidgetIds = [
+	'alerts',
+	'system',
+	'summary',
+	'operations',
+	'storage',
+	'history',
+	'network',
+	'disk_io',
+] as const;
+
+export type DashboardWidgetId = (typeof dashboardWidgetIds)[number];
+export type DashboardPreset = 'overview' | 'storage' | 'monitoring' | 'custom';
+export type DashboardDensity = 'comfortable' | 'compact';
+export type DashboardWidgetWidth = 'half' | 'full';
+
+export interface DashboardWidgetConfig {
+	id: DashboardWidgetId;
+	visible: boolean;
+	width: DashboardWidgetWidth;
+}
+
+export interface DashboardPreferences {
+	version: typeof DASHBOARD_PREFERENCES_VERSION;
+	preset: DashboardPreset;
+	density: DashboardDensity;
+	widgets: DashboardWidgetConfig[];
+}
+
+export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string }> = {
+	alerts: { label: 'Alerts', description: 'Active warnings and critical conditions.' },
+	system: { label: 'System status', description: 'Host identity, uptime, and service health.' },
+	summary: { label: 'Resource summary', description: 'CPU, memory, temperature, and total storage.' },
+	operations: { label: 'Active operations', description: 'Scrubs, evacuations, and reconciliation work.' },
+	storage: { label: 'Compact storage', description: 'Filesystems and member devices in a dense table.' },
+	history: { label: 'CPU and memory history', description: 'Resource history for the selected time range.' },
+	network: { label: 'Network', description: 'Interface status, throughput, and traffic history.' },
+	disk_io: { label: 'Disk I/O', description: 'Per-device read and write activity.' },
+};
+
+const defaultCustomWidgets: DashboardWidgetConfig[] = [
+	{ id: 'alerts', visible: true, width: 'full' },
+	{ id: 'system', visible: true, width: 'full' },
+	{ id: 'summary', visible: true, width: 'full' },
+	{ id: 'operations', visible: true, width: 'full' },
+	{ id: 'storage', visible: true, width: 'full' },
+	{ id: 'history', visible: true, width: 'full' },
+	{ id: 'network', visible: true, width: 'half' },
+	{ id: 'disk_io', visible: true, width: 'half' },
+];
+
+type FixedPreset = Exclude<DashboardPreset, 'custom'>;
+
+export const dashboardPresets: Record<FixedPreset, {
+	label: string;
+	description: string;
+	density: DashboardDensity;
+	widgets: DashboardWidgetConfig[];
+}> = {
+	overview: {
+		label: 'Overview',
+		description: 'The balanced system and performance dashboard.',
+		density: 'comfortable',
+		widgets: defaultCustomWidgets.filter((widget) => widget.id !== 'storage' && widget.id !== 'operations'),
+	},
+	storage: {
+		label: 'Storage Compact',
+		description: 'A dense one-page view of filesystems and member disks.',
+		density: 'compact',
+		widgets: defaultCustomWidgets.filter((widget) =>
+			['alerts', 'system', 'operations', 'storage'].includes(widget.id)
+		),
+	},
+	monitoring: {
+		label: 'Monitoring',
+		description: 'Resource history and live network and disk activity.',
+		density: 'comfortable',
+		widgets: defaultCustomWidgets.filter((widget) => widget.id !== 'storage' && widget.id !== 'system'),
+	},
+};
+
+function cloneWidgets(widgets: DashboardWidgetConfig[]): DashboardWidgetConfig[] {
+	return widgets.map((widget) => ({ ...widget }));
+}
+
+export function defaultDashboardPreferences(): DashboardPreferences {
+	return {
+		version: DASHBOARD_PREFERENCES_VERSION,
+		preset: 'overview',
+		density: 'comfortable',
+		widgets: cloneWidgets(defaultCustomWidgets),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
+	const fallback = defaultDashboardPreferences();
+	if (!isRecord(value) || value.version !== DASHBOARD_PREFERENCES_VERSION) return fallback;
+
+	const preset = value.preset;
+	if (preset !== 'overview' && preset !== 'storage' && preset !== 'monitoring' && preset !== 'custom') {
+		return fallback;
+	}
+	const density = value.density === 'compact' ? 'compact' : 'comfortable';
+	const configured = Array.isArray(value.widgets) ? value.widgets : [];
+	const byId = new Map<DashboardWidgetId, DashboardWidgetConfig>();
+	for (const candidate of configured) {
+		if (!isRecord(candidate) || !dashboardWidgetIds.includes(candidate.id as DashboardWidgetId)) continue;
+		const id = candidate.id as DashboardWidgetId;
+		if (byId.has(id)) continue;
+		byId.set(id, {
+			id,
+			visible: candidate.visible !== false,
+			width: candidate.width === 'half' ? 'half' : 'full',
+		});
+	}
+
+	const widgets = [...byId.values()];
+	for (const widget of defaultCustomWidgets) {
+		if (!byId.has(widget.id)) widgets.push({ ...widget });
+	}
+
+	return { version: DASHBOARD_PREFERENCES_VERSION, preset, density, widgets };
+}
+
+export function parseDashboardPreferences(raw: string | null): DashboardPreferences {
+	if (!raw) return defaultDashboardPreferences();
+	try {
+		return normalizeDashboardPreferences(JSON.parse(raw));
+	} catch {
+		return defaultDashboardPreferences();
+	}
+}
+
+export function resolveDashboardWidgets(preferences: DashboardPreferences): DashboardWidgetConfig[] {
+	const widgets = preferences.preset === 'custom'
+		? preferences.widgets
+		: dashboardPresets[preferences.preset].widgets;
+	return cloneWidgets(widgets).filter((widget) => widget.visible);
+}
+
+export function resolveDashboardDensity(preferences: DashboardPreferences): DashboardDensity {
+	return preferences.preset === 'custom'
+		? preferences.density
+		: dashboardPresets[preferences.preset].density;
+}
+
+function createDashboardPrefs() {
+	let value = $state<DashboardPreferences>(parseDashboardPreferences(
+		typeof localStorage !== 'undefined' ? localStorage.getItem(DASHBOARD_PREFERENCES_KEY) : null
+	));
+
+	function set(next: DashboardPreferences) {
+		value = normalizeDashboardPreferences(next);
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(value));
+		}
+	}
+
+	return {
+		get value() {
+			return value;
+		},
+		set,
+		reset() {
+			set(defaultDashboardPreferences());
+		},
+	};
+}
+
+export const dashboardPrefs = createDashboardPrefs();

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -151,6 +151,20 @@ export function resolveDashboardDensity(preferences: DashboardPreferences): Dash
 		: dashboardPresets[preferences.preset].density;
 }
 
+export function swapDashboardWidgets(
+	widgets: DashboardWidgetConfig[],
+	source: DashboardWidgetId,
+	target: DashboardWidgetId,
+): DashboardWidgetConfig[] {
+	const sourceIndex = widgets.findIndex((widget) => widget.id === source);
+	const targetIndex = widgets.findIndex((widget) => widget.id === target);
+	if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) return cloneWidgets(widgets);
+
+	const next = cloneWidgets(widgets);
+	[next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+	return next;
+}
+
 function createDashboardPrefs() {
 	let value = $state<DashboardPreferences>(parseDashboardPreferences(
 		typeof localStorage !== 'undefined' ? localStorage.getItem(DASHBOARD_PREFERENCES_KEY) : null

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -7,8 +7,10 @@
 	import {
 		dashboardPrefs,
 		dashboardPresets,
+		dashboardWidgetMeta,
 		resolveDashboardDensity,
 		resolveDashboardWidgets,
+		swapDashboardWidgets,
 		type DashboardPreferences,
 		type DashboardWidgetId,
 		type DashboardWidgetWidth,
@@ -37,7 +39,7 @@
 	import StorageWidget from '$lib/components/dashboard/storage-widget.svelte';
 	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
 	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
-	import { Settings2 } from '@lucide/svelte';
+	import { ArrowDown, ArrowUp, GripVertical, Settings2 } from '@lucide/svelte';
 
 	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
 	type DiskRate = { readRate: number; writeRate: number };
@@ -92,6 +94,9 @@
 	let memorySamples = $state<ChartSample[]>([]);
 	let historyLoading = $state(false);
 	let historyRequest = 0;
+	let draggedWidget = $state<DashboardWidgetId | null>(null);
+	let dragTargetWidget = $state<DashboardWidgetId | null>(null);
+	let movementAnnouncement = $state('');
 
 	const networkHistory = createIoHistory();
 	const diskHistory = createIoHistory();
@@ -120,6 +125,70 @@
 
 	function widgetClass(width: DashboardWidgetWidth): string {
 		return width === 'full' ? 'min-w-0 xl:col-span-2' : 'min-w-0 xl:col-span-1';
+	}
+
+	function masonryItem(node: HTMLElement) {
+		let frame = 0;
+		const update = () => {
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(() => {
+				const gridStyle = getComputedStyle(node.parentElement!);
+				const rowHeight = Number.parseFloat(gridStyle.gridAutoRows) || 8;
+				const gap = Number.parseFloat(gridStyle.rowGap) || 0;
+				const rows = Math.ceil((node.getBoundingClientRect().height + gap) / (rowHeight + gap));
+				node.style.gridRowEnd = `span ${Math.max(1, rows)}`;
+			});
+		};
+		const observer = new ResizeObserver(update);
+		observer.observe(node);
+		update();
+		return {
+			destroy() {
+				cancelAnimationFrame(frame);
+				observer.disconnect();
+			},
+		};
+	}
+
+	function swapCustomWidgets(source: DashboardWidgetId, target: DashboardWidgetId) {
+		const preferences = dashboardPrefs.value;
+		if (preferences.preset !== 'custom' || source === target) return;
+		dashboardPrefs.set({
+			...preferences,
+			widgets: swapDashboardWidgets(preferences.widgets, source, target),
+		});
+		movementAnnouncement = `${dashboardWidgetMeta[source].label} swapped with ${dashboardWidgetMeta[target].label}.`;
+	}
+
+	function moveCustomWidget(id: DashboardWidgetId, direction: -1 | 1) {
+		const index = widgets.findIndex((widget) => widget.id === id);
+		const target = widgets[index + direction];
+		if (index < 0 || !target) return;
+		swapCustomWidgets(id, target.id);
+	}
+
+	function startWidgetDrag(event: DragEvent, id: DashboardWidgetId) {
+		draggedWidget = id;
+		event.dataTransfer?.setData('text/plain', id);
+		if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+	}
+
+	function targetWidgetDrag(event: DragEvent, id: DashboardWidgetId) {
+		if (!draggedWidget || draggedWidget === id) return;
+		event.preventDefault();
+		dragTargetWidget = id;
+		if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+	}
+
+	function dropWidget(event: DragEvent, target: DashboardWidgetId) {
+		event.preventDefault();
+		if (draggedWidget) swapCustomWidgets(draggedWidget, target);
+		endWidgetDrag();
+	}
+
+	function endWidgetDrag() {
+		draggedWidget = null;
+		dragTargetWidget = null;
 	}
 
 	function handleEvent(_: string, params: unknown) {
@@ -409,6 +478,7 @@
 	</div>
 	<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
 </div>
+<div class="sr-only" aria-live="polite">{movementAnnouncement}</div>
 
 {#if filesystemsLoaded && filesystems.length === 0}
 	<Card class="mb-4 border-primary/30 bg-primary/5">
@@ -422,9 +492,24 @@
 {#if loading}
 	<Card><CardContent class="py-10 text-center text-sm text-muted-foreground">Loading dashboard...</CardContent></Card>
 {:else}
-	<div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+	<div class="grid grid-cols-1 auto-rows-[8px] gap-4 xl:grid-cols-2">
 		{#each widgets as widget (widget.id)}
-			<div class={widgetClass(widget.width)}>
+			<div
+				use:masonryItem
+				role="group"
+				aria-label={dashboardWidgetMeta[widget.id].label}
+				class="self-start rounded-lg transition-shadow {widgetClass(widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
+				ondragover={(event) => targetWidgetDrag(event, widget.id)}
+				ondrop={(event) => dropWidget(event, widget.id)}
+			>
+				{#if dashboardPrefs.value.preset === 'custom'}
+					<div class="mb-1 flex items-center justify-end gap-1 text-muted-foreground">
+						<span class="mr-auto text-[0.65rem] font-medium uppercase tracking-wide">{dashboardWidgetMeta[widget.id].label}</span>
+						<button type="button" onclick={() => moveCustomWidget(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
+						<button type="button" onclick={() => moveCustomWidget(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
+						<button type="button" draggable={true} onclick={() => moveCustomWidget(widget.id, widgets.at(-1)?.id === widget.id ? -1 : 1)} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="cursor-grab rounded p-1 hover:bg-accent hover:text-foreground active:cursor-grabbing" aria-label={`Drag ${dashboardWidgetMeta[widget.id].label} to swap positions, or activate to move it ${widgets.at(-1)?.id === widget.id ? 'earlier' : 'later'}`} title="Drag to swap positions"><GripVertical class="h-3.5 w-3.5" /></button>
+					</div>
+				{/if}
 				{#if widget.id === 'alerts'}
 					<AlertsWidget {alerts} loaded={alertsLoaded} {density} />
 				{:else if widget.id === 'system'}

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -1,613 +1,452 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { getClient } from '$lib/client';
-	import { formatBytes, formatUptime, formatPercent } from '$lib/format';
-	import { formatTemp } from '$lib/temperature.svelte';
-	import { withToast } from '$lib/toast.svelte';
-	import type { SystemInfo, SystemHealth, SystemStats, Filesystem, DiskHealth, DiskIoStats, NetIfStats, ActiveAlert, Settings, ResourceHistory } from '$lib/types';
-	import { Button } from '$lib/components/ui/button';
-	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
-	import { Badge } from '$lib/components/ui/badge';
-	import { createIoHistory } from '$lib/history.svelte';
-	import IoChart from '$lib/components/io-chart.svelte';
+	import { onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { ChevronDown, ChevronRight } from '@lucide/svelte';
+	import { getClient } from '$lib/client';
+	import { withToast } from '$lib/toast.svelte';
+	import { createIoHistory } from '$lib/history.svelte';
+	import {
+		dashboardPrefs,
+		dashboardPresets,
+		resolveDashboardDensity,
+		resolveDashboardWidgets,
+		type DashboardPreferences,
+		type DashboardWidgetId,
+		type DashboardWidgetWidth,
+	} from '$lib/dashboard.svelte';
+	import type {
+		ActiveAlert,
+		DiskHealth,
+		DiskIoStats,
+		Filesystem,
+		FsUsage,
+		NetIfStats,
+		ResourceHistory,
+		SystemHealth,
+		SystemInfo,
+		SystemStats,
+		SystemStatus,
+	} from '$lib/types';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import AlertsWidget from '$lib/components/dashboard/alerts-widget.svelte';
+	import CustomizeDialog from '$lib/components/dashboard/customize-dialog.svelte';
+	import DiskIoWidget from '$lib/components/dashboard/disk-io-widget.svelte';
+	import HistoryWidget from '$lib/components/dashboard/history-widget.svelte';
+	import NetworkWidget from '$lib/components/dashboard/network-widget.svelte';
+	import OperationsWidget from '$lib/components/dashboard/operations-widget.svelte';
+	import StorageWidget from '$lib/components/dashboard/storage-widget.svelte';
+	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
+	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
+	import { Settings2 } from '@lucide/svelte';
 
-	let info: SystemInfo | null = $state(null);
-	let healthExpanded = $state(false);
-	let health: SystemHealth | null = $state(null);
-	let stats: SystemStats | null = $state(null);
-	let filesystems: Filesystem[] = $state([]);
-	let settings: Settings | null = $state(null);
-	let alerts: ActiveAlert[] = $state([]);
-	let refreshTimer: ReturnType<typeof setInterval> | null = null;
-	let metricsRange = $state<'5m' | '1h' | '1d' | '7d' | '30d'>('5m');
-	let metricsOffset = $state(0); // ms into the past, 0 = live
-
-	const rangeDurations: Record<string, number> = {
-		'5m': 300_000, '1h': 3_600_000, '1d': 86_400_000, '7d': 604_800_000, '30d': 2_592_000_000,
-	};
-
-	let prevDiskIo: DiskIoStats[] = $state([]);
-	let prevNetIo: NetIfStats[] = $state([]);
-	let prevSampleTime = $state(0);
-	let diskIoRates: Map<string, { readRate: number; writeRate: number }> = $state(new Map());
-	let netIoRates: Map<string, { rxRate: number; txRate: number }> = $state(new Map());
-	let netSamples: Map<string, { time: Date; in: number; out: number }[]> = $state(new Map());
-	let diskSamples: Map<string, { time: Date; in: number; out: number }[]> = $state(new Map());
-	let cpuChartSamples: { time: Date; in: number; out: number }[] = $state([]);
-	let memChartSamples: { time: Date; in: number; out: number }[] = $state([]);
-
-	const netHistory = createIoHistory();
-	const diskHistory = createIoHistory();
-	const cpuHistory = createIoHistory();
-	const memHistory = createIoHistory();
+	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
+	type DiskRate = { readRate: number; writeRate: number };
+	type NetworkRate = { rxRate: number; txRate: number };
+	type ChartSample = { time: Date; in: number; out: number };
 
 	const client = getClient();
+	const rangeDurations: Record<MetricsRange, number> = {
+		'5m': 300_000,
+		'1h': 3_600_000,
+		'1d': 86_400_000,
+		'7d': 604_800_000,
+		'30d': 2_592_000_000,
+	};
+
+	let info = $state<SystemInfo | null>(null);
+	let health = $state<SystemHealth | null>(null);
+	let stats = $state<SystemStats | null>(null);
+	let filesystems = $state<Filesystem[]>([]);
+	let alerts = $state<ActiveAlert[]>([]);
+	let systemStatus = $state<SystemStatus | null>(null);
+	let diskHealth = $state<DiskHealth[]>([]);
+	let filesystemUsages = $state<Record<string, FsUsage>>({});
+	let loading = $state(true);
+	let filesystemsLoaded = $state(false);
+	let infoLoaded = $state(false);
+	let healthLoaded = $state(false);
+	let alertsLoaded = $state(false);
+	let operationsLoaded = $state(false);
+	let customizeOpen = $state(false);
+	let refreshTimer: ReturnType<typeof setInterval> | null = null;
+	let refreshTick = 0;
+	let refreshInFlight = false;
+	let filesystemRequest = 0;
+	let storageRequest = 0;
+	let statsRequest = 0;
+	let infoRequest = 0;
+	let healthRequest = 0;
+	let alertsRequest = 0;
+	let operationsRequest = 0;
+
+	let metricsRange = $state<MetricsRange>('5m');
+	let metricsOffset = $state(0);
+	let previousDiskIo = $state<DiskIoStats[]>([]);
+	let previousNetworkIo = $state<NetIfStats[]>([]);
+	let previousSampleTime = $state(0);
+	let diskRates = $state<Map<string, DiskRate>>(new Map());
+	let networkRates = $state<Map<string, NetworkRate>>(new Map());
+	let networkSamples = $state<Map<string, ChartSample[]>>(new Map());
+	let diskSamples = $state<Map<string, ChartSample[]>>(new Map());
+	let cpuSamples = $state<ChartSample[]>([]);
+	let memorySamples = $state<ChartSample[]>([]);
+	let historyLoading = $state(false);
+	let historyRequest = 0;
+
+	const networkHistory = createIoHistory();
+	const diskHistory = createIoHistory();
+	const cpuHistory = createIoHistory();
+	const memoryHistory = createIoHistory();
+
+	let widgets = $derived(resolveDashboardWidgets(dashboardPrefs.value));
+	let density = $derived(resolveDashboardDensity(dashboardPrefs.value));
+	let presetLabel = $derived(
+		dashboardPrefs.value.preset === 'custom'
+			? 'Custom'
+			: dashboardPresets[dashboardPrefs.value.preset].label
+	);
+
+	function hasWidget(id: DashboardWidgetId): boolean {
+		return widgets.some((widget) => widget.id === id);
+	}
+
+	function needsStats(): boolean {
+		return widgets.some((widget) => ['summary', 'storage', 'history', 'network', 'disk_io'].includes(widget.id));
+	}
+
+	function needsMetricsHistory(): boolean {
+		return widgets.some((widget) => ['history', 'network', 'disk_io'].includes(widget.id));
+	}
+
+	function widgetClass(width: DashboardWidgetWidth): string {
+		return width === 'full' ? 'min-w-0 xl:col-span-2' : 'min-w-0 xl:col-span-1';
+	}
+
+	function handleEvent(_: string, params: unknown) {
+		const event = params as { collection?: string };
+		if (event?.collection === 'filesystem') void loadFilesystemData();
+	}
 
 	onMount(() => {
-		loadAll();
-		refreshTimer = setInterval(refreshStats, 15000);
-		return () => { if (refreshTimer) clearInterval(refreshTimer); };
+		client.onEvent(handleEvent);
+		void loadVisibleData(true).finally(() => loading = false);
+		refreshTimer = setInterval(refreshVisibleData, 15_000);
+		return () => {
+			client.offEvent(handleEvent);
+			if (refreshTimer) clearInterval(refreshTimer);
+		};
 	});
 
-	async function loadAll() {
-		await withToast(async () => {
-			[info, health, stats, filesystems, settings, alerts] = await Promise.all([
-				client.call<SystemInfo>('system.info'),
-				client.call<SystemHealth>('system.health'),
-				client.call<SystemStats>('system.stats'),
-				client.call<Filesystem[]>('fs.list'),
-				client.call<Settings>('system.settings.get'),
-				client.call<ActiveAlert[]>('system.alerts'),
-			]);
-		});
-		if (stats) {
-			prevDiskIo = stats.disk_io;
-			prevNetIo = stats.network;
-			prevSampleTime = Date.now();
+	async function loadVisibleData(showErrors: boolean) {
+		const load = async () => {
+			const tasks: Promise<unknown>[] = [
+				fetchFilesystemInventory(),
+			];
+			if (hasWidget('system')) {
+				tasks.push(loadSystemInfo());
+				tasks.push(loadSystemHealth());
+			}
+			if (needsStats()) {
+				const request = ++statsRequest;
+				tasks.push(client.call<SystemStats>('system.stats').then((value) => {
+					if (request !== statsRequest) return;
+					stats = value;
+					previousDiskIo = value.disk_io;
+					previousNetworkIo = value.network;
+					previousSampleTime = Date.now();
+				}));
+			}
+			if (hasWidget('alerts')) tasks.push(loadAlerts());
+			if (hasWidget('operations')) tasks.push(loadOperations());
+			const results = await Promise.allSettled(tasks);
+			if (hasWidget('storage')) await loadStorageDetails();
+			if (needsMetricsHistory()) await loadMetrics();
+			const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+			if (failure) throw failure.reason;
+		};
+
+		if (showErrors) await withToast(load);
+		else {
+			try { await load(); } catch { /* Keep the last good widget data. */ }
 		}
-		// Load history in the background — don't block dashboard rendering
-		loadMetrics();
 	}
 
-	function applyHistory(netHist: ResourceHistory[], diskHist: ResourceHistory[], cpuHist: ResourceHistory[], memHist: ResourceHistory[]) {
-		netHistory.clear();
-		diskHistory.clear();
-		cpuHistory.clear();
-		memHistory.clear();
-
-		for (const rh of netHist) {
-			for (const s of rh.samples) {
-				netHistory.push(rh.name, new Date(s.ts), s.in_rate, s.out_rate);
-			}
-		}
-		for (const rh of diskHist) {
-			for (const s of rh.samples) {
-				diskHistory.push(rh.name, new Date(s.ts), s.in_rate, s.out_rate);
-			}
-		}
-		for (const rh of cpuHist) {
-			for (const s of rh.samples) {
-				cpuHistory.push('cpu', new Date(s.ts), s.in_rate, 0);
-			}
-		}
-		for (const rh of memHist) {
-			for (const s of rh.samples) {
-				memHistory.push('mem', new Date(s.ts), s.in_rate, 0);
-			}
-		}
-		if (stats) {
-			netSamples = new Map(
-				stats.network.map(n => [n.name, [...netHistory.getSamples(n.name)]])
-			);
-			diskSamples = new Map(
-				stats.disk_io.map(d => [d.name, [...diskHistory.getSamples(d.name)]])
-			);
-		}
-		cpuChartSamples = [...cpuHistory.getSamples('cpu')];
-		memChartSamples = [...memHistory.getSamples('mem')];
+	async function fetchFilesystemInventory() {
+		const request = ++filesystemRequest;
+		const value = await client.call<Filesystem[]>('fs.list');
+		if (request !== filesystemRequest) return;
+		filesystems = value;
+		filesystemsLoaded = true;
 	}
 
-	async function loadMetrics() {
+	async function loadSystemInfo() {
+		const request = ++infoRequest;
+		const value = await client.call<SystemInfo>('system.info');
+		if (request !== infoRequest) return;
+		info = value;
+		infoLoaded = true;
+	}
+
+	async function loadSystemHealth() {
+		const request = ++healthRequest;
+		const value = await client.call<SystemHealth>('system.health');
+		if (request !== healthRequest) return;
+		health = value;
+		healthLoaded = true;
+	}
+
+	async function loadAlerts() {
+		const request = ++alertsRequest;
+		const value = await client.call<ActiveAlert[]>('system.alerts');
+		if (request !== alertsRequest) return;
+		alerts = value;
+		alertsLoaded = true;
+	}
+
+	async function loadOperations() {
+		const request = ++operationsRequest;
+		const value = await client.call<SystemStatus>('system.status');
+		if (request !== operationsRequest) return;
+		systemStatus = value;
+		operationsLoaded = true;
+	}
+
+	async function loadFilesystemData() {
+		try {
+			await fetchFilesystemInventory();
+			if (hasWidget('storage')) await loadStorageDetails();
+		} catch { /* Keep the last good filesystem inventory. */ }
+	}
+
+	async function loadStorageDetails() {
+		const request = ++storageRequest;
+		const mountedFilesystems = filesystems.filter((filesystem) => filesystem.mounted);
+		const [freshHealth, usageEntries] = await Promise.all([
+			client.call<DiskHealth[]>('system.disks').catch(() => null),
+			Promise.all(mountedFilesystems.map(async (filesystem) => {
+				try {
+					return [filesystem.name, await client.call<FsUsage>('fs.usage', { name: filesystem.name })] as const;
+				} catch {
+					return null;
+				}
+			})),
+		]);
+		if (request !== storageRequest) return;
+		if (freshHealth) diskHealth = freshHealth;
+		const mountedNames = new Set(mountedFilesystems.map((filesystem) => filesystem.name));
+		const retainedUsages = Object.fromEntries(Object.entries(filesystemUsages).filter(([name]) => mountedNames.has(name)));
+		filesystemUsages = {
+			...retainedUsages,
+			...Object.fromEntries(usageEntries.filter((entry): entry is readonly [string, FsUsage] => entry !== null)),
+		};
+	}
+
+	async function refreshVisibleData() {
+		if (refreshInFlight) return;
+		refreshInFlight = true;
+		refreshTick += 1;
+		try {
+			const tasks: Promise<unknown>[] = [];
+			if (needsStats()) tasks.push(refreshStats());
+			if (hasWidget('alerts')) tasks.push(loadAlerts());
+			if (hasWidget('operations')) tasks.push(loadOperations());
+			if (hasWidget('system') && refreshTick % 4 === 0) {
+				tasks.push(loadSystemHealth());
+				if (!infoLoaded) tasks.push(loadSystemInfo());
+			}
+			if (refreshTick % 4 === 0) tasks.push(loadFilesystemData());
+			else if (hasWidget('storage') && refreshTick % 2 === 0) tasks.push(loadStorageDetails());
+			await Promise.all(tasks);
+		} catch {
+			/* Polling is best effort. */
+		} finally {
+			refreshInFlight = false;
+		}
+	}
+
+	async function refreshStats() {
+		const request = ++statsRequest;
+		const next = await client.call<SystemStats>('system.stats');
+		if (request !== statsRequest) return;
+		const now = Date.now();
+		const elapsed = (now - previousSampleTime) / 1000;
+		const sampleTime = new Date(now);
+
+		if (previousSampleTime > 0 && elapsed > 0) {
+			const nextDiskRates = new Map<string, DiskRate>();
+			for (const current of next.disk_io) {
+				const previous = previousDiskIo.find((device) => device.name === current.name);
+				if (!previous) continue;
+				const readRate = Math.max(0, (current.read_bytes - previous.read_bytes) / elapsed);
+				const writeRate = Math.max(0, (current.write_bytes - previous.write_bytes) / elapsed);
+				nextDiskRates.set(current.name, { readRate, writeRate });
+				if (metricsRange === '5m' && metricsOffset === 0) diskHistory.push(current.name, sampleTime, readRate, writeRate);
+			}
+			diskRates = nextDiskRates;
+			if (metricsRange === '5m' && metricsOffset === 0) {
+				diskSamples = new Map(next.disk_io.map((device) => [device.name, liveSamples(diskHistory.getSamples(device.name), sampleTime)]));
+			}
+
+			const nextNetworkRates = new Map<string, NetworkRate>();
+			for (const current of next.network) {
+				const previous = previousNetworkIo.find((iface) => iface.name === current.name);
+				if (!previous) continue;
+				const rxRate = Math.max(0, (current.rx_bytes - previous.rx_bytes) / elapsed);
+				const txRate = Math.max(0, (current.tx_bytes - previous.tx_bytes) / elapsed);
+				nextNetworkRates.set(current.name, { rxRate, txRate });
+				if (metricsRange === '5m' && metricsOffset === 0) networkHistory.push(current.name, sampleTime, rxRate, txRate);
+			}
+			networkRates = nextNetworkRates;
+			if (metricsRange === '5m' && metricsOffset === 0) {
+				networkSamples = new Map(next.network.map((iface) => [iface.name, liveSamples(networkHistory.getSamples(iface.name), sampleTime)]));
+			}
+
+			if (metricsRange === '5m' && metricsOffset === 0) {
+				const cpuPercent = Math.min(100, (next.cpu.load_1 / next.cpu.count) * 100);
+				const memoryPercent = next.memory.total_bytes > 0 ? next.memory.used_bytes / next.memory.total_bytes * 100 : 0;
+				cpuHistory.push('cpu', sampleTime, cpuPercent, 0);
+				memoryHistory.push('memory', sampleTime, memoryPercent, 0);
+				cpuSamples = liveSamples(cpuHistory.getSamples('cpu'), sampleTime);
+				memorySamples = liveSamples(memoryHistory.getSamples('memory'), sampleTime);
+			}
+		}
+
+		previousDiskIo = next.disk_io;
+		previousNetworkIo = next.network;
+		previousSampleTime = now;
+		stats = next;
+	}
+
+	function liveSamples(samples: ChartSample[], now: Date): ChartSample[] {
+		const cutoff = now.getTime() - rangeDurations['5m'];
+		return samples.filter((sample) => sample.time.getTime() >= cutoff);
+	}
+
+	function applyHistory(
+		network: ResourceHistory[] | null,
+		disk: ResourceHistory[] | null,
+		cpu: ResourceHistory[] | null,
+		memory: ResourceHistory[] | null,
+	) {
+		if (network) {
+			networkHistory.clear();
+			for (const resource of network) for (const sample of resource.samples) networkHistory.push(resource.name, new Date(sample.ts), sample.in_rate, sample.out_rate);
+			networkSamples = new Map(network.map((resource) => [resource.name, [...networkHistory.getSamples(resource.name)]]));
+		}
+		if (disk) {
+			diskHistory.clear();
+			for (const resource of disk) for (const sample of resource.samples) diskHistory.push(resource.name, new Date(sample.ts), sample.in_rate, sample.out_rate);
+			diskSamples = new Map(disk.map((resource) => [resource.name, [...diskHistory.getSamples(resource.name)]]));
+		}
+		if (cpu) {
+			cpuHistory.clear();
+			for (const resource of cpu) for (const sample of resource.samples) cpuHistory.push('cpu', new Date(sample.ts), sample.in_rate, 0);
+			cpuSamples = [...cpuHistory.getSamples('cpu')];
+		}
+		if (memory) {
+			memoryHistory.clear();
+			for (const resource of memory) for (const sample of resource.samples) memoryHistory.push('memory', new Date(sample.ts), sample.in_rate, 0);
+			memorySamples = [...memoryHistory.getSamples('memory')];
+		}
+	}
+
+	async function loadMetrics(clearFailedSeries = false) {
+		const request = ++historyRequest;
+		historyLoading = true;
 		try {
 			const params = { range: metricsRange, ...(metricsOffset > 0 ? { offset: metricsOffset } : {}) };
-			const [netHist, diskHist, cpuHist, memHist] = await Promise.all([
-				client.call<ResourceHistory[]>('system.metrics.history', { kind: 'net', ...params }),
-				client.call<ResourceHistory[]>('system.metrics.history', { kind: 'disk', ...params }),
-				client.call<ResourceHistory[]>('system.metrics.history', { kind: 'cpu', ...params }),
-				client.call<ResourceHistory[]>('system.metrics.history', { kind: 'mem', ...params }),
+			const [network, disk, cpu, memory] = await Promise.allSettled([
+				hasWidget('network') ? client.call<ResourceHistory[]>('system.metrics.history', { kind: 'net', ...params }) : Promise.resolve([]),
+				hasWidget('disk_io') ? client.call<ResourceHistory[]>('system.metrics.history', { kind: 'disk', ...params }) : Promise.resolve([]),
+				hasWidget('history') ? client.call<ResourceHistory[]>('system.metrics.history', { kind: 'cpu', ...params }) : Promise.resolve([]),
+				hasWidget('history') ? client.call<ResourceHistory[]>('system.metrics.history', { kind: 'mem', ...params }) : Promise.resolve([]),
 			]);
-			applyHistory(netHist, diskHist, cpuHist, memHist);
+			if (request === historyRequest) applyHistory(
+				network.status === 'fulfilled' ? network.value : clearFailedSeries ? [] : null,
+				disk.status === 'fulfilled' ? disk.value : clearFailedSeries ? [] : null,
+				cpu.status === 'fulfilled' ? cpu.value : clearFailedSeries ? [] : null,
+				memory.status === 'fulfilled' ? memory.value : clearFailedSeries ? [] : null,
+			);
 		} catch {
-			// Metrics history not available yet, charts will populate over time
+			/* History fills from live samples when unavailable. */
+		} finally {
+			if (request === historyRequest) historyLoading = false;
 		}
 	}
 
-	async function changeRange(r: typeof metricsRange) {
-		metricsRange = r;
+	async function changeRange(range: MetricsRange) {
+		metricsRange = range;
 		metricsOffset = 0;
-		await loadMetrics();
+		await loadMetrics(true);
 	}
 
 	async function navigateBack() {
 		metricsOffset += rangeDurations[metricsRange];
-		await loadMetrics();
+		await loadMetrics(true);
 	}
 
 	async function navigateForward() {
 		metricsOffset = Math.max(0, metricsOffset - rangeDurations[metricsRange]);
-		await loadMetrics();
+		await loadMetrics(true);
 	}
 
 	async function navigateLive() {
 		metricsOffset = 0;
-		await loadMetrics();
+		await loadMetrics(true);
 	}
 
-	async function refreshStats() {
-		try {
-			const newStats = await client.call<SystemStats>('system.stats');
-			const now = Date.now();
-			const elapsed = (now - prevSampleTime) / 1000;
-			const sampleTime = new Date(now);
-
-			if (prevSampleTime > 0 && elapsed > 0) {
-				const dRates = new Map<string, { readRate: number; writeRate: number }>();
-				for (const curr of newStats.disk_io) {
-					const prev = prevDiskIo.find(d => d.name === curr.name);
-					if (prev) {
-						const readRate = Math.max(0, (curr.read_bytes - prev.read_bytes) / elapsed);
-						const writeRate = Math.max(0, (curr.write_bytes - prev.write_bytes) / elapsed);
-						dRates.set(curr.name, { readRate, writeRate });
-						if (metricsRange === '5m' && metricsOffset === 0) diskHistory.push(curr.name, sampleTime, readRate, writeRate);
-					}
-				}
-				diskIoRates = dRates;
-				if (metricsRange === '5m' && metricsOffset === 0) diskSamples = new Map(
-					newStats.disk_io.map(d => [d.name, [...diskHistory.getSamples(d.name)]])
-				);
-
-				const nRates = new Map<string, { rxRate: number; txRate: number }>();
-				for (const curr of newStats.network) {
-					const prev = prevNetIo.find(n => n.name === curr.name);
-					if (prev) {
-						const rxRate = Math.max(0, (curr.rx_bytes - prev.rx_bytes) / elapsed);
-						const txRate = Math.max(0, (curr.tx_bytes - prev.tx_bytes) / elapsed);
-						nRates.set(curr.name, { rxRate, txRate });
-						if (metricsRange === '5m' && metricsOffset === 0) netHistory.push(curr.name, sampleTime, rxRate, txRate);
-					}
-				}
-				netIoRates = nRates;
-				if (metricsRange === '5m' && metricsOffset === 0) netSamples = new Map(
-					newStats.network.map(n => [n.name, [...netHistory.getSamples(n.name)]])
-				);
-
-				// CPU and memory
-				const cpuPct = Math.min(100, (newStats.cpu.load_1 / newStats.cpu.count) * 100);
-				if (metricsRange === '5m' && metricsOffset === 0) {
-					cpuHistory.push('cpu', sampleTime, cpuPct, 0);
-					cpuChartSamples = [...cpuHistory.getSamples('cpu')];
-				}
-
-				const memPct = newStats.memory.total_bytes > 0
-					? (newStats.memory.used_bytes / newStats.memory.total_bytes) * 100
-					: 0;
-				if (metricsRange === '5m' && metricsOffset === 0) {
-					memHistory.push('mem', sampleTime, memPct, 0);
-					memChartSamples = [...memHistory.getSamples('mem')];
-				}
-			}
-
-			prevDiskIo = newStats.disk_io;
-			prevNetIo = newStats.network;
-			prevSampleTime = now;
-			stats = newStats;
-			alerts = await client.call<ActiveAlert[]>('system.alerts');
-		} catch {
-			// Silently ignore refresh errors
-		}
-	}
-
-	function cpuPercent(s: SystemStats): number {
-		return Math.min(100, (s.cpu.load_1 / s.cpu.count) * 100);
-	}
-
-	function memPercent(s: SystemStats): number {
-		if (s.memory.total_bytes === 0) return 0;
-		return (s.memory.used_bytes / s.memory.total_bytes) * 100;
-	}
-
-	function totalStorage(p: Filesystem[]): { used: number; total: number } {
-		let used = 0, total = 0;
-		for (const fs of p) {
-			if (fs.total_bytes > 0) {
-				used += fs.used_bytes;
-				total += fs.total_bytes;
-			}
-		}
-		return { used, total };
-	}
-
-	function storagePercent(p: Filesystem[]): number {
-		const s = totalStorage(p);
-		if (s.total === 0) return 0;
-		return (s.used / s.total) * 100;
-	}
-
-	function barColor(percent: number): string {
-		if (percent > 90) return 'bg-red-500';
-		if (percent > 75) return 'bg-amber-500';
-		return 'bg-primary';
-	}
-
-	function ipv4Only(addresses: string[]): string[] {
-		return addresses.filter(a => !a.includes(':'));
+	async function applyPreferences(preferences: DashboardPreferences) {
+		dashboardPrefs.set(preferences);
+		await tick();
+		await loadVisibleData(false);
 	}
 </script>
 
-{#if alerts.length > 0}
-	<div class="mb-4 flex flex-col gap-2">
-		{#each alerts as alert}
-			<div class="flex items-center gap-3 rounded-lg border px-4 py-2.5 text-sm {
-				alert.severity === 'critical' ? 'border-red-800 bg-red-950 text-red-200' : 'border-amber-800 bg-amber-950 text-amber-200'
-			}">
-				<span class="shrink-0 text-base font-bold">{alert.severity === 'critical' ? '!' : '⚠'}</span>
-				<span class="flex-1">{alert.message}</span>
+<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+	<div>
+		<div class="text-sm font-semibold">{presetLabel} dashboard</div>
+		<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
+	</div>
+	<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
+</div>
+
+{#if filesystemsLoaded && filesystems.length === 0}
+	<Card class="mb-4 border-primary/30 bg-primary/5">
+		<CardContent class="flex flex-wrap items-center gap-6 py-6">
+			<div class="min-w-0 flex-1"><h2 class="text-lg font-bold">Get started with NASty</h2><p class="mt-1 text-sm text-muted-foreground">Create your first filesystem to start storing and sharing data.</p></div>
+			<Button onclick={() => goto('/filesystems?create')}>Create filesystem</Button>
+		</CardContent>
+	</Card>
+{/if}
+
+{#if loading}
+	<Card><CardContent class="py-10 text-center text-sm text-muted-foreground">Loading dashboard...</CardContent></Card>
+{:else}
+	<div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+		{#each widgets as widget (widget.id)}
+			<div class={widgetClass(widget.width)}>
+				{#if widget.id === 'alerts'}
+					<AlertsWidget {alerts} loaded={alertsLoaded} {density} />
+				{:else if widget.id === 'system'}
+					<SystemWidget {info} {health} loaded={infoLoaded || healthLoaded} {density} />
+				{:else if widget.id === 'summary' && stats}
+					<SummaryWidget {stats} {filesystems} width={widget.width} {density} />
+				{:else if widget.id === 'operations'}
+					<OperationsWidget operations={systemStatus?.operations ?? []} loaded={operationsLoaded} {density} />
+				{:else if widget.id === 'storage'}
+					<StorageWidget {filesystems} usages={filesystemUsages} health={diskHealth} rates={diskRates} {density} />
+				{:else if widget.id === 'history'}
+					<HistoryWidget cpuSamples={cpuSamples} memorySamples={memorySamples} range={metricsRange} offset={metricsOffset} rangeDuration={rangeDurations[metricsRange]} loading={historyLoading} width={widget.width} {density} onRange={(range) => void changeRange(range)} onBack={() => void navigateBack()} onForward={() => void navigateForward()} onLive={() => void navigateLive()} />
+				{:else if widget.id === 'network' && stats}
+					<NetworkWidget interfaces={stats.network} rates={networkRates} samples={networkSamples} {density} />
+				{:else if widget.id === 'disk_io' && stats}
+					<DiskIoWidget devices={stats.disk_io} rates={diskRates} samples={diskSamples} {density} />
+				{:else}
+					<Card><CardContent class="py-8 text-center text-sm text-muted-foreground">Widget data is unavailable.</CardContent></Card>
+				{/if}
 			</div>
 		{/each}
 	</div>
 {/if}
 
-<!-- System info bar -->
-{#if info || health}
-	<Card class="mb-4">
-		<CardContent class="py-4">
-			<div class="flex flex-wrap items-center gap-x-8 gap-y-2">
-				{#if info}
-					<div class="flex items-center gap-2">
-						<span class="text-lg font-bold">{info.hostname}</span>
-						<span class="text-xs text-muted-foreground">v{info.version}</span>
-					</div>
-					<div class="flex gap-4 text-sm text-muted-foreground">
-						<span>Kernel {info.kernel}</span>
-						<span>Up {formatUptime(info.uptime_seconds)}</span>
-					</div>
-				{/if}
-				{#if health}
-					<button
-						onclick={() => healthExpanded = !healthExpanded}
-						class="ml-auto flex items-center gap-3 hover:opacity-80 transition-opacity"
-					>
-						<span class="text-sm font-semibold {health.status === 'ok' ? 'text-green-400' : 'text-red-400'}">
-							{health.status.toUpperCase()}
-						</span>
-						{#each health.services as svc}
-							<div class="flex items-center gap-1.5 text-xs text-muted-foreground">
-								<span class="h-1.5 w-1.5 rounded-full {svc.running ? 'bg-green-400' : 'bg-red-400'}"></span>
-								{svc.name}
-							</div>
-						{/each}
-						{#if healthExpanded}
-							<ChevronDown class="h-4 w-4 text-muted-foreground" />
-						{:else}
-							<ChevronRight class="h-4 w-4 text-muted-foreground" />
-						{/if}
-					</button>
-				{/if}
-			</div>
-
-			{#if healthExpanded && health}
-				<div class="mt-4 border-t border-border pt-4">
-					<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-						{#each health.services as svc}
-							<div class="rounded-md border border-border p-3">
-								<div class="mb-2 flex items-center justify-between">
-									<div class="flex items-center gap-2">
-										<span class="h-2 w-2 rounded-full {svc.running ? 'bg-green-400' : 'bg-red-400'}"></span>
-										<span class="text-sm font-medium">{svc.name}</span>
-									</div>
-									<span class="rounded-md px-2 py-0.5 text-xs font-medium {svc.running
-										? 'border border-green-700 bg-green-950 text-green-400'
-										: 'border border-red-700 bg-red-950 text-red-400'}">{svc.running ? 'Running' : 'Down'}</span>
-								</div>
-								{#if svc.running && svc.pid}
-									<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-										<div class="text-muted-foreground">PID</div>
-										<div class="font-mono text-right">{svc.pid}</div>
-										<div class="text-muted-foreground">Memory</div>
-										<div class="font-mono text-right">{svc.memory_bytes != null ? formatBytes(svc.memory_bytes) : '—'}</div>
-										<div class="text-muted-foreground">CPU Time</div>
-										<div class="font-mono text-right">{svc.cpu_seconds != null ? svc.cpu_seconds.toFixed(1) + 's' : '—'}</div>
-										<div class="text-muted-foreground">Uptime</div>
-										<div class="font-mono text-right">{svc.uptime_seconds != null ? formatUptime(svc.uptime_seconds) : '—'}</div>
-									</div>
-								{/if}
-							</div>
-						{/each}
-					</div>
-				</div>
-			{/if}
-		</CardContent>
-	</Card>
-{/if}
-
-<!-- Onboarding — shown only when no filesystems exist -->
-{#if stats && filesystems.length === 0}
-	<Card class="mb-4 border-primary/30 bg-primary/5">
-		<CardContent class="flex items-center gap-6 py-6">
-			<div class="flex-1">
-				<h2 class="text-lg font-bold">Get started with NASty</h2>
-				<p class="mt-1 text-sm text-muted-foreground">Create your first filesystem to start storing and sharing data.</p>
-			</div>
-			<Button onclick={() => goto('/filesystems?create')}>Create Filesystem</Button>
-		</CardContent>
-	</Card>
-{/if}
-
-<!-- Resource gauges -->
-{#if stats}
-	<div class="mb-3 flex items-center justify-between">
-		<div class="flex items-center gap-2">
-			<span class="text-sm font-semibold">History</span>
-			{#if metricsOffset > 0}
-				<span class="text-xs text-muted-foreground">
-					{new Date(Date.now() - metricsOffset - rangeDurations[metricsRange]).toLocaleTimeString()} — {new Date(Date.now() - metricsOffset).toLocaleTimeString()}
-				</span>
-			{/if}
-		</div>
-		<div class="flex items-center gap-1">
-			{#if metricsOffset > 0}
-				<button
-					onclick={navigateLive}
-					class="rounded-md border border-border px-2 py-1 text-xs font-medium text-primary hover:bg-accent transition-colors"
-				>Live</button>
-			{/if}
-			<button
-				onclick={navigateBack}
-				class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-				title="Back"
-			>&larr;</button>
-			<div class="flex rounded-md border border-border">
-				{#each (['5m', '1h', '1d', '7d', '30d'] as const) as r}
-					<button
-						onclick={() => changeRange(r)}
-						class="px-3 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {metricsRange === r ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}"
-					>{r}</button>
-				{/each}
-			</div>
-			<button
-				onclick={navigateForward}
-				disabled={metricsOffset === 0}
-				class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-default"
-				title="Forward"
-			>&rarr;</button>
-		</div>
-	</div>
-	<!-- Stats summary row -->
-	{@const hasTemp = stats.cpu.temp_c != null || stats.cpu.freq_mhz != null}
-	{@const hasStorage = filesystems.length > 0}
-	{@const statCols = 2 + (hasTemp ? 1 : 0) + (hasStorage ? 1 : 0)}
-	<div class="mb-4 grid grid-cols-2 gap-4 {statCols === 4 ? 'sm:grid-cols-4' : statCols === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2'}">
-		<Card>
-			<CardContent class="pt-4 pb-3">
-				<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU Load</div>
-				<div class="mt-1 flex items-baseline gap-2">
-					<span class="text-2xl font-bold">{stats.cpu.load_1.toFixed(2)}</span>
-					<span class="text-xs text-muted-foreground">/ {stats.cpu.count} cores</span>
-				</div>
-				<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary">
-					<div class="h-full rounded-full transition-all duration-500 {barColor(cpuPercent(stats))}" style="width: {cpuPercent(stats)}%"></div>
-				</div>
-				<div class="mt-1.5 flex justify-between text-xs tabular-nums text-muted-foreground">
-					<span>1m {stats.cpu.load_1.toFixed(2)}</span>
-					<span>5m {stats.cpu.load_5.toFixed(2)}</span>
-					<span>15m {stats.cpu.load_15.toFixed(2)}</span>
-				</div>
-			</CardContent>
-		</Card>
-
-		<Card>
-			<CardContent class="pt-4 pb-3">
-				<div class="text-xs uppercase tracking-wide text-muted-foreground">Memory</div>
-				<div class="mt-1 flex items-baseline gap-2">
-					<span class="text-2xl font-bold">{formatPercent(stats.memory.used_bytes, stats.memory.total_bytes)}</span>
-					<span class="text-xs text-muted-foreground">{formatBytes(stats.memory.used_bytes)} / {formatBytes(stats.memory.total_bytes)}</span>
-				</div>
-				<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary">
-					<div class="h-full rounded-full transition-all duration-500 {barColor(memPercent(stats))}" style="width: {memPercent(stats)}%"></div>
-				</div>
-				{#if stats.memory.swap_total_bytes > 0}
-					<div class="mt-1.5 text-xs text-muted-foreground">
-						Swap: {formatBytes(stats.memory.swap_used_bytes)} / {formatBytes(stats.memory.swap_total_bytes)}
-					</div>
-				{/if}
-				{#if stats.memory.bcachefs_btree_cache_bytes != null}
-					<div
-						class="mt-1.5 text-xs text-muted-foreground"
-						title="Kernel-reported btree-node main buffers across mounted bcachefs filesystems. Approximate; included node states vary by module version, and other bcachefs and VFS allocations are excluded."
-					>
-						Btree node cache: {formatBytes(stats.memory.bcachefs_btree_cache_bytes)} ({formatPercent(stats.memory.bcachefs_btree_cache_bytes, stats.memory.total_bytes)})
-					</div>
-				{/if}
-			</CardContent>
-		</Card>
-
-		{#if stats.cpu.temp_c != null || stats.cpu.freq_mhz != null}
-		<Card>
-			<CardContent class="pt-4 pb-3">
-				<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU Temp</div>
-				<div class="mt-1 flex items-baseline gap-2">
-					<span class="text-2xl font-bold">{formatTemp(stats.cpu.temp_c) ?? '—'}</span>
-				</div>
-				<div class="mt-2 text-xs text-muted-foreground">
-					{#if stats.cpu.freq_mhz != null}
-						{stats.cpu.freq_mhz >= 1000 ? (stats.cpu.freq_mhz / 1000).toFixed(1) + ' GHz' : stats.cpu.freq_mhz + ' MHz'}
-					{/if}
-					{#if stats.cpu.governor}
-						<span class="ml-2">{stats.cpu.governor}</span>
-					{/if}
-				</div>
-			</CardContent>
-		</Card>
-		{/if}
-
-		{#if filesystems.length > 0}
-			{@const storage = totalStorage(filesystems)}
-			<Card>
-				<CardContent class="pt-4 pb-3">
-					<div class="text-xs uppercase tracking-wide text-muted-foreground">Storage</div>
-					<div class="mt-1 flex items-baseline gap-2">
-						<span class="text-2xl font-bold">{formatPercent(storage.used, storage.total)}</span>
-						<span class="text-xs text-muted-foreground">{formatBytes(storage.used)} / {formatBytes(storage.total)}</span>
-					</div>
-					<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary">
-						<div class="h-full rounded-full transition-all duration-500 {barColor(storagePercent(filesystems))}" style="width: {storagePercent(filesystems)}%"></div>
-					</div>
-					<div class="mt-1.5 text-xs text-muted-foreground">
-						{filesystems.length} filesystem{filesystems.length !== 1 ? 's' : ''}
-					</div>
-				</CardContent>
-			</Card>
-		{/if}
-	</div>
-
-	<!-- Charts row — equal height, aligned -->
-	<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-		<Card>
-			<CardHeader class="pb-2">
-				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU Usage</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<IoChart
-					samples={cpuChartSamples}
-					inLabel="Usage"
-					inColor="var(--chart-3)"
-					yFormat={(v) => v.toFixed(0) + '%'}
-					tooltipFormat={(v) => v.toFixed(1) + '%'}
-				/>
-			</CardContent>
-		</Card>
-		<Card>
-			<CardHeader class="pb-2">
-				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Memory Usage</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<IoChart
-					samples={memChartSamples}
-					inLabel="Used"
-					inColor="var(--chart-5)"
-					yFormat={(v) => v.toFixed(0) + '%'}
-					tooltipFormat={(v) => v.toFixed(1) + '%'}
-				/>
-			</CardContent>
-		</Card>
-	</div>
-
-{/if}
-
-<!-- Network & Disk I/O -->
-{#if stats}
-	<div class="mb-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-		{#if stats.network.length > 0}
-			<Card>
-				<CardHeader class="pb-2">
-					<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Network</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<div class="divide-y divide-border">
-						{#each stats.network as iface}
-							{@const rates = netIoRates.get(iface.name)}
-							{@const ips = ipv4Only(iface.addresses)}
-							{@const samples = netSamples.get(iface.name) ?? []}
-							<div class="py-2.5 first:pt-0 last:pb-0">
-								<div class="mb-1.5 flex items-center gap-2">
-									<span class="text-sm font-semibold">{iface.name}</span>
-									<span class="h-2 w-2 rounded-full {iface.up ? 'bg-green-400' : 'bg-red-400'}"></span>
-									{#if iface.speed_mbps}
-										<span class="text-xs text-muted-foreground">{iface.speed_mbps >= 1000 ? `${iface.speed_mbps / 1000}G` : `${iface.speed_mbps}M`}</span>
-									{/if}
-									{#if ips.length > 0}
-										<span class="ml-auto font-mono text-xs">{ips.join(', ')}</span>
-									{/if}
-								</div>
-								<div class="mb-2 flex gap-6 text-xs">
-									<div class="flex items-center gap-1.5">
-										<span class="w-5 text-right font-semibold text-muted-foreground">RX</span>
-										<span class="tabular-nums font-semibold">{rates ? `${formatBytes(rates.rxRate)}/s` : formatBytes(iface.rx_bytes)}</span>
-									</div>
-									<div class="flex items-center gap-1.5">
-										<span class="w-5 text-right font-semibold text-muted-foreground">TX</span>
-										<span class="tabular-nums font-semibold">{rates ? `${formatBytes(rates.txRate)}/s` : formatBytes(iface.tx_bytes)}</span>
-									</div>
-									<div class="ml-auto flex items-center gap-1.5 text-muted-foreground">
-										<span>Total</span>
-										<span class="tabular-nums">{formatBytes(iface.rx_bytes + iface.tx_bytes)}</span>
-									</div>
-								</div>
-								<IoChart
-									{samples}
-									inLabel="RX"
-									outLabel="TX"
-									inColor="var(--chart-2)"
-									outColor="var(--chart-1)"
-								/>
-							</div>
-						{/each}
-					</div>
-				</CardContent>
-			</Card>
-		{/if}
-
-		{#if stats.disk_io.length > 0}
-			<Card>
-				<CardHeader class="pb-2">
-					<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Disk I/O</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<div class="divide-y divide-border">
-						{#each stats.disk_io as dio}
-							{@const rates = diskIoRates.get(dio.name)}
-							{@const samples = diskSamples.get(dio.name) ?? []}
-							<div class="py-2.5 first:pt-0 last:pb-0">
-								<div class="mb-1.5 flex items-center gap-2">
-									<span class="text-sm font-semibold">{dio.name}</span>
-									{#if dio.io_in_progress > 0}
-										<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[0.65rem] font-medium text-amber-500">{dio.io_in_progress} active</span>
-									{/if}
-									<span class="ml-auto text-xs tabular-nums text-muted-foreground">{formatBytes(dio.read_bytes + dio.write_bytes)}</span>
-								</div>
-								<div class="mb-2 flex gap-6 text-xs">
-									<div class="flex items-center gap-1.5">
-										<span class="w-5 text-right font-bold text-muted-foreground">R</span>
-										{#if rates}
-											<span class="tabular-nums font-semibold">{formatBytes(rates.readRate)}/s</span>
-										{:else}
-											<span class="tabular-nums text-muted-foreground">{formatBytes(dio.read_bytes)}</span>
-										{/if}
-									</div>
-									<div class="flex items-center gap-1.5">
-										<span class="w-5 text-right font-bold text-muted-foreground">W</span>
-										{#if rates}
-											<span class="tabular-nums font-semibold">{formatBytes(rates.writeRate)}/s</span>
-										{:else}
-											<span class="tabular-nums text-muted-foreground">{formatBytes(dio.write_bytes)}</span>
-										{/if}
-									</div>
-								</div>
-								<IoChart
-									{samples}
-									inLabel="Read"
-									outLabel="Write"
-									inColor="var(--chart-2)"
-									outColor="var(--chart-4)"
-								/>
-							</div>
-						{/each}
-					</div>
-				</CardContent>
-			</Card>
-		{/if}
-	</div>
-{/if}
-
+<CustomizeDialog bind:open={customizeOpen} preferences={dashboardPrefs.value} onSave={(preferences) => void applyPreferences(preferences)} />


### PR DESCRIPTION
## Summary
- add Overview, Storage Compact, Monitoring, and configurable Custom dashboard layouts
- centralize conditional RPC loading and resilient polling while preserving bcachefs capacity and SMART semantics
- extract responsive dashboard widgets and add accessible alert, storage, and chart presentation
- persist versioned browser-local preferences with normalization tests

## Validation
- `npm run check`
- `npm test` (235 tests)
- `npm run build`
- `git diff --check origin/main...HEAD`

Closes #809