### PR TITLE
webui: refine dashboard customization controls

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -214,7 +214,7 @@
 </script>
 
 <Dialog.Root bind:open>
-	<Dialog.Content class="flex max-h-[85vh] w-[94vw] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+	<Dialog.Content class="flex max-h-[85vh] w-[94vw] flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl">
 		<Dialog.Header class="border-b border-border px-6 py-5">
 			<Dialog.Title class="flex items-center gap-2"><LayoutDashboard class="h-5 w-5" /> Customize dashboard</Dialog.Title>
 			<Dialog.Description>Choose a focused preset or manage named Custom views built from predefined widgets.</Dialog.Description>


### PR DESCRIPTION
## Summary
- widen the dashboard customization dialog on tablet and desktop so widget controls avoid unnecessary wrapping
- allow Overview, Storage Compact, and Monitoring tabs to be hidden
- fall back to the retained active Custom view when the current built-in tab is hidden
- omit the built-in/custom separator when every built-in tab is hidden

Follow-up to #819.

## Testing
- `npm run check`
- `npm test` (267 tests)
- `npm run build`
- `git diff --check`