### PR TITLE
backup: recover abandoned jobs

### DIFF
--- a/engine/nasty-backup/src/jobs.rs
+++ b/engine/nasty-backup/src/jobs.rs
@@ -27,13 +27,15 @@
 //! [`Pending`]: BackupJobState::Pending
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -168,6 +170,8 @@ pub enum JobError {
 /// day doesn't accumulate thousands of entries.
 const JOB_RETENTION: Duration = Duration::hours(1);
 
+const UNEXPECTED_TASK_ERROR: &str = "Backup operation stopped unexpectedly; retry the operation";
+
 /// In-memory store of currently-active and recently-finished backup
 /// jobs. Cheap-to-clone Arc so the spawned task can update its own
 /// entry without going through the BackupService.
@@ -257,6 +261,32 @@ impl JobRegistry {
         }
     }
 
+    async fn recover_abandoned(&self, job_id: &str, running: &Mutex<Option<String>>) -> bool {
+        let mut map = self.inner.write().await;
+        let Some(job) = map.get(job_id) else {
+            return false;
+        };
+        if job.state.is_terminal() {
+            return false;
+        }
+        let profile_id = job.profile_id.clone();
+
+        // Keep start() excluded until the stale running marker is cleared and
+        // the abandoned job is terminal, so a same-profile replacement cannot
+        // be mistaken for the old run.
+        let mut running = running.lock().await;
+        if running.as_deref() == Some(profile_id.as_str()) {
+            *running = None;
+        }
+
+        let job = map.get_mut(job_id).expect("job was checked above");
+        job.state = BackupJobState::Failed;
+        job.finished_at = Some(now_rfc3339());
+        job.error = Some(UNEXPECTED_TASK_ERROR.to_string());
+        warn!("{} failed", job.log_target());
+        true
+    }
+
     pub async fn get(&self, job_id: &str) -> Option<BackupJob> {
         let mut map = self.inner.write().await;
         self.gc_locked(&mut map);
@@ -302,6 +332,43 @@ impl JobRegistry {
     }
 }
 
+pub(crate) fn spawn_monitored<F>(
+    registry: JobRegistry,
+    running: Arc<Mutex<Option<String>>>,
+    job_id: String,
+    task: F,
+) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let worker = tokio::spawn(task);
+    tokio::spawn(monitor_task(registry, running, job_id, worker))
+}
+
+async fn monitor_task(
+    registry: JobRegistry,
+    running: Arc<Mutex<Option<String>>>,
+    job_id: String,
+    worker: JoinHandle<()>,
+) {
+    match worker.await {
+        Ok(()) => {}
+        Err(error) => {
+            let outcome = if error.is_cancelled() {
+                "was cancelled"
+            } else if error.is_panic() {
+                "panicked"
+            } else {
+                "ended abnormally"
+            };
+            // JoinError may contain a panic payload, so log only its classification.
+            warn!("backup job {job_id} worker {outcome}");
+        }
+    }
+
+    registry.recover_abandoned(&job_id, &running).await;
+}
+
 fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(s)
         .ok()
