### PR TITLE
webui: switch bcachefs from status chip

### DIFF
--- a/webui/src/lib/bcachefs-update.test.ts
+++ b/webui/src/lib/bcachefs-update.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { buildBcachefsSyncInputs } from './bcachefs-update';
+
+describe('bcachefs sync payload', () => {
+	test('re-pins and refreshes only bcachefs-tools', () => {
+		expect(buildBcachefsSyncInputs([
+			{ name: 'nasty', url: 'github:nasty-project/nasty/main' },
+			{ name: 'bcachefs-tools', url: 'github:koverstreet/bcachefs-tools/v1.39.4' },
+			{ name: 'tailscale-nixpkgs', url: 'github:NixOS/nixpkgs/nixos-unstable' },
+		], 'v1.39.5')).toEqual([
+			{ name: 'nasty', url: 'github:nasty-project/nasty/main', update: false },
+			{ name: 'bcachefs-tools', url: 'github:koverstreet/bcachefs-tools/v1.39.5', update: true },
+			{ name: 'tailscale-nixpkgs', url: 'github:NixOS/nixpkgs/nixos-unstable', update: false },
+		]);
+	});
+
+	test('rejects missing target input or recommendation', () => {
+		expect(buildBcachefsSyncInputs([
+			{ name: 'nasty', url: 'github:nasty-project/nasty/main' },
+		], 'v1.39.5')).toBeNull();
+		expect(buildBcachefsSyncInputs([
+			{ name: 'bcachefs-tools', url: 'github:koverstreet/bcachefs-tools/v1.39.4' },
+		], '')).toBeNull();
+	});
+
+	test('preserves other refresh selections from the Update page', () => {
+		const inputs = buildBcachefsSyncInputs([
+			{ name: 'nasty', url: 'github:nasty-project/nasty/main', update: true },
+			{ name: 'bcachefs-tools', url: 'github:koverstreet/bcachefs-tools/v1.39.4', update: false },
+		], 'v1.39.5');
+
+		expect(inputs?.map((input) => [input.name, input.update])).toEqual([
+			['nasty', true],
+			['bcachefs-tools', true],
+		]);
+	});
+});

--- a/webui/src/lib/bcachefs-update.ts
+++ b/webui/src/lib/bcachefs-update.ts
@@ -1,0 +1,20 @@
+export interface VersionSwitchInput {
+	name: string;
+	url: string;
+	update: boolean;
+}
+
+export function buildBcachefsSyncInputs(
+	inputs: readonly { name: string; url: string; update?: boolean }[],
+	recommendedRef: string
+): VersionSwitchInput[] | null {
+	if (!recommendedRef || !inputs.some((input) => input.name === 'bcachefs-tools')) return null;
+
+	return inputs.map((input) => ({
+		name: input.name,
+		url: input.name === 'bcachefs-tools'
+			? `github:koverstreet/bcachefs-tools/${recommendedRef}`
+			: input.url,
+		update: input.name === 'bcachefs-tools' ? true : input.update ?? false,
+	}));
+}

--- a/webui/src/routes/+layout.svelte
+++ b/webui/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import { getClient, resetClient } from '$lib/client';
 	import { login as doLogin, logout as doLogout, loginWebauthn as doLoginWebauthn } from '$lib/auth';
-	import { error as showError, isBusy } from '$lib/toast.svelte';
+	import { error as showError, isBusy, withToast } from '$lib/toast.svelte';
 	import Toasts from '$lib/components/Toasts.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import ConfirmDangerousDialog from '$lib/components/ConfirmDangerousDialog.svelte';
@@ -14,7 +14,7 @@
 	import LauncherSidebarNav from '$lib/components/LauncherSidebarNav.svelte';
 	import { confirm } from '$lib/confirm.svelte';
 	import type { AuthResult } from '$lib/rpc';
-	import type { BackupProfile, BootStatus, BootPhase, SecureBootReadinessReport, SystemStatus, UpdateInfo } from '$lib/types';
+	import type { BackupProfile, BootStatus, BootPhase, SecureBootReadinessReport, SystemStatus, UpdateInfo, UpdateStatus, VersionInfo } from '$lib/types';
 	import favicon from '$lib/assets/favicon.svg';
 	import logoLight from '$lib/assets/nasty.svg';
 	import logoDark from '$lib/assets/nasty-white.svg';
