### PR TITLE
webui: add dashboard service and container health counters

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -1855,6 +1855,11 @@ pub struct App {
     pub created: String,
     /// App kind: "simple" or "compose".
     pub kind: String,
+    /// Container instances expected from persisted configuration. Simple apps
+    /// contain their app name; compose service names repeat for configured
+    /// replicas, while services behind inactive profiles are excluded.
+    #[serde(default)]
+    pub expected_containers: Option<Vec<String>>,
     /// Individual containers (for compose apps with multiple services).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub containers: Vec<AppContainer>,
@@ -1882,6 +1887,88 @@ pub struct App {
     /// The app's IP on that network, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network_ip: Option<String>,
+}
+
+fn parse_compose_inventory(
+    content: &str,
+    active_services: Option<&std::collections::HashSet<String>>,
+) -> Option<(Vec<String>, Vec<String>)> {
+    let parsed: serde_json::Value = serde_yaml_ng::from_str(content).ok()?;
+    let services = parsed.get("services")?.as_object()?;
+    let mut names = Vec::new();
+    for (name, service) in services {
+        let active = active_services.map_or_else(
+            || {
+                !service
+                    .get("profiles")
+                    .and_then(|profiles| profiles.as_array())
+                    .is_some_and(|profiles| !profiles.is_empty())
+            },
+            |active| active.contains(name),
+        );
+        if !active {
+            continue;
+        }
+        let replicas = service
+            .get("scale")
+            .and_then(|scale| scale.as_u64())
+            .or_else(|| service.get("deploy")?.get("replicas")?.as_u64())
+            .unwrap_or(1);
+        for _ in 0..replicas {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    let mut images: Vec<String> = services
+        .values()
+        .filter_map(|service| service.get("image")?.as_str().map(String::from))
+        .collect();
+    images.sort();
+    Some((names, images))
+}
+
+async fn compose_config_output(
+    compose_path: &std::path::Path,
+    args: &[&str],
+) -> Result<String, AppsError> {
+    let path = compose_path.to_string_lossy();
+    let mut command = Command::new("docker");
+    command.args(["compose", "-f", path.as_ref(), "config"]);
+    command.args(args);
+    if let Some(parent) = compose_path.parent() {
+        command.current_dir(parent);
+    }
+    let output = command
+        .output()
+        .await
+        .map_err(|error| AppsError::CommandFailed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(AppsError::DockerFailed(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+async fn effective_compose_inventory(
+    compose_path: &std::path::Path,
+) -> Result<(Vec<String>, Vec<String>), AppsError> {
+    let (config, services) = tokio::try_join!(
+        compose_config_output(compose_path, &["--format", "json"]),
+        compose_config_output(compose_path, &["--services"]),
+    )?;
+    let active_services = services
+        .lines()
+        .map(str::trim)
+        .filter(|service| !service.is_empty())
+        .map(String::from)
+        .collect();
+    parse_compose_inventory(&config, Some(&active_services)).ok_or_else(|| {
+        AppsError::CommandFailed(format!(
+            "parse effective compose inventory for {}",
+            compose_path.display()
+        ))
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -3498,7 +3585,7 @@ impl AppsService {
             return self.list_internal().await;
         }
         // Docker not running — return offline list from filesystem
-        Self::list_offline().await
+        Self::list_offline(true).await
     }
 
     /// Live resource usage for every NASty-managed app that has at
@@ -3622,7 +3709,7 @@ impl AppsService {
     /// List apps from on-disk state when Docker is not running.
     /// Compose apps are detected by docker-compose.yml files.
     /// Simple apps are detected by {name}.json manifest files.
-    async fn list_offline() -> Result<Vec<App>, AppsError> {
+    async fn list_offline(include_compose: bool) -> Result<Vec<App>, AppsError> {
         let apps_dir = std::path::Path::new(COMPOSE_DIR);
         if !apps_dir.is_dir() {
             return Ok(Vec::new());
@@ -3636,6 +3723,9 @@ impl AppsService {
             let name = entry.file_name().to_string_lossy().to_string();
 
             if path.is_dir() {
+                if !include_compose {
+                    continue;
+                }
                 if let Err(e) = validate_app_name(&name) {
                     warn!("apps: ignoring unsafe compose directory name '{name}': {e}");
                     continue;
@@ -3643,24 +3733,23 @@ impl AppsService {
                 // Compose app: directory with docker-compose.yml
                 let compose_path = path.join("docker-compose.yml");
                 if compose_path.exists() {
-                    let images: Vec<String> = tokio::fs::read_to_string(&compose_path)
+                    let raw_inventory = tokio::fs::read_to_string(&compose_path)
                         .await
                         .ok()
-                        .and_then(|content| {
-                            let parsed: serde_json::Value =
-                                serde_yaml_ng::from_str(&content).ok()?;
-                            Some(
-                                parsed
-                                    .get("services")?
-                                    .as_object()?
-                                    .values()
-                                    .filter_map(|svc| {
-                                        svc.get("image")?.as_str().map(|s| s.to_string())
-                                    })
-                                    .collect(),
-                            )
-                        })
-                        .unwrap_or_default();
+                        .and_then(|content| parse_compose_inventory(&content, None));
+                    let (expected_containers, images) =
+                        match effective_compose_inventory(&compose_path).await {
+                            Ok((expected, images)) => (Some(expected), images),
+                            Err(error) => {
+                                warn!(
+                                    "apps: effective compose inventory for '{name}' failed: {error}"
+                                );
+                                (
+                                    None,
+                                    raw_inventory.map(|(_, images)| images).unwrap_or_default(),
+                                )
+                            }
+                        };
                     let image = if images.len() == 1 {
                         images[0].clone()
                     } else {
@@ -3679,6 +3768,7 @@ impl AppsService {
                         status: "stopped".to_string(),
                         created: String::new(),
                         kind: "compose".to_string(),
+                        expected_containers,
                         containers: Vec::new(),
                         ports: Vec::new(),
                         unsafe_mode,
@@ -3731,11 +3821,12 @@ impl AppsService {
                         .and_then(|s| s.as_str())
                         .map(String::from);
                     apps.push(App {
-                        name: app_name,
+                        name: app_name.clone(),
                         image,
                         status: "stopped".to_string(),
                         created: String::new(),
                         kind: "simple".to_string(),
+                        expected_containers: Some(vec![app_name.clone()]),
                         containers: Vec::new(),
                         ports: Vec::new(),
                         unsafe_mode,
@@ -3809,11 +3900,12 @@ impl AppsService {
                 })
                 .or_else(|| labels.and_then(|l| l.get(LABEL_APP_NETWORK_IP)).cloned());
             apps.push(App {
-                name: app_name,
+                name: app_name.clone(),
                 image: c.image.as_deref().unwrap_or("").to_string(),
                 status: container_status_str(c),
                 created: c.created.map(chrono_from_timestamp).unwrap_or_default(),
                 kind,
+                expected_containers: Some(vec![app_name.clone()]),
                 containers: vec![],
                 ports: extract_ports(c),
                 unsafe_mode,
@@ -3821,6 +3913,14 @@ impl AppsService {
                 network,
                 network_ip,
             });
+        }
+
+        // A managed simple app remains expected even if its Docker container was
+        // removed out of band. Merge persisted manifests that live discovery missed.
+        for offline in Self::list_offline(false).await? {
+            if offline.kind == "simple" && seen_names.insert(offline.name.clone()) {
+                apps.push(offline);
+            }
         }
 
         // Discover compose apps from the compose directory. Once Docker is
@@ -3833,6 +3933,9 @@ impl AppsService {
         };
         if let Some(entries) = entries.as_mut() {
             while let Some(entry) = entries.next_entry().await.map_err(AppsError::Io)? {
+                if !entry.path().is_dir() {
+                    continue;
+                }
                 let name = entry.file_name().to_string_lossy().to_string();
                 if seen_names.contains(&name) {
                     continue;
@@ -3845,6 +3948,7 @@ impl AppsService {
                 if !compose_path.exists() {
                     continue;
                 }
+                let (expected_containers, _) = effective_compose_inventory(&compose_path).await?;
 
                 // Find all containers from this compose project
                 let mut pf = HashMap::new();
@@ -3926,6 +4030,7 @@ impl AppsService {
                     status: overall_status,
                     created,
                     kind: "compose".to_string(),
+                    expected_containers: Some(expected_containers),
                     containers,
                     ports: all_ports,
                     unsafe_mode,
@@ -6854,9 +6959,9 @@ async fn fetch_manifest_json(
 mod tests {
     use super::{
         AppVolume, InstallAppRequest, StartupConfig, completes_ok_within, compose_file_args,
-        docker_data_root_status, extract_user_env, render_env_file, render_startup_override,
-        validate_app_name, validate_new_app_name, validate_new_app_request,
-        validate_simple_volumes, validate_volume_name,
+        docker_data_root_status, extract_user_env, parse_compose_inventory, render_env_file,
+        render_startup_override, validate_app_name, validate_new_app_name,
+        validate_new_app_request, validate_simple_volumes, validate_volume_name,
     };
     use std::path::PathBuf;
     use std::time::Duration;
@@ -6995,6 +7100,38 @@ mod tests {
         let empty = render_startup_override(&[]);
         assert!(empty.contains("services:\n"));
         assert!(!empty.contains("restart:"));
+    }
+
+    #[test]
+    fn compose_inventory_reports_declared_service_names() {
+        let compose = r#"
+services:
+  web:
+    image: example/web:latest
+  worker:
+    build: .
+    scale: 2
+  db:
+    image: postgres:18
+    deploy:
+      replicas: 2
+  debug:
+    image: example/debug:latest
+    profiles: [debug]
+"#;
+        let (services, images) =
+            parse_compose_inventory(compose, None).expect("valid compose inventory");
+
+        assert_eq!(services, ["db", "db", "web", "worker", "worker"]);
+        assert_eq!(
+            images,
+            ["example/debug:latest", "example/web:latest", "postgres:18"]
+        );
+
+        let active = std::collections::HashSet::from(["debug".to_string(), "web".to_string()]);
+        let (active_services, _) =
+            parse_compose_inventory(compose, Some(&active)).expect("effective inventory");
+        assert_eq!(active_services, ["debug", "web"]);
     }
 
     #[test]

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -1,6 +1,7 @@
 import { render } from 'svelte/server';
 import { describe, expect, test } from 'vitest';
 import AlertsWidget from './alerts-widget.svelte';
+import HealthWidget from './health-widget.svelte';
 import HistoryWidget from './history-widget.svelte';
 import OperationsWidget from './operations-widget.svelte';
 import SystemWidget from './system-widget.svelte';
@@ -110,5 +111,76 @@ describe('tiny dashboard widgets', () => {
 		expect(body).toContain('5m peak 12.0%');
 		expect(body).toContain('45.0%');
 		expect(body).not.toContain('role="img"');
+	});
+});
+
+describe('dashboard health widget', () => {
+	test('renders linked service and managed container counts with explicit health states', () => {
+		const body = render(HealthWidget, {
+			props: {
+				services: { enabled: 3, running: 2 },
+				servicesFreshness: 'current',
+				containers: { runtime: 'running', expected: 2, running: 2 },
+				containersFreshness: 'current',
+				density: 'comfortable',
+				width: 'full',
+			},
+		}).body;
+
+		expect(body).toContain('href="/services"');
+		expect(body).toContain('3 enabled');
+		expect(body).toContain('2 running');
+		expect(body).toContain('1 enabled service not running.');
+		expect(body).toContain('href="/apps"');
+		expect(body).toContain('2 expected');
+		expect(body).toContain('All expected containers are running.');
+		expect(body).toContain('Simple apps count once; Compose service instances count individually.');
+		expect(body).toContain('md:grid-cols-2');
+		expect(body).toContain('px-5 py-4');
+	});
+
+	test('distinguishes disabled, loading, unavailable, and stale states in text', () => {
+		const disabled = render(HealthWidget, {
+			props: {
+				services: null,
+				servicesFreshness: 'loading',
+				containers: { runtime: 'disabled', expected: null, running: null },
+				containersFreshness: 'current',
+				density: 'compact',
+				width: 'half',
+			},
+		}).body;
+		const stale = render(HealthWidget, {
+			props: {
+				services: { enabled: 1, running: 1 },
+				servicesFreshness: 'stale',
+				containers: null,
+				containersFreshness: 'unavailable',
+				density: 'compact',
+				width: 'half',
+			},
+		}).body;
+		const refreshing = render(HealthWidget, {
+			props: {
+				services: { enabled: 1, running: 1 },
+				servicesFreshness: 'refreshing',
+				containers: { runtime: 'running', expected: 1, running: 1 },
+				containersFreshness: 'refreshing',
+				density: 'compact',
+				width: 'half',
+			},
+		}).body;
+
+		expect(disabled).toContain('Checking enabled services.');
+		expect(disabled).toContain('Docker runtime is disabled.');
+		expect(disabled).toContain('px-4 py-3');
+		expect(disabled).not.toContain('md:grid-cols-2');
+		expect(stale).toContain('Stale - healthy');
+		expect(stale).toContain('Refresh failed; showing last known healthy state.');
+		expect(stale).toContain('Managed container health could not be loaded.');
+		expect(stale).toContain('role="status"');
+		expect(refreshing).toContain('Refreshing - healthy');
+		expect(refreshing).toContain('Refreshing; showing last known healthy state.');
+		expect(refreshing).not.toContain('Refresh failed');
 	});
 });

--- a/webui/src/lib/components/dashboard/health-widget.svelte
+++ b/webui/src/lib/components/dashboard/health-widget.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import type {
+		DashboardHealthFreshness,
+		ManagedContainerHealthSummary,
+		ServiceHealthSummary,
+	} from '$lib/dashboard-health';
+	import { Card, CardContent } from '$lib/components/ui/card';
+
+	let {
+		services,
+		servicesFreshness,
+		containers,
+		containersFreshness,
+		density,
+		width,
+	}: {
+		services: ServiceHealthSummary | null;
+		servicesFreshness: DashboardHealthFreshness;
+		containers: ManagedContainerHealthSummary | null;
+		containersFreshness: DashboardHealthFreshness;
+		density: DashboardDensity;
+		width: DashboardWidgetWidth;
+	} = $props();
+
+	type TilePresentation = {
+		label: string;
+		detail: string;
+		tone: 'healthy' | 'warning' | 'neutral';
+	};
+
+	function stalePresentation(previous: TilePresentation): TilePresentation {
+		return {
+			label: `Stale - ${previous.label.toLowerCase()}`,
+			detail: `Refresh failed; showing last known ${previous.label.toLowerCase()} state.`,
+			tone: 'warning',
+		};
+	}
+
+	function refreshingPresentation(previous: TilePresentation): TilePresentation {
+		return {
+			label: `Refreshing - ${previous.label.toLowerCase()}`,
+			detail: `Refreshing; showing last known ${previous.label.toLowerCase()} state.`,
+			tone: 'neutral',
+		};
+	}
+
+	function servicePresentation(): TilePresentation {
+		if (servicesFreshness === 'loading') return { label: 'Loading', detail: 'Checking enabled services.', tone: 'neutral' };
+		if (!services || servicesFreshness === 'unavailable') return { label: 'Unavailable', detail: 'Service health could not be loaded.', tone: 'neutral' };
+		const current: TilePresentation = services.enabled === 0
+			? { label: 'No services enabled', detail: 'No services are expected to run.', tone: 'neutral' }
+			: services.running === services.enabled
+				? { label: 'Healthy', detail: 'All enabled services are running.', tone: 'healthy' }
+				: { label: 'Unhealthy', detail: `${services.enabled - services.running} enabled service${services.enabled - services.running === 1 ? '' : 's'} not running.`, tone: 'warning' };
+		if (servicesFreshness === 'refreshing') return refreshingPresentation(current);
+		return servicesFreshness === 'stale' ? stalePresentation(current) : current;
+	}
+
+	function containerPresentation(): TilePresentation {
+		if (containersFreshness === 'loading') return { label: 'Loading', detail: 'Checking managed containers.', tone: 'neutral' };
+		if (!containers || containersFreshness === 'unavailable') return { label: 'Unavailable', detail: 'Managed container health could not be loaded.', tone: 'neutral' };
+		let current: TilePresentation;
+		if (containers.runtime === 'disabled') {
+			current = { label: 'Disabled', detail: 'Docker runtime is disabled.', tone: 'neutral' };
+		} else if (containers.runtime === 'down') {
+			current = { label: 'Unhealthy', detail: `Docker runtime is enabled but not running.${containers.expected == null ? ' Expected count unavailable.' : ''}`, tone: 'warning' };
+		} else if (containers.expected == null || containers.running == null) {
+			current = { label: 'Unavailable', detail: 'Expected container inventory is unavailable.', tone: 'neutral' };
+		} else if (containers.expected === 0) {
+			current = { label: 'Healthy', detail: 'No managed containers are configured.', tone: 'healthy' };
+		} else if (containers.running === containers.expected) {
+			current = { label: 'Healthy', detail: 'All expected containers are running.', tone: 'healthy' };
+		} else {
+			const stopped = containers.expected - containers.running;
+			current = { label: 'Unhealthy', detail: `${stopped} expected container${stopped === 1 ? '' : 's'} not running.`, tone: 'warning' };
+		}
+		if (containersFreshness === 'refreshing') return refreshingPresentation(current);
+		return containersFreshness === 'stale' ? stalePresentation(current) : current;
+	}
+
+	function tileClass(tone: TilePresentation['tone']): string {
+		if (tone === 'healthy') return 'border-emerald-500/30 bg-emerald-500/5';
+		if (tone === 'warning') return 'border-amber-500/40 bg-amber-500/5';
+		return 'border-border';
+	}
+
+	function labelClass(tone: TilePresentation['tone']): string {
+		if (tone === 'healthy') return 'text-emerald-500';
+		if (tone === 'warning') return 'text-amber-500';
+		return 'text-muted-foreground';
+	}
+
+	let serviceState = $derived(servicePresentation());
+	let containerState = $derived(containerPresentation());
+</script>
+
+<div class="grid gap-3 {width === 'full' ? 'md:grid-cols-2' : ''}">
+	<Card class="h-full overflow-hidden {tileClass(serviceState.tone)}">
+		<a href="/services" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Services: ${serviceState.label}. ${services ? `${services.enabled} enabled, ${services.running} running.` : serviceState.detail}`}>
+			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>
+				<div class="flex items-center justify-between gap-3">
+					<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Services</div>
+					<div class="text-xs font-semibold {labelClass(serviceState.tone)}">{serviceState.label}</div>
+				</div>
+				{#if services}
+					<div class="mt-2 text-xl font-bold tabular-nums">{services.enabled} enabled <span class="text-muted-foreground">/</span> {services.running} running</div>
+				{:else}
+					<div class="mt-2 text-xl font-bold text-muted-foreground">{serviceState.label}</div>
+				{/if}
+				<div class="mt-1 text-xs text-muted-foreground" role={servicesFreshness === 'refreshing' || servicesFreshness === 'stale' || servicesFreshness === 'unavailable' ? 'status' : undefined}>{serviceState.detail}</div>
+			</CardContent>
+		</a>
+	</Card>
+
+	<Card class="h-full overflow-hidden {tileClass(containerState.tone)}">
+		<a href="/apps" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Managed containers: ${containerState.label}. ${containers?.expected != null ? `${containers.expected} expected, ${containers.running} running.` : containerState.detail}`}>
+			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>
+				<div class="flex items-center justify-between gap-3">
+					<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Managed containers</div>
+					<div class="text-xs font-semibold {labelClass(containerState.tone)}">{containerState.label}</div>
+				</div>
+				{#if containers?.expected != null && containers.running != null}
+					<div class="mt-2 text-xl font-bold tabular-nums">{containers.expected} expected <span class="text-muted-foreground">/</span> {containers.running} running</div>
+				{:else}
+					<div class="mt-2 text-xl font-bold text-muted-foreground">{containerState.label}</div>
+				{/if}
+				<div class="mt-1 text-xs text-muted-foreground" role={containersFreshness === 'refreshing' || containersFreshness === 'stale' || containersFreshness === 'unavailable' ? 'status' : undefined}>{containerState.detail}</div>
+				{#if containers && containers.runtime !== 'disabled'}
+					<div class="mt-1 text-[0.68rem] text-muted-foreground/80">Simple apps count once; Compose service instances count individually.</div>
+				{/if}
+			</CardContent>
+		</a>
+	</Card>
+</div>

--- a/webui/src/lib/dashboard-health.test.ts
+++ b/webui/src/lib/dashboard-health.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest';
+import type { App, AppsStatus, ProtocolStatus } from '$lib/types';
+import {
+	shouldPollDashboardHealth,
+	summarizeEnabledServices,
+	summarizeManagedContainers,
+} from './dashboard-health';
+
+const appsStatus = (overrides: Partial<AppsStatus> = {}): AppsStatus => ({
+	enabled: true,
+	running: true,
+	app_count: 0,
+	storage_ok: true,
+	...overrides,
+});
+
+const app = (name: string, overrides: Partial<App> = {}): App => ({
+	name,
+	image: `${name}:latest`,
+	status: 'running',
+	created: '2026-09-01T00:00:00Z',
+	kind: 'simple',
+	...overrides,
+});
+
+describe('dashboard health summaries', () => {
+	test('counts only enabled services as expected or running', () => {
+		const protocols: ProtocolStatus[] = [
+			{ name: 'ssh', display_name: 'SSH', enabled: true, running: true, system_service: true },
+			{ name: 'smb', display_name: 'SMB', enabled: true, running: false, system_service: false },
+			{ name: 'nvmeof', display_name: 'NVMe-oF', enabled: false, running: true, system_service: false },
+		];
+
+		expect(summarizeEnabledServices(protocols)).toEqual({ enabled: 2, running: 1 });
+	});
+
+	test('counts configured simple and compose containers without counting stack rows', () => {
+		const apps: App[] = [
+			app('simple-running'),
+			app('simple-stopped', { status: 'exited' }),
+			app('compose-running', {
+				kind: 'compose',
+				expected_containers: ['web', 'db'],
+				containers: [
+					{ name: 'web', container_id: '1', image: 'web', status: 'running' },
+					{ name: 'db', container_id: '2', image: 'db', status: 'running' },
+				],
+			}),
+			app('compose-partial', {
+				kind: 'compose',
+				expected_containers: ['web', 'db'],
+				containers: [
+					{ name: 'web', container_id: '3', image: 'web', status: 'running' },
+					{ name: 'db', container_id: '4', image: 'db', status: 'exited' },
+				],
+			}),
+			app('compose-empty', { kind: 'compose', expected_containers: ['worker'], containers: [] }),
+		];
+
+		expect(summarizeManagedContainers(appsStatus(), apps)).toEqual({
+			runtime: 'running',
+			expected: 7,
+			running: 4,
+		});
+	});
+
+	test('treats a disabled runtime as neutral and an enabled stopped runtime as down', () => {
+		expect(summarizeManagedContainers(appsStatus({ enabled: false, running: false }), [app('offline')])).toEqual({
+			runtime: 'disabled',
+			expected: null,
+			running: null,
+		});
+		expect(summarizeManagedContainers(appsStatus({ running: false }), [app('offline')])).toEqual({
+			runtime: 'down',
+			expected: 1,
+			running: 0,
+		});
+	});
+
+	test('marks compose expectations unknown when an older inventory omits service names', () => {
+		expect(summarizeManagedContainers(appsStatus(), [app('compose', { kind: 'compose', containers: [] })])).toEqual({
+			runtime: 'running',
+			expected: null,
+			running: null,
+		});
+	});
+
+	test('treats an explicit zero-replica compose expectation as known', () => {
+		expect(summarizeManagedContainers(appsStatus(), [app('compose', {
+			kind: 'compose',
+			expected_containers: [],
+			containers: [],
+		})])).toEqual({
+			runtime: 'running',
+			expected: 0,
+			running: 0,
+		});
+	});
+
+	test('counts a configured compose service as stopped when its container is absent', () => {
+		const compose = app('compose', {
+			kind: 'compose',
+			expected_containers: ['web', 'db'],
+			containers: [{ name: 'web', container_id: '1', image: 'web', status: 'running' }],
+		});
+
+		expect(summarizeManagedContainers(appsStatus(), [compose])).toEqual({
+			runtime: 'running',
+			expected: 2,
+			running: 1,
+		});
+	});
+
+	test('matches running compose replicas to expected instances', () => {
+		const compose = app('scaled', {
+			kind: 'compose',
+			expected_containers: ['web', 'web', 'web'],
+			containers: [
+				{ name: 'web', container_id: '1', image: 'web', status: 'running' },
+				{ name: 'web', container_id: '2', image: 'web', status: 'running' },
+				{ name: 'web', container_id: '3', image: 'web', status: 'exited' },
+			],
+		});
+
+		expect(summarizeManagedContainers(appsStatus(), [compose])).toEqual({
+			runtime: 'running',
+			expected: 3,
+			running: 2,
+		});
+	});
+
+	test('polls only when the widget and browser document are visible', () => {
+		expect(shouldPollDashboardHealth(true, false)).toBe(true);
+		expect(shouldPollDashboardHealth(false, false)).toBe(false);
+		expect(shouldPollDashboardHealth(true, true)).toBe(false);
+	});
+});

--- a/webui/src/lib/dashboard-health.ts
+++ b/webui/src/lib/dashboard-health.ts
@@ -1,0 +1,62 @@
+import type { App, AppsStatus, ProtocolStatus } from '$lib/types';
+
+export type DashboardHealthFreshness = 'loading' | 'refreshing' | 'current' | 'stale' | 'unavailable';
+
+export interface ServiceHealthSummary {
+	enabled: number;
+	running: number;
+}
+
+export interface ManagedContainerHealthSummary {
+	runtime: 'disabled' | 'running' | 'down';
+	expected: number | null;
+	running: number | null;
+}
+
+export function summarizeEnabledServices(protocols: ProtocolStatus[]): ServiceHealthSummary {
+	const enabled = protocols.filter((protocol) => protocol.enabled);
+	return {
+		enabled: enabled.length,
+		running: enabled.filter((protocol) => protocol.running).length,
+	};
+}
+
+export function summarizeManagedContainers(status: AppsStatus, apps: App[]): ManagedContainerHealthSummary {
+	if (!status.enabled) return { runtime: 'disabled', expected: null, running: null };
+
+	let expected = 0;
+	let running = 0;
+	for (const app of apps) {
+		const expectedContainers = app.expected_containers ?? (app.kind === 'simple' ? [app.name] : null);
+		if (!expectedContainers) {
+			return { runtime: status.running ? 'running' : 'down', expected: null, running: null };
+		}
+		expected += expectedContainers.length;
+		if (!status.running) continue;
+		if (app.kind !== 'compose') {
+			if (app.status === 'running') running += 1;
+			continue;
+		}
+		const runningByService = new Map<string, number>();
+		for (const container of app.containers ?? []) {
+			if (container.status !== 'running') continue;
+			runningByService.set(container.name, (runningByService.get(container.name) ?? 0) + 1);
+		}
+		for (const name of expectedContainers) {
+			const available = runningByService.get(name) ?? 0;
+			if (available === 0) continue;
+			running += 1;
+			runningByService.set(name, available - 1);
+		}
+	}
+
+	return {
+		runtime: status.running ? 'running' : 'down',
+		expected,
+		running: status.running ? running : 0,
+	};
+}
+
+export function shouldPollDashboardHealth(widgetVisible: boolean, documentHidden: boolean): boolean {
+	return widgetVisible && !documentHidden;
+}

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -53,7 +53,7 @@ describe('dashboard preferences', () => {
 			density: 'compact',
 		});
 		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard' });
-		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(8);
+		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(9);
 	});
 
 	test('migrates v2 named views to standard widget presentations', () => {
@@ -127,7 +127,7 @@ describe('dashboard preferences', () => {
 		expect(parsed.activeViewId).toBe('ops');
 		expect(parsed.customViews.map((view) => view.id)).toEqual(['ops', 'custom-1']);
 		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
-		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(8);
+		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(9);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
@@ -223,7 +223,7 @@ describe('dashboard preferences', () => {
 		const swapped = swapDashboardWidgets(widgets, 'alerts', 'storage');
 
 		expect(swapped.map((widget) => widget.id)).toEqual([
-			'storage', 'system', 'summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
+			'storage', 'system', 'health', 'summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
 		]);
 		expect(widgets[0].id).toBe('alerts');
 		expect(swapDashboardWidgets(widgets, 'alerts', 'alerts')).not.toBe(widgets);

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -7,6 +7,7 @@ export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 export const dashboardWidgetIds = [
 	'alerts',
 	'system',
+	'health',
 	'summary',
 	'operations',
 	'storage',
@@ -45,6 +46,7 @@ export interface DashboardPreferences {
 export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string; supportsTiny: boolean }> = {
 	alerts: { label: 'Alerts', description: 'Active warnings and critical conditions.', supportsTiny: true },
 	system: { label: 'System status', description: 'Host identity, uptime, and service health.', supportsTiny: true },
+	health: { label: 'Service and container health', description: 'Enabled services and expected managed containers currently running.', supportsTiny: false },
 	summary: { label: 'Resource summary', description: 'CPU, memory, temperature, and total storage.', supportsTiny: false },
 	operations: { label: 'Active operations', description: 'Scrubs, evacuations, and reconciliation work.', supportsTiny: true },
 	storage: { label: 'Compact storage', description: 'Filesystems and member devices in a dense table.', supportsTiny: false },
@@ -60,6 +62,7 @@ export function dashboardWidgetSupportsTiny(id: DashboardWidgetId): boolean {
 const defaultCustomWidgets: DashboardWidgetConfig[] = [
 	{ id: 'alerts', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'system', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'health', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'summary', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'operations', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'storage', visible: true, width: 'full', presentation: 'standard' },

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1811,6 +1811,8 @@ export interface App {
 	status: string;
 	created: string;
 	kind: string; // "simple" or "compose"
+	/** Expected container instances; Compose service names repeat for replicas. */
+	expected_containers?: string[] | null;
 	containers?: AppContainer[];
 	ports?: MappedPort[];
 	/** True if deployed with allow_unsafe (elevated privileges). */

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -20,23 +20,35 @@
 	} from '$lib/dashboard.svelte';
 	import type {
 		ActiveAlert,
+		App,
+		AppsStatus,
 		DiskHealth,
 		DiskIoStats,
 		Filesystem,
 		FsUsage,
 		NetIfStats,
+		ProtocolStatus,
 		ResourceHistory,
 		SystemHealth,
 		SystemInfo,
 		SystemStats,
 		SystemStatus,
 	} from '$lib/types';
+	import {
+		shouldPollDashboardHealth,
+		summarizeEnabledServices,
+		summarizeManagedContainers,
+		type DashboardHealthFreshness,
+		type ManagedContainerHealthSummary,
+		type ServiceHealthSummary,
+	} from '$lib/dashboard-health';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import AlertsWidget from '$lib/components/dashboard/alerts-widget.svelte';
 	import CustomizeDialog from '$lib/components/dashboard/customize-dialog.svelte';
 	import DiskIoWidget from '$lib/components/dashboard/disk-io-widget.svelte';
 	import HistoryControls from '$lib/components/dashboard/history-controls.svelte';
+	import HealthWidget from '$lib/components/dashboard/health-widget.svelte';
 	import HistoryWidget from '$lib/components/dashboard/history-widget.svelte';
 	import NetworkWidget from '$lib/components/dashboard/network-widget.svelte';
 	import OperationsWidget from '$lib/components/dashboard/operations-widget.svelte';
@@ -73,6 +85,10 @@
 	let healthLoaded = $state(false);
 	let alertsLoaded = $state(false);
 	let operationsLoaded = $state(false);
+	let serviceHealth = $state<ServiceHealthSummary | null>(null);
+	let serviceHealthFreshness = $state<DashboardHealthFreshness>('loading');
+	let containerHealth = $state<ManagedContainerHealthSummary | null>(null);
+	let containerHealthFreshness = $state<DashboardHealthFreshness>('loading');
 	let customizeOpen = $state(false);
 	let refreshTimer: ReturnType<typeof setInterval> | null = null;
 	let refreshTick = 0;
@@ -84,6 +100,7 @@
 	let healthRequest = 0;
 	let alertsRequest = 0;
 	let operationsRequest = 0;
+	let dashboardHealthInFlight: Promise<void> | null = null;
 
 	let metricsRange = $state<MetricsRange>('5m');
 	let metricsOffset = $state(0);
@@ -131,6 +148,10 @@
 
 	function needsMetricsHistory(): boolean {
 		return widgets.some((widget) => ['history', 'network', 'disk_io'].includes(widget.id));
+	}
+
+	function healthPollingEnabled(): boolean {
+		return shouldPollDashboardHealth(hasWidget('health'), document.hidden);
 	}
 
 	function widgetClass(width: DashboardWidgetWidth): string {
@@ -207,10 +228,15 @@
 
 	onMount(() => {
 		client.onEvent(handleEvent);
+		const handleVisibilityChange = () => {
+			if (healthPollingEnabled()) void loadDashboardHealth(true);
+		};
+		document.addEventListener('visibilitychange', handleVisibilityChange);
 		void loadVisibleData(true).finally(() => loading = false);
 		refreshTimer = setInterval(refreshVisibleData, 15_000);
 		return () => {
 			client.offEvent(handleEvent);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
 			if (refreshTimer) clearInterval(refreshTimer);
 		};
 	});
@@ -236,6 +262,7 @@
 			}
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
+			if (healthPollingEnabled()) tasks.push(loadDashboardHealth(true));
 			const results = await Promise.allSettled(tasks);
 			if (hasWidget('storage')) await loadStorageDetails();
 			if (needsMetricsHistory()) await loadMetrics();
@@ -289,6 +316,59 @@
 		operationsLoaded = true;
 	}
 
+	function loadDashboardHealth(markExistingRefreshing = false): Promise<void> {
+		if (dashboardHealthInFlight) return dashboardHealthInFlight;
+		if (markExistingRefreshing && serviceHealth) serviceHealthFreshness = 'refreshing';
+		if (markExistingRefreshing && containerHealth) containerHealthFreshness = 'refreshing';
+		if (!serviceHealth) serviceHealthFreshness = 'loading';
+		if (!containerHealth) containerHealthFreshness = 'loading';
+
+		const request = Promise.all([loadServiceHealth(), loadContainerHealth()]).then(() => undefined);
+		dashboardHealthInFlight = request;
+		void request.finally(() => {
+			if (dashboardHealthInFlight === request) dashboardHealthInFlight = null;
+		});
+		return request;
+	}
+
+	async function loadServiceHealth() {
+		try {
+			serviceHealth = summarizeEnabledServices(await client.call<ProtocolStatus[]>('service.protocol.list'));
+			serviceHealthFreshness = 'current';
+		} catch {
+			serviceHealthFreshness = serviceHealth ? 'stale' : 'unavailable';
+		}
+	}
+
+	async function loadContainerHealth() {
+		let status: AppsStatus;
+		try {
+			status = await client.call<AppsStatus>('apps.status');
+		} catch {
+			containerHealthFreshness = containerHealth ? 'stale' : 'unavailable';
+			return;
+		}
+
+		if (!status.enabled) {
+			containerHealth = summarizeManagedContainers(status, []);
+			containerHealthFreshness = 'current';
+			return;
+		}
+		if (!status.running) {
+			containerHealth = { runtime: 'down', expected: null, running: 0 };
+			containerHealthFreshness = 'current';
+		}
+
+		try {
+			containerHealth = summarizeManagedContainers(status, await client.call<App[]>('apps.list'));
+			containerHealthFreshness = 'current';
+		} catch {
+			if (status.running) {
+				containerHealthFreshness = containerHealth ? 'stale' : 'unavailable';
+			}
+		}
+	}
+
 	async function loadFilesystemData() {
 		try {
 			await fetchFilesystemInventory();
@@ -328,6 +408,7 @@
 			if (needsStats()) tasks.push(refreshStats());
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
+			if (healthPollingEnabled()) tasks.push(loadDashboardHealth());
 			if (hasWidget('system') && refreshTick % 4 === 0) {
 				tasks.push(loadSystemHealth());
 				if (!infoLoaded) tasks.push(loadSystemInfo());
@@ -493,28 +574,46 @@
 		if (next === preferences) return;
 		await applyPreferences(next);
 	}
+
+	function handleDashboardTabKeydown(event: KeyboardEvent) {
+		if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+		const target = event.currentTarget as HTMLButtonElement;
+		const tabs = Array.from(target.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? []);
+		const current = tabs.indexOf(target);
+		if (current < 0 || tabs.length === 0) return;
+		const next = event.key === 'Home' ? 0
+			: event.key === 'End' ? tabs.length - 1
+			: (current + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+		event.preventDefault();
+		tabs[next].focus();
+		tabs[next].click();
+	}
 </script>
 
-<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
-	<div>
-		<div class="text-sm font-semibold">{presetLabel} dashboard</div>
-		<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
-	</div>
-	<div class="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-		<label for="dashboard-view-switcher" class="sr-only">Dashboard view</label>
-		<select id="dashboard-view-switcher" value={dashboardSelection} onchange={(event) => void switchDashboard(event.currentTarget.value)} class="h-9 min-w-0 flex-1 rounded-md border border-border bg-background px-3 text-sm sm:max-w-48">
-			<optgroup label="Presets">
-				{#each Object.entries(dashboardPresets) as [id, preset]}<option value={id}>{preset.label}</option>{/each}
-			</optgroup>
-			<optgroup label="Custom views">
-				{#each dashboardPrefs.value.customViews as view (view.id)}<option value={`custom:${view.id}`}>{view.name}</option>{/each}
-			</optgroup>
-		</select>
+<div class="mb-4">
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<div class="text-sm font-semibold">{presetLabel} dashboard</div>
+			<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
+		</div>
 		<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
+	</div>
+	<div class="mt-3 overflow-x-auto border-b border-border">
+		<div class="flex min-w-max items-end" role="tablist" aria-label="Dashboard views">
+			{#each Object.entries(dashboardPresets) as [id, preset]}
+				<button type="button" role="tab" aria-selected={dashboardSelection === id} aria-controls="dashboard-panel" tabindex={dashboardSelection === id ? 0 : -1} onclick={() => void switchDashboard(id)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{preset.label}</button>
+			{/each}
+			<span class="mx-1 mb-2 h-5 w-px bg-border" aria-hidden="true"></span>
+			{#each dashboardPrefs.value.customViews as view (view.id)}
+				{@const selection = `custom:${view.id}`}
+				<button type="button" role="tab" aria-selected={dashboardSelection === selection} aria-controls="dashboard-panel" tabindex={dashboardSelection === selection ? 0 : -1} onclick={() => void switchDashboard(selection)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === selection ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{view.name}</button>
+			{/each}
+		</div>
 	</div>
 </div>
 <div class="sr-only" aria-live="polite">{movementAnnouncement}</div>
 
+<div id="dashboard-panel" role="tabpanel" aria-label={`${presetLabel} dashboard`}>
 {#if filesystemsLoaded && filesystems.length === 0}
 	<Card class="mb-4 border-primary/30 bg-primary/5">
 		<CardContent class="flex flex-wrap items-center gap-6 py-6">
@@ -559,6 +658,8 @@
 					<AlertsWidget {alerts} loaded={alertsLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'system'}
 					<SystemWidget {info} {health} {infoLoaded} {healthLoaded} {density} presentation={widget.presentation} />
+				{:else if widget.id === 'health'}
+					<HealthWidget services={serviceHealth} servicesFreshness={serviceHealthFreshness} containers={containerHealth} containersFreshness={containerHealthFreshness} {density} width={widget.width} />
 				{:else if widget.id === 'summary' && stats}
 					<SummaryWidget {stats} {filesystems} width={widget.width} {density} />
 				{:else if widget.id === 'operations'}
@@ -578,5 +679,6 @@
 		{/each}
 	</div>
 {/if}
+</div>
 
 <CustomizeDialog bind:open={customizeOpen} preferences={dashboardPrefs.value} onSave={(preferences) => void applyPreferences(preferences)} />


### PR DESCRIPTION
## Summary
- add linked dashboard counters for enabled services and expected managed containers with explicit healthy, unhealthy, disabled, loading, refreshing, stale, and unavailable states
- derive exact Compose expectations from the effective Compose model, including active profiles and replicas, and retain configured simple apps when containers disappear
- poll only while the widget and browser tab are visible, deduplicate refreshes, and retain last good data on transient failures
- replace the dashboard view dropdown with a responsive, keyboard-accessible top tab strip

## Counting semantics
- services: only enabled protocol services are expected; disabled services are excluded
- containers: each simple app expects one container; Compose service instances count individually after profile and replica resolution
- disabled Docker is neutral; enabled Docker or expected/running mismatches are unhealthy

## Testing
- `npm run check`
- `npm test` (263 tests)
- `npm run build`
- `cargo test --manifest-path engine/Cargo.toml -p nasty-apps` (148 tests)
- `cargo check --manifest-path engine/Cargo.toml -p nasty-engine`
- `cargo fmt --manifest-path engine/Cargo.toml --package nasty-apps -- --check`

Closes #815