### PR TITLE
webui: reuse sidebar update check

### DIFF
--- a/webui/src/lib/release-update.test.ts
+++ b/webui/src/lib/release-update.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from 'vitest';
-import { releaseUpdateDisplay, requestReleaseUpdateCheck, shouldCheckReleaseUpdate } from './release-update';
+import type { UpdateInfo } from './types';
+import { getReleaseUpdateSnapshot, invalidateReleaseUpdateCheck, publishReleaseUpdate, releaseUpdateDisplay, requestReleaseUpdateCheck, setReleaseUpdateSnapshot, shouldCheckReleaseUpdate } from './release-update';
 
-const info = {
+const info: UpdateInfo = {
 	current_version: '1.2.3',
 	latest_version: '1.2.4',
 	update_available: null,
+	channel: 'mild',
+	last_attempt: null,
 	error: null,
+	inputs: null,
 };
 
 describe('release update display', () => {
@@ -46,6 +50,18 @@ describe('release update display', () => {
 		expect(shouldCheckReleaseUpdate({ ...info, error: 'offline' })).toBe(false);
 	});
 
+	test('retains the latest check state for routes mounted after it completes', () => {
+		setReleaseUpdateSnapshot(null, 'loading');
+		expect(getReleaseUpdateSnapshot()).toEqual({ info: null, requestState: 'loading' });
+
+		const available = { ...info, update_available: true };
+		publishReleaseUpdate(available, 'ready');
+		expect(getReleaseUpdateSnapshot()).toEqual({ info: available, requestState: 'ready' });
+
+		publishReleaseUpdate(null, 'idle');
+		expect(getReleaseUpdateSnapshot()).toEqual({ info: null, requestState: 'idle' });
+	});
+
 	test('deduplicates concurrent remote checks', async () => {
 		let resolve!: (value: typeof info) => void;
 		let calls = 0;
@@ -70,5 +86,27 @@ describe('release update display', () => {
 		expect(calls).toBe(2);
 		resolve(info);
 		await third;
+	});
+
+	test('starts a fresh check after the previous request is invalidated', async () => {
+		const resolvers: ((value: UpdateInfo) => void)[] = [];
+		let calls = 0;
+		const client = {
+			call: <T>() => {
+				calls++;
+				return new Promise<UpdateInfo>((resolve) => { resolvers.push(resolve); }) as Promise<T>;
+			},
+		};
+		const stale = requestReleaseUpdateCheck(client);
+		invalidateReleaseUpdateCheck();
+		const fresh = requestReleaseUpdateCheck(client);
+
+		expect(fresh).not.toBe(stale);
+		expect(calls).toBe(2);
+		resolvers[0](info);
+		await stale;
+		expect(requestReleaseUpdateCheck(client)).toBe(fresh);
+		resolvers[1](info);
+		await fresh;
 	});
 });

--- a/webui/src/lib/release-update.ts
+++ b/webui/src/lib/release-update.ts
@@ -14,6 +14,7 @@ interface UpdateRpcClient {
 }
 
 let updateCheckInFlight: Promise<UpdateInfo> | null = null;
+let releaseUpdateSnapshot: ReleaseUpdateChangedDetail | null = null;
 const UPDATE_CHECK_TIMEOUT_MS = 180_000;
 
 export interface ReleaseUpdateDisplay {
@@ -32,10 +33,22 @@ export function publishReleaseUpdate(
 	info: UpdateInfo | null,
 	requestState: ReleaseUpdateRequestState,
 ) {
+	setReleaseUpdateSnapshot(info, requestState);
 	if (typeof window === 'undefined') return;
 	window.dispatchEvent(new CustomEvent<ReleaseUpdateChangedDetail>(RELEASE_UPDATE_CHANGED_EVENT, {
 		detail: { info, requestState },
 	}));
+}
+
+export function getReleaseUpdateSnapshot(): ReleaseUpdateChangedDetail | null {
+	return releaseUpdateSnapshot;
+}
+
+export function setReleaseUpdateSnapshot(
+	info: UpdateInfo | null,
+	requestState: ReleaseUpdateRequestState,
+) {
+	releaseUpdateSnapshot = { info, requestState };
 }
 
 export function requestReleaseUpdateCheck(client: UpdateRpcClient): Promise<UpdateInfo> {
@@ -47,6 +60,10 @@ export function requestReleaseUpdateCheck(client: UpdateRpcClient): Promise<Upda
 	};
 	request.then(clear, clear);
 	return request;
+}
+
+export function invalidateReleaseUpdateCheck() {
+	updateCheckInFlight = null;
 }
 
 export function releaseUpdateDisplay(

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -64,7 +64,7 @@
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
 	import { theme } from '$lib/theme.svelte';
 	import { terminalStatus } from '$lib/terminalStatus.svelte';
-	import { RELEASE_UPDATE_CHANGED_EVENT, releaseUpdateDisplay, requestReleaseUpdateCheck, shouldCheckReleaseUpdate, type ReleaseUpdateChangedDetail, type ReleaseUpdateRequestState } from '$lib/release-update';
+	import { RELEASE_UPDATE_CHANGED_EVENT, publishReleaseUpdate, releaseUpdateDisplay, requestReleaseUpdateCheck, setReleaseUpdateSnapshot, shouldCheckReleaseUpdate, type ReleaseUpdateChangedDetail, type ReleaseUpdateRequestState } from '$lib/release-update';
 	import { isManagementRole, isStandardUser, redirectForRole } from '$lib/access';
 	import { CORE_RECOVERY_PATHS, RECOVERY_BACKUP_CHANGED_EVENT, SECURE_BOOT_RECOVERY_SOURCE } from '$lib/recoveryBackup';
 
@@ -369,6 +369,7 @@
 	async function loadReleaseUpdate() {
 		const request = ++releaseRequest;
 		releaseRequestState = 'loading';
+		setReleaseUpdateSnapshot(releaseInfo, 'loading');
 		try {
 			let info = await getClient().call<UpdateInfo>('system.update.version');
 			if (request !== releaseRequest) return;
@@ -381,8 +382,12 @@
 				releaseInfo = info;
 			}
 			releaseRequestState = 'ready';
+			publishReleaseUpdate(releaseInfo, 'ready');
 		} catch {
-			if (request === releaseRequest) releaseRequestState = 'failed';
+			if (request === releaseRequest) {
+				releaseRequestState = 'failed';
+				publishReleaseUpdate(releaseInfo, 'failed');
+			}
 		}
 	}
 

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -28,7 +28,7 @@
 		shouldShowUpdateStatus,
 		versionUpdatePhases
 	} from '$lib/update-progress';
-	import { publishReleaseUpdate, requestReleaseUpdateCheck } from '$lib/release-update';
+	import { getReleaseUpdateSnapshot, invalidateReleaseUpdateCheck, publishReleaseUpdate, RELEASE_UPDATE_CHANGED_EVENT, requestReleaseUpdateCheck, type ReleaseUpdateChangedDetail } from '$lib/release-update';
 
 	type Tab = 'version' | 'generations' | 'firmware';
 	type VersionRow = {
@@ -65,6 +65,7 @@
 
 	const client = getClient();
 	const VERSION_PAGE_ACTION_KEY = 'nasty.version-page.action';
+	const initialReleaseUpdate = getReleaseUpdateSnapshot();
 
 	let activeTab: Tab = $state(
 		typeof window !== 'undefined' && window.location.hash === '#generations' ? 'generations'
@@ -73,14 +74,16 @@
 	);
 
 	let info = $state<UpdateInfo | null>(null);
-	let checkInfo = $state<UpdateInfo | null>(null);
+	let checkInfo = $state<UpdateInfo | null>(
+		initialReleaseUpdate?.requestState === 'ready' ? initialReleaseUpdate.info : null
+	);
 	let buildDir = $state<UpdateBuildDirConfig | null>(null);
 	let buildDirDraft = $state<string>('');
 	let savingBuildDir = $state(false);
 	const summaryInputs: VersionInputInfo[] | null = $derived(
 		checkInfo?.inputs ?? info?.inputs ?? null
 	);
-	let checking = $state(false);
+	let checking = $state(initialReleaseUpdate?.requestState === 'loading');
 	let startingDevUpgrade = $state(false);
 	let taggedReleaseBanner: TaggedReleaseBannerState = $state({ kind: 'loading' });
 	let versionRows: VersionRow[] = $state([]);
@@ -98,6 +101,7 @@
 	let logEl: HTMLPreElement | undefined = $state();
 	let logCollapsed = $state(true);
 	let taggedReleaseBannerRequestId = 0;
+	let releaseCheckRequestId = 0;
 
 	let generations: Generation[] = $state([]);
 	let generationsLoading = $state(false);
@@ -184,6 +188,13 @@
 	});
 
 	onMount(() => {
+		const applyReleaseUpdate = (detail: ReleaseUpdateChangedDetail) => {
+			checking = detail.requestState === 'loading';
+			if (detail.requestState === 'ready') checkInfo = detail.info;
+		};
+		const handleReleaseUpdateChanged = (event: Event) => {
+			applyReleaseUpdate((event as CustomEvent<ReleaseUpdateChangedDetail>).detail);
+		};
 		const onReconnect = () => {
 			Promise.all([
 				loadVersionPage(),
@@ -200,9 +211,13 @@
 		});
 
 		client.onReconnect(onReconnect);
+		window.addEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
+		const releaseUpdate = getReleaseUpdateSnapshot();
+		if (releaseUpdate) applyReleaseUpdate(releaseUpdate);
 
 		return () => {
 			client.offReconnect(onReconnect);
+			window.removeEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
 		};
 	});
 
@@ -379,6 +394,7 @@
 		taggedReleaseBanner = { kind: 'switching' };
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
+		clearReleaseUpdateCheck();
 		const result = await withToast(
 			() => client.call('system.version.switch', {
 				inputs: versionRows.map((row) => ({
@@ -439,6 +455,7 @@
 		startingUpgrade = true;
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
+		clearReleaseUpdateCheck();
 		const result = await withToast(
 			() => client.call('system.version.upgrade_tagged_release', undefined, 120000),
 			'Tagged release upgrade started'
@@ -452,16 +469,29 @@
 	}
 
 	async function checkForUpdates() {
+		const requestId = ++releaseCheckRequestId;
 		checking = true;
 		publishReleaseUpdate(checkInfo ?? info, 'loading');
 		try {
-			checkInfo = await requestReleaseUpdateCheck(client);
+			const next = await requestReleaseUpdateCheck(client);
+			if (requestId !== releaseCheckRequestId) return;
+			checkInfo = next;
 			publishReleaseUpdate(checkInfo, 'ready');
 		} catch {
+			if (requestId !== releaseCheckRequestId) return;
 			checkInfo = null;
 			publishReleaseUpdate(null, 'failed');
+		} finally {
+			if (requestId === releaseCheckRequestId) checking = false;
 		}
+	}
+
+	function clearReleaseUpdateCheck() {
+		releaseCheckRequestId++;
+		invalidateReleaseUpdateCheck();
 		checking = false;
+		checkInfo = null;
+		publishReleaseUpdate(null, 'idle');
 	}
 
 	async function saveBuildDir() {
@@ -490,6 +520,7 @@
 		startingDevUpgrade = true;
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
+		clearReleaseUpdateCheck();
 		const result = await withToast(
 			() => client.call('system.version.switch', {
 				inputs: versionRows.map((row) => ({
@@ -523,7 +554,7 @@
 					status = await client.call<UpdateStatus>('system.update.status');
 					if (status && (status.state === 'success' || status.state === 'failed')) {
 						stopPolling();
-						checkInfo = null; // clear stale "available" after upgrade
+						clearReleaseUpdateCheck();
 						await loadVersionPage();
 						writeVersionPageAction(null);
 						// Nudge the layout's cached sysInfo so the top-bar
@@ -585,6 +616,7 @@
 
 		logCollapsed = false;
 		status = { state: 'running', log: '', reboot_required: false, webui_changed: false };
+		clearReleaseUpdateCheck();
 		const ok = await withToast(
 			() => client.call('system.generations.switch', { generation: gen }),
 			`Switching to generation ${gen}`


### PR DESCRIPTION
## Summary
- retain and publish the release check already used by the sidebar
- initialize the Update page from that result so an available development upgrade is actionable immediately
- replay checks that finish during navigation without issuing a duplicate remote request
- invalidate stale and in-flight results when any version-changing action starts

Fixes the disconnect between the update indicator added in #817 and the Version page.

## Testing
- `npm run check`
- `npm test` (269 tests)
- `npm run build`
- `git diff --check`