### PR TITLE
security: restrict secret-bearing app reads

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -67,6 +67,10 @@ DNS credential fields.
 
 ### App read methods expose secrets to ReadOnly users
 
+Status: fixed by making simple-app configuration and inspect reads
+Operator-level with existing-app scope enforcement, and compose source reads
+unscoped Admin-only.
+
 `apps.config` returns environment values, `apps.inspect` returns raw Docker
 inspect data, and `apps.compose.get` returns the stack `.env` file.
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -13,7 +13,7 @@ use crate::subvolume_dependents::SubvolumeDependents;
 use nasty_apps::{
     App, AppConfig, AppIngress, AppStats, AppdataRelocateStatus, AppsStatus, CaddyRouteSummary,
     CheckComposeRequest, CheckComposeResult, CheckDevicesRequest, CheckPortsRequest,
-    CheckVolumesRequest, ComposeStartupEntry, DeviceMissing, EnableAppsRequest,
+    CheckVolumesRequest, ComposeContent, ComposeStartupEntry, DeviceMissing, EnableAppsRequest,
     FixVolumePermsRequest, ImageInspectResult, InstallAppRequest, InstallComposeRequest,
     ManagedNetwork, NetworkSummary, PortConflict, PruneResult, SetComposeStartupRequest,
     SetIngressRequest, VolumeMismatch,
@@ -2908,7 +2908,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "apps.config",
                     desc: "Return the deployed configuration of a named simple app (image, ports, env, volumes, resource limits, allow_unsafe), with env entries tagged where they match the image's own defaults so the WebUI Edit form can grey them out.",
-                    role: MethodRole::Any,
+                    role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "App name.")),
                     result: Some(gen_schema::<AppConfig>(generator)),
                 },
@@ -2954,7 +2954,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "apps.inspect",
                     desc: "Return the raw Docker `inspect` JSON for a named simple app's container as an untyped object.",
