### PR TITLE
authz: enforce scoped admin boundaries

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -1,0 +1,194 @@
+# API Role Review
+
+Date: 2026-09-07
+
+## Scope
+
+Static review of all 329 methods registered in
+`engine/nasty-engine/src/registry/methods.rs`:
+
+- 130 `Any`
+- 78 `Operator`
+- 121 `Admin`
+
+The registry declarations match the central dispatcher. The findings below are
+semantic authorization problems that the registry/dispatcher consistency tests
+cannot detect, including credential scope, sensitive response data, and
+payload-dependent privilege.
+
+## Critical
+
+### Scoped Admin credentials can escape their scope
+
+Status: fixed in the current uncommitted worktree.
+
+`auth.token.create` lets a filesystem-scoped Admin create an unscoped Admin
+token. `auth.create_user` similarly lets a scoped Admin create an Admin user
+whose interactive login is unscoped.
+
+References:
+
+- `engine/nasty-engine/src/router/mod.rs:443`
+- `engine/nasty-engine/src/auth.rs:704`
+- `engine/nasty-engine/src/auth.rs:884`
+
+These operations must require an unscoped Admin session.
+
+### Scoped Admin can alter resources outside its filesystem
+
+Status: fixed in the current uncommitted worktree for filesystem-addressed
+operations and global raw-device mutations.
+
+Many Admin filesystem handlers do not check `session.filesystem`. A scoped
+Admin can export or delete another filesystem's encryption key, destroy or
+unmount filesystems, alter filesystem devices, and wipe arbitrary devices.
+
+Affected operations include `fs.destroy`, `fs.key.export`, `fs.key.delete`,
+`device.wipe`, filesystem device operations, mount/unmount, lock/unlock,
+scrub/fsck, and reconciliation controls.
+
+References:
+
+- `engine/nasty-engine/src/router/fs.rs:74-475`
+- `engine/nasty-engine/src/router/fs.rs:226`
+
+Filesystem-addressed operations must enforce the configured filesystem scope.
+Global raw-device operations must require root-equivalent access.
+
+## High
+
+### `system.settings.get` exposes secret-bearing settings
+
+The `Any` method returns the unsanitized settings structure, including OIDC and
+DNS credential fields.
+
+- `engine/nasty-engine/src/router/system.rs:560`
+- `engine/nasty-system/src/settings.rs:285-350`
+
+### App read methods expose secrets to ReadOnly users
+
+`apps.config` returns environment values, `apps.inspect` returns raw Docker
+inspect data, and `apps.compose.get` returns the stack `.env` file.
+
+- `engine/nasty-engine/src/registry/methods.rs:2909-2913`
+- `engine/nasty-engine/src/registry/methods.rs:2955-2961`
+- `engine/nasty-engine/src/registry/methods.rs:3116-3122`
+- `engine/nasty-apps/src/lib.rs:4047-4057`
+- `engine/nasty-apps/src/lib.rs:4135-4181`
+- `engine/nasty-apps/src/lib.rs:4744-4759`
+
+### `system.logs` exposes journals to ReadOnly users
+
+The RPC is `Any`, while the equivalent live stream requires root-equivalent
+access because journals can leak secrets, addresses, and audit details.
+
+- `engine/nasty-engine/src/router/system.rs:258-301`
+- `engine/nasty-engine/src/log_stream.rs:102-123`
+
+### `firmware.update` is Operator-level
+
+The method performs a host firmware flash through `fwupdmgr update ... -y` and
+should require an unscoped Admin.
+
+- `engine/nasty-engine/src/registry/methods.rs:2138-2146`
+- `engine/nasty-system/src/firmware.rs:203-228`
+
+### Generic protocol toggles control system safety services
+
+Operator-level `service.protocol.enable` and `service.protocol.disable` also
+control SSH, NUT, watchdog, SMART, Avahi, and the backup REST server. System
+service payloads should require Admin; disabling watchdog currently lacks the
+enabling path's Admin check.
+
+- `engine/nasty-engine/src/registry/methods.rs:447-464`
+- `engine/nasty-system/src/protocol.rs:16-54`
+
+### Scoped Operator tokens can mutate global SMB identities
+
+The Operator allowlist permits user deletion, password reset, and group
+membership changes, but the handlers do not reject owner-scoped API tokens.
+
+- `engine/nasty-engine/src/router/mod.rs:100-110`
+- `engine/nasty-engine/src/router/smb.rs:20-116`
+
+### `apps.update` does not authorize the existing app
+
+The handler validates only replacement paths. A scoped Operator can replace an
+app it does not own, and the backend removes the existing container before
+reinstalling it.
+
+- `engine/nasty-engine/src/router/apps.rs:204-227`
+- `engine/nasty-apps/src/lib.rs:3498-3532`
+
+### Scoped Admin can control the global backup REST server
+
+`service.rest_server.configure`, `service.rest_server.credentials`, and
+`service.rest_server.rotate_credentials` lack unscoped Admin checks.
+
+- `engine/nasty-engine/src/router/service.rs:285-367`
+
+## Medium
+
+### Scoped reads return global resource inventories
+
+Share `list`/`get`, backup profile/snapshot/job reads, and several filesystem
+status/dependency methods do not consistently filter filesystem or owner scope.
+
+- `engine/nasty-engine/src/router/share.rs:530-539`
+- `engine/nasty-engine/src/router/share.rs:607-616`
+- `engine/nasty-engine/src/router/share.rs:709-718`
+- `engine/nasty-engine/src/router/share.rs:1054-1063`
+- `engine/nasty-engine/src/router/backup.rs:68-75`
+- `engine/nasty-engine/src/router/backup.rs:116-189`
+
+### Notification webhook credentials are incompletely redacted
+
+`notifications.config.get` masks dedicated secret fields but leaves webhook
+URLs and arbitrary headers visible to ReadOnly callers.
+
+- `engine/nasty-system/src/notifications.rs:57-71`
+- `engine/nasty-system/src/notifications.rs:167-214`
+
+### `audit.list` returns every user's records
+
+The method is `Any`; `audit.mine` already provides a self-scoped alternative.
+
+- `engine/nasty-engine/src/router/audit.rs:20-39`
+
+### `apps.fix_volume_perms` can recursively chown broad host paths
+
+The method accepts absolute paths outside `/fs` except for a small denylist. A
+scoped Admin can therefore modify ownership outside its assigned filesystem.
+
+- `engine/nasty-engine/src/router/apps.rs:267-273`
+- `engine/nasty-apps/src/lib.rs:772-826`
+- `engine/nasty-apps/src/lib.rs:5253-5294`
+
+### `firmware.check` is not a pure read
+
+The `Any` method forces a host-wide LVFS metadata refresh before returning
+available updates.
+
+- `engine/nasty-system/src/firmware.rs:133-174`
+
+## Over-Restricted
+
+- `share.iscsi.set_portals` is Admin while equivalent add/remove operations are
+  Operator: `engine/nasty-engine/src/registry/methods.rs:1039-1057`.
+- `system.network.pending` and `system.network.nm_preview` are pure reads but
+  Admin-only: `engine/nasty-engine/src/registry/methods.rs:1935-1953`.
+
+## Additional API Defects
+
+- `apps.compose.get` is documented as returning a string but returns a
+  `ComposeContent` object containing `compose_file` and `env_file`.
+- `MethodRole::Any` says "any authenticated user", but most such methods are
+  unavailable to `Role::User`, which has a separate explicit allowlist.
+
+## Existing Coverage
+
+The router tests verify that registry role declarations and central dispatcher
+allowlists agree. They do not verify response redaction, payload-dependent
+privilege, or comprehensive filesystem/owner scope enforcement. The external
+RBAC test covers basic filesystem and subvolume isolation but not the findings
+above.

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -192,6 +192,10 @@ pub fn authorize_session(session: &Session, access: EndpointAccess) -> Result<()
     Ok(())
 }
 