@@ -323,6 +390,17 @@ impl BackupJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn active_job() -> (JobRegistry, BackupJob, Arc<Mutex<Option<String>>>) {
+        let registry = JobRegistry::new();
+        let job = registry
+            .start("profile-a", BackupJobKind::RunBackup)
+            .await
+            .unwrap();
+        registry.mark_running(&job.id).await;
+        let running = Arc::new(Mutex::new(Some(job.profile_id.clone())));
+        (registry, job, running)
+    }
 
     fn delta_ago_rfc3339(seconds: i64) -> String {
         (Utc::now() - Duration::seconds(seconds)).to_rfc3339()
@@ -515,5 +593,141 @@ mod tests {
         assert_eq!(reg.get(&job.id).await.unwrap().progress_fraction, Some(1.0));
         reg.mark_progress(&job.id, -0.3).await;
         assert_eq!(reg.get(&job.id).await.unwrap().progress_fraction, Some(0.0));
+    }
+
+    #[tokio::test]
+    async fn monitor_stores_generic_error_for_panicked_task() {
+        let (registry, job, running) = active_job().await;
+        let monitor = spawn_monitored(registry.clone(), running.clone(), job.id.clone(), async {
+            panic!("secret panic payload")
+        });
+        monitor.await.unwrap();
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Failed);
+        assert_eq!(finished.error.as_deref(), Some(UNEXPECTED_TASK_ERROR));
+        assert!(!finished.error.unwrap().contains("secret panic payload"));
+        assert!(running.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn monitor_fails_aborted_task() {
+        let (registry, job, running) = active_job().await;
+        let worker = tokio::spawn(std::future::pending());
+        worker.abort();
+
+        monitor_task(registry.clone(), running.clone(), job.id.clone(), worker).await;
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Failed);
+        assert_eq!(finished.error.as_deref(), Some(UNEXPECTED_TASK_ERROR));
+        assert!(running.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn monitor_fails_clean_exit_without_terminal_state() {
+        let (registry, job, running) = active_job().await;
+        let monitor = spawn_monitored(registry.clone(), running.clone(), job.id.clone(), async {});
+        monitor.await.unwrap();
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Failed);
+        assert_eq!(finished.error.as_deref(), Some(UNEXPECTED_TASK_ERROR));
+        assert!(running.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn monitor_preserves_normal_terminal_completion() {
+        let (registry, job, running) = active_job().await;
+        let worker_registry = registry.clone();
+        let worker_running = running.clone();
+        let worker_job_id = job.id.clone();
+        let monitor = spawn_monitored(
+            registry.clone(),
+            running.clone(),
+            job.id.clone(),
+            async move {
+                *worker_running.lock().await = None;
+                worker_registry
+                    .mark_succeeded(&worker_job_id, serde_json::json!("complete"))
+                    .await;
+            },
+        );
+        monitor.await.unwrap();
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Succeeded);
+        assert_eq!(finished.result, Some(serde_json::json!("complete")));
+        assert!(finished.error.is_none());
+        assert!(running.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn recovery_blocks_same_profile_start_until_running_is_cleared() {
+        use std::pin::pin;
+        use std::task::Poll;
+
+        let (registry, job, running) = active_job().await;
+        let running_guard = running.lock().await;
+        let mut recovery = pin!(registry.recover_abandoned(&job.id, &running));
+
+        std::future::poll_fn(|cx| {
+            assert!(matches!(recovery.as_mut().poll(cx), Poll::Pending));
+            Poll::Ready(())
+        })
+        .await;
+
+        let mut replacement = pin!(registry.start(&job.profile_id, BackupJobKind::RunBackup));
+        std::future::poll_fn(|cx| {
+            assert!(matches!(replacement.as_mut().poll(cx), Poll::Pending));
+            Poll::Ready(())
+        })
+        .await;
+
+        drop(running_guard);
+        assert!(recovery.await);
+        let replacement = replacement.await.unwrap();
+        *running.lock().await = Some(replacement.profile_id.clone());
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Failed);
+        assert_eq!(running.lock().await.as_deref(), Some("profile-a"));
+    }
+
+    #[tokio::test]
+    async fn monitor_does_not_clear_newer_run_after_old_job_terminalized() {
+        let (registry, job, running) = active_job().await;
+        let worker_registry = registry.clone();
+        let worker_job_id = job.id.clone();
+        let (terminal_tx, terminal_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let monitor = spawn_monitored(
+            registry.clone(),
+            running.clone(),
+            job.id.clone(),
+            async move {
+                worker_registry
+                    .mark_succeeded(&worker_job_id, serde_json::json!("complete"))
+                    .await;
+                terminal_tx.send(()).unwrap();
+                finish_rx.await.unwrap();
+                panic!("panic after terminal state");
+            },
+        );
+
+        terminal_rx.await.unwrap();
+        let replacement = registry
+            .start(&job.profile_id, BackupJobKind::RunBackup)
+            .await
+            .unwrap();
+        *running.lock().await = Some(replacement.profile_id);
+        finish_tx.send(()).unwrap();
+        monitor.await.unwrap();
+
+        let finished = registry.get(&job.id).await.unwrap();
+        assert_eq!(finished.state, BackupJobState::Succeeded);
+        assert_eq!(finished.result, Some(serde_json::json!("complete")));
+        assert!(finished.error.is_none());
+        assert_eq!(running.lock().await.as_deref(), Some("profile-a"));
     }
 }

--- a/engine/nasty-backup/src/lib.rs
+++ b/engine/nasty-backup/src/lib.rs
@@ -7,7 +7,7 @@ pub mod jobs;
 pub mod restore;
 pub mod scheduler;
 
-use jobs::{BackupJob, BackupJobKind, JobError, JobRegistry};
+use jobs::{BackupJob, BackupJobKind, JobError, JobRegistry, spawn_monitored};
 use nasty_common::secrets::{self, EncryptedBlob, SecretsStatus};
 use restore::{RestoreProgress, RestoreProgressBars, validate_restore_dest};
 use rustic_backend::BackendOptions;
@@ -1251,21 +1251,26 @@ impl BackupService {
         let profile_id = id.to_string();
         let registry = self.jobs.clone();
         let service = self.clone_for_task();
-        tokio::spawn(async move {
-            registry.mark_running(&job_id).await;
-            match service.init_repo(&profile_id).await {
-                Ok(msg) => {
-                    registry
-                        .mark_succeeded(&job_id, serde_json::Value::String(msg))
-                        .await;
+        spawn_monitored(
+            registry.clone(),
+            self.running.clone(),
+            job_id.clone(),
+            async move {
+                registry.mark_running(&job_id).await;
+                match service.init_repo(&profile_id).await {
+                    Ok(msg) => {
+                        registry
+                            .mark_succeeded(&job_id, serde_json::Value::String(msg))
+                            .await;
+                    }
+                    Err(e) => {
+                        registry
+                            .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                            .await;
+                    }
                 }
-                Err(e) => {
-                    registry
-                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
-                        .await;
-                }
-            }
-        });
+            },
+        );
         Ok(job)
     }
 
@@ -1279,29 +1284,35 @@ impl BackupService {
         let profile_id = id.to_string();
         let registry = self.jobs.clone();
         let service = self.clone_for_task();
-        tokio::spawn(async move {
-            registry.mark_running(&job_id).await;
-            match service.run_backup(&profile_id).await {
-                Ok(result) => {
-                    let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
-                    if result.success {
-                        registry.mark_succeeded(&job_id, value).await;
-                    } else {
-                        // run_backup() returns Ok with success=false
-                        // when rustic reported a failure. Map that to
-                        // a Failed job state so the WebUI's polling
-                        // loop renders it consistently with the
-                        // "engine returned an error" case.
-                        registry.mark_failed(&job_id, result.message.clone()).await;
+        spawn_monitored(
+            registry.clone(),
+            self.running.clone(),
+            job_id.clone(),
+            async move {
+                registry.mark_running(&job_id).await;
+                match service.run_backup(&profile_id).await {
+                    Ok(result) => {
+                        let value =
+                            serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+                        if result.success {
+                            registry.mark_succeeded(&job_id, value).await;
+                        } else {
+                            // run_backup() returns Ok with success=false
+                            // when rustic reported a failure. Map that to
+                            // a Failed job state so the WebUI's polling
+                            // loop renders it consistently with the
+                            // "engine returned an error" case.
+                            registry.mark_failed(&job_id, result.message.clone()).await;
+                        }
+                    }
+                    Err(e) => {
+                        registry
+                            .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                            .await;
                     }
                 }
-                Err(e) => {
-                    registry
-                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
-                        .await;
-                }
-            }
-        });
+            },
+        );
         Ok(job)
     }
 
@@ -1312,21 +1323,26 @@ impl BackupService {
         let profile_id = id.to_string();
         let registry = self.jobs.clone();
         let service = self.clone_for_task();
-        tokio::spawn(async move {
-            registry.mark_running(&job_id).await;
-            match service.check_repo(&profile_id).await {
-                Ok(msg) => {
-                    registry
-                        .mark_succeeded(&job_id, serde_json::Value::String(msg))
-                        .await;
+        spawn_monitored(
+            registry.clone(),
+            self.running.clone(),
+            job_id.clone(),
+            async move {
+                registry.mark_running(&job_id).await;
+                match service.check_repo(&profile_id).await {
+                    Ok(msg) => {
+                        registry
+                            .mark_succeeded(&job_id, serde_json::Value::String(msg))
+                            .await;
+                    }
+                    Err(e) => {
+                        registry
+                            .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                            .await;
+                    }
                 }
-                Err(e) => {
-                    registry
-                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
-                        .await;
-                }
-            }
-        });
+            },
+        );
         Ok(job)
     }
 
@@ -1365,38 +1381,44 @@ impl BackupService {
         let progress = RestoreProgress::new();
         let poll_progress = progress.clone();
 
-        tokio::spawn(async move {
-            registry.mark_running(&job_id).await;
+        spawn_monitored(
+            registry.clone(),
+            self.running.clone(),
+            job_id.clone(),
+            async move {
+                registry.mark_running(&job_id).await;
 
-            let work = service.restore_inner(&profile_id, &snapshot_id, resolved_dest, progress);
-            tokio::pin!(work);
-            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
-            ticker.tick().await; // first tick fires immediately; skip it
+                let work =
+                    service.restore_inner(&profile_id, &snapshot_id, resolved_dest, progress);
+                tokio::pin!(work);
+                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
+                ticker.tick().await; // first tick fires immediately; skip it
 
-            loop {
-                tokio::select! {
-                    res = &mut work => {
-                        match res {
-                            Ok(summary) => {
-                                let value = serde_json::to_value(&summary)
-                                    .unwrap_or(serde_json::Value::Null);
-                                registry.mark_progress(&job_id, 1.0).await;
-                                registry.mark_succeeded(&job_id, value).await;
+                loop {
+                    tokio::select! {
+                        res = &mut work => {
+                            match res {
+                                Ok(summary) => {
+                                    let value = serde_json::to_value(&summary)
+                                        .unwrap_or(serde_json::Value::Null);
+                                    registry.mark_progress(&job_id, 1.0).await;
+                                    registry.mark_succeeded(&job_id, value).await;
+                                }
+                                Err(e) => {
+                                    registry
+                                        .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
+                                        .await
+                                }
                             }
-                            Err(e) => {
-                                registry
-                                    .mark_failed(&job_id, redact_url_credentials(&e.to_string()))
-                                    .await
-                            }
+                            break;
                         }
-                        break;
-                    }
-                    _ = ticker.tick() => {
-                        registry.mark_progress(&job_id, poll_progress.fraction()).await;
+                        _ = ticker.tick() => {
+                            registry.mark_progress(&job_id, poll_progress.fraction()).await;
+                        }
                     }
                 }
-            }
-        });
+            },
+        );
 
         Ok(job)
     }


### PR DESCRIPTION
## Summary
- monitor detached initialize, run, check, and restore workers for panic, cancellation, and clean exits without terminal state
- fail abandoned jobs with a generic operator-safe error instead of leaving them permanently active
- atomically clear the matching running marker while terminalizing abandoned work
- preserve legitimate terminal states and prevent stale monitors from clearing newer same-profile runs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --all-targets --no-fail-fast`

Follow-up to #838.