@@ -67,6 +67,7 @@
 	import { RELEASE_UPDATE_CHANGED_EVENT, publishReleaseUpdate, releaseUpdateDisplay, requestReleaseUpdateCheck, setReleaseUpdateSnapshot, shouldCheckReleaseUpdate, type ReleaseUpdateChangedDetail, type ReleaseUpdateRequestState } from '$lib/release-update';
 	import { isManagementRole, isStandardUser, redirectForRole } from '$lib/access';
 	import { CORE_RECOVERY_PATHS, RECOVERY_BACKUP_CHANGED_EVENT, SECURE_BOOT_RECOVERY_SOURCE } from '$lib/recoveryBackup';
+	import { buildBcachefsSyncInputs } from '$lib/bcachefs-update';
 
 	let { children } = $props();
 	let connected = $state(false);
@@ -327,6 +328,94 @@
 		const rec = sysInfo?.bcachefs_recommended_ref;
 		return !!rec && rec !== sysInfo?.bcachefs_pinned_ref;
 	});
+	const BCACHEFS_CHIP_SWITCH_KEY = 'nasty:bcachefs-chip-switch';
+	let bcachefsSwitching = $state(false);
+	let bcachefsSwitchPoll: ReturnType<typeof setInterval> | null = null;
+
+	function writeBcachefsSwitchMarker(active: boolean) {
+		if (typeof window === 'undefined') return;
+		if (active) sessionStorage.setItem(BCACHEFS_CHIP_SWITCH_KEY, '1');
+		else sessionStorage.removeItem(BCACHEFS_CHIP_SWITCH_KEY);
+	}
+
+	function hasBcachefsSwitchMarker(): boolean {
+		return typeof window !== 'undefined' && sessionStorage.getItem(BCACHEFS_CHIP_SWITCH_KEY) === '1';
+	}
+
+	function stopBcachefsSwitchPolling() {
+		if (bcachefsSwitchPoll) {
+			clearInterval(bcachefsSwitchPoll);
+			bcachefsSwitchPoll = null;
+		}
+		getClient().setAggressiveReconnect(false);
+	}
+
+	function finishBcachefsSwitch(status: UpdateStatus) {
+		if (!bcachefsSwitching && !hasBcachefsSwitchMarker()) return;
+		stopBcachefsSwitchPolling();
+		writeBcachefsSwitchMarker(false);
+		bcachefsSwitching = false;
+		sysInfoRefresh.triggerReconcile();
+		if (status.state === 'success') {
+			if (status.webui_changed) refreshState.set();
+			if (status.reboot_required) rebootState.set();
+		} else if (status.state === 'failed') {
+			showError('bcachefs switch failed. Open Update for details.');
+		}
+	}
+
+	function startBcachefsSwitchPolling() {
+		bcachefsSwitching = true;
+		const client = getClient();
+		client.setAggressiveReconnect(true);
+		if (bcachefsSwitchPoll) return;
+		bcachefsSwitchPoll = setInterval(async () => {
+			try {
+				const status = await client.call<UpdateStatus>('system.update.status');
+				if (status.state !== 'running') finishBcachefsSwitch(status);
+			} catch {
+				// Activation may briefly restart the engine; reconnect resumes polling.
+			}
+		}, 3000);
+	}
+
+	async function reconcileBcachefsSwitch() {
+		try {
+			const status = await getClient().call<UpdateStatus>('system.update.status', undefined, 300000);
+			if (status.state === 'running') startBcachefsSwitchPolling();
+			else finishBcachefsSwitch(status);
+		} catch {
+			startBcachefsSwitchPolling();
+		}
+	}
+
+	async function switchBcachefsFromChip() {
+		const recommendedRef = sysInfo?.bcachefs_recommended_ref;
+		if (authInfo?.role !== 'admin' || !recommendedRef || bcachefsSwitching) return;
+		if (!await confirm(
+			`Switch bcachefs to ${recommendedRef}?`,
+			`This re-pins bcachefs-tools to ${recommendedRef} — the version bundled with this NASty release — and rebuilds immediately. You may need to reboot afterward to load the new kernel module.`,
+			{ confirmLabel: 'Switch', cancelLabel: 'Cancel' }
+		)) return;
+
+		const version = await withToast(() => getClient().call<VersionInfo>('system.version.get'));
+		if (!version) return;
+		const inputs = buildBcachefsSyncInputs(version.inputs, recommendedRef);
+		if (!inputs) {
+			showError('The bcachefs-tools input is missing from the system version configuration.');
+			return;
+		}
+
+		bcachefsSwitching = true;
+		writeBcachefsSwitchMarker(true);
+		getClient().setAggressiveReconnect(true);
+		const result = await withToast(
+			() => getClient().call('system.version.switch', { inputs }, 120000),
+			'bcachefs switch started'
+		);
+		if (result !== undefined) startBcachefsSwitchPolling();
+		else await reconcileBcachefsSwitch();
+	}
 	let clock24h = $state(true);
 
 	// Network rollback countdown — ticks once per second while a rollback is
