### PR TITLE
security: authorize protocol toggles by payload

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -107,12 +107,15 @@ should require an unscoped Admin.
 
 ### Generic protocol toggles control system safety services
 
+Status: fixed with payload-aware authorization for both enable and disable.
+
 Operator-level `service.protocol.enable` and `service.protocol.disable` also
 control SSH, NUT, watchdog, SMART, Avahi, and the backup REST server. System
-service payloads should require Admin; disabling watchdog currently lacks the
-enabling path's Admin check.
+service payloads now require an unscoped Admin, while share-protocol payloads
+remain available to unscoped Operators and Admins.
 
 - `engine/nasty-engine/src/registry/methods.rs:447-464`
+- `engine/nasty-engine/src/router/service.rs:14-38`
 - `engine/nasty-system/src/protocol.rs:16-54`
 
 ### Scoped Operator tokens can mutate global SMB identities

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -445,7 +445,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "service.protocol.enable",
-                    desc: "Enable a protocol or system service. Available names: `nfs`, `smb`, `iscsi`, `nvmeof`, `nut`, `ssh`, `avahi`, `smart`, `watchdog`, `rest-server`. Arming `watchdog` requires an unscoped Admin.",
+                    desc: "Enable a protocol or system service. Share protocols (`nfs`, `smb`, `iscsi`, `nvmeof`) require an unscoped Operator; system services (`nut`, `ssh`, `avahi`, `smart`, `watchdog`, `rest-server`) require an unscoped Admin.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "name",
@@ -455,7 +455,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "service.protocol.disable",
-                    desc: "Disable a protocol service.",
+                    desc: "Disable a protocol or system service. Share protocols require an unscoped Operator; system services require an unscoped Admin.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "name",

--- a/engine/nasty-engine/src/router/service.rs
+++ b/engine/nasty-engine/src/router/service.rs
@@ -9,7 +9,31 @@ use serde::Deserialize;
 
 use super::*;
 use crate::AppState;
