### PR TITLE
webui: add free dashboard widget placement

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -7,6 +7,7 @@
 		dashboardPresets,
 		dashboardViewNameAvailable,
 		dashboardWidgetMeta,
+		dashboardWidgetSnapColumn,
 		dashboardWidgetSupportsNarrowWidth,
 		dashboardWidgetSupportsTiny,
 		defaultDashboardPreferences,
@@ -23,7 +24,7 @@
 	} from '$lib/dashboard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { ArrowDown, ArrowUp, Copy, LayoutDashboard, Pencil, Plus, RotateCcw, Trash2 } from '@lucide/svelte';
+	import { Copy, LayoutDashboard, Pencil, Plus, RotateCcw, Trash2 } from '@lucide/svelte';
 
 	type NameAction = 'create' | 'duplicate' | 'rename';
 
@@ -105,11 +106,13 @@
 	function updatePresentation(index: number, value: string) {
 		const widget = activeView.widgets[index];
 		const presentation = value === 'tiny' && dashboardWidgetSupportsTiny(widget.id) ? 'tiny' : 'standard';
+		const width = (widget.width === 'quarter' || widget.width === 'third') && !dashboardWidgetSupportsNarrowWidth(widget.id, presentation)
+			? 'half'
+			: widget.width;
 		updateWidget(index, {
 			presentation,
-			width: (widget.width === 'quarter' || widget.width === 'third') && !dashboardWidgetSupportsNarrowWidth(widget.id, presentation)
-				? 'half'
-				: widget.width,
+			width,
+			column: dashboardWidgetSnapColumn(width, widget.column),
 		});
 	}
 
@@ -123,12 +126,10 @@
 		return value === 'quarter' || value === 'third' || value === 'half' ? value : 'full';
 	}
 
-	function moveWidget(index: number, direction: -1 | 1) {
-		const target = index + direction;
-		if (target < 0 || target >= activeView.widgets.length) return;
-		const widgets = activeView.widgets.map((widget) => ({ ...widget }));
-		[widgets[index], widgets[target]] = [widgets[target], widgets[index]];
-		draft = updateActiveDashboardView(draft, { widgets });
+	function updateWidth(index: number, value: string) {
+		const widget = activeView.widgets[index];
+		const width = parseWidgetWidth(value);
+		updateWidget(index, { width, column: dashboardWidgetSnapColumn(width, widget.column) });
 	}
 
 	function resetCustom() {
@@ -279,7 +280,7 @@
 				</div>
 
 				<div class="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-5">
-					<div><h3 class="text-sm font-semibold">{activeView.name} widgets</h3><p class="text-xs text-muted-foreground">Widgets use a 12-column wide-screen grid and can span the full row, one half, one third, or one quarter.</p></div>
+					<div><h3 class="text-sm font-semibold">{activeView.name} widgets</h3><p class="text-xs text-muted-foreground">Choose widget sizes here, then place visible widgets directly on the wide-screen dashboard grid.</p></div>
 					<div class="flex items-center gap-2">
 						<label for="dashboard-density" class="text-xs font-medium text-muted-foreground">Density</label>
 						<select id="dashboard-density" value={activeView.density} onchange={(event) => updateDensity(event.currentTarget.value)} class="h-8 rounded-md border border-border bg-background px-2 text-xs">
@@ -296,11 +297,7 @@
 							{#if dashboardWidgetSupportsTiny(widget.id)}
 								<select value={widget.presentation} disabled={!widget.visible} onchange={(event) => updatePresentation(index, event.currentTarget.value)} aria-label={`${dashboardWidgetMeta[widget.id].label} presentation`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="standard">Standard</option><option value="tiny">Tiny</option></select>
 							{/if}
-							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidget(index, { width: parseWidgetWidth(event.currentTarget.value) })} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">1/2</option>{#if dashboardWidgetSupportsNarrowWidth(widget.id, widget.presentation)}<option value="third">1/3</option><option value="quarter">1/4</option>{/if}</select>
-							<div class="flex">
-								<Button variant="ghost" size="icon-sm" disabled={index === 0} onclick={() => moveWidget(index, -1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp /></Button>
-								<Button variant="ghost" size="icon-sm" disabled={index === activeView.widgets.length - 1} onclick={() => moveWidget(index, 1)} aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown /></Button>
-							</div>
+							<select value={widget.width} disabled={!widget.visible} onchange={(event) => updateWidth(index, event.currentTarget.value)} aria-label={`${dashboardWidgetMeta[widget.id].label} width`} class="h-8 rounded-md border border-border bg-background px-2 text-xs disabled:opacity-40"><option value="full">Full</option><option value="half">1/2</option>{#if dashboardWidgetSupportsNarrowWidth(widget.id, widget.presentation)}<option value="third">1/3</option><option value="quarter">1/4</option>{/if}</select>
 						</div>
 					{/each}
 				</div>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -5,27 +5,32 @@ import {
 	LEGACY_DASHBOARD_V2_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V3_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V4_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_V5_PREFERENCES_KEY,
 	createDashboardView,
 	dashboardPrefs,
 	dashboardPresetTabVisible,
 	dashboardViewNameAvailable,
 	dashboardWidgetIds,
+	dashboardWidgetSnapColumn,
 	dashboardWidgetSupportsTiny,
 	dashboardWidgetSupportsNarrowWidth,
+	dashboardWidgetValidColumns,
 	dashboardWidgetWidthClass,
 	defaultDashboardPreferences,
 	deleteDashboardView,
 	getActiveDashboardView,
 	initializeDashboardPreferences,
+	layoutDashboardWidgets,
 	loadDashboardPreferences,
 	parseDashboardPreferences,
+	placeDashboardWidget,
 	renameDashboardView,
 	resolveDashboardDensity,
 	resolveDashboardWidgets,
 	selectDashboardView,
 	setDashboardPresetTabVisible,
-	swapDashboardWidgets,
 	updateActiveDashboardView,
+	type DashboardWidgetConfig,
 } from './dashboard.svelte';
 
 beforeEach(() => {
@@ -37,7 +42,7 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":6,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":7,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
 	test('migrates the v1 custom layout without losing its configuration', () => {
@@ -51,14 +56,14 @@ describe('dashboard preferences', () => {
 			],
 		}));
 
-		expect(parsed.version).toBe(5);
+		expect(parsed.version).toBe(6);
 		expect(parsed.preset).toBe('custom');
 		expect(parsed.customViews).toHaveLength(1);
 		expect(getActiveDashboardView(parsed)).toMatchObject({
 			name: 'Custom',
 			density: 'compact',
 		});
-		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard' });
+		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard', column: 0, row: 0, priority: 0 });
 		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(13);
 	});
 
@@ -78,13 +83,13 @@ describe('dashboard preferences', () => {
 			}],
 		}));
 
-		expect(parsed.version).toBe(5);
+		expect(parsed.version).toBe(6);
 		expect(parsed.activeViewId).toBe('daily');
 		expect(getActiveDashboardView(parsed)).toMatchObject({ name: 'Daily', density: 'compact' });
 		expect(getActiveDashboardView(parsed).widgets.every((widget) => widget.presentation === 'standard')).toBe(true);
 	});
 
-	test('initializes v5 storage from the newest available legacy key without overwriting v5 preferences', () => {
+	test('initializes v6 storage from the newest available legacy key without overwriting v6 preferences', () => {
 		localStorage.clear();
 		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
 			version: 1,
@@ -116,10 +121,15 @@ describe('dashboard preferences', () => {
 				widgets: [{ id: 'health', visible: true, width: 'full', presentation: 'standard' }],
 			}],
 		}));
-		expect(initializeDashboardPreferences(localStorage).preset).toBe('custom');
-		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+		localStorage.setItem(LEGACY_DASHBOARD_V5_PREFERENCES_KEY, JSON.stringify({
+			...defaultDashboardPreferences(),
 			version: 5,
-			preset: 'custom',
+			preset: 'monitoring',
+		}));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 6,
+			preset: 'monitoring',
 		});
 
 		const stored = defaultDashboardPreferences();
