### PR TITLE
webui: add compute dashboard widget

### DIFF
--- a/webui/src/lib/components/dashboard/compute-widget.svelte
+++ b/webui/src/lib/components/dashboard/compute-widget.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DashboardHealthFreshness, ManagedContainerHealthSummary } from '$lib/dashboard-health';
+	import type { AppsStatus, VmStatus } from '$lib/types';
+	import { formatBytes } from '$lib/format';
+	import { Card, CardContent } from '$lib/components/ui/card';
+
+	let {
+		vms = null,
+		vmFreshness,
+		appsStatus = null,
+		containers = null,
+		containerFreshness,
+		density,
+	}: {
+		vms?: VmStatus[] | null;
+		vmFreshness: DashboardHealthFreshness;
+		appsStatus?: AppsStatus | null;
+		containers?: ManagedContainerHealthSummary | null;
+		containerFreshness: DashboardHealthFreshness;
+		density: DashboardDensity;
+	} = $props();
+
+	let runningVms = $derived(vms?.filter((vm) => vm.running) ?? []);
+	let activeVcpus = $derived(runningVms.reduce((total, vm) => total + vm.cpus, 0));
+	let activeMemory = $derived(runningVms.reduce((total, vm) => total + vm.memory_mib, 0) * 1024 * 1024);
+
+	function freshnessLabel(freshness: DashboardHealthFreshness): string | null {
+		if (freshness === 'loading') return 'Loading';
+		if (freshness === 'refreshing') return 'Refreshing';
+		if (freshness === 'stale') return 'Stale';
+		if (freshness === 'unavailable') return 'Unavailable';
+		return null;
+	}
+
+	function freshnessClass(freshness: DashboardHealthFreshness): string {
+		return freshness === 'stale' ? 'text-amber-500' : 'text-muted-foreground';
+	}
+
+	function freshnessDescription(freshness: DashboardHealthFreshness): string {
+		return freshness === 'current' ? '' : ` Data ${freshness}.`;
+	}
+
+	function vmAriaLabel(): string {
+		if (!vms) return vmFreshness === 'loading' ? 'Virtual machine status loading.' : 'Virtual machine status unavailable.';
+		return `Virtual machines: ${runningVms.length} of ${vms.length} running. ${activeVcpus} active vCPU and ${formatBytes(activeMemory)} active memory.${freshnessDescription(vmFreshness)}`;
+	}
+
+	function dockerLabel(): string {
+		if (!appsStatus) return containerFreshness === 'loading' ? 'Loading' : 'Unavailable';
+		if (!appsStatus.enabled) return 'Disabled';
+		if (!appsStatus.running) return 'Runtime down';
+		if (containers?.expected == null || containers.running == null) return 'Inventory unavailable';
+		return `${containers.running} / ${containers.expected}`;
+	}
+
+	function dockerDetail(): string {
+		if (!appsStatus) return containerFreshness === 'loading' ? 'Checking Docker runtime.' : 'Docker status could not be loaded.';
+		if (!appsStatus.enabled) return 'Docker runtime is disabled.';
+		if (!appsStatus.running) return 'Docker is enabled but not running.';
+		if (containers?.expected == null || containers.running == null) return `${appsStatus.app_count} configured app${appsStatus.app_count === 1 ? '' : 's'}.`;
+		return `${appsStatus.app_count} app${appsStatus.app_count === 1 ? '' : 's'} - containers running`;
+	}
+
+	function dockerClass(): string {
+		if (containerFreshness === 'stale') return 'text-amber-500';
+		if (!appsStatus || !appsStatus.enabled) return 'text-muted-foreground';
+		if (!appsStatus.running) return 'text-amber-500';
+		if (containers?.expected != null && containers.running === containers.expected) return 'text-emerald-500';
+		return 'text-amber-500';
+	}
+</script>
+
+<Card class="h-full overflow-hidden">
+	<CardContent class="p-0">
+		<div class="grid grid-cols-2 divide-x divide-border">
+			<a href="/vms" class="min-w-0 {density === 'compact' ? 'p-3' : 'p-4'} outline-none transition-colors hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring" aria-label={vmAriaLabel()}>
+				<div class="flex min-w-0 items-center justify-between gap-2">
+					<div class="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">Virtual machines</div>
+					{#if freshnessLabel(vmFreshness)}<div class="shrink-0 text-[0.68rem] font-semibold {freshnessClass(vmFreshness)}" role={vmFreshness === 'refreshing' || vmFreshness === 'stale' || vmFreshness === 'unavailable' ? 'status' : undefined}>{freshnessLabel(vmFreshness)}</div>{/if}
+				</div>
+				{#if vms}
+					<div class="mt-2 text-2xl font-bold tabular-nums">{runningVms.length} <span class="text-base font-medium text-muted-foreground">/ {vms.length}</span></div>
+					<div class="text-xs text-muted-foreground">running</div>
+					<div class="mt-2 truncate text-xs text-muted-foreground" title={`${activeVcpus} active vCPU - ${formatBytes(activeMemory)} active memory`}>{runningVms.length > 0 ? `${activeVcpus} vCPU - ${formatBytes(activeMemory)} active` : vms.length > 0 ? 'No active VM allocation' : 'No VMs defined'}</div>
+				{:else}
+					<div class="mt-2 text-lg font-bold text-muted-foreground">{vmFreshness === 'loading' ? 'Loading' : 'Unavailable'}</div>
+					<div class="mt-2 text-xs text-muted-foreground">{vmFreshness === 'loading' ? 'Checking VM inventory.' : 'VM inventory could not be loaded.'}</div>
+				{/if}
+			</a>
+
+			<a href="/apps" class="min-w-0 {density === 'compact' ? 'p-3' : 'p-4'} outline-none transition-colors hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring" aria-label={`Docker apps: ${dockerLabel()}. ${dockerDetail()}${freshnessDescription(containerFreshness)}`}>
+				<div class="flex min-w-0 items-center justify-between gap-2">
+					<div class="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">Docker apps</div>
+					{#if freshnessLabel(containerFreshness)}<div class="shrink-0 text-[0.68rem] font-semibold {freshnessClass(containerFreshness)}" role={containerFreshness === 'refreshing' || containerFreshness === 'stale' || containerFreshness === 'unavailable' ? 'status' : undefined}>{freshnessLabel(containerFreshness)}</div>{/if}
+				</div>
+				<div class="mt-2 truncate text-2xl font-bold tabular-nums {dockerClass()}" title={dockerLabel()}>{dockerLabel()}</div>
+				<div class="mt-2 text-xs text-muted-foreground">{dockerDetail()}</div>
+			</a>
+		</div>
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -1,12 +1,13 @@
 import { render } from 'svelte/server';
 import { describe, expect, test } from 'vitest';
 import AlertsWidget from './alerts-widget.svelte';
+import ComputeWidget from './compute-widget.svelte';
 import HealthWidget from './health-widget.svelte';
 import HistoryWidget from './history-widget.svelte';
 import OperationsWidget from './operations-widget.svelte';
 import SummaryWidget from './summary-widget.svelte';
 import SystemWidget from './system-widget.svelte';
-import type { ActiveAlert, Filesystem, SystemInfo, SystemStats } from '$lib/types';
+import type { ActiveAlert, AppsStatus, Filesystem, SystemInfo, SystemStats, VmStatus } from '$lib/types';
 
 const alert = (severity: ActiveAlert['severity'], message: string): ActiveAlert => ({
 	rule_id: message,
@@ -55,6 +56,28 @@ const filesystem: Filesystem = {
 	available_bytes: 300,
 	options: {} as Filesystem['options'],
 };
+
+const appsStatus: AppsStatus = {
+	enabled: true,
+	running: true,
+	app_count: 2,
+	storage_ok: true,
+};
+
+const vm = (name: string, running: boolean, cpus: number, memory_mib: number): VmStatus => ({
+	id: name,
+	name,
+	cpus,
+	memory_mib,
+	disks: [],
+	networks: [],
+	passthrough_devices: [],
+	cdroms: [],
+	boot_order: 'disk',
+	uefi: true,
+	autostart: false,
+	running,
+});
 
 describe('tiny dashboard widgets', () => {
 	test('keeps critical alert and active operation states explicit', () => {
@@ -209,6 +232,85 @@ describe('dashboard health widget', () => {
 		expect(refreshing).toContain('Refreshing - healthy');
 		expect(refreshing).toContain('Refreshing; showing last known healthy state.');
 		expect(refreshing).not.toContain('Refresh failed');
+	});
+});
+
+describe('dashboard compute widget', () => {
+	test('summarizes active VM allocations and Docker workloads with destination links', () => {
+		const body = render(ComputeWidget, {
+			props: {
+				vms: [vm('router', true, 2, 2048), vm('lab', false, 4, 4096)],
+				vmFreshness: 'current',
+				appsStatus,
+				containers: { runtime: 'running', expected: 4, running: 3 },
+				containerFreshness: 'current',
+				density: 'comfortable',
+			},
+		}).body;
+
+		expect(body).toContain('href="/vms"');
+		expect(body).toContain('1 <span class="text-base font-medium text-muted-foreground">/ 2</span>');
+		expect(body).toContain('2 vCPU - 2.0 GiB active');
+		expect(body).toContain('href="/apps"');
+		expect(body).toContain('3 / 4');
+		expect(body).toContain('2 apps - containers running');
+	});
+
+	test('keeps runtime and freshness failures explicit', () => {
+		const disabled = render(ComputeWidget, {
+			props: {
+				vms: [],
+				vmFreshness: 'stale',
+				appsStatus: { ...appsStatus, enabled: false, running: false, app_count: 0 },
+				containers: { runtime: 'disabled', expected: null, running: null },
+				containerFreshness: 'current',
+				density: 'compact',
+			},
+		}).body;
+		const unavailable = render(ComputeWidget, {
+			props: {
+				vms: null,
+				vmFreshness: 'unavailable',
+				appsStatus: null,
+				containers: null,
+				containerFreshness: 'unavailable',
+				density: 'compact',
+			},
+		}).body;
+
+		expect(disabled).toContain('Stale');
+		expect(disabled).toContain('Data stale.');
+		expect(disabled).toContain('No VMs defined');
+		expect(disabled).toContain('Docker runtime is disabled.');
+		expect(unavailable).toContain('VM inventory could not be loaded.');
+		expect(unavailable).toContain('Docker status could not be loaded.');
+		expect(unavailable).toContain('role="status"');
+	});
+
+	test('distinguishes loading and partial Docker inventory from failures', () => {
+		const loading = render(ComputeWidget, {
+			props: {
+				vmFreshness: 'loading',
+				containerFreshness: 'loading',
+				density: 'compact',
+			},
+		}).body;
+		const partial = render(ComputeWidget, {
+			props: {
+				vms: [],
+				vmFreshness: 'current',
+				appsStatus,
+				containers: { runtime: 'running', expected: null, running: null },
+				containerFreshness: 'unavailable',
+				density: 'compact',
+			},
+		}).body;
+
+		expect(loading).toContain('Checking VM inventory.');
+		expect(loading).toContain('Checking Docker runtime.');
+		expect(loading).not.toContain('could not be loaded');
+		expect(partial).toContain('Inventory unavailable');
+		expect(partial).toContain('2 configured apps.');
 	});
 });
 

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -64,7 +64,8 @@ describe('dashboard preferences', () => {
 			density: 'compact',
 		});
 		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard', column: 0, row: 0, priority: 0 });
-		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(13);
+		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(14);
+		expect(getActiveDashboardView(parsed).widgets.find((widget) => widget.id === 'compute')).toMatchObject({ visible: false, width: 'half' });
 	});
 
 	test('migrates v2 named views to standard widget presentations', () => {
@@ -196,6 +197,28 @@ describe('dashboard preferences', () => {
 		expect(widgets.find((widget) => widget.id === 'container_health')).toMatchObject({ column: 6, row: 0, priority: 0 });
 	});
 
+	test('adds Compute disabled without disturbing deployed v6 widget placement', () => {
+		const existingWidgets: DashboardWidgetConfig[] = [
+			{ id: 'alerts', visible: false, width: 'full', presentation: 'tiny', column: 0, row: 7, priority: 4 },
+			{ id: 'storage', visible: true, width: 'half', presentation: 'standard', column: 6, row: 3, priority: 2 },
+		];
+		const parsed = parseDashboardPreferences(JSON.stringify({
+			version: 6,
+			preset: 'custom',
+			hiddenPresetTabs: [],
+			activeViewId: 'deployed',
+			customViews: [{ id: 'deployed', name: 'Deployed', density: 'compact', widgets: existingWidgets }],
+		}));
+		const widgets = getActiveDashboardView(parsed).widgets;
+
+		expect(widgets.slice(0, existingWidgets.length)).toEqual(existingWidgets);
+		expect(widgets.find((widget) => widget.id === 'compute')).toMatchObject({
+			visible: false,
+			width: 'half',
+			presentation: 'standard',
+		});
+	});
+
 	test('normalizes named views, active selection, and newly added widget ids', () => {
 		const parsed = parseDashboardPreferences(JSON.stringify({
 			version: 3,
@@ -221,7 +244,7 @@ describe('dashboard preferences', () => {
 		expect(parsed.activeViewId).toBe('ops');
 		expect(parsed.customViews.map((view) => view.id)).toEqual(['ops', 'custom-1']);
 		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
-		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(13);
+		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(14);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
@@ -244,7 +267,7 @@ describe('dashboard preferences', () => {
 	test('limits narrow widths to compact-safe presentations', () => {
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'standard')).toBe(false);
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'tiny')).toBe(true);
-		for (const id of ['service_health', 'container_health', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'] as const) {
+		for (const id of ['service_health', 'container_health', 'compute', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'] as const) {
 			expect(dashboardWidgetSupportsNarrowWidth(id, 'standard')).toBe(true);
 		}
 		expect(dashboardWidgetSupportsNarrowWidth('storage', 'standard')).toBe(false);
@@ -260,6 +283,7 @@ describe('dashboard preferences', () => {
 		expect(dashboardWidgetWidthClass('alerts', 'third')).toContain('xl:col-span-4');
 		expect(dashboardWidgetWidthClass('alerts', 'quarter')).toContain('xl:col-span-3');
 		expect(dashboardWidgetWidthClass('service_health', 'half')).toContain('md:col-span-6');
+		expect(dashboardWidgetWidthClass('compute', 'quarter')).toContain('xl:col-span-3');
 		expect(dashboardWidgetWidthClass('cpu_load', 'quarter')).toContain('lg:col-span-3');
 	});
 

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -13,6 +13,7 @@ export const dashboardWidgetIds = [
 	'system',
 	'service_health',
 	'container_health',
+	'compute',
 	'cpu_load',
 	'memory_usage',
 	'cpu_status',
@@ -74,6 +75,7 @@ export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; des
 	system: { label: 'System status', description: 'Host identity, uptime, and service health.', supportsTiny: true },
 	service_health: { label: 'Service health', description: 'Enabled services currently running.', supportsTiny: false },
 	container_health: { label: 'Container health', description: 'Expected managed containers currently running.', supportsTiny: false },
+	compute: { label: 'Compute', description: 'Virtual machines and Docker workloads at a glance.', supportsTiny: false },
 	cpu_load: { label: 'CPU load', description: 'Current load across available CPU cores.', supportsTiny: false },
 	memory_usage: { label: 'Memory', description: 'Current memory use and bcachefs cache.', supportsTiny: false },
 	cpu_status: { label: 'CPU status', description: 'CPU temperature, frequency, and governor.', supportsTiny: false },
@@ -93,7 +95,7 @@ export function dashboardWidgetSupportsNarrowWidth(
 	id: DashboardWidgetId,
 	presentation: DashboardWidgetPresentation,
 ): boolean {
-	return ['service_health', 'container_health', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
+	return ['service_health', 'container_health', 'compute', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
 		|| (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
 }
 
@@ -118,7 +120,7 @@ export function dashboardWidgetSnapColumn(width: DashboardWidgetWidth, requested
 }
 
 export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: DashboardWidgetWidth): string {
-	const responsive = id === 'service_health' || id === 'container_health'
+	const responsive = id === 'service_health' || id === 'container_health' || id === 'compute'
 		? 'col-span-12 md:col-span-6'
 		: ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
 			? 'col-span-6 lg:col-span-3'
@@ -164,6 +166,7 @@ const defaultCustomWidgets: DashboardWidgetConfig[] = positionWidgets([
 	{ id: 'history', visible: true, width: 'full', presentation: 'standard' },
 	{ id: 'network', visible: true, width: 'half', presentation: 'standard' },
 	{ id: 'disk_io', visible: true, width: 'half', presentation: 'standard' },
+	{ id: 'compute', visible: false, width: 'half', presentation: 'standard' },
 ]);
 
 export const dashboardPresets: Record<DashboardFixedPreset, {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -40,6 +40,7 @@
 		SystemInfo,
 		SystemStats,
 		SystemStatus,
+		VmStatus,
 	} from '$lib/types';
 	import {
 		shouldPollDashboardHealth,
@@ -52,6 +53,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import AlertsWidget from '$lib/components/dashboard/alerts-widget.svelte';
+	import ComputeWidget from '$lib/components/dashboard/compute-widget.svelte';
 	import CustomizeDialog from '$lib/components/dashboard/customize-dialog.svelte';
 	import DiskIoWidget from '$lib/components/dashboard/disk-io-widget.svelte';
 	import HistoryControls from '$lib/components/dashboard/history-controls.svelte';
@@ -96,6 +98,9 @@
 	let serviceHealthFreshness = $state<DashboardHealthFreshness>('loading');
 	let containerHealth = $state<ManagedContainerHealthSummary | null>(null);
 	let containerHealthFreshness = $state<DashboardHealthFreshness>('loading');
+	let appsStatus = $state<AppsStatus | null>(null);
+	let vms = $state<VmStatus[] | null>(null);
+	let vmFreshness = $state<DashboardHealthFreshness>('loading');
 	let customizeOpen = $state(false);
 	let refreshTimer: ReturnType<typeof setInterval> | null = null;
 	let refreshTick = 0;
@@ -109,6 +114,7 @@
 	let operationsRequest = 0;
 	let serviceHealthInFlight: Promise<void> | null = null;
 	let containerHealthInFlight: Promise<void> | null = null;
+	let vmHealthInFlight: Promise<void> | null = null;
 
 	let metricsRange = $state<MetricsRange>('5m');
 	let metricsOffset = $state(0);
@@ -175,7 +181,12 @@
 	}
 
 	function healthPollingEnabled(id: 'service_health' | 'container_health'): boolean {
-		return shouldPollDashboardHealth(hasWidget(id), document.hidden);
+		const visible = hasWidget(id) || (id === 'container_health' && hasWidget('compute'));
+		return shouldPollDashboardHealth(visible, document.hidden);
+	}
+
+	function vmPollingEnabled(): boolean {
+		return shouldPollDashboardHealth(hasWidget('compute'), document.hidden);
 	}
 
 	function masonryItem(node: HTMLElement, id: DashboardWidgetId) {
@@ -325,6 +336,7 @@
 		const handleVisibilityChange = () => {
 			if (healthPollingEnabled('service_health')) void loadServiceHealth(true);
 			if (healthPollingEnabled('container_health')) void loadContainerHealth(true);
+			if (vmPollingEnabled()) void loadVmHealth(true);
 		};
 		document.addEventListener('visibilitychange', handleVisibilityChange);
 		void loadVisibleData(true).finally(() => loading = false);
@@ -359,6 +371,7 @@
 			if (hasWidget('operations')) tasks.push(loadOperations());
 			if (healthPollingEnabled('service_health')) tasks.push(loadServiceHealth(true));
 			if (healthPollingEnabled('container_health')) tasks.push(loadContainerHealth(true));
+			if (vmPollingEnabled()) tasks.push(loadVmHealth(true));
 			const results = await Promise.allSettled(tasks);
 			if (hasWidget('storage')) await loadStorageDetails();
 			if (needsMetricsHistory()) await loadMetrics();
@@ -452,27 +465,56 @@
 		try {
 			status = await client.call<AppsStatus>('apps.status');
 		} catch {
-			containerHealthFreshness = containerHealth ? 'stale' : 'unavailable';
+			containerHealthFreshness = containerHealth && appsStatus ? 'stale' : 'unavailable';
 			return;
 		}
 
 		if (!status.enabled) {
+			appsStatus = status;
 			containerHealth = summarizeManagedContainers(status, []);
 			containerHealthFreshness = 'current';
 			return;
 		}
-		if (!status.running) {
-			containerHealth = { runtime: 'down', expected: null, running: 0 };
-			containerHealthFreshness = 'current';
-		}
 
 		try {
-			containerHealth = summarizeManagedContainers(status, await client.call<App[]>('apps.list'));
+			const nextContainerHealth = summarizeManagedContainers(status, await client.call<App[]>('apps.list'));
+			appsStatus = status;
+			containerHealth = nextContainerHealth;
 			containerHealthFreshness = 'current';
 		} catch {
-			if (status.running) {
-				containerHealthFreshness = containerHealth ? 'stale' : 'unavailable';
+			if (!status.running) {
+				appsStatus = status;
+				containerHealth = { runtime: 'down', expected: null, running: 0 };
+				containerHealthFreshness = 'current';
+			} else if (containerHealth?.expected != null && appsStatus?.enabled === status.enabled && appsStatus.running === status.running) {
+				containerHealthFreshness = 'stale';
+			} else {
+				appsStatus = status;
+				containerHealth = { runtime: 'running', expected: null, running: null };
+				containerHealthFreshness = 'unavailable';
 			}
+		}
+	}
+
+	function loadVmHealth(markExistingRefreshing = false): Promise<void> {
+		if (vmHealthInFlight) return vmHealthInFlight;
+		if (markExistingRefreshing && vms) vmFreshness = 'refreshing';
+		if (!vms) vmFreshness = 'loading';
+
+		const request = fetchVmHealth();
+		vmHealthInFlight = request;
+		void request.finally(() => {
+			if (vmHealthInFlight === request) vmHealthInFlight = null;
+		});
+		return request;
+	}
+
+	async function fetchVmHealth() {
+		try {
+			vms = await client.call<VmStatus[]>('vm.list');
+			vmFreshness = 'current';
+		} catch {
+			vmFreshness = vms ? 'stale' : 'unavailable';
 		}
 	}
 
@@ -509,6 +551,7 @@
 	async function refreshVisibleData() {
 		if (healthPollingEnabled('service_health')) void loadServiceHealth();
 		if (healthPollingEnabled('container_health')) void loadContainerHealth();
+		if (vmPollingEnabled()) void loadVmHealth();
 		if (refreshInFlight) return;
 		refreshInFlight = true;
 		refreshTick += 1;
@@ -793,6 +836,8 @@
 					<HealthWidget kind="services" services={serviceHealth} freshness={serviceHealthFreshness} {density} />
 				{:else if widget.id === 'container_health'}
 					<HealthWidget kind="containers" containers={containerHealth} freshness={containerHealthFreshness} {density} />
+				{:else if widget.id === 'compute'}
+					<ComputeWidget {vms} {appsStatus} containers={containerHealth} {vmFreshness} containerFreshness={containerHealthFreshness} {density} />
 				{:else if widget.id === 'cpu_load' || widget.id === 'memory_usage' || widget.id === 'cpu_status' || widget.id === 'storage_summary'}
 					<SummaryWidget kind={widget.id} {stats} {filesystems} {filesystemsLoaded} {density} />
 				{:else if widget.id === 'operations'}


### PR DESCRIPTION
## Summary
- add an optional Compute widget for VM and Docker workload status
- share Docker polling with Container Health and poll VM inventory only while visible
- preserve deployed v6 dashboard layouts with the new widget disabled by default

Related to #809.

## Testing
- npm run check
- npm test (279 tests)
- npm run build
- git diff --check