### PR TITLE
Add quick removal to dashboard edit mode

### DIFF
--- a/webui/src/lib/dashboard.svelte.test.ts
+++ b/webui/src/lib/dashboard.svelte.test.ts
@@ -29,6 +29,7 @@ import {
 	resolveDashboardDensity,
 	resolveDashboardWidgets,
 	selectDashboardView,
+	setDashboardWidgetVisibility,
 	setDashboardPresetTabVisible,
 	updateActiveDashboardView,
 	updateDashboardWidgetAppearance,
@@ -308,6 +309,19 @@ describe('dashboard preferences', () => {
 		const unsupportedNarrow = updateDashboardWidgetAppearance(widgets, 'storage', { width: 'quarter' });
 		expect(unsupportedNarrow[1]).toMatchObject({ width: 'half', presentation: 'standard', column: 0 });
 		expect(widgets[0]).toMatchObject({ width: 'quarter', presentation: 'tiny', column: 9 });
+	});
+
+	test('hides a widget without discarding its configuration or hiding the last widget', () => {
+		const widgets: DashboardWidgetConfig[] = [
+			{ id: 'alerts', visible: true, width: 'quarter', presentation: 'tiny', column: 9, row: 2, priority: 4 },
+			{ id: 'storage', visible: true, width: 'full', presentation: 'standard', column: 0, row: 0, priority: 0 },
+		];
+
+		const hidden = setDashboardWidgetVisibility(widgets, 'alerts', false);
+		expect(hidden[0]).toEqual({ ...widgets[0], visible: false });
+		expect(widgets[0].visible).toBe(true);
+		expect(setDashboardWidgetVisibility(hidden, 'storage', false)[1].visible).toBe(true);
+		expect(setDashboardWidgetVisibility(hidden, 'alerts', true)[0]).toEqual(widgets[0]);
 	});
 
 	test('hides any built-in preset tab and falls back to a custom view', () => {

--- a/webui/src/lib/dashboard.svelte.ts
+++ b/webui/src/lib/dashboard.svelte.ts
@@ -162,6 +162,16 @@ export function updateDashboardWidgetAppearance(
 	});
 }
 
+export function setDashboardWidgetVisibility(
+	widgets: DashboardWidgetConfig[],
+	id: DashboardWidgetId,
+	visible: boolean,
+): DashboardWidgetConfig[] {
+	if (!widgets.some((widget) => widget.id === id)) return cloneWidgets(widgets);
+	if (!visible && widgets.filter((widget) => widget.visible).length <= 1) return cloneWidgets(widgets);
+	return widgets.map((widget) => widget.id === id ? { ...widget, visible } : { ...widget });
+}
+
 type DashboardWidgetDefinition = Omit<DashboardWidgetConfig, 'column' | 'row' | 'priority'>;
 
 function positionWidgets(widgets: DashboardWidgetDefinition[]): DashboardWidgetConfig[] {

--- a/webui/src/routes/+page.svelte
+++ b/webui/src/routes/+page.svelte
@@ -18,6 +18,7 @@
 		resolveDashboardDensity,
 		resolveDashboardWidgets,
 		selectDashboardView,
+		setDashboardWidgetVisibility,
 		updateActiveDashboardView,
 		updateDashboardWidgetAppearance,
 		type DashboardPreferences,
@@ -70,7 +71,7 @@
 	import SummaryWidget from '$lib/components/dashboard/summary-widget.svelte';
 	import SystemWidget from '$lib/components/dashboard/system-widget.svelte';
 	import WidgetOptions from '$lib/components/dashboard/widget-options.svelte';
-	import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, GripVertical, Settings2 } from '@lucide/svelte';
+	import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, GripVertical, Settings2, X } from '@lucide/svelte';
 
 	type MetricsRange = '5m' | '1h' | '1d' | '7d' | '30d';
 	type DiskRate = { readRate: number; writeRate: number };
@@ -248,6 +249,23 @@
 			widgets: updateDashboardWidgetAppearance(getActiveDashboardView(preferences).widgets, id, patch),
 		}));
 		if (reloadHistory) void loadMetrics(true);
+	}
+
+	async function hideWidget(id: DashboardWidgetId) {
+		const preferences = dashboardPrefs.value;
+		if (preferences.preset !== 'custom' || widgets.length <= 1) return;
+		const index = widgets.findIndex((widget) => widget.id === id);
+		if (index < 0) return;
+		const nextWidgetId = widgets[index + 1]?.id ?? widgets[index - 1]?.id;
+		const activeView = getActiveDashboardView(preferences);
+		dashboardPrefs.set(updateActiveDashboardView(preferences, {
+			widgets: setDashboardWidgetVisibility(activeView.widgets, id, false),
+		}));
+		announceMovement(`${dashboardWidgetMeta[id].label} removed from ${activeView.name}.`);
+		await tick();
+		const nextRemoveButton = document.querySelector<HTMLButtonElement>(`[data-dashboard-remove="${nextWidgetId}"]`);
+		if (nextRemoveButton && !nextRemoveButton.disabled) nextRemoveButton.focus();
+		else editDoneButton?.focus();
 	}
 
 	async function beginDashboardEditing() {
@@ -835,7 +853,7 @@
 		<div>
 			<div class="text-sm font-semibold">{presetLabel} dashboard</div>
 			<div class="text-xs text-muted-foreground">{widgets.length} visible widget{widgets.length === 1 ? '' : 's'} - {density} density</div>
-			{#if editingDashboard}<div class="text-xs text-muted-foreground">Move widgets with the direction controls or drag handle. Use each options menu to change its size or presentation.</div>{/if}
+			{#if editingDashboard}<div class="text-xs text-muted-foreground">Move widgets with the direction controls or drag handle. Use each options menu to change its size or presentation, or X to remove it from this view.</div>{/if}
 		</div>
 		{#if editingDashboard}
 			<div class="flex items-center gap-2">
@@ -923,6 +941,15 @@
 									<span draggable={true} ondragstart={(event) => startWidgetDrag(event, widget.id)} ondragend={endWidgetDrag} class="inline-flex cursor-grab rounded p-1.5 hover:bg-accent hover:text-foreground active:cursor-grabbing" title="Drag to a grid position" aria-hidden="true"><GripVertical class="h-3.5 w-3.5" /></span>
 								</div>
 								<WidgetOptions {widget} onChange={(patch) => updateWidgetAppearance(widget.id, patch)} />
+								<button
+									type="button"
+									onclick={() => void hideWidget(widget.id)}
+									disabled={widgets.length <= 1}
+									data-dashboard-remove={widget.id}
+									class="rounded p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-20"
+									aria-label={`Remove ${dashboardWidgetMeta[widget.id].label} from this view`}
+									title={widgets.length <= 1 ? 'At least one widget must remain visible' : 'Remove from this view'}
+								><X class="h-3.5 w-3.5" /></button>
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
## Summary
- add an X beside each widget's edit controls to remove it from the active custom view
- preserve hidden widget size, presentation, and placement for re-enabling through Widgets & views
- prevent removing the final visible widget and keep keyboard focus in a useful location

## Testing
- `npm run check`
- `npm test`
- `npm run build`