### PR TITLE
security: authorize existing app updates

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -132,6 +132,9 @@ tokens before processing the mutation.
 
 ### `apps.update` does not authorize the existing app
 
+Status: fixed by authorizing the installed app and its existing volume paths
+before validating or applying the replacement configuration.
+
 The handler validates only replacement paths. A scoped Operator can replace an
 app it does not own, and the backend removes the existing container before
 reinstalling it.

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -209,6 +209,11 @@ pub(super) async fn try_route(
         },
         "apps.update" => match parse_params::<nasty_apps::InstallAppRequest>(req) {
             Ok(p) => {
+                if let Some(response) =
+                    existing_app_access_error(req, state, session, &p.name).await
+                {
+                    return Some(response);
+                }
                 if simple_requires_admin(&p)
                     && let Some(response) =
                         require_root_equivalent(req, session, "unsafe_app_payload")
@@ -754,7 +759,7 @@ mod tests {
     }
 
     #[test]
-    fn existing_app_secret_reads_gate_privileged_apps_as_admin() {
+    fn existing_app_access_gates_privileged_apps_as_admin() {
         assert!(!app_requires_admin(&existing_app(serde_json::json!({}))));
         assert!(app_requires_admin(&existing_app(serde_json::json!({
             "kind": "compose"


### PR DESCRIPTION
## Summary
- authorize the installed app before processing `apps.update` replacement data
- enforce existing privileged-app and scoped-volume boundaries before the destructive update path
- record the fix in the API role review

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine router::apps::tests`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`