### PR TITLE
webui: show release status in sidebar

### DIFF
--- a/webui/src/lib/release-update.test.ts
+++ b/webui/src/lib/release-update.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+import { releaseUpdateDisplay, requestReleaseUpdateCheck, shouldCheckReleaseUpdate } from './release-update';
+
+const info = {
+	current_version: '1.2.3',
+	latest_version: '1.2.4',
+	update_available: null,
+	error: null,
+};
+
+describe('release update display', () => {
+	test('distinguishes loading and unchecked states', () => {
+		expect(releaseUpdateDisplay(null, 'loading')).toMatchObject({ kind: 'loading', label: 'checking' });
+		expect(releaseUpdateDisplay(info, 'ready')).toMatchObject({ kind: 'unknown', label: 'unchecked' });
+	});
+
+	test('marks a confirmed current version', () => {
+		expect(releaseUpdateDisplay({ ...info, update_available: false }, 'ready')).toEqual({
+			kind: 'current',
+			label: 'current',
+			title: 'NASty 1.2.3 is current.',
+		});
+	});
+
+	test('describes an available version and the Update page action', () => {
+		expect(releaseUpdateDisplay({ ...info, update_available: true }, 'ready')).toEqual({
+			kind: 'available',
+			label: 'update',
+			title: 'NASty update 1.2.4 is available. Open the Update page.',
+		});
+	});
+
+	test('keeps transport and lookup failures distinct from current', () => {
+		expect(releaseUpdateDisplay(null, 'failed')).toMatchObject({ kind: 'failed', label: 'check failed' });
+		expect(releaseUpdateDisplay({ ...info, error: 'GitHub rate limited' }, 'ready')).toEqual({
+			kind: 'failed',
+			label: 'check failed',
+			title: 'NASty update check failed: GitHub rate limited',
+		});
+	});
+
+	test('requests a remote check only when local status is unknown', () => {
+		expect(shouldCheckReleaseUpdate(info)).toBe(true);
+		expect(shouldCheckReleaseUpdate({ ...info, update_available: false })).toBe(false);
+		expect(shouldCheckReleaseUpdate({ ...info, update_available: true })).toBe(false);
+		expect(shouldCheckReleaseUpdate({ ...info, error: 'offline' })).toBe(false);
+	});
+
+	test('deduplicates concurrent remote checks', async () => {
+		let resolve!: (value: typeof info) => void;
+		let calls = 0;
+		let timeout = 0;
+		const client = {
+			call: <T>(_method: string, _params?: unknown, timeoutMs?: number) => {
+				calls++;
+				timeout = timeoutMs ?? 0;
+				return new Promise<typeof info>((done) => { resolve = done; }) as Promise<T>;
+			},
+		};
+		const first = requestReleaseUpdateCheck(client);
+		const second = requestReleaseUpdateCheck(client);
+
+		expect(second).toBe(first);
+		expect(calls).toBe(1);
+		expect(timeout).toBe(180_000);
+		resolve(info);
+		await first;
+		await Promise.resolve();
+		const third = requestReleaseUpdateCheck(client);
+		expect(calls).toBe(2);
+		resolve(info);
+		await third;
+	});
+});

