### PR TITLE
update: poll release status every five minutes

### DIFF
--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -311,6 +311,13 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                     result: Some(gen_schema::<UpdateInfo>(generator)),
                 },
                 Method {
+                    name: "system.update.check_cached",
+                    desc: "Check for available updates, reusing an appliance-wide result for up to five minutes.",
+                    role: MethodRole::Any,
+                    params: MethodParams::None,
+                    result: Some(gen_schema::<UpdateInfo>(generator)),
+                },
+                Method {
                     name: "system.update.apply",
                     desc: "Fetch and apply the latest NixOS generation. Runs `nixos-rebuild switch` in the background.",
                     role: MethodRole::Admin,

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -304,6 +304,7 @@ fn is_read_only(method: &str) -> bool {
                 | "service.base_names.get"
                 | "system.update.version"
                 | "system.update.check"
+                | "system.update.check_cached"
                 | "backup.secrets_status"
                 | "system.update.status"
                 | "system.update.build_dir.get"

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -714,6 +714,10 @@ pub(super) async fn try_route(
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
+        "system.update.check_cached" => match state.updates.check_cached().await {
+            Ok(v) => ok(req, v),
+            Err(e) => err(req, e),
+        },
         "system.update.apply" => match state.updates.apply().await {
             Ok(()) => {
                 state.system.invalidate_bcachefs_cache().await;

--- a/engine/nasty-system/src/update.rs
+++ b/engine/nasty-system/src/update.rs
@@ -4,8 +4,9 @@ use rowan::ast::AstNode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 /// Primary version path — writable by the update script, not managed by NixOS.
@@ -71,6 +72,9 @@ const EMBEDDED_WRAPPER_TEMPLATE: &str =
 const EMBEDDED_NASTY_FLAKE: &str = include_str!("../../../flake.nix");
 
 const GITHUB_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+const RELEASE_CHECK_TIMEOUT: Duration = Duration::from_secs(150);
+const RELEASE_CHECK_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const SYSTEMCTL_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
@@ -716,7 +720,7 @@ pub struct UpdateBuildDirConfig {
     pub resolved: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct VersionInputInfo {
     /// Flake input name (e.g. `bcachefs-tools`, `nasty`).
     pub name: String,
@@ -786,7 +790,7 @@ pub enum UpdateError {
     Io(#[from] std::io::Error),
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct UpdateInfo {
     /// Currently installed version (short commit SHA or `dev`).
     pub current_version: String,
@@ -832,11 +836,21 @@ pub struct UpdateStatus {
     pub webui_changed: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct NastyInputSource {
     owner: String,
     repo: String,
     tracked_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReleaseCheckContext {
+    current_version: String,
+    channel: ReleaseChannel,
+    nasty_input: NastyInputSource,
+    wrapper_flake_version: Option<String>,
+    last_attempt: Option<String>,
+    inputs: Option<Vec<VersionInputInfo>>,
 }
 
 #[derive(Debug, Clone)]
@@ -891,7 +905,9 @@ struct NixosGeneration {
     current: bool,
 }
 
-pub struct UpdateService;
+pub struct UpdateService {
+    release_check_cache: Mutex<Option<(Instant, ReleaseCheckContext, UpdateInfo)>>,
+}
 
 impl Default for UpdateService {
     fn default() -> Self {
@@ -901,7 +917,9 @@ impl Default for UpdateService {
 
 impl UpdateService {
     pub fn new() -> Self {
-        Self
+        Self {
+            release_check_cache: Mutex::new(None),
+        }
     }
 
     /// Get current installed version
@@ -1189,9 +1207,70 @@ impl UpdateService {
 
     /// Check if an update is available by comparing local rev to GitHub
     pub async fn check(&self) -> Result<UpdateInfo, UpdateError> {
-        let current = read_current_version().await;
-        let channel = read_channel().await;
-        let nasty_input = read_nasty_input_source().await;
+        self.run_check(false).await
+    }
+
+    /// Check for updates, reusing a recent appliance-wide result for polling.
+    pub async fn check_cached(&self) -> Result<UpdateInfo, UpdateError> {
+        self.run_check(true).await
+    }
+
+    async fn run_check(&self, allow_cached: bool) -> Result<UpdateInfo, UpdateError> {
+        tokio::time::timeout(RELEASE_CHECK_TIMEOUT, self.run_check_inner(allow_cached))
+            .await
+            .map_err(|_| UpdateError::CommandFailed("update check timed out".to_string()))?
+    }
+
+    async fn run_check_inner(&self, allow_cached: bool) -> Result<UpdateInfo, UpdateError> {
+        let requested_at = Instant::now();
+        let context = self.release_check_context().await;
+
+        // Keep the lock across the lookup so simultaneous browser sessions
+        // coalesce into one upstream request rather than racing GitHub.
+        let mut cache = self.release_check_cache.lock().await;
+        if let Some((checked_at, cached_context, info)) = cache.as_ref() {
+            let is_recent = checked_at.elapsed() < RELEASE_CHECK_CACHE_TTL;
+            let refreshed_while_waiting = *checked_at >= requested_at;
+            if cached_context == &context
+                && ((allow_cached && is_recent) || refreshed_while_waiting)
+            {
+                return Ok(info.clone());
+            }
+        }
+
+        let info = self.check_uncached(&context).await?;
+        *cache = Some((Instant::now(), context, info.clone()));
+        Ok(info)
+    }
+
+    async fn release_check_context(&self) -> ReleaseCheckContext {
+        let (current_version, channel, nasty_input, wrapper_flake, last_attempt, inputs) = tokio::join!(
+            read_current_version(),
+            read_channel(),
+            read_nasty_input_source(),
+            tokio::fs::read_to_string(format!("{NIXOS_FLAKE_DIR}/flake.nix")),
+            last_upgrade_attempt_result(),
+            self.version_info(),
+        );
+        ReleaseCheckContext {
+            current_version,
+            channel,
+            nasty_input,
+            wrapper_flake_version: wrapper_flake
+                .ok()
+                .and_then(|content| read_wrapper_flake_version(&content).ok().flatten()),
+            last_attempt,
+            inputs: inputs.ok().map(|info| info.inputs),
+        }
+    }
+
+    async fn check_uncached(
+        &self,
+        context: &ReleaseCheckContext,
+    ) -> Result<UpdateInfo, UpdateError> {
+        let current = &context.current_version;
+        let channel = context.channel;
+        let nasty_input = &context.nasty_input;
 
         // Mild follows only published stable GitHub releases. Spicy follows s*
         // tags, while Nasty tracks the wrapper flake's configured branch/ref.
@@ -1289,21 +1368,19 @@ impl UpdateService {
         // operator can retry. The version comparison alone would say
         // "up to date" in this state because `nix flake update` rewrites
         // flake.lock *before* the rebuild runs.
-        let last_attempt = last_upgrade_attempt_result().await;
+        let last_attempt = context.last_attempt.clone();
         if last_attempt.as_deref() == Some("failed") {
             available = Some(true);
         }
 
-        let inputs = self.version_info().await.ok().map(|v| v.inputs);
-
         Ok(UpdateInfo {
-            current_version: current,
+            current_version: current.clone(),
             latest_version: Some(latest),
             update_available: available,
             channel,
             last_attempt,
             error: lookup_error,
-            inputs,
+            inputs: context.inputs.clone(),
         })
     }
 
@@ -1970,10 +2047,11 @@ async fn check_latest_tag(
     args.push(&url);
     args.push(&ref_pattern);
 
-    let output = tokio::process::Command::new("git")
-        .args(&args)
-        .output()
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.args(&args).kill_on_drop(true);
+    let output = tokio::time::timeout(GITHUB_FETCH_TIMEOUT, cmd.output())
         .await
+        .map_err(|_| UpdateError::CommandFailed("git ls-remote timed out".to_string()))?
         .map_err(|e| UpdateError::CommandFailed(format!("git ls-remote: {e}")))?;
 
     if !output.status.success() {
@@ -2881,10 +2959,11 @@ async fn check_via_git_ls_remote(
         ));
     }
     cmd.args(["ls-remote", repo_url, git_ref]);
+    cmd.kill_on_drop(true);
 
-    let output = cmd
-        .output()
+    let output = tokio::time::timeout(GITHUB_FETCH_TIMEOUT, cmd.output())
         .await
+        .map_err(|_| UpdateError::CommandFailed("git ls-remote timed out".to_string()))?
         .map_err(|e| UpdateError::CommandFailed(format!("git ls-remote: {e}")))?;
 
     if !output.status.success() {
@@ -3179,10 +3258,12 @@ fn unquote_nix_string(raw: &str) -> Option<String> {
 /// would say "up to date" because `nix flake update` updates the lock
 /// BEFORE the rebuild runs.
 async fn last_upgrade_attempt_result() -> Option<String> {
-    let out = tokio::process::Command::new("systemctl")
-        .args(["show", UPDATE_UNIT, "--property=ActiveState,Result"])
-        .output()
+    let mut cmd = tokio::process::Command::new("systemctl");
+    cmd.args(["show", UPDATE_UNIT, "--property=ActiveState,Result"])
+        .kill_on_drop(true);
+    let out = tokio::time::timeout(SYSTEMCTL_QUERY_TIMEOUT, cmd.output())
         .await
+        .ok()?
         .ok()?;
     let text = String::from_utf8_lossy(&out.stdout);
     let mut active = "";
@@ -3434,14 +3515,40 @@ async fn read_flake_lock_bcachefs() -> (Option<String>, Option<String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        GitHubRelease, ReleaseChannel, is_booted_generation, map_systemd_state,
-        normalize_git_tag_ref, parse_flake_input_urls, parse_official_nasty_ref,
+        GitHubRelease, ReleaseChannel, UpdateInfo, UpdateService, is_booted_generation,
+        map_systemd_state, normalize_git_tag_ref, parse_flake_input_urls, parse_official_nasty_ref,
         parse_release_tag_version, published_stable_release_tag, read_wrapper_flake_version,
         rewrite_flake_input_urls, should_rebootstrap_wrapper_flake, unquote_nix_string,
         wrapper_flake_content_hash,
     };
     use std::collections::HashMap;
     use std::path::Path;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn cached_update_check_reuses_recent_appliance_result() {
+        let service = UpdateService::new();
+        let context = service.release_check_context().await;
+        *service.release_check_cache.lock().await = Some((
+            Instant::now(),
+            context,
+            UpdateInfo {
+                current_version: "cached-current".to_string(),
+                latest_version: Some("cached-latest".to_string()),
+                update_available: Some(true),
+                channel: ReleaseChannel::Mild,
+                last_attempt: None,
+                error: None,
+                inputs: None,
+            },
+        ));
+
+        let info = service.check_cached().await.unwrap();
+
+        assert_eq!(info.current_version, "cached-current");
+        assert_eq!(info.latest_version.as_deref(), Some("cached-latest"));
+        assert_eq!(info.update_available, Some(true));
+    }
 
     #[test]
     fn normalizes_annotated_git_tag_refs() {

--- a/webui/src/lib/release-update.test.ts
+++ b/webui/src/lib/release-update.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { UpdateInfo } from './types';
 import { getReleaseUpdateSnapshot, invalidateReleaseUpdateCheck, publishReleaseUpdate, releaseUpdateDisplay, requestReleaseUpdateCheck, setReleaseUpdateSnapshot, shouldCheckReleaseUpdate } from './release-update';
 
@@ -13,6 +13,10 @@ const info: UpdateInfo = {
 };
 
 describe('release update display', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	test('distinguishes loading and unchecked states', () => {
 		expect(releaseUpdateDisplay(null, 'loading')).toMatchObject({ kind: 'loading', label: 'checking' });
 		expect(releaseUpdateDisplay(info, 'ready')).toMatchObject({ kind: 'unknown', label: 'unchecked' });
@@ -66,9 +70,11 @@ describe('release update display', () => {
 		let resolve!: (value: typeof info) => void;
 		let calls = 0;
 		let timeout = 0;
+		let method = '';
 		const client = {
-			call: <T>(_method: string, _params?: unknown, timeoutMs?: number) => {
+			call: <T>(nextMethod: string, _params?: unknown, timeoutMs?: number) => {
 				calls++;
+				method = nextMethod;
 				timeout = timeoutMs ?? 0;
 				return new Promise<typeof info>((done) => { resolve = done; }) as Promise<T>;
 			},
@@ -78,6 +84,7 @@ describe('release update display', () => {
 
 		expect(second).toBe(first);
 		expect(calls).toBe(1);
+		expect(method).toBe('system.update.check');
 		expect(timeout).toBe(180_000);
 		resolve(info);
 		await first;
@@ -86,6 +93,21 @@ describe('release update display', () => {
 		expect(calls).toBe(2);
 		resolve(info);
 		await third;
+	});
+
+	test('uses the REST gateway for cached background polling', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve(info),
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const client = { call: <T>() => Promise.resolve(info) as Promise<T> };
+
+		await requestReleaseUpdateCheck(client, 'cached');
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/v1/system/update/check_cached',
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
 	});
 
 	test('starts a fresh check after the previous request is invalidated', async () => {

--- a/webui/src/lib/release-update.ts
+++ b/webui/src/lib/release-update.ts
@@ -13,9 +13,26 @@ interface UpdateRpcClient {
 	call<T>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
 }
 
-let updateCheckInFlight: Promise<UpdateInfo> | null = null;
+export type ReleaseUpdateCheckMode = 'fresh' | 'cached';
+
+const updateChecksInFlight: Record<ReleaseUpdateCheckMode, Promise<UpdateInfo> | null> = {
+	fresh: null,
+	cached: null,
+};
 let releaseUpdateSnapshot: ReleaseUpdateChangedDetail | null = null;
 const UPDATE_CHECK_TIMEOUT_MS = 180_000;
+
+async function fetchCachedReleaseUpdateCheck(): Promise<UpdateInfo> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS);
+	try {
+		const response = await fetch('/api/v1/system/update/check_cached', { signal: controller.signal });
+		if (!response.ok) throw new Error(`Update check failed with HTTP ${response.status}`);
+		return await response.json() as UpdateInfo;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
 
 export interface ReleaseUpdateDisplay {
 	kind: ReleaseUpdateKind;
@@ -51,19 +68,25 @@ export function setReleaseUpdateSnapshot(
 	releaseUpdateSnapshot = { info, requestState };
 }
 
-export function requestReleaseUpdateCheck(client: UpdateRpcClient): Promise<UpdateInfo> {
-	if (updateCheckInFlight) return updateCheckInFlight;
-	const request = client.call<UpdateInfo>('system.update.check', undefined, UPDATE_CHECK_TIMEOUT_MS);
-	updateCheckInFlight = request;
+export function requestReleaseUpdateCheck(
+	client: UpdateRpcClient,
+	mode: ReleaseUpdateCheckMode = 'fresh',
+): Promise<UpdateInfo> {
+	if (updateChecksInFlight[mode]) return updateChecksInFlight[mode];
+	const request = mode === 'cached'
+		? fetchCachedReleaseUpdateCheck()
+		: client.call<UpdateInfo>('system.update.check', undefined, UPDATE_CHECK_TIMEOUT_MS);
+	updateChecksInFlight[mode] = request;
 	const clear = () => {
-		if (updateCheckInFlight === request) updateCheckInFlight = null;
+		if (updateChecksInFlight[mode] === request) updateChecksInFlight[mode] = null;
 	};
 	request.then(clear, clear);
 	return request;
 }
 
 export function invalidateReleaseUpdateCheck() {
-	updateCheckInFlight = null;
+	updateChecksInFlight.fresh = null;
+	updateChecksInFlight.cached = null;
 }
 
 export function releaseUpdateDisplay(

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -301,11 +301,15 @@
 		localStorage.setItem(SIDEBAR_KEY, sidebarCollapsed ? '1' : '0');
 	}
 
-	// Version info (loaded once after connect)
+	// Version and release status shown in the sidebar footer.
 	let sysInfo: { hostname: string; version: string; kernel: string; bcachefs_version: string; bcachefs_commit: string | null; bcachefs_pinned_ref: string | null; bcachefs_recommended_ref: string | null; bcachefs_is_custom: boolean; bcachefs_debug_checks: boolean; kvm_available: boolean; is_virtual: boolean } | null = $state(null);
 	let releaseInfo: UpdateInfo | null = $state(null);
 	let releaseRequestState: ReleaseUpdateRequestState = $state('idle');
 	let releaseRequest = 0;
+	const RELEASE_UPDATE_POLL_MS = 5 * 60_000;
+	let releaseUpdatePoll: ReturnType<typeof setTimeout> | null = null;
+	let releaseUpdatePolling = false;
+	let releaseUpdateRefresh: Promise<void> | null = null;
 	let releaseUpdate = $derived(releaseUpdateDisplay(releaseInfo, releaseRequestState));
 	let releaseUpdateClass = $derived(
 		releaseUpdate.kind === 'current' ? 'text-emerald-400'
@@ -377,7 +381,7 @@
 			// The local endpoint is cheap and may gain a cached result later. Only
 			// fall through to the remote lookup when the status is still unknown.
 			if (shouldCheckReleaseUpdate(info)) {
-				info = await requestReleaseUpdateCheck(getClient());
+				info = await requestReleaseUpdateCheck(getClient(), 'cached');
 				if (request !== releaseRequest) return;
 				releaseInfo = info;
 			}
@@ -389,6 +393,41 @@
 				publishReleaseUpdate(releaseInfo, 'failed');
 			}
 		}
+	}
+
+	function refreshReleaseUpdate() {
+		if (releaseUpdateRefresh) return releaseUpdateRefresh;
+		const request = loadReleaseUpdate();
+		releaseUpdateRefresh = request;
+		void request.finally(() => {
+			if (releaseUpdateRefresh === request) releaseUpdateRefresh = null;
+		});
+		return request;
+	}
+
+	function scheduleReleaseUpdatePoll() {
+		if (!releaseUpdatePolling) return;
+		if (releaseUpdatePoll) clearTimeout(releaseUpdatePoll);
+		releaseUpdatePoll = setTimeout(async () => {
+			releaseUpdatePoll = null;
+			if (connected && isManagementRole(authInfo?.role) && !document.hidden) {
+				await refreshReleaseUpdate();
+			}
+			scheduleReleaseUpdatePoll();
+		}, RELEASE_UPDATE_POLL_MS);
+	}
+
+	function triggerReleaseUpdateRefresh() {
+		if (!connected || !isManagementRole(authInfo?.role) || document.hidden) return;
+		if (releaseUpdatePoll) {
+			clearTimeout(releaseUpdatePoll);
+			releaseUpdatePoll = null;
+		}
+		void refreshReleaseUpdate().finally(scheduleReleaseUpdatePoll);
+	}
+
+	function handleReleaseUpdateVisibility() {
+		if (!document.hidden) triggerReleaseUpdateRefresh();
 	}
 
 	function handleReleaseUpdateChanged(event: Event) {
@@ -519,6 +558,7 @@
 		// — without this trigger it shows the pre-reboot version until the
 		// user hits cmd+R.
 		sysInfoRefresh.trigger();
+		triggerReleaseUpdateRefresh();
 	};
 	const onDisconnect = () => {
 		dbg(`disconnect cb fired — arming ${RECONNECT_OVERLAY_DELAY_MS}ms reconnect-overlay timer (powering=${powering}, prior timer=${reconnectingTimer ? 'rearming' : 'fresh'})`);
@@ -541,9 +581,11 @@
 
 	onMount(() => {
 		if (isPublicShare) return;
+		releaseUpdatePolling = true;
 		tryConnect();
 		window.addEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
 		window.addEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
+		document.addEventListener('visibilitychange', handleReleaseUpdateVisibility);
 		const tick = setInterval(() => { now = new Date(); }, 1000);
 		const rebootPoll = setInterval(checkRebootRequired, 30_000);
 		const statusPoll = setInterval(refreshSystemStatus, 20_000);
@@ -551,7 +593,9 @@
 		const sshPoll = setInterval(checkSshStatus, 30_000);
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
+			releaseUpdatePolling = false;
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
+			if (releaseUpdatePoll) clearTimeout(releaseUpdatePoll);
 			lifecycleClient?.offReconnect(onReconnect);
 			lifecycleClient?.offDisconnect(onDisconnect);
 			lifecycleClient?.disconnect();
@@ -564,6 +608,7 @@
 			clearInterval(authPoll);
 			window.removeEventListener(RECOVERY_BACKUP_CHANGED_EVENT, checkConfigBackup);
 			window.removeEventListener(RELEASE_UPDATE_CHANGED_EVENT, handleReleaseUpdateChanged);
+			document.removeEventListener('visibilitychange', handleReleaseUpdateVisibility);
 		};
 	});
 
@@ -612,7 +657,7 @@
 			if (isManagementRole(authInfo.role)) {
 				checkSshStatus();
 				checkConfigBackup();
-				void loadReleaseUpdate();
+				triggerReleaseUpdateRefresh();
 			}
 			// Capture engine commit on first connect for reconnect version check
 			if (!initialCommit) {

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -84,6 +84,7 @@
 		checkInfo?.inputs ?? info?.inputs ?? null
 	);
 	let checking = $state(initialReleaseUpdate?.requestState === 'loading');
+	let manualReleaseCheckPending = false;
 	let startingDevUpgrade = $state(false);
 	let taggedReleaseBanner: TaggedReleaseBannerState = $state({ kind: 'loading' });
 	let versionRows: VersionRow[] = $state([]);
@@ -189,6 +190,7 @@
 
 	onMount(() => {
 		const applyReleaseUpdate = (detail: ReleaseUpdateChangedDetail) => {
+			if (manualReleaseCheckPending) return;
 			checking = detail.requestState === 'loading';
 			if (detail.requestState === 'ready') checkInfo = detail.info;
 		};
@@ -470,6 +472,7 @@
 
 	async function checkForUpdates() {
 		const requestId = ++releaseCheckRequestId;
+		manualReleaseCheckPending = true;
 		checking = true;
 		publishReleaseUpdate(checkInfo ?? info, 'loading');
 		try {
@@ -482,12 +485,16 @@
 			checkInfo = null;
 			publishReleaseUpdate(null, 'failed');
 		} finally {
-			if (requestId === releaseCheckRequestId) checking = false;
+			if (requestId === releaseCheckRequestId) {
+				manualReleaseCheckPending = false;
+				checking = false;
+			}
 		}
 	}
 
 	function clearReleaseUpdateCheck() {
 		releaseCheckRequestId++;
+		manualReleaseCheckPending = false;
 		invalidateReleaseUpdateCheck();
 		checking = false;
 		checkInfo = null;


### PR DESCRIPTION
## Summary
- refresh the sidebar release indicator immediately and every five minutes while visible
- coalesce background release lookups behind an appliance-wide, context-aware five-minute cache
- use the REST gateway for background checks so slow upstream requests do not block the UI WebSocket
- preserve fresh manual checks and bound all remote/subprocess lookups with timeouts

## Testing
- `cargo test -p nasty-system -p nasty-engine` (679 passed)
- `npm run check`
- `npm test` (286 passed)
- `npm run build`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent focused review: no blocking findings