### PR TITLE
backup: surface failed runs and alerts

### DIFF
--- a/engine/nasty-backup/src/jobs.rs
+++ b/engine/nasty-backup/src/jobs.rs
@@ -34,6 +34,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::RwLock;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 fn now_rfc3339() -> String {
@@ -205,6 +206,7 @@ impl JobRegistry {
 
         let job = BackupJob::new(profile_id.to_string(), kind);
         map.insert(job.id.clone(), job.clone());
+        info!("{} queued", job.log_target());
         Ok(job)
     }
 
@@ -217,6 +219,7 @@ impl JobRegistry {
         if let Some(job) = map.get_mut(job_id) {
             job.state = BackupJobState::Running;
             job.started_at = Some(now_rfc3339());
+            info!("{} started", job.log_target());
         }
     }
 
@@ -236,6 +239,7 @@ impl JobRegistry {
             job.state = BackupJobState::Succeeded;
             job.finished_at = Some(now_rfc3339());
             job.result = Some(result);
+            info!("{} succeeded", job.log_target());
         }
     }
 
@@ -249,6 +253,7 @@ impl JobRegistry {
             job.state = BackupJobState::Failed;
             job.finished_at = Some(now_rfc3339());
             job.error = Some(error);
+            warn!("{} failed", job.log_target());
         }
     }
 

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -351,6 +351,9 @@ impl BackupProfile {
         }
         clone.password_encrypted = None;
         clone.target = clone.target.redacted();
+        if let Some(last_run) = clone.last_run.as_mut() {
+            last_run.message = redact_url_credentials(&last_run.message);
+        }
         clone
     }
 }
@@ -390,7 +393,7 @@ impl BackupTarget {
                 password,
                 password_encrypted: _,
             } => BackupTarget::Rest {
-                url: url.clone(),
+                url: strip_url_userinfo(url),
                 username: username.clone(),
                 password: password.as_ref().map(|_| "***".to_string()),
                 password_encrypted: None,
@@ -398,6 +401,70 @@ impl BackupTarget {
             other => other.clone(),
         }
     }
+}
+
+fn decode_url_userinfo(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let hex = bytes.get(index + 1..index + 3)?;
+            let encoded = std::str::from_utf8(hex).ok()?;
+            decoded.push(u8::from_str_radix(encoded, 16).ok()?);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn strip_url_userinfo(value: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(value) else {
+        return redact_url_credentials(value);
+    };
+    if parsed.username().is_empty() && parsed.password().is_none() {
+        return value.to_string();
+    }
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.into()
+}
+
+/// Move credentials embedded by older clients into the dedicated fields so
+/// they can be encrypted without changing the configured repository.
+fn normalize_rest_url_userinfo(target: &mut BackupTarget) -> bool {
+    let BackupTarget::Rest {
+        url,
+        username,
+        password,
+        password_encrypted,
+    } = target
+    else {
+        return false;
+    };
+    let Ok(mut parsed) = url::Url::parse(url.as_str()) else {
+        return false;
+    };
+    if parsed.username().is_empty() && parsed.password().is_none() {
+        return false;
+    }
+
+    if username.as_deref().is_none_or(str::is_empty) {
+        *username = decode_url_userinfo(parsed.username());
+    }
+    if password.is_none()
+        && password_encrypted.is_none()
+        && let Some(legacy_password) = parsed.password().and_then(decode_url_userinfo)
+    {
+        *password = Some(legacy_password);
+    }
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    *url = parsed.into();
+    true
 }
 
 /// Encrypt the plaintext secret fields on a profile into their
@@ -779,7 +846,10 @@ fn schedule_entries(
                 schedule: expression.to_string(),
                 next_run_at,
                 schedule_error,
-                last_run: profile.last_run.clone(),
+                last_run: profile.last_run.clone().map(|mut last_run| {
+                    last_run.message = redact_url_credentials(&last_run.message);
+                    last_run
+                }),
             })
         })
         .collect();
@@ -819,7 +889,7 @@ pub enum BackupError {
 
 impl BackupError {
     pub fn to_rpc_error(&self) -> String {
-        self.to_string()
+        redact_url_credentials(&self.to_string())
     }
 }
 
@@ -828,6 +898,45 @@ fn validate_sources(sources: &[String]) -> Result<(), BackupError> {
         return Err(BackupError::Failed("backup sources cannot be empty".into()));
     }
     Ok(())
+}
+
+pub fn redact_url_credentials(message: &str) -> String {
+    let mut redacted = message.to_string();
+    let mut search_from = 0;
+    while search_from < redacted.len() {
+        let bytes = redacted.as_bytes();
+        let Some((relative_start, scheme_len)) = (0..bytes.len() - search_from).find_map(|index| {
+            let rest = &bytes[search_from + index..];
+            if rest
+                .get(..8)
+                .is_some_and(|scheme| scheme.eq_ignore_ascii_case(b"https://"))
+            {
+                Some((index, 8))
+            } else if rest
+                .get(..7)
+                .is_some_and(|scheme| scheme.eq_ignore_ascii_case(b"http://"))
+            {
+                Some((index, 7))
+            } else {
+                None
+            }
+        }) else {
+            break;
+        };
+        let scheme_start = search_from + relative_start;
+        let authority_start = scheme_start + scheme_len;
+        let authority_end = redacted[authority_start..]
+            .char_indices()
+            .find(|(_, c)| c.is_whitespace() || matches!(c, '/' | '?' | '#' | ')' | ']'))
+            .map_or(redacted.len(), |(index, _)| authority_start + index);
+        let Some(at) = redacted[authority_start..authority_end].rfind('@') else {
+            search_from = authority_end;
+            continue;
+        };
+        redacted.replace_range(authority_start..authority_start + at, "[redacted]");
+        search_from = authority_start + "[redacted]@".len();
+    }
+    redacted
 }
 
 fn backup_definition_matches(left: &BackupProfile, right: &BackupProfile) -> bool {
@@ -1008,6 +1117,7 @@ impl BackupService {
         let mut profiles = self.profiles.lock().await;
         let mut changed = false;
         for profile in profiles.iter_mut() {
+            let normalized = normalize_rest_url_userinfo(&mut profile.target);
             let before = (
                 profile.password_encrypted.is_some(),
                 encrypted_target_set(&profile.target),
@@ -1017,7 +1127,7 @@ impl BackupService {
                 profile.password_encrypted.is_some(),
                 encrypted_target_set(&profile.target),
             );
-            if before != after {
+            if normalized || before != after {
                 changed = true;
                 info!(
                     "Migrated secrets for backup profile '{}' ({})",
@@ -1051,6 +1161,7 @@ impl BackupService {
         if let Some(pem) = &profile.trusted_cacert {
             validate_pem_cert(pem)?;
         }
+        normalize_rest_url_userinfo(&mut profile.target);
         encrypt_profile_secrets_in_place(&mut profile).await;
 
         let mut profiles = self.profiles.lock().await;
@@ -1077,6 +1188,7 @@ impl BackupService {
         // existing); we carry the existing encrypted value forward
         // when the update doesn't supply a new one.
         let existing = self.get_profile_internal(id).await?;
+        normalize_rest_url_userinfo(&mut update.target);
         carry_forward_existing_secrets(&mut update, &existing);
         invalidate_last_run_if_definition_changed(&mut update, &existing);
         if let Some(pem) = &update.trusted_cacert {
@@ -1148,7 +1260,9 @@ impl BackupService {
                         .await;
                 }
                 Err(e) => {
-                    registry.mark_failed(&job_id, e.to_string()).await;
+                    registry
+                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                        .await;
                 }
             }
         });
@@ -1182,7 +1296,9 @@ impl BackupService {
                     }
                 }
                 Err(e) => {
-                    registry.mark_failed(&job_id, e.to_string()).await;
+                    registry
+                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                        .await;
                 }
             }
         });
@@ -1205,7 +1321,9 @@ impl BackupService {
                         .await;
                 }
                 Err(e) => {
-                    registry.mark_failed(&job_id, e.to_string()).await;
+                    registry
+                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                        .await;
                 }
             }
         });
