### PR TITLE
webui: add tiny dashboard widget presentations

### DIFF
--- a/webui/src/lib/components/dashboard/alerts-widget.svelte
+++ b/webui/src/lib/components/dashboard/alerts-widget.svelte
@@ -1,35 +1,54 @@
 <script lang="ts">
-	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DashboardDensity, DashboardWidgetPresentation } from '$lib/dashboard.svelte';
 	import type { ActiveAlert } from '$lib/types';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { CheckCircle2, TriangleAlert } from '@lucide/svelte';
 
-	let { alerts, loaded, density }: { alerts: ActiveAlert[]; loaded: boolean; density: DashboardDensity } = $props();
+	let { alerts, loaded, density, presentation }: { alerts: ActiveAlert[]; loaded: boolean; density: DashboardDensity; presentation: DashboardWidgetPresentation } = $props();
+	let criticalCount = $derived(alerts.filter((alert) => alert.severity === 'critical').length);
 </script>
 
-<Card aria-live="polite" class={alerts.some((alert) => alert.severity === 'critical') ? 'border-red-800/80' : ''}>
-	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
-		<CardTitle class="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+{#if presentation === 'tiny'}
+	<Card aria-live="polite" class={criticalCount > 0 ? 'border-red-800/80' : ''}>
+		<CardContent class="flex min-h-10 items-center gap-2 px-3 py-2 text-xs">
 			{#if !loaded}
-				<TriangleAlert class="h-4 w-4 text-muted-foreground" /> Alert status unavailable
+				<TriangleAlert class="h-4 w-4 shrink-0 text-muted-foreground" />
+				<span class="font-medium text-muted-foreground">Alert status unavailable</span>
 			{:else if alerts.length === 0}
-				<CheckCircle2 class="h-4 w-4 text-emerald-400" /> No active alerts
+				<CheckCircle2 class="h-4 w-4 shrink-0 text-emerald-400" />
+				<span class="font-medium">No active alerts</span>
 			{:else}
-				<TriangleAlert class="h-4 w-4 text-amber-400" /> {alerts.length} active alert{alerts.length === 1 ? '' : 's'}
+				<TriangleAlert class="h-4 w-4 shrink-0 {criticalCount > 0 ? 'text-red-400' : 'text-amber-400'}" />
+				<span class="font-medium {criticalCount > 0 ? 'text-red-300' : 'text-amber-300'}">{alerts.length} active alert{alerts.length === 1 ? '' : 's'}{criticalCount > 0 ? ` - ${criticalCount} critical` : ''}</span>
+				<a href="/alerts" class="ml-auto shrink-0 text-primary hover:underline">Open alerts</a>
 			{/if}
-		</CardTitle>
-	</CardHeader>
-	{#if loaded && alerts.length > 0}
-		<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
-			<div class="space-y-2">
-				{#each alerts as alert}
-					<div class="flex items-start gap-3 rounded-md border px-3 py-2 text-sm {alert.severity === 'critical' ? 'border-red-800 bg-red-950/70 text-red-200' : 'border-amber-800 bg-amber-950/60 text-amber-200'}">
-						<span class="mt-1 h-2 w-2 shrink-0 rounded-full {alert.severity === 'critical' ? 'bg-red-400' : 'bg-amber-400'}"></span>
-						<span class="text-[0.65rem] font-bold uppercase tracking-wide">{alert.severity}</span>
-						<span class="min-w-0 flex-1">{alert.message}</span>
-					</div>
-				{/each}
-			</div>
 		</CardContent>
-	{/if}
-</Card>
+	</Card>
+{:else}
+	<Card aria-live="polite" class={criticalCount > 0 ? 'border-red-800/80' : ''}>
+		<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
+			<CardTitle class="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+				{#if !loaded}
+					<TriangleAlert class="h-4 w-4 text-muted-foreground" /> Alert status unavailable
+				{:else if alerts.length === 0}
+					<CheckCircle2 class="h-4 w-4 text-emerald-400" /> No active alerts
+				{:else}
+					<TriangleAlert class="h-4 w-4 text-amber-400" /> {alerts.length} active alert{alerts.length === 1 ? '' : 's'}
+				{/if}
+			</CardTitle>
+		</CardHeader>
+		{#if loaded && alerts.length > 0}
+			<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+				<div class="space-y-2">
+					{#each alerts as alert}
+						<div class="flex items-start gap-3 rounded-md border px-3 py-2 text-sm {alert.severity === 'critical' ? 'border-red-800 bg-red-950/70 text-red-200' : 'border-amber-800 bg-amber-950/60 text-amber-200'}">
+							<span class="mt-1 h-2 w-2 shrink-0 rounded-full {alert.severity === 'critical' ? 'bg-red-400' : 'bg-amber-400'}"></span>
+							<span class="text-[0.65rem] font-bold uppercase tracking-wide">{alert.severity}</span>
+							<span class="min-w-0 flex-1">{alert.message}</span>
+						</div>
+					{/each}
+				</div>
+			</CardContent>
+		{/if}
+	</Card>
+{/if}

--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -6,6 +6,7 @@
 		dashboardPresets,
 		dashboardViewNameAvailable,
 		dashboardWidgetMeta,
+		dashboardWidgetSupportsTiny,
 		defaultDashboardPreferences,
 		deleteDashboardView,
 		getActiveDashboardView,
@@ -249,9 +250,12 @@
 
 				<div class="mt-3 divide-y divide-border rounded-lg border border-border">
 					{#each activeView.widgets as widget, index (widget.id)}
-						<div class="flex items-center gap-3 px-3 py-2.5">
+						<div class="flex flex-wrap items-center gap-3 px-3 py-2.5">
 							<input type="checkbox" checked={widget.visible} disabled={widget.visible && activeView.widgets.filter((candidate) => candidate.visible).length === 1} onchange={(event) => updateWidget(index, { visible: event.currentTarget.checked })} aria-label={`Show ${dashboardWidgetMeta[widget.id].label}`} class="h-4 w-4 accent-primary disabled:opacity-40" />
-							<div class="min-w-0 flex-1"><div class="text-sm font-medium">{dashboardWidgetMeta[widget.id].label}</div><div class="truncate text-xs text-muted-foreground">{dashboardWidgetMeta[widget.id].description}</div></div>
+							<div class="min-w-40 flex-1"><div class="text-sm font-medium">{dashboardWidgetMeta[widget.id].label}</div><div class="truncate text-xs text-muted-foreground">{dashboardWidgetMeta[widget.id].description}</div></div>
+							{#if dashboardWidgetSupportsTiny(widget.id)}
+								<select value={widget.presentation} disabled={!widget.visible} onchange={(event) => updateWidget(index, { presentation: event.currentTarget.value === 'tiny' ? 'tiny' : 'standard' })} aria-label={`${dashboardWidgetMeta[widget.id].label} presentation`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="standard">Standard</option><option value="tiny">Tiny</option></select>
+							{/if}
 							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: event.currentTarget.value === 'half' ? 'half' : 'full' })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">Half</option></select>
 							<div class="flex">
 								<Button variant="ghost" size="icon-sm" disabled={index === 0} onclick={() => moveWidget(index, -1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp /></Button>

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -1,0 +1,114 @@
+import { render } from 'svelte/server';
+import { describe, expect, test } from 'vitest';
+import AlertsWidget from './alerts-widget.svelte';
+import HistoryWidget from './history-widget.svelte';
+import OperationsWidget from './operations-widget.svelte';
+import SystemWidget from './system-widget.svelte';
+import type { ActiveAlert, SystemInfo } from '$lib/types';
+
+const alert = (severity: ActiveAlert['severity'], message: string): ActiveAlert => ({
+	rule_id: message,
+	rule_name: message,
+	severity,
+	metric: 'cpu_load_percent',
+	message,
+	current_value: 90,
+	threshold: 80,
+	source: 'system',
+	instance_id: message,
+	acknowledged: false,
+	acknowledged_at: null,
+	acknowledged_by: null,
+});
+
+const info: SystemInfo = {
+	hostname: 'nasty',
+	version: '1.2.3',
+	uptime_seconds: 3600,
+	kernel: '6.18.0',
+	bcachefs_version: '1.39.4',
+	bcachefs_commit: null,
+	bcachefs_pinned_ref: null,
+	bcachefs_recommended_ref: null,
+	bcachefs_is_custom: false,
+	timezone: 'UTC',
+	ntp_synced: true,
+};
+
+describe('tiny dashboard widgets', () => {
+	test('keeps critical alert and active operation states explicit', () => {
+		const alerts = render(AlertsWidget, {
+			props: {
+				alerts: [alert('warning', 'Warm disk'), alert('critical', 'Hot disk')],
+				loaded: true,
+				density: 'compact',
+				presentation: 'tiny',
+			},
+		}).body;
+		const operations = render(OperationsWidget, {
+			props: {
+				operations: [{ kind: 'scrub', fs: 'pool', detail: 'Checking pool', progress_percent: 42 }],
+				loaded: true,
+				density: 'compact',
+				presentation: 'tiny',
+			},
+		}).body;
+
+		expect(alerts).toContain('2 active alerts - 1 critical');
+		expect(alerts).toContain('Open alerts');
+		expect(operations).toContain('1 active - Scrub on pool');
+		expect(operations).toContain('Open operations');
+	});
+
+	test('reports unavailable and down system states without relying on color', () => {
+		const unavailable = render(SystemWidget, {
+			props: { info: null, health: null, infoLoaded: false, healthLoaded: false, density: 'compact', presentation: 'tiny' },
+		}).body;
+		const healthUnavailable = render(SystemWidget, {
+			props: { info, health: null, infoLoaded: true, healthLoaded: false, density: 'compact', presentation: 'tiny' },
+		}).body;
+		const infoUnavailable = render(SystemWidget, {
+			props: { info: null, health: { status: 'ok', services: [] }, infoLoaded: false, healthLoaded: true, density: 'compact', presentation: 'tiny' },
+		}).body;
+		const unhealthy = render(SystemWidget, {
+			props: {
+				info,
+				health: { status: 'critical', services: [{ name: 'Engine', running: false }] },
+				infoLoaded: true,
+				healthLoaded: true,
+				density: 'compact',
+				presentation: 'tiny',
+			},
+		}).body;
+
+		expect(unavailable).toContain('System status unavailable');
+		expect(healthUnavailable).toContain('Health unavailable');
+		expect(infoUnavailable).toContain('System info unavailable');
+		expect(unhealthy).toContain('1 service down');
+	});
+
+	test('renders current and peak history values instead of full charts', () => {
+		const body = render(HistoryWidget, {
+			props: {
+				cpuSamples: [
+					{ time: new Date('2026-09-01T10:00:00Z'), in: 12, out: 0 },
+					{ time: new Date('2026-09-01T10:01:00Z'), in: 8, out: 0 },
+				],
+				memorySamples: [
+					{ time: new Date('2026-09-01T10:00:00Z'), in: 40, out: 0 },
+					{ time: new Date('2026-09-01T10:01:00Z'), in: 45, out: 0 },
+				],
+				range: '5m',
+				loading: false,
+				width: 'half',
+				density: 'compact',
+				presentation: 'tiny',
+			},
+		}).body;
+
+		expect(body).toContain('8.0%');
+		expect(body).toContain('5m peak 12.0%');
+		expect(body).toContain('45.0%');
+		expect(body).not.toContain('role="img"');
+	});
+});

--- a/webui/src/lib/components/dashboard/history-controls.svelte
+++ b/webui/src/lib/components/dashboard/history-controls.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
+
+	let {
+		range,
+		offset,
+		loading,
+		onRange,
+		onBack,
+		onForward,
+		onLive,
+		class: className = '',
+	}: {
+		range: MetricsRange;
+		offset: number;
+		loading: boolean;
+		onRange: (range: MetricsRange) => void;
+		onBack: () => void;
+		onForward: () => void;
+		onLive: () => void;
+		class?: string;
+	} = $props();
+</script>
+
+<div class="flex min-w-0 max-w-full items-center gap-1 overflow-x-auto {className}">
+	{#if offset > 0}<button type="button" onclick={onLive} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs font-medium text-primary hover:bg-accent disabled:opacity-40">Live</button>{/if}
+	<button type="button" onclick={onBack} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-40" aria-label="Earlier history">&larr;</button>
+	<div class="flex rounded-md border border-border">
+		{#each (['5m', '1h', '1d', '7d', '30d'] as const) as option}
+			<button type="button" onclick={() => onRange(option)} disabled={loading} aria-pressed={range === option} class="px-2.5 py-1 text-xs font-medium first:rounded-l-md last:rounded-r-md disabled:opacity-40 {range === option ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">{option}</button>
+		{/each}
+	</div>
+	<button type="button" onclick={onForward} disabled={offset === 0 || loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:cursor-default disabled:opacity-30" aria-label="Later history">&rarr;</button>
+</div>

--- a/webui/src/lib/components/dashboard/history-widget.svelte
+++ b/webui/src/lib/components/dashboard/history-widget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import type { DashboardDensity, DashboardWidgetPresentation, DashboardWidgetWidth } from '$lib/dashboard.svelte';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import IoChart from '$lib/components/io-chart.svelte';
 
@@ -10,50 +10,58 @@
 		cpuSamples,
 		memorySamples,
 		range,
-		offset,
-		rangeDuration,
 		density,
 		width,
 		loading,
-		onRange,
-		onBack,
-		onForward,
-		onLive,
+		presentation,
 	}: {
 		cpuSamples: Sample[];
 		memorySamples: Sample[];
 		range: MetricsRange;
-		offset: number;
-		rangeDuration: number;
 		density: DashboardDensity;
 		width: DashboardWidgetWidth;
 		loading: boolean;
-		onRange: (range: MetricsRange) => void;
-		onBack: () => void;
-		onForward: () => void;
-		onLive: () => void;
+		presentation: DashboardWidgetPresentation;
 	} = $props();
+
+	function summarize(samples: Sample[]): { current: number; peak: number } | null {
+		if (samples.length === 0) return null;
+		return {
+			current: samples.at(-1)!.in,
+			peak: Math.max(...samples.map((sample) => sample.in)),
+		};
+	}
+
+	let cpu = $derived(summarize(cpuSamples));
+	let memory = $derived(summarize(memorySamples));
 </script>
 
-<div>
-	<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-		<div class="flex items-center gap-2">
-			<span class="text-sm font-semibold">History{loading ? ' - loading' : ''}</span>
-			{#if offset > 0}
-				<span class="text-xs text-muted-foreground">{new Date(Date.now() - offset - rangeDuration).toLocaleString()} - {new Date(Date.now() - offset).toLocaleString()}</span>
-			{/if}
-		</div>
-		<div class="flex max-w-full items-center gap-1 overflow-x-auto pb-1">
-			{#if offset > 0}<button type="button" onclick={onLive} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs font-medium text-primary hover:bg-accent disabled:opacity-40">Live</button>{/if}
-			<button type="button" onclick={onBack} disabled={loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-40" aria-label="Earlier history">&larr;</button>
-			<div class="flex rounded-md border border-border">
-				{#each (['5m', '1h', '1d', '7d', '30d'] as const) as option}
-					<button type="button" onclick={() => onRange(option)} disabled={loading} aria-pressed={range === option} class="px-2.5 py-1 text-xs font-medium first:rounded-l-md last:rounded-r-md disabled:opacity-40 {range === option ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}">{option}</button>
-				{/each}
-			</div>
-			<button type="button" onclick={onForward} disabled={offset === 0 || loading} class="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:cursor-default disabled:opacity-30" aria-label="Later history">&rarr;</button>
-		</div>
+{#if presentation === 'tiny'}
+	<div class="grid grid-cols-2 gap-3">
+		<Card>
+			<CardContent class="px-4 py-3">
+				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle>
+				{#if cpu}
+					<div class="mt-1 text-2xl font-bold tabular-nums">{cpu.current.toFixed(1)}%</div>
+					<div class="mt-1 text-xs text-muted-foreground">{range} peak {cpu.peak.toFixed(1)}%</div>
+				{:else}
+					<div class="mt-2 text-sm font-medium text-muted-foreground" role="status">{loading ? 'Loading...' : 'Unavailable'}</div>
+				{/if}
+			</CardContent>
+		</Card>
+		<Card>
+			<CardContent class="px-4 py-3">
+				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Memory usage</CardTitle>
+				{#if memory}
+					<div class="mt-1 text-2xl font-bold tabular-nums">{memory.current.toFixed(1)}%</div>
+					<div class="mt-1 text-xs text-muted-foreground">{range} peak {memory.peak.toFixed(1)}%</div>
+				{:else}
+					<div class="mt-2 text-sm font-medium text-muted-foreground" role="status">{loading ? 'Loading...' : 'Unavailable'}</div>
+				{/if}
+			</CardContent>
+		</Card>
 	</div>
+{:else}
 	<div class="grid grid-cols-1 gap-3 {width === 'full' ? 'sm:grid-cols-2' : ''}">
 		<Card>
 			<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}><CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle></CardHeader>
@@ -64,4 +72,4 @@
 			<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}><IoChart samples={memorySamples} inLabel="Used" inColor="var(--chart-5)" yFormat={(value) => value.toFixed(0) + '%'} tooltipFormat={(value) => value.toFixed(1) + '%'} ariaLabel="Memory usage history" emptyMessage={loading ? 'Loading data...' : 'No data for selected interval.'} /></CardContent>
 		</Card>
 	</div>
-</div>
+{/if}

--- a/webui/src/lib/components/dashboard/operations-widget.svelte
+++ b/webui/src/lib/components/dashboard/operations-widget.svelte
@@ -1,38 +1,56 @@
 <script lang="ts">
 	import type { ActiveOperation } from '$lib/types';
-	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DashboardDensity, DashboardWidgetPresentation } from '$lib/dashboard.svelte';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Activity, CheckCircle2, TriangleAlert } from '@lucide/svelte';
 
-	let { operations, loaded, density }: { operations: ActiveOperation[]; loaded: boolean; density: DashboardDensity } = $props();
+	let { operations, loaded, density, presentation }: { operations: ActiveOperation[]; loaded: boolean; density: DashboardDensity; presentation: DashboardWidgetPresentation } = $props();
 
 	function kindLabel(kind: string): string {
 		return ({ scrub: 'Scrub', evacuate: 'Evacuate', reconcile: 'Reconcile', copygc: 'Copy-GC' } as Record<string, string>)[kind] ?? kind;
 	}
 </script>
 
-<Card>
-	<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
-		<CardTitle class="flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-muted-foreground">
-			<span class="flex items-center gap-2">{#if !loaded}<TriangleAlert class="h-4 w-4 text-muted-foreground" />{:else if operations.length > 0}<Activity class="h-4 w-4 text-amber-400" />{:else}<CheckCircle2 class="h-4 w-4 text-emerald-400" />{/if} Active operations</span>
-			<a href="/operations" class="normal-case tracking-normal text-primary hover:underline">Open operations</a>
-		</CardTitle>
-	</CardHeader>
-	<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
-		{#if !loaded}
-			<p class="text-sm text-muted-foreground">Operation status is unavailable.</p>
-		{:else if operations.length === 0}
-			<p class="text-sm text-muted-foreground">No scrub, evacuation, or reconciliation work is active.</p>
-		{:else}
-			<div class="grid gap-2 md:grid-cols-2">
-				{#each operations as operation}
-					<div class="rounded-md border border-border px-3 py-2">
-						<div class="flex items-center gap-2"><span class="text-sm font-semibold">{kindLabel(operation.kind)}</span><span class="font-mono text-xs text-muted-foreground">{operation.fs}</span>{#if operation.progress_percent != null}<span class="ml-auto text-xs tabular-nums text-amber-400">{operation.progress_percent.toFixed(0)}%</span>{/if}</div>
-						<p class="mt-1 truncate text-xs text-muted-foreground" title={operation.detail}>{operation.detail}</p>
-						{#if operation.progress_percent != null}<div class="mt-2 h-1.5 overflow-hidden rounded bg-muted"><div class="h-full bg-amber-500" style="width: {Math.max(0, Math.min(100, operation.progress_percent))}%"></div></div>{/if}
-					</div>
-				{/each}
-			</div>
-		{/if}
-	</CardContent>
-</Card>
+{#if presentation === 'tiny'}
+	<Card>
+		<CardContent class="flex min-h-10 items-center gap-2 px-3 py-2 text-xs" aria-live="polite">
+			{#if !loaded}
+				<TriangleAlert class="h-4 w-4 shrink-0 text-muted-foreground" />
+				<span class="font-medium text-muted-foreground">Operation status unavailable</span>
+			{:else if operations.length === 0}
+				<CheckCircle2 class="h-4 w-4 shrink-0 text-emerald-400" />
+				<span class="font-medium">No active operations</span>
+			{:else}
+				<Activity class="h-4 w-4 shrink-0 text-amber-400" />
+				<span class="min-w-0 truncate font-medium text-amber-300" title={operations[0].detail}>{operations.length} active - {kindLabel(operations[0].kind)} on {operations[0].fs}</span>
+				<a href="/operations" class="ml-auto shrink-0 text-primary hover:underline">Open operations</a>
+			{/if}
+		</CardContent>
+	</Card>
+{:else}
+	<Card>
+		<CardHeader class={density === 'compact' ? 'px-4 py-2.5' : 'pb-2'}>
+			<CardTitle class="flex items-center justify-between gap-3 text-xs uppercase tracking-wide text-muted-foreground">
+				<span class="flex items-center gap-2">{#if !loaded}<TriangleAlert class="h-4 w-4 text-muted-foreground" />{:else if operations.length > 0}<Activity class="h-4 w-4 text-amber-400" />{:else}<CheckCircle2 class="h-4 w-4 text-emerald-400" />{/if} Active operations</span>
+				<a href="/operations" class="normal-case tracking-normal text-primary hover:underline">Open operations</a>
+			</CardTitle>
+		</CardHeader>
+		<CardContent class={density === 'compact' ? 'px-4 pb-3' : ''}>
+			{#if !loaded}
+				<p class="text-sm text-muted-foreground">Operation status is unavailable.</p>
+			{:else if operations.length === 0}
+				<p class="text-sm text-muted-foreground">No scrub, evacuation, or reconciliation work is active.</p>
+			{:else}
+				<div class="grid gap-2 md:grid-cols-2">
+					{#each operations as operation}
+						<div class="rounded-md border border-border px-3 py-2">
+							<div class="flex items-center gap-2"><span class="text-sm font-semibold">{kindLabel(operation.kind)}</span><span class="font-mono text-xs text-muted-foreground">{operation.fs}</span>{#if operation.progress_percent != null}<span class="ml-auto text-xs tabular-nums text-amber-400">{operation.progress_percent.toFixed(0)}%</span>{/if}</div>
+							<p class="mt-1 truncate text-xs text-muted-foreground" title={operation.detail}>{operation.detail}</p>
+							{#if operation.progress_percent != null}<div class="mt-2 h-1.5 overflow-hidden rounded bg-muted"><div class="h-full bg-amber-500" style="width: {Math.max(0, Math.min(100, operation.progress_percent))}%"></div></div>{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+{/if}

--- a/webui/src/lib/components/dashboard/system-widget.svelte
+++ b/webui/src/lib/components/dashboard/system-widget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DashboardDensity, DashboardWidgetPresentation } from '$lib/dashboard.svelte';
 	import type { SystemHealth, SystemInfo } from '$lib/types';
 	import { formatBytes, formatUptime } from '$lib/format';
 	import { Card, CardContent } from '$lib/components/ui/card';
@@ -8,73 +8,103 @@
 	let {
 		info,
 		health,
-		loaded,
+		infoLoaded,
+		healthLoaded,
 		density,
-	}: { info: SystemInfo | null; health: SystemHealth | null; loaded: boolean; density: DashboardDensity } = $props();
+		presentation,
+	}: { info: SystemInfo | null; health: SystemHealth | null; infoLoaded: boolean; healthLoaded: boolean; density: DashboardDensity; presentation: DashboardWidgetPresentation } = $props();
 	let expanded = $state(false);
+	let downCount = $derived(health?.services.filter((service) => !service.running).length ?? 0);
+	let loaded = $derived(infoLoaded || healthLoaded);
 </script>
 
-<Card>
-	<CardContent class={density === 'compact' ? 'py-3' : 'py-4'}>
-		{#if !loaded}
-			<p class="text-sm text-muted-foreground">System status is unavailable.</p>
-		{/if}
-		<div class="flex flex-wrap items-center gap-x-8 gap-y-2">
-			{#if info}
-				<div class="flex items-center gap-2">
-					<span class="text-lg font-bold">{info.hostname}</span>
-					<span class="text-xs text-muted-foreground">v{info.version}</span>
-				</div>
-				<div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
-					<span>Kernel {info.kernel}</span>
-					<span>Up {formatUptime(info.uptime_seconds)}</span>
-				</div>
-			{/if}
-			{#if health}
-				<button
-					type="button"
-					onclick={() => expanded = !expanded}
-					class="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-3 transition-opacity hover:opacity-80"
-					aria-expanded={expanded}
-				>
-					<span class="text-sm font-semibold {health.status === 'ok' ? 'text-emerald-400' : 'text-red-400'}">
-						{health.status.toUpperCase()}
+{#if presentation === 'tiny'}
+	<Card>
+		<CardContent class="flex min-h-10 flex-wrap items-center gap-x-4 gap-y-1 px-3 py-2 text-xs">
+			{#if !loaded}
+				<span class="font-medium text-muted-foreground">System status unavailable</span>
+			{:else}
+				{#if info}
+					<span class="font-semibold">{info.hostname}</span>
+					<span class="text-muted-foreground">v{info.version}</span>
+					<span class="text-muted-foreground">Up {formatUptime(info.uptime_seconds)}</span>
+				{:else if !infoLoaded}
+					<span class="font-medium text-muted-foreground">System info unavailable</span>
+				{/if}
+				{#if health}
+					<span class="ml-auto flex items-center gap-1.5 font-semibold {health.status === 'ok' && downCount === 0 ? 'text-emerald-400' : 'text-red-400'}">
+						<span class="h-1.5 w-1.5 rounded-full {health.status === 'ok' && downCount === 0 ? 'bg-emerald-400' : 'bg-red-400'}"></span>
+						{downCount > 0 ? `${downCount} service${downCount === 1 ? '' : 's'} down` : health.status.toUpperCase()}
 					</span>
-					{#each health.services as service}
-						<span class="flex items-center gap-1.5 text-xs text-muted-foreground">
-							<span class="h-1.5 w-1.5 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
-							{service.name}<span class="sr-only">{service.running ? 'running' : 'down'}</span>
-						</span>
-					{/each}
-					{#if expanded}<ChevronDown class="h-4 w-4" />{:else}<ChevronRight class="h-4 w-4" />{/if}
-				</button>
+				{:else if !healthLoaded}
+					<span class="ml-auto font-medium text-muted-foreground">Health unavailable</span>
+				{/if}
 			{/if}
-		</div>
-
-		{#if expanded && health}
-			<div class="mt-4 grid grid-cols-1 gap-3 border-t border-border pt-4 sm:grid-cols-2">
-				{#each health.services as service}
-					<div class="rounded-md border border-border p-3">
-						<div class="mb-2 flex items-center justify-between">
-							<div class="flex items-center gap-2">
-								<span class="h-2 w-2 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
-								<span class="text-sm font-medium">{service.name}</span>
-							</div>
-							<span class="rounded-md border px-2 py-0.5 text-xs font-medium {service.running ? 'border-emerald-700 bg-emerald-950 text-emerald-400' : 'border-red-700 bg-red-950 text-red-400'}">
-								{service.running ? 'Running' : 'Down'}
-							</span>
-						</div>
-						{#if service.running && service.pid}
-							<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-								<span class="text-muted-foreground">PID</span><span class="text-right font-mono">{service.pid}</span>
-								<span class="text-muted-foreground">Memory</span><span class="text-right font-mono">{service.memory_bytes != null ? formatBytes(service.memory_bytes) : '-'}</span>
-								<span class="text-muted-foreground">CPU Time</span><span class="text-right font-mono">{service.cpu_seconds != null ? service.cpu_seconds.toFixed(1) + 's' : '-'}</span>
-								<span class="text-muted-foreground">Uptime</span><span class="text-right font-mono">{service.uptime_seconds != null ? formatUptime(service.uptime_seconds) : '-'}</span>
-							</div>
-						{/if}
+		</CardContent>
+	</Card>
+{:else}
+	<Card>
+		<CardContent class={density === 'compact' ? 'py-3' : 'py-4'}>
+			{#if !loaded}
+				<p class="text-sm text-muted-foreground">System status is unavailable.</p>
+			{/if}
+			<div class="flex flex-wrap items-center gap-x-8 gap-y-2">
+				{#if info}
+					<div class="flex items-center gap-2">
+						<span class="text-lg font-bold">{info.hostname}</span>
+						<span class="text-xs text-muted-foreground">v{info.version}</span>
 					</div>
-				{/each}
+					<div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+						<span>Kernel {info.kernel}</span>
+						<span>Up {formatUptime(info.uptime_seconds)}</span>
+					</div>
+				{/if}
+				{#if health}
+					<button
+						type="button"
+						onclick={() => expanded = !expanded}
+						class="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-3 transition-opacity hover:opacity-80"
+						aria-expanded={expanded}
+					>
+						<span class="text-sm font-semibold {health.status === 'ok' ? 'text-emerald-400' : 'text-red-400'}">
+							{health.status.toUpperCase()}
+						</span>
+						{#each health.services as service}
+							<span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+								<span class="h-1.5 w-1.5 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
+								{service.name}<span class="sr-only">{service.running ? 'running' : 'down'}</span>
+							</span>
+						{/each}
+						{#if expanded}<ChevronDown class="h-4 w-4" />{:else}<ChevronRight class="h-4 w-4" />{/if}
+					</button>
+				{/if}
 			</div>
-		{/if}
-	</CardContent>
-</Card>
+
+			{#if expanded && health}
+				<div class="mt-4 grid grid-cols-1 gap-3 border-t border-border pt-4 sm:grid-cols-2">
+					{#each health.services as service}
+						<div class="rounded-md border border-border p-3">
+							<div class="mb-2 flex items-center justify-between">
+								<div class="flex items-center gap-2">
+									<span class="h-2 w-2 rounded-full {service.running ? 'bg-emerald-400' : 'bg-red-400'}"></span>
+									<span class="text-sm font-medium">{service.name}</span>
+								</div>
+								<span class="rounded-md border px-2 py-0.5 text-xs font-medium {service.running ? 'border-emerald-700 bg-emerald-950 text-emerald-400' : 'border-red-700 bg-red-950 text-red-400'}">
+									{service.running ? 'Running' : 'Down'}
+								</span>
+							</div>
+							{#if service.running && service.pid}
+								<div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+									<span class="text-muted-foreground">PID</span><span class="text-right font-mono">{service.pid}</span>
+									<span class="text-muted-foreground">Memory</span><span class="text-right font-mono">{service.memory_bytes != null ? formatBytes(service.memory_bytes) : '-'}</span>
+									<span class="text-muted-foreground">CPU Time</span><span class="text-right font-mono">{service.cpu_seconds != null ? service.cpu_seconds.toFixed(1) + 's' : '-'}</span>
+									<span class="text-muted-foreground">Uptime</span><span class="text-right font-mono">{service.uptime_seconds != null ? formatUptime(service.uptime_seconds) : '-'}</span>
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+{/if}

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import {
 	DASHBOARD_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_V2_PREFERENCES_KEY,
 	createDashboardView,
 	dashboardPrefs,
 	dashboardViewNameAvailable,
+	dashboardWidgetIds,
+	dashboardWidgetSupportsTiny,
 	defaultDashboardPreferences,
 	deleteDashboardView,
 	getActiveDashboardView,
@@ -28,7 +31,7 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":3,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":4,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
 	test('migrates the v1 custom layout without losing its configuration', () => {
@@ -42,28 +45,56 @@ describe('dashboard preferences', () => {
 			],
 		}));
 
-		expect(parsed.version).toBe(2);
+		expect(parsed.version).toBe(3);
 		expect(parsed.preset).toBe('custom');
 		expect(parsed.customViews).toHaveLength(1);
 		expect(getActiveDashboardView(parsed)).toMatchObject({
 			name: 'Custom',
 			density: 'compact',
 		});
-		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half' });
+		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard' });
 		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(8);
 	});
 
-	test('initializes v2 storage from the legacy key without overwriting v2 preferences', () => {
+	test('migrates v2 named views to standard widget presentations', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 2,
+			preset: 'custom',
+			activeViewId: 'daily',
+			customViews: [{
+				id: 'daily',
+				name: 'Daily',
+				density: 'compact',
+				widgets: [
+					{ id: 'alerts', visible: true, width: 'half' },
+					{ id: 'history', visible: true, width: 'full' },
+				],
+			}],
+		}));
+
+		expect(parsed.version).toBe(3);
+		expect(parsed.activeViewId).toBe('daily');
+		expect(getActiveDashboardView(parsed)).toMatchObject({ name: 'Daily', density: 'compact' });
+		expect(getActiveDashboardView(parsed).widgets.every((widget) => widget.presentation === 'standard')).toBe(true);
+	});
+
+	test('initializes v3 storage from the newest available legacy key without overwriting v3 preferences', () => {
 		localStorage.clear();
 		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
 			version: 1,
-			preset: 'storage',
+			preset: 'overview',
 			density: 'compact',
 			widgets: [],
 		}));
+		localStorage.setItem(LEGACY_DASHBOARD_V2_PREFERENCES_KEY, JSON.stringify({
+			version: 2,
+			preset: 'storage',
+			activeViewId: 'custom-1',
+			customViews: defaultDashboardPreferences().customViews,
+		}));
 		expect(initializeDashboardPreferences(localStorage).preset).toBe('storage');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 2,
+			version: 3,
 			preset: 'storage',
 		});
 
@@ -76,7 +107,7 @@ describe('dashboard preferences', () => {
 
 	test('normalizes named views, active selection, and newly added widget ids', () => {
 		const parsed = parseDashboardPreferences(JSON.stringify({
-			version: 2,
+			version: 3,
 			preset: 'custom',
 			activeViewId: ' ops ',
 			customViews: [
@@ -84,7 +115,10 @@ describe('dashboard preferences', () => {
 					id: 'ops',
 					name: 'Operations',
 					density: 'compact',
-					widgets: [{ id: 'storage', visible: false, width: 'half' }],
+					widgets: [
+						{ id: 'storage', visible: false, width: 'half', presentation: 'tiny' },
+						{ id: 'alerts', visible: true, width: 'half', presentation: 'tiny' },
+					],
 				},
 				{ id: 'ops', name: 'operations', widgets: [] },
 			],
@@ -95,12 +129,20 @@ describe('dashboard preferences', () => {
 		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
 		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(8);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
+		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
+		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
 		expect(resolveDashboardDensity(parsed)).toBe('compact');
+	});
+
+	test('limits tiny presentation to widgets with a useful reduced form', () => {
+		expect(dashboardWidgetIds.filter(dashboardWidgetSupportsTiny)).toEqual([
+			'alerts', 'system', 'operations', 'history',
+		]);
 	});
 
 	test('repairs a custom view with no visible widgets', () => {
 		const parsed = parseDashboardPreferences(JSON.stringify({
-			version: 2,
+			version: 3,
 			preset: 'custom',
 			activeViewId: 'empty',
 			customViews: [{
@@ -126,12 +168,18 @@ describe('dashboard preferences', () => {
 
 	test('creates, duplicates, renames, selects, and deletes named views', () => {
 		let preferences = createDashboardView(defaultDashboardPreferences(), 'Storage ops');
-		preferences = updateActiveDashboardView(preferences, { density: 'compact' });
+		preferences = updateActiveDashboardView(preferences, {
+			density: 'compact',
+			widgets: getActiveDashboardView(preferences).widgets.map((widget) =>
+				widget.id === 'history' ? { ...widget, presentation: 'tiny' } : widget
+			),
+		});
 		const storageView = getActiveDashboardView(preferences);
 		preferences = createDashboardView(preferences, 'Storage ops copy', storageView);
 		const copyId = preferences.activeViewId;
 
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
+		expect(getActiveDashboardView(preferences).widgets.find((widget) => widget.id === 'history')?.presentation).toBe('tiny');
 		expect(dashboardViewNameAvailable(preferences, 'storage OPS')).toBe(false);
 		preferences = renameDashboardView(preferences, copyId, 'Daily');
 		expect(getActiveDashboardView(preferences).name).toBe('Daily');
@@ -157,13 +205,13 @@ describe('dashboard preferences', () => {
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
 	});
 
-	test('persists the active named view in v2 storage', () => {
+	test('persists the active named view in v3 storage', () => {
 		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 2,
+			version: 3,
 			preset: 'custom',
 			activeViewId: preferences.activeViewId,
 		});

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,6 +1,7 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v2';
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v3';
+export const LEGACY_DASHBOARD_V2_PREFERENCES_KEY = 'nasty:dashboard:v2';
 export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 2;
+export const DASHBOARD_PREFERENCES_VERSION = 3;
 export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 
 export const dashboardWidgetIds = [
@@ -18,11 +19,13 @@ export type DashboardWidgetId = (typeof dashboardWidgetIds)[number];
 export type DashboardPreset = 'overview' | 'storage' | 'monitoring' | 'custom';
 export type DashboardDensity = 'comfortable' | 'compact';
 export type DashboardWidgetWidth = 'half' | 'full';
+export type DashboardWidgetPresentation = 'standard' | 'tiny';
 
 export interface DashboardWidgetConfig {
 	id: DashboardWidgetId;
 	visible: boolean;
 	width: DashboardWidgetWidth;
+	presentation: DashboardWidgetPresentation;
 }
 
 export interface DashboardCustomView {
@@ -39,26 +42,30 @@ export interface DashboardPreferences {
 	customViews: DashboardCustomView[];
 }
 
-export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string }> = {
-	alerts: { label: 'Alerts', description: 'Active warnings and critical conditions.' },
-	system: { label: 'System status', description: 'Host identity, uptime, and service health.' },
-	summary: { label: 'Resource summary', description: 'CPU, memory, temperature, and total storage.' },
-	operations: { label: 'Active operations', description: 'Scrubs, evacuations, and reconciliation work.' },
-	storage: { label: 'Compact storage', description: 'Filesystems and member devices in a dense table.' },
-	history: { label: 'CPU and memory history', description: 'Resource history for the selected time range.' },
-	network: { label: 'Network', description: 'Interface status, throughput, and traffic history.' },
-	disk_io: { label: 'Disk I/O', description: 'Per-device read and write activity.' },
+export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string; supportsTiny: boolean }> = {
+	alerts: { label: 'Alerts', description: 'Active warnings and critical conditions.', supportsTiny: true },
+	system: { label: 'System status', description: 'Host identity, uptime, and service health.', supportsTiny: true },
+	summary: { label: 'Resource summary', description: 'CPU, memory, temperature, and total storage.', supportsTiny: false },
+	operations: { label: 'Active operations', description: 'Scrubs, evacuations, and reconciliation work.', supportsTiny: true },
+	storage: { label: 'Compact storage', description: 'Filesystems and member devices in a dense table.', supportsTiny: false },
+	history: { label: 'CPU and memory history', description: 'Resource history for the selected time range.', supportsTiny: true },
+	network: { label: 'Network', description: 'Interface status, throughput, and traffic history.', supportsTiny: false },
+	disk_io: { label: 'Disk I/O', description: 'Per-device read and write activity.', supportsTiny: false },
 };
 
+export function dashboardWidgetSupportsTiny(id: DashboardWidgetId): boolean {
+	return dashboardWidgetMeta[id].supportsTiny;
+}
+
 const defaultCustomWidgets: DashboardWidgetConfig[] = [
-	{ id: 'alerts', visible: true, width: 'full' },
-	{ id: 'system', visible: true, width: 'full' },
-	{ id: 'summary', visible: true, width: 'full' },
-	{ id: 'operations', visible: true, width: 'full' },
-	{ id: 'storage', visible: true, width: 'full' },
-	{ id: 'history', visible: true, width: 'full' },
-	{ id: 'network', visible: true, width: 'half' },
-	{ id: 'disk_io', visible: true, width: 'half' },
+	{ id: 'alerts', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'system', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'summary', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'operations', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'storage', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'history', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'network', visible: true, width: 'half', presentation: 'standard' },
+	{ id: 'disk_io', visible: true, width: 'half', presentation: 'standard' },
 ];
 
 type FixedPreset = Exclude<DashboardPreset, 'custom'>;
@@ -129,6 +136,7 @@ function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
 			id,
 			visible: candidate.visible !== false,
 			width: candidate.width === 'half' ? 'half' : 'full',
+			presentation: candidate.presentation === 'tiny' && dashboardWidgetSupportsTiny(id) ? 'tiny' : 'standard',
 		});
 	}
 
@@ -211,7 +219,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	if (!isRecord(value)) return defaultDashboardPreferences();
 	if (value.version === 1) return migrateLegacyPreferences(value);
-	if (value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+	if (value.version !== 2 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
 
 	const customViews = normalizeCustomViews(value.customViews);
 	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
@@ -239,6 +247,7 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
 	return parseDashboardPreferences(
 		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_V2_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_PREFERENCES_KEY)
 	);
 }

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -36,6 +36,7 @@
 	import AlertsWidget from '$lib/components/dashboard/alerts-widget.svelte';
 	import CustomizeDialog from '$lib/components/dashboard/customize-dialog.svelte';
 	import DiskIoWidget from '$lib/components/dashboard/disk-io-widget.svelte';
+	import HistoryControls from '$lib/components/dashboard/history-controls.svelte';
 	import HistoryWidget from '$lib/components/dashboard/history-widget.svelte';
 	import NetworkWidget from '$lib/components/dashboard/network-widget.svelte';
 	import OperationsWidget from '$lib/components/dashboard/operations-widget.svelte';
@@ -473,6 +474,9 @@
 	}
 
 	async function applyPreferences(preferences: DashboardPreferences) {
+		if (resolveDashboardWidgets(preferences).some((widget) => widget.id === 'history' && widget.presentation === 'tiny')) {
+			metricsOffset = 0;
+		}
 		dashboardPrefs.set(preferences);
 		await tick();
 		await loadVisibleData(false);
@@ -533,26 +537,36 @@
 				ondragover={(event) => targetWidgetDrag(event, widget.id)}
 				ondrop={(event) => dropWidget(event, widget.id)}
 			>
-				{#if dashboardPrefs.value.preset === 'custom'}
-					<div class="mb-1 flex items-center justify-end gap-1 text-muted-foreground">
-						<span class="mr-auto text-[0.65rem] font-medium uppercase tracking-wide">{dashboardWidgetMeta[widget.id].label}</span>
-						<button type="button" onclick={() => moveCustomWidget(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
-						<button type="button" onclick={() => moveCustomWidget(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
-						<button type="button" draggable={true} onclick={() => moveCustomWidget(widget.id, widgets.at(-1)?.id === widget.id ? -1 : 1)} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="cursor-grab rounded p-1 hover:bg-accent hover:text-foreground active:cursor-grabbing" aria-label={`Drag ${dashboardWidgetMeta[widget.id].label} to swap positions, or activate to move it ${widgets.at(-1)?.id === widget.id ? 'earlier' : 'later'}`} title="Drag to swap positions"><GripVertical class="h-3.5 w-3.5" /></button>
+				{#if dashboardPrefs.value.preset === 'custom' || (widget.id === 'history' && widget.presentation === 'standard')}
+					<div class="mb-1 flex min-h-8 flex-wrap items-center gap-1 text-muted-foreground xl:flex-nowrap">
+						<span class="text-[0.65rem] font-medium uppercase tracking-wide">{dashboardPrefs.value.preset === 'custom' ? `${dashboardWidgetMeta[widget.id].label}${widget.id === 'history' && historyLoading ? ' - loading' : ''}` : `History${historyLoading ? ' - loading' : ''}`}</span>
+						{#if widget.id === 'history' && widget.presentation === 'standard'}
+							{#if metricsOffset > 0}
+								<span class="ml-1 min-w-0 truncate text-xs normal-case tracking-normal" title={`${new Date(Date.now() - metricsOffset - rangeDurations[metricsRange]).toLocaleString()} - ${new Date(Date.now() - metricsOffset).toLocaleString()}`}>{new Date(Date.now() - metricsOffset - rangeDurations[metricsRange]).toLocaleString()} - {new Date(Date.now() - metricsOffset).toLocaleString()}</span>
+							{/if}
+							<HistoryControls range={metricsRange} offset={metricsOffset} loading={historyLoading} class="ml-auto" onRange={(range) => void changeRange(range)} onBack={() => void navigateBack()} onForward={() => void navigateForward()} onLive={() => void navigateLive()} />
+						{/if}
+						{#if dashboardPrefs.value.preset === 'custom'}
+							<div class={widget.id === 'history' && widget.presentation === 'standard' ? 'flex' : 'ml-auto flex'}>
+								<button type="button" onclick={() => moveCustomWidget(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
+								<button type="button" onclick={() => moveCustomWidget(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
+								<button type="button" draggable={true} onclick={() => moveCustomWidget(widget.id, widgets.at(-1)?.id === widget.id ? -1 : 1)} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="cursor-grab rounded p-1 hover:bg-accent hover:text-foreground active:cursor-grabbing" aria-label={`Drag ${dashboardWidgetMeta[widget.id].label} to swap positions, or activate to move it ${widgets.at(-1)?.id === widget.id ? 'earlier' : 'later'}`} title="Drag to swap positions"><GripVertical class="h-3.5 w-3.5" /></button>
+							</div>
+						{/if}
 					</div>
 				{/if}
 				{#if widget.id === 'alerts'}
-					<AlertsWidget {alerts} loaded={alertsLoaded} {density} />
+					<AlertsWidget {alerts} loaded={alertsLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'system'}
-					<SystemWidget {info} {health} loaded={infoLoaded || healthLoaded} {density} />
+					<SystemWidget {info} {health} {infoLoaded} {healthLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'summary' && stats}
 					<SummaryWidget {stats} {filesystems} width={widget.width} {density} />
 				{:else if widget.id === 'operations'}
-					<OperationsWidget operations={systemStatus?.operations ?? []} loaded={operationsLoaded} {density} />
+					<OperationsWidget operations={systemStatus?.operations ?? []} loaded={operationsLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'storage'}
 					<StorageWidget {filesystems} usages={filesystemUsages} health={diskHealth} rates={diskRates} {density} />
 				{:else if widget.id === 'history'}
-					<HistoryWidget cpuSamples={cpuSamples} memorySamples={memorySamples} range={metricsRange} offset={metricsOffset} rangeDuration={rangeDurations[metricsRange]} loading={historyLoading} width={widget.width} {density} onRange={(range) => void changeRange(range)} onBack={() => void navigateBack()} onForward={() => void navigateForward()} onLive={() => void navigateLive()} />
+					<HistoryWidget cpuSamples={cpuSamples} memorySamples={memorySamples} range={metricsRange} loading={historyLoading} width={widget.width} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'network' && stats}
 					<NetworkWidget interfaces={stats.network} rates={networkRates} samples={networkSamples} {density} />
 				{:else if widget.id === 'disk_io' && stats}


### PR DESCRIPTION
## Summary

- add per-widget Standard/Tiny presentation controls for Alerts, System Status, Active Operations, and CPU/Memory History
- migrate dashboard preferences from v1/v2 to v3 while preserving existing named views as Standard
- keep critical, active, unavailable, and partial-load states explicit in reduced cards
- render tiny History as current/peak cards while retaining the full chart presentation
- share History controls with the dashboard chrome so paired half-width widget cards keep a common desktop baseline

## Verification

- `npm run check`
- `npm test` (247 tests)
- `npm run build`
- `git diff --check`

The build retains the pre-existing `theme.svelte.ts` state-reference warning.

Closes #813