### PR TITLE
security: restrict system journal access

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -7,9 +7,9 @@ Date: 2026-09-07
 Static review of all 329 methods registered in
 `engine/nasty-engine/src/registry/methods.rs`:
 
-- 130 `Any`
-- 78 `Operator`
-- 121 `Admin`
+- 126 `Any`
+- 80 `Operator`
+- 123 `Admin`
 
 The registry declarations match the central dispatcher. The findings below are
 semantic authorization problems that the registry/dispatcher consistency tests
@@ -85,6 +85,9 @@ inspect data, and `apps.compose.get` returns the stack `.env` file.
 - `engine/nasty-apps/src/lib.rs:4744-4759`
 
 ### `system.logs` exposes journals to ReadOnly users
+
+Status: fixed by requiring an unscoped Admin session for historical journal
+reads, matching the existing live-stream authorization boundary.
 
 The RPC is `Any`, while the equivalent live stream requires root-equivalent
 access because journals can leak secrets, addresses, and audit details.

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1448,8 +1448,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "system.logs",
-                    desc: "Return the tail of a systemd unit's journal.",
-                    role: MethodRole::Any,
+                    desc: "Return the tail of a systemd unit's journal. Requires an unscoped Admin session because journal entries can contain sensitive system data.",
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(serde_json::json!({
                         "type": "object",
                         "properties": {

--- a/engine/nasty-engine/src/rest_gateway.rs
+++ b/engine/nasty-engine/src/rest_gateway.rs
@@ -231,7 +231,10 @@ fn map_error_to_status(code: i64, message: &str) -> StatusCode {
         return StatusCode::NOT_FOUND;
     }
     let lower = message.to_ascii_lowercase();
-    if lower.contains("permission denied") || lower.contains("access denied") {
+    if lower.contains("permission denied")
+        || lower.contains("access denied")
+        || lower.contains("scoped credentials")
+    {
         return StatusCode::FORBIDDEN;
     }
     if lower.contains("not found") {
@@ -340,6 +343,10 @@ mod tests {
         // Case-insensitive.
         assert_eq!(
             map_error_to_status(-32603, "ACCESS DENIED"),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            map_error_to_status(-32603, "Scoped credentials cannot access this endpoint"),
             StatusCode::FORBIDDEN
         );
     }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -275,7 +275,6 @@ fn is_read_only(method: &str) -> bool {
                 | "system.stats"
                 | "system.disks"
                 | "system.network.get"
-                | "system.logs"
                 | "system.logs.units"
                 | "system.ssh.status"
                 | "system.alerts"
@@ -2218,6 +2217,14 @@ mod tests {
         }
         assert!(!is_read_only("apps.compose.get"));
         assert!(!is_operator_allowed("apps.compose.get"));
+    }
+
+    #[test]
+    fn system_journal_contents_are_admin_only_but_unit_metadata_is_readable() {
+        assert!(!is_read_only("system.logs"));
+        assert!(!is_operator_allowed("system.logs"));
+        assert!(is_read_only("system.logs.units"));
+        assert!(is_universally_allowed("system.logs.units"));
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -256,6 +256,9 @@ pub(super) async fn try_route(
             Err(e) => err(req, e),
         },
         "system.logs" => {
+            if let Some(response) = require_root_equivalent(req, session, "system_journal_read") {
+                return Some(response);
+            }
             let unit = str_param(req, "unit").unwrap_or("nasty-engine");
             let lines: u32 = req
                 .params

--- a/webui/src/lib/navigation.test.ts
+++ b/webui/src/lib/navigation.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe('navigation model', () => {
 	test('preserves the full hierarchy and order', () => {
-		const entries = resolveNavigation({ kvmAvailable: true });
+		const entries = resolveNavigation({ kvmAvailable: true, role: 'admin' });
 		expect(entries.map((entry) => entry.label)).toEqual([
 			'Dashboard', 'Storage', 'Sharing', 'Protection', 'Compute', 'Terminal', 'System'
 		]);
@@ -32,29 +32,29 @@ describe('navigation model', () => {
 	});
 
 	test('uses unique stable IDs and routes', () => {
-		const items = flattenNavigation(resolveNavigation({ kvmAvailable: true }));
+		const items = flattenNavigation(resolveNavigation({ kvmAvailable: true, role: 'admin' }));
 		expect(new Set(items.map((entry) => entry.id)).size).toBe(items.length);
 		expect(new Set(items.map((entry) => entry.href)).size).toBe(items.length);
 	});
 
 	test('gates VMs on KVM without changing Apps', () => {
-		const withoutKvm = flattenNavigation(resolveNavigation({ kvmAvailable: false }));
+		const withoutKvm = flattenNavigation(resolveNavigation({ kvmAvailable: false, role: 'admin' }));
 		expect(withoutKvm.some((item) => item.href === '/vms')).toBe(false);
 		expect(withoutKvm.some((item) => item.href === '/apps')).toBe(true);
 
-		const withKvm = flattenNavigation(resolveNavigation({ kvmAvailable: true }));
+		const withKvm = flattenNavigation(resolveNavigation({ kvmAvailable: true, role: 'admin' }));
 		expect(withKvm.some((item) => item.href === '/vms')).toBe(true);
 	});
 
 	test('derives the existing Common menu order', () => {
-		const common = commonNavigation(resolveNavigation({ kvmAvailable: true }));
+		const common = commonNavigation(resolveNavigation({ kvmAvailable: true, role: 'admin' }));
 		expect(common.map((item) => item.href)).toEqual([
 			'/', '/filesystems', '/subvolumes', '/disks', '/files', '/apps', '/vms', '/backups', '/logs'
 		]);
 	});
 
 	test('matches active items and their owning group', () => {
-		const entries = resolveNavigation({ kvmAvailable: true });
+		const entries = resolveNavigation({ kvmAvailable: true, role: 'admin' });
 		expect(currentNavigationItem('/subvolumes/details', entries).href).toBe('/subvolumes');
 		expect(activeNavigationGroup('/subvolumes/details', entries)).toBe('storage');
 		expect(activeNavigationGroup('/sharing', entries)).toBeNull();
@@ -62,7 +62,7 @@ describe('navigation model', () => {
 	});
 
 	test('search uses item keywords and group labels', () => {
-		const entries = resolveNavigation({ kvmAvailable: true });
+		const entries = resolveNavigation({ kvmAvailable: true, role: 'admin' });
 		expect(searchNavigation(entries, 'copygc')).toEqual(new Set(['/operations']));
 		expect(searchNavigation(entries, 'storage')).toEqual(new Set([
 			'/filesystems', '/subvolumes', '/disks', '/operations', '/files'
@@ -70,13 +70,13 @@ describe('navigation model', () => {
 	});
 
 	test('finds Disks by I/O scheduler terminology', () => {
-		const entries = resolveNavigation({ kvmAvailable: true });
+		const entries = resolveNavigation({ kvmAvailable: true, role: 'admin' });
 		expect(searchNavigation(entries, 'scheduler')).toEqual(new Set(['/disks']));
 		expect(searchNavigation(entries, 'elevator')).toEqual(new Set(['/disks']));
 	});
 
 	test('search cannot expose capability-gated entries', () => {
-		const entries = resolveNavigation({ kvmAvailable: false });
+		const entries = resolveNavigation({ kvmAvailable: false, role: 'admin' });
 		expect(searchNavigation(entries, 'virtual machine')).toEqual(new Set());
 	});
 
@@ -88,5 +88,14 @@ describe('navigation model', () => {
 		expect(searchNavigation(entries, 'filesystem')).toEqual(new Set());
 		expect(searchNavigation(entries, 'access control')).toEqual(new Set());
 		expect(currentNavigationItem('/menu', entries)).toBe(LAUNCHER_NAV_ITEM);
+	});
+
+	test('shows system logs only to admins', () => {
+		for (const role of ['operator', 'readonly', 'user'] as const) {
+			const items = flattenNavigation(resolveNavigation({ kvmAvailable: true, role }));
+			expect(items.some((item) => item.href === '/logs')).toBe(false);
+		}
+		const adminItems = flattenNavigation(resolveNavigation({ kvmAvailable: true, role: 'admin' }));
+		expect(adminItems.some((item) => item.href === '/logs')).toBe(true);
 	});
 });

--- a/webui/src/lib/navigation.ts
+++ b/webui/src/lib/navigation.ts
@@ -39,7 +39,7 @@ export interface NavItem {
 	icon: NavIcon;
 	keywords: string[];
 	commonRank?: number;
-	requires?: 'kvm';
+	requires?: 'kvm' | 'admin';
 }
 
 export interface NavGroup {
@@ -117,7 +117,7 @@ const NAVIGATION: NavEntry[] = [
 		children: [
 			item('services', '/services', 'Services', Server, ['service', 'protocol', 'nfs', 'smb', 'iscsi', 'smart', 'avahi', 'mdns', 'enable', 'disable', 'rest server', 'backup server', 'receiver', 'htpasswd', 'docker', 'container', 'runtime', 'ups', 'nut', 'battery', 'power', 'shutdown', 'uninterruptible', 'watchdog', 'load', 'memory', 'ping', 'reboot']),
 			item('hardware', '/hardware', 'Hardware', CircuitBoard, ['hardware', 'pci', 'iommu', 'group', 'passthrough', 'vfio', 'gpu', 'device', 'driver', 'lspci', 'tpm', 'tpm2', 'secure boot', 'secureboot', 'cpu', 'memory', 'ram', 'dmi', 'bios', 'firmware', 'motherboard', 'mainboard', 'usb', 'nic']),
-			item('logs', '/logs', 'Logs', ScrollText, ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'], { commonRank: 8 }),
+			item('logs', '/logs', 'Logs', ScrollText, ['log', 'journal', 'systemd', 'debug', 'error', 'follow', 'stream', 'filter', 'level', 'tail', 'kernel', 'dmesg'], { commonRank: 8, requires: 'admin' }),
 			item('update', '/update', 'Update', RefreshCw, ['update', 'upgrade', 'version', 'release', 'nixos', 'rebuild', 'generation', 'nasty', 'nixpkgs', 'bcachefs', 'flake', 'lock', 'rollback', 'pin']),
 			item('users', '/users', 'Access Control', ShieldCheck, ['user', 'password', 'role', 'admin', 'group', 'permission', 'token', 'api', 'access', 'auth', 'login', 'security key', 'webauthn', 'passkey', 'yubikey', 'touch id', 'windows hello', 'authenticator', 'fido', '2fa', 'mfa', 'sso', 'oidc', 'single sign-on', 'provider']),
 			item('settings', '/settings', 'Settings', Settings, ['setting', 'hostname', 'timezone', 'clock', 'motd', 'dashboard notice', 'directory', 'active directory', 'domain', 'ad', 'network', 'ip', 'dhcp', 'dns', 'bond', 'vlan', 'bridge', 'static', 'gateway', 'route', 'mtu', 'notification', 'email', 'smtp', 'telegram', 'webhook', 'tuning', 'nfs threads', 'metrics', 'prometheus', 'telemetry', 'log level', 'theme', 'dark', 'light', 'appearance', 'custom nix', 'custom.nix', 'nixos', 'package', 'systemd'])
@@ -133,7 +133,9 @@ export function isNavGroup(entry: NavEntry): entry is NavGroup {
 }
 
 function isVisible(item: NavItem, context: NavigationContext): boolean {
-	return item.requires !== 'kvm' || context.kvmAvailable;
+	if (item.requires === 'kvm') return context.kvmAvailable;
+	if (item.requires === 'admin') return context.role === 'admin';
+	return true;
 }
 
 export function resolveNavigation(context: NavigationContext): NavEntry[] {

--- a/webui/src/routes/backups/+page.svelte
+++ b/webui/src/routes/backups/+page.svelte
@@ -840,6 +840,13 @@
 			runLogPoll = null;
 		}
 		const current = profiles.find(profile => profile.id === viewRunLogProfile?.id) ?? viewRunLogProfile;
+		if (!isAdmin) {
+			viewRunLogProfile = current;
+			runLogOutput = current.last_run
+				? `Latest recorded result (${formatRunTimestamp(current.last_run.timestamp)}):\n${current.last_run.message}`
+				: 'No completed run has been recorded yet.';
+			return;
+		}
 		const wasRunning = activeJobs[current.id]?.kind === 'run_backup'
 			&& (activeJobs[current.id].state === 'pending' || activeJobs[current.id].state === 'running');
 		const request = ++runLogRequest;


### PR DESCRIPTION
## Summary
- require an unscoped Admin session for historical `system.logs` journal reads, matching the live stream
- keep the fixed `system.logs.units` metadata inventory available to management readers
- map scoped credential denials to HTTP 403
- hide Logs navigation from non-Admins and avoid journal calls from non-Admin backup history views
- update API role counts and add dispatcher/navigation regression coverage

## Testing
- `cargo test -p nasty-engine`
- `cargo fmt --all --check`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `npm test`
- `npm run check`
- `npm run build`
- `git diff --check`