@@ -1265,7 +1383,11 @@ impl BackupService {
                                 registry.mark_progress(&job_id, 1.0).await;
                                 registry.mark_succeeded(&job_id, value).await;
                             }
-                            Err(e) => registry.mark_failed(&job_id, e.to_string()).await,
+                            Err(e) => {
+                                registry
+                                    .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                                    .await
+                            }
                         }
                         break;
                     }
@@ -1281,6 +1403,7 @@ impl BackupService {
 
     pub async fn init_repo(&self, id: &str) -> Result<String, BackupError> {
         let profile = self.get_profile_internal(id).await?;
+        let initialized_profile = profile.clone();
         let password = resolve_profile_password(&profile).await?;
         let resolved = profile.resolve_runtime().await?;
         nasty_common::priority::spawn_bulk(move || {
@@ -1297,64 +1420,75 @@ impl BackupService {
         .map_err(|e| BackupError::Failed(format!("spawn: {e}")))??;
 
         let mut profiles = self.profiles.lock().await;
-        if let Some(p) = profiles.iter_mut().find(|p| p.id == id) {
-            p.repo_initialized = true;
+        let current = profiles
+            .iter_mut()
+            .find(|profile| profile.id == id)
+            .ok_or_else(|| BackupError::NotFound(id.into()))?;
+        if !backup_definition_matches(current, &initialized_profile) {
+            return Err(BackupError::Failed(
+                "profile changed during repository initialization; initialize the current target again"
+                    .into(),
+            ));
         }
+        current.repo_initialized = true;
         save_profiles(&profiles).await;
         info!("Initialized backup repo for profile '{id}'");
         Ok("Repository initialized".into())
     }
 
     pub async fn run_backup(&self, id: &str) -> Result<BackupRunResult, BackupError> {
-        let profile = self.get_profile_internal(id).await?;
-        validate_sources(&profile.sources)?;
-
-        // Auto-init repo if not yet initialized
-        if !profile.repo_initialized {
-            info!(
-                "Auto-initializing backup repo for profile '{}'",
-                profile.name
-            );
-            self.init_repo(id).await?;
-        }
-
-        let profile = self.get_profile_internal(id).await?;
-        let password = resolve_profile_password(&profile).await?;
-        let resolved = profile.resolve_runtime().await?;
+        let run_profile = self.get_profile_internal(id).await?;
+        let mut executed_profile = run_profile.clone();
         let start = std::time::Instant::now();
         *self.running.lock().await = Some(id.to_string());
+        info!("Starting backup for profile '{}' ({id})", run_profile.name);
 
-        let run_profile = profile.clone();
-        let sources = profile.sources.clone();
-        let backup_result = nasty_common::priority::spawn_bulk(move || {
-            let repo = make_repo(&profile, &resolved)?;
-            let repo = repo
-                .open(&creds(&password))
-                .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
-            let repo = repo
-                .to_indexed_ids()
-                .map_err(|e| BackupError::Failed(format!("index: {e}")))?;
+        let backup_result: Result<_, BackupError> = async {
+            validate_sources(&run_profile.sources)?;
 
-            let source = PathList::from_iter(sources.iter().map(|s| s.as_str()));
-            let snap = SnapshotOptions::default()
-                .to_snapshot()
-                .map_err(|e| BackupError::Failed(format!("snapshot opts: {e}")))?;
+            if !run_profile.repo_initialized {
+                info!(
+                    "Auto-initializing backup repo for profile '{}' ({id})",
+                    run_profile.name
+                );
+                self.init_repo(id).await?;
+            }
 
-            let result = repo
-                .backup(&BackupOptions::default(), &source, snap)
-                .map_err(|e| BackupError::Failed(format!("backup: {e}")))?;
+            let profile = self.get_profile_internal(id).await?;
+            executed_profile = profile.clone();
+            let password = resolve_profile_password(&profile).await?;
+            let resolved = profile.resolve_runtime().await?;
+            let sources = profile.sources.clone();
+            nasty_common::priority::spawn_bulk(move || {
+                let repo = make_repo(&profile, &resolved)?;
+                let repo = repo
+                    .open(&creds(&password))
+                    .map_err(|e| BackupError::Failed(format!("open: {e}")))?;
+                let repo = repo
+                    .to_indexed_ids()
+                    .map_err(|e| BackupError::Failed(format!("index: {e}")))?;
 
-            Ok::<_, BackupError>((
-                result.summary.as_ref().map(|s| s.data_added),
-                result.summary.as_ref().map(|s| s.files_new),
-                result.summary.as_ref().map(|s| s.files_changed),
-            ))
-        })
+                let source = PathList::from_iter(sources.iter().map(|s| s.as_str()));
+                let snap = SnapshotOptions::default()
+                    .to_snapshot()
+                    .map_err(|e| BackupError::Failed(format!("snapshot opts: {e}")))?;
+
+                let result = repo
+                    .backup(&BackupOptions::default(), &source, snap)
+                    .map_err(|e| BackupError::Failed(format!("backup: {e}")))?;
+
+                Ok::<_, BackupError>((
+                    result.summary.as_ref().map(|s| s.data_added),
+                    result.summary.as_ref().map(|s| s.files_new),
+                    result.summary.as_ref().map(|s| s.files_changed),
+                ))
+            })
+            .await
+            .map_err(|e| BackupError::Failed(format!("spawn: {e}")))?
+        }
         .await;
 
         *self.running.lock().await = None;
-        let backup_result =
-            backup_result.map_err(|e| BackupError::Failed(format!("spawn: {e}")))?;
         let duration = start.elapsed().as_secs();
 
         let result = match backup_result {
@@ -1370,7 +1504,7 @@ impl BackupService {
             Err(e) => BackupRunResult {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 success: false,
-                message: format!("Backup failed: {e}"),
+                message: format!("Backup failed: {}", redact_url_credentials(&e.to_string())),
                 duration_secs: duration,
                 bytes_added: None,
                 files_new: None,
@@ -1383,7 +1517,7 @@ impl BackupService {
             let unchanged = profiles
                 .iter_mut()
                 .find(|profile| profile.id == id)
-                .filter(|profile| backup_definition_matches(profile, &run_profile));
+                .filter(|profile| backup_definition_matches(profile, &executed_profile));
             if let Some(p) = unchanged {
                 p.last_run = Some(result.clone());
                 save_profiles(&profiles).await;
@@ -1397,12 +1531,21 @@ impl BackupService {
         };
 
         if result.success {
-            info!("Backup completed in {}s", duration);
-            if result_recorded && let Err(e) = self.prune(run_profile).await {
-                warn!("Auto-prune failed: {e}");
+            info!(
+                "Backup completed for profile '{}' ({id}) in {duration}s",
+                run_profile.name
+            );
+            if result_recorded && let Err(e) = self.prune(executed_profile).await {
+                warn!(
+                    "Auto-prune failed for profile '{id}': {}",
+                    redact_url_credentials(&e.to_string())
+                );
             }
         } else {
-            error!("Backup failed: {}", result.message);
+            error!(
+                "Backup failed for profile '{}' ({id}): {}",
+                run_profile.name, result.message
+            );
         }
         Ok(result)
     }
@@ -1685,6 +1828,19 @@ mod tests {
         };
         invalidate_last_run_if_definition_changed(&mut retargeted, &existing);
         assert!(retargeted.last_run.is_none());
+    }
+
+    #[test]
+    fn backup_errors_redact_http_userinfo() {
+        let message = "request failed for HTTPS://alice:p%40ss@example.com/repo/config; retry http://bob:secret@backup.test/x";
+        let redacted = redact_url_credentials(message);
+
+        assert_eq!(
+            redacted,
+            "request failed for HTTPS://[redacted]@example.com/repo/config; retry http://[redacted]@backup.test/x"
+        );
+        assert!(!redacted.contains("p%40ss"));
+        assert!(!redacted.contains("secret"));
     }
 
     #[test]
@@ -2080,6 +2236,16 @@ mod tests {
     }
 
     #[test]
+    fn error_to_rpc_error_redacts_url_credentials() {
+        let error = BackupError::Failed("open HTTPS://user:secret@example.com/config".into());
+
+        assert_eq!(
+            error.to_rpc_error(),
+            "backup failed: open HTTPS://[redacted]@example.com/config"
+        );
+    }
+
+    #[test]
     fn redacted_blanks_password_and_cloud_secrets() {
         // Single most important property of redacted(): the JSON
         // returned by backup.profile.list / backup.profile.get NEVER
@@ -2105,6 +2271,94 @@ mod tests {
         } else {
             panic!("expected S3 variant");
         }
+    }
+
+    #[test]
+    fn redacted_sanitizes_historical_run_errors() {
+        let mut profile = baseline_profile(BackupTarget::Local {
+            path: "/srv".into(),
+        });
+        profile.last_run = Some(BackupRunResult {
+            timestamp: "2026-09-03T20:42:11Z".into(),
+            success: false,
+            message: "request https://user:secret@example.com/config failed".into(),
+            duration_secs: 1,
+            bytes_added: None,
+            files_new: None,
+            files_changed: None,
+        });
+
+        let redacted = profile.redacted();
+
+        assert_eq!(
+            redacted.last_run.unwrap().message,
+            "request https://[redacted]@example.com/config failed"
+        );
+    }
+
+    #[test]
+    fn redacted_strips_legacy_rest_url_userinfo() {
+        let profile = baseline_profile(BackupTarget::Rest {
+            url: "https://alice:secret@example.com/repo".into(),
+            username: None,
+            password: None,
+            password_encrypted: None,
+        });
+
+        let BackupTarget::Rest { url, .. } = profile.redacted().target else {
+            panic!("expected REST target");
+        };
+        assert_eq!(url, "https://example.com/repo");
+    }
+
+    #[test]
+    fn legacy_rest_url_userinfo_moves_to_dedicated_fields() {
+        let mut target = BackupTarget::Rest {
+            url: "https://alice%40home:p%40ss@example.com/repo".into(),
+            username: None,
+            password: None,
+            password_encrypted: None,
+        };
+
+        assert!(normalize_rest_url_userinfo(&mut target));
+        let BackupTarget::Rest {
+            url,
+            username,
+            password,
+            ..
+        } = target
+        else {
+            panic!("expected REST target");
+        };
+        assert_eq!(url, "https://example.com/repo");
+        assert_eq!(username.as_deref(), Some("alice@home"));
+        assert_eq!(password.as_deref(), Some("p@ss"));
+    }
+
+    #[test]
+    fn schedule_entries_redact_historical_run_errors() {
+        let mut profile = baseline_profile(BackupTarget::Local {
+            path: "/srv".into(),
+        });
+        profile.schedule = Some("0 3 * * *".into());
+        profile.last_run = Some(BackupRunResult {
+            timestamp: "2026-09-03T20:42:11Z".into(),
+            success: false,
+            message: "request https://user:secret@example.com/config failed".into(),
+            duration_secs: 1,
+            bytes_added: None,
+            files_new: None,
+            files_changed: None,
+        });
+
+        let entries = schedule_entries(
+            &[profile],
+            chrono::Utc.with_ymd_and_hms(2026, 9, 3, 0, 0, 0).unwrap(),
+        );
+        assert_eq!(
+            entries[0].last_run.as_ref().unwrap().message,
+            "request https://[redacted]@example.com/config failed"
+        );
     }
 
     #[test]

--- a/engine/nasty-backup/src/scheduler.rs
+++ b/engine/nasty-backup/src/scheduler.rs
@@ -159,6 +159,10 @@ impl SchedulerTick {
         }
         to_fire
     }
+
+    fn retry(&mut self, profile_id: &str) {
+        self.last_attempted.remove(profile_id);
+    }
 }
 
 /// Tick interval for the scheduler loop. 60 s is well under any
@@ -169,8 +173,8 @@ pub const TICK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Long-running scheduler loop. Polls the profile list every
 /// [`TICK_INTERVAL`], evaluates each enabled profile's schedule, and
-/// spawns `run_backup(id)` for every due fire. Each fire is its own
-/// `tokio::spawn` so a slow / hung backup on one profile doesn't
+/// starts a tracked backup job for every due fire. The job wrapper
+/// spawns the actual work, so a slow backup on one profile doesn't
 /// block the scheduler from advancing the others.
 ///
 /// Never returns. Call once from `main` as a long-lived
@@ -190,26 +194,17 @@ pub async fn run_scheduler_loop(service: BackupService) {
         let due = tick_state.evaluate(&profiles, now);
 
         for profile_id in due {
-            let scheduler_service = service.clone_for_task();
-            tokio::spawn(async move {
-                match scheduler_service.run_backup(&profile_id).await {
-                    Ok(result) if result.success => {
-                        info!(
-                            "scheduled backup completed for '{profile_id}' in {}s",
-                            result.duration_secs
-                        );
-                    }
-                    Ok(result) => {
-                        warn!(
-                            "scheduled backup for '{profile_id}' finished with error: {}",
-                            result.message
-                        );
-                    }
-                    Err(e) => {
-                        warn!("scheduled backup for '{profile_id}' failed to start: {e}");
-                    }
+            match service.start_run_backup(&profile_id).await {
+                Ok(job) => {
+                    info!("scheduled backup job {} started for '{profile_id}'", job.id);
                 }
-            });
+                Err(e) => {
+                    tick_state.retry(&profile_id);
+                    warn!(
+                        "scheduled backup for '{profile_id}' could not start and will retry next tick: {e}"
+                    );
+                }
+            }
         }
     }
 }
@@ -315,6 +310,17 @@ mod tests {
         // re-fire.
         let fired = tick.evaluate(&profiles, ts(2026, 6, 5, 3, 1));
         assert!(fired.is_empty(), "got unexpected re-fire: {fired:?}");
+    }
+
+    #[test]
+    fn rejected_job_is_due_again_after_retry() {
+        let started = ts(2026, 6, 5, 2, 59);
+        let mut tick = SchedulerTick::new(started);
+        let profiles = vec![profile_with_schedule("p", "0 3 * * *", true)];
+
+        assert_eq!(tick.evaluate(&profiles, ts(2026, 6, 5, 3, 0)), ["p"]);
+        tick.retry("p");
+        assert_eq!(tick.evaluate(&profiles, ts(2026, 6, 5, 3, 1)), ["p"]);
     }
 
     #[test]

--- a/engine/nasty-engine/src/main.rs
+++ b/engine/nasty-engine/src/main.rs
@@ -189,7 +189,7 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let default_filter = "nasty_engine=debug,nasty_storage=debug,nasty_sharing=debug,nasty_snapshot=debug,nasty_system=info,tower_http=debug";
+    let default_filter = "nasty_engine=debug,nasty_storage=debug,nasty_sharing=debug,nasty_snapshot=debug,nasty_system=info,nasty_backup=info,tower_http=debug";
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| default_filter.into());
     let (filter_layer, reload_handle) = reload::Layer::new(filter);

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1316,6 +1316,22 @@ pub(crate) async fn evaluate_active_alerts_inner(
 ) -> Vec<nasty_system::alerts::AlertOccurrence> {
     use nasty_system::alerts;
 
+    let backup_failures: Vec<alerts::BackupFailure> = state
+        .backups
+        .list_profiles()
+        .await
+        .into_iter()
+        .filter_map(|profile| {
+            let last_run = profile.last_run?;
+            (!last_run.success).then(|| alerts::BackupFailure {
+                profile_id: profile.id,
+                profile_name: profile.name,
+                timestamp: last_run.timestamp,
+                message: last_run.message,
+            })
+        })
+        .collect();
+
     // System stats — required for CPU/memory/temp rules. If the metrics
     // service is down, evaluating those rules without data is meaningless;
     // return an empty alert set rather than fabricating false positives.
@@ -1326,7 +1342,16 @@ pub(crate) async fn evaluate_active_alerts_inner(
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("alert evaluation: stats fetch failed: {e}");
-                return state.alerts.reconcile_active(Vec::new(), |_| false).await;
+                let active = state
+                    .alerts
+                    .evaluate_backup_failures(&backup_failures)
+                    .await;
+                return state
+                    .alerts
+                    .reconcile_active(active, |alert| {
+                        alert.metric == alerts::AlertMetric::BackupFailure
+                    })
+                    .await;
             }
         };
 
@@ -1598,6 +1623,7 @@ pub(crate) async fn evaluate_active_alerts_inner(
             &bcachefs_health,
             &kernel_alert,
             &certificates,
+            &backup_failures,
         )
         .await;
     for metric in unavailable_disk_metrics {

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -1323,7 +1323,7 @@ pub(crate) async fn evaluate_active_alerts_inner(
         .into_iter()
         .filter_map(|profile| {
             let last_run = profile.last_run?;
-            (!last_run.success).then(|| alerts::BackupFailure {
+            (!last_run.success).then_some(alerts::BackupFailure {
                 profile_id: profile.id,
                 profile_name: profile.name,
                 timestamp: last_run.timestamp,
@@ -1623,9 +1623,14 @@ pub(crate) async fn evaluate_active_alerts_inner(
             &bcachefs_health,
             &kernel_alert,
             &certificates,
-            &backup_failures,
         )
         .await;
+    active.extend(
+        state
+            .alerts
+            .evaluate_backup_failures(&backup_failures)
+            .await,
+    );
     for metric in unavailable_disk_metrics {
         coverage.mark_metric(metric);
     }

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -289,7 +289,14 @@ pub(super) async fn try_route(
                 .output()
                 .await;
             match output {
-                Ok(o) => ok(req, String::from_utf8_lossy(&o.stdout).to_string()),
+                Ok(o) if o.status.success() => ok(
+                    req,
+                    nasty_backup::redact_url_credentials(&String::from_utf8_lossy(&o.stdout)),
+                ),
+                Ok(o) => err(
+                    req,
+                    format!("journalctl: {}", String::from_utf8_lossy(&o.stderr).trim()),
+                ),
                 Err(e) => err(req, format!("journalctl: {e}")),
             }
         }

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -265,7 +265,6 @@ impl AlertService {
         bcachefs_health: &[BcachefsHealth],
         kernel_errors: &KernelErrorAlert,
         certificates: &[CertificateHealth],
-        backup_failures: &[BackupFailure],
     ) -> (Vec<ActiveAlert>, Vec<AlertMetric>) {
         let state = self.state.read().await;
         let disk_free = DiskFreeSpace {
@@ -289,7 +288,6 @@ impl AlertService {
             disk_free,
         );
         alerts.extend(evaluate_certificate_rules(&state.rules, certificates));
-        alerts.extend(evaluate_backup_rules(&state.rules, backup_failures));
         (alerts, unavailable)
     }
 

--- a/engine/nasty-system/src/alerts.rs
+++ b/engine/nasty-system/src/alerts.rs
@@ -63,6 +63,8 @@ pub enum AlertMetric {
     CertificateExpiryDays,
     /// Caddy reported a failed ACME issuance or renewal attempt.
     CertificateRenewalFailure,
+    /// The latest recorded run for a backup profile failed.
+    BackupFailure,
     // Kernel error monitoring
     KernelErrors,
 }
@@ -263,6 +265,7 @@ impl AlertService {
         bcachefs_health: &[BcachefsHealth],
         kernel_errors: &KernelErrorAlert,
         certificates: &[CertificateHealth],
+        backup_failures: &[BackupFailure],
     ) -> (Vec<ActiveAlert>, Vec<AlertMetric>) {
         let state = self.state.read().await;
         let disk_free = DiskFreeSpace {
@@ -286,7 +289,16 @@ impl AlertService {
             disk_free,
         );
         alerts.extend(evaluate_certificate_rules(&state.rules, certificates));
+        alerts.extend(evaluate_backup_rules(&state.rules, backup_failures));
         (alerts, unavailable)
+    }
+
+    pub async fn evaluate_backup_failures(
+        &self,
+        backup_failures: &[BackupFailure],
+    ) -> Vec<ActiveAlert> {
+        let state = self.state.read().await;
+        evaluate_backup_rules(&state.rules, backup_failures)
     }
 
     /// Serialize evaluation and acknowledgement so neither can overwrite the
@@ -385,7 +397,10 @@ fn reconcile_instances(
         let mut instance = remaining
             .iter()
             .position(|instance| {
-                instance.alert.rule_id == alert.rule_id && instance.alert.source == alert.source
+                instance.alert.rule_id == alert.rule_id
+                    && instance.alert.source == alert.source
+                    && (alert.metric != AlertMetric::BackupFailure
+                        || instance.alert.message == alert.message)
             })
             .map(|position| remaining.remove(position))
             .unwrap_or_else(|| AlertInstanceState {
@@ -860,9 +875,11 @@ fn evaluate_rules(
                     });
                 }
             }
-            AlertMetric::CertificateExpiryDays | AlertMetric::CertificateRenewalFailure => {
-                // Evaluated separately because certificate state is not part
-                // of the metrics-service snapshot.
+            AlertMetric::CertificateExpiryDays
+            | AlertMetric::CertificateRenewalFailure
+            | AlertMetric::BackupFailure => {
+                // Evaluated separately because these states are not part of
+                // the metrics-service snapshot.
             }
         }
     }
@@ -939,6 +956,54 @@ fn evaluate_certificate_rules(
     alerts
 }
 
+fn evaluate_backup_rules(rules: &[AlertRule], failures: &[BackupFailure]) -> Vec<ActiveAlert> {
+    let mut alerts = Vec::new();
+    for rule in rules
+        .iter()
+        .filter(|rule| rule.enabled && rule.metric == AlertMetric::BackupFailure)
+    {
+        if !check_condition(1.0, &rule.condition, rule.threshold) {
+            continue;
+        }
+        for failure in failures {
+            let detail = backup_failure_summary(&failure.message);
+            alerts.push(ActiveAlert {
+                rule_id: rule.id.clone(),
+                rule_name: rule.name.clone(),
+                severity: rule.severity.clone(),
+                metric: rule.metric.clone(),
+                message: format!(
+                    "Backup profile \"{}\" failed at {}: {detail}",
+                    failure.profile_name, failure.timestamp
+                ),
+                current_value: 1.0,
+                threshold: rule.threshold,
+                source: failure.profile_id.clone(),
+            });
+        }
+    }
+    alerts
+}
+
+fn backup_failure_summary(message: &str) -> &str {
+    let lines: Vec<_> = message.lines().collect();
+    for marker in ["Caused by:", "Message:"] {
+        for (index, line) in lines.iter().enumerate().rev() {
+            if line.trim() == marker
+                && let Some(detail) = lines[index + 1..]
+                    .iter()
+                    .find(|line| !line.trim().is_empty())
+            {
+                return detail.trim();
+            }
+        }
+    }
+    lines
+        .iter()
+        .find(|line| !line.trim().is_empty())
+        .map_or("unknown error", |line| line.trim())
+}
+
 /// Minimal filesystem info for alert evaluation
 #[derive(Debug)]
 pub struct FsUsage {
@@ -952,6 +1017,14 @@ pub struct CertificateHealth {
     pub host: String,
     pub expires_in_days: Option<i64>,
     pub renewal_error: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct BackupFailure {
+    pub profile_id: String,
+    pub profile_name: String,
+    pub timestamp: String,
+    pub message: String,
 }
 
 /// ATA SMART attribute IDs flagged as critical per Scrutiny's
@@ -1400,6 +1473,15 @@ fn default_rules() -> Vec<AlertRule> {
             threshold: 1.0,
             severity: AlertSeverity::Critical,
         },
+        AlertRule {
+            id: "backup-failure".into(),
+            name: "Backup failed".into(),
+            enabled: true,
+            metric: AlertMetric::BackupFailure,
+            condition: AlertCondition::Equals,
+            threshold: 1.0,
+            severity: AlertSeverity::Warning,
+        },
         // Kernel error monitoring
         AlertRule {
             id: "kernel-errors".into(),
@@ -1486,6 +1568,23 @@ mod tests {
         let (_, recurrence) = reconcile_instances(&instances, vec![test_alert(3.0)], |_| true);
         assert_ne!(recurrence[0].instance_id, first_id);
         assert!(!recurrence[0].acknowledged);
+    }
+
+    #[test]
+    fn later_backup_failure_starts_a_new_occurrence() {
+        let mut first_alert = test_alert(1.0);
+        first_alert.rule_id = "backup-failure".into();
+        first_alert.metric = AlertMetric::BackupFailure;
+        first_alert.source = "profile-a".into();
+        first_alert.message = "Backup failed at 2026-09-03T20:42:11Z".into();
+        let (mut instances, first) = reconcile_instances(&[], vec![first_alert.clone()], |_| true);
+        mark_acknowledged(&mut instances, &first[0].instance_id, "operator", "now").unwrap();
+
+        first_alert.message = "Backup failed at 2026-09-04T20:42:11Z".into();
+        let (_, later) = reconcile_instances(&instances, vec![first_alert], |_| true);
+
+        assert_ne!(later[0].instance_id, first[0].instance_id);
+        assert!(!later[0].acknowledged);
     }
 
     #[test]
@@ -2359,6 +2458,26 @@ mod tests {
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0].source, "nas.example.com");
         assert!(alerts[0].message.contains("Invalid access token"));
+    }
+
+    #[test]
+    fn backup_failure_rules_fire_per_profile_with_concise_message() {
+        let failure = rule(AlertMetric::BackupFailure, AlertCondition::Equals, 1.0);
+        let failures = vec![BackupFailure {
+            profile_id: "offsite-id".into(),
+            profile_name: "Offsite".into(),
+            timestamp: "2026-09-03T20:42:11Z".into(),
+            message: "Backup failed: rustic_core backend error\n\nMessage:\nBackoff failed\n\nCaused by:\nconnection refused\n\nBacktrace: hidden".into(),
+        }];
+
+        let alerts = evaluate_backup_rules(&[failure], &failures);
+
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].source, "offsite-id");
+        assert!(alerts[0].message.contains("Offsite"));
+        assert!(alerts[0].message.contains("connection refused"));
+        assert!(!alerts[0].message.contains("rustic_core"));
+        assert!(!alerts[0].message.contains("Backtrace"));
     }
 
     // ── default_rules smoke ────────────────────────────────────────

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -174,7 +174,7 @@ in {
         # log non-zero exits + spawn errors there). Without it in the
         # allowlist those warnings are dropped — e.g. a compose stack that
         # fails to come up at boot logged nothing engine-side (#437 testing).
-        default = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,nasty::cmd=info,tower_http=info";
+        default = "nasty_engine=info,nasty_storage=info,nasty_sharing=info,nasty_snapshot=info,nasty_system=info,nasty_apps=info,nasty_backup=info,nasty::cmd=info,tower_http=info";
         description = "RUST_LOG filter for engine";
       };
     };

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1485,7 +1485,7 @@ export interface AlertRule {
 	severity: AlertSeverity;
 }
 
-export type AlertMetric = 'fs_usage_percent' | 'cpu_load_percent' | 'memory_usage_percent' | 'disk_temperature' | 'smart_health' | 'smart_attribute' | 'swap_usage_percent' | 'bcachefs_degraded' | 'bcachefs_device_error' | 'bcachefs_device_state' | 'bcachefs_io_errors' | 'bcachefs_scrub_errors' | 'bcachefs_reconcile_stalled' | 'root_disk_free_gb' | 'boot_disk_free_mb' | 'certificate_expiry_days' | 'certificate_renewal_failure' | 'kernel_errors';
+export type AlertMetric = 'fs_usage_percent' | 'cpu_load_percent' | 'memory_usage_percent' | 'disk_temperature' | 'smart_health' | 'smart_attribute' | 'swap_usage_percent' | 'bcachefs_degraded' | 'bcachefs_device_error' | 'bcachefs_device_state' | 'bcachefs_io_errors' | 'bcachefs_scrub_errors' | 'bcachefs_reconcile_stalled' | 'root_disk_free_gb' | 'boot_disk_free_mb' | 'certificate_expiry_days' | 'certificate_renewal_failure' | 'backup_failure' | 'kernel_errors';
 export type AlertCondition = 'above' | 'below' | 'equals';
 export type AlertSeverity = 'warning' | 'critical';
 

--- a/webui/src/routes/alerts/+page.svelte
+++ b/webui/src/routes/alerts/+page.svelte
@@ -54,6 +54,7 @@
 		boot_disk_free_mb: '/boot (ESP) Free (MB)',
 		certificate_expiry_days: 'TLS Certificate Validity (days)',
 		certificate_renewal_failure: 'TLS Certificate Renewal Failure',
+		backup_failure: 'Backup Failure',
 		kernel_errors: 'Kernel Errors',
 	});
 
@@ -156,17 +157,19 @@
 		// disk_temperature thresholds are stored in Celsius. If the user is
 		// viewing Fahrenheit, the value typed in the input is in °F — convert
 		// before sending so the alert evaluator sees the canonical unit.
+		const condition = newMetric === 'backup_failure' ? 'equals' : newCondition;
+		const threshold = newMetric === 'backup_failure' ? 1 : newThreshold;
 		const stored =
 			newMetric === 'disk_temperature' && tempUnit.current === 'fahrenheit'
-				? Math.round(((newThreshold - 32) * 5) / 9)
-				: newThreshold;
+				? Math.round(((threshold - 32) * 5) / 9)
+				: threshold;
 		const ok = await withToast(
 			() => client.call('alert.rules.create', {
 				id: '',
 				name: newName,
 				enabled: true,
 				metric: newMetric,
-				condition: newCondition,
+				condition,
 				threshold: stored,
 				severity: newSeverity,
 			}),
@@ -176,6 +179,7 @@
 			showCreate = false;
 			newName = '';
 			createTried = false;
+			newCondition = 'above';
 			newThreshold = 80;
 			await refresh();
 		}
@@ -259,20 +263,24 @@
 						{/each}
 					</select>
 				</div>
-				<div class="flex-1">
-					<Label for="rule-condition">Condition</Label>
-					<select id="rule-condition" bind:value={newCondition} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
-						{#each Object.entries(conditionLabels) as [val, label]}
-							<option value={val}>{label}</option>
-						{/each}
-					</select>
-				</div>
+				{#if newMetric !== 'backup_failure'}
+					<div class="flex-1">
+						<Label for="rule-condition">Condition</Label>
+						<select id="rule-condition" bind:value={newCondition} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">
+							{#each Object.entries(conditionLabels) as [val, label]}
+								<option value={val}>{label}</option>
+							{/each}
+						</select>
+					</div>
+				{/if}
 			</div>
 			<div class="mb-4 flex gap-4">
-				<div class="flex-1">
-					<Label for="rule-threshold">Threshold</Label>
-					<Input id="rule-threshold" type="number" bind:value={newThreshold} class="mt-1" />
-				</div>
+				{#if newMetric !== 'backup_failure'}
+					<div class="flex-1">
+						<Label for="rule-threshold">Threshold</Label>
+						<Input id="rule-threshold" type="number" bind:value={newThreshold} class="mt-1" />
+					</div>
+				{/if}
 				<div class="flex-1">
 					<Label for="rule-severity">Severity</Label>
 					<select id="rule-severity" bind:value={newSeverity} class="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm">

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -808,6 +808,20 @@
 		return lines.find(line => line.trim())?.trim() ?? message;
 	}
 
+	function formatRunTimestamp(timestamp: string): string {
+		const date = new Date(timestamp);
+		if (Number.isNaN(date.getTime())) return timestamp;
+		return new Intl.DateTimeFormat(undefined, {
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+			timeZoneName: 'short',
+		}).format(date);
+	}
+
 	function closeRunLogs() {
 		runLogRequest++;
 		viewRunLogProfile = null;
@@ -842,7 +856,7 @@
 			const latest = profiles.find(profile => profile.id === current.id) ?? current;
 			viewRunLogProfile = latest;
 			const recorded = latest.last_run
-				? `Latest recorded result (${latest.last_run.timestamp}):\n${latest.last_run.message}`
+				? `Latest recorded result (${formatRunTimestamp(latest.last_run.timestamp)}):\n${latest.last_run.message}`
 				: 'No completed run has been recorded yet.';
 			runLogOutput = journal.trim()
 				? `${journal.trimEnd()}\n\n${recorded}`
@@ -852,7 +866,7 @@
 			const latest = profiles.find(profile => profile.id === current.id) ?? current;
 			viewRunLogProfile = latest;
 			const recorded = latest.last_run
-				? `Latest recorded result (${latest.last_run.timestamp}):\n${latest.last_run.message}`
+				? `Latest recorded result (${formatRunTimestamp(latest.last_run.timestamp)}):\n${latest.last_run.message}`
 				: 'No completed run has been recorded yet.';
 			runLogOutput = `Unable to load the engine journal.\n\n${recorded}`;
 		} finally {
@@ -1167,7 +1181,7 @@
 								</div>
 								{#if profile.last_run}
 									<div class="mt-1 text-xs {profile.last_run.success ? 'text-green-400' : 'text-red-400'}">
-										Last: {profile.last_run.success ? 'Success' : 'Failed'} — {profile.last_run.timestamp.slice(0, 19).replace('T', ' ')} ({profile.last_run.duration_secs}s)
+										Last: {profile.last_run.success ? 'Success' : 'Failed'} — {formatRunTimestamp(profile.last_run.timestamp)} ({profile.last_run.duration_secs}s)
 									</div>
 									{#if !profile.last_run.success}
 										<div class="mt-1 max-w-3xl break-words text-xs text-red-300">{backupFailureSummary(profile.last_run.message)}</div>
@@ -1341,7 +1355,7 @@
 				{#if viewRunLogProfile && activeJobs[viewRunLogProfile.id]?.kind === 'run_backup'}
 					{viewRunLogProfile.name} — backup currently in progress
 				{:else if viewRunLogProfile?.last_run}
-					{viewRunLogProfile.name} — {viewRunLogProfile.last_run.timestamp.slice(0, 19).replace('T', ' ')} — {viewRunLogProfile.last_run.success ? 'Succeeded' : 'Failed'} in {viewRunLogProfile.last_run.duration_secs}s
+					{viewRunLogProfile.name} — {formatRunTimestamp(viewRunLogProfile.last_run.timestamp)} — {viewRunLogProfile.last_run.success ? 'Succeeded' : 'Failed'} in {viewRunLogProfile.last_run.duration_secs}s
 				{/if}
 			</Dialog.Description>
 		</Dialog.Header>

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -31,6 +31,13 @@
 			: []),
 	]);
 	let backupStatus: BackupStatus | null = $state(null);
+	let viewRunLogProfile: BackupProfile | null = $state(null);
+	let runLogOutput = $state('');
+	let runLogLoading = $state(false);
+	let runLogPoll: ReturnType<typeof setTimeout> | null = null;
+	let runLogRequest = 0;
+	let backupStateRequest = 0;
+	let pageActive = true;
 	/** Loaded once on mount from backup.secrets_status — drives the
 	 * small status pill near the page header. `null` means the
 	 * status hasn't been fetched yet (briefly during initial load) or
@@ -448,6 +455,7 @@
 	// cancel it on SPA navigation — otherwise the 3-second interval keeps
 	// running until the backup finishes server-side, which can be minutes.
 	let runBackupPoll: ReturnType<typeof setInterval> | null = null;
+	let backupStatePoll: ReturnType<typeof setInterval> | null = null;
 	function stopRunBackupPoll() {
 		if (runBackupPoll !== null) { clearInterval(runBackupPoll); runBackupPoll = null; }
 	}
@@ -469,6 +477,25 @@
 
 	function stopAllJobPolls() {
 		for (const id of Object.keys(jobPollers)) stopJobPoll(id);
+	}
+
+	async function refreshBackupState() {
+		const request = ++backupStateRequest;
+		try {
+			const [nextProfiles, nextStatus, jobs] = await Promise.all([
+				client.call<BackupProfile[]>('backup.profile.list'),
+				client.call<BackupStatus>('backup.status'),
+				client.call<BackupJob[]>('backup.jobs.list'),
+			]);
+			if (!pageActive || request !== backupStateRequest) return;
+			profiles = nextProfiles;
+			backupStatus = nextStatus;
+			for (const job of jobs) {
+				if ((job.state === 'pending' || job.state === 'running') && !activeJobs[job.profile_id]) {
+					rehydrateJobPolling(job);
+				}
+			}
+		} catch { /* Keep the last known state during a transient disconnect. */ }
 	}
 
 	/** Attach a 2 s poll for an already-started job, updating the inline
@@ -550,6 +577,7 @@
 
 	onMount(async () => {
 		await Promise.all([refresh(), loadRecoveryContext()]);
+		if (!pageActive) return;
 		loading = false;
 		// Load filesystems (and subvolumes) up front rather than only when
 		// the create form is opened — the restore dialog's destination
@@ -563,6 +591,7 @@
 		try {
 			secretsStatus = await client.call<SecretsStatus>('backup.secrets_status');
 		} catch { /* leave null */ }
+		if (!pageActive) return;
 
 		// Re-attach pollers for any backup jobs the engine is still
 		// running. Without this, reloading the Backups page mid-init
@@ -573,12 +602,15 @@
 		// last_run from the engine.
 		try {
 			const activeOnEngine = await client.call<BackupJob[]>('backup.jobs.list');
+			if (!pageActive) return;
 			for (const job of activeOnEngine) {
 				if (job.state === 'pending' || job.state === 'running') {
 					rehydrateJobPolling(job);
 				}
 			}
 		} catch { /* engine didn't expose jobs.list; ignore */ }
+		if (!pageActive) return;
+		backupStatePoll = setInterval(refreshBackupState, 15_000);
 
 		// Auto-open create form with config preset from ?create=config
 		if ($page.url.searchParams.get('create') === 'config' && isAdmin) {
@@ -600,21 +632,34 @@
 	}
 
 	onDestroy(() => {
+		pageActive = false;
+		backupStateRequest++;
+		runLogRequest++;
 		stopRunBackupPoll();
 		stopAllJobPolls();
+		if (backupStatePoll) clearInterval(backupStatePoll);
+		if (runLogPoll) clearTimeout(runLogPoll);
 	});
 
 	let snapshotCounts: Record<string, number> = $state({});
 
 	async function refresh() {
+		const request = ++backupStateRequest;
 		try {
-			profiles = await client.call<BackupProfile[]>('backup.profile.list');
+			const [nextProfiles, nextStatus] = await Promise.all([
+				client.call<BackupProfile[]>('backup.profile.list'),
+				client.call<BackupStatus>('backup.status'),
+			]);
+			if (!pageActive || request !== backupStateRequest) return;
+			profiles = nextProfiles;
+			backupStatus = nextStatus;
 			window.dispatchEvent(new Event(RECOVERY_BACKUP_CHANGED_EVENT));
-			backupStatus = await client.call<BackupStatus>('backup.status');
 			// Fetch snapshot counts for initialized repos
 			for (const p of profiles.filter(p => p.repo_initialized)) {
 				client.call<BackupSnapshot[]>('backup.snapshots', { id: p.id })
-					.then(snaps => { snapshotCounts[p.id] = snaps.length; })
+					.then(snaps => {
+						if (pageActive && request === backupStateRequest) snapshotCounts[p.id] = snaps.length;
+					})
 					.catch(() => {});
 			}
 		} catch { /* ignore */ }
@@ -749,6 +794,85 @@
 		if (t.type === 'rest') return t.url;
 		if (t.type === 'b2') return `b2:${t.bucket}`;
 		return '?';
+	}
+
+	function backupFailureSummary(message: string): string {
+		const lines = message.split('\n');
+		for (const marker of ['Caused by:', 'Message:']) {
+			for (let index = lines.length - 1; index >= 0; index--) {
+				if (lines[index].trim() !== marker) continue;
+				const detail = lines.slice(index + 1).find(line => line.trim());
+				if (detail) return detail.trim();
+			}
+		}
+		return lines.find(line => line.trim())?.trim() ?? message;
+	}
+
+	function closeRunLogs() {
+		runLogRequest++;
+		viewRunLogProfile = null;
+		runLogOutput = '';
+		runLogLoading = false;
+		if (runLogPoll) {
+			clearTimeout(runLogPoll);
+			runLogPoll = null;
+		}
+	}
+
+	async function loadRunLogs() {
+		if (!viewRunLogProfile || runLogLoading) return;
+		if (runLogPoll) {
+			clearTimeout(runLogPoll);
+			runLogPoll = null;
+		}
+		const current = profiles.find(profile => profile.id === viewRunLogProfile?.id) ?? viewRunLogProfile;
+		const wasRunning = activeJobs[current.id]?.kind === 'run_backup'
+			&& (activeJobs[current.id].state === 'pending' || activeJobs[current.id].state === 'running');
+		const request = ++runLogRequest;
+		viewRunLogProfile = current;
+		runLogLoading = true;
+		try {
+			const grep = current.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const journal = await client.call<string>('system.logs', {
+				unit: 'nasty-engine',
+				lines: 500,
+				grep: `(${grep}.*kind run|Starting backup.*${grep}|Backup completed.*${grep}|Backup failed.*${grep}|Auto-prune failed.*${grep})`,
+			});
+			if (request !== runLogRequest || viewRunLogProfile?.id !== current.id) return;
+			const latest = profiles.find(profile => profile.id === current.id) ?? current;
+			viewRunLogProfile = latest;
+			const recorded = latest.last_run
+				? `Latest recorded result (${latest.last_run.timestamp}):\n${latest.last_run.message}`
+				: 'No completed run has been recorded yet.';
+			runLogOutput = journal.trim()
+				? `${journal.trimEnd()}\n\n${recorded}`
+				: `No matching journal entries are available.\n\n${recorded}`;
+		} catch {
+			if (request !== runLogRequest || viewRunLogProfile?.id !== current.id) return;
+			const latest = profiles.find(profile => profile.id === current.id) ?? current;
+			viewRunLogProfile = latest;
+			const recorded = latest.last_run
+				? `Latest recorded result (${latest.last_run.timestamp}):\n${latest.last_run.message}`
+				: 'No completed run has been recorded yet.';
+			runLogOutput = `Unable to load the engine journal.\n\n${recorded}`;
+		} finally {
+			if (request === runLogRequest) {
+				runLogLoading = false;
+				const active = activeJobs[current.id];
+				const stillRunning = active?.kind === 'run_backup'
+					&& (active.state === 'pending' || active.state === 'running');
+				if (viewRunLogProfile?.id === current.id && (wasRunning || stillRunning)) {
+					runLogPoll = setTimeout(loadRunLogs, 3_000);
+				}
+			}
+		}
+	}
+
+	function openRunLogs(profile: BackupProfile) {
+		if (runLogPoll) clearTimeout(runLogPoll);
+		viewRunLogProfile = profile;
+		runLogOutput = '';
+		void loadRunLogs();
 	}
 
 	function profileHasSystemSources(profile: BackupProfile): boolean {
@@ -1045,9 +1169,15 @@
 									<div class="mt-1 text-xs {profile.last_run.success ? 'text-green-400' : 'text-red-400'}">
 										Last: {profile.last_run.success ? 'Success' : 'Failed'} — {profile.last_run.timestamp.slice(0, 19).replace('T', ' ')} ({profile.last_run.duration_secs}s)
 									</div>
+									{#if !profile.last_run.success}
+										<div class="mt-1 max-w-3xl break-words text-xs text-red-300">{backupFailureSummary(profile.last_run.message)}</div>
+									{/if}
 								{/if}
 							</div>
-							<div class="flex gap-2">
+							<div class="flex flex-wrap justify-end gap-2">
+								{#if profile.last_run || activeJobs[profile.id]?.kind === 'run_backup'}
+									<Button size="xs" variant="outline" onclick={() => openRunLogs(profile)}>Logs</Button>
+								{/if}
 								{#if canManageProfile}
 								{#if !profile.repo_initialized}
 									<Button size="xs" onclick={() => initRepo(profile.id)} disabled={activeJobs[profile.id] !== undefined}>
@@ -1063,8 +1193,8 @@
 										{activeJobs[profile.id]?.kind === 'check_repo' ? 'Checking…' : 'Check'}
 									</Button>
 								{/if}
-								<Button size="xs" variant="secondary" onclick={() => startEdit(profile)}>Edit</Button>
-								<Button size="xs" variant="destructive" onclick={() => deleteProfile(profile.id)}>Delete</Button>
+				<Button size="xs" variant="secondary" onclick={() => startEdit(profile)} disabled={activeJobs[profile.id] !== undefined}>Edit</Button>
+				<Button size="xs" variant="destructive" onclick={() => deleteProfile(profile.id)} disabled={activeJobs[profile.id] !== undefined}>Delete</Button>
 								{:else if profileHasSystemSources(profile)}
 									<Badge variant="secondary" class="text-[0.6rem]">Admin required</Badge>
 								{/if}
@@ -1190,7 +1320,7 @@
 									</div>
 								</div>
 								<div class="flex gap-2">
-									<Button size="sm" onclick={saveEdit}>Save</Button>
+									<Button size="sm" onclick={saveEdit} disabled={activeJobs[profile.id] !== undefined}>Save</Button>
 									<Button size="sm" variant="secondary" onclick={() => editId = null}>Cancel</Button>
 								</div>
 							</div>
@@ -1201,6 +1331,34 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Backup profile history modal -->
+<Dialog.Root open={viewRunLogProfile !== null} onOpenChange={(open) => { if (!open) closeRunLogs(); }}>
+	<Dialog.Content class="flex max-h-[75vh] w-[92vw] max-w-4xl flex-col gap-0 bg-card p-0">
+		<Dialog.Header class="border-b border-border px-4 py-3 pr-12">
+			<Dialog.Title class="text-sm">Backup profile history</Dialog.Title>
+			<Dialog.Description class="text-xs">
+				{#if viewRunLogProfile && activeJobs[viewRunLogProfile.id]?.kind === 'run_backup'}
+					{viewRunLogProfile.name} — backup currently in progress
+				{:else if viewRunLogProfile?.last_run}
+					{viewRunLogProfile.name} — {viewRunLogProfile.last_run.timestamp.slice(0, 19).replace('T', ' ')} — {viewRunLogProfile.last_run.success ? 'Succeeded' : 'Failed'} in {viewRunLogProfile.last_run.duration_secs}s
+				{/if}
+			</Dialog.Description>
+		</Dialog.Header>
+		<div class="min-h-0 flex-1 overflow-auto p-4">
+			<div class="mb-3 flex justify-end">
+				<Button size="xs" variant="secondary" disabled={runLogLoading} onclick={loadRunLogs}>
+					{runLogLoading ? 'Loading…' : 'Refresh'}
+				</Button>
+			</div>
+			{#if runLogLoading && !runLogOutput}
+				<p class="text-sm text-muted-foreground">Loading backup logs...</p>
+			{:else}
+				<pre class="min-h-32 whitespace-pre-wrap break-words rounded-md bg-black/40 p-4 font-mono text-xs leading-relaxed text-foreground">{runLogOutput}</pre>
+			{/if}
+		</div>
+	</Dialog.Content>
+</Dialog.Root>
 
 <!-- Snapshots modal -->
 <Dialog.Root open={viewSnapshotsId !== null} onOpenChange={(open) => { if (!open) viewSnapshotsId = null; }}>


### PR DESCRIPTION
## Summary
- persist backup failures from validation, initialization, credential resolution, and repository access in profile run history
- run scheduled backups through the job registry and expose failure details plus live profile history in the Backups UI
- add a default Backup Failure alert that resolves after success and creates a new occurrence for each failed run
- redact URL credentials across profiles, schedules, jobs, RPC errors, alerts, and journal output while migrating legacy REST userinfo into encrypted fields
- guard backup polling and profile edits against stale responses and initialization races

## Testing
- `cargo test -p nasty-backup` (69 passed)
- `cargo test -p nasty-system` (427 passed)
- `cargo test -p nasty-engine` (254 passed)
- `npm run check`
- `npm test` (288 passed)
- `npm run build`
- `nix-instantiate --parse nixos/modules/nasty.nix`
- `git diff --check`