### PR TITLE
security: restrict firmware flashing

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -8,8 +8,8 @@ Static review of all 329 methods registered in
 `engine/nasty-engine/src/registry/methods.rs`:
 
 - 126 `Any`
-- 80 `Operator`
-- 123 `Admin`
+- 79 `Operator`
+- 124 `Admin`
 
 The registry declarations match the central dispatcher. The findings below are
 semantic authorization problems that the registry/dispatcher consistency tests
@@ -96,6 +96,8 @@ access because journals can leak secrets, addresses, and audit details.
 - `engine/nasty-engine/src/log_stream.rs:102-123`
 
 ### `firmware.update` is Operator-level
+
+Status: fixed by requiring an unscoped Admin session before invoking fwupd.
 
 The method performs a host firmware flash through `fwupdmgr update ... -y` and
 should require an unscoped Admin.

--- a/engine/nasty-engine/src/auth.rs
+++ b/engine/nasty-engine/src/auth.rs
@@ -2397,6 +2397,10 @@ mod tests {
             },
             Session {
                 owner: Some("automation".to_string()),
+                ..session(Role::Admin)
+            },
+            Session {
+                owner: Some("automation".to_string()),
                 ..session(Role::Operator)
             },
         ] {

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2136,8 +2136,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "firmware.update",
-                    desc: "Apply the available firmware update for the named device via fwupd. Refuses the call if Secure Boot constraints block the capsule-apply path.",
-                    role: MethodRole::Operator,
+                    desc: "Apply the available firmware update for the named device via fwupd. Requires an unscoped Admin session and refuses the call if Secure Boot constraints block the capsule-apply path.",
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "device_id",
                         "fwupd device identifier (from firmware.devices).",

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -180,7 +180,6 @@ fn is_operator_allowed(method: &str) -> bool {
                 // `vm.create` etc.; without import they can't
                 // populate the disk to boot from.
                 | "vm.images.ensure"
-                | "firmware.update"
         )
 }
 
