### PR TITLE
webui: split dashboard health and resource widgets

### DIFF
--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -4,8 +4,9 @@ import AlertsWidget from './alerts-widget.svelte';
 import HealthWidget from './health-widget.svelte';
 import HistoryWidget from './history-widget.svelte';
 import OperationsWidget from './operations-widget.svelte';
+import SummaryWidget from './summary-widget.svelte';
 import SystemWidget from './system-widget.svelte';
-import type { ActiveAlert, SystemInfo } from '$lib/types';
+import type { ActiveAlert, Filesystem, SystemInfo, SystemStats } from '$lib/types';
 
 const alert = (severity: ActiveAlert['severity'], message: string): ActiveAlert => ({
 	rule_id: message,
@@ -34,6 +35,25 @@ const info: SystemInfo = {
 	bcachefs_is_custom: false,
 	timezone: 'UTC',
 	ntp_synced: true,
+};
+
+const stats: SystemStats = {
+	cpu: { count: 4, load_1: 1, load_5: 0.75, load_15: 0.5, temp_c: 42, freq_mhz: 2400, governor: 'powersave' },
+	memory: { total_bytes: 1000, used_bytes: 500, available_bytes: 500, swap_total_bytes: 0, swap_used_bytes: 0, bcachefs_btree_cache_bytes: 100 },
+	network: [],
+	disk_io: [],
+};
+
+const filesystem: Filesystem = {
+	name: 'pool',
+	uuid: 'pool-uuid',
+	devices: [],
+	mount_point: '/mnt/pool',
+	mounted: true,
+	total_bytes: 400,
+	used_bytes: 100,
+	available_bytes: 300,
+	options: {} as Filesystem['options'],
 };
 
 describe('tiny dashboard widgets', () => {
@@ -116,73 +136,111 @@ describe('tiny dashboard widgets', () => {
 });
 
 describe('dashboard health widget', () => {
-	test('renders linked service and managed container counts with explicit health states', () => {
-		const body = render(HealthWidget, {
+	test('renders service and managed container health as independent linked cards', () => {
+		const services = render(HealthWidget, {
 			props: {
+				kind: 'services',
 				services: { enabled: 3, running: 2 },
-				servicesFreshness: 'current',
-				containers: { runtime: 'running', expected: 2, running: 2 },
-				containersFreshness: 'current',
+				freshness: 'current',
 				density: 'comfortable',
-				width: 'full',
+			},
+		}).body;
+		const containers = render(HealthWidget, {
+			props: {
+				kind: 'containers',
+				containers: { runtime: 'running', expected: 2, running: 2 },
+				freshness: 'current',
+				density: 'comfortable',
 			},
 		}).body;
 
-		expect(body).toContain('href="/services"');
-		expect(body).toContain('3 enabled');
-		expect(body).toContain('2 running');
-		expect(body).toContain('1 enabled service not running.');
-		expect(body).toContain('href="/apps"');
-		expect(body).toContain('2 expected');
-		expect(body).toContain('All expected containers are running.');
-		expect(body).toContain('Simple apps count once; Compose service instances count individually.');
-		expect(body).toContain('md:grid-cols-2');
-		expect(body).toContain('px-5 py-4');
+		expect(services).toContain('href="/services"');
+		expect(services).toContain('3 enabled');
+		expect(services).toContain('2 running');
+		expect(services).toContain('1 enabled service not running.');
+		expect(services).not.toContain('href="/apps"');
+		expect(containers).toContain('href="/apps"');
+		expect(containers).toContain('2 expected');
+		expect(containers).toContain('All expected containers are running.');
+		expect(containers).toContain('Simple apps count once; Compose service instances count individually.');
+		expect(containers).not.toContain('href="/services"');
 	});
 
 	test('distinguishes disabled, loading, unavailable, and stale states in text', () => {
+		const loading = render(HealthWidget, {
+			props: {
+				kind: 'services',
+				services: null,
+				freshness: 'loading',
+				density: 'compact',
+			},
+		}).body;
 		const disabled = render(HealthWidget, {
 			props: {
-				services: null,
-				servicesFreshness: 'loading',
+				kind: 'containers',
 				containers: { runtime: 'disabled', expected: null, running: null },
-				containersFreshness: 'current',
+				freshness: 'current',
 				density: 'compact',
-				width: 'half',
 			},
 		}).body;
 		const stale = render(HealthWidget, {
 			props: {
+				kind: 'services',
 				services: { enabled: 1, running: 1 },
-				servicesFreshness: 'stale',
-				containers: null,
-				containersFreshness: 'unavailable',
+				freshness: 'stale',
 				density: 'compact',
-				width: 'quarter',
 			},
 		}).body;
 		const refreshing = render(HealthWidget, {
 			props: {
-				services: { enabled: 1, running: 1 },
-				servicesFreshness: 'refreshing',
+				kind: 'containers',
 				containers: { runtime: 'running', expected: 1, running: 1 },
-				containersFreshness: 'refreshing',
+				freshness: 'refreshing',
 				density: 'compact',
-				width: 'half',
 			},
 		}).body;
 
-		expect(disabled).toContain('Checking enabled services.');
+		expect(loading).toContain('Checking enabled services.');
 		expect(disabled).toContain('Docker runtime is disabled.');
 		expect(disabled).toContain('px-4 py-3');
-		expect(disabled).toContain('md:grid-cols-2');
 		expect(stale).toContain('Stale - healthy');
-		expect(stale).toContain('xl:grid-cols-1');
 		expect(stale).toContain('Refresh failed; showing last known healthy state.');
-		expect(stale).toContain('Managed container health could not be loaded.');
 		expect(stale).toContain('role="status"');
 		expect(refreshing).toContain('Refreshing - healthy');
 		expect(refreshing).toContain('Refreshing; showing last known healthy state.');
 		expect(refreshing).not.toContain('Refresh failed');
+	});
+});
+
+describe('dashboard resource summary widgets', () => {
+	test('renders each resource as an independent card', () => {
+		const cpu = render(SummaryWidget, { props: { kind: 'cpu_load', stats, density: 'comfortable' } }).body;
+		const memory = render(SummaryWidget, { props: { kind: 'memory_usage', stats, density: 'comfortable' } }).body;
+		const status = render(SummaryWidget, { props: { kind: 'cpu_status', stats, density: 'comfortable' } }).body;
+		const storage = render(SummaryWidget, { props: { kind: 'storage_summary', filesystems: [filesystem], density: 'comfortable' } }).body;
+
+		expect(cpu).toContain('CPU load');
+		expect(cpu).toContain('1.00');
+		expect(cpu).not.toContain('Memory');
+		expect(memory).toContain('Memory');
+		expect(memory).toContain('Btree cache');
+		expect(memory).not.toContain('CPU load');
+		expect(status).toContain('2.4 GHz - powersave');
+		expect(storage).toContain('Storage');
+		expect(storage).toContain('1 filesystem');
+	});
+
+	test('keeps unavailable standalone resources visible', () => {
+		const cpu = render(SummaryWidget, { props: { kind: 'cpu_load', stats: null, density: 'compact' } }).body;
+		const status = render(SummaryWidget, {
+			props: { kind: 'cpu_status', stats: { ...stats, cpu: { ...stats.cpu, temp_c: null, freq_mhz: null } }, density: 'compact' },
+		}).body;
+		const storage = render(SummaryWidget, { props: { kind: 'storage_summary', filesystems: [], density: 'compact' } }).body;
+		const unavailableStorage = render(SummaryWidget, { props: { kind: 'storage_summary', filesystemsLoaded: false, density: 'compact' } }).body;
+
+		expect(cpu).toContain('Unavailable');
+		expect(status).toContain('CPU temperature and frequency are unavailable.');
+		expect(storage).toContain('No filesystems');
+		expect(unavailableStorage).toContain('Filesystem inventory could not be loaded.');
 	});
 });

--- a/webui/src/lib/components/dashboard/health-widget.svelte
+++ b/webui/src/lib/components/dashboard/health-widget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
 	import type {
 		DashboardHealthFreshness,
 		ManagedContainerHealthSummary,
@@ -8,19 +8,17 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 
 	let {
-		services,
-		servicesFreshness,
-		containers,
-		containersFreshness,
+		kind,
+		services = null,
+		containers = null,
+		freshness,
 		density,
-		width,
 	}: {
-		services: ServiceHealthSummary | null;
-		servicesFreshness: DashboardHealthFreshness;
-		containers: ManagedContainerHealthSummary | null;
-		containersFreshness: DashboardHealthFreshness;
+		kind: 'services' | 'containers';
+		services?: ServiceHealthSummary | null;
+		containers?: ManagedContainerHealthSummary | null;
+		freshness: DashboardHealthFreshness;
 		density: DashboardDensity;
-		width: DashboardWidgetWidth;
 	} = $props();
 
 	type TilePresentation = {
@@ -46,20 +44,20 @@
 	}
 
 	function servicePresentation(): TilePresentation {
-		if (servicesFreshness === 'loading') return { label: 'Loading', detail: 'Checking enabled services.', tone: 'neutral' };
-		if (!services || servicesFreshness === 'unavailable') return { label: 'Unavailable', detail: 'Service health could not be loaded.', tone: 'neutral' };
+		if (freshness === 'loading') return { label: 'Loading', detail: 'Checking enabled services.', tone: 'neutral' };
+		if (!services || freshness === 'unavailable') return { label: 'Unavailable', detail: 'Service health could not be loaded.', tone: 'neutral' };
 		const current: TilePresentation = services.enabled === 0
 			? { label: 'No services enabled', detail: 'No services are expected to run.', tone: 'neutral' }
 			: services.running === services.enabled
 				? { label: 'Healthy', detail: 'All enabled services are running.', tone: 'healthy' }
 				: { label: 'Unhealthy', detail: `${services.enabled - services.running} enabled service${services.enabled - services.running === 1 ? '' : 's'} not running.`, tone: 'warning' };
-		if (servicesFreshness === 'refreshing') return refreshingPresentation(current);
-		return servicesFreshness === 'stale' ? stalePresentation(current) : current;
+		if (freshness === 'refreshing') return refreshingPresentation(current);
+		return freshness === 'stale' ? stalePresentation(current) : current;
 	}
 
 	function containerPresentation(): TilePresentation {
-		if (containersFreshness === 'loading') return { label: 'Loading', detail: 'Checking managed containers.', tone: 'neutral' };
-		if (!containers || containersFreshness === 'unavailable') return { label: 'Unavailable', detail: 'Managed container health could not be loaded.', tone: 'neutral' };
+		if (freshness === 'loading') return { label: 'Loading', detail: 'Checking managed containers.', tone: 'neutral' };
+		if (!containers || freshness === 'unavailable') return { label: 'Unavailable', detail: 'Managed container health could not be loaded.', tone: 'neutral' };
 		let current: TilePresentation;
 		if (containers.runtime === 'disabled') {
 			current = { label: 'Disabled', detail: 'Docker runtime is disabled.', tone: 'neutral' };
@@ -75,8 +73,8 @@
 			const stopped = containers.expected - containers.running;
 			current = { label: 'Unhealthy', detail: `${stopped} expected container${stopped === 1 ? '' : 's'} not running.`, tone: 'warning' };
 		}
-		if (containersFreshness === 'refreshing') return refreshingPresentation(current);
-		return containersFreshness === 'stale' ? stalePresentation(current) : current;
+		if (freshness === 'refreshing') return refreshingPresentation(current);
+		return freshness === 'stale' ? stalePresentation(current) : current;
 	}
 
 	function tileClass(tone: TilePresentation['tone']): string {
@@ -91,45 +89,42 @@
 		return 'text-muted-foreground';
 	}
 
-	let serviceState = $derived(servicePresentation());
-	let containerState = $derived(containerPresentation());
+	let state = $derived(kind === 'services' ? servicePresentation() : containerPresentation());
 </script>
 
-<div class="grid gap-3 {width === 'full' || width === 'half' ? 'md:grid-cols-2' : 'md:grid-cols-2 xl:grid-cols-1'}">
-	<Card class="h-full overflow-hidden {tileClass(serviceState.tone)}">
-		<a href="/services" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Services: ${serviceState.label}. ${services ? `${services.enabled} enabled, ${services.running} running.` : serviceState.detail}`}>
+<Card class="h-full overflow-hidden {tileClass(state.tone)}">
+	{#if kind === 'services'}
+		<a href="/services" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Services: ${state.label}. ${services ? `${services.enabled} enabled, ${services.running} running.` : state.detail}`}>
 			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>
 				<div class="flex items-center justify-between gap-3">
 					<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Services</div>
-					<div class="text-xs font-semibold {labelClass(serviceState.tone)}">{serviceState.label}</div>
+					<div class="text-xs font-semibold {labelClass(state.tone)}">{state.label}</div>
 				</div>
 				{#if services}
 					<div class="mt-2 text-xl font-bold tabular-nums">{services.enabled} enabled <span class="text-muted-foreground">/</span> {services.running} running</div>
 				{:else}
-					<div class="mt-2 text-xl font-bold text-muted-foreground">{serviceState.label}</div>
+					<div class="mt-2 text-xl font-bold text-muted-foreground">{state.label}</div>
 				{/if}
-				<div class="mt-1 text-xs text-muted-foreground" role={servicesFreshness === 'refreshing' || servicesFreshness === 'stale' || servicesFreshness === 'unavailable' ? 'status' : undefined}>{serviceState.detail}</div>
+				<div class="mt-1 text-xs text-muted-foreground" role={freshness === 'refreshing' || freshness === 'stale' || freshness === 'unavailable' ? 'status' : undefined}>{state.detail}</div>
 			</CardContent>
 		</a>
-	</Card>
-
-	<Card class="h-full overflow-hidden {tileClass(containerState.tone)}">
-		<a href="/apps" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Managed containers: ${containerState.label}. ${containers?.expected != null ? `${containers.expected} expected, ${containers.running} running.` : containerState.detail}`}>
+	{:else}
+		<a href="/apps" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Managed containers: ${state.label}. ${containers?.expected != null ? `${containers.expected} expected, ${containers.running} running.` : state.detail}`}>
 			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>
 				<div class="flex items-center justify-between gap-3">
 					<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Managed containers</div>
-					<div class="text-xs font-semibold {labelClass(containerState.tone)}">{containerState.label}</div>
+					<div class="text-xs font-semibold {labelClass(state.tone)}">{state.label}</div>
 				</div>
 				{#if containers?.expected != null && containers.running != null}
 					<div class="mt-2 text-xl font-bold tabular-nums">{containers.expected} expected <span class="text-muted-foreground">/</span> {containers.running} running</div>
 				{:else}
-					<div class="mt-2 text-xl font-bold text-muted-foreground">{containerState.label}</div>
+					<div class="mt-2 text-xl font-bold text-muted-foreground">{state.label}</div>
 				{/if}
-				<div class="mt-1 text-xs text-muted-foreground" role={containersFreshness === 'refreshing' || containersFreshness === 'stale' || containersFreshness === 'unavailable' ? 'status' : undefined}>{containerState.detail}</div>
+				<div class="mt-1 text-xs text-muted-foreground" role={freshness === 'refreshing' || freshness === 'stale' || freshness === 'unavailable' ? 'status' : undefined}>{state.detail}</div>
 				{#if containers && containers.runtime !== 'disabled'}
 					<div class="mt-1 text-[0.68rem] text-muted-foreground/80">Simple apps count once; Compose service instances count individually.</div>
 				{/if}
 			</CardContent>
 		</a>
-	</Card>
-</div>
+	{/if}
+</Card>

--- a/webui/src/lib/components/dashboard/summary-widget.svelte
+++ b/webui/src/lib/components/dashboard/summary-widget.svelte
@@ -1,23 +1,24 @@
 <script lang="ts">
-	import type { DashboardDensity, DashboardWidgetWidth } from '$lib/dashboard.svelte';
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
 	import type { Filesystem, SystemStats } from '$lib/types';
 	import { formatBytes, formatPercent } from '$lib/format';
 	import { formatTemp } from '$lib/temperature.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 
-	let { stats, filesystems, density, width }: {
-		stats: SystemStats;
-		filesystems: Filesystem[];
+	let { kind, stats = null, filesystems = [], filesystemsLoaded = true, density }: {
+		kind: 'cpu_load' | 'memory_usage' | 'cpu_status' | 'storage_summary';
+		stats?: SystemStats | null;
+		filesystems?: Filesystem[];
+		filesystemsLoaded?: boolean;
 		density: DashboardDensity;
-		width: DashboardWidgetWidth;
 	} = $props();
 
 	function cpuPercent(): number {
-		return Math.min(100, (stats.cpu.load_1 / stats.cpu.count) * 100);
+		return stats ? Math.min(100, (stats.cpu.load_1 / stats.cpu.count) * 100) : 0;
 	}
 
 	function memoryPercent(): number {
-		return stats.memory.total_bytes > 0 ? (stats.memory.used_bytes / stats.memory.total_bytes) * 100 : 0;
+		return stats && stats.memory.total_bytes > 0 ? (stats.memory.used_bytes / stats.memory.total_bytes) * 100 : 0;
 	}
 
 	function totalStorage(): { used: number; total: number; unknown: number } {
@@ -41,39 +42,41 @@
 	let storage = $derived(totalStorage());
 </script>
 
-<div class="grid grid-cols-2 gap-3 {width === 'full' ? 'lg:grid-cols-4' : width === 'third' || width === 'quarter' ? 'xl:grid-cols-1' : ''}">
-	<Card>
-		<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+<Card class="h-full">
+	<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+		{#if kind === 'cpu_load'}
 			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU load</div>
-			<div class="mt-1 flex items-baseline gap-2"><span class="text-2xl font-bold">{stats.cpu.load_1.toFixed(2)}</span><span class="text-xs text-muted-foreground">/ {stats.cpu.count} cores</span></div>
-			<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(cpuPercent())}" style="width: {cpuPercent()}%"></div></div>
-			<div class="mt-1.5 flex justify-between text-xs tabular-nums text-muted-foreground"><span>5m {stats.cpu.load_5.toFixed(2)}</span><span>15m {stats.cpu.load_15.toFixed(2)}</span></div>
-		</CardContent>
-	</Card>
-
-	<Card>
-		<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
+			{#if stats}
+				<div class="mt-1 flex items-baseline gap-2"><span class="text-2xl font-bold">{stats.cpu.load_1.toFixed(2)}</span><span class="text-xs text-muted-foreground">/ {stats.cpu.count} cores</span></div>
+				<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(cpuPercent())}" style="width: {cpuPercent()}%"></div></div>
+				<div class="mt-1.5 flex justify-between text-xs tabular-nums text-muted-foreground"><span>5m {stats.cpu.load_5.toFixed(2)}</span><span>15m {stats.cpu.load_15.toFixed(2)}</span></div>
+			{:else}
+				<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
+			{/if}
+		{:else if kind === 'memory_usage'}
 			<div class="text-xs uppercase tracking-wide text-muted-foreground">Memory</div>
-			<div class="mt-1 flex flex-wrap items-baseline gap-x-2"><span class="text-2xl font-bold">{formatPercent(stats.memory.used_bytes, stats.memory.total_bytes)}</span><span class="text-xs text-muted-foreground">{formatBytes(stats.memory.used_bytes)} / {formatBytes(stats.memory.total_bytes)}</span></div>
-			<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(memoryPercent())}" style="width: {memoryPercent()}%"></div></div>
-			{#if stats.memory.bcachefs_btree_cache_bytes != null}<div class="mt-1.5 truncate text-xs text-muted-foreground" title="Approximate kernel-reported bcachefs btree-node buffers">Btree cache {formatBytes(stats.memory.bcachefs_btree_cache_bytes)}</div>{/if}
-		</CardContent>
-	</Card>
-
-	{#if stats.cpu.temp_c != null || stats.cpu.freq_mhz != null}
-		<Card>
-			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
-				<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU</div>
+			{#if stats}
+				<div class="mt-1 flex flex-wrap items-baseline gap-x-2"><span class="text-2xl font-bold">{formatPercent(stats.memory.used_bytes, stats.memory.total_bytes)}</span><span class="text-xs text-muted-foreground">{formatBytes(stats.memory.used_bytes)} / {formatBytes(stats.memory.total_bytes)}</span></div>
+				<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(memoryPercent())}" style="width: {memoryPercent()}%"></div></div>
+				{#if stats.memory.bcachefs_btree_cache_bytes != null}<div class="mt-1.5 truncate text-xs text-muted-foreground" title="Approximate kernel-reported bcachefs btree-node buffers">Btree cache {formatBytes(stats.memory.bcachefs_btree_cache_bytes)}</div>{/if}
+			{:else}
+				<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
+			{/if}
+		{:else if kind === 'cpu_status'}
+			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU</div>
+			{#if stats && (stats.cpu.temp_c != null || stats.cpu.freq_mhz != null)}
 				<div class="mt-1 text-2xl font-bold">{formatTemp(stats.cpu.temp_c) ?? '-'}</div>
 				<div class="mt-2 text-xs text-muted-foreground">{stats.cpu.freq_mhz != null ? (stats.cpu.freq_mhz >= 1000 ? (stats.cpu.freq_mhz / 1000).toFixed(1) + ' GHz' : stats.cpu.freq_mhz + ' MHz') : ''}{stats.cpu.governor ? ` - ${stats.cpu.governor}` : ''}</div>
-			</CardContent>
-		</Card>
-	{/if}
-
-	{#if filesystems.length > 0}
-		<Card>
-			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
-				<div class="text-xs uppercase tracking-wide text-muted-foreground">Storage</div>
+			{:else}
+				<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
+				<div class="mt-2 text-xs text-muted-foreground">CPU temperature and frequency are unavailable.</div>
+			{/if}
+		{:else}
+			<div class="text-xs uppercase tracking-wide text-muted-foreground">Storage</div>
+			{#if !filesystemsLoaded}
+				<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
+				<div class="mt-2 text-xs text-muted-foreground">Filesystem inventory could not be loaded.</div>
+			{:else if filesystems.length > 0}
 				{#if storage.total > 0}
 					<div class="mt-1 flex flex-wrap items-baseline gap-x-2"><span class="text-2xl font-bold">{formatPercent(storage.used, storage.total)}</span><span class="text-xs text-muted-foreground">{formatBytes(storage.used)} / {formatBytes(storage.total)}</span></div>
 					<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary"><div class="h-full rounded-full {barColor(storage.used / storage.total * 100)}" style="width: {storage.used / storage.total * 100}%"></div></div>
@@ -81,7 +84,10 @@
 					<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
 				{/if}
 				<div class="mt-1.5 text-xs text-muted-foreground">{filesystems.length} filesystem{filesystems.length === 1 ? '' : 's'}{storage.unknown > 0 ? ` - ${storage.unknown} unavailable` : ''}</div>
-			</CardContent>
-		</Card>
-	{/if}
-</div>
+			{:else}
+				<div class="mt-1 text-2xl font-bold text-muted-foreground">No filesystems</div>
+				<div class="mt-2 text-xs text-muted-foreground">Storage capacity will appear after a filesystem is created.</div>
+			{/if}
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -4,6 +4,7 @@ import {
 	LEGACY_DASHBOARD_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V2_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V3_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_V4_PREFERENCES_KEY,
 	createDashboardView,
 	dashboardPrefs,
 	dashboardPresetTabVisible,
@@ -36,7 +37,7 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":5,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":6,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
 	test('migrates the v1 custom layout without losing its configuration', () => {
@@ -50,7 +51,7 @@ describe('dashboard preferences', () => {
 			],
 		}));
 
-		expect(parsed.version).toBe(4);
+		expect(parsed.version).toBe(5);
 		expect(parsed.preset).toBe('custom');
 		expect(parsed.customViews).toHaveLength(1);
 		expect(getActiveDashboardView(parsed)).toMatchObject({
@@ -58,7 +59,7 @@ describe('dashboard preferences', () => {
 			density: 'compact',
 		});
 		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard' });
-		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(9);
+		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(13);
 	});
 
 	test('migrates v2 named views to standard widget presentations', () => {
@@ -77,13 +78,13 @@ describe('dashboard preferences', () => {
 			}],
 		}));
 
-		expect(parsed.version).toBe(4);
+		expect(parsed.version).toBe(5);
 		expect(parsed.activeViewId).toBe('daily');
 		expect(getActiveDashboardView(parsed)).toMatchObject({ name: 'Daily', density: 'compact' });
 		expect(getActiveDashboardView(parsed).widgets.every((widget) => widget.presentation === 'standard')).toBe(true);
 	});
 
-	test('initializes v4 storage from the newest available legacy key without overwriting v4 preferences', () => {
+	test('initializes v5 storage from the newest available legacy key without overwriting v5 preferences', () => {
 		localStorage.clear();
 		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
 			version: 1,
@@ -103,10 +104,22 @@ describe('dashboard preferences', () => {
 			version: 3,
 			preset: 'monitoring',
 		}));
-		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
-		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+		localStorage.setItem(LEGACY_DASHBOARD_V4_PREFERENCES_KEY, JSON.stringify({
 			version: 4,
-			preset: 'monitoring',
+			preset: 'custom',
+			hiddenPresetTabs: [],
+			activeViewId: 'legacy',
+			customViews: [{
+				id: 'legacy',
+				name: 'Legacy',
+				density: 'comfortable',
+				widgets: [{ id: 'health', visible: true, width: 'full', presentation: 'standard' }],
+			}],
+		}));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('custom');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 5,
+			preset: 'custom',
 		});
 
 		const stored = defaultDashboardPreferences();
@@ -114,6 +127,40 @@ describe('dashboard preferences', () => {
 		localStorage.setItem(DASHBOARD_PREFERENCES_KEY, JSON.stringify(stored));
 		expect(initializeDashboardPreferences(localStorage).preset).toBe('storage');
 		expect(loadDashboardPreferences(localStorage).preset).toBe('storage');
+	});
+
+	test('expands v4 health and resource groups in place without losing configuration', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 4,
+			preset: 'custom',
+			hiddenPresetTabs: ['overview'],
+			activeViewId: 'legacy',
+			customViews: [{
+				id: 'legacy',
+				name: 'Legacy',
+				density: 'compact',
+				widgets: [
+					{ id: 'alerts', visible: true, width: 'full', presentation: 'tiny' },
+					{ id: 'health', visible: false, width: 'half', presentation: 'standard' },
+					{ id: 'network', visible: true, width: 'half', presentation: 'standard' },
+					{ id: 'summary', visible: true, width: 'half', presentation: 'standard' },
+				],
+			}],
+		}));
+		const widgets = getActiveDashboardView(parsed).widgets;
+
+		expect(widgets.slice(0, 9).map((widget) => widget.id)).toEqual([
+			'alerts', 'service_health', 'container_health', 'network',
+			'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary', 'system',
+		]);
+		expect(widgets.filter((widget) => widget.id === 'service_health' || widget.id === 'container_health'))
+			.toEqual([
+				{ id: 'service_health', visible: false, width: 'quarter', presentation: 'standard' },
+				{ id: 'container_health', visible: false, width: 'quarter', presentation: 'standard' },
+			]);
+		expect(widgets.filter((widget) => ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(widget.id)).map((widget) => widget.width))
+			.toEqual(['quarter', 'quarter', 'quarter', 'quarter']);
+		expect(parsed.hiddenPresetTabs).toEqual(['overview']);
 	});
 
 	test('normalizes named views, active selection, and newly added widget ids', () => {
@@ -141,7 +188,7 @@ describe('dashboard preferences', () => {
 		expect(parsed.activeViewId).toBe('ops');
 		expect(parsed.customViews.map((view) => view.id)).toEqual(['ops', 'custom-1']);
 		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
-		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(9);
+		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(13);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
@@ -164,8 +211,9 @@ describe('dashboard preferences', () => {
 	test('limits narrow widths to compact-safe presentations', () => {
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'standard')).toBe(false);
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'tiny')).toBe(true);
-		expect(dashboardWidgetSupportsNarrowWidth('health', 'standard')).toBe(true);
-		expect(dashboardWidgetSupportsNarrowWidth('summary', 'standard')).toBe(true);
+		for (const id of ['service_health', 'container_health', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'] as const) {
+			expect(dashboardWidgetSupportsNarrowWidth(id, 'standard')).toBe(true);
+		}
 		expect(dashboardWidgetSupportsNarrowWidth('storage', 'standard')).toBe(false);
 		expect(dashboardWidgetSupportsNarrowWidth('network', 'standard')).toBe(false);
 		expect(dashboardWidgetSupportsNarrowWidth('disk_io', 'standard')).toBe(false);
@@ -174,10 +222,12 @@ describe('dashboard preferences', () => {
 	});
 
 	test('maps custom widths onto the 12-column dashboard grid', () => {
-		expect(dashboardWidgetWidthClass('full')).toContain('xl:col-span-12');
-		expect(dashboardWidgetWidthClass('half')).toContain('xl:col-span-6');
-		expect(dashboardWidgetWidthClass('third')).toContain('xl:col-span-4');
-		expect(dashboardWidgetWidthClass('quarter')).toContain('xl:col-span-3');
+		expect(dashboardWidgetWidthClass('alerts', 'full')).toContain('xl:col-span-12');
+		expect(dashboardWidgetWidthClass('alerts', 'half')).toContain('xl:col-span-6');
+		expect(dashboardWidgetWidthClass('alerts', 'third')).toContain('xl:col-span-4');
+		expect(dashboardWidgetWidthClass('alerts', 'quarter')).toContain('xl:col-span-3');
+		expect(dashboardWidgetWidthClass('service_health', 'half')).toContain('md:col-span-6');
+		expect(dashboardWidgetWidthClass('cpu_load', 'quarter')).toContain('lg:col-span-3');
 	});
 
 	test('hides any built-in preset tab and falls back to a custom view', () => {
@@ -226,6 +276,9 @@ describe('dashboard preferences', () => {
 
 	test('resolves fixed presets independently from named custom views', () => {
 		const preferences = defaultDashboardPreferences();
+		const independentTiles = ['service_health', 'container_health', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'];
+		expect(resolveDashboardWidgets(preferences).map((widget) => widget.id)).toEqual(expect.arrayContaining(independentTiles));
+
 		preferences.preset = 'storage';
 		preferences.customViews[0].widgets = preferences.customViews[0].widgets.map((widget) => ({ ...widget, visible: false }));
 
@@ -233,6 +286,8 @@ describe('dashboard preferences', () => {
 			'alerts', 'system', 'operations', 'storage',
 		]);
 		expect(resolveDashboardDensity(preferences)).toBe('compact');
+		preferences.preset = 'monitoring';
+		expect(resolveDashboardWidgets(preferences).map((widget) => widget.id)).toEqual(expect.arrayContaining(independentTiles));
 	});
 
 	test('creates, duplicates, renames, selects, and deletes named views', () => {
@@ -274,13 +329,13 @@ describe('dashboard preferences', () => {
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
 	});
 
-	test('persists the active named view in v4 storage', () => {
+	test('persists the active named view in v5 storage', () => {
 		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 4,
+			version: 5,
 			preset: 'custom',
 			activeViewId: preferences.activeViewId,
 		});
@@ -292,7 +347,8 @@ describe('dashboard preferences', () => {
 		const swapped = swapDashboardWidgets(widgets, 'alerts', 'storage');
 
 		expect(swapped.map((widget) => widget.id)).toEqual([
-			'storage', 'system', 'health', 'summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
+			'storage', 'system', 'service_health', 'container_health', 'cpu_load', 'memory_usage',
+			'cpu_status', 'storage_summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
 		]);
 		expect(widgets[0].id).toBe('alerts');
 		expect(swapDashboardWidgets(widgets, 'alerts', 'alerts')).not.toBe(widgets);

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,15 +1,20 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v4';
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v5';
+export const LEGACY_DASHBOARD_V4_PREFERENCES_KEY = 'nasty:dashboard:v4';
 export const LEGACY_DASHBOARD_V3_PREFERENCES_KEY = 'nasty:dashboard:v3';
 export const LEGACY_DASHBOARD_V2_PREFERENCES_KEY = 'nasty:dashboard:v2';
 export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 4;
+export const DASHBOARD_PREFERENCES_VERSION = 5;
 export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 
 export const dashboardWidgetIds = [
 	'alerts',
 	'system',
-	'health',
-	'summary',
+	'service_health',
+	'container_health',
+	'cpu_load',
+	'memory_usage',
+	'cpu_status',
+	'storage_summary',
 	'operations',
 	'storage',
 	'history',
@@ -52,8 +57,12 @@ export interface DashboardPreferences {
 export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; description: string; supportsTiny: boolean }> = {
 	alerts: { label: 'Alerts', description: 'Active warnings and critical conditions.', supportsTiny: true },
 	system: { label: 'System status', description: 'Host identity, uptime, and service health.', supportsTiny: true },
-	health: { label: 'Service and container health', description: 'Enabled services and expected managed containers currently running.', supportsTiny: false },
-	summary: { label: 'Resource summary', description: 'CPU, memory, temperature, and total storage.', supportsTiny: false },
+	service_health: { label: 'Service health', description: 'Enabled services currently running.', supportsTiny: false },
+	container_health: { label: 'Container health', description: 'Expected managed containers currently running.', supportsTiny: false },
+	cpu_load: { label: 'CPU load', description: 'Current load across available CPU cores.', supportsTiny: false },
+	memory_usage: { label: 'Memory', description: 'Current memory use and bcachefs cache.', supportsTiny: false },
+	cpu_status: { label: 'CPU status', description: 'CPU temperature, frequency, and governor.', supportsTiny: false },
+	storage_summary: { label: 'Storage summary', description: 'Combined mounted filesystem capacity.', supportsTiny: false },
 	operations: { label: 'Active operations', description: 'Scrubs, evacuations, and reconciliation work.', supportsTiny: true },
 	storage: { label: 'Compact storage', description: 'Filesystems and member devices in a dense table.', supportsTiny: false },
 	history: { label: 'CPU and memory history', description: 'Resource history for the selected time range.', supportsTiny: true },
@@ -69,21 +78,31 @@ export function dashboardWidgetSupportsNarrowWidth(
 	id: DashboardWidgetId,
 	presentation: DashboardWidgetPresentation,
 ): boolean {
-	return id === 'health' || id === 'summary' || (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
+	return ['service_health', 'container_health', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
+		|| (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
 }
 
-export function dashboardWidgetWidthClass(width: DashboardWidgetWidth): string {
-	if (width === 'quarter') return 'min-w-0 xl:col-span-3';
-	if (width === 'third') return 'min-w-0 xl:col-span-4';
-	if (width === 'half') return 'min-w-0 xl:col-span-6';
-	return 'min-w-0 xl:col-span-12';
+export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: DashboardWidgetWidth): string {
+	const responsive = id === 'service_health' || id === 'container_health'
+		? 'col-span-12 md:col-span-6'
+		: ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
+			? 'col-span-6 lg:col-span-3'
+			: 'col-span-12';
+	if (width === 'quarter') return `min-w-0 ${responsive} xl:col-span-3`;
+	if (width === 'third') return `min-w-0 ${responsive} xl:col-span-4`;
+	if (width === 'half') return `min-w-0 ${responsive} xl:col-span-6`;
+	return `min-w-0 ${responsive} xl:col-span-12`;
 }
 
 const defaultCustomWidgets: DashboardWidgetConfig[] = [
 	{ id: 'alerts', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'system', visible: true, width: 'full', presentation: 'standard' },
-	{ id: 'health', visible: true, width: 'full', presentation: 'standard' },
-	{ id: 'summary', visible: true, width: 'full', presentation: 'standard' },
+	{ id: 'service_health', visible: true, width: 'half', presentation: 'standard' },
+	{ id: 'container_health', visible: true, width: 'half', presentation: 'standard' },
+	{ id: 'cpu_load', visible: true, width: 'quarter', presentation: 'standard' },
+	{ id: 'memory_usage', visible: true, width: 'quarter', presentation: 'standard' },
+	{ id: 'cpu_status', visible: true, width: 'quarter', presentation: 'standard' },
+	{ id: 'storage_summary', visible: true, width: 'quarter', presentation: 'standard' },
 	{ id: 'operations', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'storage', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'history', visible: true, width: 'full', presentation: 'standard' },
@@ -147,8 +166,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function expandLegacyWidgets(configured: unknown[]): unknown[] {
+	return configured.flatMap((candidate) => {
+		if (!isRecord(candidate) || (candidate.id !== 'health' && candidate.id !== 'summary')) return [candidate];
+		const requestedWidth: DashboardWidgetWidth = candidate.width === 'quarter' || candidate.width === 'third' || candidate.width === 'half'
+			? candidate.width
+			: 'full';
+		const width: DashboardWidgetWidth = candidate.id === 'health'
+			? requestedWidth === 'full' ? 'half' : requestedWidth === 'half' ? 'quarter' : requestedWidth
+			: requestedWidth === 'full' || requestedWidth === 'half' ? 'quarter' : requestedWidth;
+		const ids: DashboardWidgetId[] = candidate.id === 'health'
+			? ['service_health', 'container_health']
+			: ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'];
+		return ids.map((id) => ({ ...candidate, id, width, presentation: 'standard' }));
+	});
+}
+
 function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
-	const configured = Array.isArray(value) ? value : [];
+	const configured = expandLegacyWidgets(Array.isArray(value) ? value : []);
 	const byId = new Map<DashboardWidgetId, DashboardWidgetConfig>();
 	for (const candidate of configured) {
 		if (!isRecord(candidate) || !dashboardWidgetIds.includes(candidate.id as DashboardWidgetId)) continue;
@@ -253,7 +288,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	if (!isRecord(value)) return defaultDashboardPreferences();
 	if (value.version === 1) return migrateLegacyPreferences(value);
-	if (value.version !== 2 && value.version !== 3 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+	if (value.version !== 2 && value.version !== 3 && value.version !== 4 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
 
 	const customViews = normalizeCustomViews(value.customViews);
 	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
@@ -286,6 +321,7 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
 	return parseDashboardPreferences(
 		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_V4_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V3_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V2_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_PREFERENCES_KEY)

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -102,7 +102,8 @@
 	let healthRequest = 0;
 	let alertsRequest = 0;
 	let operationsRequest = 0;
-	let dashboardHealthInFlight: Promise<void> | null = null;
+	let serviceHealthInFlight: Promise<void> | null = null;
+	let containerHealthInFlight: Promise<void> | null = null;
 
 	let metricsRange = $state<MetricsRange>('5m');
 	let metricsOffset = $state(0);
@@ -149,15 +150,15 @@
 	}
 
 	function needsStats(): boolean {
-		return widgets.some((widget) => ['summary', 'storage', 'history', 'network', 'disk_io'].includes(widget.id));
+		return widgets.some((widget) => ['cpu_load', 'memory_usage', 'cpu_status', 'storage', 'history', 'network', 'disk_io'].includes(widget.id));
 	}
 
 	function needsMetricsHistory(): boolean {
 		return widgets.some((widget) => ['history', 'network', 'disk_io'].includes(widget.id));
 	}
 
-	function healthPollingEnabled(): boolean {
-		return shouldPollDashboardHealth(hasWidget('health'), document.hidden);
+	function healthPollingEnabled(id: 'service_health' | 'container_health'): boolean {
+		return shouldPollDashboardHealth(hasWidget(id), document.hidden);
 	}
 
 	function masonryItem(node: HTMLElement) {
@@ -231,7 +232,8 @@
 	onMount(() => {
 		client.onEvent(handleEvent);
 		const handleVisibilityChange = () => {
-			if (healthPollingEnabled()) void loadDashboardHealth(true);
+			if (healthPollingEnabled('service_health')) void loadServiceHealth(true);
+			if (healthPollingEnabled('container_health')) void loadContainerHealth(true);
 		};
 		document.addEventListener('visibilitychange', handleVisibilityChange);
 		void loadVisibleData(true).finally(() => loading = false);
@@ -264,7 +266,8 @@
 			}
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
-			if (healthPollingEnabled()) tasks.push(loadDashboardHealth(true));
+			if (healthPollingEnabled('service_health')) tasks.push(loadServiceHealth(true));
+			if (healthPollingEnabled('container_health')) tasks.push(loadContainerHealth(true));
 			const results = await Promise.allSettled(tasks);
 			if (hasWidget('storage')) await loadStorageDetails();
 			if (needsMetricsHistory()) await loadMetrics();
@@ -318,22 +321,20 @@
 		operationsLoaded = true;
 	}
 
-	function loadDashboardHealth(markExistingRefreshing = false): Promise<void> {
-		if (dashboardHealthInFlight) return dashboardHealthInFlight;
+	function loadServiceHealth(markExistingRefreshing = false): Promise<void> {
+		if (serviceHealthInFlight) return serviceHealthInFlight;
 		if (markExistingRefreshing && serviceHealth) serviceHealthFreshness = 'refreshing';
-		if (markExistingRefreshing && containerHealth) containerHealthFreshness = 'refreshing';
 		if (!serviceHealth) serviceHealthFreshness = 'loading';
-		if (!containerHealth) containerHealthFreshness = 'loading';
 
-		const request = Promise.all([loadServiceHealth(), loadContainerHealth()]).then(() => undefined);
-		dashboardHealthInFlight = request;
+		const request = fetchServiceHealth();
+		serviceHealthInFlight = request;
 		void request.finally(() => {
-			if (dashboardHealthInFlight === request) dashboardHealthInFlight = null;
+			if (serviceHealthInFlight === request) serviceHealthInFlight = null;
 		});
 		return request;
 	}
 
-	async function loadServiceHealth() {
+	async function fetchServiceHealth() {
 		try {
 			serviceHealth = summarizeEnabledServices(await client.call<ProtocolStatus[]>('service.protocol.list'));
 			serviceHealthFreshness = 'current';
@@ -342,7 +343,20 @@
 		}
 	}
 
-	async function loadContainerHealth() {
+	function loadContainerHealth(markExistingRefreshing = false): Promise<void> {
+		if (containerHealthInFlight) return containerHealthInFlight;
+		if (markExistingRefreshing && containerHealth) containerHealthFreshness = 'refreshing';
+		if (!containerHealth) containerHealthFreshness = 'loading';
+
+		const request = fetchContainerHealth();
+		containerHealthInFlight = request;
+		void request.finally(() => {
+			if (containerHealthInFlight === request) containerHealthInFlight = null;
+		});
+		return request;
+	}
+
+	async function fetchContainerHealth() {
 		let status: AppsStatus;
 		try {
 			status = await client.call<AppsStatus>('apps.status');
@@ -402,6 +416,8 @@
 	}
 
 	async function refreshVisibleData() {
+		if (healthPollingEnabled('service_health')) void loadServiceHealth();
+		if (healthPollingEnabled('container_health')) void loadContainerHealth();
 		if (refreshInFlight) return;
 		refreshInFlight = true;
 		refreshTick += 1;
@@ -410,7 +426,6 @@
 			if (needsStats()) tasks.push(refreshStats());
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
-			if (healthPollingEnabled()) tasks.push(loadDashboardHealth());
 			if (hasWidget('system') && refreshTick % 4 === 0) {
 				tasks.push(loadSystemHealth());
 				if (!infoLoaded) tasks.push(loadSystemInfo());
@@ -628,13 +643,13 @@
 {#if loading}
 	<Card><CardContent class="py-10 text-center text-sm text-muted-foreground">Loading dashboard...</CardContent></Card>
 {:else}
-	<div class="grid grid-cols-1 auto-rows-[8px] gap-4 xl:grid-cols-12">
+	<div class="grid grid-cols-12 auto-rows-[8px] gap-4">
 		{#each widgets as widget (widget.id)}
 			<div
 				use:masonryItem
 				role="group"
 				aria-label={dashboardWidgetMeta[widget.id].label}
-				class="self-start rounded-lg transition-shadow {dashboardWidgetWidthClass(widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
+				class="self-start rounded-lg transition-shadow {dashboardWidgetWidthClass(widget.id, widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
 				ondragover={(event) => targetWidgetDrag(event, widget.id)}
 				ondrop={(event) => dropWidget(event, widget.id)}
 			>
@@ -660,10 +675,12 @@
 					<AlertsWidget {alerts} loaded={alertsLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'system'}
 					<SystemWidget {info} {health} {infoLoaded} {healthLoaded} {density} presentation={widget.presentation} />
-				{:else if widget.id === 'health'}
-					<HealthWidget services={serviceHealth} servicesFreshness={serviceHealthFreshness} containers={containerHealth} containersFreshness={containerHealthFreshness} {density} width={widget.width} />
-				{:else if widget.id === 'summary' && stats}
-					<SummaryWidget {stats} {filesystems} width={widget.width} {density} />
+				{:else if widget.id === 'service_health'}
+					<HealthWidget kind="services" services={serviceHealth} freshness={serviceHealthFreshness} {density} />
+				{:else if widget.id === 'container_health'}
+					<HealthWidget kind="containers" containers={containerHealth} freshness={containerHealthFreshness} {density} />
+				{:else if widget.id === 'cpu_load' || widget.id === 'memory_usage' || widget.id === 'cpu_status' || widget.id === 'storage_summary'}
+					<SummaryWidget kind={widget.id} {stats} {filesystems} {filesystemsLoaded} {density} />
 				{:else if widget.id === 'operations'}
 					<OperationsWidget operations={systemStatus?.operations ?? []} loaded={operationsLoaded} {density} presentation={widget.presentation} />
 				{:else if widget.id === 'storage'}


### PR DESCRIPTION
## Summary
- split service and managed-container health into independently configurable dashboard cards
- split CPU load, memory, CPU status, and storage summary into independent cards with responsive defaults
- migrate existing v4 custom layouts to the v5 widget schema while preserving visibility, order, and practical widths
- load and poll each health card independently, and keep unavailable resource cards explicit

Follow-up to #819.

## Testing
- `npm run check`
- `npm test` (270 tests)
- `npm run build`
- `git diff --check`