### PR TITLE
webui: avoid theme initialization warning

### DIFF
--- a/webui/src/lib/theme.svelte.ts
+++ b/webui/src/lib/theme.svelte.ts
@@ -13,7 +13,8 @@ function createTheme() {
 		return 'dark';
 	}
 
-	let current = $state<'dark' | 'light'>(getInitial());
+	const initial = getInitial();
+	let current = $state<'dark' | 'light'>(initial);
 
 	function apply(theme: 'dark' | 'light') {
 		if (typeof document !== 'undefined') {
@@ -22,7 +23,7 @@ function createTheme() {
 	}
 
 	// Apply on first load
-	apply(current);
+	apply(initial);
 
 	return {
 		get current() { return current; },


### PR DESCRIPTION
## Summary
- retain the resolved initial theme in a non-reactive constant
- use that value for both state initialization and the initial DOM class update
- remove the Svelte state-capture warning without changing theme behavior

## Testing
- npm run check
- npm test (275 tests)
- npm run build (no warnings)
- git diff --check