@@ -2225,6 +2224,13 @@ mod tests {
         assert!(!is_operator_allowed("system.logs"));
         assert!(is_read_only("system.logs.units"));
         assert!(is_universally_allowed("system.logs.units"));
+    }
+
+    #[test]
+    fn firmware_flash_is_admin_only() {
+        assert!(!is_read_only("firmware.update"));
+        assert!(!is_universally_allowed("firmware.update"));
+        assert!(!is_operator_allowed("firmware.update"));
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -798,10 +798,15 @@ pub(super) async fn try_route(
         "firmware.constraints" => ok(req, state.firmware.constraints().await),
         "firmware.devices" => ok(req, state.firmware.list_devices().await),
         "firmware.check" => ok(req, state.firmware.check_updates().await),
-        "firmware.update" => match require_str(req, "device_id") {
-            Ok(id) => ok(req, state.firmware.update_device(id).await),
-            Err(r) => r,
-        },
+        "firmware.update" => {
+            if let Some(response) = require_root_equivalent(req, session, "firmware_flash") {
+                return Some(response);
+            }
+            match require_str(req, "device_id") {
+                Ok(id) => ok(req, state.firmware.update_device(id).await),
+                Err(r) => r,
+            }
+        }
         "system.update.channel.set" => match require_str(req, "channel") {
             Ok(ch) => match ch.parse::<nasty_system::update::ReleaseChannel>() {
                 Ok(channel) => match state.updates.set_channel(channel).await {

--- a/webui/src/lib/access.test.ts
+++ b/webui/src/lib/access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { canAccessAuthenticatedRoute, redirectForRole } from './access';
+import { canAccessAuthenticatedRoute, hasRootEquivalentAccess, redirectForRole } from './access';
 
 describe('authenticated route policy', () => {
 	test('standard users can access only the portal route', () => {
@@ -16,6 +16,15 @@ describe('authenticated route policy', () => {
 			expect(canAccessAuthenticatedRoute(role, '/files')).toBe(true);
 			expect(redirectForRole(role, '/files')).toBeNull();
 			expect(redirectForRole(role, '/portal')).toBe('/');
+		}
+	});
+
+	test('root-equivalent access requires an unscoped admin', () => {
+		expect(hasRootEquivalentAccess('admin', false)).toBe(true);
+		expect(hasRootEquivalentAccess('admin', true)).toBe(false);
+		for (const role of ['operator', 'readonly', 'user'] as const) {
+			expect(hasRootEquivalentAccess(role, false)).toBe(false);
+			expect(hasRootEquivalentAccess(role, true)).toBe(false);
 		}
 	});
 });

--- a/webui/src/lib/access.ts
+++ b/webui/src/lib/access.ts
@@ -10,6 +10,10 @@ export function isManagementRole(role: string | null | undefined): role is Exclu
 	return role === 'admin' || role === 'operator' || role === 'readonly';
 }
 
+export function hasRootEquivalentAccess(role: string | null | undefined, scoped: boolean): boolean {
+	return role === 'admin' && !scoped;
+}
+
 export function canAccessAuthenticatedRoute(role: string, path: string): boolean {
 	const portalRoute = path === PORTAL_PATH || path.startsWith(`${PORTAL_PATH}/`);
 	return isStandardUser(role) ? portalRoute : !portalRoute;

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -10,11 +10,13 @@
 		FirmwareDevice,
 		FirmwareUpdateResult,
 		FirmwareConstraints,
+		AuthMe,
 		VersionInfo,
 		VersionInputInfo,
 		VersionTaggedReleaseStatus,
 		UpdateBuildDirConfig
 	} from '$lib/types';
+	import { hasRootEquivalentAccess } from '$lib/access';
 	import { Tag, Trash2, ArrowRightLeft, X, Check, ChevronDown, ChevronRight } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -116,6 +118,7 @@
 	let firmwareLoading = $state(false);
 	let firmwareLoaded = $state(false);
 	let firmwareUpdating: Record<string, boolean> = $state({});
+	let canFlashFirmware = $state(false);
 	// Apply-side blockers (today: Secure Boot enforcing — upstream
 	// lanzaboote#591 breaks fwupd's EFI-capsule shim). Engine owns
 	// the reason string; we render it verbatim in the banner and
@@ -663,6 +666,11 @@
 
 	async function loadFirmware() {
 		firmwareLoading = true;
+		canFlashFirmware = false;
+		try {
+			const identity = await client.call<AuthMe>('auth.me');
+			canFlashFirmware = hasRootEquivalentAccess(identity.role, identity.scoped);
+		} catch { /* Fail closed if session details are unavailable. */ }
 		try {
 			firmwareAvailable = await client.call<boolean>('firmware.available');
 			if (firmwareAvailable) {
@@ -681,6 +689,7 @@
 	}
 
 	async function updateFirmware(deviceId: string) {
+		if (!canFlashFirmware) return;
 		if (!await confirm(
 			'Apply firmware update?',
 			'This will flash new firmware to the device. Do not power off during the update. A reboot may be required.'
@@ -1306,11 +1315,13 @@
 											{#if dev.update_available}
 												<Button
 													size="xs"
-													onclick={() => updateFirmware(dev.device_id)}
-													disabled={firmwareUpdating[dev.device_id] || firmwareConstraints?.sb_blocks_apply}
-													title={firmwareConstraints?.sb_blocks_apply
-														? firmwareConstraints.sb_blocks_apply_reason
-														: undefined}
+												onclick={() => updateFirmware(dev.device_id)}
+												disabled={!canFlashFirmware || firmwareUpdating[dev.device_id] || firmwareConstraints?.sb_blocks_apply}
+													title={!canFlashFirmware
+														? 'Firmware flashing requires an unscoped Administrator session.'
+														: firmwareConstraints?.sb_blocks_apply
+															? firmwareConstraints.sb_blocks_apply_reason
+															: undefined}
 												>
 													{firmwareUpdating[dev.device_id] ? 'Updating...' : 'Update'}
 												</Button>


### PR DESCRIPTION
## Summary
- require an unscoped Admin session for `firmware.update` before parsing the device or invoking fwupd
- align registry metadata and the central dispatcher with the root-equivalent handler policy
- disable firmware Apply controls unless `auth.me` confirms unscoped Admin access
- add role, owner-scope, and WebUI access-policy regression coverage
- update API role counts and finding status

## Testing
- `cargo test -p nasty-engine`
- `cargo fmt --all --check`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `npm test`
- `npm run check`
- `npm run build`
- `git diff --check`