### PR TITLE
webui: add denser dashboard layouts

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -3,18 +3,23 @@
 	import {
 		DASHBOARD_VIEW_NAME_MAX_LENGTH,
 		createDashboardView,
+		dashboardOptionalPresets,
 		dashboardPresets,
 		dashboardViewNameAvailable,
 		dashboardWidgetMeta,
+		dashboardWidgetSupportsNarrowWidth,
 		dashboardWidgetSupportsTiny,
 		defaultDashboardPreferences,
 		deleteDashboardView,
 		getActiveDashboardView,
 		renameDashboardView,
 		selectDashboardView,
+		setDashboardPresetTabVisible,
 		updateActiveDashboardView,
 		type DashboardPreferences,
+		type DashboardOptionalPreset,
 		type DashboardPreset,
+		type DashboardWidgetWidth,
 	} from '$lib/dashboard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -60,6 +65,7 @@
 	function clone(value: DashboardPreferences): DashboardPreferences {
 		return {
 			...value,
+			hiddenPresetTabs: [...value.hiddenPresetTabs],
 			customViews: value.customViews.map((view) => ({
 				...view,
 				widgets: view.widgets.map((widget) => ({ ...widget })),
@@ -68,9 +74,19 @@
 	}
 
 	function selectPreset(preset: DashboardPreset) {
-		draft = { ...draft, preset };
+		const preferences = dashboardOptionalPresets.includes(preset as DashboardOptionalPreset)
+			? setDashboardPresetTabVisible(draft, preset as DashboardOptionalPreset, true)
+			: draft;
+		draft = {
+			...preferences,
+			preset,
+		};
 		cancelNameAction();
 		deletePending = false;
+	}
+
+	function setPresetTabVisible(preset: DashboardOptionalPreset, visible: boolean) {
+		draft = setDashboardPresetTabVisible(draft, preset, visible);
 	}
 
 	function selectView(id: string) {
@@ -86,10 +102,25 @@
 		draft = updateActiveDashboardView(draft, { widgets });
 	}
 
+	function updatePresentation(index: number, value: string) {
+		const widget = activeView.widgets[index];
+		const presentation = value === 'tiny' && dashboardWidgetSupportsTiny(widget.id) ? 'tiny' : 'standard';
+		updateWidget(index, {
+			presentation,
+			width: (widget.width === 'quarter' || widget.width === 'third') && !dashboardWidgetSupportsNarrowWidth(widget.id, presentation)
+				? 'half'
+				: widget.width,
+		});
+	}
+
 	function updateDensity(value: string) {
 		draft = updateActiveDashboardView(draft, {
 			density: value === 'compact' ? 'compact' : 'comfortable',
 		});
+	}
+
+	function parseWidgetWidth(value: string): DashboardWidgetWidth {
+		return value === 'quarter' || value === 'third' || value === 'half' ? value : 'full';
 	}
 
 	function moveWidget(index: number, direction: -1 | 1) {
@@ -202,6 +233,15 @@
 					<p class="mt-1 text-xs leading-relaxed text-muted-foreground">{draft.customViews.length} named view{draft.customViews.length === 1 ? '' : 's'}.</p>
 				</button>
 			</div>
+			<div class="mt-4 rounded-lg border border-border bg-muted/20 px-4 py-3">
+				<div class="text-sm font-semibold">Preset tabs</div>
+				<p class="mt-0.5 text-xs text-muted-foreground">Choose which optional built-in views appear above the dashboard. Overview always stays visible.</p>
+				<div class="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+					{#each dashboardOptionalPresets as preset}
+						<label class="flex items-center gap-2 text-sm"><input type="checkbox" checked={!draft.hiddenPresetTabs.includes(preset)} onchange={(event) => setPresetTabVisible(preset, event.currentTarget.checked)} class="h-4 w-4 accent-primary" />{dashboardPresets[preset].label}</label>
+					{/each}
+				</div>
+			</div>
 
 			{#if draft.preset === 'custom'}
 				<div class="mt-6 border-t border-border pt-5">
@@ -239,7 +279,7 @@
 				</div>
 
 				<div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-					<div><h3 class="text-sm font-semibold">{activeView.name} widgets</h3><p class="text-xs text-muted-foreground">Half-width widgets pack into open column space on wide screens. Full-width widgets start a new row.</p></div>
+					<div><h3 class="text-sm font-semibold">{activeView.name} widgets</h3><p class="text-xs text-muted-foreground">Widgets use a 12-column wide-screen grid and can span the full row, one half, one third, or one quarter.</p></div>
 					<div class="flex items-center gap-2">
 						<label for="dashboard-density" class="text-xs font-medium text-muted-foreground">Density</label>
 						<select id="dashboard-density" value={activeView.density} onchange={(event) => updateDensity(event.currentTarget.value)} class="h-8 rounded-md border border-border bg-background px-2 text-xs">
@@ -254,9 +294,9 @@
 							<input type="checkbox" checked={widget.visible} disabled={widget.visible && activeView.widgets.filter((candidate) => candidate.visible).length === 1} onchange={(event) => updateWidget(index, { visible: event.currentTarget.checked })} aria-label={`Show ${dashboardWidgetMeta[widget.id].label}`} class="h-4 w-4 accent-primary disabled:opacity-40" />
 							<div class="min-w-40 flex-1"><div class="text-sm font-medium">{dashboardWidgetMeta[widget.id].label}</div><div class="truncate text-xs text-muted-foreground">{dashboardWidgetMeta[widget.id].description}</div></div>
 							{#if dashboardWidgetSupportsTiny(widget.id)}
-								<select value={widget.presentation} disabled={!widget.visible} onchange={(event) => updateWidget(index, { presentation: event.currentTarget.value === 'tiny' ? 'tiny' : 'standard' })} aria-label={`${dashboardWidgetMeta[widget.id].label} presentation`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="standard">Standard</option><option value="tiny">Tiny</option></select>
+								<select value={widget.presentation} disabled={!widget.visible} onchange={(event) => updatePresentation(index, event.currentTarget.value)} aria-label={`${dashboardWidgetMeta[widget.id].label} presentation`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="standard">Standard</option><option value="tiny">Tiny</option></select>
 							{/if}
-							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: event.currentTarget.value === 'half' ? 'half' : 'full' })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">Half</option></select>
+							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: parseWidgetWidth(event.currentTarget.value) })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">1/2</option>{#if dashboardWidgetSupportsNarrowWidth(widget.id, widget.presentation)}<option value="third">1/3</option><option value="quarter">1/4</option>{/if}</select>
 							<div class="flex">
 								<Button variant="ghost" size="icon-sm" disabled={index === 0} onclick={() => moveWidget(index, -1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp /></Button>
 								<Button variant="ghost" size="icon-sm" disabled={index === activeView.widgets.length - 1} onclick={() => moveWidget(index, 1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown /></Button>

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -101,7 +101,7 @@ describe('tiny dashboard widgets', () => {
 				],
 				range: '5m',
 				loading: false,
-				width: 'half',
+				width: 'quarter',
 				density: 'compact',
 				presentation: 'tiny',
 			},
@@ -110,6 +110,7 @@ describe('tiny dashboard widgets', () => {
 		expect(body).toContain('8.0%');
 		expect(body).toContain('5m peak 12.0%');
 		expect(body).toContain('45.0%');
+		expect(body).toContain('xl:grid-cols-1');
 		expect(body).not.toContain('role="img"');
 	});
 });
@@ -157,7 +158,7 @@ describe('dashboard health widget', () => {
 				containers: null,
 				containersFreshness: 'unavailable',
 				density: 'compact',
-				width: 'half',
+				width: 'quarter',
 			},
 		}).body;
 		const refreshing = render(HealthWidget, {
@@ -174,8 +175,9 @@ describe('dashboard health widget', () => {
 		expect(disabled).toContain('Checking enabled services.');
 		expect(disabled).toContain('Docker runtime is disabled.');
 		expect(disabled).toContain('px-4 py-3');
-		expect(disabled).not.toContain('md:grid-cols-2');
+		expect(disabled).toContain('md:grid-cols-2');
 		expect(stale).toContain('Stale - healthy');
+		expect(stale).toContain('xl:grid-cols-1');
 		expect(stale).toContain('Refresh failed; showing last known healthy state.');
 		expect(stale).toContain('Managed container health could not be loaded.');
 		expect(stale).toContain('role="status"');

--- a/webui/src/lib/components/dashboard/health-widget.svelte
+++ b/webui/src/lib/components/dashboard/health-widget.svelte
@@ -95,7 +95,7 @@
 	let containerState = $derived(containerPresentation());
 </script>
 
-<div class="grid gap-3 {width === 'full' ? 'md:grid-cols-2' : ''}">
+<div class="grid gap-3 {width === 'full' || width === 'half' ? 'md:grid-cols-2' : 'md:grid-cols-2 xl:grid-cols-1'}">
 	<Card class="h-full overflow-hidden {tileClass(serviceState.tone)}">
 		<a href="/services" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Services: ${serviceState.label}. ${services ? `${services.enabled} enabled, ${services.running} running.` : serviceState.detail}`}>
 			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>

--- a/webui/src/lib/components/dashboard/history-widget.svelte
+++ b/webui/src/lib/components/dashboard/history-widget.svelte
@@ -37,7 +37,7 @@
 </script>
 
 {#if presentation === 'tiny'}
-	<div class="grid grid-cols-2 gap-3">
+	<div class="grid grid-cols-2 gap-3 {width === 'third' || width === 'quarter' ? 'xl:grid-cols-1' : ''}">
 		<Card>
 			<CardContent class="px-4 py-3">
 				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle>

--- a/webui/src/lib/components/dashboard/summary-widget.svelte
+++ b/webui/src/lib/components/dashboard/summary-widget.svelte
@@ -41,7 +41,7 @@
 	let storage = $derived(totalStorage());
 </script>
 
-<div class="grid grid-cols-2 gap-3 {width === 'full' ? 'lg:grid-cols-4' : ''}">
+<div class="grid grid-cols-2 gap-3 {width === 'full' ? 'lg:grid-cols-4' : width === 'third' || width === 'quarter' ? 'xl:grid-cols-1' : ''}">
 	<Card>
 		<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
 			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU load</div>

--- a/webui/src/lib/components/dashboard/system-widget.svelte
+++ b/webui/src/lib/components/dashboard/system-widget.svelte
@@ -25,8 +25,8 @@
 				<span class="font-medium text-muted-foreground">System status unavailable</span>
 			{:else}
 				{#if info}
-					<span class="font-semibold">{info.hostname}</span>
-					<span class="text-muted-foreground">v{info.version}</span>
+					<span class="min-w-0 max-w-full truncate font-semibold" title={info.hostname}>{info.hostname}</span>
+					<span class="max-w-full truncate text-muted-foreground" title={`Version ${info.version}`}>v{info.version}</span>
 					<span class="text-muted-foreground">Up {formatUptime(info.uptime_seconds)}</span>
 				{:else if !infoLoaded}
 					<span class="font-medium text-muted-foreground">System info unavailable</span>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -3,11 +3,15 @@ import {
 	DASHBOARD_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V2_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_V3_PREFERENCES_KEY,
 	createDashboardView,
 	dashboardPrefs,
+	dashboardPresetTabVisible,
 	dashboardViewNameAvailable,
 	dashboardWidgetIds,
 	dashboardWidgetSupportsTiny,
+	dashboardWidgetSupportsNarrowWidth,
+	dashboardWidgetWidthClass,
 	defaultDashboardPreferences,
 	deleteDashboardView,
 	getActiveDashboardView,
@@ -18,6 +22,7 @@ import {
 	resolveDashboardDensity,
 	resolveDashboardWidgets,
 	selectDashboardView,
+	setDashboardPresetTabVisible,
 	swapDashboardWidgets,
 	updateActiveDashboardView,
 } from './dashboard.svelte';
@@ -31,7 +36,7 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":4,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":5,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
 	test('migrates the v1 custom layout without losing its configuration', () => {
@@ -45,7 +50,7 @@ describe('dashboard preferences', () => {
 			],
 		}));
 
-		expect(parsed.version).toBe(3);
+		expect(parsed.version).toBe(4);
 		expect(parsed.preset).toBe('custom');
 		expect(parsed.customViews).toHaveLength(1);
 		expect(getActiveDashboardView(parsed)).toMatchObject({
@@ -72,13 +77,13 @@ describe('dashboard preferences', () => {
 			}],
 		}));
 
-		expect(parsed.version).toBe(3);
+		expect(parsed.version).toBe(4);
 		expect(parsed.activeViewId).toBe('daily');
 		expect(getActiveDashboardView(parsed)).toMatchObject({ name: 'Daily', density: 'compact' });
 		expect(getActiveDashboardView(parsed).widgets.every((widget) => widget.presentation === 'standard')).toBe(true);
 	});
 
-	test('initializes v3 storage from the newest available legacy key without overwriting v3 preferences', () => {
+	test('initializes v4 storage from the newest available legacy key without overwriting v4 preferences', () => {
 		localStorage.clear();
 		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
 			version: 1,
@@ -92,23 +97,30 @@ describe('dashboard preferences', () => {
 			activeViewId: 'custom-1',
 			customViews: defaultDashboardPreferences().customViews,
 		}));
-		expect(initializeDashboardPreferences(localStorage).preset).toBe('storage');
-		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+		const { hiddenPresetTabs: _, ...shippedV3 } = defaultDashboardPreferences();
+		localStorage.setItem(LEGACY_DASHBOARD_V3_PREFERENCES_KEY, JSON.stringify({
+			...shippedV3,
 			version: 3,
-			preset: 'storage',
+			preset: 'monitoring',
+		}));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 4,
+			preset: 'monitoring',
 		});
 
 		const stored = defaultDashboardPreferences();
-		stored.preset = 'monitoring';
+		stored.preset = 'storage';
 		localStorage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(stored));
-		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
-		expect(loadDashboardPreferences(localStorage).preset).toBe('monitoring');
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('storage');
+		expect(loadDashboardPreferences(localStorage).preset).toBe('storage');
 	});
 
 	test('normalizes named views, active selection, and newly added widget ids', () => {
 		const parsed = parseDashboardPreferences(JSON.stringify({
 			version: 3,
 			preset: 'custom',
+			hiddenPresetTabs: ['storage', 'overview', 'storage', 'monitoring', 'unknown'],
 			activeViewId: ' ops ',
 			customViews: [
 				{
@@ -117,7 +129,9 @@ describe('dashboard preferences', () => {
 					density: 'compact',
 					widgets: [
 						{ id: 'storage', visible: false, width: 'half', presentation: 'tiny' },
-						{ id: 'alerts', visible: true, width: 'half', presentation: 'tiny' },
+						{ id: 'alerts', visible: true, width: 'quarter', presentation: 'tiny' },
+						{ id: 'system', visible: true, width: 'third', presentation: 'tiny' },
+						{ id: 'network', visible: true, width: 'quarter', presentation: 'standard' },
 					],
 				},
 				{ id: 'ops', name: 'operations', widgets: [] },
@@ -131,6 +145,13 @@ describe('dashboard preferences', () => {
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
+		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.width).toBe('quarter');
+		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'system')?.width).toBe('third');
+		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'network')?.width).toBe('half');
+		expect(parsed.hiddenPresetTabs).toEqual(['storage', 'monitoring']);
+		expect(dashboardPresetTabVisible(parsed, 'overview')).toBe(true);
+		expect(dashboardPresetTabVisible(parsed, 'storage')).toBe(false);
+		expect(dashboardPresetTabVisible(parsed, 'monitoring')).toBe(false);
 		expect(resolveDashboardDensity(parsed)).toBe('compact');
 	});
 
@@ -138,6 +159,48 @@ describe('dashboard preferences', () => {
 		expect(dashboardWidgetIds.filter(dashboardWidgetSupportsTiny)).toEqual([
 			'alerts', 'system', 'operations', 'history',
 		]);
+	});
+
+	test('limits narrow widths to compact-safe presentations', () => {
+		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'standard')).toBe(false);
+		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'tiny')).toBe(true);
+		expect(dashboardWidgetSupportsNarrowWidth('health', 'standard')).toBe(true);
+		expect(dashboardWidgetSupportsNarrowWidth('summary', 'standard')).toBe(true);
+		expect(dashboardWidgetSupportsNarrowWidth('storage', 'standard')).toBe(false);
+		expect(dashboardWidgetSupportsNarrowWidth('network', 'standard')).toBe(false);
+		expect(dashboardWidgetSupportsNarrowWidth('disk_io', 'standard')).toBe(false);
+		expect(dashboardWidgetSupportsNarrowWidth('operations', 'tiny')).toBe(true);
+		expect(dashboardWidgetSupportsNarrowWidth('history', 'tiny')).toBe(true);
+	});
+
+	test('maps custom widths onto the 12-column dashboard grid', () => {
+		expect(dashboardWidgetWidthClass('full')).toContain('xl:col-span-12');
+		expect(dashboardWidgetWidthClass('half')).toContain('xl:col-span-6');
+		expect(dashboardWidgetWidthClass('third')).toContain('xl:col-span-4');
+		expect(dashboardWidgetWidthClass('quarter')).toContain('xl:col-span-3');
+	});
+
+	test('hides optional preset tabs and leaves overview available', () => {
+		let preferences = defaultDashboardPreferences();
+		preferences.preset = 'storage';
+		preferences = setDashboardPresetTabVisible(preferences, 'storage', false);
+
+		expect(preferences.preset).toBe('overview');
+		expect(dashboardPresetTabVisible(preferences, 'overview')).toBe(true);
+		expect(dashboardPresetTabVisible(preferences, 'storage')).toBe(false);
+		preferences = setDashboardPresetTabVisible(preferences, 'storage', true);
+		expect(dashboardPresetTabVisible(preferences, 'storage')).toBe(true);
+	});
+
+	test('repairs a persisted active preset whose tab is hidden', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			...defaultDashboardPreferences(),
+			preset: 'storage',
+			hiddenPresetTabs: ['storage'],
+		}));
+
+		expect(parsed.preset).toBe('overview');
+		expect(parsed.hiddenPresetTabs).toEqual(['storage']);
 	});
 
 	test('repairs a custom view with no visible widgets', () => {
@@ -205,13 +268,13 @@ describe('dashboard preferences', () => {
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
 	});
 
-	test('persists the active named view in v3 storage', () => {
+	test('persists the active named view in v4 storage', () => {
 		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 3,
+			version: 4,
 			preset: 'custom',
 			activeViewId: preferences.activeViewId,
 		});

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,7 +1,8 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v3';
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v4';
+export const LEGACY_DASHBOARD_V3_PREFERENCES_KEY = 'nasty:dashboard:v3';
 export const LEGACY_DASHBOARD_V2_PREFERENCES_KEY = 'nasty:dashboard:v2';
 export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 3;
+export const DASHBOARD_PREFERENCES_VERSION = 4;
 export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 
 export const dashboardWidgetIds = [
@@ -18,9 +19,13 @@ export const dashboardWidgetIds = [
 
 export type DashboardWidgetId = (typeof dashboardWidgetIds)[number];
 export type DashboardPreset = 'overview' | 'storage' | 'monitoring' | 'custom';
+export type DashboardFixedPreset = Exclude<DashboardPreset, 'custom'>;
+export type DashboardOptionalPreset = Exclude<DashboardFixedPreset, 'overview'>;
 export type DashboardDensity = 'comfortable' | 'compact';
-export type DashboardWidgetWidth = 'half' | 'full';
+export type DashboardWidgetWidth = 'quarter' | 'third' | 'half' | 'full';
 export type DashboardWidgetPresentation = 'standard' | 'tiny';
+
+export const dashboardOptionalPresets: DashboardOptionalPreset[] = ['storage', 'monitoring'];
 
 export interface DashboardWidgetConfig {
 	id: DashboardWidgetId;
@@ -39,6 +44,7 @@ export interface DashboardCustomView {
 export interface DashboardPreferences {
 	version: typeof DASHBOARD_PREFERENCES_VERSION;
 	preset: DashboardPreset;
+	hiddenPresetTabs: DashboardOptionalPreset[];
 	activeViewId: string;
 	customViews: DashboardCustomView[];
 }
@@ -59,6 +65,20 @@ export function dashboardWidgetSupportsTiny(id: DashboardWidgetId): boolean {
 	return dashboardWidgetMeta[id].supportsTiny;
 }
 
+export function dashboardWidgetSupportsNarrowWidth(
+	id: DashboardWidgetId,
+	presentation: DashboardWidgetPresentation,
+): boolean {
+	return id === 'health' || id === 'summary' || (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
+}
+
+export function dashboardWidgetWidthClass(width: DashboardWidgetWidth): string {
+	if (width === 'quarter') return 'min-w-0 xl:col-span-3';
+	if (width === 'third') return 'min-w-0 xl:col-span-4';
+	if (width === 'half') return 'min-w-0 xl:col-span-6';
+	return 'min-w-0 xl:col-span-12';
+}
+
 const defaultCustomWidgets: DashboardWidgetConfig[] = [
 	{ id: 'alerts', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'system', visible: true, width: 'full', presentation: 'standard' },
@@ -71,9 +91,7 @@ const defaultCustomWidgets: DashboardWidgetConfig[] = [
 	{ id: 'disk_io', visible: true, width: 'half', presentation: 'standard' },
 ];
 
-type FixedPreset = Exclude<DashboardPreset, 'custom'>;
-
-export const dashboardPresets: Record<FixedPreset, {
+export const dashboardPresets: Record<DashboardFixedPreset, {
 	label: string;
 	description: string;
 	density: DashboardDensity;
@@ -119,6 +137,7 @@ export function defaultDashboardPreferences(): DashboardPreferences {
 	return {
 		version: DASHBOARD_PREFERENCES_VERSION,
 		preset: 'overview',
+		hiddenPresetTabs: [],
 		activeViewId: customView.id,
 		customViews: [customView],
 	};
@@ -135,11 +154,17 @@ function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
 		if (!isRecord(candidate) || !dashboardWidgetIds.includes(candidate.id as DashboardWidgetId)) continue;
 		const id = candidate.id as DashboardWidgetId;
 		if (byId.has(id)) continue;
+		const presentation = candidate.presentation === 'tiny' && dashboardWidgetSupportsTiny(id) ? 'tiny' : 'standard';
+		const requestedWidth = candidate.width === 'quarter' || candidate.width === 'third' || candidate.width === 'half'
+			? candidate.width
+			: 'full';
 		byId.set(id, {
 			id,
 			visible: candidate.visible !== false,
-			width: candidate.width === 'half' ? 'half' : 'full',
-			presentation: candidate.presentation === 'tiny' && dashboardWidgetSupportsTiny(id) ? 'tiny' : 'standard',
+			width: (requestedWidth === 'quarter' || requestedWidth === 'third') && !dashboardWidgetSupportsNarrowWidth(id, presentation)
+				? 'half'
+				: requestedWidth,
+			presentation,
 		});
 	}
 
@@ -153,6 +178,11 @@ function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
 
 function normalizePreset(value: unknown): DashboardPreset {
 	return value === 'storage' || value === 'monitoring' || value === 'custom' ? value : 'overview';
+}
+
+function normalizeHiddenPresetTabs(value: unknown): DashboardOptionalPreset[] {
+	if (!Array.isArray(value)) return [];
+	return dashboardOptionalPresets.filter((preset) => value.includes(preset));
 }
 
 function normalizeViewName(value: unknown, fallback: string): string {
@@ -214,6 +244,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 	return {
 		version: DASHBOARD_PREFERENCES_VERSION,
 		preset: normalizePreset(value.preset),
+		hiddenPresetTabs: [],
 		activeViewId: customView.id,
 		customViews: [customView],
 	};
@@ -222,7 +253,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	if (!isRecord(value)) return defaultDashboardPreferences();
 	if (value.version === 1) return migrateLegacyPreferences(value);
-	if (value.version !== 2 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+	if (value.version !== 2 && value.version !== 3 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
 
 	const customViews = normalizeCustomViews(value.customViews);
 	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
@@ -230,9 +261,14 @@ function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 		? requestedActiveViewId
 		: customViews[0].id;
 
+	const hiddenPresetTabs = normalizeHiddenPresetTabs(value.hiddenPresetTabs);
+	const requestedPreset = normalizePreset(value.preset);
 	return {
 		version: DASHBOARD_PREFERENCES_VERSION,
-		preset: normalizePreset(value.preset),
+		preset: requestedPreset !== 'custom' && requestedPreset !== 'overview' && hiddenPresetTabs.includes(requestedPreset)
+			? 'overview'
+			: requestedPreset,
+		hiddenPresetTabs,
 		activeViewId,
 		customViews,
 	};
@@ -250,6 +286,7 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
 	return parseDashboardPreferences(
 		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_V3_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V2_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_PREFERENCES_KEY)
 	);
@@ -280,6 +317,28 @@ export function resolveDashboardDensity(preferences: DashboardPreferences): Dash
 	return preferences.preset === 'custom'
 		? getActiveDashboardView(preferences).density
 		: dashboardPresets[preferences.preset].density;
+}
+
+export function dashboardPresetTabVisible(
+	preferences: DashboardPreferences,
+	preset: DashboardFixedPreset,
+): boolean {
+	return preset === 'overview' || !preferences.hiddenPresetTabs.includes(preset);
+}
+
+export function setDashboardPresetTabVisible(
+	preferences: DashboardPreferences,
+	preset: DashboardOptionalPreset,
+	visible: boolean,
+): DashboardPreferences {
+	const hiddenPresetTabs = visible
+		? preferences.hiddenPresetTabs.filter((candidate) => candidate !== preset)
+		: [...new Set([...preferences.hiddenPresetTabs, preset])];
+	return {
+		...preferences,
+		hiddenPresetTabs,
+		preset: !visible && preferences.preset === preset ? 'overview' : preferences.preset,
+	};
 }
 
 export function dashboardViewNameAvailable(

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -6,8 +6,10 @@
 	import { createIoHistory } from '$lib/history.svelte';
 	import {
 		dashboardPrefs,
+		dashboardPresetTabVisible,
 		dashboardPresets,
 		dashboardWidgetMeta,
+		dashboardWidgetWidthClass,
 		getActiveDashboardView,
 		resolveDashboardDensity,
 		resolveDashboardWidgets,
@@ -15,8 +17,8 @@
 		swapDashboardWidgets,
 		updateActiveDashboardView,
 		type DashboardPreferences,
+		type DashboardFixedPreset,
 		type DashboardWidgetId,
-		type DashboardWidgetWidth,
 	} from '$lib/dashboard.svelte';
 	import type {
 		ActiveAlert,
@@ -137,6 +139,10 @@
 			? `custom:${activeCustomView.id}`
 			: dashboardPrefs.value.preset
 	);
+	let presetTabs = $derived(
+		(Object.entries(dashboardPresets) as [DashboardFixedPreset, (typeof dashboardPresets)[DashboardFixedPreset]][])
+			.filter(([id]) => dashboardPresetTabVisible(dashboardPrefs.value, id))
+	);
 
 	function hasWidget(id: DashboardWidgetId): boolean {
 		return widgets.some((widget) => widget.id === id);
@@ -152,10 +158,6 @@
 
 	function healthPollingEnabled(): boolean {
 		return shouldPollDashboardHealth(hasWidget('health'), document.hidden);
-	}
-
-	function widgetClass(width: DashboardWidgetWidth): string {
-		return width === 'full' ? 'min-w-0 xl:col-span-2' : 'min-w-0 xl:col-span-1';
 	}
 
 	function masonryItem(node: HTMLElement) {
@@ -600,7 +602,7 @@
 	</div>
 	<div class="mt-3 overflow-x-auto border-b border-border">
 		<div class="flex min-w-max items-end" role="tablist" aria-label="Dashboard views">
-			{#each Object.entries(dashboardPresets) as [id, preset]}
+			{#each presetTabs as [id, preset]}
 				<button type="button" role="tab" aria-selected={dashboardSelection === id} aria-controls="dashboard-panel" tabindex={dashboardSelection === id ? 0 : -1} onclick={() => void switchDashboard(id)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{preset.label}</button>
 			{/each}
 			<span class="mx-1 mb-2 h-5 w-px bg-border" aria-hidden="true"></span>
@@ -626,13 +628,13 @@
 {#if loading}
 	<Card><CardContent class="py-10 text-center text-sm text-muted-foreground">Loading dashboard...</CardContent></Card>
 {:else}
-	<div class="grid grid-cols-1 auto-rows-[8px] gap-4 xl:grid-cols-2">
+	<div class="grid grid-cols-1 auto-rows-[8px] gap-4 xl:grid-cols-12">
 		{#each widgets as widget (widget.id)}
 			<div
 				use:masonryItem
 				role="group"
 				aria-label={dashboardWidgetMeta[widget.id].label}
-				class="self-start rounded-lg transition-shadow {widgetClass(widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
+				class="self-start rounded-lg transition-shadow {dashboardWidgetWidthClass(widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
 				ondragover={(event) => targetWidgetDrag(event, widget.id)}
 				ondrop={(event) => dropWidget(event, widget.id)}
 			>


### PR DESCRIPTION
## Summary
- add third- and quarter-width custom dashboard widgets on a responsive 12-column grid
- constrain narrow widths to compact-safe widget presentations and adapt narrow widget layouts
- let users hide optional Storage Compact and Monitoring preset tabs while keeping Overview available
- migrate dashboard preferences to v4 without overwriting retained v3 data

Follow-up to #809 and Kev’s feedback: https://github.com/nasty-project/nasty/issues/809#issuecomment-5504738053

## Testing
- `npm run check`
- `npm test` (267 tests)
- `npm run build`
- `git diff --check`