### PR TITLE
Honor configured timezone in dashboard clock

### DIFF
--- a/webui/src/lib/components/dashboard/clock-widget.svelte
+++ b/webui/src/lib/components/dashboard/clock-widget.svelte
@@ -24,7 +24,7 @@
 
 	let now = $state(new Date());
 	let serverOffset = $state<number | null>(hostOffset(untrack(() => info?.current_time)));
-	let timezone = $derived(info?.timezone ?? settings?.timezone ?? 'UTC');
+	let timezone = $derived(settings?.timezone ?? info?.timezone ?? 'UTC');
 	let hostNow = $derived(serverOffset === null ? null : new Date(now.getTime() + serverOffset));
 	let clockParts = $derived(hostNow ? getClockParts(hostNow, timezone) : { hour: 0, minute: 0, second: 0 });
 	let hourAngle = $derived((clockParts.hour % 12 + clockParts.minute / 60) * 30);

--- a/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
+++ b/webui/src/lib/components/dashboard/dashboard-widgets.test.ts
@@ -336,6 +336,20 @@ describe('dashboard clock and schedule widgets', () => {
 		expect(body).toContain('Storage maintenance tonight.');
 	});
 
+	test('uses the configured timezone when runtime timezone detection falls back to UTC', () => {
+		const body = render(ClockWidget, {
+			props: {
+				info: { ...info, current_time: '2026-09-02T02:00:00.500Z', timezone: 'UTC' },
+				settings: { ...settings, timezone: 'America/New_York' },
+				loaded: true,
+				density: 'comfortable',
+			},
+		}).body;
+
+		expect(body).toContain('America/New_York');
+		expect(body).toContain('rotate(300 50 50)');
+	});
+
 	test('does not substitute browser time when host time is unavailable', () => {
 		const legacyInfo = { ...info, current_time: undefined } as unknown as SystemInfo;
 		const body = render(ClockWidget, {


### PR DESCRIPTION
## Summary
- prefer the persisted timezone setting over runtime timezone detection in the dashboard clock
- retain runtime timezone as a fallback when settings are unavailable
- cover a UTC-runtime/non-UTC-setting case across a local calendar-day boundary

## Testing
- npm run check
- npm test
- npm run build
- LANG=de_DE.UTF-8 npm test -- --run src/lib/components/dashboard/dashboard-widgets.test.ts
- git diff --check