### PR TITLE
security: scope storage and alert inventories

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -156,15 +156,15 @@ credentials and before changing the global REST server storage path.
 
 ### Scoped reads return global resource inventories
 
-Status: partially fixed. NFS, SMB, iSCSI, and NVMe-oF list/get responses are
-filtered by filesystem and owner scope, and direct profile-derived backup RPCs
-require an unscoped session. Residual filesystem and alert-derived inventory
-reads remain open.
+Status: partially fixed. Share inventories and direct subvolume/dependency reads
+now enforce filesystem and owner scope. Direct profile-derived backup reads,
+global alert APIs, aggregate system status, and block-device inventory require
+an unscoped session. Filesystem operations and diagnostics filter filesystem
+scope and reject owner scope where attribution is unavailable.
 
-Share `list`/`get` and direct backup profile/snapshot/job reads now enforce
-scope. Several filesystem status/dependency methods and global alerts/status do
-not consistently filter filesystem or owner scope; backup alerts can include
-profile identifiers, names, timestamps, and errors.
+Broader host telemetry and adjacent storage reads remain open, including global
+system statistics, disk health, TLS host status, update build-directory mounts,
+and the shared VM image inventory.
 
 - `engine/nasty-engine/src/router/share.rs:530-539`
 - `engine/nasty-engine/src/router/share.rs:607-616`
@@ -172,8 +172,11 @@ profile identifiers, names, timestamps, and errors.
 - `engine/nasty-engine/src/router/share.rs:1054-1063`
 - `engine/nasty-engine/src/router/backup.rs:27-44`
 - `engine/nasty-engine/src/router/backup.rs:81-88`