-                    role: MethodRole::Any,
+                    role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "App name.")),
                     result: Some(
                         serde_json::json!({"type": "object", "description": "Raw Docker `inspect` payload — shape follows the Docker API."}),
@@ -3114,12 +3114,10 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "apps.compose.get",
-                    desc: "Return the raw docker-compose.yml file contents for a named compose-based app.",
-                    role: MethodRole::Any,
+                    desc: "Return the raw docker-compose.yml and operator-provided .env file contents for a named compose-based app.",
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Compose app name.")),
-                    result: Some(
-                        serde_json::json!({"type": "string", "description": "Raw docker-compose.yml body."}),
-                    ),
+                    result: Some(gen_schema::<ComposeContent>(generator)),
                 },
                 Method {
                     name: "apps.compose.logs",

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -15,16 +15,17 @@ fn simple_requires_admin(req: &nasty_apps::InstallAppRequest) -> bool {
     req.allow_unsafe || req.network.as_deref() == Some("host")
 }
 
+fn app_requires_admin(app: &nasty_apps::App) -> bool {
+    app.kind == "compose" || app.unsafe_mode || app.network.as_deref() == Some("host")
+}
+
 async fn existing_app_requires_admin(state: &AppState, name: &str) -> Result<bool, String> {
     let app = state
         .apps
         .get(name)
         .await
         .map_err(|error| error.to_string())?;
-    if app.kind == "compose" || app.unsafe_mode || app.network.as_deref() == Some("host") {
-        return Ok(true);
-    }
-    Ok(false)
+    Ok(app_requires_admin(&app))
 }
 
 async fn existing_app_access_error(
@@ -154,10 +155,15 @@ pub(super) async fn try_route(
             Err(r) => r,
         },
         "apps.inspect" => match require_str(req, "name") {
-            Ok(name) => match state.apps.inspect(name).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.inspect(name).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.install" => match parse_params::<nasty_apps::InstallAppRequest>(req) {
@@ -272,10 +278,15 @@ pub(super) async fn try_route(
             Err(e) => invalid(req, e),
         },
         "apps.config" => match require_str(req, "name") {
-            Ok(name) => match state.apps.get_config(name).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            Ok(name) => {
+                if let Some(response) = existing_app_access_error(req, state, session, name).await {
+                    return Some(response);
+                }
+                match state.apps.get_config(name).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                }
+            }
             Err(r) => r,
         },
         "apps.remove" => match require_str(req, "name") {
@@ -440,13 +451,18 @@ pub(super) async fn try_route(
             }
             Err(r) => r,
         },
-        "apps.compose.get" => match require_str(req, "name") {
-            Ok(name) => match state.apps.compose_get(name).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
-            Err(r) => r,
-        },
+        "apps.compose.get" => {
+            if let Some(response) = require_root_equivalent(req, session, "compose_source_read") {
+                return Some(response);
+            }
+            match require_str(req, "name") {
+                Ok(name) => match state.apps.compose_get(name).await {
+                    Ok(v) => ok(req, v),
+                    Err(e) => err(req, e),
+                },
+                Err(r) => r,
+            }
+        }
         "apps.compose.logs" => {
             let name = match require_str(req, "name") {
                 Ok(n) => n,
@@ -707,6 +723,23 @@ mod tests {
         serde_json::from_value(value).expect("valid test request")
     }
 
+    fn existing_app(extra: serde_json::Value) -> nasty_apps::App {
+        let mut value = serde_json::json!({
+            "name": "safe-app",
+            "image": "example/app:latest",
+            "status": "running",
+            "created": "2026-01-01T00:00:00Z",
+            "kind": "simple"
+        });
+        value.as_object_mut().unwrap().extend(
+            extra
+                .as_object()
+                .expect("test app extension must be an object")
+                .clone(),
+        );
+        serde_json::from_value(value).expect("valid test app")
+    }
+
     #[test]
     fn simple_admin_gate_covers_unsafe_mounts_and_host_networking() {
         assert!(!simple_requires_admin(&simple_request(serde_json::json!(
@@ -716,6 +749,20 @@ mod tests {
             "allow_unsafe": true
         }))));
         assert!(simple_requires_admin(&simple_request(serde_json::json!({
+            "network": "host"
+        }))));
+    }
+
+    #[test]
+    fn existing_app_secret_reads_gate_privileged_apps_as_admin() {
+        assert!(!app_requires_admin(&existing_app(serde_json::json!({}))));
+        assert!(app_requires_admin(&existing_app(serde_json::json!({
+            "kind": "compose"
+        }))));
+        assert!(app_requires_admin(&existing_app(serde_json::json!({
+            "unsafe_mode": true
+        }))));
+        assert!(app_requires_admin(&existing_app(serde_json::json!({
             "network": "host"
         }))));
     }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -137,6 +137,8 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "vm.clone"
                 | "apps.install"
                 | "apps.update"
+                | "apps.config"
+                | "apps.inspect"
                 | "apps.remove"
                 | "apps.stop"
                 | "apps.start"
@@ -249,6 +251,11 @@ fn is_read_only(method: &str) -> bool {
             // can hold sensitive settings. Its `.get` suffix would otherwise slip
             // it into the universally-allowed read set; keep it Admin-only.
             | "system.custom_config.get"
+            // These return container environment, raw Docker metadata, or
+            // compose source that can contain credentials.
+            | "apps.config"
+            | "apps.inspect"
+            | "apps.compose.get"
     ) {
         return false;
     }
@@ -329,7 +336,6 @@ fn is_read_only(method: &str) -> bool {
                 | "apps.logs"
                 | "apps.compose.logs"
                 | "apps.container.logs"
-                | "apps.inspect"
                 | "system.firewall.status"
                 | "vm.capabilities"
                 | "vm.images.import_info"
@@ -338,7 +344,6 @@ fn is_read_only(method: &str) -> bool {
                 | "firmware.check"
                 | "firmware.devices"
                 | "notifications.config.get"
-                | "apps.config"
                 | "apps.inspect_image"
                 | "apps.caddy.routes"
                 | "apps.ingress.check_conflict"
@@ -2203,6 +2208,16 @@ mod tests {
             assert!(!is_read_only(method));
             assert!(is_operator_allowed(method));
         }
+    }
+
+    #[test]
+    fn secret_bearing_app_reads_require_management_roles() {
+        for method in ["apps.config", "apps.inspect"] {
+            assert!(!is_read_only(method));
+            assert!(is_operator_allowed(method));
+        }
+        assert!(!is_read_only("apps.compose.get"));
+        assert!(!is_operator_allowed("apps.compose.get"));
     }
 
     /// The .list / .get suffix matches that existed before this


### PR DESCRIPTION
## Summary
- require Operator access plus existing-app scope checks for simple app config and Docker inspect reads
- require unscoped Admin access for compose source and `.env` reads
- align registry roles with dispatcher enforcement and correct the compose response schema
- add regression coverage for role classification and privileged app types

## Testing
- `cargo test -p nasty-engine`
- `cargo fmt --all --check`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `git diff --check`