### PR TITLE
webui: allow hiding overview dashboard tab

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -74,9 +74,9 @@
 	}
 
 	function selectPreset(preset: DashboardPreset) {
-		const preferences = dashboardOptionalPresets.includes(preset as DashboardOptionalPreset)
-			? setDashboardPresetTabVisible(draft, preset as DashboardOptionalPreset, true)
-			: draft;
+		const preferences = preset === 'custom'
+			? draft
+			: setDashboardPresetTabVisible(draft, preset, true);
 		draft = {
 			...preferences,
 			preset,
@@ -235,7 +235,7 @@
 			</div>
 			<div class="mt-4 rounded-lg border border-border bg-muted/20 px-4 py-3">
 				<div class="text-sm font-semibold">Preset tabs</div>
-				<p class="mt-0.5 text-xs text-muted-foreground">Choose which optional built-in views appear above the dashboard. Overview always stays visible.</p>
+				<p class="mt-0.5 text-xs text-muted-foreground">Choose which built-in views appear above the dashboard. Your Custom views stay available.</p>
 				<div class="mt-3 flex flex-wrap gap-x-5 gap-y-2">
 					{#each dashboardOptionalPresets as preset}
 						<label class="flex items-center gap-2 text-sm"><input type="checkbox" checked={!draft.hiddenPresetTabs.includes(preset)} onchange={(event) => setPresetTabVisible(preset, event.currentTarget.checked)} class="h-4 w-4 accent-primary" />{dashboardPresets[preset].label}</label>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -148,8 +148,8 @@ describe('dashboard preferences', () => {
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.width).toBe('quarter');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'system')?.width).toBe('third');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'network')?.width).toBe('half');
-		expect(parsed.hiddenPresetTabs).toEqual(['storage', 'monitoring']);
-		expect(dashboardPresetTabVisible(parsed, 'overview')).toBe(true);
+		expect(parsed.hiddenPresetTabs).toEqual(['overview', 'storage', 'monitoring']);
+		expect(dashboardPresetTabVisible(parsed, 'overview')).toBe(false);
 		expect(dashboardPresetTabVisible(parsed, 'storage')).toBe(false);
 		expect(dashboardPresetTabVisible(parsed, 'monitoring')).toBe(false);
 		expect(resolveDashboardDensity(parsed)).toBe('compact');
@@ -180,16 +180,22 @@ describe('dashboard preferences', () => {
 		expect(dashboardWidgetWidthClass('quarter')).toContain('xl:col-span-3');
 	});
 
