### PR TITLE
bcachefs: bump bundled tools + DKMS module to v1.39.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1788130033,
-        "narHash": "sha256-cnSlmUH+1odSO1knyrXrWUf7EjY9U4n2IlxVKMczB3Y=",
+        "lastModified": 1788807635,
+        "narHash": "sha256-k9JW6GMXFwphkYGcYMwA59uafNj0EV96wTnbzeuVM1w=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "d997ad76e906ca9cbe1d4045d3880185e504191d",
+        "rev": "5e1272bd83f48fb9f2bfbeaaf2024d3537db8098",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.4",
+        "ref": "v1.39.5",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.4 release tag.
+    # Pinned to v1.39.5 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.4";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.5";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.4";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.5";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the

--- a/nixos/tests/bcachefs-smoke.nix
+++ b/nixos/tests/bcachefs-smoke.nix
@@ -20,7 +20,7 @@ pkgs.testers.runNixOSTest {
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
-    machine.succeed("bcachefs version | grep -F 1.39.4")
+    machine.succeed("bcachefs version | grep -F 1.39.5")
     machine.succeed("test -x /etc/systemd/system-generators/bcachefs-mount-generator")
 
     # Format the empty 1 GiB disk and mount it.


### PR DESCRIPTION
## Summary
- bump the bundled bcachefs-tools and DKMS source from v1.39.4 to v1.39.5
- refresh the locked source revision and NAR hash
- update the installer fallback pin and smoke-test version assertion

## Testing
- `nix eval --raw .#packages.x86_64-linux.bcachefs-tools.version` -> `1.39.5`
- `nix eval --raw .#packages.aarch64-linux.bcachefs-tools.version` -> `1.39.5`
- `nix flake check --no-build`
- `nix flake check --all-systems --no-build` evaluated both bcachefs package derivations and the bcachefs smoke check; unrelated Linux VM configurations hit the expected Darwin platform limitation