### PR TITLE
webui: add named custom dashboard views

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -1,14 +1,25 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import {
+		DASHBOARD_VIEW_NAME_MAX_LENGTH,
+		createDashboardView,
 		dashboardPresets,
+		dashboardViewNameAvailable,
 		dashboardWidgetMeta,
 		defaultDashboardPreferences,
+		deleteDashboardView,
+		getActiveDashboardView,
+		renameDashboardView,
+		selectDashboardView,
+		updateActiveDashboardView,
 		type DashboardPreferences,
 		type DashboardPreset,
 	} from '$lib/dashboard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { ArrowDown, ArrowUp, LayoutDashboard, RotateCcw } from '@lucide/svelte';
+	import { ArrowDown, ArrowUp, Copy, LayoutDashboard, Pencil, Plus, RotateCcw, Trash2 } from '@lucide/svelte';
+
+	type NameAction = 'create' | 'duplicate' | 'rename';
 
 	let { open = $bindable(false), preferences, onSave }: {
 		open: boolean;
@@ -17,53 +28,164 @@
 	} = $props();
 
 	let draft = $state<DashboardPreferences>(defaultDashboardPreferences());
+	let nameAction = $state<NameAction | null>(null);
+	let nameDraft = $state('');
+	let deletePending = $state(false);
+	let nameInput = $state<HTMLInputElement>();
+	let nameActionButton = $state<HTMLElement>();
+	let deleteButton = $state<HTMLElement>();
+	let viewSelect = $state<HTMLSelectElement>();
 	let wasOpen = false;
 
 	$effect(() => {
-		if (open && !wasOpen) draft = clone(preferences);
+		if (open && !wasOpen) {
+			draft = clone(preferences);
+			cancelNameAction();
+			deletePending = false;
+			deleteButton = undefined;
+		}
 		wasOpen = open;
 	});
 
+	let activeView = $derived(getActiveDashboardView(draft));
+	let nameAvailable = $derived(dashboardViewNameAvailable(
+		draft,
+		nameDraft,
+		nameAction === 'rename' ? activeView.id : undefined,
+	));
+	let invalidView = $derived(draft.customViews.find((view) => !view.widgets.some((widget) => widget.visible)));
+	let canSave = $derived(!invalidView);
+
 	function clone(value: DashboardPreferences): DashboardPreferences {
-		return { ...value, widgets: value.widgets.map((widget) => ({ ...widget })) };
+		return {
+			...value,
+			customViews: value.customViews.map((view) => ({
+				...view,
+				widgets: view.widgets.map((widget) => ({ ...widget })),
+			})),
+		};
 	}
 
 	function selectPreset(preset: DashboardPreset) {
 		draft = { ...draft, preset };
+		cancelNameAction();
+		deletePending = false;
 	}
 
