### PR TITLE
Upgrade SimpleWebAuthn browser to 14

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-kU7EGOxdTR/U/+/0ZZ436Moy8E5aml2fVxsfewOHiHQ=";
+      npmDepsHash = "sha256-HF0ZBdsCydVC095MqEgHb+LA3R2QqrxMsnpqXTjDKYI=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -16,7 +16,7 @@
 				"@codemirror/theme-one-dark": "^6.1.3",
 				"@codemirror/view": "^6.43.4",
 				"@novnc/novnc": "^1.6.0",
-				"@simplewebauthn/browser": "^13.3.0",
+				"@simplewebauthn/browser": "^14.0.0",
 				"@xterm/addon-fit": "^0.11.0",
 				"@xterm/addon-web-links": "^0.12.0",
 				"@xterm/xterm": "^6.0.0",
@@ -705,9 +705,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@simplewebauthn/browser": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
-			"integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-14.0.0.tgz",
+			"integrity": "sha512-1odWVqeEBTl7lJ9zMKLEsmTlnyrDO5iRcTvfMKKk1WThUnp/i8JJdffdj2icP+tty159s4PgwE3BiMoEW9NFow==",
 			"license": "MIT"
 		},
 		"node_modules/@standard-schema/spec": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -43,7 +43,7 @@
 		"@codemirror/theme-one-dark": "^6.1.3",
 		"@codemirror/view": "^6.43.4",
 		"@novnc/novnc": "^1.6.0",
-		"@simplewebauthn/browser": "^13.3.0",
+		"@simplewebauthn/browser": "^14.0.0",
 		"@xterm/addon-fit": "^0.11.0",
 		"@xterm/addon-web-links": "^0.12.0",
 		"@xterm/xterm": "^6.0.0",


### PR DESCRIPTION
## Summary
- upgrade `@simplewebauthn/browser` to 14.0.0
- retain the existing v14-compatible registration and authentication calls
- refresh the Nix npm dependency hash

## Validation
- `npm ci --legacy-peer-deps`
- `npm run check`
- `npm test` (288 tests)
- `npm run build`
- reproducible `prefetch-npm-deps` hash
- `git diff --check`