@@ -155,12 +165,35 @@ describe('dashboard preferences', () => {
 		]);
 		expect(widgets.filter((widget) => widget.id === 'service_health' || widget.id === 'container_health'))
 			.toEqual([
-				{ id: 'service_health', visible: false, width: 'quarter', presentation: 'standard' },
-				{ id: 'container_health', visible: false, width: 'quarter', presentation: 'standard' },
+				{ id: 'service_health', visible: false, width: 'quarter', presentation: 'standard', column: 0, row: 1, priority: 0 },
+				{ id: 'container_health', visible: false, width: 'quarter', presentation: 'standard', column: 0, row: 1, priority: 0 },
 			]);
 		expect(widgets.filter((widget) => ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(widget.id)).map((widget) => widget.width))
 			.toEqual(['quarter', 'quarter', 'quarter', 'quarter']);
 		expect(parsed.hiddenPresetTabs).toEqual(['overview']);
+	});
+
+	test('migrates v5 visible widgets without reserving space for hidden widgets', () => {
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 5,
+			preset: 'custom',
+			hiddenPresetTabs: [],
+			activeViewId: 'legacy',
+			customViews: [{
+				id: 'legacy',
+				name: 'Legacy',
+				density: 'comfortable',
+				widgets: [
+					{ id: 'alerts', visible: false, width: 'full', presentation: 'standard' },
+					{ id: 'service_health', visible: true, width: 'half', presentation: 'standard' },
+					{ id: 'container_health', visible: true, width: 'half', presentation: 'standard' },
+				],
+			}],
+		}));
+		const widgets = getActiveDashboardView(parsed).widgets;
+
+		expect(widgets.find((widget) => widget.id === 'service_health')).toMatchObject({ column: 0, row: 0, priority: 0 });
+		expect(widgets.find((widget) => widget.id === 'container_health')).toMatchObject({ column: 6, row: 0, priority: 0 });
 	});
 
 	test('normalizes named views, active selection, and newly added widget ids', () => {
@@ -329,28 +362,61 @@ describe('dashboard preferences', () => {
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
 	});
 
-	test('persists the active named view in v5 storage', () => {
+	test('persists the active named view in v6 storage', () => {
 		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 5,
+			version: 6,
 			preset: 'custom',
 			activeViewId: preferences.activeViewId,
 		});
 	});
 
-	test('swaps custom widgets without mutating the saved view', () => {
-		const preferences = defaultDashboardPreferences();
-		const widgets = getActiveDashboardView(preferences).widgets;
-		const swapped = swapDashboardWidgets(widgets, 'alerts', 'storage');
+	test('snaps widgets to starts that match their width', () => {
+		expect(dashboardWidgetValidColumns('quarter')).toEqual([0, 3, 6, 9]);
+		expect(dashboardWidgetValidColumns('third')).toEqual([0, 4, 8]);
+		expect(dashboardWidgetValidColumns('half')).toEqual([0, 6]);
+		expect(dashboardWidgetValidColumns('full')).toEqual([0]);
+		expect(dashboardWidgetSnapColumn('quarter', 8)).toBe(9);
+		expect(dashboardWidgetSnapColumn('half', 4)).toBe(6);
+	});
 
-		expect(swapped.map((widget) => widget.id)).toEqual([
-			'storage', 'system', 'service_health', 'container_health', 'cpu_load', 'memory_usage',
-			'cpu_status', 'storage_summary', 'operations', 'alerts', 'history', 'network', 'disk_io',
-		]);
-		expect(widgets[0].id).toBe('alerts');
-		expect(swapDashboardWidgets(widgets, 'alerts', 'alerts')).not.toBe(widgets);
+	test('packs dynamic widget heights without overlapping neighboring columns', () => {
+		const widgets: DashboardWidgetConfig[] = [
+			{ id: 'storage', visible: true, width: 'half', presentation: 'standard', column: 0, row: 0, priority: 0 },
+			{ id: 'cpu_load', visible: true, width: 'quarter', presentation: 'standard', column: 6, row: 0, priority: 0 },
+			{ id: 'memory_usage', visible: true, width: 'quarter', presentation: 'standard', column: 9, row: 0, priority: 0 },
+			{ id: 'cpu_status', visible: true, width: 'quarter', presentation: 'standard', column: 6, row: 1, priority: 0 },
+		];
+		const layout = layoutDashboardWidgets(widgets, { storage: 8, cpu_load: 2, memory_usage: 2, cpu_status: 2 });
+
+		expect(layout.storage).toMatchObject({ column: 0, row: 0, columnSpan: 6, rowSpan: 8 });
+		expect(layout.cpu_load).toMatchObject({ column: 6, row: 0, rowSpan: 2 });
+		expect(layout.memory_usage).toMatchObject({ column: 9, row: 0, rowSpan: 2 });
+		expect(layout.cpu_status).toMatchObject({ column: 6, row: 2, rowSpan: 2 });
+	});
+
+	test('places a moved widget first and pushes collisions down without mutating the view', () => {
+		const widgets: DashboardWidgetConfig[] = [
+			{ id: 'storage', visible: true, width: 'half', presentation: 'standard', column: 0, row: 0, priority: 0 },
+			{ id: 'cpu_load', visible: true, width: 'quarter', presentation: 'standard', column: 6, row: 0, priority: 0 },
+			{ id: 'cpu_status', visible: true, width: 'quarter', presentation: 'standard', column: 6, row: 2, priority: 0 },
+		];
+		const placed = placeDashboardWidget(widgets, 'cpu_status', 0, 0);
+
+		expect(placed.find((widget) => widget.id === 'cpu_status')).toMatchObject({ column: 0, row: 0 });
+		expect(placed.find((widget) => widget.id === 'cpu_status')?.priority).toBe(1);
+		expect(placed.find((widget) => widget.id === 'storage')).toMatchObject({ column: 0, row: 0, priority: 0 });
+		expect(placed.find((widget) => widget.id === 'cpu_load')).toMatchObject({ column: 6, row: 0 });
+		expect(widgets.find((widget) => widget.id === 'storage')).toMatchObject({ column: 0, row: 0 });
+
+		const layout = layoutDashboardWidgets(placed, { storage: 8, cpu_load: 2, cpu_status: 2 });
+		expect(layout.cpu_status).toMatchObject({ column: 0, row: 0 });
+		expect(layout.storage).toMatchObject({ column: 0, row: 2 });
+
+		const shorterLayout = layoutDashboardWidgets(placed, { storage: 8, cpu_load: 2, cpu_status: 1 });
+		expect(shorterLayout.storage).toMatchObject({ column: 0, row: 1 });
 	});
 });

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,10 +1,12 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v5';
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v6';
+export const LEGACY_DASHBOARD_V5_PREFERENCES_KEY = 'nasty:dashboard:v5';
 export const LEGACY_DASHBOARD_V4_PREFERENCES_KEY = 'nasty:dashboard:v4';
 export const LEGACY_DASHBOARD_V3_PREFERENCES_KEY = 'nasty:dashboard:v3';
 export const LEGACY_DASHBOARD_V2_PREFERENCES_KEY = 'nasty:dashboard:v2';
 export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 5;
+export const DASHBOARD_PREFERENCES_VERSION = 6;
 export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
+export const DASHBOARD_GRID_COLUMNS = 12;
 
 export const dashboardWidgetIds = [
 	'alerts',
@@ -37,7 +39,20 @@ export interface DashboardWidgetConfig {
 	visible: boolean;
 	width: DashboardWidgetWidth;
 	presentation: DashboardWidgetPresentation;
+	column: number;
+	row: number;
+	priority: number;
 }
+
+export interface DashboardGridPosition {
+	column: number;
+	row: number;
+	columnSpan: number;
+	rowSpan: number;
+}
+
+export type DashboardGridLayout = Partial<Record<DashboardWidgetId, DashboardGridPosition>>;
+export type DashboardWidgetRowSpans = Partial<Record<DashboardWidgetId, number>>;
 
 export interface DashboardCustomView {
 	id: string;
@@ -82,6 +97,26 @@ export function dashboardWidgetSupportsNarrowWidth(
 		|| (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
 }
 
+export function dashboardWidgetColumnSpan(width: DashboardWidgetWidth): number {
+	if (width === 'quarter') return 3;
+	if (width === 'third') return 4;
+	if (width === 'half') return 6;
+	return DASHBOARD_GRID_COLUMNS;
+}
+
+export function dashboardWidgetValidColumns(width: DashboardWidgetWidth): number[] {
+	const span = dashboardWidgetColumnSpan(width);
+	return Array.from({ length: DASHBOARD_GRID_COLUMNS / span }, (_, index) => index * span);
+}
+
+export function dashboardWidgetSnapColumn(width: DashboardWidgetWidth, requested: number): number {
+	const columns = dashboardWidgetValidColumns(width);
+	if (!Number.isFinite(requested)) return columns[0];
+	return columns.reduce((nearest, candidate) =>
+		Math.abs(candidate - requested) < Math.abs(nearest - requested) ? candidate : nearest
+	);
+}
+
 export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: DashboardWidgetWidth): string {
 	const responsive = id === 'service_health' || id === 'container_health'
 		? 'col-span-12 md:col-span-6'
@@ -94,7 +129,28 @@ export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: Dashboar
 	return `min-w-0 ${responsive} xl:col-span-12`;
 }
 
-const defaultCustomWidgets: DashboardWidgetConfig[] = [
+type DashboardWidgetDefinition = Omit<DashboardWidgetConfig, 'column' | 'row' | 'priority'>;
+
+function positionWidgets(widgets: DashboardWidgetDefinition[]): DashboardWidgetConfig[] {
+	let column = 0;
+	let row = 0;
+	return widgets.map((widget) => {
+		const columnSpan = dashboardWidgetColumnSpan(widget.width);
+		if (column + columnSpan > DASHBOARD_GRID_COLUMNS) {
+			column = 0;
+			row += 1;
+		}
+		const positioned = { ...widget, column, row, priority: 0 };
+		column += columnSpan;
+		if (column === DASHBOARD_GRID_COLUMNS) {
+			column = 0;
+			row += 1;
+		}
+		return positioned;
+	});
+}
+
+const defaultCustomWidgets: DashboardWidgetConfig[] = positionWidgets([
 	{ id: 'alerts', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'system', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'service_health', visible: true, width: 'half', presentation: 'standard' },
@@ -108,7 +164,7 @@ const defaultCustomWidgets: DashboardWidgetConfig[] = [
 	{ id: 'history', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'network', visible: true, width: 'half', presentation: 'standard' },
 	{ id: 'disk_io', visible: true, width: 'half', presentation: 'standard' },
-];
+]);
 
 export const dashboardPresets: Record<DashboardFixedPreset, {
 	label: string;
@@ -185,6 +241,22 @@ function expandLegacyWidgets(configured: unknown[]): unknown[] {
 function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
 	const configured = expandLegacyWidgets(Array.isArray(value) ? value : []);
 	const byId = new Map<DashboardWidgetId, DashboardWidgetConfig>();
+	let fallbackColumn = 0;
+	let fallbackRow = 0;
+	const nextFallbackPosition = (width: DashboardWidgetWidth) => {
+		const columnSpan = dashboardWidgetColumnSpan(width);
+		if (fallbackColumn + columnSpan > DASHBOARD_GRID_COLUMNS) {
+			fallbackColumn = 0;
+			fallbackRow += 1;
+		}
+		const position = { column: fallbackColumn, row: fallbackRow };
+		fallbackColumn += columnSpan;
+		if (fallbackColumn === DASHBOARD_GRID_COLUMNS) {
+			fallbackColumn = 0;
+			fallbackRow += 1;
+		}
+		return position;
+	};
 	for (const candidate of configured) {
 		if (!isRecord(candidate) || !dashboardWidgetIds.includes(candidate.id as DashboardWidgetId)) continue;
 		const id = candidate.id as DashboardWidgetId;
@@ -193,19 +265,31 @@ function normalizeWidgets(value: unknown): DashboardWidgetConfig[] {
 		const requestedWidth = candidate.width === 'quarter' || candidate.width === 'third' || candidate.width === 'half'
 			? candidate.width
 			: 'full';
+		const width = (requestedWidth === 'quarter' || requestedWidth === 'third') && !dashboardWidgetSupportsNarrowWidth(id, presentation)
+			? 'half'
+			: requestedWidth;
+		const visible = candidate.visible !== false;
+		const fallback = visible ? nextFallbackPosition(width) : { column: fallbackColumn, row: fallbackRow };
 		byId.set(id, {
 			id,
-			visible: candidate.visible !== false,
-			width: (requestedWidth === 'quarter' || requestedWidth === 'third') && !dashboardWidgetSupportsNarrowWidth(id, presentation)
-				? 'half'
-				: requestedWidth,
+			visible,
+			width,
 			presentation,
+			column: typeof candidate.column === 'number' && Number.isInteger(candidate.column)
+				? dashboardWidgetSnapColumn(width, candidate.column)
+				: fallback.column,
+			row: typeof candidate.row === 'number' && Number.isInteger(candidate.row)
+				? Math.max(0, Math.min(10_000, candidate.row))
+				: fallback.row,
+			priority: typeof candidate.priority === 'number' && Number.isInteger(candidate.priority)
+				? Math.max(0, Math.min(1_000_000_000, candidate.priority))
+				: 0,
 		});
 	}
 
 	const widgets = [...byId.values()];
 	for (const widget of defaultCustomWidgets) {
-		if (!byId.has(widget.id)) widgets.push({ ...widget });
+		if (!byId.has(widget.id)) widgets.push({ ...widget, ...nextFallbackPosition(widget.width), priority: 0 });
 	}
 	if (!widgets.some((widget) => widget.visible)) widgets[0] = { ...widgets[0], visible: true };
 	return widgets;
@@ -288,7 +372,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	if (!isRecord(value)) return defaultDashboardPreferences();
 	if (value.version === 1) return migrateLegacyPreferences(value);
-	if (value.version !== 2 && value.version !== 3 && value.version !== 4 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+	if (value.version !== 2 && value.version !== 3 && value.version !== 4 && value.version !== 5 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
 
 	const customViews = normalizeCustomViews(value.customViews);
 	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
@@ -321,6 +405,7 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
 	return parseDashboardPreferences(
 		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_V5_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V4_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V3_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V2_PREFERENCES_KEY)
@@ -453,18 +538,69 @@ export function updateActiveDashboardView(
 	};
 }
 
-export function swapDashboardWidgets(
-	widgets: DashboardWidgetConfig[],
-	source: DashboardWidgetId,
-	target: DashboardWidgetId,
-): DashboardWidgetConfig[] {
-	const sourceIndex = widgets.findIndex((widget) => widget.id === source);
-	const targetIndex = widgets.findIndex((widget) => widget.id === target);
-	if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) return cloneWidgets(widgets);
+function rectanglesOverlap(a: DashboardGridPosition, b: DashboardGridPosition): boolean {
+	return a.column < b.column + b.columnSpan
+		&& a.column + a.columnSpan > b.column
+		&& a.row < b.row + b.rowSpan
+		&& a.row + a.rowSpan > b.row;
+}
 
-	const next = cloneWidgets(widgets);
-	[next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
-	return next;
+export function layoutDashboardWidgets(
+	widgets: DashboardWidgetConfig[],
+	rowSpans: DashboardWidgetRowSpans,
+	moving?: { id: DashboardWidgetId; column: number; row: number },
+): DashboardGridLayout {
+	const movingPriority = Math.max(0, ...widgets.map((widget) => widget.priority)) + 1;
+	const candidates = widgets
+		.filter((widget) => widget.visible)
+		.map((widget, index) => ({
+			id: widget.id,
+			column: moving?.id === widget.id
+				? dashboardWidgetSnapColumn(widget.width, moving.column)
+				: dashboardWidgetSnapColumn(widget.width, widget.column),
+			row: moving?.id === widget.id ? Math.max(0, Math.round(moving.row)) : widget.row,
+			columnSpan: dashboardWidgetColumnSpan(widget.width),
+			rowSpan: Math.max(1, Math.round(rowSpans[widget.id] ?? 1)),
+			priority: moving?.id === widget.id ? movingPriority : widget.priority,
+			index,
+		}));
+	candidates.sort((a, b) => a.row - b.row || b.priority - a.priority || a.column - b.column || a.index - b.index);
+
+	const placed: DashboardGridPosition[] = [];
+	const layout: DashboardGridLayout = {};
+	for (const candidate of candidates) {
+		const position: DashboardGridPosition = { ...candidate };
+		let collisions = placed.filter((existing) => rectanglesOverlap(position, existing));
+		while (collisions.length > 0) {
+			position.row = Math.max(...collisions.map((existing) => existing.row + existing.rowSpan));
+			collisions = placed.filter((existing) => rectanglesOverlap(position, existing));
+		}
+		placed.push(position);
+		layout[candidate.id] = position;
+	}
+	return layout;
+}
+
+export function placeDashboardWidget(
+	widgets: DashboardWidgetConfig[],
+	id: DashboardWidgetId,
+	column: number,
+	row: number,
+): DashboardWidgetConfig[] {
+	if (!widgets.some((widget) => widget.id === id && widget.visible)) return cloneWidgets(widgets);
+	const widget = widgets.find((candidate) => candidate.id === id)!;
+	const nextPriority = Math.max(0, ...widgets.map((candidate) => candidate.priority)) + 1;
+	return cloneWidgets(widgets)
+		.map((candidate) => candidate.id === id
+			? {
+				...candidate,
+				column: dashboardWidgetSnapColumn(widget.width, column),
+				row: Math.max(0, Math.round(row)),
+				priority: nextPriority,
+			}
+			: candidate
+		)
+		.sort((a, b) => a.row - b.row || a.column - b.column || dashboardWidgetIds.indexOf(a.id) - dashboardWidgetIds.indexOf(b.id));
 }
 
 function createDashboardPrefs() {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -8,17 +8,22 @@
 		dashboardPrefs,
 		dashboardPresetTabVisible,
 		dashboardPresets,
+		dashboardWidgetColumnSpan,
 		dashboardWidgetMeta,
+		dashboardWidgetValidColumns,
 		dashboardWidgetWidthClass,
 		getActiveDashboardView,
+		layoutDashboardWidgets,
+		placeDashboardWidget,
 		resolveDashboardDensity,
 		resolveDashboardWidgets,
 		selectDashboardView,
-		swapDashboardWidgets,
 		updateActiveDashboardView,
 		type DashboardPreferences,
 		type DashboardFixedPreset,
+		type DashboardWidgetConfig,
 		type DashboardWidgetId,
+		type DashboardWidgetRowSpans,
 	} from '$lib/dashboard.svelte';
 	import type {
 		ActiveAlert,
@@ -57,7 +62,7 @@
 	import StorageWidget from '$lib/components/dashboard/storage-widget.svelte';
 	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
 	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
-	import { ArrowDown, ArrowUp, GripVertical, Settings2 } from '@lucide/svelte';
+	import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, GripVertical, Settings2 } from '@lucide/svelte';
 
 	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
 	type DiskRate = { readRate: number; writeRate: number };
@@ -119,7 +124,11 @@
 	let historyLoading = $state(false);
 	let historyRequest = 0;
 	let draggedWidget = $state<DashboardWidgetId | null>(null);
-	let dragTargetWidget = $state<DashboardWidgetId | null>(null);
+	let dragTarget = $state<{ column: number; row: number } | null>(null);
+	let dragOrigin: { column: number; row: number } | null = null;
+	let dragOffset = { x: 0, y: 0 };
+	let dragRowMetrics = $state({ height: 8, gap: 16 });
+	let widgetRowSpans = $state<DashboardWidgetRowSpans>({});
 	let movementAnnouncement = $state('');
 
 	const networkHistory = createIoHistory();
@@ -130,6 +139,14 @@
 	let widgets = $derived(resolveDashboardWidgets(dashboardPrefs.value));
 	let density = $derived(resolveDashboardDensity(dashboardPrefs.value));
 	let activeCustomView = $derived(getActiveDashboardView(dashboardPrefs.value));
+	let gridLayout = $derived(layoutDashboardWidgets(widgets, widgetRowSpans));
+	let draggedConfig = $derived(widgets.find((widget) => widget.id === draggedWidget));
+	let validDropColumns = $derived(draggedConfig ? dashboardWidgetValidColumns(draggedConfig.width) : []);
+	let dragLayout = $derived(draggedWidget && dragTarget
+		? layoutDashboardWidgets(widgets, widgetRowSpans, { id: draggedWidget, ...dragTarget })
+		: null
+	);
+	let dragPreview = $derived(draggedWidget && dragLayout ? dragLayout[draggedWidget] : null);
 	let presetLabel = $derived(
 		dashboardPrefs.value.preset === 'custom'
 			? activeCustomView.name
@@ -161,7 +178,7 @@
 		return shouldPollDashboardHealth(hasWidget(id), document.hidden);
 	}
 
-	function masonryItem(node: HTMLElement) {
+	function masonryItem(node: HTMLElement, id: DashboardWidgetId) {
 		let frame = 0;
 		const update = () => {
 			cancelAnimationFrame(frame);
@@ -170,7 +187,8 @@
 				const rowHeight = Number.parseFloat(gridStyle.gridAutoRows) || 8;
 				const gap = Number.parseFloat(gridStyle.rowGap) || 0;
 				const rows = Math.ceil((node.getBoundingClientRect().height + gap) / (rowHeight + gap));
-				node.style.gridRowEnd = `span ${Math.max(1, rows)}`;
+				const rowSpan = Math.max(1, rows);
+				if (widgetRowSpans[id] !== rowSpan) widgetRowSpans = { ...widgetRowSpans, [id]: rowSpan };
 			});
 		};
 		const observer = new ResizeObserver(update);
@@ -184,44 +202,117 @@
 		};
 	}
 
-	function swapCustomWidgets(source: DashboardWidgetId, target: DashboardWidgetId) {
+	function saveWidgetPlacement(id: DashboardWidgetId, column: number, row: number) {
 		const preferences = dashboardPrefs.value;
-		if (preferences.preset !== 'custom' || source === target) return;
+		if (preferences.preset !== 'custom') return;
 		dashboardPrefs.set(updateActiveDashboardView(preferences, {
-			widgets: swapDashboardWidgets(getActiveDashboardView(preferences).widgets, source, target),
+			widgets: placeDashboardWidget(getActiveDashboardView(preferences).widgets, id, column, row),
 		}));
-		movementAnnouncement = `${dashboardWidgetMeta[source].label} swapped with ${dashboardWidgetMeta[target].label}.`;
 	}
 
-	function moveCustomWidget(id: DashboardWidgetId, direction: -1 | 1) {
-		const index = widgets.findIndex((widget) => widget.id === id);
-		const target = widgets[index + direction];
-		if (index < 0 || !target) return;
-		swapCustomWidgets(id, target.id);
+	function announceMovement(message: string) {
+		movementAnnouncement = '';
+		requestAnimationFrame(() => movementAnnouncement = message);
+	}
+
+	function moveCustomWidget(id: DashboardWidgetId, horizontal: -1 | 0 | 1, vertical: -1 | 0 | 1) {
+		const position = gridLayout[id];
+		const widget = widgets.find((candidate) => candidate.id === id);
+		if (!position || !widget) return;
+		const column = position.column + horizontal * dashboardWidgetColumnSpan(widget.width);
+		let row = vertical < 0
+			? Math.max(0, widget.row - position.rowSpan)
+			: position.row + vertical * position.rowSpan;
+		if (column < 0 || column + position.columnSpan > 12) return;
+		let proposed = layoutDashboardWidgets(widgets, widgetRowSpans, { id, column, row })[id];
+		while (vertical < 0 && proposed && proposed.row >= position.row && row > 0) {
+			row = Math.max(0, row - position.rowSpan);
+			proposed = layoutDashboardWidgets(widgets, widgetRowSpans, { id, column, row })[id];
+		}
+		if (!proposed || (proposed.column === position.column && proposed.row === position.row)) return;
+		saveWidgetPlacement(id, column, row);
+		announceMovement(`${dashboardWidgetMeta[id].label} moved ${horizontal < 0 ? 'left' : horizontal > 0 ? 'right' : vertical < 0 ? 'up' : 'down'}.`);
+	}
+
+	function moveCustomWidgetInOrder(id: DashboardWidgetId, direction: -1 | 1) {
+		const preferences = dashboardPrefs.value;
+		if (preferences.preset !== 'custom') return;
+		const target = widgets[widgets.findIndex((widget) => widget.id === id) + direction];
+		if (!target) return;
+		const activeWidgets = getActiveDashboardView(preferences).widgets.map((widget) => ({ ...widget }));
+		const sourceIndex = activeWidgets.findIndex((widget) => widget.id === id);
+		const targetIndex = activeWidgets.findIndex((widget) => widget.id === target.id);
+		[activeWidgets[sourceIndex], activeWidgets[targetIndex]] = [activeWidgets[targetIndex], activeWidgets[sourceIndex]];
+		dashboardPrefs.set(updateActiveDashboardView(preferences, { widgets: activeWidgets }));
+		announceMovement(`${dashboardWidgetMeta[id].label} moved ${direction < 0 ? 'earlier' : 'later'} in the stacked layout.`);
 	}
 
 	function startWidgetDrag(event: DragEvent, id: DashboardWidgetId) {
 		draggedWidget = id;
+		const position = gridLayout[id];
+		dragTarget = position ? { column: position.column, row: position.row } : null;
+		dragOrigin = dragTarget;
+		const widget = (event.currentTarget as HTMLElement).closest<HTMLElement>('[data-dashboard-widget]');
+		const rect = widget?.getBoundingClientRect();
+		dragOffset = rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : { x: 0, y: 0 };
 		event.dataTransfer?.setData('text/plain', id);
 		if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
 	}
 
-	function targetWidgetDrag(event: DragEvent, id: DashboardWidgetId) {
-		if (!draggedWidget || draggedWidget === id) return;
+	function targetGridDrag(event: DragEvent) {
+		if (!draggedWidget || !draggedConfig) return;
 		event.preventDefault();
-		dragTargetWidget = id;
 		if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+		const grid = event.currentTarget as HTMLElement;
+		const rect = grid.getBoundingClientRect();
+		const style = getComputedStyle(grid);
+		const rowHeight = Number.parseFloat(style.gridAutoRows) || 8;
+		const rowGap = Number.parseFloat(style.rowGap) || 0;
+		dragRowMetrics = { height: rowHeight, gap: rowGap };
+		const columnGap = Number.parseFloat(style.columnGap) || 0;
+		const columnWidth = (rect.width - columnGap * 11) / 12;
+		const requestedLeft = event.clientX - rect.left - dragOffset.x;
+		const column = dashboardWidgetValidColumns(draggedConfig.width).reduce((nearest, candidate) =>
+			Math.abs(candidate * (columnWidth + columnGap) - requestedLeft) < Math.abs(nearest * (columnWidth + columnGap) - requestedLeft)
+				? candidate
+				: nearest
+		);
+		dragTarget = {
+			column,
+			row: Math.max(0, Math.round((event.clientY - rect.top - dragOffset.y) / (rowHeight + rowGap))),
+		};
 	}
 
-	function dropWidget(event: DragEvent, target: DashboardWidgetId) {
+	function dropWidget(event: DragEvent) {
 		event.preventDefault();
-		if (draggedWidget) swapCustomWidgets(draggedWidget, target);
+		if (draggedWidget && dragTarget && dragPreview && dragOrigin
+			&& (dragTarget.column !== dragOrigin.column || dragTarget.row !== dragOrigin.row)
+			&& (dragPreview.column !== dragOrigin.column || dragPreview.row !== dragOrigin.row)) {
+			saveWidgetPlacement(draggedWidget, dragTarget.column, dragTarget.row);
+			announceMovement(`${dashboardWidgetMeta[draggedWidget].label} moved to grid column ${dragTarget.column + 1}.`);
+		}
 		endWidgetDrag();
 	}
 
 	function endWidgetDrag() {
 		draggedWidget = null;
-		dragTargetWidget = null;
+		dragTarget = null;
+		dragOrigin = null;
+	}
+
+	function widgetGridStyle(widget: DashboardWidgetConfig): string {
+		const position = gridLayout[widget.id];
+		return position
+			? `--dashboard-column: ${position.column + 1}; --dashboard-row: ${position.row + 1}; grid-row-end: span ${position.rowSpan};`
+			: '';
+	}
+
+	function previewTop(row: number): number {
+		return row * (dragRowMetrics.height + dragRowMetrics.gap);
+	}
+
+	function previewHeight(rowSpan: number): number {
+		return rowSpan * dragRowMetrics.height + Math.max(0, rowSpan - 1) * dragRowMetrics.gap;
 	}
 
 	function handleEvent(_: string, params: unknown) {
@@ -612,6 +703,7 @@
 		<div>
 			<div class="text-sm font-semibold">{presetLabel} dashboard</div>
 			<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
+			{#if dashboardPrefs.value.preset === 'custom'}<div class="hidden text-xs text-muted-foreground xl:block">Drag a widget handle into a highlighted grid lane, or use its direction controls.</div>{/if}
 		</div>
 		<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
 	</div>
@@ -643,15 +735,31 @@
 {#if loading}
 	<Card><CardContent class="py-10 text-center text-sm text-muted-foreground">Loading dashboard...</CardContent></Card>
 {:else}
-	<div class="grid grid-cols-12 auto-rows-[8px] gap-4">
+	<div class="relative grid grid-cols-12 auto-rows-[8px] gap-4" role="group" aria-label="Dashboard widget grid" ondragover={targetGridDrag} ondrop={dropWidget}>
+		{#if draggedWidget && draggedConfig}
+			<div class="pointer-events-none absolute inset-0 z-20 hidden grid-cols-12 grid-rows-1 gap-4 xl:grid" aria-hidden="true">
+				{#each validDropColumns as column}
+					<div
+						class="h-full rounded-lg border border-dashed transition-colors {dragTarget?.column === column ? 'border-primary/70 bg-primary/10' : 'border-border/60 bg-muted/10'}"
+						style={`grid-column: ${column + 1} / span ${dashboardWidgetColumnSpan(draggedConfig.width)}; grid-row: 1;`}
+					></div>
+				{/each}
+				{#if dragPreview}
+					<div class="relative h-full" style={`grid-column: ${dragPreview.column + 1} / span ${dragPreview.columnSpan}; grid-row: 1;`}>
+						<div class="absolute inset-x-0 rounded-lg border-2 border-primary bg-primary/15 shadow-lg" style={`top: ${previewTop(dragPreview.row)}px; height: ${previewHeight(dragPreview.rowSpan)}px;`}></div>
+					</div>
+				{/if}
+			</div>
+		{/if}
 		{#each widgets as widget (widget.id)}
+			{@const position = gridLayout[widget.id]}
 			<div
-				use:masonryItem
+				use:masonryItem={widget.id}
 				role="group"
 				aria-label={dashboardWidgetMeta[widget.id].label}
-				class="self-start rounded-lg transition-shadow {dashboardWidgetWidthClass(widget.id, widget.width)} {dragTargetWidget === widget.id ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}"
-				ondragover={(event) => targetWidgetDrag(event, widget.id)}
-				ondrop={(event) => dropWidget(event, widget.id)}
+				data-dashboard-widget={widget.id}
+				style={widgetGridStyle(widget)}
+				class="self-start rounded-lg transition-[opacity,box-shadow] {dashboardWidgetWidthClass(widget.id, widget.width)} {dashboardPrefs.value.preset === 'custom' ? 'dashboard-positioned' : ''} {draggedWidget === widget.id ? 'opacity-45' : ''}"
 			>
 				{#if dashboardPrefs.value.preset === 'custom' || (widget.id === 'history' && widget.presentation === 'standard')}
 					<div class="mb-1 flex min-h-8 flex-wrap items-center gap-1 text-muted-foreground xl:flex-nowrap">
@@ -663,10 +771,16 @@
 							<HistoryControls range={metricsRange} offset={metricsOffset} loading={historyLoading} class="ml-auto" onRange={(range) => void changeRange(range)} onBack={() => void navigateBack()} onForward={() => void navigateForward()} onLive={() => void navigateLive()} />
 						{/if}
 						{#if dashboardPrefs.value.preset === 'custom'}
-							<div class={widget.id === 'history' && widget.presentation === 'standard' ? 'flex' : 'ml-auto flex'}>
-								<button type="button" onclick={() => moveCustomWidget(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
-								<button type="button" onclick={() => moveCustomWidget(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-30" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
-								<button type="button" draggable={true} onclick={() => moveCustomWidget(widget.id, widgets.at(-1)?.id === widget.id ? -1 : 1)} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="cursor-grab rounded p-1 hover:bg-accent hover:text-foreground active:cursor-grabbing" aria-label={`Drag ${dashboardWidgetMeta[widget.id].label} to swap positions, or activate to move it ${widgets.at(-1)?.id === widget.id ? 'earlier' : 'later'}`} title="Drag to swap positions"><GripVertical class="h-3.5 w-3.5" /></button>
+							<div class="ml-auto flex xl:hidden">
+								<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
+								<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
+							</div>
+							<div class="ml-auto hidden opacity-50 transition-opacity hover:opacity-100 focus-within:opacity-100 xl:flex">
+								<button type="button" onclick={() => moveCustomWidget(widget.id, -1, 0)} disabled={!position || position.column === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} left`}><ArrowLeft class="h-3.5 w-3.5" /></button>
+								<button type="button" onclick={() => moveCustomWidget(widget.id, 1, 0)} disabled={!position || position.column + position.columnSpan >= 12} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} right`}><ArrowRight class="h-3.5 w-3.5" /></button>
+								<button type="button" onclick={() => moveCustomWidget(widget.id, 0, -1)} disabled={!position || position.row === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp class="h-3.5 w-3.5" /></button>
+								<button type="button" onclick={() => moveCustomWidget(widget.id, 0, 1)} class="rounded p-1.5 hover:bg-accent hover:text-foreground" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown class="h-3.5 w-3.5" /></button>
+								<span draggable={true} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="inline-flex cursor-grab rounded p-1.5 hover:bg-accent hover:text-foreground active:cursor-grabbing" title="Drag to a grid position" aria-hidden="true"><GripVertical class="h-3.5 w-3.5" /></span>
 							</div>
 						{/if}
 					</div>
@@ -701,3 +815,12 @@
 </div>
 
 <CustomizeDialog bind:open={customizeOpen} preferences={dashboardPrefs.value} onSave={(preferences) => void applyPreferences(preferences)} />
+
+<style>
+	@media (min-width: 80rem) {
+		.dashboard-positioned {
+			grid-column-start: var(--dashboard-column);
+			grid-row-start: var(--dashboard-row);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- persist wide-screen grid coordinates for Custom dashboard widgets and push runtime collisions downward without saving transient heights
- replace widget-to-widget swaps with free drag placement, width-aware lane guides, and a resolved drop preview
- preserve grab offsets and ignore no-op drops so widgets do not jump when dragging starts or ends
- retain directional placement controls on desktop and explicit ordering controls for stacked mobile layouts
- migrate v5 preferences to the v6 placement schema while preserving visible widget order

Follow-up to #823 and the placement wishlist in #809.

## Testing
- `npm run check`
- `npm test` (275 tests)
- `npm run build`
- `git diff --check`