-	test('hides optional preset tabs and leaves overview available', () => {
-		let preferences = defaultDashboardPreferences();
-		preferences.preset = 'storage';
-		preferences = setDashboardPresetTabVisible(preferences, 'storage', false);
+	test('hides any built-in preset tab and falls back to a custom view', () => {
+		let preferences = createDashboardView(defaultDashboardPreferences(), 'Mine');
+		const activeViewId = preferences.activeViewId;
+		preferences.preset = 'overview';
+		preferences = setDashboardPresetTabVisible(preferences, 'overview', false);
 
-		expect(preferences.preset).toBe('overview');
-		expect(dashboardPresetTabVisible(preferences, 'overview')).toBe(true);
+		expect(preferences.preset).toBe('custom');
+		expect(preferences.activeViewId).toBe(activeViewId);
+		expect(getActiveDashboardView(preferences).name).toBe('Mine');
+		expect(dashboardPresetTabVisible(preferences, 'overview')).toBe(false);
+		preferences = setDashboardPresetTabVisible(preferences, 'storage', false);
+		preferences = setDashboardPresetTabVisible(preferences, 'monitoring', false);
 		expect(dashboardPresetTabVisible(preferences, 'storage')).toBe(false);
-		preferences = setDashboardPresetTabVisible(preferences, 'storage', true);
-		expect(dashboardPresetTabVisible(preferences, 'storage')).toBe(true);
+		expect(dashboardPresetTabVisible(preferences, 'monitoring')).toBe(false);
+		preferences = setDashboardPresetTabVisible(preferences, 'overview', true);
+		expect(dashboardPresetTabVisible(preferences, 'overview')).toBe(true);
 	});
 
 	test('repairs a persisted active preset whose tab is hidden', () => {
@@ -199,7 +205,7 @@ describe('dashboard preferences', () => {
 			hiddenPresetTabs: ['storage'],
 		}));
 
-		expect(parsed.preset).toBe('overview');
+		expect(parsed.preset).toBe('custom');
 		expect(parsed.hiddenPresetTabs).toEqual(['storage']);
 	});
 

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -20,12 +20,12 @@ export const dashboardWidgetIds = [
 export type DashboardWidgetId = (typeof dashboardWidgetIds)[number];
 export type DashboardPreset = 'overview' | 'storage' | 'monitoring' | 'custom';
 export type DashboardFixedPreset = Exclude<DashboardPreset, 'custom'>;
-export type DashboardOptionalPreset = Exclude<DashboardFixedPreset, 'overview'>;
+export type DashboardOptionalPreset = DashboardFixedPreset;
 export type DashboardDensity = 'comfortable' | 'compact';
 export type DashboardWidgetWidth = 'quarter' | 'third' | 'half' | 'full';
 export type DashboardWidgetPresentation = 'standard' | 'tiny';
 
-export const dashboardOptionalPresets: DashboardOptionalPreset[] = ['storage', 'monitoring'];
+export const dashboardOptionalPresets: DashboardOptionalPreset[] = ['overview', 'storage', 'monitoring'];
 
 export interface DashboardWidgetConfig {
 	id: DashboardWidgetId;
@@ -265,8 +265,8 @@ function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	const requestedPreset = normalizePreset(value.preset);
 	return {
 		version: DASHBOARD_PREFERENCES_VERSION,
-		preset: requestedPreset !== 'custom' && requestedPreset !== 'overview' && hiddenPresetTabs.includes(requestedPreset)
-			? 'overview'
+		preset: requestedPreset !== 'custom' && hiddenPresetTabs.includes(requestedPreset)
+			? 'custom'
 			: requestedPreset,
 		hiddenPresetTabs,
 		activeViewId,
@@ -323,7 +323,7 @@ export function dashboardPresetTabVisible(
 	preferences: DashboardPreferences,
 	preset: DashboardFixedPreset,
 ): boolean {
-	return preset === 'overview' || !preferences.hiddenPresetTabs.includes(preset);
+	return !preferences.hiddenPresetTabs.includes(preset);
 }
 
 export function setDashboardPresetTabVisible(
@@ -337,7 +337,7 @@ export function setDashboardPresetTabVisible(
 	return {
 		...preferences,
 		hiddenPresetTabs,
-		preset: !visible && preferences.preset === preset ? 'overview' : preferences.preset,
+		preset: !visible && preferences.preset === preset ? 'custom' : preferences.preset,
 	};
 }
 

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -605,7 +605,7 @@
 			{#each presetTabs as [id, preset]}
 				<button type="button" role="tab" aria-selected={dashboardSelection === id} aria-controls="dashboard-panel" tabindex={dashboardSelection === id ? 0 : -1} onclick={() => void switchDashboard(id)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{preset.label}</button>
 			{/each}
-			<span class="mx-1 mb-2 h-5 w-px bg-border" aria-hidden="true"></span>
+			{#if presetTabs.length > 0}<span class="mx-1 mb-2 h-5 w-px bg-border" aria-hidden="true"></span>{/if}
 			{#each dashboardPrefs.value.customViews as view (view.id)}
 				{@const selection = `custom:${view.id}`}
 				<button type="button" role="tab" aria-selected={dashboardSelection === selection} aria-controls="dashboard-panel" tabindex={dashboardSelection === selection ? 0 : -1} onclick={() => void switchDashboard(selection)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === selection ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{view.name}</button>


### PR DESCRIPTION
## Summary
- allow Overview, Storage Compact, and Monitoring tabs to be hidden
- fall back to the retained active Custom view when the current built-in tab is hidden
- preserve the selected named custom view during that fallback
- omit the built-in/custom separator when every built-in tab is hidden

Follow-up to #819.

## Testing
- `npm run check`
- `npm test` (267 tests)
- `npm run build`
- `git diff --check`