-use crate::auth::{Role, Session};
+use crate::auth::{EndpointAccess, Session};
+
+fn protocol_mutation_access(protocol: nasty_system::protocol::Protocol) -> EndpointAccess {
+    if protocol.is_system_service() {
+        EndpointAccess::RootEquivalent
+    } else {
+        EndpointAccess::UnscopedMutation
+    }
+}
+
+fn require_protocol_mutation_access(
+    req: &Request,
+    session: &Session,
+    protocol: nasty_system::protocol::Protocol,
+) -> Option<Response> {
+    match protocol_mutation_access(protocol) {
+        EndpointAccess::RootEquivalent => {
+            require_root_equivalent(req, session, "system_service_protocol_mutation")
+        }
+        EndpointAccess::UnscopedMutation => {
+            require_unscoped_mutation(req, session, "global_share_protocol_mutation")
+        }
+        _ => unreachable!("protocol mutations use an explicit access tier"),
+    }
+}
 
 pub(super) async fn protocol_has_admin_only_sources(
     state: &AppState,
@@ -80,15 +104,7 @@ pub(super) async fn try_route(
         "service.protocol.enable" => match require_str(req, "name") {
             Ok(name) => {
                 if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
-                    if let Some(response) =
-                        require_unscoped_mutation(req, session, "global_protocol_enable")
-                    {
-                        return Some(response);
-                    }
-                    if proto == nasty_system::protocol::Protocol::Watchdog
-                        && let Some(response) =
-                            require_root_equivalent(req, session, "watchdog_reboot_policy")
-                    {
+                    if let Some(response) = require_protocol_mutation_access(req, session, proto) {
                         return Some(response);
                     }
                     if matches!(
@@ -215,26 +231,25 @@ pub(super) async fn try_route(
         },
         "service.protocol.disable" => match require_str(req, "name") {
             Ok(name) => {
-                if let Some(response) =
-                    require_unscoped_mutation(req, session, "global_protocol_disable")
-                {
-                    return Some(response);
-                }
-                match state.protocols.disable(name).await {
-                    Ok(v) => {
-                        if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
-                            match state.firewall.close(proto).await {
-                                Ok(()) => ok(req, v),
-                                Err(e) => err(
-                                    req,
-                                    format!("protocol disabled but firewall update failed: {e}"),
-                                ),
-                            }
-                        } else {
-                            ok(req, v)
-                        }
+                if let Some(proto) = nasty_system::protocol::Protocol::from_name(name) {
+                    if let Some(response) = require_protocol_mutation_access(req, session, proto) {
+                        return Some(response);
                     }
-                    Err(e) => err(req, e),
+                    match state.protocols.disable(name).await {
+                        Ok(v) => match state.firewall.close(proto).await {
+                            Ok(()) => ok(req, v),
+                            Err(e) => err(
+                                req,
+                                format!("protocol disabled but firewall update failed: {e}"),
+                            ),
+                        },
+                        Err(e) => err(req, e),
+                    }
+                } else {
+                    match state.protocols.disable(name).await {
+                        Ok(v) => ok(req, v),
+                        Err(e) => err(req, e),
+                    }
                 }
             }
             Err(r) => r,
@@ -368,4 +383,62 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::protocol_mutation_access;
+    use crate::auth::{EndpointAccess, Role, Session, authorize_session};
+    use nasty_system::protocol::Protocol;
+
+    fn session(role: Role, scoped: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role,
+            file_principal: None,
+            filesystem: scoped.then(|| "tank".into()),
+            owner: None,
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn share_protocol_mutations_allow_only_unscoped_operators_and_admins() {
+        for protocol in [
+            Protocol::Nfs,
+            Protocol::Smb,
+            Protocol::Iscsi,
+            Protocol::Nvmeof,
+        ] {
+            let access = protocol_mutation_access(protocol);
+            assert_eq!(access, EndpointAccess::UnscopedMutation);
+            assert!(authorize_session(&session(Role::Operator, false), access).is_ok());
+            assert!(authorize_session(&session(Role::Admin, false), access).is_ok());
+            assert!(authorize_session(&session(Role::Operator, true), access).is_err());
+            assert!(authorize_session(&session(Role::Admin, true), access).is_err());
+            assert!(authorize_session(&session(Role::ReadOnly, false), access).is_err());
+        }
+    }
+
+    #[test]
+    fn system_service_mutations_require_an_unscoped_admin() {
+        for protocol in [
+            Protocol::Nut,
+            Protocol::Ssh,
+            Protocol::Avahi,
+            Protocol::Smart,
+            Protocol::Watchdog,
+            Protocol::RestServer,
+        ] {
+            let access = protocol_mutation_access(protocol);
+            assert_eq!(access, EndpointAccess::RootEquivalent);
+            assert!(authorize_session(&session(Role::Admin, false), access).is_ok());
+            assert!(authorize_session(&session(Role::Admin, true), access).is_err());
+            assert!(authorize_session(&session(Role::Operator, false), access).is_err());
+            assert!(authorize_session(&session(Role::ReadOnly, false), access).is_err());
+        }
+    }
 }

--- a/engine/nasty-system/src/protocol.rs
+++ b/engine/nasty-system/src/protocol.rs
@@ -43,15 +43,15 @@ impl Protocol {
     ];
 
     pub fn is_system_service(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Protocol::Nut
-                | Protocol::Ssh
-                | Protocol::Avahi
-                | Protocol::Smart
-                | Protocol::Watchdog
-                | Protocol::RestServer
-        )
+            | Protocol::Ssh
+            | Protocol::Avahi
+            | Protocol::Smart
+            | Protocol::Watchdog
+            | Protocol::RestServer => true,
+            Protocol::Nfs | Protocol::Smb | Protocol::Iscsi | Protocol::Nvmeof => false,
+        }
     }
 
     pub fn name(&self) -> &'static str {

--- a/webui/src/lib/access.test.ts
+++ b/webui/src/lib/access.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { canAccessAuthenticatedRoute, hasRootEquivalentAccess, redirectForRole } from './access';
+import {
+	canAccessAuthenticatedRoute,
+	canMutateProtocol,
+	hasRootEquivalentAccess,
+	redirectForRole,
+} from './access';
 
 describe('authenticated route policy', () => {
 	test('standard users can access only the portal route', () => {
@@ -25,6 +30,24 @@ describe('authenticated route policy', () => {
 		for (const role of ['operator', 'readonly', 'user'] as const) {
 			expect(hasRootEquivalentAccess(role, false)).toBe(false);
 			expect(hasRootEquivalentAccess(role, true)).toBe(false);
+		}
+	});
+
+	test('share protocol mutations allow unscoped operators and admins', () => {
+		for (const role of ['admin', 'operator'] as const) {
+			expect(canMutateProtocol(role, false, false)).toBe(true);
+			expect(canMutateProtocol(role, true, false)).toBe(false);
+		}
+		for (const role of ['readonly', 'user'] as const) {
+			expect(canMutateProtocol(role, false, false)).toBe(false);
+		}
+	});
+
+	test('system service mutations require an unscoped admin', () => {
+		expect(canMutateProtocol('admin', false, true)).toBe(true);
+		expect(canMutateProtocol('admin', true, true)).toBe(false);
+		for (const role of ['operator', 'readonly', 'user'] as const) {
+			expect(canMutateProtocol(role, false, true)).toBe(false);
 		}
 	});
 });

--- a/webui/src/lib/access.ts
+++ b/webui/src/lib/access.ts
@@ -14,6 +14,15 @@ export function hasRootEquivalentAccess(role: string | null | undefined, scoped:
 	return role === 'admin' && !scoped;
 }
 
+export function canMutateProtocol(
+	role: string | null | undefined,
+	scoped: boolean,
+	systemService: boolean
+): boolean {
+	if (scoped) return false;
+	return systemService ? role === 'admin' : role === 'admin' || role === 'operator';
+}
+
 export function canAccessAuthenticatedRoute(role: string, path: string): boolean {
 	const portalRoute = path === PORTAL_PATH || path.startsWith(`${PORTAL_PATH}/`);
 	return isStandardUser(role) ? portalRoute : !portalRoute;

--- a/webui/src/routes/disks/+page.svelte
+++ b/webui/src/routes/disks/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { getClient } from '$lib/client';
+	import { hasRootEquivalentAccess } from '$lib/access';
 	import { formatBytes } from '$lib/format';
 	import { formatTemp } from '$lib/temperature.svelte';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { BlockDevice, DiskHealth, ProtocolStatus, SmartAttribute } from '$lib/types';
+	import type { AuthMe, BlockDevice, DiskHealth, ProtocolStatus, SmartAttribute } from '$lib/types';
 	import { ataAttributeMetadata } from '$lib/smart_attribute_metadata';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -23,7 +24,7 @@
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	let schedulerValues = $state<Record<string, string>>({});
 	let schedulerPending = $state<Record<string, boolean>>({});
-	let isAdmin = $state(false);
+	let hasRootAccess = $state(false);
 
 	const client = getClient();
 
@@ -57,10 +58,10 @@
 
 	async function loadIdentity() {
 		try {
-			const identity = await client.call<{ role: string }>('auth.me');
-			isAdmin = identity.role === 'admin';
+			const identity = await client.call<AuthMe>('auth.me');
+			hasRootAccess = hasRootEquivalentAccess(identity.role, identity.scoped);
 		} catch {
-			isAdmin = false;
+			hasRootAccess = false;
 		}
 	}
 
@@ -379,9 +380,9 @@
 									class="w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
 									value={schedulerValues[dev.path] ?? dev.io_scheduler.configured ?? ''}
 									onchange={(e) => setIoScheduler(dev, e.currentTarget.value)}
-									disabled={schedulerPending[dev.path] || !isAdmin}
+									disabled={schedulerPending[dev.path] || !hasRootAccess}
 									aria-label={`I/O scheduler for ${dev.path}`}
-									title={isAdmin ? 'Persist an I/O scheduler for this disk' : 'Administrator access is required to change the I/O scheduler'}
+									title={hasRootAccess ? 'Persist an I/O scheduler for this disk' : 'Administrator access is required to change the I/O scheduler'}
 								>
 									<option value="">Unmanaged (leave active unchanged)</option>
 									{#if dev.io_scheduler.configured && !dev.io_scheduler.available.includes(dev.io_scheduler.configured)}
@@ -428,7 +429,7 @@
 				<Badge variant={smartProtocol.enabled ? 'default' : 'secondary'}>
 					{smartProtocol.enabled ? 'Enabled' : 'Disabled'}
 				</Badge>
-				<Button variant="secondary" size="xs" onclick={toggleSmart}>
+				<Button variant="secondary" size="xs" onclick={toggleSmart} disabled={!hasRootAccess} title={hasRootAccess ? `${smartProtocol.enabled ? 'Disable' : 'Enable'} SMART monitoring` : 'Administrator access is required to manage SMART monitoring'}>
 					{smartProtocol.enabled ? 'Disable' : 'Enable'}
 				</Button>
 			{/if}

--- a/webui/src/routes/services/+page.svelte
+++ b/webui/src/routes/services/+page.svelte
@@ -2,9 +2,10 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { page } from '$app/stores';
 	import { getClient } from '$lib/client';
+	import { canMutateProtocol } from '$lib/access';
 	import { withToast, error } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { ProtocolStatus, AppsStatus, Filesystem, TuningConfig, NutConfig, UpsStatus, WatchdogConfig } from '$lib/types';
+	import type { AuthMe, ProtocolStatus, AppsStatus, Filesystem, TuningConfig, NutConfig, UpsStatus, WatchdogConfig } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Input } from '$lib/components/ui/input';
@@ -15,6 +16,7 @@
 	let selectedFs = $state('');
 	let dockerEnabling = $state(false);
 	let loading = $state(true);
+	let identity: AuthMe | null = $state(null);
 
 	// Per-service config panels
 	let configOpen = $state<string | null>(null);
@@ -397,7 +399,10 @@
 
 	onMount(async () => {
 		client.onEvent(handleEvent);
-		await refresh();
+		await Promise.all([
+			refresh(),
+			client.call<AuthMe>('auth.me').then((value) => { identity = value; }).catch(() => { identity = null; }),
+		]);
 		loading = false;
 		// Deep-link: /services?configure=<name> opens that service's config panel.
 		// Used by the SSH "Manage SSH" banner button (and any future banners).
@@ -460,6 +465,10 @@
 		await refresh();
 	}
 
+	function canToggle(proto: ProtocolStatus): boolean {
+		return identity !== null && canMutateProtocol(identity.role, identity.scoped, proto.system_service);
+	}
+
 	const sharingProtocols = $derived(protocols.filter(p => !p.system_service));
 	const systemServices = $derived(protocols.filter(p => p.system_service));
 </script>
@@ -484,6 +493,8 @@
 								size="xs"
 								class="w-[65px] justify-center"
 								onclick={() => toggle(proto)}
+								disabled={!canToggle(proto)}
+								title={canToggle(proto) ? `${proto.enabled ? 'Disable' : 'Enable'} ${proto.display_name}` : proto.system_service ? 'Administrator access is required to manage this system service' : 'Unscoped operator access is required to manage this protocol'}
 							>
 								{proto.enabled ? 'Disable' : 'Enable'}
 							</Button>

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -2,9 +2,10 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { getClient } from '$lib/client';
+	import { canMutateProtocol, hasRootEquivalentAccess } from '$lib/access';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
-	import type { Subvolume, ProtocolStatus } from '$lib/types';
+	import type { AuthMe, Subvolume, ProtocolStatus } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { rdma, rdmaLoad, rdmaSet } from '$lib/sharing/rdma.svelte';
@@ -79,6 +80,7 @@
 
 	let shareSubvolumes: Subvolume[] = $state([]);
 	let isAdmin = $state(false);
+	let canMutateShareProtocols = $state(false);
 
 	// Inline subvolume creation within share wizard
 	let showInlineCreate = $state(false);
@@ -304,9 +306,13 @@
 	onMount(async () => {
 		client.onEvent(handleEvent);
 		await Promise.all([
-			client.call<{ role: string; scoped: boolean }>('auth.me').then(identity => {
-				isAdmin = identity.role === 'admin' && !identity.scoped;
-			}).catch(() => { isAdmin = false; }),
+			client.call<AuthMe>('auth.me').then(identity => {
+				isAdmin = hasRootEquivalentAccess(identity.role, identity.scoped);
+				canMutateShareProtocols = canMutateProtocol(identity.role, identity.scoped, false);
+			}).catch(() => {
+				isAdmin = false;
+				canMutateShareProtocols = false;
+			}),
 			nfsRefresh().then(() => { nfs.loading = false; }),
 			smbRefresh().then(() => { smb.loading = false; }),
 			iscsiRefresh().then(() => { iscsi.loading = false; }),
@@ -365,7 +371,7 @@
 				<div class="mb-4 flex items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
 					<AlertTriangle size={16} class="shrink-0 text-amber-500" />
 					<span class="flex-1 text-sm">{selectedProto.display_name} service is not enabled.</span>
-					<Button size="xs" onclick={async () => { await toggleProtocol(shareProtocol === 'nvmeof' ? 'nvmeof' : shareProtocol, false); await ({ nfs: nfsLoadProtocol, smb: smbLoadProtocol, iscsi: iscsiLoadProtocol, nvmeof: nvmeLoadProtocol })[shareProtocol](); }}>
+					<Button size="xs" onclick={async () => { await toggleProtocol(shareProtocol === 'nvmeof' ? 'nvmeof' : shareProtocol, false); await ({ nfs: nfsLoadProtocol, smb: smbLoadProtocol, iscsi: iscsiLoadProtocol, nvmeof: nvmeLoadProtocol })[shareProtocol](); }} disabled={!canMutateShareProtocols} title={canMutateShareProtocols ? `Enable ${selectedProto.display_name}` : 'Unscoped operator access is required to enable this protocol'}>
 						Enable
 					</Button>
 				</div>


### PR DESCRIPTION
## Summary
- require unscoped Admin access for system-service protocol payloads while preserving unscoped Operator access for share protocols
- apply the same authorization policy to enable and disable, with exhaustive protocol classification
- align Services, Disks, and Sharing controls with the backend policy and document the API boundary

## Testing
- `cargo test -p nasty-engine`
- `cargo test -p nasty-system`
- `npm test`
- `npm run check`
- `cargo fmt --all -- --check`