-	function updateWidget(index: number, patch: Partial<DashboardPreferences['widgets'][number]>) {
-		draft = {
-			...draft,
-			widgets: draft.widgets.map((widget, position) => position === index ? { ...widget, ...patch } : widget),
-		};
+	function selectView(id: string) {
+		draft = selectDashboardView(draft, id);
+		cancelNameAction();
+		deletePending = false;
+	}
+
+	function updateWidget(index: number, patch: Partial<(typeof activeView.widgets)[number]>) {
+		const widgets = activeView.widgets.map((widget, position) =>
+			position === index ? { ...widget, ...patch } : widget
+		);
+		draft = updateActiveDashboardView(draft, { widgets });
+	}
+
+	function updateDensity(value: string) {
+		draft = updateActiveDashboardView(draft, {
+			density: value === 'compact' ? 'compact' : 'comfortable',
+		});
 	}
 
 	function moveWidget(index: number, direction: -1 | 1) {
 		const target = index + direction;
-		if (target < 0 || target >= draft.widgets.length) return;
-		const widgets = [...draft.widgets];
+		if (target < 0 || target >= activeView.widgets.length) return;
+		const widgets = activeView.widgets.map((widget) => ({ ...widget }));
 		[widgets[index], widgets[target]] = [widgets[target], widgets[index]];
-		draft = { ...draft, widgets };
+		draft = updateActiveDashboardView(draft, { widgets });
 	}
 
 	function resetCustom() {
-		draft = { ...defaultDashboardPreferences(), preset: 'custom' };
+		const defaults = getActiveDashboardView(defaultDashboardPreferences());
+		draft = updateActiveDashboardView(draft, {
+			density: defaults.density,
+			widgets: defaults.widgets,
+		});
+	}
+
+	function suggestedCopyName(): string {
+		const base = `${activeView.name} copy`.slice(0, DASHBOARD_VIEW_NAME_MAX_LENGTH);
+		if (dashboardViewNameAvailable(draft, base)) return base;
+		let index = 2;
+		let candidate = '';
+		do {
+			const suffix = ` ${index}`;
+			candidate = `${base.slice(0, DASHBOARD_VIEW_NAME_MAX_LENGTH - suffix.length)}${suffix}`;
+			index += 1;
+		} while (!dashboardViewNameAvailable(draft, candidate));
+		return candidate;
+	}
+
+	async function beginNameAction(action: NameAction, button: HTMLElement) {
+		deletePending = false;
+		deleteButton = undefined;
+		nameActionButton = button;
+		nameAction = action;
+		nameDraft = action === 'rename' ? activeView.name : action === 'duplicate' ? suggestedCopyName() : '';
+		await tick();
+		nameInput?.focus();
+	}
+
+	function cancelNameAction(restoreFocus = false) {
+		const focusTarget = nameActionButton;
+		nameAction = null;
+		nameDraft = '';
+		nameActionButton = undefined;
+		if (restoreFocus && focusTarget) requestAnimationFrame(() => focusTarget.focus());
+	}
+
+	function submitNameAction() {
+		if (!nameAction || !nameAvailable) return;
+		if (nameAction === 'rename') {
+			draft = renameDashboardView(draft, activeView.id, nameDraft);
+		} else {
+			draft = createDashboardView(draft, nameDraft, nameAction === 'duplicate' ? activeView : undefined);
+		}
+		cancelNameAction(true);
+	}
+
+	function handleNameKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') submitNameAction();
+		if (event.key === 'Escape') cancelNameAction(true);
+	}
+
+	function removeActiveView() {
+		if (draft.customViews.length <= 1) return;
+		draft = deleteDashboardView(draft, activeView.id);
+		cancelNameAction();
+		deletePending = false;
+		deleteButton = undefined;
+		requestAnimationFrame(() => viewSelect?.focus());
+	}
+
+	function beginDelete(button: HTMLElement) {
+		cancelNameAction();
+		deleteButton = button;
+		deletePending = true;
+	}
+
+	function cancelDelete() {
+		const focusTarget = deleteButton;
+		deletePending = false;
+		deleteButton = undefined;
+		requestAnimationFrame(() => focusTarget?.focus());
 	}
 
 	function save() {
 		onSave(clone(draft));
 		open = false;
 	}
-
-	let canSave = $derived(draft.preset !== 'custom' || draft.widgets.some((widget) => widget.visible));
 </script>
 
 <Dialog.Root bind:open>
 	<Dialog.Content class="flex max-h-[85vh] w-[94vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
 		<Dialog.Header class="border-b border-border px-6 py-5">
 			<Dialog.Title class="flex items-center gap-2"><LayoutDashboard class="h-5 w-5" /> Customize dashboard</Dialog.Title>
-			<Dialog.Description>Choose a focused preset or build a responsive dashboard from predefined widgets.</Dialog.Description>
+			<Dialog.Description>Choose a focused preset or manage named Custom views built from predefined widgets.</Dialog.Description>
 		</Dialog.Header>
 
 		<div class="overflow-y-auto px-6 py-5">
@@ -76,40 +198,74 @@
 				{/each}
 				<button type="button" onclick={() => selectPreset('custom')} aria-pressed={draft.preset === 'custom'} class="rounded-lg border p-3 text-left transition-colors {draft.preset === 'custom' ? 'border-primary bg-primary/10' : 'border-border hover:bg-accent'}">
 					<div class="text-sm font-semibold">Custom</div>
