### PR TITLE
security: redact settings API secrets

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -59,6 +59,9 @@ Global raw-device operations must require root-equivalent access.
 
 ### `system.settings.get` exposes secret-bearing settings
 
+Status: fixed by redacting plaintext credentials and encrypted blobs from
+settings API responses while preserving configured/unconfigured markers.
+
 The `Any` method returns the unsanitized settings structure, including OIDC and
 DNS credential fields.
 

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -557,7 +557,10 @@ pub(super) async fn try_route(
             Ok(v) => ok(req, v),
             Err(e) => err(req, e),
         },
-        "system.settings.get" => ok(req, state.settings.get().await),
+        "system.settings.get" => ok(
+            req,
+            nasty_system::settings::redact_settings_secrets(state.settings.get().await),
+        ),
         "system.settings.update" => {
             match parse_params::<nasty_system::settings::SettingsUpdate>(req) {
                 Ok(p) => match p.files_domain.as_deref() {
@@ -571,14 +574,16 @@ pub(super) async fn try_route(
                         .await
                         {
                             Ok(()) => match state.settings.update(p).await {
-                                Ok(v) => ok(req, v),
+                                Ok(v) => {
+                                    ok(req, nasty_system::settings::redact_settings_secrets(v))
+                                }
                                 Err(e) => err(req, e),
                             },
                             Err(e) => err(req, e),
                         }
                     }
                     None => match state.settings.update(p).await {
-                        Ok(v) => ok(req, v),
+                        Ok(v) => ok(req, nasty_system::settings::redact_settings_secrets(v)),
                         Err(e) => err(req, e),
                     },
                 },

--- a/engine/nasty-system/src/settings.rs
+++ b/engine/nasty-system/src/settings.rs
@@ -425,6 +425,19 @@ pub fn redact_oidc_secret(mut s: OidcSettings) -> OidcSettings {
     s
 }
 
+/// Replace settings secrets with presence markers for API responses.
+pub fn redact_settings_secrets(mut settings: Settings) -> Settings {
+    let dns_is_set = settings
+        .tls_dns_credentials
+        .as_deref()
+        .is_some_and(|value| !value.is_empty())
+        || settings.tls_dns_credentials_encrypted.is_some();
+    settings.tls_dns_credentials = dns_is_set.then(|| DNS_CREDS_PLACEHOLDER.to_string());
+    settings.tls_dns_credentials_encrypted = None;
+    settings.oidc = redact_oidc_secret(settings.oidc);
+    settings
+}
+
 /// Encrypt the plaintext `client_secret` into `client_secret_encrypted`
 /// and blank the plaintext. Idempotent (already-encrypted or empty →
 /// no-op). systemd-creds failure is non-fatal: warn and keep plaintext.
@@ -2116,12 +2129,12 @@ async fn read_cert_info(cert_path: &str) -> CertInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        AcmeJournalState, DASHBOARD_MOTD_MAX_CHARS, EncryptedBlob, OidcSettings, Settings,
-        SettingsUpdate, apply_domain_updates, build_policy_set, caddy_acme_env,
-        certificate_endpoint_allowed, certificate_expires_in_days, certificate_state,
-        classify_acme_journal_event, merge_host_lists, normalize_dashboard_motd,
-        redact_oidc_secret, resolve_dns_credentials, to_nix_string, validate_files_domain,
-        wildcard_covers_host,
+        AcmeJournalState, DASHBOARD_MOTD_MAX_CHARS, DNS_CREDS_PLACEHOLDER, EncryptedBlob,
+        OidcSettings, Settings, SettingsUpdate, apply_domain_updates, build_policy_set,
+        caddy_acme_env, certificate_endpoint_allowed, certificate_expires_in_days,
+        certificate_state, classify_acme_journal_event, merge_host_lists, normalize_dashboard_motd,
+        redact_oidc_secret, redact_settings_secrets, resolve_dns_credentials, to_nix_string,
+        validate_files_domain, wildcard_covers_host,
     };
 
     fn fake_blob() -> EncryptedBlob {
@@ -2266,6 +2279,66 @@ mod tests {
         let r = redact_oidc_secret(OidcSettings::default());
         assert_eq!(r.client_secret.as_deref(), Some("<unset>"));
         assert!(r.client_secret_encrypted.is_none());
+    }
+
+    #[test]
+    fn redact_settings_removes_plaintext_and_encrypted_secrets() {
+        let settings = Settings {
+            hostname: Some("nas".into()),
+            tls_dns_credentials: Some("CF_API_TOKEN=secret".into()),
+            tls_dns_credentials_encrypted: Some(fake_blob()),
+            oidc: OidcSettings {
+                client_secret: Some("oidc-secret".into()),
+                client_secret_encrypted: Some(fake_blob()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let redacted = redact_settings_secrets(settings);
+
+        assert_eq!(redacted.hostname.as_deref(), Some("nas"));
+        assert_eq!(
+            redacted.tls_dns_credentials.as_deref(),
+            Some(DNS_CREDS_PLACEHOLDER)
+        );
+        assert!(redacted.tls_dns_credentials_encrypted.is_none());
+        assert_eq!(redacted.oidc.client_secret.as_deref(), Some("<set>"));
+        assert!(redacted.oidc.client_secret_encrypted.is_none());
+        let json = serde_json::to_string(&redacted).unwrap();
+        assert!(!json.contains("CF_API_TOKEN=secret"));
+        assert!(!json.contains("oidc-secret"));
+        assert!(!json.contains("c2VhbGVkLWJsb2I="));
+    }
+
+    #[test]
+    fn redact_settings_marks_unset_dns_credentials_as_absent() {
+        let redacted = redact_settings_secrets(Settings::default());
+
+        assert!(redacted.tls_dns_credentials.is_none());
+        assert!(redacted.tls_dns_credentials_encrypted.is_none());
+        assert_eq!(redacted.oidc.client_secret.as_deref(), Some("<unset>"));
+    }
+
+    #[test]
+    fn redact_settings_marks_encrypted_only_dns_credentials_as_set() {
+        let settings = Settings {
+            tls_dns_credentials_encrypted: Some(fake_blob()),
+            ..Default::default()
+        };
+
+        let redacted = redact_settings_secrets(settings);
+
+        assert_eq!(
+            redacted.tls_dns_credentials.as_deref(),
+            Some(DNS_CREDS_PLACEHOLDER)
+        );
+        assert!(redacted.tls_dns_credentials_encrypted.is_none());
+        assert!(
+            !serde_json::to_string(&redacted)
+                .unwrap()
+                .contains("c2VhbGVkLWJsb2I=")
+        );
     }
 
     #[test]

--- a/webui/src/lib/types.ts
+++ b/webui/src/lib/types.ts
@@ -1206,11 +1206,10 @@ export interface Settings {
 	tls_acme_enabled: boolean;
 	tls_challenge_type: 'tls-alpn' | 'http' | 'dns';
 	tls_dns_provider: string | null;
-	/** Blanked by the engine once sealed; send "<unchanged>" to keep the
-	 * stored value (#442 follow-up). */
+	/** API responses use "<unchanged>" when credentials exist; sending that
+	 * value back preserves the stored secret (#442 follow-up). */
 	tls_dns_credentials: string | null;
-	/** Opaque systemd-creds ciphertext — presence means credentials are
-	 * stored. Never sent back by the UI. */
+	/** Legacy response field. The engine no longer returns ciphertext. */
 	tls_dns_credentials_encrypted?: unknown;
 	tls_acme_staging: boolean;
 	tls_dns_resolver: string | null;


### PR DESCRIPTION
## Summary
- redact OIDC and DNS credentials from settings API responses
- remove encrypted credential blobs while retaining configured-state markers
- sanitize both settings get and update responses and document the response contract

## Testing
- `cargo test -p nasty-system redact_settings`
- `cargo fmt --all --check`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `npm run check`
- `npm run build`