### PR TITLE
Upgrade Vitest to 5

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
       pname = "nasty-webui";
       version = nasty-version;
       src = ./webui;
-      npmDepsHash = "sha256-kU7EGOxdTR/U/+/0ZZ436Moy8E5aml2fVxsfewOHiHQ=";
+      npmDepsHash = "sha256-zznT6bVTijBWV0iXcdkovAdnfVVpex//ZdfK1PrpuHo=";
       npmFlags = [ "--legacy-peer-deps" ];
       buildPhase = ''
         npm run prepare

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -42,7 +42,7 @@
 				"tw-animate-css": "^1.4.0",
 				"typescript": "^6.0.3",
 				"vite": "^8.2.2",
-				"vitest": "^4.1.11"
+				"vitest": "^5.0.0"
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
@@ -1246,34 +1246,17 @@
 				"undici-types": "~8.3.0"
 			}
 		},
-		"node_modules/@vitest/expect": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
-			"integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@standard-schema/spec": "^1.1.0",
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.11",
-				"@vitest/utils": "4.1.11",
-				"chai": "^6.2.2",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
-			"integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+			"integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.11",
+				"@jridgewell/trace-mapping": "0.3.31",
+				"@vitest/spy": "5.0.0",
 				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
+				"magic-string": "^1.2.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -1291,70 +1274,22 @@
 				}
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
-			"integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+		"node_modules/@vitest/mocker/node_modules/magic-string": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+			"integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/runner": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
-			"integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "4.1.11",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/snapshot": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-			"integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.11",
-				"@vitest/utils": "4.1.11",
-				"magic-string": "^0.30.21",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
-			"integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+			"integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
 			"dev": true,
 			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
-			"integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.11",
-				"convert-source-map": "^2.0.0",
-				"tinyrainbow": "^3.1.0"
-			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
@@ -1508,13 +1443,6 @@
 			"engines": {
 				"node": ">= 10"
 			}
-		},
-		"node_modules/convert-source-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -2566,13 +2494,6 @@
 				"node": ">=12.20.0"
 			}
 		},
-		"node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2953,16 +2874,19 @@
 			}
 		},
 		"node_modules/tinybench": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+			"integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
 		},
 		"node_modules/tinyexec": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
-			"integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2984,16 +2908,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyrainbow": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/totalist": {
@@ -3416,38 +3330,31 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
-			"integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+			"integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.11",
-				"@vitest/mocker": "4.1.11",
-				"@vitest/pretty-format": "4.1.11",
-				"@vitest/runner": "4.1.11",
-				"@vitest/snapshot": "4.1.11",
-				"@vitest/spy": "4.1.11",
-				"@vitest/utils": "4.1.11",
-				"es-module-lexer": "^2.0.0",
-				"expect-type": "^1.3.0",
-				"magic-string": "^0.30.21",
-				"obug": "^2.1.1",
-				"pathe": "^2.0.3",
-				"picomatch": "^4.0.3",
-				"std-env": "^4.0.0-rc.1",
-				"tinybench": "^2.9.0",
-				"tinyexec": "^1.0.2",
-				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.1.0",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/mocker": "5.0.0",
+				"chai": "^6.2.2",
+				"es-module-lexer": "^2.3.2",
+				"expect-type": "^1.4.0",
+				"magic-string": "^1.2.3",
+				"obug": "^2.1.4",
+				"picomatch": "^4.0.7",
+				"std-env": "^4.2.0",
+				"tinybench": "6.1.4",
+				"tinyexec": "1.3.0",
+				"tinyglobby": "^0.2.17",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+				"node": "^22.12.0 || ^24.0.0 || >=26.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -3455,16 +3362,16 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
-				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.11",
-				"@vitest/browser-preview": "4.1.11",
-				"@vitest/browser-webdriverio": "4.1.11",
-				"@vitest/coverage-istanbul": "4.1.11",
-				"@vitest/coverage-v8": "4.1.11",
-				"@vitest/ui": "4.1.11",
+				"@types/node": "^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "5.0.0",
+				"@vitest/browser-preview": "5.0.0",
+				"@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+				"@vitest/coverage-istanbul": "5.0.0",
+				"@vitest/coverage-v8": "5.0.0",
+				"@vitest/ui": "5.0.0",
 				"happy-dom": "*",
 				"jsdom": "*",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -3503,6 +3410,16 @@
 				"vite": {
 					"optional": false
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/magic-string": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+			"integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/w3c-keyname": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -33,7 +33,7 @@
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^6.0.3",
 		"vite": "^8.2.2",
-		"vitest": "^4.1.11"
+		"vitest": "^5.0.0"
 	},
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.2",


### PR DESCRIPTION
## Summary
- upgrade Vitest to 5.0.0
- refresh the Vitest transitive dependency graph
- update the Nix npm dependency hash

## Validation
- `npm ci --legacy-peer-deps`
- `npm run check`
- `npm test` (288 tests)
- `npm test` with Node 22.23.2 (288 tests)
- `npm run build`
- reproducible `prefetch-npm-deps` hash
- `nix flake check --no-build`
- `git diff --check`