### PR TITLE
Fix compact dashboard spacing and stray scrollbar

### DIFF
--- a/webui/src/lib/components/dashboard/history-widget.svelte
+++ b/webui/src/lib/components/dashboard/history-widget.svelte
@@ -38,7 +38,7 @@
 
 {#if presentation === 'tiny'}
 	<div class="grid grid-cols-2 gap-3 {width === 'third' || width === 'quarter' ? 'xl:grid-cols-1' : ''}">
-		<Card>
+		<Card class="gap-0 py-0">
 			<CardContent class="px-4 py-3">
 				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle>
 				{#if cpu}
@@ -49,7 +49,7 @@
 				{/if}
 			</CardContent>
 		</Card>
-		<Card>
+		<Card class="gap-0 py-0">
 			<CardContent class="px-4 py-3">
 				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Memory usage</CardTitle>
 				{#if memory}

--- a/webui/src/lib/components/dashboard/summary-widget.svelte
+++ b/webui/src/lib/components/dashboard/summary-widget.svelte
@@ -42,7 +42,7 @@
 	let storage = $derived(totalStorage());
 </script>
 
-<Card class="h-full">
+<Card class="h-full {density === 'compact' ? 'gap-0 py-0' : ''}">
 	<CardContent class={density === 'compact' ? 'px-4 py-3' : 'pt-4 pb-3'}>
 		{#if kind === 'cpu_load'}
 			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU load</div>

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -799,7 +799,7 @@
 			<Button bind:ref={customizeButton} variant="outline" size="sm" onclick={() => void beginDashboardEditing()}><Settings2 /> Customize</Button>
 		{/if}
 	</div>
-	<div class="mt-3 overflow-x-auto border-b border-border">
+	<div class="mt-3 overflow-x-auto overflow-y-hidden border-b border-border">
 		<div class="flex min-w-max items-end" role="tablist" aria-label="Dashboard views">
 			{#each presetTabs as [id, preset]}
 				<button type="button" role="tab" aria-selected={dashboardSelection === id} aria-controls="dashboard-panel" tabindex={dashboardSelection === id ? 0 : -1} onclick={() => void switchDashboard(id)} onkeydown={handleDashboardTabKeydown} class="-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors {dashboardSelection === id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'}">{preset.label}</button>


### PR DESCRIPTION
## Summary
- prevent the dashboard view tab strip from creating a vertical scrollbar
- remove inherited outer card padding from compact resource summaries
- tighten tiny CPU and memory history cards without changing standard layouts

## Testing
- `npm run check`
- `npm test`
- `npm run build`