@@ -558,6 +647,7 @@
 		// — without this trigger it shows the pre-reboot version until the
 		// user hits cmd+R.
 		sysInfoRefresh.trigger();
+		if (bcachefsSwitching) void reconcileBcachefsSwitch();
 		triggerReleaseUpdateRefresh();
 	};
 	const onDisconnect = () => {
@@ -594,6 +684,7 @@
 		const backupPoll = setInterval(checkConfigBackup, 30_000);
 		return () => {
 			releaseUpdatePolling = false;
+			stopBcachefsSwitchPolling();
 			if (reconnectingTimer) clearTimeout(reconnectingTimer);
 			if (releaseUpdatePoll) clearTimeout(releaseUpdatePoll);
 			lifecycleClient?.offReconnect(onReconnect);
@@ -654,6 +745,10 @@
 			if (destination) await goto(destination, { replaceState: true });
 			connected = true;
 			showLogin = false;
+			if (authInfo.role === 'admin' && hasBcachefsSwitchMarker()) {
+				bcachefsSwitching = true;
+				void reconcileBcachefsSwitch();
+			}
 			if (isManagementRole(authInfo.role)) {
 				checkSshStatus();
 				checkConfigBackup();
@@ -1245,24 +1340,37 @@
 					     case directly — previously the offer was hidden unless a
 					     debug flag or pending reboot happened to be set too. -->
 					{#if sysInfo && (bcachefsUpdateAvail || sysInfo.bcachefs_is_custom || sysInfo.bcachefs_debug_checks)}
-						<a
-							href="/update#bcachefs"
-							class={bcachefsUpdateAvail
-								? 'flex items-center gap-2 rounded-md border-2 border-blue-500/70 px-3 py-1.5 text-sm text-blue-400 no-underline transition-all hover:bg-blue-500/10 hover:border-blue-400 hover:shadow-[0_0_16px_rgba(96,165,250,0.5)]'
-								: 'flex items-center gap-2 rounded-md border-2 border-white/15 px-3 py-1.5 text-sm text-muted-foreground/80 no-underline transition-all hover:bg-white/5 hover:border-white/30'}
-							title={bcachefsUpdateAvail
-								? `bcachefs update available — NASty ships ${sysInfo.bcachefs_recommended_ref} (you're pinned at ${sysInfo.bcachefs_pinned_ref ?? '—'}). Click to switch.`
-								: 'bcachefs status — click for details'}
-						>
-							<span>bcachefs</span>
-							{#if bcachefsUpdateAvail}
-								<span class="font-mono text-xs">→ {sysInfo.bcachefs_recommended_ref}</span>
-							{/if}
-							<span class="flex items-center gap-1.5">
-								<span title="Reboot pending — running module differs from the pinned version"><Settings size={14} class={sysInfo.bcachefs_is_custom ? 'text-amber-400' : 'text-muted-foreground/30'} /></span>
-								<span title="Debug checks enabled in the running module"><Bug size={14} class={sysInfo.bcachefs_debug_checks ? 'text-blue-400' : 'text-muted-foreground/30'} /></span>
-							</span>
-						</a>
+						{#if bcachefsUpdateAvail}
+							<button
+								onclick={switchBcachefsFromChip}
+								disabled={authInfo?.role !== 'admin' || bcachefsSwitching}
+								class="flex items-center gap-2 rounded-md border-2 border-blue-500/70 px-3 py-1.5 text-sm text-blue-400 transition-all hover:bg-blue-500/10 hover:border-blue-400 hover:shadow-[0_0_16px_rgba(96,165,250,0.5)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:shadow-none"
+								title={bcachefsSwitching
+									? 'bcachefs switch in progress'
+									: authInfo?.role === 'admin'
+										? `bcachefs update available — NASty ships ${sysInfo.bcachefs_recommended_ref} (you're pinned at ${sysInfo.bcachefs_pinned_ref ?? '—'}). Click to switch.`
+										: 'Administrator access is required to switch bcachefs'}
+							>
+								<span>bcachefs</span>
+								<span class="font-mono text-xs">{bcachefsSwitching ? 'Switching...' : `→ ${sysInfo.bcachefs_recommended_ref}`}</span>
+								<span class="flex items-center gap-1.5">
+									<span title="Reboot pending — running module differs from the pinned version"><Settings size={14} class={sysInfo.bcachefs_is_custom ? 'text-amber-400' : 'text-muted-foreground/30'} /></span>
+									<span title="Debug checks enabled in the running module"><Bug size={14} class={sysInfo.bcachefs_debug_checks ? 'text-blue-400' : 'text-muted-foreground/30'} /></span>
+								</span>
+							</button>
+						{:else}
+							<a
+								href="/update"
+								class="flex items-center gap-2 rounded-md border-2 border-white/15 px-3 py-1.5 text-sm text-muted-foreground/80 no-underline transition-all hover:bg-white/5 hover:border-white/30"
+								title="bcachefs status — click for details"
+							>
+								<span>bcachefs</span>
+								<span class="flex items-center gap-1.5">
+									<span title="Reboot pending — running module differs from the pinned version"><Settings size={14} class={sysInfo.bcachefs_is_custom ? 'text-amber-400' : 'text-muted-foreground/30'} /></span>
+									<span title="Debug checks enabled in the running module"><Bug size={14} class={sysInfo.bcachefs_debug_checks ? 'text-blue-400' : 'text-muted-foreground/30'} /></span>
+								</span>
+							</a>
+						{/if}
 					{/if}
 					{#if rollbackState.pending}
 						<!-- Pending network rollback. Sticky on every page so the

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -25,6 +25,7 @@
 	import { refreshState } from '$lib/refresh.svelte';
 	import { rebootState } from '$lib/reboot.svelte';
 	import { sysInfoRefresh } from '$lib/sysInfoRefresh.svelte';
+	import { buildBcachefsSyncInputs, type VersionSwitchInput } from '$lib/bcachefs-update';
 	import {
 		reachedUpdatePhase,
 		shouldShowUpdateStatus,
@@ -393,7 +394,11 @@
 		await doVersionSwitch();
 	}
 
-	async function doVersionSwitch() {
+	async function doVersionSwitch(inputs: VersionSwitchInput[] = versionRows.map((row) => ({
+		name: row.name,
+		url: row.url.trim(),
+		update: row.update
+	}))) {
 		startingSwitch = true;
 		writeVersionPageAction('version-switch');
 		taggedReleaseBanner = { kind: 'switching' };
@@ -402,11 +407,7 @@
 		clearReleaseUpdateCheck();
 		const result = await withToast(
 			() => client.call('system.version.switch', {
-				inputs: versionRows.map((row) => ({
-					name: row.name,
-					url: row.url.trim(),
-					update: row.update
-				}))
+				inputs
 			}, 120000),
 			'Version switch started'
 		);
@@ -433,8 +434,9 @@
 	);
 
 	async function syncBcachefsToBundled() {
-		const row = versionRows.find((r) => r.name === 'bcachefs-tools');
-		if (!recommendedBcachefs || !row) return;
+		if (!recommendedBcachefs) return;
+		const inputs = buildBcachefsSyncInputs(versionRows, recommendedBcachefs);
+		if (!inputs) return;
 		if (
 			!(await confirm(
 				`Switch bcachefs to ${recommendedBcachefs}?`,
@@ -444,9 +446,7 @@
 		)
 			return;
 		syncingBcachefs = true;
-		row.url = `github:koverstreet/bcachefs-tools/${recommendedBcachefs}`;
-		row.update = true;
-		await doVersionSwitch();
+		await doVersionSwitch(inputs);
 		syncingBcachefs = false;
 	}
 


### PR DESCRIPTION
## Summary
- turn the available bcachefs status chip into an admin-only confirm-and-switch action
- track the switch across reconnects and reloads, then surface reload or reboot requirements
- share and test bcachefs switch payload construction with the existing Update page flow

## Testing
- `npm test` (29 files, 295 tests)
- `npm run check`
- `npm run build`
- `git diff --check origin/main...HEAD`