### PR TITLE
security: restrict scoped backup reads

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -156,19 +156,24 @@ credentials and before changing the global REST server storage path.
 
 ### Scoped reads return global resource inventories
 
-Status: partially fixed by filtering all NFS, SMB, iSCSI, and NVMe-oF list/get
-responses against filesystem and owner scope. Backup and residual filesystem
-inventory reads remain open.
+Status: partially fixed. NFS, SMB, iSCSI, and NVMe-oF list/get responses are
+filtered by filesystem and owner scope, and direct profile-derived backup RPCs
+require an unscoped session. Residual filesystem and alert-derived inventory
+reads remain open.
 
-Share `list`/`get`, backup profile/snapshot/job reads, and several filesystem
-status/dependency methods do not consistently filter filesystem or owner scope.
+Share `list`/`get` and direct backup profile/snapshot/job reads now enforce
+scope. Several filesystem status/dependency methods and global alerts/status do
+not consistently filter filesystem or owner scope; backup alerts can include
+profile identifiers, names, timestamps, and errors.
 
 - `engine/nasty-engine/src/router/share.rs:530-539`
 - `engine/nasty-engine/src/router/share.rs:607-616`
 - `engine/nasty-engine/src/router/share.rs:709-718`
 - `engine/nasty-engine/src/router/share.rs:1054-1063`
-- `engine/nasty-engine/src/router/backup.rs:68-75`
-- `engine/nasty-engine/src/router/backup.rs:116-189`
+- `engine/nasty-engine/src/router/backup.rs:27-44`
+- `engine/nasty-engine/src/router/backup.rs:81-88`
+- `engine/nasty-engine/src/router/alerts.rs:24-49`
+- `engine/nasty-engine/src/router/system.rs:982-1058`
 
 ### Notification webhook credentials are incompletely redacted
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2617,28 +2617,28 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "backup.status",
-                    desc: "Report whether any backup is currently running and which profile id it belongs to.",
+                    desc: "Report whether any backup is currently running and which profile id it belongs to. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<BackupStatus>(generator)),
                 },
                 Method {
                     name: "backup.profile.list",
-                    desc: "Return all configured backup profiles.",
+                    desc: "Return all configured backup profiles. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<BackupProfile>>(generator)),
                 },
                 Method {
                     name: "backup.schedule.list",
-                    desc: "Return enabled backup schedules with their next nominal UTC cron occurrence.",
+                    desc: "Return enabled backup schedules with their next nominal UTC cron occurrence. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<BackupScheduleEntry>>(generator)),
                 },
                 Method {
                     name: "backup.profile.get",
-                    desc: "Return a single backup profile by id.",
+                    desc: "Return a single backup profile by id. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Backup profile identifier.")),
                     result: Some(gen_schema::<BackupProfile>(generator)),
@@ -2673,7 +2673,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "backup.snapshots",
-                    desc: "List all snapshots stored in the profile's repository (id, time, hostname, paths, tags).",
+                    desc: "List all snapshots stored in the profile's repository (id, time, hostname, paths, tags). Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Backup profile identifier.")),
                     result: Some(gen_schema::<Vec<BackupSnapshot>>(generator)),
@@ -2710,7 +2710,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "backup.jobs.list",
-                    desc: "List active and recently-finished backup jobs (init / run / check), newest first. Optional `profile_id` filter narrows the list to one profile. Terminal jobs are GC'd one hour after they finish, so this returns a bounded window rather than full history.",
+                    desc: "List active and recently-finished backup jobs (init / run / check), newest first. Optional `profile_id` filter narrows the list to one profile. Terminal jobs are GC'd one hour after they finish, so this returns a bounded window rather than full history. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(serde_json::json!({
                         "type": "object",
@@ -2725,7 +2725,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "backup.jobs.get",
-                    desc: "Return one backup job by id. 404-equivalent error when the id is unknown (job never existed or was GC'd after its retention window).",
+                    desc: "Return one backup job by id. 404-equivalent error when the id is unknown (job never existed or was GC'd after its retention window). Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "id",

