### PR TITLE
Add dashboard clock and backup schedule widgets

### DIFF
--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -743,6 +743,57 @@ pub struct BackupStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BackupScheduleEntry {
+    pub profile_id: String,
+    pub profile_name: String,
+    pub schedule: String,
+    /// Next nominal cron occurrence in UTC, formatted as RFC 3339.
+    pub next_run_at: Option<String>,
+    /// Present when an enabled profile contains an invalid cron expression.
+    pub schedule_error: Option<String>,
+    pub last_run: Option<BackupRunResult>,
+}
+
+fn schedule_entries(
+    profiles: &[BackupProfile],
+    now: chrono::DateTime<chrono::Utc>,
+) -> Vec<BackupScheduleEntry> {
+    let mut entries: Vec<_> = profiles
+        .iter()
+        .filter(|profile| profile.enabled)
+        .filter_map(|profile| {
+            let expression = profile.schedule.as_deref()?.trim();
+            if expression.is_empty() {
+                return None;
+            }
+            let (next_run_at, schedule_error) = match scheduler::parse_cron(expression) {
+                Ok(schedule) => (
+                    schedule.after(&now).next().map(|next| next.to_rfc3339()),
+                    None,
+                ),
+                Err(error) => (None, Some(error.to_string())),
+            };
+            Some(BackupScheduleEntry {
+                profile_id: profile.id.clone(),
+                profile_name: profile.name.clone(),
+                schedule: expression.to_string(),
+                next_run_at,
+                schedule_error,
+                last_run: profile.last_run.clone(),
+            })
+        })
+        .collect();
+    entries.sort_by(|left, right| {
+        left.next_run_at
+            .is_none()
+            .cmp(&right.next_run_at.is_none())
+            .then_with(|| left.next_run_at.cmp(&right.next_run_at))
+            .then_with(|| left.profile_name.cmp(&right.profile_name))
+    });
+    entries
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RestoreSummary {
     /// Number of files written to the destination.
     pub files_restored: u64,
@@ -894,6 +945,14 @@ impl BackupService {
             .iter()
             .map(|p| p.redacted())
             .collect()
+    }
+
+    pub async fn list_schedule(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<BackupScheduleEntry> {
+        let profiles = self.profiles.lock().await;
+        schedule_entries(&profiles, now)
     }
 
     /// Return the in-memory profiles only after verifying that persisted state
@@ -1557,6 +1616,7 @@ async fn save_profiles(profiles: &[BackupProfile]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     #[test]
     fn backup_sources_must_not_be_empty() {
@@ -1625,6 +1685,36 @@ mod tests {
         };
         invalidate_last_run_if_definition_changed(&mut retargeted, &existing);
         assert!(retargeted.last_run.is_none());
+    }
+
+    #[test]
+    fn schedule_entries_use_scheduler_cron_and_sort_invalid_last() {
+        let now = chrono::Utc.with_ymd_and_hms(2026, 9, 2, 20, 0, 0).unwrap();
+        let mut daily = baseline_profile(BackupTarget::Local {
+            path: "/backup".into(),
+        });
+        daily.id = "daily".into();
+        daily.name = "Daily data".into();
+        daily.schedule = Some("0 3 * * *".into());
+        let mut invalid = daily.clone();
+        invalid.id = "invalid".into();
+        invalid.name = "Broken".into();
+        invalid.schedule = Some("not cron".into());
+        let mut disabled = daily.clone();
+        disabled.id = "disabled".into();
+        disabled.enabled = false;
+
+        let entries = schedule_entries(&[invalid, disabled, daily], now);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].profile_id, "daily");
+        assert_eq!(
+            entries[0].next_run_at.as_deref(),
+            Some("2026-09-03T03:00:00+00:00")
+        );
+        assert!(entries[0].schedule_error.is_none());
+        assert_eq!(entries[1].profile_id, "invalid");
+        assert!(entries[1].next_run_at.is_none());
+        assert!(entries[1].schedule_error.is_some());
     }
 
     fn s3_with_plaintext(secret: &str, region: Option<&str>) -> BackupTarget {

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -18,7 +18,7 @@ use nasty_apps::{
     ManagedNetwork, NetworkSummary, PortConflict, PruneResult, SetComposeStartupRequest,
     SetIngressRequest, VolumeMismatch,
 };
-use nasty_backup::{BackupProfile, BackupSnapshot, BackupStatus};
+use nasty_backup::{BackupProfile, BackupScheduleEntry, BackupSnapshot, BackupStatus};
 use nasty_sharing::iscsi::{
     AddAclRequest, AddLunRequest, AddPortalRequest, CreateTargetRequest, DeleteTargetRequest,
     IscsiTarget, RemoveAclRequest, RemoveLunRequest, RemovePortalRequest, RepairLunRequest,
@@ -2621,6 +2621,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<BackupProfile>>(generator)),
+                },
+                Method {
+                    name: "backup.schedule.list",
+                    desc: "Return enabled backup schedules with their next nominal UTC cron occurrence.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<Vec<BackupScheduleEntry>>(generator)),
                 },
                 Method {
                     name: "backup.profile.get",

--- a/engine/nasty-engine/src/router/backup.rs
+++ b/engine/nasty-engine/src/router/backup.rs
@@ -66,6 +66,7 @@ pub(super) async fn try_route(
 ) -> Option<Response> {
     Some(match req.method.as_str() {
         "backup.profile.list" => ok(req, state.backups.list_profiles().await),
+        "backup.schedule.list" => ok(req, state.backups.list_schedule(chrono::Utc::now()).await),
         "backup.profile.get" => match require_str(req, "id") {
             Ok(id) => match state.backups.get_profile(id).await {
                 Ok(v) => ok(req, v),

--- a/engine/nasty-system/src/lib.rs
+++ b/engine/nasty-system/src/lib.rs
@@ -95,6 +95,8 @@ pub struct SystemInfo {
     pub timezone: String,
     /// Whether the system clock is NTP-synchronized.
     pub ntp_synced: bool,
+    /// Current system time in UTC, formatted as RFC 3339.
+    pub current_time: String,
     /// Whether the loaded bcachefs kernel module contains debug symbols.
     pub bcachefs_debug_symbols: bool,
     /// Whether the RUNNING bcachefs module was built with debug checks.
@@ -353,6 +355,7 @@ impl SystemService {
             bcachefs_is_custom,
             timezone,
             ntp_synced,
+            current_time: chrono::Utc::now().to_rfc3339(),
             bcachefs_debug_symbols: cached.debug_symbols,
             bcachefs_debug_checks: cached.bcachefs_debug_checks,
             kvm_available: std::path::Path::new("/dev/kvm").exists(),

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -254,6 +254,9 @@ pub struct Settings {
     /// Whether to display clocks in 24-hour format.
     #[serde(default = "default_clock_24h")]
     pub clock_24h: bool,
+    /// Optional message shown with the dashboard clock.
+    #[serde(default)]
+    pub dashboard_motd: String,
     /// Unit for displayed temperatures (CPU, disks, alert thresholds).
     /// Storage and alert evaluation always use Celsius internally — this
     /// only affects rendering in the WebUI.
@@ -535,6 +538,7 @@ impl Default for Settings {
             timezone: default_timezone(),
             hostname: None,
             clock_24h: default_clock_24h(),
+            dashboard_motd: String::new(),
             temp_unit: TempUnit::default(),
             tls_domain: None,
             files_domain: None,
@@ -561,6 +565,8 @@ pub struct SettingsUpdate {
     pub hostname: Option<String>,
     /// Whether to use 24-hour clock display (optional).
     pub clock_24h: Option<bool>,
+    /// Message shown with the dashboard clock (optional, empty clears it).
+    pub dashboard_motd: Option<String>,
     /// Display unit for temperatures (optional).
     pub temp_unit: Option<TempUnit>,
     /// Domain name for Let's Encrypt TLS (set to empty string to disable).
@@ -685,6 +691,11 @@ impl SettingsService {
     pub async fn update(&self, update: SettingsUpdate) -> Result<Settings, String> {
         let mut current = self.state.write().await;
         let mut settings = current.clone();
+        let dashboard_motd = update
+            .dashboard_motd
+            .as_deref()
+            .map(normalize_dashboard_motd)
+            .transpose()?;
         // Validate and stage the coupled TLS fields before applying any
         // external side effects such as timezone or hostname changes.
         let mut tls_changed = apply_domain_updates(
@@ -711,6 +722,9 @@ impl SettingsService {
         }
         if let Some(h24) = update.clock_24h {
             settings.clock_24h = h24;
+        }
+        if let Some(motd) = dashboard_motd {
+            settings.dashboard_motd = motd;
         }
         if let Some(unit) = update.temp_unit {
             settings.temp_unit = unit;
@@ -810,6 +824,19 @@ impl SettingsService {
         }
         Ok(settings)
     }
+}
+
+const DASHBOARD_MOTD_MAX_CHARS: usize = 500;
+
+fn normalize_dashboard_motd(value: &str) -> Result<String, String> {
+    let value = value.trim();
+    let length = value.chars().count();
+    if length > DASHBOARD_MOTD_MAX_CHARS {
+        return Err(format!(
+            "dashboard message is too long ({length} > {DASHBOARD_MOTD_MAX_CHARS} characters)"
+        ));
+    }
+    Ok(value.to_string())
 }
 
 /// Validate a non-empty files portal hostname as an ASCII FQDN suitable for a
@@ -2089,11 +2116,12 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        AcmeJournalState, EncryptedBlob, OidcSettings, Settings, SettingsUpdate,
-        apply_domain_updates, build_policy_set, caddy_acme_env, certificate_endpoint_allowed,
-        certificate_expires_in_days, certificate_state, classify_acme_journal_event,
-        merge_host_lists, redact_oidc_secret, resolve_dns_credentials, to_nix_string,
-        validate_files_domain, wildcard_covers_host,
+        AcmeJournalState, DASHBOARD_MOTD_MAX_CHARS, EncryptedBlob, OidcSettings, Settings,
+        SettingsUpdate, apply_domain_updates, build_policy_set, caddy_acme_env,
+        certificate_endpoint_allowed, certificate_expires_in_days, certificate_state,
+        classify_acme_journal_event, merge_host_lists, normalize_dashboard_motd,
+        redact_oidc_secret, resolve_dns_credentials, to_nix_string, validate_files_domain,
+        wildcard_covers_host,
     };
 
     fn fake_blob() -> EncryptedBlob {
@@ -2266,6 +2294,19 @@ mod tests {
         value.as_object_mut().unwrap().remove("files_domain");
         let settings: Settings = serde_json::from_value(value).unwrap();
         assert_eq!(settings.files_domain, None);
+    }
+
+    #[test]
+    fn dashboard_motd_defaults_and_normalizes_safely() {
+        let mut value = serde_json::to_value(Settings::default()).unwrap();
+        value.as_object_mut().unwrap().remove("dashboard_motd");
+        let settings: Settings = serde_json::from_value(value).unwrap();
+        assert!(settings.dashboard_motd.is_empty());
+        assert_eq!(
+            normalize_dashboard_motd("  Storage maintenance tonight.  ").unwrap(),
+            "Storage maintenance tonight."
+        );
+        assert!(normalize_dashboard_motd(&"x".repeat(DASHBOARD_MOTD_MAX_CHARS + 1)).is_err());
     }
 
     #[test]

--- a/webui/src/lib/components/dashboard/clock-widget.svelte
+++ b/webui/src/lib/components/dashboard/clock-widget.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import { onMount, untrack } from 'svelte';
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { Settings, SystemInfo } from '$lib/types';
+	import { Card, CardContent } from '$lib/components/ui/card';
+
+	let {
+		info = null,
+		settings = null,
+		loaded,
+		density,
+	}: {
+		info?: SystemInfo | null;
+		settings?: Settings | null;
+		loaded: boolean;
+		density: DashboardDensity;
+	} = $props();
+
+	function hostOffset(currentTime: string | undefined): number | null {
+		if (!currentTime) return null;
+		const timestamp = Date.parse(currentTime);
+		return Number.isFinite(timestamp) ? timestamp - Date.now() : null;
+	}
+
+	let now = $state(new Date());
+	let serverOffset = $state<number | null>(hostOffset(untrack(() => info?.current_time)));
+	let timezone = $derived(info?.timezone ?? settings?.timezone ?? 'UTC');
+	let hostNow = $derived(serverOffset === null ? null : new Date(now.getTime() + serverOffset));
+	let clockParts = $derived(hostNow ? getClockParts(hostNow, timezone) : { hour: 0, minute: 0, second: 0 });
+	let hourAngle = $derived((clockParts.hour % 12 + clockParts.minute / 60) * 30);
+	let minuteAngle = $derived((clockParts.minute + clockParts.second / 60) * 6);
+	let secondAngle = $derived(clockParts.second * 6);
+	let formattedTime = $derived(hostNow ? new Intl.DateTimeFormat(undefined, {
+		hour: 'numeric',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: !(settings?.clock_24h ?? true),
+		timeZone: timezone,
+	}).format(hostNow) : '');
+	let formattedDate = $derived(hostNow ? new Intl.DateTimeFormat(undefined, {
+		weekday: 'long',
+		month: 'long',
+		day: 'numeric',
+		year: 'numeric',
+		timeZone: timezone,
+	}).format(hostNow) : '');
+
+	$effect(() => {
+		serverOffset = hostOffset(info?.current_time);
+		now = new Date();
+	});
+
+	onMount(() => {
+		const timer = window.setInterval(() => now = new Date(), 1_000);
+		return () => window.clearInterval(timer);
+	});
+
+	function getClockParts(date: Date, timeZone: string) {
+		const parts = new Intl.DateTimeFormat('en-US', {
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+			hourCycle: 'h23',
+			timeZone,
+		}).formatToParts(date);
+		const value = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((part) => part.type === type)?.value ?? 0);
+		return { hour: value('hour'), minute: value('minute'), second: value('second') };
+	}
+</script>
+
+<Card class="h-full overflow-hidden">
+	<CardContent class={density === 'compact' ? 'p-3' : 'p-4'}>
+		{#if hostNow}
+			<div class="flex items-center gap-4">
+				<svg viewBox="0 0 100 100" class="h-24 w-24 shrink-0 text-foreground" role="img" aria-label={`Analog clock showing ${formattedTime}`}>
+					<circle cx="50" cy="50" r="46" class="fill-secondary/30 stroke-border" stroke-width="2" />
+					{#each Array.from({ length: 12 }) as _, index}
+						<line x1="50" y1="7" x2="50" y2={index % 3 === 0 ? 14 : 11} transform={`rotate(${index * 30} 50 50)`} class="stroke-muted-foreground" stroke-width={index % 3 === 0 ? 2 : 1} stroke-linecap="round" />
+					{/each}
+					<line x1="50" y1="50" x2="50" y2="28" transform={`rotate(${hourAngle} 50 50)`} class="stroke-foreground" stroke-width="4" stroke-linecap="round" />
+					<line x1="50" y1="50" x2="50" y2="19" transform={`rotate(${minuteAngle} 50 50)`} class="stroke-foreground" stroke-width="2.5" stroke-linecap="round" />
+					<line x1="50" y1="55" x2="50" y2="15" transform={`rotate(${secondAngle} 50 50)`} class="stroke-primary" stroke-width="1.25" stroke-linecap="round" />
+					<circle cx="50" cy="50" r="3" class="fill-primary" />
+				</svg>
+				<div class="min-w-0">
+					<div class="truncate text-2xl font-bold tabular-nums" title={formattedTime}>{formattedTime}</div>
+					<div class="mt-1 text-sm text-muted-foreground">{formattedDate}</div>
+					<div class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+						<span class="font-mono">{timezone}</span>
+						<span class="flex items-center gap-1.5">
+							<span class="h-1.5 w-1.5 rounded-full {info?.ntp_synced ? 'bg-emerald-500' : 'bg-amber-500'}"></span>
+							{info?.ntp_synced ? 'NTP synchronized' : 'NTP not synchronized'}
+						</span>
+					</div>
+				</div>
+			</div>
+		{:else}
+			<div class="flex min-h-24 items-center justify-center text-sm text-muted-foreground" role="status">
+				{loaded ? 'Host time is unavailable.' : 'Loading host time...'}
+			</div>
+		{/if}
+		{#if settings?.dashboard_motd}
+			<div class="mt-4 break-words whitespace-pre-line border-t border-border pt-3 text-sm leading-relaxed">{settings.dashboard_motd}</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/clock-widget.svelte
+++ b/webui/src/lib/components/dashboard/clock-widget.svelte
@@ -68,7 +68,7 @@
 	}
 </script>
 
-<Card class="h-full overflow-hidden">
+<Card class="h-full gap-0 overflow-hidden py-0">
 	<CardContent class={density === 'compact' ? 'p-3' : 'p-4'}>
 		{#if hostNow}
 			<div class="flex items-center gap-4">

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -1,14 +1,16 @@
 import { render } from 'svelte/server';
 import { describe, expect, test } from 'vitest';
 import AlertsWidget from './alerts-widget.svelte';
+import ClockWidget from './clock-widget.svelte';
 import ComputeWidget from './compute-widget.svelte';
 import HealthWidget from './health-widget.svelte';
 import HistoryWidget from './history-widget.svelte';
 import OperationsWidget from './operations-widget.svelte';
+import ScheduleWidget from './schedule-widget.svelte';
 import SummaryWidget from './summary-widget.svelte';
 import SystemWidget from './system-widget.svelte';
 import WidgetOptions from './widget-options.svelte';
-import type { ActiveAlert, AppsStatus, Filesystem, SystemInfo, SystemStats, VmStatus } from '$lib/types';
+import type { ActiveAlert, AppsStatus, BackupScheduleEntry, Filesystem, Settings, SystemInfo, SystemStats, VmStatus } from '$lib/types';
 
 const alert = (severity: ActiveAlert['severity'], message: string): ActiveAlert => ({
 	rule_id: message,
@@ -37,6 +39,7 @@ const info: SystemInfo = {
 	bcachefs_is_custom: false,
 	timezone: 'UTC',
 	ntp_synced: true,
+	current_time: '2026-09-02T20:00:00Z',
 };
 
 const stats: SystemStats = {
@@ -64,6 +67,12 @@ const appsStatus: AppsStatus = {
 	app_count: 2,
 	storage_ok: true,
 };
+
+const settings = {
+	timezone: 'UTC',
+	clock_24h: true,
+	dashboard_motd: 'Storage maintenance tonight.',
+} as Settings;
 
 const vm = (name: string, running: boolean, cpus: number, memory_mib: number): VmStatus => ({
 	id: name,
@@ -312,6 +321,59 @@ describe('dashboard compute widget', () => {
 		expect(loading).not.toContain('could not be loaded');
 		expect(partial).toContain('Inventory unavailable');
 		expect(partial).toContain('2 configured apps.');
+	});
+});
+
+describe('dashboard clock and schedule widgets', () => {
+	test('renders host time state and the configured dashboard notice', () => {
+		const body = render(ClockWidget, {
+			props: { info, settings, loaded: true, density: 'comfortable' },
+		}).body;
+
+		expect(body).toContain('Analog clock showing');
+		expect(body).toContain('UTC');
+		expect(body).toContain('NTP synchronized');
+		expect(body).toContain('Storage maintenance tonight.');
+	});
+
+	test('does not substitute browser time when host time is unavailable', () => {
+		const legacyInfo = { ...info, current_time: undefined } as unknown as SystemInfo;
+		const body = render(ClockWidget, {
+			props: { info: legacyInfo, settings, loaded: true, density: 'comfortable' },
+		}).body;
+
+		expect(body).toContain('Host time is unavailable.');
+		expect(body).not.toContain('Analog clock showing');
+	});
+
+	test('renders upcoming and invalid backup schedules explicitly', () => {
+		const entries: BackupScheduleEntry[] = [
+			{
+				profile_id: 'daily',
+				profile_name: 'Daily data',
+				schedule: '0 3 * * *',
+				next_run_at: '2099-09-03T03:00:00+00:00',
+				schedule_error: null,
+				last_run: null,
+			},
+			{
+				profile_id: 'broken',
+				profile_name: 'Broken profile',
+				schedule: 'not cron',
+				next_run_at: null,
+				schedule_error: 'invalid cron',
+				last_run: null,
+			},
+		];
+		const body = render(ScheduleWidget, {
+			props: { entries, currentTime: info.current_time, freshness: 'current', density: 'comfortable' },
+		}).body;
+
+		expect(body).toContain('Upcoming backups');
+		expect(body).toContain('Daily data');
+		expect(body).toContain('Broken profile');
+		expect(body).toContain('Invalid schedule');
+		expect(body).toContain('href="/backups"');
 	});
 });
 

--- a/webui/src/lib/components/dashboard/schedule-widget.svelte
+++ b/webui/src/lib/components/dashboard/schedule-widget.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { onMount, untrack } from 'svelte';
+	import type { DashboardDensity } from '$lib/dashboard.svelte';
+	import type { DashboardHealthFreshness } from '$lib/dashboard-health';
+	import type { BackupScheduleEntry } from '$lib/types';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import { CalendarClock } from '@lucide/svelte';
+
+	let {
+		entries = null,
+		currentTime = null,
+		freshness,
+		density,
+	}: {
+		entries?: BackupScheduleEntry[] | null;
+		currentTime?: string | null;
+		freshness: DashboardHealthFreshness;
+		density: DashboardDensity;
+	} = $props();
+
+	function hostOffset(timestamp: string | null): number | null {
+		if (!timestamp) return null;
+		const parsed = Date.parse(timestamp);
+		return Number.isFinite(parsed) ? parsed - Date.now() : null;
+	}
+
+	let now = $state(new Date());
+	let serverOffset = $state<number | null>(hostOffset(untrack(() => currentTime)));
+	let hostNow = $derived(serverOffset === null ? null : new Date(now.getTime() + serverOffset));
+	let visibleEntries = $derived((entries ?? []).slice(0, density === 'compact' ? 3 : 4));
+
+	$effect(() => {
+		serverOffset = hostOffset(currentTime);
+		now = new Date();
+	});
+
+	onMount(() => {
+		const timer = window.setInterval(() => now = new Date(), 30_000);
+		return () => window.clearInterval(timer);
+	});
+
+	function datePart(timestamp: string, part: 'day' | 'month'): string {
+		return new Intl.DateTimeFormat(undefined, {
+			day: part === 'day' ? '2-digit' : undefined,
+			month: part === 'month' ? 'short' : undefined,
+			timeZone: 'UTC',
+		}).format(new Date(timestamp));
+	}
+
+	function timeLabel(timestamp: string): string {
+		return new Intl.DateTimeFormat(undefined, {
+			weekday: 'short',
+			hour: '2-digit',
+			minute: '2-digit',
+			hourCycle: 'h23',
+			timeZone: 'UTC',
+		}).format(new Date(timestamp));
+	}
+
+	function relativeLabel(timestamp: string): string | null {
+		if (!hostNow) return null;
+		const minutes = Math.max(0, Math.ceil((new Date(timestamp).getTime() - hostNow.getTime()) / 60_000));
+		if (minutes < 1) return 'due now';
+		if (minutes < 60) return `in ${minutes}m`;
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return `in ${hours}h ${minutes % 60}m`;
+		const days = Math.floor(hours / 24);
+		return `in ${days}d ${hours % 24}h`;
+	}
+</script>
+
+<Card class="h-full overflow-hidden">
+	<CardContent class={density === 'compact' ? 'p-3' : 'p-4'}>
+		<div class="mb-3 flex items-center justify-between gap-3">
+			<div class="flex items-center gap-2">
+				<CalendarClock class="h-4 w-4 text-primary" />
+				<span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Upcoming backups</span>
+			</div>
+			<div class="flex items-center gap-2 text-[0.68rem] font-medium text-muted-foreground">
+				{#if freshness === 'refreshing'}<span>Refreshing</span>{/if}
+				{#if freshness === 'stale'}<span class="text-amber-500" role="status">Stale</span>{/if}
+				<span>Next cron - UTC</span>
+			</div>
+		</div>
+
+		{#if freshness === 'loading'}
+			<p class="text-sm text-muted-foreground">Loading backup schedule...</p>
+		{:else if freshness === 'unavailable' || entries === null}
+			<p class="text-sm text-muted-foreground">Backup schedule could not be loaded.</p>
+		{:else if entries.length === 0}
+			<div class="rounded-md border border-dashed border-border px-3 py-4 text-center">
+				<p class="text-sm font-medium">No scheduled backups</p>
+				<a href="/backups" class="mt-1 inline-block text-xs text-primary hover:underline">Manage backup profiles</a>
+			</div>
+		{:else}
+			<div class="divide-y divide-border">
+				{#each visibleEntries as entry}
+					{@const relative = entry.next_run_at ? relativeLabel(entry.next_run_at) : null}
+					<a href="/backups" class="flex items-center gap-3 py-2 first:pt-0 last:pb-0 outline-none hover:text-primary focus-visible:ring-2 focus-visible:ring-ring" title={entry.schedule_error ?? entry.schedule}>
+						{#if entry.next_run_at}
+							<div class="w-11 shrink-0 rounded-md border border-border bg-secondary/30 py-1 text-center leading-none">
+								<div class="text-[0.6rem] font-semibold uppercase text-muted-foreground">{datePart(entry.next_run_at, 'month')}</div>
+								<div class="mt-1 text-lg font-bold tabular-nums">{datePart(entry.next_run_at, 'day')}</div>
+							</div>
+						{:else}
+							<div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-amber-500/50 bg-amber-500/10 text-lg font-bold text-amber-500">!</div>
+						{/if}
+						<div class="min-w-0 flex-1">
+							<div class="truncate text-sm font-semibold">{entry.profile_name}</div>
+							{#if entry.next_run_at}
+								<div class="mt-0.5 text-xs text-muted-foreground">{timeLabel(entry.next_run_at)}{relative ? ` - ${relative}` : ''}</div>
+							{:else}
+								<div class="mt-0.5 truncate text-xs text-amber-500">{entry.schedule_error ? 'Invalid schedule' : 'No future runs'}</div>
+							{/if}
+						</div>
+						{#if entry.last_run}
+							<span class="h-2 w-2 shrink-0 rounded-full {entry.last_run.success ? 'bg-emerald-500' : 'bg-red-500'}" title={`Last run ${entry.last_run.success ? 'succeeded' : 'failed'}`}>
+								<span class="sr-only">Last run {entry.last_run.success ? 'succeeded' : 'failed'}</span>
+							</span>
+						{/if}
+					</a>
+				{/each}
+			</div>
+			{#if entries.length > visibleEntries.length}
+				<a href="/backups" class="mt-3 block text-right text-xs text-primary hover:underline">{entries.length - visibleEntries.length} more scheduled</a>
+			{/if}
+		{/if}
+	</CardContent>
+</Card>

--- a/webui/src/lib/components/dashboard/schedule-widget.svelte
+++ b/webui/src/lib/components/dashboard/schedule-widget.svelte
@@ -69,7 +69,7 @@
 	}
 </script>
 
-<Card class="h-full overflow-hidden">
+<Card class="h-full gap-0 overflow-hidden py-0">
 	<CardContent class={density === 'compact' ? 'p-3' : 'p-4'}>
 		<div class="mb-3 flex items-center justify-between gap-3">
 			<div class="flex items-center gap-2">

--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -6,6 +6,7 @@ import {
 	LEGACY_DASHBOARD_V3_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V4_PREFERENCES_KEY,
 	LEGACY_DASHBOARD_V5_PREFERENCES_KEY,
+	LEGACY_DASHBOARD_V6_PREFERENCES_KEY,
 	createDashboardView,
 	dashboardPrefs,
 	dashboardPresetTabVisible,
@@ -43,7 +44,7 @@ describe('dashboard preferences', () => {
 	test('defaults missing, malformed, and unknown versions to overview', () => {
 		expect(parseDashboardPreferences(null).preset).toBe('overview');
 		expect(parseDashboardPreferences('{')).toEqual(defaultDashboardPreferences());
-		expect(parseDashboardPreferences('{"version":7,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
+		expect(parseDashboardPreferences('{"version":8,"preset":"storage"}')).toEqual(defaultDashboardPreferences());
 	});
 
 	test('migrates the v1 custom layout without losing its configuration', () => {
@@ -57,7 +58,7 @@ describe('dashboard preferences', () => {
 			],
 		}));
 
-		expect(parsed.version).toBe(6);
+		expect(parsed.version).toBe(7);
 		expect(parsed.preset).toBe('custom');
 		expect(parsed.customViews).toHaveLength(1);
 		expect(getActiveDashboardView(parsed)).toMatchObject({
@@ -65,7 +66,7 @@ describe('dashboard preferences', () => {
 			density: 'compact',
 		});
 		expect(getActiveDashboardView(parsed).widgets[0]).toEqual({ id: 'storage', visible: false, width: 'half', presentation: 'standard', column: 0, row: 0, priority: 0 });
-		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(14);
+		expect(new Set(getActiveDashboardView(parsed).widgets.map((widget) => widget.id)).size).toBe(16);
 		expect(getActiveDashboardView(parsed).widgets.find((widget) => widget.id === 'compute')).toMatchObject({ visible: false, width: 'half' });
 	});
 
@@ -85,13 +86,13 @@ describe('dashboard preferences', () => {
 			}],
 		}));
 
-		expect(parsed.version).toBe(6);
+		expect(parsed.version).toBe(7);
 		expect(parsed.activeViewId).toBe('daily');
 		expect(getActiveDashboardView(parsed)).toMatchObject({ name: 'Daily', density: 'compact' });
 		expect(getActiveDashboardView(parsed).widgets.every((widget) => widget.presentation === 'standard')).toBe(true);
 	});
 
-	test('initializes v6 storage from the newest available legacy key without overwriting v6 preferences', () => {
+	test('initializes v7 storage from the newest available legacy key without overwriting v7 preferences', () => {
 		localStorage.clear();
 		localStorage.setItem(LEGACY_DASHBOARD_PREFERENCES_KEY, JSON.stringify({
 			version: 1,
@@ -128,10 +129,15 @@ describe('dashboard preferences', () => {
 			version: 5,
 			preset: 'monitoring',
 		}));
-		expect(initializeDashboardPreferences(localStorage).preset).toBe('monitoring');
-		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+		localStorage.setItem(LEGACY_DASHBOARD_V6_PREFERENCES_KEY, JSON.stringify({
+			...defaultDashboardPreferences(),
 			version: 6,
-			preset: 'monitoring',
+			preset: 'custom',
+		}));
+		expect(initializeDashboardPreferences(localStorage).preset).toBe('custom');
+		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
+			version: 7,
+			preset: 'custom',
 		});
 
 		const stored = defaultDashboardPreferences();
@@ -198,7 +204,7 @@ describe('dashboard preferences', () => {
 		expect(widgets.find((widget) => widget.id === 'container_health')).toMatchObject({ column: 6, row: 0, priority: 0 });
 	});
 
-	test('adds Compute disabled without disturbing deployed v6 widget placement', () => {
+	test('adds new widgets disabled without disturbing deployed v6 widget placement', () => {
 		const existingWidgets: DashboardWidgetConfig[] = [
 			{ id: 'alerts', visible: false, width: 'full', presentation: 'tiny', column: 0, row: 7, priority: 4 },
 			{ id: 'storage', visible: true, width: 'half', presentation: 'standard', column: 6, row: 3, priority: 2 },
@@ -218,6 +224,8 @@ describe('dashboard preferences', () => {
 			width: 'half',
 			presentation: 'standard',
 		});
+		expect(widgets.find((widget) => widget.id === 'clock')).toMatchObject({ visible: false, width: 'quarter' });
+		expect(widgets.find((widget) => widget.id === 'schedule')).toMatchObject({ visible: false, width: 'half' });
 	});
 
 	test('normalizes named views, active selection, and newly added widget ids', () => {
@@ -245,7 +253,7 @@ describe('dashboard preferences', () => {
 		expect(parsed.activeViewId).toBe('ops');
 		expect(parsed.customViews.map((view) => view.id)).toEqual(['ops', 'custom-1']);
 		expect(parsed.customViews.map((view) => view.name)).toEqual(['Operations', 'operations 2']);
-		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(14);
+		expect(new Set(parsed.customViews[0].widgets.map((widget) => widget.id)).size).toBe(16);
 		expect(resolveDashboardWidgets(parsed)).not.toContainEqual(expect.objectContaining({ id: 'storage' }));
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'storage')?.presentation).toBe('standard');
 		expect(parsed.customViews[0].widgets.find((widget) => widget.id === 'alerts')?.presentation).toBe('tiny');
@@ -268,7 +276,7 @@ describe('dashboard preferences', () => {
 	test('limits narrow widths to compact-safe presentations', () => {
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'standard')).toBe(false);
 		expect(dashboardWidgetSupportsNarrowWidth('alerts', 'tiny')).toBe(true);
-		for (const id of ['service_health', 'container_health', 'compute', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'] as const) {
+		for (const id of ['service_health', 'container_health', 'compute', 'clock', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'] as const) {
 			expect(dashboardWidgetSupportsNarrowWidth(id, 'standard')).toBe(true);
 		}
 		expect(dashboardWidgetSupportsNarrowWidth('storage', 'standard')).toBe(false);
@@ -285,6 +293,7 @@ describe('dashboard preferences', () => {
 		expect(dashboardWidgetWidthClass('alerts', 'quarter')).toContain('xl:col-span-3');
 		expect(dashboardWidgetWidthClass('service_health', 'half')).toContain('md:col-span-6');
 		expect(dashboardWidgetWidthClass('compute', 'quarter')).toContain('xl:col-span-3');
+		expect(dashboardWidgetWidthClass('clock', 'quarter')).toContain('xl:col-span-3');
 		expect(dashboardWidgetWidthClass('cpu_load', 'quarter')).toContain('lg:col-span-3');
 	});
 
@@ -400,13 +409,13 @@ describe('dashboard preferences', () => {
 		expect(getActiveDashboardView(preferences).density).toBe('compact');
 	});
 
-	test('persists the active named view in v6 storage', () => {
+	test('persists the active named view in v7 storage', () => {
 		const preferences = createDashboardView(defaultDashboardPreferences(), 'Monitoring desk');
 		dashboardPrefs.set(preferences);
 
 		expect(dashboardPrefs.value.preset).toBe('custom');
 		expect(JSON.parse(localStorage.getItem(DASHBOARD_PREFERENCES_KEY) ?? '{}')).toMatchObject({
-			version: 6,
+			version: 7,
 			preset: 'custom',
 			activeViewId: preferences.activeViewId,
 		});

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -1,10 +1,11 @@
-export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v6';
+export const DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v7';
+export const LEGACY_DASHBOARD_V6_PREFERENCES_KEY = 'nasty:dashboard:v6';
 export const LEGACY_DASHBOARD_V5_PREFERENCES_KEY = 'nasty:dashboard:v5';
 export const LEGACY_DASHBOARD_V4_PREFERENCES_KEY = 'nasty:dashboard:v4';
 export const LEGACY_DASHBOARD_V3_PREFERENCES_KEY = 'nasty:dashboard:v3';
 export const LEGACY_DASHBOARD_V2_PREFERENCES_KEY = 'nasty:dashboard:v2';
 export const LEGACY_DASHBOARD_PREFERENCES_KEY = 'nasty:dashboard:v1';
-export const DASHBOARD_PREFERENCES_VERSION = 6;
+export const DASHBOARD_PREFERENCES_VERSION = 7;
 export const DASHBOARD_VIEW_NAME_MAX_LENGTH = 40;
 export const DASHBOARD_GRID_COLUMNS = 12;
 
@@ -14,6 +15,8 @@ export const dashboardWidgetIds = [
 	'service_health',
 	'container_health',
 	'compute',
+	'clock',
+	'schedule',
 	'cpu_load',
 	'memory_usage',
 	'cpu_status',
@@ -76,6 +79,8 @@ export const dashboardWidgetMeta: Record<DashboardWidgetId, { label: string; des
 	service_health: { label: 'Service health', description: 'Enabled services currently running.', supportsTiny: false },
 	container_health: { label: 'Container health', description: 'Expected managed containers currently running.', supportsTiny: false },
 	compute: { label: 'Compute', description: 'Virtual machines and Docker workloads at a glance.', supportsTiny: false },
+	clock: { label: 'Clock & notice', description: 'Host time, date, timezone, and dashboard notice.', supportsTiny: false },
+	schedule: { label: 'Backup schedule', description: 'Upcoming scheduled backup runs.', supportsTiny: false },
 	cpu_load: { label: 'CPU load', description: 'Current load across available CPU cores.', supportsTiny: false },
 	memory_usage: { label: 'Memory', description: 'Current memory use and bcachefs cache.', supportsTiny: false },
 	cpu_status: { label: 'CPU status', description: 'CPU temperature, frequency, and governor.', supportsTiny: false },
@@ -95,7 +100,7 @@ export function dashboardWidgetSupportsNarrowWidth(
 	id: DashboardWidgetId,
 	presentation: DashboardWidgetPresentation,
 ): boolean {
-	return ['service_health', 'container_health', 'compute', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
+	return ['service_health', 'container_health', 'compute', 'clock', 'cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
 		|| (dashboardWidgetSupportsTiny(id) && presentation === 'tiny');
 }
 
@@ -120,9 +125,11 @@ export function dashboardWidgetSnapColumn(width: DashboardWidgetWidth, requested
 }
 
 export function dashboardWidgetWidthClass(id: DashboardWidgetId, width: DashboardWidgetWidth): string {
-	const responsive = id === 'service_health' || id === 'container_health' || id === 'compute'
+	const responsive = id === 'service_health' || id === 'container_health' || id === 'compute' || id === 'schedule'
 		? 'col-span-12 md:col-span-6'
-		: ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
+		: id === 'clock'
+			? 'col-span-12 md:col-span-6'
+			: ['cpu_load', 'memory_usage', 'cpu_status', 'storage_summary'].includes(id)
 			? 'col-span-6 lg:col-span-3'
 			: 'col-span-12';
 	if (width === 'quarter') return `min-w-0 ${responsive} xl:col-span-3`;
@@ -191,6 +198,8 @@ const defaultCustomWidgets: DashboardWidgetConfig[] = positionWidgets([
 	{ id: 'network', visible: true, width: 'half', presentation: 'standard' },
 	{ id: 'disk_io', visible: true, width: 'half', presentation: 'standard' },
 	{ id: 'compute', visible: false, width: 'half', presentation: 'standard' },
+	{ id: 'clock', visible: false, width: 'quarter', presentation: 'standard' },
+	{ id: 'schedule', visible: false, width: 'half', presentation: 'standard' },
 ]);
 
 export const dashboardPresets: Record<DashboardFixedPreset, {
@@ -399,7 +408,7 @@ function migrateLegacyPreferences(value: Record<string, unknown>): DashboardPref
 function normalizeDashboardPreferences(value: unknown): DashboardPreferences {
 	if (!isRecord(value)) return defaultDashboardPreferences();
 	if (value.version === 1) return migrateLegacyPreferences(value);
-	if (value.version !== 2 && value.version !== 3 && value.version !== 4 && value.version !== 5 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
+	if (value.version !== 2 && value.version !== 3 && value.version !== 4 && value.version !== 5 && value.version !== 6 && value.version !== DASHBOARD_PREFERENCES_VERSION) return defaultDashboardPreferences();
 
 	const customViews = normalizeCustomViews(value.customViews);
 	const requestedActiveViewId = typeof value.activeViewId === 'string' ? value.activeViewId.trim() : '';
@@ -432,6 +441,7 @@ export function parseDashboardPreferences(raw: string | null): DashboardPreferen
 export function loadDashboardPreferences(storage: Pick<Storage, 'getItem'>): DashboardPreferences {
 	return parseDashboardPreferences(
 		storage.getItem(DASHBOARD_PREFERENCES_KEY)
+		?? storage.getItem(LEGACY_DASHBOARD_V6_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V5_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V4_PREFERENCES_KEY)
 		?? storage.getItem(LEGACY_DASHBOARD_V3_PREFERENCES_KEY)

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -120,7 +120,7 @@ const NAVIGATION: NavEntry[] = [
 			item('logs', '/logs', 'Logs', ScrollText, ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'], { commonRank: 8 }),
 			item('update', '/update', 'Update', RefreshCw, ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin']),
 			item('users', '/users', 'Access Control', ShieldCheck, ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider']),
-			item('settings', '/settings', 'Settings', Settings, ['setting', 'hostname', 'timezone', 'clock', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'])
+			item('settings', '/settings', 'Settings', Settings, ['setting', 'hostname', 'timezone', 'clock', 'motd', 'dashboard notice', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'])
 		]
 	}
 ];

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -65,6 +65,7 @@ export interface SystemInfo {
 	bcachefs_is_custom: boolean;
 	timezone: string;
 	ntp_synced: boolean;
+	current_time?: string;
 }
 
 export interface SystemHealth {
@@ -1197,6 +1198,7 @@ export interface Settings {
 	timezone: string;
 	hostname: string | null;
 	clock_24h: boolean;
+	dashboard_motd: string;
 	temp_unit: TempUnit;
 	tls_domain: string | null;
 	files_domain: string | null;
@@ -1532,6 +1534,15 @@ export interface BackupProfile {
 	 * rest-server / MinIO). Engine writes it to disk and passes the
 	 * path through to rustic_backend's `cacert` option. */
 	trusted_cacert?: string;
+}
+
+export interface BackupScheduleEntry {
+	profile_id: string;
+	profile_name: string;
+	schedule: string;
+	next_run_at: string | null;
+	schedule_error: string | null;
+	last_run: BackupRunResult | null;
 }
 
 export type BackupTarget =

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -30,6 +30,7 @@
 		ActiveAlert,
 		App,
 		AppsStatus,
+		BackupScheduleEntry,
 		DiskHealth,
 		DiskIoStats,
 		Filesystem,
@@ -37,6 +38,7 @@
 		NetIfStats,
 		ProtocolStatus,
 		ResourceHistory,
+		Settings,
 		SystemHealth,
 		SystemInfo,
 		SystemStats,
@@ -54,6 +56,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import AlertsWidget from '$lib/components/dashboard/alerts-widget.svelte';
+	import ClockWidget from '$lib/components/dashboard/clock-widget.svelte';
 	import ComputeWidget from '$lib/components/dashboard/compute-widget.svelte';
 	import CustomizeDialog from '$lib/components/dashboard/customize-dialog.svelte';
 	import DiskIoWidget from '$lib/components/dashboard/disk-io-widget.svelte';
@@ -62,6 +65,7 @@
 	import HistoryWidget from '$lib/components/dashboard/history-widget.svelte';
 	import NetworkWidget from '$lib/components/dashboard/network-widget.svelte';
 	import OperationsWidget from '$lib/components/dashboard/operations-widget.svelte';
+	import ScheduleWidget from '$lib/components/dashboard/schedule-widget.svelte';
 	import StorageWidget from '$lib/components/dashboard/storage-widget.svelte';
 	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
 	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
@@ -103,6 +107,10 @@
 	let appsStatus = $state<AppsStatus | null>(null);
 	let vms = $state<VmStatus[] | null>(null);
 	let vmFreshness = $state<DashboardHealthFreshness>('loading');
+	let settings = $state<Settings | null>(null);
+	let clockDataLoaded = $state(false);
+	let scheduleEntries = $state<BackupScheduleEntry[] | null>(null);
+	let scheduleFreshness = $state<DashboardHealthFreshness>('loading');
 	let customizeOpen = $state(false);
 	let editingDashboard = $state(false);
 	let customizeButton = $state<HTMLButtonElement | null>(null);
@@ -117,6 +125,8 @@
 	let healthRequest = 0;
 	let alertsRequest = 0;
 	let operationsRequest = 0;
+	let clockRequest = 0;
+	let scheduleRequest = 0;
 	let serviceHealthInFlight: Promise<void> | null = null;
 	let containerHealthInFlight: Promise<void> | null = null;
 	let vmHealthInFlight: Promise<void> | null = null;
@@ -389,8 +399,10 @@
 			const tasks: Promise<unknown>[] = [
 				fetchFilesystemInventory(),
 			];
+			if (hasWidget('system') || hasWidget('clock') || hasWidget('schedule')) {
+				tasks.push(hasWidget('clock') ? loadClockData() : loadSystemInfo());
+			}
 			if (hasWidget('system')) {
-				tasks.push(loadSystemInfo());
 				tasks.push(loadSystemHealth());
 			}
 			if (needsStats()) {
@@ -405,6 +417,7 @@
 			}
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
+			if (hasWidget('schedule')) tasks.push(loadBackupSchedule());
 			if (healthPollingEnabled('service_health')) tasks.push(loadServiceHealth(true));
 			if (healthPollingEnabled('container_health')) tasks.push(loadContainerHealth(true));
 			if (vmPollingEnabled()) tasks.push(loadVmHealth(true));
@@ -435,6 +448,38 @@
 		if (request !== infoRequest) return;
 		info = value;
 		infoLoaded = true;
+	}
+
+	async function loadClockData() {
+		const request = ++clockRequest;
+		const [nextInfo, nextSettings] = await Promise.allSettled([
+			client.call<SystemInfo>('system.info'),
+			client.call<Settings>('system.settings.get'),
+		]);
+		if (request !== clockRequest) return;
+		if (nextInfo.status === 'fulfilled') {
+			info = nextInfo.value;
+			infoLoaded = true;
+		}
+		if (nextSettings.status === 'fulfilled') {
+			settings = { ...nextSettings.value, dashboard_motd: nextSettings.value.dashboard_motd ?? '' };
+		}
+		clockDataLoaded = true;
+		const failure = [nextInfo, nextSettings].find((result): result is PromiseRejectedResult => result.status === 'rejected');
+		if (failure) throw failure.reason;
+	}
+
+	async function loadBackupSchedule() {
+		const request = ++scheduleRequest;
+		scheduleFreshness = scheduleEntries ? 'refreshing' : 'loading';
+		try {
+			const entries = await client.call<BackupScheduleEntry[]>('backup.schedule.list');
+			if (request !== scheduleRequest) return;
+			scheduleEntries = entries;
+			scheduleFreshness = 'current';
+		} catch {
+			if (request === scheduleRequest) scheduleFreshness = scheduleEntries ? 'stale' : 'unavailable';
+		}
 	}
 
 	async function loadSystemHealth() {
@@ -596,9 +641,11 @@
 			if (needsStats()) tasks.push(refreshStats());
 			if (hasWidget('alerts')) tasks.push(loadAlerts());
 			if (hasWidget('operations')) tasks.push(loadOperations());
-			if (hasWidget('system') && refreshTick % 4 === 0) {
-				tasks.push(loadSystemHealth());
-				if (!infoLoaded) tasks.push(loadSystemInfo());
+			if (refreshTick % 4 === 0) {
+				if (hasWidget('clock')) tasks.push(loadClockData());
+				else if (hasWidget('schedule') || (hasWidget('system') && !infoLoaded)) tasks.push(loadSystemInfo());
+				if (hasWidget('system')) tasks.push(loadSystemHealth());
+				if (hasWidget('schedule')) tasks.push(loadBackupSchedule());
 			}
 			if (refreshTick % 4 === 0) tasks.push(loadFilesystemData());
 			else if (hasWidget('storage') && refreshTick % 2 === 0) tasks.push(loadStorageDetails());
@@ -890,6 +937,10 @@
 					<HealthWidget kind="containers" containers={containerHealth} freshness={containerHealthFreshness} {density} />
 				{:else if widget.id === 'compute'}
 					<ComputeWidget {vms} {appsStatus} containers={containerHealth} {vmFreshness} containerFreshness={containerHealthFreshness} {density} />
+				{:else if widget.id === 'clock'}
+					<ClockWidget {info} {settings} loaded={clockDataLoaded} {density} />
+				{:else if widget.id === 'schedule'}
+					<ScheduleWidget entries={scheduleEntries} currentTime={info?.current_time} freshness={scheduleFreshness} {density} />
 				{:else if widget.id === 'cpu_load' || widget.id === 'memory_usage' || widget.id === 'cpu_status' || widget.id === 'storage_summary'}
 					<SummaryWidget kind={widget.id} {stats} {filesystems} {filesystemsLoaded} {density} />
 				{:else if widget.id === 'operations'}

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getClient } from '$lib/client';
-	import { withToast } from '$lib/toast.svelte';
+	import { error as toastError, success as toastSuccess, withToast } from '$lib/toast.svelte';
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { tempUnit } from '$lib/temperature.svelte';
 	import { requiredFieldCls } from '$lib/utils';
@@ -86,7 +86,12 @@
 	let timezones: string[] = $state([]);
 	let saving = $state(false);
 	let savingHostname = $state(false);
+	let savingDashboardMotd = $state(false);
 	let hostnameInput = $state('');
+
+	function unicodeLength(value: string): number {
+		return [...value].length;
+	}
 
 	// Network
 	let networkState: NetworkState | null = $state(null);
@@ -296,6 +301,7 @@
 				// only when the operator clears the field.
 				client.call<string>('system.log.level').catch(() => ''),
 			]);
+			settings = { ...settings, dashboard_motd: settings.dashboard_motd ?? '' };
 			hostnameInput = settings.hostname ?? info.hostname;
 			logFilter = liveLogFilter;
 			try {
@@ -348,6 +354,25 @@
 			() => client.call('system.settings.update', { clock_24h: val }),
 			val ? '24-hour clock enabled' : '12-hour clock enabled'
 		);
+	}
+
+	async function saveDashboardMotd() {
+		if (!settings) return;
+		savingDashboardMotd = true;
+		try {
+			const updated = await withToast(
+				() => client.call<Settings>('system.settings.update', { dashboard_motd: settings!.dashboard_motd })
+			);
+			if (!updated) return;
+			if (typeof updated.dashboard_motd !== 'string') {
+				toastError('Dashboard notices require a newer engine version.');
+				return;
+			}
+			settings = updated;
+			toastSuccess('Dashboard notice updated');
+		} finally {
+			savingDashboardMotd = false;
+		}
 	}
 
 	async function saveTempUnit(val: 'celsius' | 'fahrenheit') {
@@ -900,6 +925,27 @@
 						</select>
 						<Button size="sm" onclick={saveTimezone} disabled={saving}>
 							{saving ? 'Saving…' : 'Apply'}
+						</Button>
+					</div>
+				</section>
+
+				<section class="rounded-lg border border-border p-5">
+					<h2 class="mb-2 text-base font-semibold">Dashboard Notice</h2>
+					<label for="dashboard-motd" class="text-sm font-medium">Message of the day</label>
+					<p id="dashboard-motd-help" class="mb-4 mt-1 text-sm text-muted-foreground">Shown below the dashboard clock. Leave empty to hide the notice.</p>
+					<textarea
+						id="dashboard-motd"
+						bind:value={settings.dashboard_motd}
+						aria-describedby="dashboard-motd-help dashboard-motd-count"
+						aria-invalid={unicodeLength(settings.dashboard_motd) > 500}
+						rows="3"
+						placeholder="Storage maintenance tonight at 22:00."
+						class="w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+					></textarea>
+					<div class="mt-3 flex items-center justify-between gap-3">
+						<span id="dashboard-motd-count" class="text-xs {unicodeLength(settings.dashboard_motd) > 500 ? 'text-destructive' : 'text-muted-foreground'}">{unicodeLength(settings.dashboard_motd)}/500 characters</span>
+						<Button size="sm" onclick={saveDashboardMotd} disabled={savingDashboardMotd || unicodeLength(settings.dashboard_motd) > 500}>
+							{savingDashboardMotd ? 'Saving...' : 'Save notice'}
 						</Button>
 					</div>
 				</section>


### PR DESCRIPTION
## Summary
- add opt-in dashboard widgets for an authoritative host clock/MOTD and upcoming backup schedules
- expose the host timestamp and next nominal UTC cron occurrences through engine RPCs
- persist and validate the dashboard notice, with dashboard preference migration and older-engine fallbacks

## Testing
- `npm run check`
- `npm test`
- `npm run build`
- `cargo fmt --all -- --check`
- `cargo test --workspace`