### PR TITLE
Polish compact dashboard widget sizing

### DIFF
--- a/webui/src/lib/components/dashboard/health-widget.svelte
+++ b/webui/src/lib/components/dashboard/health-widget.svelte
@@ -109,21 +109,21 @@
 			</CardContent>
 		</a>
 	{:else}
-		<a href="/apps" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Managed containers: ${state.label}. ${containers?.expected != null ? `${containers.expected} expected, ${containers.running} running.` : state.detail}`}>
+		<a href="/apps" class="block h-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background" aria-label={`Managed containers: ${state.label}. ${containers?.expected != null ? `${containers.expected} expected, ${containers.running} running. Simple apps count once; Compose service instances count individually.` : state.detail}`}>
 			<CardContent class={density === 'compact' ? 'px-4 py-3' : 'px-5 py-4'}>
 				<div class="flex items-center justify-between gap-3">
 					<div class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Managed containers</div>
 					<div class="text-xs font-semibold {labelClass(state.tone)}">{state.label}</div>
 				</div>
 				{#if containers?.expected != null && containers.running != null}
-					<div class="mt-2 text-xl font-bold tabular-nums">{containers.expected} expected <span class="text-muted-foreground">/</span> {containers.running} running</div>
+					<div class="mt-2 flex items-baseline gap-2">
+						<span class="text-xl font-bold tabular-nums">{containers.expected} expected <span class="text-muted-foreground">/</span> {containers.running} running</span>
+						<span class="hidden min-w-0 truncate text-[0.65rem] text-muted-foreground/80 2xl:inline" title="Simple apps count once; Compose service instances count individually.">apps + Compose services</span>
+					</div>
 				{:else}
 					<div class="mt-2 text-xl font-bold text-muted-foreground">{state.label}</div>
 				{/if}
 				<div class="mt-1 text-xs text-muted-foreground" role={freshness === 'refreshing' || freshness === 'stale' || freshness === 'unavailable' ? 'status' : undefined}>{state.detail}</div>
-				{#if containers && containers.runtime !== 'disabled'}
-					<div class="mt-1 text-[0.68rem] text-muted-foreground/80">Simple apps count once; Compose service instances count individually.</div>
-				{/if}
 			</CardContent>
 		</a>
 	{/if}

--- a/webui/src/lib/components/dashboard/history-widget.svelte
+++ b/webui/src/lib/components/dashboard/history-widget.svelte
@@ -32,6 +32,10 @@
 		};
 	}
 
+	function boundedPercent(value: number): number {
+		return Math.min(100, Math.max(0, value));
+	}
+
 	let cpu = $derived(summarize(cpuSamples));
 	let memory = $derived(summarize(memorySamples));
 </script>
@@ -43,7 +47,8 @@
 				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">CPU usage</CardTitle>
 				{#if cpu}
 					<div class="mt-1 text-2xl font-bold tabular-nums">{cpu.current.toFixed(1)}%</div>
-					<div class="mt-1 text-xs text-muted-foreground">{range} peak {cpu.peak.toFixed(1)}%</div>
+					<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary" aria-hidden="true"><div class="h-full rounded-full bg-[var(--chart-3)]" style="width: {boundedPercent(cpu.current)}%"></div></div>
+					<div class="mt-1.5 text-xs text-muted-foreground">{range} peak {cpu.peak.toFixed(1)}%</div>
 				{:else}
 					<div class="mt-2 text-sm font-medium text-muted-foreground" role="status">{loading ? 'Loading...' : 'Unavailable'}</div>
 				{/if}
@@ -54,7 +59,8 @@
 				<CardTitle class="text-xs uppercase tracking-wide text-muted-foreground">Memory usage</CardTitle>
 				{#if memory}
 					<div class="mt-1 text-2xl font-bold tabular-nums">{memory.current.toFixed(1)}%</div>
-					<div class="mt-1 text-xs text-muted-foreground">{range} peak {memory.peak.toFixed(1)}%</div>
+					<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary" aria-hidden="true"><div class="h-full rounded-full bg-[var(--chart-5)]" style="width: {boundedPercent(memory.current)}%"></div></div>
+					<div class="mt-1.5 text-xs text-muted-foreground">{range} peak {memory.peak.toFixed(1)}%</div>
 				{:else}
 					<div class="mt-2 text-sm font-medium text-muted-foreground" role="status">{loading ? 'Loading...' : 'Unavailable'}</div>
 				{/if}

--- a/webui/src/lib/components/dashboard/summary-widget.svelte
+++ b/webui/src/lib/components/dashboard/summary-widget.svelte
@@ -2,7 +2,7 @@
 	import type { DashboardDensity } from '$lib/dashboard.svelte';
 	import type { Filesystem, SystemStats } from '$lib/types';
 	import { formatBytes, formatPercent } from '$lib/format';
-	import { formatTemp } from '$lib/temperature.svelte';
+	import { formatTemp, tempUnit } from '$lib/temperature.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 
 	let { kind, stats = null, filesystems = [], filesystemsLoaded = true, density }: {
@@ -19,6 +19,14 @@
 
 	function memoryPercent(): number {
 		return stats && stats.memory.total_bytes > 0 ? (stats.memory.used_bytes / stats.memory.total_bytes) * 100 : 0;
+	}
+
+	function cpuTemperatureScale(): number {
+		return stats?.cpu.temp_c == null ? 0 : Math.min(100, Math.max(0, stats.cpu.temp_c));
+	}
+
+	function cpuTemperatureScaleLabel(): string {
+		return tempUnit.current === 'fahrenheit' ? '32-212 F scale' : '0-100 C scale';
 	}
 
 	function totalStorage(): { used: number; total: number; unknown: number } {
@@ -66,7 +74,11 @@
 			<div class="text-xs uppercase tracking-wide text-muted-foreground">CPU</div>
 			{#if stats && (stats.cpu.temp_c != null || stats.cpu.freq_mhz != null)}
 				<div class="mt-1 text-2xl font-bold">{formatTemp(stats.cpu.temp_c) ?? '-'}</div>
-				<div class="mt-2 text-xs text-muted-foreground">{stats.cpu.freq_mhz != null ? (stats.cpu.freq_mhz >= 1000 ? (stats.cpu.freq_mhz / 1000).toFixed(1) + ' GHz' : stats.cpu.freq_mhz + ' MHz') : ''}{stats.cpu.governor ? ` - ${stats.cpu.governor}` : ''}</div>
+				{#if stats.cpu.temp_c != null}<div class="mt-2 h-1.5 overflow-hidden rounded-full bg-secondary" aria-hidden="true"><div class="h-full rounded-full bg-primary" style="width: {cpuTemperatureScale()}%"></div></div>{/if}
+				<div class="mt-1.5 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+					<span class="min-w-0 truncate">{stats.cpu.freq_mhz != null ? (stats.cpu.freq_mhz >= 1000 ? (stats.cpu.freq_mhz / 1000).toFixed(1) + ' GHz' : stats.cpu.freq_mhz + ' MHz') : ''}{stats.cpu.governor ? ` - ${stats.cpu.governor}` : ''}</span>
+					{#if stats.cpu.temp_c != null}<span class="shrink-0 text-[0.6rem] uppercase">{cpuTemperatureScaleLabel()}</span>{/if}
+				</div>
 			{:else}
 				<div class="mt-1 text-2xl font-bold text-muted-foreground">Unavailable</div>
 				<div class="mt-2 text-xs text-muted-foreground">CPU temperature and frequency are unavailable.</div>


### PR DESCRIPTION
## Summary
- align Services and Managed Containers by keeping the container-count explanation on the metric row instead of a separate row
- add bounded current-value bars to tiny CPU and memory history cards
- add a unit-aware temperature gauge to CPU Status

Addresses the follow-up feedback in https://github.com/nasty-project/nasty/issues/809#issuecomment-5528258984.

## Testing
- npm run check
- npm test
- npm run build
- git diff --check