+fn require_unscoped_admin(session: &Session) -> Result<(), AuthError> {
+    authorize_session(session, EndpointAccess::RootEquivalent).map_err(|_| AuthError::Forbidden)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ApiToken {
     pub id: String,
@@ -710,9 +714,7 @@ impl AuthService {
         expires_in_secs: Option<u64>,
         allowed_ips: Vec<String>,
     ) -> Result<ApiToken, AuthError> {
-        if session.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(session)?;
         if role == Role::User {
             return Err(AuthError::Forbidden);
         }
@@ -772,9 +774,7 @@ impl AuthService {
 
     /// List API tokens without exposing the token value
     pub async fn list_api_tokens(&self, session: &Session) -> Result<Vec<ApiTokenInfo>, AuthError> {
-        if session.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(session)?;
         let state = self.state.read().await;
         Ok(state
             .api_tokens
@@ -793,9 +793,7 @@ impl AuthService {
 
     /// Delete an API token by ID (admin only)
     pub async fn delete_api_token(&self, session: &Session, id: &str) -> Result<(), AuthError> {
-        if session.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(session)?;
 
         let mut current = self.state.write().await;
         let mut state = current.clone();
@@ -890,9 +888,7 @@ impl AuthService {
         file_principal: Option<String>,
         smb: &nasty_sharing::smb::SmbService,
     ) -> Result<(), AuthError> {
-        if session.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(session)?;
 
         if password.len() < 8 {
             return Err(AuthError::WeakPassword);
@@ -937,9 +933,7 @@ impl AuthService {
 
     /// Delete a user (admin only, cannot delete self)
     pub async fn delete_user(&self, session: &Session, username: &str) -> Result<(), AuthError> {
-        if session.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(session)?;
         if session.username == username {
             return Err(AuthError::Forbidden);
         }
@@ -1151,9 +1145,7 @@ impl AuthService {
         actor: &Session,
         target_username: &str,
     ) -> Result<usize, AuthError> {
-        if actor.role != Role::Admin {
-            return Err(AuthError::Forbidden);
-        }
+        require_unscoped_admin(actor)?;
         let mut current = self.state.write().await;
         let mut state = current.clone();
         let user = state
@@ -2494,6 +2486,42 @@ mod tests {
             .await
             .expect_err("standard-user tokens must be rejected");
         assert!(matches!(error, AuthError::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn scoped_admin_cannot_create_tokens_or_users() {
+        let service = AuthService {
+            state: Arc::new(RwLock::new(initialized_state())),
+            rate_limit: Arc::new(RwLock::new(RateLimitState::default())),
+        };
+        let mut scoped_admin = session(Role::Admin);
+        scoped_admin.filesystem = Some("tank".into());
+
+        let token_error = service
+            .create_api_token(
+                &scoped_admin,
+                "escaped-admin",
+                Role::Admin,
+                None,
+                None,
+                Vec::new(),
+            )
+            .await
+            .expect_err("scoped admin must not mint an unscoped token");
+        assert!(matches!(token_error, AuthError::Forbidden));
+
+        let user_error = service
+            .create_user(
+                &scoped_admin,
+                "escaped-admin",
+                "password123",
+                Role::Admin,
+                None,
+                &nasty_sharing::smb::SmbService::new(),
+            )
+            .await
+            .expect_err("scoped admin must not create an unscoped login");
+        assert!(matches!(user_error, AuthError::Forbidden));
     }
 
     #[tokio::test]

--- a/engine/nasty-engine/src/router/auth.rs
+++ b/engine/nasty-engine/src/router/auth.rs
@@ -49,6 +49,9 @@ pub(super) async fn try_route(
             }
         }
         "auth.create_user" => {
+            if let Some(response) = require_root_equivalent(req, session, "global_user_admin") {
+                return Some(response);
+            }
             #[derive(Deserialize)]
             struct P {
                 username: String,
@@ -75,19 +78,32 @@ pub(super) async fn try_route(
                 Err(e) => invalid(req, e),
             }
         }
-        "auth.delete_user" => match require_str(req, "username") {
-            Ok(username) => match state.auth.delete_user(session, username).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
-            Err(r) => r,
-        },
+        "auth.delete_user" => {
+            if let Some(response) = require_root_equivalent(req, session, "global_user_admin") {
+                return Some(response);
+            }
+            match require_str(req, "username") {
+                Ok(username) => match state.auth.delete_user(session, username).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
+                Err(r) => r,
+            }
+        }
         "auth.list_users" => ok(req, state.auth.list_users().await),
-        "auth.token.list" => match state.auth.list_api_tokens(session).await {
-            Ok(v) => ok(req, v),
-            Err(e) => err(req, e),
-        },
+        "auth.token.list" => {
+            if let Some(response) = require_root_equivalent(req, session, "global_token_admin") {
+                return Some(response);
+            }
+            match state.auth.list_api_tokens(session).await {
+                Ok(v) => ok(req, v),
+                Err(e) => err(req, e),
+            }
+        }
         "auth.token.create" => {
+            if let Some(response) = require_root_equivalent(req, session, "global_token_admin") {
+                return Some(response);
+            }
             #[derive(Deserialize)]
             struct P {
                 name: String,
@@ -116,20 +132,25 @@ pub(super) async fn try_route(
                 Err(e) => invalid(req, e),
             }
         }
-        "auth.token.delete" => match require_str(req, "id") {
-            Ok(id) => match state.auth.delete_api_token(session, id).await {
-                Ok(()) => ok(req, "ok"),
-                Err(e) => err(req, e),
-            },
-            Err(r) => r,
-        },
+        "auth.token.delete" => {
+            if let Some(response) = require_root_equivalent(req, session, "global_token_admin") {
+                return Some(response);
+            }
+            match require_str(req, "id") {
+                Ok(id) => match state.auth.delete_api_token(session, id).await {
+                    Ok(()) => ok(req, "ok"),
+                    Err(e) => err(req, e),
+                },
+                Err(r) => r,
+            }
+        }
         "auth.oidc.config_status" => {
             let oidc = state.settings.get().await.oidc;
             ok(req, nasty_system::settings::redact_oidc_secret(oidc))
         }
         "auth.oidc.update_config" => {
-            if session.role != Role::Admin {
-                return Some(err(req, "admin only".to_string()));
+            if let Some(response) = require_root_equivalent(req, session, "global_oidc_admin") {
+                return Some(response);
             }
             match parse_params::<nasty_system::settings::OidcSettings>(req) {
                 Ok(new_settings) => {
@@ -161,8 +182,8 @@ pub(super) async fn try_route(
             }
         }
         "auth.oidc.test" => {
-            if session.role != Role::Admin {
-                return Some(err(req, "admin only".to_string()));
+            if let Some(response) = require_root_equivalent(req, session, "global_oidc_admin") {
+                return Some(response);
             }
             let sample = req
                 .params
@@ -246,8 +267,8 @@ pub(super) async fn try_route(
         // here so a non-admin call doesn't even reach the state
         // mutation path. Audit log written by AuthService.
         "auth.webauthn.reset_for_user" => {
-            if session.role != Role::Admin {
-                return Some(err(req, "admin only".to_string()));
+            if let Some(response) = require_root_equivalent(req, session, "global_webauthn_admin") {
+                return Some(response);
             }
             match require_str(req, "username") {
                 Ok(target) => match state.auth.reset_webauthn_credentials(session, target).await {

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -11,6 +11,56 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn filesystem_param(method: &str) -> Option<&'static str> {
+    match method {
+        "fs.device.add"
+        | "fs.device.remove"
+        | "fs.device.evacuate"
+        | "fs.device.evacuate.cancel"
+        | "fs.device.set_state"
+        | "fs.device.set_label"
+        | "fs.device.online"
+        | "fs.device.offline" => Some("filesystem"),
+        "fs.get"
+        | "fs.destroy"
+        | "fs.forget"
+        | "fs.mount"
+        | "fs.unmount"
+        | "fs.unlock"
+        | "fs.lock"
+        | "fs.dependents"
+        | "fs.key.export"
+        | "fs.key.delete"
+        | "fs.tpm.status"
+        | "fs.tpm.bind"
+        | "fs.tpm.unbind"
+        | "fs.options.update"
+        | "fs.usage"
+        | "fs.scrub.start"
+        | "fs.scrub.status"
+        | "fs.scrub.cancel"
+        | "fs.fsck.start"
+        | "fs.fsck.status"
+        | "fs.reconcile.status"
+        | "fs.reconcile.enable"
+        | "fs.reconcile.disable"
+        | "fs.copygc.enable"
+        | "fs.copygc.disable" => Some("name"),
+        _ => None,
+    }
+}
+
+fn requires_root_equivalent(method: &str) -> bool {
+    matches!(
+        method,
+        "fs.create" | "device.wipe" | "device.set_type" | "device.set_io_scheduler"
+    )
+}
+
+fn filesystem_scope_denied(scope: Option<&str>, requested: Option<&str>) -> bool {
+    matches!((scope, requested), (Some(scope), Some(requested)) if requested != scope)
+}
+
 async fn require_block_share_recovery_access(
     req: &Request,
     state: &AppState,
@@ -39,6 +89,17 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if requires_root_equivalent(&req.method)
+        && let Some(response) = require_root_equivalent(req, session, "global_storage_mutation")
+    {
+        return Some(response);
+    }
+    if let Some(param) = filesystem_param(&req.method)
+        && filesystem_scope_denied(session.filesystem.as_deref(), str_param(req, param))
+    {
+        return Some(err(req, "access denied"));
+    }
+
     Some(match req.method.as_str() {
         "fs.list" => match state.filesystems.list().await {
             Ok(mut v) => {
@@ -575,5 +636,34 @@ pub(crate) async fn reconcile_block_shares_under_lock(state: &AppState) -> Resul
         Ok(())
     } else {
         Err(failures.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filesystem_param, filesystem_scope_denied, requires_root_equivalent};
+
+    #[test]
+    fn filesystem_operations_identify_and_enforce_their_scope_parameter() {
+        assert_eq!(filesystem_param("fs.destroy"), Some("name"));
+        assert_eq!(filesystem_param("fs.key.export"), Some("name"));
+        assert_eq!(filesystem_param("fs.device.remove"), Some("filesystem"));
+        assert_eq!(filesystem_param("device.wipe"), None);
+        assert!(!filesystem_scope_denied(Some("tank"), Some("tank")));
+        assert!(filesystem_scope_denied(Some("tank"), Some("other")));
+        assert!(!filesystem_scope_denied(None, Some("other")));
+    }
+
+    #[test]
+    fn global_storage_mutations_require_root_equivalent_access() {
+        for method in [
+            "fs.create",
+            "device.wipe",
+            "device.set_type",
+            "device.set_io_scheduler",
+        ] {
+            assert!(requires_root_equivalent(method), "{method}");
+        }
+        assert!(!requires_root_equivalent("fs.destroy"));
     }
 }


### PR DESCRIPTION
## Summary
- require unscoped Admin sessions for global user, token, OIDC, and WebAuthn administration
- enforce filesystem scope across filesystem-addressed operations and require root-equivalent access for global storage mutations
- add regression coverage and document the complete API role review

## Tests
- `cargo test -p nasty-engine`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`