--- a/webui/src/lib/release-update.ts
+++ b/webui/src/lib/release-update.ts
@@ -1,0 +1,86 @@
+import type { UpdateInfo } from '$lib/types';
+
+export type ReleaseUpdateRequestState = 'idle' | 'loading' | 'ready' | 'failed';
+export type ReleaseUpdateKind = 'loading' | 'current' | 'available' | 'unknown' | 'failed';
+export const RELEASE_UPDATE_CHANGED_EVENT = 'nasty:release-update-changed';
+
+export interface ReleaseUpdateChangedDetail {
+	info: UpdateInfo | null;
+	requestState: ReleaseUpdateRequestState;
+}
+
+interface UpdateRpcClient {
+	call<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+}
+
+let updateCheckInFlight: Promise<UpdateInfo> | null = null;
+const UPDATE_CHECK_TIMEOUT_MS = 180_000;
+
+export interface ReleaseUpdateDisplay {
+	kind: ReleaseUpdateKind;
+	label: string;
+	title: string;
+}
+
+export function shouldCheckReleaseUpdate(
+	info: Pick<UpdateInfo, 'update_available' | 'error'>,
+): boolean {
+	return info.update_available === null && !info.error;
+}
+
+export function publishReleaseUpdate(
+	info: UpdateInfo | null,
+	requestState: ReleaseUpdateRequestState,
+) {
+	if (typeof window === 'undefined') return;
+	window.dispatchEvent(new CustomEvent<ReleaseUpdateChangedDetail>(RELEASE_UPDATE_CHANGED_EVENT, {
+		detail: { info, requestState },
+	}));
+}
+
+export function requestReleaseUpdateCheck(client: UpdateRpcClient): Promise<UpdateInfo> {
+	if (updateCheckInFlight) return updateCheckInFlight;
+	const request = client.call<UpdateInfo>('system.update.check', undefined, UPDATE_CHECK_TIMEOUT_MS);
+	updateCheckInFlight = request;
+	const clear = () => {
+		if (updateCheckInFlight === request) updateCheckInFlight = null;
+	};
+	request.then(clear, clear);
+	return request;
+}
+
+export function releaseUpdateDisplay(
+	info: Pick<UpdateInfo, 'current_version' | 'latest_version' | 'update_available' | 'error'> | null,
+	requestState: ReleaseUpdateRequestState,
+): ReleaseUpdateDisplay {
+	if (requestState === 'loading') {
+		return { kind: 'loading', label: 'checking', title: 'Checking for NASty updates.' };
+	}
+	if (requestState === 'failed') {
+		return { kind: 'failed', label: 'check failed', title: 'NASty update status could not be loaded.' };
+	}
+	if (info?.error) {
+		return { kind: 'failed', label: 'check failed', title: `NASty update check failed: ${info.error}` };
+	}
+	if (info?.update_available === true) {
+		return {
+			kind: 'available',
+			label: 'update',
+			title: info.latest_version
+				? `NASty update ${info.latest_version} is available. Open the Update page.`
+				: 'A NASty update is available. Open the Update page.',
+		};
+	}
+	if (info?.update_available === false) {
+		return {
+			kind: 'current',
+			label: 'current',
+			title: `NASty ${info.current_version} is current.`,
+		};
+	}
+	return {
+		kind: 'unknown',
+		label: 'unchecked',
+		title: 'NASty update status has not been checked.',
+	};
+}

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	import LauncherSidebarNav from '$lib/components/LauncherSidebarNav.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
-	import type { BackupProfile, BootStatus, BootPhase, SecureBootReadinessReport, SystemStatus } from '$lib/types';
+	import type { BackupProfile, BootStatus, BootPhase, SecureBootReadinessReport, SystemStatus, UpdateInfo } from '$lib/types';
 	import favicon from '$lib/assets/favicon.svg';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
@@ -64,6 +64,7 @@
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
+	import { RELEASE_UPDATE_CHANGED_EVENT, releaseUpdateDisplay, requestReleaseUpdateCheck, shouldCheckReleaseUpdate, type ReleaseUpdateChangedDetail, type ReleaseUpdateRequestState } from '$lib/release-update';
 	import { isManagementRole, isStandardUser, redirectForRole } from '$lib/access';
 	import { CORE_RECOVERY_PATHS, RECOVERY_BACKUP_CHANGED_EVENT, SECURE_BOOT_RECOVERY_SOURCE } from '$lib/recoveryBackup';
 
@@ -302,6 +303,15 @@
 
 	// Version info (loaded once after connect)
 	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_recommended_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
+	let releaseInfo: UpdateInfo | null = $state(null);
+	let releaseRequestState: ReleaseUpdateRequestState = $state('idle');
+	let releaseRequest = 0;
+	let releaseUpdate = $derived(releaseUpdateDisplay(releaseInfo, releaseRequestState));
+	let releaseUpdateClass = $derived(
+		releaseUpdate.kind === 'current' ? 'text-emerald-400'
+		: releaseUpdate.kind === 'available' ? 'text-amber-400'
+		: 'text-muted-foreground/60'
+	);
 	setContext(NAVIGATION_CONTEXT, {
 		get kvmAvailable() { return sysInfo?.kvm_available === true; },
 		get role() { return authInfo?.role; }
@@ -355,6 +365,34 @@
 			}).catch(() => {});
 		}
 	});