-- `engine/nasty-engine/src/router/alerts.rs:24-49`
-- `engine/nasty-engine/src/router/system.rs:982-1058`
+- `engine/nasty-engine/src/router/fs.rs:64-85`
+- `engine/nasty-engine/src/router/bcachefs.rs:14-35`
+- `engine/nasty-engine/src/router/subvolume.rs:14-30`
+- `engine/nasty-engine/src/router/alerts.rs:14-29`
+- `engine/nasty-engine/src/router/system.rs:985-994`
 
 ### Notification webhook credentials are incompletely redacted
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -237,14 +237,14 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "system.status",
-                    desc: "Aggregated system status for the sidebar band (#528): one level (healthy / activity / critical), a headline, the in-progress array operations (device evacuation, scrub, reconcile), and active alert counts. Cached ~10s.",
+                    desc: "Aggregated system status for the sidebar band (#528): one level (healthy / activity / critical), a headline, the in-progress array operations (device evacuation, scrub, reconcile), and active alert counts. Cached ~10s. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<SystemStatus>(generator)),
                 },
                 Method {
                     name: "system.operations.list",
-                    desc: "List controllable data operations across mounted filesystems for the Operations panel (#553): per-pool scrubs (start when idle, cancel when running), device evacuations (cancel while draining, with an idle acknowledgement when none run), and the pausable background jobs reconcile and copygc, each with the action the UI can take.",
+                    desc: "List controllable data operations across mounted filesystems for the Operations panel (#553): per-pool scrubs (start when idle, cancel when running), device evacuations (cancel while draining, with an idle acknowledgement when none run), and the pausable background jobs reconcile and copygc, each with the action the UI can take. Filesystem-scoped sessions see only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<Operation>>(generator)),
@@ -272,7 +272,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "system.alerts",
-                    desc: "Evaluate alert rules against current system state and return any active alerts.",
+                    desc: "Evaluate alert rules against current system state and return any active alerts. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<AlertOccurrence>>(generator)),
@@ -470,7 +470,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "alert.acknowledge",
-                    desc: "Acknowledge one active alert occurrence until its condition resolves.",
+                    desc: "Acknowledge one active alert occurrence until its condition resolves. Requires an unscoped session.",
                     role: MethodRole::Operator,
                     params: MethodParams::AdHoc(ad_hoc_one(
                         "instance_id",
@@ -480,28 +480,28 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "alert.rules.list",
-                    desc: "List all alert rules.",
+                    desc: "List all alert rules. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<AlertRule>>(generator)),
                 },
                 Method {
                     name: "alert.rules.create",
-                    desc: "Create a new alert rule.",
+                    desc: "Create a new alert rule. Requires an unscoped session.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<AlertRule>(generator)),
                     result: Some(gen_schema::<AlertRule>(generator)),
                 },
                 Method {
                     name: "alert.rules.update",
-                    desc: "Update an existing alert rule. Only provided fields are changed.",
+                    desc: "Update an existing alert rule. Only provided fields are changed. Requires an unscoped session.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<AlertRuleUpdate>(generator)),
                     result: Some(gen_schema::<AlertRule>(generator)),
                 },
                 Method {
                     name: "alert.rules.delete",
-                    desc: "Delete an alert rule by ID.",
+                    desc: "Delete an alert rule by ID. Requires an unscoped session.",
                     role: MethodRole::Admin,
                     params: MethodParams::AdHoc(ad_hoc_one("id", "Unique rule identifier.")),
                     result: None,
@@ -513,7 +513,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "device.list",
-                    desc: "List all block devices and partitions visible to the system.",
+                    desc: "List all block devices and partitions visible to the system. Requires an unscoped session.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<BlockDevice>>(generator)),
@@ -549,21 +549,21 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "fs.list",
-                    desc: "List all filesystems. Filesystem-scoped tokens see only their assigned filesystem.",
+                    desc: "List all filesystems. Filesystem-scoped sessions see only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<Filesystem>>(generator)),
                 },
                 Method {
                     name: "fs.unavailable.list",
-                    desc: "List UUID-bound host registrations whose filesystem is not currently visible. Filesystem-scoped tokens see only their assigned filesystem.",
+                    desc: "List UUID-bound host registrations whose filesystem is not currently visible. Filesystem-scoped sessions see only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<UnavailableFilesystem>>(generator)),
                 },
                 Method {
                     name: "fs.get",
-                    desc: "Get a single filesystem by name.",
+                    desc: "Get a single filesystem by name. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<Filesystem>(generator)),
@@ -614,7 +614,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "fs.usage",
-                    desc: "Return detailed bcachefs `fs usage` breakdown.",
+                    desc: "Return detailed bcachefs `fs usage` breakdown. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<FsUsage>(generator)),
@@ -628,7 +628,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "fs.scrub.status",
-                    desc: "Return current scrub status.",
+                    desc: "Return current scrub status. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<ScrubStatus>(generator)),
@@ -650,28 +650,28 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "fs.fsck.status",
-                    desc: "Return current fsck status.",
+                    desc: "Return current fsck status. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<FsckStatus>(generator)),
                 },
                 Method {
                     name: "fs.reconcile.status",
-                    desc: "Return bcachefs background work (reconcile) status.",
+                    desc: "Return bcachefs background work (reconcile) status. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<ReconcileStatus>(generator)),
                 },
                 Method {
                     name: "bcachefs.usage",
-                    desc: "Return raw `bcachefs fs usage` output for a filesystem.",
+                    desc: "Return raw `bcachefs fs usage` output for a filesystem. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<FsUsage>(generator)),
                 },
                 Method {
                     name: "fs.tpm.status",
-                    desc: "Report TPM2 host capability and per-filesystem bind state. `tpm_available` reflects whether `/dev/tpmrm0` is present; `bound` reflects whether a sealed-key blob exists for this filesystem.",
+                    desc: "Report TPM2 host capability and per-filesystem bind state. `tpm_available` reflects whether `/dev/tpmrm0` is present; `bound` reflects whether a sealed-key blob exists for this filesystem. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<TpmBindStatus>(generator)),
@@ -2232,14 +2232,14 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "fs.dependents",
-                    desc: "Return all downstream entities (subvolumes, apps, VMs, backup jobs, NFS/SMB/iSCSI/NVMe-oF shares) that reference a given filesystem, used to preview impact before destructive operations like lock.",
+                    desc: "Return all downstream entities (subvolumes, apps, VMs, backup jobs, NFS/SMB/iSCSI/NVMe-oF shares) that reference a given filesystem, used to preview impact before destructive operations like lock. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(gen_schema::<FsDependents>(generator)),
                 },
                 Method {
                     name: "fs.locked_dependents",
-                    desc: "Return the reverse-index of currently locked encrypted filesystems mapped to their app/VM dependents (for the WebUI's \"locked on FS\" badges).",
+                    desc: "Return the reverse-index of currently locked encrypted filesystems mapped to their app/VM dependents (for the WebUI's \"locked on FS\" badges). Filesystem-scoped sessions see only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<FsDependents>>(generator)),
@@ -2252,7 +2252,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "bcachefs.top",
-                    desc: "Capture ~2 seconds of `bcachefs fs top` output for the named filesystem via a PTY, strip ANSI/header noise, and return the last complete frame as plain text.",
+                    desc: "Capture ~2 seconds of `bcachefs fs top` output for the named filesystem via a PTY, strip ANSI/header noise, and return the last complete frame as plain text. Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(
@@ -2261,7 +2261,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "bcachefs.timestats",
-                    desc: "Run `bcachefs fs timestats --json --once` against the named filesystem's mount point and return the parsed JSON (latency/duration histograms for bcachefs operations).",
+                    desc: "Run `bcachefs fs timestats --json --once` against the named filesystem's mount point and return the parsed JSON (latency/duration histograms for bcachefs operations). Filesystem-scoped sessions may read only their assigned filesystem; owner-scoped sessions are denied.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_one("name", "Filesystem name.")),
                     result: Some(
@@ -2276,7 +2276,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "subvolume.children",
-                    desc: "List nested child subvolume names found beneath the named parent subvolume on the given filesystem.",
+                    desc: "List nested child subvolume names found beneath the named parent subvolume on the given filesystem, filtered by the session's filesystem and owner scopes.",
                     role: MethodRole::Any,
                     params: MethodParams::AdHoc(ad_hoc_two(
                         "filesystem",
@@ -2305,7 +2305,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "subvolume.list_dependents",
-                    desc: "Batched read returning the set of downstream entities (apps, VMs, backup jobs, shares of every protocol) attributed to each subvolume on the system, optionally filtered to the session's scoped filesystem.",
+                    desc: "Batched read returning the set of downstream entities (apps, VMs, backup jobs, shares of every protocol) attributed to each subvolume visible under the session's filesystem and owner scopes.",
                     role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<SubvolumeDependents>>(generator)),

--- a/engine/nasty-engine/src/router/alerts.rs
+++ b/engine/nasty-engine/src/router/alerts.rs
@@ -11,11 +11,31 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn alert_requires_unscoped(method: &str) -> bool {
+    matches!(
+        method,
+        "system.alerts"
+            | "alert.acknowledge"
+            | "alert.rules.list"
+            | "alert.rules.create"
+            | "alert.rules.update"
+            | "alert.rules.delete"
+    )
+}
+
+fn alert_scope_access_error(method: &str, session: &Session) -> Option<&'static str> {
+    (alert_requires_unscoped(method) && (session.filesystem.is_some() || session.owner.is_some()))
+        .then_some("access denied: alert management requires unscoped credentials")
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if let Some(message) = alert_scope_access_error(&req.method, session) {
+        return Some(err(req, message));
+    }
     Some(match req.method.as_str() {
         "telemetry.send" => {
             let sent = crate::telemetry::send_report(state).await;
@@ -85,4 +105,42 @@ pub(super) async fn try_route(
         },
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{alert_requires_unscoped, alert_scope_access_error};
+    use crate::auth::{Role, Session};
+
+    fn session(filesystem: bool, owner: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role: Role::ReadOnly,
+            file_principal: None,
+            filesystem: filesystem.then(|| "tank".into()),
+            owner: owner.then(|| "token-a".into()),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn global_alert_reads_and_mutations_require_unscoped_credentials() {
+        for method in [
+            "system.alerts",
+            "alert.acknowledge",
+            "alert.rules.list",
+            "alert.rules.create",
+            "alert.rules.update",
+            "alert.rules.delete",
+        ] {
+            assert!(alert_requires_unscoped(method), "{method}");
+            assert!(alert_scope_access_error(method, &session(true, false)).is_some());
+            assert!(alert_scope_access_error(method, &session(false, true)).is_some());
+            assert!(alert_scope_access_error(method, &session(false, false)).is_none());
+        }
+        assert!(!alert_requires_unscoped("telemetry.send"));
+    }
 }

--- a/engine/nasty-engine/src/router/bcachefs.rs
+++ b/engine/nasty-engine/src/router/bcachefs.rs
@@ -11,11 +11,29 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn bcachefs_scope_denied(session: &Session, requested: Option<&str>) -> bool {
+    session.owner.is_some()
+        || matches!(
+            (session.filesystem.as_deref(), requested),
+            (Some(scope), Some(requested)) if requested != scope
+        )
+}
+
+fn is_bcachefs_read(method: &str) -> bool {
+    matches!(
+        method,
+        "bcachefs.usage" | "bcachefs.top" | "bcachefs.timestats"
+    )
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if is_bcachefs_read(&req.method) && bcachefs_scope_denied(session, str_param(req, "name")) {
+        return Some(err(req, "access denied"));
+    }
     Some(match req.method.as_str() {
         "bcachefs.usage" => match require_str(req, "name") {
             Ok(name) => match state.filesystems.bcachefs_usage(name).await {
@@ -40,4 +58,45 @@ pub(super) async fn try_route(
         },
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bcachefs_scope_denied, is_bcachefs_read};
+    use crate::auth::{Role, Session};
+
+    fn session(filesystem: Option<&str>, owner: Option<&str>) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role: Role::ReadOnly,
+            file_principal: None,
+            filesystem: filesystem.map(str::to_string),
+            owner: owner.map(str::to_string),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn diagnostics_require_a_matching_filesystem_and_no_owner_scope() {
+        for method in ["bcachefs.usage", "bcachefs.top", "bcachefs.timestats"] {
+            assert!(is_bcachefs_read(method), "{method}");
+        }
+        assert!(!is_bcachefs_read("system.status"));
+        assert!(!bcachefs_scope_denied(&session(None, None), Some("tank")));
+        assert!(!bcachefs_scope_denied(
+            &session(Some("tank"), None),
+            Some("tank")
+        ));
+        assert!(bcachefs_scope_denied(
+            &session(Some("tank"), None),
+            Some("other")
+        ));
+        assert!(bcachefs_scope_denied(
+            &session(Some("tank"), Some("token-a")),
+            Some("tank")
+        ));
+    }
 }

--- a/engine/nasty-engine/src/router/fs.rs
+++ b/engine/nasty-engine/src/router/fs.rs
@@ -61,6 +61,29 @@ fn filesystem_scope_denied(scope: Option<&str>, requested: Option<&str>) -> bool
     matches!((scope, requested), (Some(scope), Some(requested)) if requested != scope)
 }
 
+fn owner_scoped_fs_read(method: &str) -> bool {
+    matches!(
+        method,
+        "fs.list"
+            | "fs.unavailable.list"
+            | "fs.get"
+            | "fs.dependents"
+            | "fs.locked_dependents"
+            | "fs.usage"
+            | "fs.scrub.status"
+            | "fs.fsck.status"
+            | "fs.reconcile.status"
+            | "fs.tpm.status"
+    )
+}
+
+fn scoped_inventory_access_error(method: &str, session: &Session) -> Option<&'static str> {
+    let scoped = session.filesystem.is_some() || session.owner.is_some();
+    ((method == "device.list" && scoped)
+        || (session.owner.is_some() && owner_scoped_fs_read(method)))
+    .then_some("access denied: scoped credentials cannot read global storage inventory")
+}
+
 async fn require_block_share_recovery_access(
     req: &Request,
     state: &AppState,
@@ -89,6 +112,9 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if let Some(message) = scoped_inventory_access_error(&req.method, session) {
+        return Some(err(req, message));
+    }
     if requires_root_equivalent(&req.method)
         && let Some(response) = require_root_equivalent(req, session, "global_storage_mutation")
     {
@@ -280,10 +306,13 @@ pub(super) async fn try_route(
             ),
             Err(r) => r,
         },
-        "fs.locked_dependents" => ok(
-            req,
-            crate::fs_dependents::find_locked_dependents(state).await,
-        ),
+        "fs.locked_dependents" => {
+            let mut dependents = crate::fs_dependents::find_locked_dependents(state).await;
+            if let Some(filesystem) = session.filesystem.as_deref() {
+                dependents.retain(|entry| entry.filesystem == filesystem);
+            }
+            ok(req, dependents)
+        }
         "fs.key.export" => match require_str(req, "name") {
             Ok(name) => match state.filesystems.export_key(name).await {
                 Ok(key) => ok(req, key),
@@ -647,7 +676,25 @@ pub(crate) async fn reconcile_block_shares_under_lock(state: &AppState) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use super::{filesystem_param, filesystem_scope_denied, requires_root_equivalent};
+    use super::{
+        filesystem_param, filesystem_scope_denied, owner_scoped_fs_read, requires_root_equivalent,
+        scoped_inventory_access_error,
+    };
+    use crate::auth::{Role, Session};
+
+    fn session(filesystem: bool, owner: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role: Role::ReadOnly,
+            file_principal: None,
+            filesystem: filesystem.then(|| "tank".into()),
+            owner: owner.then(|| "token-a".into()),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
 
     #[test]
     fn filesystem_operations_identify_and_enforce_their_scope_parameter() {
@@ -671,5 +718,36 @@ mod tests {
             assert!(requires_root_equivalent(method), "{method}");
         }
         assert!(!requires_root_equivalent("fs.destroy"));
+    }
+
+    #[test]
+    fn storage_inventory_reads_fail_closed_when_the_scope_cannot_be_applied() {
+        let unscoped = session(false, false);
+        let filesystem_scoped = session(true, false);
+        let owner_scoped = session(false, true);
+
+        assert!(scoped_inventory_access_error("fs.list", &unscoped).is_none());
+        assert!(scoped_inventory_access_error("fs.list", &filesystem_scoped).is_none());
+        for method in [
+            "fs.list",
+            "fs.unavailable.list",
+            "fs.get",
+            "fs.dependents",
+            "fs.locked_dependents",
+            "fs.usage",
+            "fs.scrub.status",
+            "fs.fsck.status",
+            "fs.reconcile.status",
+            "fs.tpm.status",
+        ] {
+            assert!(owner_scoped_fs_read(method), "{method}");
+            assert!(
+                scoped_inventory_access_error(method, &owner_scoped).is_some(),
+                "{method}"
+            );
+        }
+        assert!(!owner_scoped_fs_read("fs.create"));
+        assert!(scoped_inventory_access_error("device.list", &filesystem_scoped).is_some());
+        assert!(scoped_inventory_access_error("device.list", &owner_scoped).is_some());
     }
 }

--- a/engine/nasty-engine/src/router/subvolume.rs
+++ b/engine/nasty-engine/src/router/subvolume.rs
@@ -11,6 +11,24 @@ use super::*;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
+fn filter_owner_visible_children(
+    mut children: Vec<String>,
+    visible_names: Option<&std::collections::HashSet<String>>,
+) -> Vec<String> {
+    let Some(visible_names) = visible_names else {
+        return children;
+    };
+    children.retain(|child| visible_names.contains(child));
+    children
+}
+
+fn owner_can_read_children(
+    parent: &str,
+    visible_names: Option<&std::collections::HashSet<String>>,
+) -> bool {
+    visible_names.is_none_or(|visible_names| visible_names.contains(parent))
+}
+
 pub(super) async fn try_route(
     req: &Request,
     state: &AppState,
@@ -46,15 +64,13 @@ pub(super) async fn try_route(
         // bucket references by owning subvolume rather than paying
         // service-fanout N times.
         "subvolume.list_dependents" => {
-            let all = crate::subvolume_dependents::find_all_subvolume_dependents(state).await;
-            // Apply the same scope guard as subvolume.list_all — a
-            // filesystem-scoped session shouldn't see usage data for
-            // subvolumes on other filesystems.
-            let filtered = match session.filesystem.as_deref() {
-                Some(fs) => all.into_iter().filter(|d| d.filesystem == fs).collect(),
-                None => all,
-            };
-            ok(req, filtered)
+            let dependents = crate::subvolume_dependents::find_all_subvolume_dependents(
+                state,
+                session.filesystem.as_deref(),
+                session.owner.as_deref(),
+            )
+            .await;
+            ok(req, dependents)
         }
         "subvolume.list" => match require_str(req, "filesystem") {
             Ok(fs_name) => {
@@ -91,10 +107,39 @@ pub(super) async fn try_route(
             (Err(r), _) | (_, Err(r)) => r,
         },
         "subvolume.children" => match (require_str(req, "filesystem"), require_str(req, "name")) {
-            (Ok(fs_name), Ok(name)) => match state.subvolumes.list_children(fs_name, name).await {
-                Ok(v) => ok(req, v),
-                Err(e) => err(req, e),
-            },
+            (Ok(fs_name), Ok(name)) => {
+                if session.filesystem.as_deref().is_some_and(|p| p != fs_name) {
+                    err(req, "access denied")
+                } else {
+                    let visible_names = if session.owner.is_some() {
+                        match state
+                            .subvolumes
+                            .list(fs_name, session.owner.as_deref())
+                            .await
+                        {
+                            Ok(visible) => Some(
+                                visible
+                                    .into_iter()
+                                    .map(|subvolume| subvolume.name)
+                                    .collect::<std::collections::HashSet<_>>(),
+                            ),
+                            Err(error) => return Some(err(req, error)),
+                        }
+                    } else {
+                        None
+                    };
+                    if !owner_can_read_children(name, visible_names.as_ref()) {
+                        return Some(err(req, "access denied"));
+                    }
+                    match state.subvolumes.list_children(fs_name, name).await {
+                        Ok(children) => ok(
+                            req,
+                            filter_owner_visible_children(children, visible_names.as_ref()),
+                        ),
+                        Err(e) => err(req, e),
+                    }
+                }
+            }
             (Err(r), _) | (_, Err(r)) => r,
         },
         "subvolume.create" => {
@@ -311,4 +356,24 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::{filter_owner_visible_children, owner_can_read_children};
+
+    #[test]
+    fn child_inventory_requires_a_visible_parent_and_filters_hidden_children() {
+        let children = vec!["parent/own".to_string(), "parent/foreign".to_string()];
+        let visible = HashSet::from(["parent".to_string(), "parent/own".to_string()]);
+        assert_eq!(
+            filter_owner_visible_children(children, Some(&visible)),
+            vec!["parent/own"]
+        );
+        assert!(owner_can_read_children("parent", Some(&visible)));
+        assert!(!owner_can_read_children("foreign-parent", Some(&visible)));
+        assert!(owner_can_read_children("foreign-parent", None));
+    }
 }

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -68,6 +68,9 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if let Some(message) = system_inventory_access_error(&req.method, session) {
+        return Some(err(req, message));
+    }
     Some(match req.method.as_str() {
         "system.info" => ok(req, state.system.info().await),
         "system.health" => ok(req, state.system.health().await),
@@ -89,7 +92,10 @@ pub(super) async fn try_route(
             }
             ok(req, status)
         }
-        "system.operations.list" => ok(req, build_operations(state).await),
+        "system.operations.list" => ok(
+            req,
+            build_operations(state, session.filesystem.as_deref()).await,
+        ),
         "system.custom_config.get" => match custom_config_get().await {
             Ok(config) => ok(req, config),
             Err(e) => err(req, format!("read /etc/nixos/custom.nix: {e}")),
@@ -976,6 +982,17 @@ pub(super) async fn try_route(
     })
 }
 
+fn system_inventory_access_error(method: &str, session: &Session) -> Option<&'static str> {
+    let scoped = session.filesystem.is_some() || session.owner.is_some();
+    ((method == "system.status" && scoped)
+        || (method == "system.operations.list" && session.owner.is_some()))
+    .then_some("access denied: scoped credentials cannot read global system inventory")
+}
+
+fn filesystem_visible(name: &str, filter: Option<&str>) -> bool {
+    filter.is_none_or(|filter| name == filter)
+}
+
 /// Aggregate the sidebar status band (#528): current alert counts (reusing the
 /// shared alert evaluation) plus a scan of every filesystem for in-progress
 /// array operations (device evacuation, running scrub, active reconcile).
@@ -1087,13 +1104,19 @@ async fn custom_config_get() -> std::io::Result<nasty_system::CustomConfig> {
 /// acknowledgement row when nothing is draining), plus the pausable
 /// background jobs reconcile and copygc (Pause/Resume), shown even when
 /// idle so they can be toggled.
-async fn build_operations(state: &AppState) -> Vec<nasty_system::Operation> {
+async fn build_operations(
+    state: &AppState,
+    filesystem_filter: Option<&str>,
+) -> Vec<nasty_system::Operation> {
     let mut ops: Vec<nasty_system::Operation> = Vec::new();
     let Ok(filesystems) = state.filesystems.list().await else {
         return ops;
     };
     let mut any_evacuating = false;
     for fs in &filesystems {
+        if !filesystem_visible(&fs.name, filesystem_filter) {
+            continue;
+        }
         if !fs.mounted {
             continue;
         }
@@ -1397,8 +1420,44 @@ mod tests {
 
 #[cfg(test)]
 mod operations_tests {
-    use super::{evacuate_idle_row, scrub_idle_detail, scrub_outcome_name};
+    use super::{
+        evacuate_idle_row, filesystem_visible, scrub_idle_detail, scrub_outcome_name,
+        system_inventory_access_error,
+    };
+    use crate::auth::{Role, Session};
     use nasty_storage::filesystem::{ScrubErrorKind, ScrubOutcome, ScrubStatus};
+
+    fn session(filesystem: bool, owner: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role: Role::ReadOnly,
+            file_principal: None,
+            filesystem: filesystem.then(|| "tank".into()),
+            owner: owner.then(|| "token-a".into()),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[test]
+    fn aggregate_system_reads_fail_closed_when_the_scope_cannot_be_applied() {
+        assert!(system_inventory_access_error("system.status", &session(false, false)).is_none());
+        assert!(system_inventory_access_error("system.status", &session(true, false)).is_some());
+        assert!(system_inventory_access_error("system.status", &session(false, true)).is_some());
+        assert!(
+            system_inventory_access_error("system.operations.list", &session(true, false))
+                .is_none()
+        );
+        assert!(
+            system_inventory_access_error("system.operations.list", &session(false, true))
+                .is_some()
+        );
+        assert!(filesystem_visible("tank", Some("tank")));
+        assert!(!filesystem_visible("other", Some("tank")));
+        assert!(filesystem_visible("other", None));
+    }
 
     fn status(last_run_at: Option<i64>, last_outcome: Option<ScrubOutcome>) -> ScrubStatus {
         ScrubStatus {

--- a/engine/nasty-engine/src/subvol_rollback.rs
+++ b/engine/nasty-engine/src/subvol_rollback.rs
@@ -55,7 +55,7 @@ pub async fn rollback_with_dependents(
     }
 
     let subvol_path = sv.path.clone();
-    let deps = find_all_subvolume_dependents(state)
+    let deps = find_all_subvolume_dependents(state, None, None)
         .await
         .into_iter()
         .find(|d| d.filesystem == req.filesystem && d.name == req.subvolume)

--- a/engine/nasty-engine/src/subvolume_dependents.rs
+++ b/engine/nasty-engine/src/subvolume_dependents.rs
@@ -59,21 +59,33 @@ fn owning_subvol<'a>(paths_desc: &'a [String], target: &str) -> Option<&'a str> 
     None
 }
 
+fn owner_visible(owner: Option<&str>, owner_filter: Option<&str>) -> bool {
+    match owner_filter {
+        Some(filter) => owner == Some(filter),
+        None => true,
+    }
+}
+
 /// Walk every downstream service once, and bucket every reference into
 /// the subvolume that owns its path. Batched (rather than per-subvolume)
 /// because the Usage column wants the value for every row at once —
 /// per-subvolume would mean N × cost-of-listing-each-service round-trips
 /// per page load, where the dominant cost (apps.list = a Docker
 /// round-trip) doesn't get cheaper at finer granularity.
-pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDependents> {
+pub async fn find_all_subvolume_dependents(
+    state: &AppState,
+    filesystem_filter: Option<&str>,
+    owner_filter: Option<&str>,
+) -> Vec<SubvolumeDependents> {
     let subvols = state
         .subvolumes
-        .list_all(None, None)
+        .list_all(filesystem_filter, None)
         .await
         .unwrap_or_default();
 
-    // Seed the result: one entry per known subvolume, keyed by path so
-    // attribution is a hashmap lookup, not a linear scan per service hit.
+    // Attribute against every subvolume before filtering the response. If a
+    // hidden nested subvolume were omitted here, its dependents could be
+    // incorrectly attributed to a visible ancestor.
     let mut by_path: HashMap<String, SubvolumeDependents> = HashMap::new();
     // Index of block-device → subvolume path, for the loop-backed case.
     let mut by_block_dev: HashMap<String, String> = HashMap::new();
@@ -256,6 +268,7 @@ pub async fn find_all_subvolume_dependents(state: &AppState) -> Vec<SubvolumeDep
     // by index if it ever wants to (today it joins on path/name).
     subvols
         .into_iter()
+        .filter(|subvolume| owner_visible(subvolume.owner.as_deref(), owner_filter))
         .filter_map(|sv| by_path.remove(&sv.path))
         .collect()
 }
@@ -287,6 +300,14 @@ mod tests {
             owning_subvol(&paths, "/fs/tank/media/movie.mkv"),
             Some("/fs/tank")
         );
+    }
+
+    #[test]
+    fn owner_visibility_fails_closed() {
+        assert!(owner_visible(Some("token-a"), Some("token-a")));
+        assert!(!owner_visible(Some("token-b"), Some("token-a")));
+        assert!(!owner_visible(None, Some("token-a")));
+        assert!(owner_visible(Some("token-b"), None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require unscoped sessions for global system status, alert APIs, and block-device inventory
- filter filesystem-scoped operation, locked-dependency, and bcachefs diagnostic reads while rejecting owner scopes that cannot be attributed safely
- apply filesystem and owner filters to subvolume child and dependent inventories without reattributing hidden nested resources
- document the enforced API contracts and remaining host-wide telemetry review scope

## Security behavior
- unscoped ReadOnly behavior is preserved
- filesystem and owner scopes combine fail-closed
- alert evaluation and caches remain global; scoped requests are rejected before cache access
- REST denial messages map to HTTP 403

## Remaining review scope
- global system statistics and disk health
- TLS host status
- update build-directory mount inventory
- shared VM image inventory

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine`
- `cargo test --workspace`
- `cargo clippy -p nasty-engine --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`