-					<p class="mt-1 text-xs leading-relaxed text-muted-foreground">Choose visibility, order, width, and density.</p>
+					<p class="mt-1 text-xs leading-relaxed text-muted-foreground">{draft.customViews.length} named view{draft.customViews.length === 1 ? '' : 's'}.</p>
 				</button>
 			</div>
 
 			{#if draft.preset === 'custom'}
+				<div class="mt-6 border-t border-border pt-5">
+					<div class="flex flex-wrap items-end gap-2">
+						<div class="min-w-48 flex-1">
+							<label for="dashboard-custom-view" class="mb-1 block text-xs font-medium text-muted-foreground">Custom view</label>
+							<select bind:this={viewSelect} id="dashboard-custom-view" value={activeView.id} onchange={(event) => selectView(event.currentTarget.value)} class="h-9 w-full rounded-md border border-border bg-background px-3 text-sm">
+								{#each draft.customViews as view (view.id)}<option value={view.id}>{view.name}</option>{/each}
+							</select>
+						</div>
+						<Button variant="outline" size="sm" onclick={(event) => void beginNameAction('create', event.currentTarget)}><Plus /> New</Button>
+						<Button variant="outline" size="sm" onclick={(event) => void beginNameAction('duplicate', event.currentTarget)}><Copy /> Duplicate</Button>
+						<Button variant="outline" size="sm" onclick={(event) => void beginNameAction('rename', event.currentTarget)}><Pencil /> Rename</Button>
+						<Button variant="outline" size="sm" disabled={draft.customViews.length <= 1} onclick={(event) => beginDelete(event.currentTarget)}><Trash2 /> Delete</Button>
+					</div>
+					{#if deletePending}
+						<div class="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-red-800 bg-red-950/40 p-3" role="alert">
+							<p class="min-w-48 flex-1 text-sm">Delete <strong>{activeView.name}</strong>? This takes effect when you apply the dashboard.</p>
+							<Button variant="destructive" size="sm" onclick={removeActiveView}>Delete view</Button>
+							<Button variant="ghost" size="sm" onclick={cancelDelete}>Cancel</Button>
+						</div>
+					{/if}
+
+					{#if nameAction}
+						<div class="mt-3 flex flex-wrap items-end gap-2 rounded-lg border border-border bg-muted/30 p-3">
+							<div class="min-w-48 flex-1">
+								<label for="dashboard-view-name" class="mb-1 block text-xs font-medium">{nameAction === 'rename' ? 'View name' : nameAction === 'duplicate' ? 'Duplicate name' : 'New view name'}</label>
+								<input bind:this={nameInput} id="dashboard-view-name" bind:value={nameDraft} onkeydown={handleNameKeydown} maxlength={DASHBOARD_VIEW_NAME_MAX_LENGTH} aria-invalid={nameDraft.trim() && !nameAvailable ? 'true' : undefined} aria-describedby={nameDraft.trim() && !nameAvailable ? 'dashboard-view-name-error' : undefined} placeholder="Dashboard view name" class="h-9 w-full rounded-md border border-border bg-background px-3 text-sm" />
+							</div>
+							<Button size="sm" disabled={!nameAvailable} onclick={submitNameAction}>{nameAction === 'rename' ? 'Rename' : nameAction === 'duplicate' ? 'Duplicate' : 'Create'}</Button>
+							<Button variant="ghost" size="sm" onclick={() => cancelNameAction(true)}>Cancel</Button>
+							{#if nameDraft.trim() && !nameAvailable}<p id="dashboard-view-name-error" class="w-full text-xs text-red-400" role="alert">Use a unique view name.</p>{/if}
+						</div>
+					{/if}
+				</div>
+
 				<div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-					<div><h3 class="text-sm font-semibold">Custom widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets pack into open column space on wide screens. Full-width widgets start a new row.</p></div>
+					<div><h3 class="text-sm font-semibold">{activeView.name} widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets pack into open column space on wide screens. Full-width widgets start a new row.</p></div>
 					<div class="flex items-center gap-2">
 						<label for="dashboard-density" class="text-xs font-medium text-muted-foreground">Density</label>
-						<select id="dashboard-density" value={draft.density} onchange={(event) => draft = { ...draft, density: (event.currentTarget as HTMLSelectElement).value === 'compact' ? 'compact' : 'comfortable' }} class="h-8 rounded-md border border-border bg-background px-2 text-xs">
+						<select id="dashboard-density" value={activeView.density} onchange={(event) => updateDensity(event.currentTarget.value)} class="h-8 rounded-md border border-border bg-background px-2 text-xs">
 							<option value="comfortable">Comfortable</option><option value="compact">Compact</option>
 						</select>
 					</div>
 				</div>
 
 				<div class="mt-3 divide-y divide-border rounded-lg border border-border">
-					{#each draft.widgets as widget, index (widget.id)}
+					{#each activeView.widgets as widget, index (widget.id)}
 						<div class="flex items-center gap-3 px-3 py-2.5">
-							<input type="checkbox" checked={widget.visible} onchange={(event) => updateWidget(index, { visible: (event.currentTarget as HTMLInputElement).checked })} aria-label={`Show ${dashboardWidgetMeta[widget.id].label}`} class="h-4 w-4 accent-primary" />
+							<input type="checkbox" checked={widget.visible} disabled={widget.visible && activeView.widgets.filter((candidate) => candidate.visible).length === 1} onchange={(event) => updateWidget(index, { visible: event.currentTarget.checked })} aria-label={`Show ${dashboardWidgetMeta[widget.id].label}`} class="h-4 w-4 accent-primary disabled:opacity-40" />
 							<div class="min-w-0 flex-1"><div class="text-sm font-medium">{dashboardWidgetMeta[widget.id].label}</div><div class="truncate text-xs text-muted-foreground">{dashboardWidgetMeta[widget.id].description}</div></div>
-							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: (event.currentTarget as HTMLSelectElement).value === 'half' ? 'half' : 'full' })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">Half</option></select>
+							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: event.currentTarget.value === 'half' ? 'half' : 'full' })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">Half</option></select>
 							<div class="flex">
 								<Button variant="ghost" size="icon-sm" disabled={index === 0} onclick={() => moveWidget(index, -1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp /></Button>
-								<Button variant="ghost" size="icon-sm" disabled={index === draft.widgets.length - 1} onclick={() => moveWidget(index, 1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown /></Button>
+								<Button variant="ghost" size="icon-sm" disabled={index === activeView.widgets.length - 1} onclick={() => moveWidget(index, 1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown /></Button>
 							</div>
 						</div>
 					{/each}
 				</div>
-				{#if !canSave}<p class="mt-2 text-xs text-red-400">Select at least one widget.</p>{/if}
 			{/if}
+			{#if invalidView}<p class="mt-3 text-xs text-red-400">Select at least one widget in {invalidView.name}.</p>{/if}
 		</div>
 
 		<Dialog.Footer class="border-t border-border px-6 py-4">
-			{#if draft.preset === 'custom'}<Button variant="ghost" onclick={resetCustom} class="mr-auto"><RotateCcw /> Reset custom</Button>{/if}
+			{#if draft.preset === 'custom'}<Button variant="ghost" onclick={resetCustom} class="mr-auto"><RotateCcw /> Reset view</Button>{/if}
 			<Button variant="outline" onclick={() => open = false}>Cancel</Button>
 			<Button disabled={!canSave} onclick={save}>Apply dashboard</Button>
 		</Dialog.Footer>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -1,12 +1,22 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import {
 	DASHBOARD_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_PREFERENCES_KEY,
+	createDashboardView,
 	dashboardPrefs,
+	dashboardViewNameAvailable,
 	defaultDashboardPreferences,
+	deleteDashboardView,
+	getActiveDashboardView,
+	initializeDashboardPreferences,
+	loadDashboardPreferences,
 	parseDashboardPreferences,
+	renameDashboardView,
 	resolveDashboardDensity,
 	resolveDashboardWidgets,
+	selectDashboardView,
 	swapDashboardWidgets,
+	updateActiveDashboardView,
 } from './dashboard.svelte';
 
 beforeEach(() => {
@@ -18,31 +28,95 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":2,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":3,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
-	test('normalizes custom widgets without losing newly added widget ids', () => {
+	test('migrates the v1 custom layout without losing its configuration', () => {
 		const parsed = parseDashboardPreferences(JSON.stringify({
 			version: 1,
 			preset: 'custom',
 			density: 'compact',
 			widgets: [
 				{ id: 'storage', visible: false, width: 'half' },
-				{ id: 'storage', visible: true, width: 'full' },
-				{ id: 'unknown', visible: true, width: 'full' },
+				{ id: 'alerts', visible: true, width: 'full' },
 			],
 		}));
 
-		expect(parsed.widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half' });
-		expect(new Set(parsed.widgets.map((widget) => widget.id)).size).toBe(8);
+		expect(parsed.version).toBe(2);
+		expect(parsed.preset).toBe('custom');
+		expect(parsed.customViews).toHaveLength(1);
+		expect(getActiveDashboardView(parsed)).toMatchObject({
+			name: 'Custom',
+			density: 'compact',
+		});
+		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half' });
+		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(8);
+	});
+
+	test('initializes v2 storage from the legacy key without overwriting v2 preferences', () => {
+		localStorage.clear();
+		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
+			version: 1,
+			preset: 'storage',
+			density: 'compact',
+			widgets: [],
+		}));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('storage');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 2,
+			preset: 'storage',
+		});
+
+		const stored = defaultDashboardPreferences();
+		stored.preset = 'monitoring';
+		localStorage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(stored));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
+		expect(loadDashboardPreferences(localStorage).preset).toBe('monitoring');
+	});
+
+	test('normalizes named views, active selection, and newly added widget ids', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 2,
+			preset: 'custom',
+			activeViewId: ' ops ',
+			customViews: [
+				{
+					id: 'ops',
+					name: 'Operations',
+					density: 'compact',
+					widgets: [{ id: 'storage', visible: false, width: 'half' }],
+				},
+				{ id: 'ops', name: 'operations', widgets: [] },
+			],
+		}));
+
+		expect(parsed.activeViewId).toBe('ops');
+		expect(parsed.customViews.map((view) => view.id)).toEqual(['ops', 'custom-1']);
+		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
+		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(8);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(resolveDashboardDensity(parsed)).toBe('compact');
 	});
 
-	test('resolves fixed presets independently from custom widget choices', () => {
+	test('repairs a custom view with no visible widgets', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 2,
+			preset: 'custom',
+			activeViewId: 'empty',
+			customViews: [{
+				id: 'empty',
+				name: 'Empty',
+				widgets: defaultDashboardPreferences().customViews[0].widgets.map((widget) => ({ ...widget, visible: false })),
+			}],
+		}));
+
+		expect(getActiveDashboardView(parsed).widgets.filter((widget) => widget.visible)).toHaveLength(1);
+	});
+
+	test('resolves fixed presets independently from named custom views', () => {
 		const preferences = defaultDashboardPreferences();
 		preferences.preset = 'storage';
-		preferences.widgets = preferences.widgets.map((widget) => ({ ...widget, visible: false }));
+		preferences.customViews[0].widgets = preferences.customViews[0].widgets.map((widget) => ({ ...widget, visible: false }));
 
 		expect(resolveDashboardWidgets(preferences).map((widget) => widget.id)).toEqual([
 			'alerts', 'system', 'operations', 'storage',
@@ -50,29 +124,60 @@ describe('dashboard preferences', () => {
 		expect(resolveDashboardDensity(preferences)).toBe('compact');
 	});
 
-	test('persists a versioned custom layout', () => {
+	test('creates, duplicates, renames, selects, and deletes named views', () => {
+		let preferences = createDashboardView(defaultDashboardPreferences(), 'Storage ops');
+		preferences = updateActiveDashboardView(preferences, { density: 'compact' });
+		const storageView = getActiveDashboardView(preferences);
+		preferences = createDashboardView(preferences, 'Storage ops copy', storageView);
+		const copyId = preferences.activeViewId;
+
+		expect(getActiveDashboardView(preferences).density).toBe('compact');
+		expect(dashboardViewNameAvailable(preferences, 'storage OPS')).toBe(false);
+		preferences = renameDashboardView(preferences, copyId, 'Daily');
+		expect(getActiveDashboardView(preferences).name).toBe('Daily');
+
+		preferences = selectDashboardView(preferences, storageView.id);
+		expect(getActiveDashboardView(preferences).name).toBe('Storage ops');
+		preferences = deleteDashboardView(preferences, storageView.id);
+		expect(preferences.customViews.some((view) => view.id === storageView.id)).toBe(false);
+		expect(preferences.customViews.some((view) => view.id === preferences.activeViewId)).toBe(true);
+	});
+
+	test('does not delete the final custom view', () => {
 		const preferences = defaultDashboardPreferences();
-		preferences.preset = 'custom';
-		preferences.density = 'compact';
-		preferences.widgets[0].visible = false;
+		expect(deleteDashboardView(preferences, preferences.activeViewId)).toBe(preferences);
+	});
+
+	test('updates only the active named view', () => {
+		let preferences = createDashboardView(defaultDashboardPreferences(), 'Second');
+		const first = preferences.customViews[0];
+		preferences = updateActiveDashboardView(preferences, { density: 'compact' });
+
+		expect(preferences.customViews.find((view) => view.id === first.id)?.density).toBe('comfortable');
+		expect(getActiveDashboardView(preferences).density).toBe('compact');
+	});
+
+	test('persists the active named view in v2 storage', () => {
+		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 1,
+			version: 2,
 			preset: 'custom',
-			density: 'compact',
+			activeViewId: preferences.activeViewId,
 		});
 	});
 
-	test('swaps custom widgets without mutating the saved layout', () => {
+	test('swaps custom widgets without mutating the saved view', () => {
 		const preferences = defaultDashboardPreferences();
-		const swapped = swapDashboardWidgets(preferences.widgets, 'alerts', 'storage');
+		const widgets = getActiveDashboardView(preferences).widgets;
+		const swapped = swapDashboardWidgets(widgets, 'alerts', 'storage');
 
 		expect(swapped.map((widget) => widget.id)).toEqual([
 			'storage', 'system', 'summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
 		]);
-		expect(preferences.widgets[0].id).toBe('alerts');
-		expect(swapDashboardWidgets(preferences.widgets, 'alerts', 'alerts')).not.toBe(preferences.widgets);
+		expect(widgets[0].id).toBe('alerts');
+		expect(swapDashboardWidgets(widgets, 'alerts', 'alerts')).not.toBe(widgets);
 	});
 });

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,5 +1,7 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 1;
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v2';
+export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
+export const DASHBOARD_PREFERENCES_VERSION = 2;
+export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 
 export const dashboardWidgetIds = [
 	'alerts',
@@ -23,11 +25,18 @@ export interface DashboardWidgetConfig {
 	width: DashboardWidgetWidth;
 }
 
+export interface DashboardCustomView {
+	id: string;
+	name: string;
+	density: DashboardDensity;
+	widgets: DashboardWidgetConfig[];
+}
+
 export interface DashboardPreferences {
 	version: typeof DASHBOARD_PREFERENCES_VERSION;
 	preset: DashboardPreset;
-	density: DashboardDensity;
-	widgets: DashboardWidgetConfig[];
+	activeViewId: string;
+	customViews: DashboardCustomView[];
 }
 
 export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string }> = {
@@ -86,12 +95,22 @@ function cloneWidgets(widgets: DashboardWidgetConfig[]): DashboardWidgetConfig[]
 	return widgets.map((widget) => ({ ...widget }));
 }
 
+function defaultCustomView(id = 'custom-1', name = 'Custom'): DashboardCustomView {
+	return {
+		id,
+		name,
+		density: 'comfortable',
+		widgets: cloneWidgets(defaultCustomWidgets),
+	};
+}
+
 export function defaultDashboardPreferences(): DashboardPreferences {
+	const customView = defaultCustomView();
 	return {
 		version: DASHBOARD_PREFERENCES_VERSION,
 		preset: 'overview',
-		density: 'comfortable',
-		widgets: cloneWidgets(defaultCustomWidgets),
+		activeViewId: customView.id,
+		customViews: [customView],
 	};
 }
 
@@ -99,16 +118,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
-	const fallback = defaultDashboardPreferences();
-	if (!isRecord(value) || value.version !== DASHBOARD_PREFERENCES_VERSION) return fallback;
-
-	const preset = value.preset;
-	if (preset !== 'overview' && preset !== 'storage' && preset !== 'monitoring' && preset !== 'custom') {
-		return fallback;
-	}
-	const density = value.density === 'compact' ? 'compact' : 'comfortable';
-	const configured = Array.isArray(value.widgets) ? value.widgets : [];
+function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
+	const configured = Array.isArray(value) ? value : [];
 	const byId = new Map<DashboardWidgetId, DashboardWidgetConfig>();
 	for (const candidate of configured) {
 		if (!isRecord(candidate) || !dashboardWidgetIds.includes(candidate.id as DashboardWidgetId)) continue;
@@ -125,8 +136,95 @@ function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	for (const widget of defaultCustomWidgets) {
 		if (!byId.has(widget.id)) widgets.push({ ...widget });
 	}
+	if (!widgets.some((widget) => widget.visible)) widgets[0] = { ...widgets[0], visible: true };
+	return widgets;
+}
 
-	return { version: DASHBOARD_PREFERENCES_VERSION, preset, density, widgets };
+function normalizePreset(value: unknown): DashboardPreset {
+	return value === 'storage' || value === 'monitoring' || value === 'custom' ? value : 'overview';
+}
+
+function normalizeViewName(value: unknown, fallback: string): string {
+	if (typeof value !== 'string') return fallback;
+	return value.trim().slice(0, DASHBOARD_VIEW_NAME_MAX_LENGTH) || fallback;
+}
+
+function nextViewId(ids: Iterable<string>): string {
+	const used = new Set(ids);
+	let index = 1;
+	while (used.has(`custom-${index}`)) index += 1;
+	return `custom-${index}`;
+}
+
+function uniqueViewName(name: string, names: Iterable<string>): string {
+	const used = new Set([...names].map((candidate) => candidate.toLocaleLowerCase()));
+	const base = normalizeViewName(name, 'Custom');
+	if (!used.has(base.toLocaleLowerCase())) return base;
+	let index = 2;
+	let candidate = '';
+	do {
+		const suffix = ` ${index}`;
+		candidate = `${base.slice(0, DASHBOARD_VIEW_NAME_MAX_LENGTH - suffix.length)}${suffix}`;
+		index += 1;
+	} while (used.has(candidate.toLocaleLowerCase()));
+	return candidate;
+}
+
+function normalizeCustomViews(value: unknown): DashboardCustomView[] {
+	const configured = Array.isArray(value) ? value : [];
+	const views: DashboardCustomView[] = [];
+	for (const candidate of configured) {
+		if (!isRecord(candidate)) continue;
+		const requestedId = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+		const id = requestedId && !views.some((view) => view.id === requestedId)
+			? requestedId
+			: nextViewId(views.map((view) => view.id));
+		const fallbackName = views.length === 0 ? 'Custom' : `Custom ${views.length + 1}`;
+		const name = uniqueViewName(
+			normalizeViewName(candidate.name, fallbackName),
+			views.map((view) => view.name),
+		);
+		views.push({
+			id,
+			name,
+			density: candidate.density === 'compact' ? 'compact' : 'comfortable',
+			widgets: normalizeWidgets(candidate.widgets),
+		});
+	}
+	return views.length > 0 ? views : [defaultCustomView()];
+}
+
+function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPreferences {
+	const customView: DashboardCustomView = {
+		...defaultCustomView(),
+		density: value.density === 'compact' ? 'compact' : 'comfortable',
+		widgets: normalizeWidgets(value.widgets),
+	};
+	return {
+		version: DASHBOARD_PREFERENCES_VERSION,
+		preset: normalizePreset(value.preset),
+		activeViewId: customView.id,
+		customViews: [customView],
+	};
+}
+
+function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
+	if (!isRecord(value)) return defaultDashboardPreferences();
+	if (value.version === 1) return migrateLegacyPreferences(value);
+	if (value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+
+	const customViews = normalizeCustomViews(value.customViews);
+	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
+	const activeViewId = customViews.some((view) => view.id === requestedActiveViewId)
+		? requestedActiveViewId
+		: customViews[0].id;
+
+	return {
+		version: DASHBOARD_PREFERENCES_VERSION,
+		preset: normalizePreset(value.preset),
+		activeViewId,
+		customViews,
+	};
 }
 
 export function parseDashboardPreferences(raw: string | null): DashboardPreferences {
@@ -138,17 +236,114 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 	}
 }
 
+export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
+	return parseDashboardPreferences(
+		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_PREFERENCES_KEY)
+	);
+}
+
+export function initializeDashboardPreferences(storage: Pick<Storage, 'getItem' | 'setItem'>): DashboardPreferences {
+	const preferences = loadDashboardPreferences(storage);
+	if (!storage.getItem(DASHBOARD_PREFERENCES_KEY)) {
+		storage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(preferences));
+	}
+	return preferences;
+}
+
+export function getActiveDashboardView(preferences: DashboardPreferences): DashboardCustomView {
+	return preferences.customViews.find((view) => view.id === preferences.activeViewId)
+		?? preferences.customViews[0]
+		?? defaultCustomView();
+}
+
 export function resolveDashboardWidgets(preferences: DashboardPreferences): DashboardWidgetConfig[] {
 	const widgets = preferences.preset === 'custom'
-		? preferences.widgets
+		? getActiveDashboardView(preferences).widgets
 		: dashboardPresets[preferences.preset].widgets;
 	return cloneWidgets(widgets).filter((widget) => widget.visible);
 }
 
 export function resolveDashboardDensity(preferences: DashboardPreferences): DashboardDensity {
 	return preferences.preset === 'custom'
-		? preferences.density
+		? getActiveDashboardView(preferences).density
 		: dashboardPresets[preferences.preset].density;
+}
+
+export function dashboardViewNameAvailable(
+	preferences: DashboardPreferences,
+	name: string,
+	excludeId?: string,
+): boolean {
+	const normalized = name.trim().slice(0, DASHBOARD_VIEW_NAME_MAX_LENGTH).toLocaleLowerCase();
+	return normalized.length > 0 && !preferences.customViews.some((view) =>
+		view.id !== excludeId && view.name.toLocaleLowerCase() === normalized
+	);
+}
+
+export function createDashboardView(
+	preferences: DashboardPreferences,
+	name: string,
+	source?: DashboardCustomView,
+): DashboardPreferences {
+	const id = nextViewId(preferences.customViews.map((view) => view.id));
+	const base = source ?? defaultCustomView(id);
+	const view: DashboardCustomView = {
+		id,
+		name: uniqueViewName(name, preferences.customViews.map((candidate) => candidate.name)),
+		density: base.density,
+		widgets: cloneWidgets(base.widgets),
+	};
+	return {
+		...preferences,
+		preset: 'custom',
+		activeViewId: id,
+		customViews: [...preferences.customViews, view],
+	};
+}
+
+export function renameDashboardView(
+	preferences: DashboardPreferences,
+	id: string,
+	name: string,
+): DashboardPreferences {
+	if (!dashboardViewNameAvailable(preferences, name, id)) return preferences;
+	return {
+		...preferences,
+		customViews: preferences.customViews.map((view) =>
+			view.id === id ? { ...view, name: normalizeViewName(name, view.name) } : view
+		),
+	};
+}
+
+export function deleteDashboardView(preferences: DashboardPreferences, id: string): DashboardPreferences {
+	if (preferences.customViews.length <= 1) return preferences;
+	const index = preferences.customViews.findIndex((view) => view.id === id);
+	if (index < 0) return preferences;
+	const customViews = preferences.customViews.filter((view) => view.id !== id);
+	const activeViewId = preferences.activeViewId === id
+		? customViews[Math.min(index, customViews.length - 1)].id
+		: preferences.activeViewId;
+	return { ...preferences, activeViewId, customViews };
+}
+
+export function selectDashboardView(preferences: DashboardPreferences, id: string): DashboardPreferences {
+	if (!preferences.customViews.some((view) => view.id === id)) return preferences;
+	return { ...preferences, preset: 'custom', activeViewId: id };
+}
+
+export function updateActiveDashboardView(
+	preferences: DashboardPreferences,
+	patch: Partial<Pick<DashboardCustomView, 'density' | 'widgets'>>,
+): DashboardPreferences {
+	return {
+		...preferences,
+		customViews: preferences.customViews.map((view) =>
+			view.id === preferences.activeViewId
+				? { ...view, ...patch, widgets: patch.widgets ? cloneWidgets(patch.widgets) : view.widgets }
+				: view
+		),
+	};
 }
 
 export function swapDashboardWidgets(
@@ -166,15 +361,13 @@ export function swapDashboardWidgets(
 }
 
 function createDashboardPrefs() {
-	let value = $state<DashboardPreferences>(parseDashboardPreferences(
-		typeof localStorage !== 'undefined' ? localStorage.getItem(DASHBOARD_PREFERENCES_KEY) : null
-	));
+	const storage = typeof localStorage !== 'undefined' ? localStorage : null;
+	const initialValue = storage ? initializeDashboardPreferences(storage) : defaultDashboardPreferences();
+	let value = $state<DashboardPreferences>(initialValue);
 
 	function set(next: DashboardPreferences) {
 		value = normalizeDashboardPreferences(next);
-		if (typeof localStorage !== 'undefined') {
-			localStorage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(value));
-		}
+		storage?.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(value));
 	}
 
 	return {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -8,9 +8,12 @@
 		dashboardPrefs,
 		dashboardPresets,
 		dashboardWidgetMeta,
+		getActiveDashboardView,
 		resolveDashboardDensity,
 		resolveDashboardWidgets,
+		selectDashboardView,
 		swapDashboardWidgets,
+		updateActiveDashboardView,
 		type DashboardPreferences,
 		type DashboardWidgetId,
 		type DashboardWidgetWidth,
@@ -105,10 +108,16 @@
 
 	let widgets = $derived(resolveDashboardWidgets(dashboardPrefs.value));
 	let density = $derived(resolveDashboardDensity(dashboardPrefs.value));
+	let activeCustomView = $derived(getActiveDashboardView(dashboardPrefs.value));
 	let presetLabel = $derived(
 		dashboardPrefs.value.preset === 'custom'
-			? 'Custom'
+			? activeCustomView.name
 			: dashboardPresets[dashboardPrefs.value.preset].label
+	);
+	let dashboardSelection = $derived(
+		dashboardPrefs.value.preset === 'custom'
+			? `custom:${activeCustomView.id}`
+			: dashboardPrefs.value.preset
 	);
 
 	function hasWidget(id: DashboardWidgetId): boolean {
@@ -153,10 +162,9 @@
 	function swapCustomWidgets(source: DashboardWidgetId, target: DashboardWidgetId) {
 		const preferences = dashboardPrefs.value;
 		if (preferences.preset !== 'custom' || source === target) return;
-		dashboardPrefs.set({
-			...preferences,
-			widgets: swapDashboardWidgets(preferences.widgets, source, target),
-		});
+		dashboardPrefs.set(updateActiveDashboardView(preferences, {
+			widgets: swapDashboardWidgets(getActiveDashboardView(preferences).widgets, source, target),
+		}));
 		movementAnnouncement = `${dashboardWidgetMeta[source].label} swapped with ${dashboardWidgetMeta[target].label}.`;
 	}
 
@@ -469,6 +477,18 @@
 		await tick();
 		await loadVisibleData(false);
 	}
+
+	async function switchDashboard(selection: string) {
+		const preferences = dashboardPrefs.value;
+		let next: DashboardPreferences = preferences;
+		if (selection.startsWith('custom:')) {
+			next = selectDashboardView(preferences, selection.slice('custom:'.length));
+		} else if (selection === 'storage' || selection === 'monitoring' || selection === 'overview') {
+			next = { ...preferences, preset: selection };
+		}
+		if (next === preferences) return;
+		await applyPreferences(next);
+	}
 </script>
 
 <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -476,7 +496,18 @@
 		<div class="text-sm font-semibold">{presetLabel} dashboard</div>
 		<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
 	</div>
-	<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
+	<div class="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+		<label for="dashboard-view-switcher" class="sr-only">Dashboard view</label>
+		<select id="dashboard-view-switcher" value={dashboardSelection} onchange={(event) => void switchDashboard(event.currentTarget.value)} class="h-9 min-w-0 flex-1 rounded-md border border-border bg-background px-3 text-sm sm:max-w-48">
+			<optgroup label="Presets">
+				{#each Object.entries(dashboardPresets) as [id, preset]}<option value={id}>{preset.label}</option>{/each}
+			</optgroup>
+			<optgroup label="Custom views">
+				{#each dashboardPrefs.value.customViews as view (view.id)}<option value={`custom:${view.id}`}>{view.name}</option>{/each}
+			</optgroup>
+		</select>
+		<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
+	</div>
 </div>
 <div class="sr-only" aria-live="polite">{movementAnnouncement}</div>
 


### PR DESCRIPTION
## Summary
- add create, duplicate, rename, select, and confirmed delete flows for named Custom dashboard views
- add a responsive dashboard switcher for presets and named views
- persist each view's widgets, ordering, widths, and density in versioned browser-local preferences
- migrate existing `nasty:dashboard:v1` layouts into the v2 named-view schema without losing configuration
- normalize malformed persisted views and preserve accessible keyboard focus through inline management flows

## Validation
- `npm run check`
- `npm test` (242 tests)
- `npm run build`
- `git diff --check origin/main...HEAD`

Closes #811