+
+	async function loadReleaseUpdate() {
+		const request = ++releaseRequest;
+		releaseRequestState = 'loading';
+		try {
+			let info = await getClient().call<UpdateInfo>('system.update.version');
+			if (request !== releaseRequest) return;
+			releaseInfo = info;
+			// The local endpoint is cheap and may gain a cached result later. Only
+			// fall through to the remote lookup when the status is still unknown.
+			if (shouldCheckReleaseUpdate(info)) {
+				info = await requestReleaseUpdateCheck(getClient());
+				if (request !== releaseRequest) return;
+				releaseInfo = info;
+			}
+			releaseRequestState = 'ready';
+		} catch {
+			if (request === releaseRequest) releaseRequestState = 'failed';
+		}
+	}
+
+	function handleReleaseUpdateChanged(event: Event) {
+		if (!connected || !isManagementRole(authInfo?.role)) return;
+		const detail = (event as CustomEvent<ReleaseUpdateChangedDetail>).detail;
+		releaseRequest++;
+		releaseInfo = detail.info;
+		releaseRequestState = detail.requestState;
+	}
 
 	async function checkAuth() {
 		if (!connected) return;
@@ -500,6 +538,7 @@
 		if (isPublicShare) return;
 		tryConnect();
 		window.addEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
+		window.addEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
 		const rebootPoll = setInterval(checkRebootRequired, 30_000);
 		const statusPoll = setInterval(refreshSystemStatus, 20_000);
@@ -519,6 +558,7 @@
 			clearInterval(statusPoll);
 			clearInterval(authPoll);
 			window.removeEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
+			window.removeEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
 		};
 	});
 
@@ -567,6 +607,7 @@
 			if (isManagementRole(authInfo.role)) {
 				checkSshStatus();
 				checkConfigBackup();
+				void loadReleaseUpdate();
 			}
 			// Capture engine commit on first connect for reconnect version check
 			if (!initialCommit) {
@@ -671,6 +712,9 @@
 		connected = false;
 		authInfo = null;
 		sysInfo = null;
+		releaseRequest++;
+		releaseInfo = null;
+		releaseRequestState = 'idle';
 		systemStatus = null;
 		statusExpanded = false;
 		sshPasswordAuth = false;
@@ -1069,7 +1113,15 @@
 					{#if sysInfo}
 						<div class="flex items-center justify-between">
 							<a href="/licenses" class="text-[0.68rem] text-muted-foreground/50 hover:text-muted-foreground transition-colors">NASty</a>
-							<span class="text-[0.68rem] font-mono text-muted-foreground/70">{sysInfo.version}</span>
+							{#if releaseUpdate.kind === 'available'}
+								<a href="/update#version" class="ml-2 flex min-w-0 items-center gap-1 text-[0.68rem] font-mono text-amber-400 transition-colors hover:text-amber-300" title={releaseUpdate.title} aria-label={`${sysInfo.version}. ${releaseUpdate.title}`}>
+									<span class="truncate">{sysInfo.version}</span><span class="shrink-0 font-sans">{releaseUpdate.label}</span><ExternalLink size={10} class="shrink-0" />
+								</a>
+							{:else}
+								<span class="ml-2 flex min-w-0 items-center gap-1 text-[0.68rem] font-mono {releaseUpdateClass}" title={releaseUpdate.title}>
+									<span class="truncate">{sysInfo.version}</span><span class="shrink-0 font-sans">{releaseUpdate.label}</span>
+								</span>
+							{/if}
 						</div>
 						<div class="flex items-center justify-between mt-0.5">
 							<span class="text-[0.68rem] text-muted-foreground/50">kernel</span>

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -28,6 +28,7 @@
 		shouldShowUpdateStatus,
 		versionUpdatePhases
 	} from '$lib/update-progress';
+	import { publishReleaseUpdate, requestReleaseUpdateCheck } from '$lib/release-update';
 
 	type Tab = 'version' | 'generations' | 'firmware';
 	type VersionRow = {
@@ -452,10 +453,13 @@
 
 	async function checkForUpdates() {
 		checking = true;
+		publishReleaseUpdate(checkInfo ?? info, 'loading');
 		try {
-			checkInfo = await client.call<UpdateInfo>('system.update.check');
+			checkInfo = await requestReleaseUpdateCheck(client);
+			publishReleaseUpdate(checkInfo, 'ready');
 		} catch {
 			checkInfo = null;
+			publishReleaseUpdate(null, 'failed');
 		}
 		checking = false;
 	}


### PR DESCRIPTION
## Summary
- show current, available, loading, and unavailable release status beside the sidebar version
- avoid redundant remote checks and synchronize manual checks from the Update page
- guard stale session responses and give the long-running update check an appropriate timeout

## Testing
- `npm run check`
- `npm test` (253 tests)
- `npm run build`

Closes #814