### PR TITLE
webui: add dashboard edit mode

### DIFF
--- a/webui/src/lib/components/dashboard/customize-dialog.svelte
+++ b/webui/src/lib/components/dashboard/customize-dialog.svelte
@@ -7,7 +7,6 @@
 		dashboardPresets,
 		dashboardViewNameAvailable,
 		dashboardWidgetMeta,
-		dashboardWidgetSnapColumn,
 		dashboardWidgetSupportsNarrowWidth,
 		dashboardWidgetSupportsTiny,
 		defaultDashboardPreferences,
@@ -16,6 +15,7 @@
 		renameDashboardView,
 		selectDashboardView,
 		setDashboardPresetTabVisible,
+		updateDashboardWidgetAppearance,
 		updateActiveDashboardView,
 		type DashboardPreferences,
 		type DashboardOptionalPreset,
@@ -106,13 +106,8 @@
 	function updatePresentation(index: number, value: string) {
 		const widget = activeView.widgets[index];
 		const presentation = value === 'tiny' && dashboardWidgetSupportsTiny(widget.id) ? 'tiny' : 'standard';
-		const width = (widget.width === 'quarter' || widget.width === 'third') && !dashboardWidgetSupportsNarrowWidth(widget.id, presentation)
-			? 'half'
-			: widget.width;
-		updateWidget(index, {
-			presentation,
-			width,
-			column: dashboardWidgetSnapColumn(width, widget.column),
+		draft = updateActiveDashboardView(draft, {
+			widgets: updateDashboardWidgetAppearance(activeView.widgets, widget.id, { presentation }),
 		});
 	}
 
@@ -129,7 +124,9 @@
 	function updateWidth(index: number, value: string) {
 		const widget = activeView.widgets[index];
 		const width = parseWidgetWidth(value);
-		updateWidget(index, { width, column: dashboardWidgetSnapColumn(width, widget.column) });
+		draft = updateActiveDashboardView(draft, {
+			widgets: updateDashboardWidgetAppearance(activeView.widgets, widget.id, { width }),
+		});
 	}
 
 	function resetCustom() {

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -7,6 +7,7 @@ import HistoryWidget from './history-widget.svelte';
 import OperationsWidget from './operations-widget.svelte';
 import SummaryWidget from './summary-widget.svelte';
 import SystemWidget from './system-widget.svelte';
+import WidgetOptions from './widget-options.svelte';
 import type { ActiveAlert, AppsStatus, Filesystem, SystemInfo, SystemStats, VmStatus } from '$lib/types';
 
 const alert = (severity: ActiveAlert['severity'], message: string): ActiveAlert => ({
@@ -344,5 +345,31 @@ describe('dashboard resource summary widgets', () => {
 		expect(status).toContain('CPU temperature and frequency are unavailable.');
 		expect(storage).toContain('No filesystems');
 		expect(unavailableStorage).toContain('Filesystem inventory could not be loaded.');
+	});
+});
+
+describe('dashboard widget options', () => {
+	test('offers supported widths and presentation modes', () => {
+		const configurable = render(WidgetOptions, {
+			props: {
+				widget: { id: 'alerts', visible: true, width: 'quarter', presentation: 'tiny', column: 0, row: 0, priority: 0 },
+				onChange: () => undefined,
+			},
+		}).body;
+		const standardOnly = render(WidgetOptions, {
+			props: {
+				widget: { id: 'storage', visible: true, width: 'full', presentation: 'standard', column: 0, row: 0, priority: 0 },
+				onChange: () => undefined,
+			},
+		}).body;
+
+		expect(configurable).toContain('Configure Alerts widget');
+		expect(configurable).toContain('1/4 width');
+		expect(configurable).toContain('Presentation');
+		expect(configurable).toContain('Tiny');
+		expect(standardOnly).toContain('Full width');
+		expect(standardOnly).toContain('1/2 width');
+		expect(standardOnly).not.toContain('1/4 width');
+		expect(standardOnly).not.toContain('Presentation');
 	});
 });

--- a/webui/src/lib/components/dashboard/widget-options.svelte
+++ b/webui/src/lib/components/dashboard/widget-options.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import {
+		dashboardWidgetSupportsNarrowWidth,
+		dashboardWidgetSupportsTiny,
+		dashboardWidgetMeta,
+		type DashboardWidgetConfig,
+		type DashboardWidgetPresentation,
+		type DashboardWidgetWidth,
+	} from '$lib/dashboard.svelte';
+	import { Check, Ellipsis } from '@lucide/svelte';
+
+	let { widget, onChange }: {
+		widget: DashboardWidgetConfig;
+		onChange: (patch: Partial<Pick<DashboardWidgetConfig, 'width' | 'presentation'>>) => void;
+	} = $props();
+
+	let open = $state(false);
+	let root: HTMLDivElement;
+	let trigger: HTMLButtonElement;
+	let panel: HTMLDivElement;
+	let panelPosition = $state({ left: 8, top: 8, width: 176 });
+	const widths: { value: DashboardWidgetWidth; label: string }[] = [
+		{ value: 'full', label: 'Full width' },
+		{ value: 'half', label: '1/2 width' },
+		{ value: 'third', label: '1/3 width' },
+		{ value: 'quarter', label: '1/4 width' },
+	];
+
+	let availableWidths = $derived(widths.filter(({ value }) =>
+		(value === 'full' || value === 'half')
+		|| dashboardWidgetSupportsNarrowWidth(widget.id, widget.presentation)
+	));
+
+	onMount(() => {
+		const closeOutside = (event: Event) => {
+			if (!root.contains(event.target as Node)) open = false;
+		};
+		const closeOnViewportChange = () => {
+			if (!open) return;
+			open = false;
+			trigger.focus();
+		};
+		document.addEventListener('pointerdown', closeOutside);
+		document.addEventListener('focusin', closeOutside);
+		window.addEventListener('resize', closeOnViewportChange);
+		window.addEventListener('scroll', closeOnViewportChange, true);
+		return () => {
+			document.removeEventListener('pointerdown', closeOutside);
+			document.removeEventListener('focusin', closeOutside);
+			window.removeEventListener('resize', closeOnViewportChange);
+			window.removeEventListener('scroll', closeOnViewportChange, true);
+		};
+	});
+
+	async function toggle() {
+		open = !open;
+		if (!open) return;
+		await tick();
+		const triggerRect = trigger.getBoundingClientRect();
+		const width = Math.min(176, Math.max(0, window.innerWidth - 16));
+		const height = panel.getBoundingClientRect().height;
+		const below = triggerRect.bottom + 4;
+		panelPosition = {
+			left: Math.max(8, Math.min(triggerRect.right - width, window.innerWidth - width - 8)),
+			top: below + height <= window.innerHeight - 8 ? below : Math.max(8, triggerRect.top - height - 4),
+			width,
+		};
+		panel.querySelector<HTMLButtonElement>('button')?.focus();
+	}
+
+	function select(patch: Partial<Pick<DashboardWidgetConfig, 'width' | 'presentation'>>) {
+		onChange(patch);
+		open = false;
+		trigger.focus();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key !== 'Escape' || !open) return;
+		event.stopPropagation();
+		open = false;
+		trigger.focus();
+	}
+
+	function selectPresentation(presentation: DashboardWidgetPresentation) {
+		select({ presentation });
+	}
+</script>
+
+<div bind:this={root} class="relative">
+	<button bind:this={trigger} type="button" onclick={() => void toggle()} onkeydown={handleKeydown} aria-label={`Configure ${dashboardWidgetMeta[widget.id].label} widget`} aria-haspopup="dialog" aria-expanded={open} class="rounded p-1.5 hover:bg-accent hover:text-foreground">
+		<Ellipsis class="h-3.5 w-3.5" />
+	</button>
+	<div bind:this={panel} hidden={!open} role="dialog" aria-label="Widget display options" tabindex="-1" onkeydown={handleKeydown} style={`left: ${panelPosition.left}px; top: ${panelPosition.top}px; width: ${panelPosition.width}px;`} class="fixed z-40 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg">
+		<div class="px-2 pb-1 pt-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">Width</div>
+		{#each availableWidths as option}
+			<button type="button" aria-pressed={widget.width === option.value} onclick={() => select({ width: option.value })} class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent">
+				<span class="w-3.5">{#if widget.width === option.value}<Check class="h-3.5 w-3.5" />{/if}</span>{option.label}
+			</button>
+		{/each}
+		{#if dashboardWidgetSupportsTiny(widget.id)}
+			<div class="my-1 border-t border-border"></div>
+			<div class="px-2 pb-1 pt-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">Presentation</div>
+			{#each ([{ value: 'standard', label: 'Standard' }, { value: 'tiny', label: 'Tiny' }] as const) as option}
+				<button type="button" aria-pressed={widget.presentation === option.value} onclick={() => selectPresentation(option.value)} class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent">
+					<span class="w-3.5">{#if widget.presentation === option.value}<Check class="h-3.5 w-3.5" />{/if}</span>{option.label}
+				</button>
+			{/each}
+		{/if}
+	</div>
+</div>

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -30,6 +30,7 @@ import {
 	selectDashboardView,
 	setDashboardPresetTabVisible,
 	updateActiveDashboardView,
+	updateDashboardWidgetAppearance,
 	type DashboardWidgetConfig,
 } from './dashboard.svelte';
 
@@ -285,6 +286,19 @@ describe('dashboard preferences', () => {
 		expect(dashboardWidgetWidthClass('service_health', 'half')).toContain('md:col-span-6');
 		expect(dashboardWidgetWidthClass('compute', 'quarter')).toContain('xl:col-span-3');
 		expect(dashboardWidgetWidthClass('cpu_load', 'quarter')).toContain('lg:col-span-3');
+	});
+
+	test('updates widget appearance while enforcing presentation width constraints', () => {
+		const widgets: DashboardWidgetConfig[] = [
+			{ id: 'alerts', visible: true, width: 'quarter', presentation: 'tiny', column: 9, row: 0, priority: 0 },
+			{ id: 'storage', visible: true, width: 'full', presentation: 'standard', column: 0, row: 1, priority: 0 },
+		];
+
+		const standard = updateDashboardWidgetAppearance(widgets, 'alerts', { presentation: 'standard' });
+		expect(standard[0]).toMatchObject({ width: 'half', presentation: 'standard', column: 6 });
+		const unsupportedNarrow = updateDashboardWidgetAppearance(widgets, 'storage', { width: 'quarter' });
+		expect(unsupportedNarrow[1]).toMatchObject({ width: 'half', presentation: 'standard', column: 0 });
+		expect(widgets[0]).toMatchObject({ width: 'quarter', presentation: 'tiny', column: 9 });
 	});
 
 	test('hides any built-in preset tab and falls back to a custom view', () => {

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -131,6 +131,30 @@ export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: Dashboar
 	return `min-w-0 ${responsive} xl:col-span-12`;
 }
 
+export function updateDashboardWidgetAppearance(
+	widgets: DashboardWidgetConfig[],
+	id: DashboardWidgetId,
+	patch: Partial<Pick<DashboardWidgetConfig, 'width' | 'presentation'>>,
+): DashboardWidgetConfig[] {
+	return widgets.map((widget) => {
+		if (widget.id !== id) return widget;
+		const presentation = patch.presentation === 'tiny' && dashboardWidgetSupportsTiny(id)
+			? 'tiny'
+			: patch.presentation === 'standard' ? 'standard' : widget.presentation;
+		const requestedWidth = patch.width ?? widget.width;
+		const width = (requestedWidth === 'quarter' || requestedWidth === 'third')
+			&& !dashboardWidgetSupportsNarrowWidth(id, presentation)
+			? 'half'
+			: requestedWidth;
+		return {
+			...widget,
+			width,
+			presentation,
+			column: dashboardWidgetSnapColumn(width, widget.column),
+		};
+	});
+}
+
 type DashboardWidgetDefinition = Omit<DashboardWidgetConfig, 'column' | 'row' | 'priority'>;
 
 function positionWidgets(widgets: DashboardWidgetDefinition[]): DashboardWidgetConfig[] {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -19,6 +19,7 @@
 		resolveDashboardWidgets,
 		selectDashboardView,
 		updateActiveDashboardView,
+		updateDashboardWidgetAppearance,
 		type DashboardPreferences,
 		type DashboardFixedPreset,
 		type DashboardWidgetConfig,
@@ -64,7 +65,8 @@
 	import StorageWidget from '$lib/components/dashboard/storage-widget.svelte';
 	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
 	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
-	import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, GripVertical, Settings2 } from '@lucide/svelte';
+	import WidgetOptions from '$lib/components/dashboard/widget-options.svelte';
+	import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, GripVertical, Settings2 } from '@lucide/svelte';
 
 	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
 	type DiskRate = { readRate: number; writeRate: number };
@@ -102,6 +104,9 @@
 	let vms = $state<VmStatus[] | null>(null);
 	let vmFreshness = $state<DashboardHealthFreshness>('loading');
 	let customizeOpen = $state(false);
+	let editingDashboard = $state(false);
+	let customizeButton = $state<HTMLButtonElement | null>(null);
+	let editDoneButton = $state<HTMLButtonElement | null>(null);
 	let refreshTimer: ReturnType<typeof setInterval> | null = null;
 	let refreshTick = 0;
 	let refreshInFlight = false;
@@ -219,6 +224,37 @@
 		dashboardPrefs.set(updateActiveDashboardView(preferences, {
 			widgets: placeDashboardWidget(getActiveDashboardView(preferences).widgets, id, column, row),
 		}));
+	}
+
+	function updateWidgetAppearance(
+		id: DashboardWidgetId,
+		patch: Partial<Pick<DashboardWidgetConfig, 'width' | 'presentation'>>,
+	) {
+		const preferences = dashboardPrefs.value;
+		if (preferences.preset !== 'custom') return;
+		const reloadHistory = id === 'history' && patch.presentation === 'tiny' && metricsOffset > 0;
+		if (reloadHistory) metricsOffset = 0;
+		dashboardPrefs.set(updateActiveDashboardView(preferences, {
+			widgets: updateDashboardWidgetAppearance(getActiveDashboardView(preferences).widgets, id, patch),
+		}));
+		if (reloadHistory) void loadMetrics(true);
+	}
+
+	async function beginDashboardEditing() {
+		if (dashboardPrefs.value.preset !== 'custom') {
+			customizeOpen = true;
+			return;
+		}
+		editingDashboard = true;
+		await tick();
+		editDoneButton?.focus();
+	}
+
+	async function finishDashboardEditing() {
+		editingDashboard = false;
+		endWidgetDrag();
+		await tick();
+		customizeButton?.focus();
 	}
 
 	function announceMovement(message: string) {
@@ -705,12 +741,17 @@
 		await loadMetrics(true);
 	}
 
-	async function applyPreferences(preferences: DashboardPreferences) {
+	async function applyPreferences(preferences: DashboardPreferences, enterEditing = false) {
 		if (resolveDashboardWidgets(preferences).some((widget) => widget.id === 'history' && widget.presentation === 'tiny')) {
 			metricsOffset = 0;
 		}
+		const wasEditing = editingDashboard;
 		dashboardPrefs.set(preferences);
+		editingDashboard = preferences.preset === 'custom' && (wasEditing || enterEditing);
 		await tick();
+		if (enterEditing) {
+			requestAnimationFrame(() => (editingDashboard ? editDoneButton : customizeButton)?.focus());
+		}
 		await loadVisibleData(false);
 	}
 
@@ -723,6 +764,7 @@
 			next = { ...preferences, preset: selection };
 		}
 		if (next === preferences) return;
+		if (next.preset !== 'custom') editingDashboard = false;
 		await applyPreferences(next);
 	}
 
@@ -746,9 +788,16 @@
 		<div>
 			<div class="text-sm font-semibold">{presetLabel} dashboard</div>
 			<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
-			{#if dashboardPrefs.value.preset === 'custom'}<div class="hidden text-xs text-muted-foreground xl:block">Drag a widget handle into a highlighted grid lane, or use its direction controls.</div>{/if}
+			{#if editingDashboard}<div class="text-xs text-muted-foreground">Move widgets with the direction controls or drag handle. Use each options menu to change its size or presentation.</div>{/if}
 		</div>
-		<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Customize</Button>
+		{#if editingDashboard}
+			<div class="flex items-center gap-2">
+				<Button variant="outline" size="sm" onclick={() => customizeOpen = true}><Settings2 /> Widgets & views</Button>
+				<Button bind:ref={editDoneButton} size="sm" onclick={() => void finishDashboardEditing()}><Check /> Done</Button>
+			</div>
+		{:else}
+			<Button bind:ref={customizeButton} variant="outline" size="sm" onclick={() => void beginDashboardEditing()}><Settings2 /> Customize</Button>
+		{/if}
 	</div>
 	<div class="mt-3 overflow-x-auto border-b border-border">
 		<div class="flex min-w-max items-end" role="tablist" aria-label="Dashboard views">
@@ -804,26 +853,29 @@
 				style={widgetGridStyle(widget)}
 				class="self-start rounded-lg transition-[opacity,box-shadow] {dashboardWidgetWidthClass(widget.id, widget.width)} {dashboardPrefs.value.preset === 'custom' ? 'dashboard-positioned' : ''} {draggedWidget === widget.id ? 'opacity-45' : ''}"
 			>
-				{#if dashboardPrefs.value.preset === 'custom' || (widget.id === 'history' && widget.presentation === 'standard')}
+				{#if editingDashboard || (widget.id === 'history' && widget.presentation === 'standard')}
 					<div class="mb-1 flex min-h-8 flex-wrap items-center gap-1 text-muted-foreground xl:flex-nowrap">
-						<span class="text-[0.65rem] font-medium uppercase tracking-wide">{dashboardPrefs.value.preset === 'custom' ? `${dashboardWidgetMeta[widget.id].label}${widget.id === 'history' && historyLoading ? ' - loading' : ''}` : `History${historyLoading ? ' - loading' : ''}`}</span>
+						<span class="text-[0.65rem] font-medium uppercase tracking-wide">{editingDashboard ? `${dashboardWidgetMeta[widget.id].label}${widget.id === 'history' && historyLoading ? ' - loading' : ''}` : `History${historyLoading ? ' - loading' : ''}`}</span>
 						{#if widget.id === 'history' && widget.presentation === 'standard'}
 							{#if metricsOffset > 0}
 								<span class="ml-1 min-w-0 truncate text-xs normal-case tracking-normal" title={`${new Date(Date.now() - metricsOffset - rangeDurations[metricsRange]).toLocaleString()} - ${new Date(Date.now() - metricsOffset).toLocaleString()}`}>{new Date(Date.now() - metricsOffset - rangeDurations[metricsRange]).toLocaleString()} - {new Date(Date.now() - metricsOffset).toLocaleString()}</span>
 							{/if}
 							<HistoryControls range={metricsRange} offset={metricsOffset} loading={historyLoading} class="ml-auto" onRange={(range) => void changeRange(range)} onBack={() => void navigateBack()} onForward={() => void navigateForward()} onLive={() => void navigateLive()} />
 						{/if}
-						{#if dashboardPrefs.value.preset === 'custom'}
-							<div class="ml-auto flex xl:hidden">
-								<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
-								<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
-							</div>
-							<div class="ml-auto hidden opacity-50 transition-opacity hover:opacity-100 focus-within:opacity-100 xl:flex">
-								<button type="button" onclick={() => moveCustomWidget(widget.id, -1, 0)} disabled={!position || position.column === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} left`}><ArrowLeft class="h-3.5 w-3.5" /></button>
-								<button type="button" onclick={() => moveCustomWidget(widget.id, 1, 0)} disabled={!position || position.column + position.columnSpan >= 12} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} right`}><ArrowRight class="h-3.5 w-3.5" /></button>
-								<button type="button" onclick={() => moveCustomWidget(widget.id, 0, -1)} disabled={!position || position.row === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp class="h-3.5 w-3.5" /></button>
-								<button type="button" onclick={() => moveCustomWidget(widget.id, 0, 1)} class="rounded p-1.5 hover:bg-accent hover:text-foreground" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown class="h-3.5 w-3.5" /></button>
-								<span draggable={true} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="inline-flex cursor-grab rounded p-1.5 hover:bg-accent hover:text-foreground active:cursor-grabbing" title="Drag to a grid position" aria-hidden="true"><GripVertical class="h-3.5 w-3.5" /></span>
+						{#if editingDashboard}
+							<div class="ml-auto flex items-center">
+								<div class="flex xl:hidden">
+									<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, -1)} disabled={widgets[0]?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} earlier`}><ArrowUp class="h-3.5 w-3.5" /></button>
+									<button type="button" onclick={() => moveCustomWidgetInOrder(widget.id, 1)} disabled={widgets.at(-1)?.id === widget.id} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} later`}><ArrowDown class="h-3.5 w-3.5" /></button>
+								</div>
+								<div class="hidden opacity-50 transition-opacity hover:opacity-100 focus-within:opacity-100 xl:flex">
+									<button type="button" onclick={() => moveCustomWidget(widget.id, -1, 0)} disabled={!position || position.column === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} left`}><ArrowLeft class="h-3.5 w-3.5" /></button>
+									<button type="button" onclick={() => moveCustomWidget(widget.id, 1, 0)} disabled={!position || position.column + position.columnSpan >= 12} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} right`}><ArrowRight class="h-3.5 w-3.5" /></button>
+									<button type="button" onclick={() => moveCustomWidget(widget.id, 0, -1)} disabled={!position || position.row === 0} class="rounded p-1.5 hover:bg-accent hover:text-foreground disabled:opacity-20" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} up`}><ArrowUp class="h-3.5 w-3.5" /></button>
+									<button type="button" onclick={() => moveCustomWidget(widget.id, 0, 1)} class="rounded p-1.5 hover:bg-accent hover:text-foreground" aria-label={`Move ${dashboardWidgetMeta[widget.id].label} down`}><ArrowDown class="h-3.5 w-3.5" /></button>
+									<span draggable={true} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="inline-flex cursor-grab rounded p-1.5 hover:bg-accent hover:text-foreground active:cursor-grabbing" title="Drag to a grid position" aria-hidden="true"><GripVertical class="h-3.5 w-3.5" /></span>
+								</div>
+								<WidgetOptions {widget} onChange={(patch) => updateWidgetAppearance(widget.id, patch)} />
 							</div>
 						{/if}
 					</div>
@@ -859,7 +911,7 @@
 {/if}
 </div>
 
-<CustomizeDialog bind:open={customizeOpen} preferences={dashboardPrefs.value} onSave={(preferences) => void applyPreferences(preferences)} />
+<CustomizeDialog bind:open={customizeOpen} preferences={dashboardPrefs.value} onSave={(preferences) => void applyPreferences(preferences, true)} />
 
 <style>
 	@media (min-width: 80rem) {


### PR DESCRIPTION
## Summary
- hide dashboard movement controls until customization mode is active
- add per-widget options for supported widths and tiny/standard presentation
- preserve layout constraints, History live data behavior, and keyboard focus across edit transitions

## Testing
- `npm run check`
- `npm test` (281 tests)
- `npm run build`
- `git diff --check origin/main...HEAD`