### PR TITLE
security: restrict scoped SMB identity mutations

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -120,11 +120,15 @@ remain available to unscoped Operators and Admins.
 
 ### Scoped Operator tokens can mutate global SMB identities
 
+Status: fixed by requiring an unscoped Operator or Admin session for every SMB
+user and group mutation.
+
 The Operator allowlist permits user deletion, password reset, and group
-membership changes, but the handlers do not reject owner-scoped API tokens.
+membership changes. These handlers now reject filesystem- and owner-scoped API
+tokens before processing the mutation.
 
 - `engine/nasty-engine/src/router/mod.rs:100-110`
-- `engine/nasty-engine/src/router/smb.rs:20-116`
+- `engine/nasty-engine/src/router/smb.rs:14-37`
 
 ### `apps.update` does not authorize the existing app
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2325,21 +2325,21 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "smb.user.create",
-                    desc: "Create a Linux system user (no shell, no home, UID auto-assigned from 3000+) and set their Samba password. Requires the SMB protocol to be enabled.",
+                    desc: "Create a Linux system user (no shell, no home, UID auto-assigned from 3000+) and set their Samba password. Requires the SMB protocol and an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<CreateSmbUserRequest>(generator)),
                     result: Some(gen_schema::<SmbUser>(generator)),
                 },
                 Method {
                     name: "smb.user.delete",
-                    desc: "Remove the user's Samba password entry and delete the Linux system account. Requires the SMB protocol to be enabled.",
+                    desc: "Remove the user's Samba password entry and delete the Linux system account. Requires the SMB protocol and an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("username", "SMB username to delete.")),
                     result: None,
                 },
                 Method {
                     name: "smb.user.set_password",
-                    desc: "Change an existing SMB user's Samba password. Requires the SMB protocol to be enabled.",
+                    desc: "Change an existing SMB user's Samba password. Requires the SMB protocol and an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_two(
                         "username",
@@ -2364,21 +2364,21 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "smb.group.create",
-                    desc: "Create a Linux system group (GID auto-assigned from the SMB range, 3000+) used for SMB access control.",
+                    desc: "Create a Linux system group (GID auto-assigned from the SMB range, 3000+) used for SMB access control. Requires an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Group name to create.")),
                     result: Some(gen_schema::<SmbGroup>(generator)),
                 },
                 Method {
                     name: "smb.group.delete",
-                    desc: "Delete the SMB-managed Linux group via `groupdel`.",
+                    desc: "Delete the SMB-managed Linux group via `groupdel`. Requires an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Group name to delete.")),
                     result: None,
                 },
                 Method {
                     name: "smb.group.add_member",
-                    desc: "Add an existing user to an existing SMB group via `usermod -aG`.",
+                    desc: "Add an existing user to an existing SMB group via `usermod -aG`. Requires an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_two(
                         "group",
@@ -2390,7 +2390,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "smb.group.remove_member",
-                    desc: "Remove a user from an SMB group via `gpasswd -d`.",
+                    desc: "Remove a user from an SMB group via `gpasswd -d`. Requires an unscoped Operator or Admin session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_two(
                         "group",

--- a/engine/nasty-engine/src/router/smb.rs
+++ b/engine/nasty-engine/src/router/smb.rs
@@ -9,13 +9,33 @@ use serde::Deserialize;
 
 use super::*;
 use crate::AppState;
-use crate::auth::{Role, Session};
+use crate::auth::Session;
+
+fn is_smb_identity_mutation(method: &str) -> bool {
+    matches!(
+        method,
+        "smb.user.create"
+            | "smb.user.delete"
+            | "smb.user.set_password"
+            | "smb.group.create"
+            | "smb.group.delete"
+            | "smb.group.add_member"
+            | "smb.group.remove_member"
+    )
+}
 
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if is_smb_identity_mutation(&req.method)
+        && let Some(response) =
+            require_unscoped_mutation(req, session, "global_smb_identity_mutation")
+    {
+        return Some(response);
+    }
+
     Some(match req.method.as_str() {
         "smb.user.list" => match state.smb.list_users().await {
             Ok(v) => ok(req, v),
@@ -116,4 +136,56 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_smb_identity_mutation;
+    use crate::auth::{EndpointAccess, Role, Session, authorize_session};
+
+    fn session(role: Role, filesystem: Option<&str>, owner: Option<&str>) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role,
+            file_principal: None,
+            filesystem: filesystem.map(str::to_string),
+            owner: owner.map(str::to_string),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn all_smb_identity_mutations_are_scope_gated() {
+        for method in [
+            "smb.user.create",
+            "smb.user.delete",
+            "smb.user.set_password",
+            "smb.group.create",
+            "smb.group.delete",
+            "smb.group.add_member",
+            "smb.group.remove_member",
+        ] {
+            assert!(
+                is_smb_identity_mutation(method),
+                "missing gate for {method}"
+            );
+        }
+        assert!(!is_smb_identity_mutation("smb.user.list"));
+        assert!(!is_smb_identity_mutation("smb.group.list"));
+    }
+
+    #[test]
+    fn smb_identity_mutations_allow_only_unscoped_operators_and_admins() {
+        let access = EndpointAccess::UnscopedMutation;
+        assert!(authorize_session(&session(Role::Operator, None, None), access).is_ok());
+        assert!(authorize_session(&session(Role::Admin, None, None), access).is_ok());
+        assert!(authorize_session(&session(Role::Operator, Some("tank"), None), access).is_err());
+        assert!(authorize_session(&session(Role::Operator, None, Some("alice")), access).is_err());
+        assert!(authorize_session(&session(Role::Admin, Some("tank"), None), access).is_err());
+        assert!(authorize_session(&session(Role::Admin, None, Some("alice")), access).is_err());
+        assert!(authorize_session(&session(Role::ReadOnly, None, None), access).is_err());
+    }
 }

--- a/webui/src/lib/access.test.ts
+++ b/webui/src/lib/access.test.ts
@@ -3,6 +3,7 @@ import {
 	canAccessAuthenticatedRoute,
 	canMutateProtocol,
 	hasRootEquivalentAccess,
+	hasUnscopedMutationAccess,
 	redirectForRole,
 } from './access';
 
@@ -30,6 +31,16 @@ describe('authenticated route policy', () => {
 		for (const role of ['operator', 'readonly', 'user'] as const) {
 			expect(hasRootEquivalentAccess(role, false)).toBe(false);
 			expect(hasRootEquivalentAccess(role, true)).toBe(false);
+		}
+	});
+
+	test('global mutations allow only unscoped operators and admins', () => {
+		for (const role of ['admin', 'operator'] as const) {
+			expect(hasUnscopedMutationAccess(role, false)).toBe(true);
+			expect(hasUnscopedMutationAccess(role, true)).toBe(false);
+		}
+		for (const role of ['readonly', 'user'] as const) {
+			expect(hasUnscopedMutationAccess(role, false)).toBe(false);
 		}
 	});
 

--- a/webui/src/lib/access.ts
+++ b/webui/src/lib/access.ts
@@ -14,13 +14,18 @@ export function hasRootEquivalentAccess(role: string | null | undefined, scoped:
 	return role === 'admin' && !scoped;
 }
 
+export function hasUnscopedMutationAccess(role: string | null | undefined, scoped: boolean): boolean {
+	return !scoped && (role === 'admin' || role === 'operator');
+}
+
 export function canMutateProtocol(
 	role: string | null | undefined,
 	scoped: boolean,
 	systemService: boolean
 ): boolean {
-	if (scoped) return false;
-	return systemService ? role === 'admin' : role === 'admin' || role === 'operator';
+	return systemService
+		? hasRootEquivalentAccess(role, scoped)
+		: hasUnscopedMutationAccess(role, scoped);
 }
 
 export function canAccessAuthenticatedRoute(role: string, path: string): boolean {

--- a/webui/src/routes/sharing/+page.svelte
+++ b/webui/src/routes/sharing/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { getClient } from '$lib/client';
-	import { canMutateProtocol, hasRootEquivalentAccess } from '$lib/access';
+	import { canMutateProtocol, hasRootEquivalentAccess, hasUnscopedMutationAccess } from '$lib/access';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthMe, Subvolume, ProtocolStatus } from '$lib/types';
@@ -81,6 +81,7 @@
 	let shareSubvolumes: Subvolume[] = $state([]);
 	let isAdmin = $state(false);
 	let canMutateShareProtocols = $state(false);
+	let canMutateSmbIdentities = $state(false);
 
 	// Inline subvolume creation within share wizard
 	let showInlineCreate = $state(false);
@@ -309,9 +310,11 @@
 			client.call<AuthMe>('auth.me').then(identity => {
 				isAdmin = hasRootEquivalentAccess(identity.role, identity.scoped);
 				canMutateShareProtocols = canMutateProtocol(identity.role, identity.scoped, false);
+				canMutateSmbIdentities = hasUnscopedMutationAccess(identity.role, identity.scoped);
 			}).catch(() => {
 				isAdmin = false;
 				canMutateShareProtocols = false;
+				canMutateSmbIdentities = false;
 			}),
 			nfsRefresh().then(() => { nfs.loading = false; }),
 			smbRefresh().then(() => { smb.loading = false; }),
@@ -462,6 +465,7 @@
 					bind:validUsers={shareSmbValidUsers}
 					bind:timeMachine={shareSmbTimeMachine}
 					bind:maxSizeGib={shareSmbTmMaxSize}
+					canMutateIdentities={canMutateSmbIdentities}
 				/>
 			{:else if shareProtocol === 'iscsi'}
 				<IscsiWizardForm bind:name={shareIscsiName} />

--- a/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
+++ b/webui/src/routes/sharing/wizard/SmbWizardForm.svelte
@@ -16,6 +16,7 @@
 		validUsers: string[];
 		timeMachine: boolean;
 		maxSizeGib: number | null;
+		canMutateIdentities: boolean;
 	}
 	let {
 		name = $bindable(),
@@ -24,6 +25,7 @@
 		validUsers = $bindable(),
 		timeMachine = $bindable(),
 		maxSizeGib = $bindable(),
+		canMutateIdentities,
 	}: Props = $props();
 
 	const client = getClient();
@@ -46,6 +48,7 @@
 	let createGroupTried = $state(false);
 
 	async function createInlineGroup() {
+		if (!canMutateIdentities) return;
 		if (!inlineGroupName.trim()) { createGroupTried = true; return; }
 		createGroupTried = false;
 		await withToast(
@@ -59,6 +62,7 @@
 	}
 
 	async function createInlineUser() {
+		if (!canMutateIdentities) return;
 		if (!inlineUsername || !inlinePassword || !inlinePasswordConfirm) { createUserTried = true; return; }
 		if (inlinePassword !== inlinePasswordConfirm) { createUserTried = true; return; }
 		createUserTried = false;
@@ -217,7 +221,7 @@
 					</div>
 				</CardContent>
 			</Card>
-		{:else}
+		{:else if canMutateIdentities}
 			<div class="mt-2 flex gap-2">
 				<Button size="sm" onclick={() => showInlineUserCreate = true}>Create System User</Button>
 			</div>

--- a/webui/src/routes/users/+page.svelte
+++ b/webui/src/routes/users/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getClient } from '$lib/client';
+	import { hasUnscopedMutationAccess } from '$lib/access';
 	import { withToast } from '$lib/toast.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import { requiredFieldCls } from '$lib/utils';
@@ -15,6 +16,7 @@
 		WebauthnCredentialSummary,
 		WebauthnRegisterStart,
 		UserRole,
+		AuthMe,
 	} from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -150,6 +152,7 @@
 	// System users (protocol access)
 	interface SystemUser { username: string; uid: number; }
 	let systemUsers: SystemUser[] = $state([]);
+	let canMutateSmbIdentities = $state(false);
 	let showCreateSystemUser = $state(false);
 	let newSysUsername = $state('');
 	let newSysPassword = $state('');
@@ -249,7 +252,12 @@
 	const client = getClient();
 
 	onMount(async () => {
-		await refresh();
+		await Promise.all([
+			refresh(),
+			client.call<AuthMe>('auth.me').then((identity) => {
+				canMutateSmbIdentities = hasUnscopedMutationAccess(identity.role, identity.scoped);
+			}).catch(() => { canMutateSmbIdentities = false; }),
+		]);
 		loadOidc();
 		loading = false;
 	});
@@ -713,9 +721,12 @@
 <p class="mb-4 text-sm text-muted-foreground">
 	Linux users for protocol access (SMB). Create users here, then reference them in share "Valid Users" for authenticated access.
 </p>
+{#if !canMutateSmbIdentities}
+	<p class="mb-4 text-sm text-amber-500">An unscoped Operator or Admin session is required to change SMB identities.</p>
+{/if}
 
 <div class="mb-4">
-	<Button size="sm" onclick={() => showCreateSystemUser = !showCreateSystemUser}>
+	<Button size="sm" onclick={() => showCreateSystemUser = !showCreateSystemUser} disabled={!canMutateSmbIdentities}>
 		{showCreateSystemUser ? 'Cancel' : 'Create System User'}
 	</Button>
 </div>
@@ -759,7 +770,7 @@
 					</div>
 				</div>
 			{/if}
-			<Button onclick={createSystemUser} disabled={creatingSysUser || !newSysUsername || !newSysPassword || newSysPassword !== newSysPasswordConfirm}>
+			<Button onclick={createSystemUser} disabled={!canMutateSmbIdentities || creatingSysUser || !newSysUsername || !newSysPassword || newSysPassword !== newSysPasswordConfirm}>
 				{creatingSysUser ? 'Creating…' : 'Create'}
 			</Button>
 		</CardContent>
@@ -793,10 +804,10 @@
 						</td>
 						<td class="p-3" onclick={(e) => e.stopPropagation()}>
 							<div class="flex gap-2">
-								<Button variant="secondary" size="xs" onclick={() => { sysPwUser = user.username; sysPwNew = ''; sysPwConfirm = ''; }}>
+								<Button variant="secondary" size="xs" onclick={() => { sysPwUser = user.username; sysPwNew = ''; sysPwConfirm = ''; }} disabled={!canMutateSmbIdentities}>
 									Change Password
 								</Button>
-								<Button variant="destructive" size="xs" onclick={() => deleteSystemUser(user.username)}>Delete</Button>
+								<Button variant="destructive" size="xs" onclick={() => deleteSystemUser(user.username)} disabled={!canMutateSmbIdentities}>Delete</Button>
 							</div>
 						</td>
 					</tr>
@@ -810,6 +821,7 @@
 										<label class="flex items-center gap-1.5 text-sm cursor-pointer rounded border px-2 py-1 transition-colors {isMember ? 'border-blue-500/40 bg-blue-500/10' : 'border-border hover:bg-muted/30'}">
 											<input type="checkbox" class="rounded border-input"
 												checked={isMember}
+												disabled={!canMutateSmbIdentities}
 												onchange={async (e) => {
 													if (isMember) {
 														// Removing membership via a checkbox toggle is
@@ -865,7 +877,7 @@
 			{/if}
 		</div>
 		<Dialog.Footer>
-			<Button size="sm" onclick={changeSysPassword}>
+			<Button size="sm" onclick={changeSysPassword} disabled={!canMutateSmbIdentities}>
 				Change Password
 			</Button>
 			<Button variant="secondary" size="sm" onclick={() => sysPwUser = null}>Cancel</Button>
@@ -880,7 +892,7 @@
 </p>
 
 <div class="mb-4">
-	<Button size="sm" onclick={() => showCreateGroup = !showCreateGroup}>
+	<Button size="sm" onclick={() => showCreateGroup = !showCreateGroup} disabled={!canMutateSmbIdentities}>
 		{showCreateGroup ? 'Cancel' : 'Create Group'}
 	</Button>
 </div>
@@ -892,7 +904,7 @@
 				<Label for="group-name">Group Name {#if !newGroupName.trim() && newGroupTried}<span class="text-xs font-normal text-amber-500">required</span>{/if}</Label>
 				<Input id="group-name" bind:value={newGroupName} placeholder="e.g. engineering" class="mt-1 {requiredFieldCls(!newGroupName.trim(), newGroupTried)}" />
 			</div>
-			<Button size="sm" onclick={createGroup}>Create</Button>
+			<Button size="sm" onclick={createGroup} disabled={!canMutateSmbIdentities}>Create</Button>
 		</CardContent>
 	</Card>
 {/if}
@@ -924,7 +936,7 @@
 						{/if}
 					</td>
 					<td class="p-3" onclick={(e) => e.stopPropagation()}>
-						<Button variant="destructive" size="xs" onclick={() => deleteGroup(group.name)}>Delete</Button>
+						<Button variant="destructive" size="xs" onclick={() => deleteGroup(group.name)} disabled={!canMutateSmbIdentities}>Delete</Button>
 					</td>
 				</tr>
 				{#if expandedGroup === group.name}
@@ -936,7 +948,7 @@
 									{#each group.members as member}
 										<span class="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs">
 											{member}
-											<button class="ml-1 text-muted-foreground hover:text-destructive" onclick={() => removeMember(group.name, member)} title="Remove">&times;</button>
+											<button class="ml-1 text-muted-foreground hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50" onclick={() => removeMember(group.name, member)} title="Remove" disabled={!canMutateSmbIdentities}>&times;</button>
 										</span>
 									{/each}
 								</div>
@@ -951,11 +963,11 @@
 											<option value={user.username}>{user.username}</option>
 										{/each}
 									</select>
-									<Button size="xs" onclick={addMember} disabled={!addMemberUser}>Add</Button>
+									<Button size="xs" onclick={addMember} disabled={!canMutateSmbIdentities || !addMemberUser}>Add</Button>
 									<Button size="xs" variant="secondary" onclick={() => addMemberGroup = null}>Cancel</Button>
 								</div>
 							{:else}
-								<Button size="xs" variant="secondary" onclick={() => addMemberGroup = group.name}>Add Member</Button>
+								<Button size="xs" variant="secondary" onclick={() => addMemberGroup = group.name} disabled={!canMutateSmbIdentities}>Add Member</Button>
 							{/if}
 						</td>
 					</tr>


### PR DESCRIPTION
## Summary
- require an unscoped Operator or Admin session for every SMB user and group mutation
- deny both filesystem- and owner-scoped credentials before processing global identity changes
- make Access Control identity management read-only for scoped sessions and hide inline identity creation in the sharing wizard
- document the endpoint scope requirements and add backend/WebUI authorization matrix tests

## Testing
- `cargo test -p nasty-engine`
- `npm test`
- `npm run check`
- `cargo fmt --all -- --check`
- `git diff --check`