--- a/engine/nasty-engine/src/router/backup.rs
+++ b/engine/nasty-engine/src/router/backup.rs
@@ -24,6 +24,25 @@ fn profile_requires_admin(profile: &nasty_backup::BackupProfile) -> bool {
     profile.sources.iter().any(|source| !is_data_source(source))
 }
 
+fn backup_read_requires_unscoped(method: &str) -> bool {
+    matches!(
+        method,
+        "backup.profile.list"
+            | "backup.schedule.list"
+            | "backup.profile.get"
+            | "backup.status"
+            | "backup.snapshots"
+            | "backup.jobs.list"
+            | "backup.jobs.get"
+    )
+}
+
+fn backup_read_access_error(method: &str, session: &Session) -> Option<&'static str> {
+    (backup_read_requires_unscoped(method)
+        && (session.filesystem.is_some() || session.owner.is_some()))
+    .then_some("backup management requires an unscoped session")
+}
+
 fn profile_access_error(
     session: &Session,
     profile: &nasty_backup::BackupProfile,
@@ -64,6 +83,9 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if let Some(message) = backup_read_access_error(&req.method, session) {
+        return Some(err(req, message));
+    }
     Some(match req.method.as_str() {
         "backup.profile.list" => ok(req, state.backups.list_profiles().await),
         "backup.schedule.list" => ok(req, state.backups.list_schedule(chrono::Utc::now()).await),
@@ -195,7 +217,10 @@ pub(super) async fn try_route(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_data_source, profile_access_error};
+    use super::{
+        backup_read_access_error, backup_read_requires_unscoped, is_data_source,
+        profile_access_error,
+    };
     use crate::auth::{Role, Session};
 
     fn profile(sources: &[&str]) -> nasty_backup::BackupProfile {
@@ -242,5 +267,35 @@ mod tests {
         assert!(profile_access_error(&session(Role::Operator, false), &system).is_some());
         assert!(profile_access_error(&session(Role::Admin, false), &system).is_none());
         assert!(profile_access_error(&session(Role::Admin, true), &system).is_some());
+    }
+
+    #[test]
+    fn profile_derived_backup_reads_require_unscoped_sessions() {
+        for method in [
+            "backup.profile.list",
+            "backup.schedule.list",
+            "backup.profile.get",
+            "backup.status",
+            "backup.snapshots",
+            "backup.jobs.list",
+            "backup.jobs.get",
+        ] {
+            assert!(backup_read_requires_unscoped(method), "{method}");
+        }
+        assert!(!backup_read_requires_unscoped("backup.secrets_status"));
+        assert!(!backup_read_requires_unscoped("backup.profile.create"));
+    }
+
+    #[test]
+    fn backup_read_scope_rejects_filesystem_and_owner_credentials() {
+        let unscoped = session(Role::ReadOnly, false);
+        let filesystem_scoped = session(Role::Admin, true);
+        let mut owner_scoped = session(Role::Admin, false);
+        owner_scoped.owner = Some("token-a".to_string());
+
+        assert!(backup_read_access_error("backup.profile.list", &unscoped).is_none());
+        assert!(backup_read_access_error("backup.profile.list", &filesystem_scoped).is_some());
+        assert!(backup_read_access_error("backup.profile.list", &owner_scoped).is_some());
+        assert!(backup_read_access_error("backup.secrets_status", &owner_scoped).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- reject filesystem- and owner-scoped sessions before direct backup profile, schedule, status, snapshot, or job reads
- preserve unscoped ReadOnly access and scoped `backup.secrets_status` access
- document the method requirements and update the authorization review ledger

## Follow-up
- global alerts and `system.status` can still expose backup-derived details; this remains tracked with the residual inventory-read work

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine router::backup::tests`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`