### PR TITLE
security: restrict volume permission repairs

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -194,12 +194,14 @@ The method is `Any`; `audit.mine` already provides a self-scoped alternative.
 
 ### `apps.fix_volume_perms` can recursively chown broad host paths
 
-The method accepts absolute paths outside `/fs` except for a small denylist. A
-scoped Admin can therefore modify ownership outside its assigned filesystem.
+Status: fixed by requiring an unscoped Admin before parsing the request. The
+service also requires an existing canonical non-symlink target and invokes
+`chown` with no-dereference and preserve-root safeguards.
 
-- `engine/nasty-engine/src/router/apps.rs:267-273`
-- `engine/nasty-apps/src/lib.rs:772-826`
-- `engine/nasty-apps/src/lib.rs:5253-5294`
+- `engine/nasty-engine/src/router/apps.rs:22-26`
+- `engine/nasty-engine/src/router/apps.rs:122-129`
+- `engine/nasty-apps/src/lib.rs:839-868`
+- `engine/nasty-apps/src/lib.rs:5294-5324`
 
 ### `firmware.check` is not a pure read
 

--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -774,28 +774,38 @@ fn fs_root_is_mounted(path: &str) -> bool {
 /// admin-policy violations the user can't fix from the wizard — the
 /// volume-warning code skips them silently because surfacing them
 /// would just be noise.
-fn validate_chown_target_security(host_path: &str) -> Result<(), AppsError> {
-    if host_path.contains("..") {
-        return Err(AppsError::ForbiddenBind(format!(
-            "'{host_path}' contains '..'"
-        )));
-    }
-    if host_path == "/" {
-        return Err(AppsError::ForbiddenBind(
-            "host root '/' is never allowed".to_string(),
-        ));
-    }
-    if host_path == "/var/lib/nasty" || host_path.starts_with("/var/lib/nasty/") {
-        return Err(AppsError::ForbiddenBind(format!(
-            "'{host_path}' targets engine state"
-        )));
-    }
-    if !host_path.starts_with('/') {
+fn validate_chown_target_security(host_path: &str) -> Result<PathBuf, AppsError> {
+    let path = Path::new(host_path);
+    if !path.is_absolute() {
         return Err(AppsError::ForbiddenBind(format!(
             "'{host_path}' is not absolute"
         )));
     }
-    Ok(())
+    if path
+        .components()
+        .any(|component| component == std::path::Component::ParentDir)
+    {
+        return Err(AppsError::ForbiddenBind(format!(
+            "'{host_path}' contains '..'"
+        )));
+    }
+    let normalized: PathBuf = path.components().collect();
+    if normalized == Path::new("/") {
+        return Err(AppsError::ForbiddenBind(
+            "host root '/' is never allowed".to_string(),
+        ));
+    }
+    if normalized == Path::new("/fs") {
+        return Err(AppsError::ForbiddenBind(
+            "filesystem root '/fs' is never allowed".to_string(),
+        ));
+    }
+    if normalized.starts_with("/var/lib/nasty") {
+        return Err(AppsError::ForbiddenBind(format!(
+            "'{host_path}' targets engine state"
+        )));
+    }
+    Ok(normalized)
 }
 
 /// Filesystem-existence half of the bind validator: a path of the
@@ -820,10 +830,42 @@ fn validate_fs_root_mounted(host_path: &str) -> Result<(), AppsError> {
 
 /// Full bind validator used by `fix_volume_perms` and the
 /// pre-create step. Combines the security and FS-mounted checks.
-fn validate_chown_target(host_path: &str) -> Result<(), AppsError> {
-    validate_chown_target_security(host_path)?;
-    validate_fs_root_mounted(host_path)?;
-    Ok(())
+fn validate_chown_target(host_path: &str) -> Result<PathBuf, AppsError> {
+    let normalized = validate_chown_target_security(host_path)?;
+    validate_fs_root_mounted(&normalized.to_string_lossy())?;
+    Ok(normalized)
+}
+
+fn existing_chown_target(host_path: &str) -> Result<PathBuf, AppsError> {
+    let normalized = validate_chown_target(host_path)?;
+    let metadata = std::fs::symlink_metadata(&normalized)
+        .map_err(|error| AppsError::CommandFailed(format!("stat({host_path}): {error}")))?;
+    if metadata.file_type().is_symlink() {
+        return Err(AppsError::ForbiddenBind(format!(
+            "'{host_path}' is a symbolic link"
+        )));
+    }
+    let canonical = std::fs::canonicalize(&normalized)
+        .map_err(|error| AppsError::CommandFailed(format!("canonicalize({host_path}): {error}")))?;
+    validate_chown_target(&canonical.to_string_lossy())?;
+    Ok(canonical)
+}
+
+fn chown_args(owner: &str, target: &Path, recursive: bool) -> Vec<String> {
+    let mut args = vec!["-h".to_string()];
+    if recursive {
+        args.extend([
+            "-R".to_string(),
+            "-P".to_string(),
+            "--preserve-root".to_string(),
+        ]);
+    }
+    args.extend([
+        "--".to_string(),
+        owner.to_string(),
+        target.to_string_lossy().into_owned(),
+    ]);
+    args
 }
 
 /// Parse a Docker image `User` field (e.g. `1000`, `1000:1000`, `nonroot`,
@@ -2405,9 +2447,8 @@ pub struct VolumeMismatch {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FixVolumePermsRequest {
-    /// Host bind-mount source to chown. Validated against the same
-    /// forbidden-bind rules as compose deploys (no `..`, no `/`, no
-    /// engine state).
+    /// Existing, non-symlink host bind-mount source to chown. Validated against
+    /// the same forbidden-bind rules as compose deploys.
     pub host_path: String,
     pub uid: u32,
     pub gid: u32,
@@ -5173,11 +5214,12 @@ impl AppsService {
             // skip those. Filesystem-missing failures (`/fs/<X>/…`
             // where `<X>` isn't mounted) ARE user-fixable and get
             // surfaced as a distinct mismatch below.
-            if validate_chown_target_security(&bind.host_path).is_err() {
-                continue;
-            }
+            let normalized = match validate_chown_target_security(&bind.host_path) {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
             let line = find_line(&req.compose, &bind.host_path);
-            if validate_fs_root_mounted(&bind.host_path).is_err() {
+            if validate_fs_root_mounted(&normalized.to_string_lossy()).is_err() {
                 // Don't even stat() — the path's prefix is invalid and
                 // would normally turn into a rootfs mkdir at deploy
                 // time. Flag it as filesystem_missing so the WebUI
@@ -5197,7 +5239,13 @@ impl AppsService {
                 });
                 continue;
             }
-            match tokio::fs::metadata(&bind.host_path).await {
+            if tokio::fs::symlink_metadata(&normalized)
+                .await
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+            {
+                continue;
+            }
+            match tokio::fs::metadata(&normalized).await {
                 Ok(md) => {
                     let cur_uid = md.uid();
                     let cur_gid = md.gid();
@@ -5250,31 +5298,18 @@ impl AppsService {
         out
     }
 
-    /// Chown a bind-mount source to (uid, gid). Optionally recursive.
-    /// Path is validated against the same forbidden-bind rules as the
-    /// deploy pipeline, so a malicious WebUI session can't wipe `/etc`
-    /// ownership through this entrypoint.
+    /// Chown an existing bind-mount source to (uid, gid). Optionally recursive.
+    /// The RPC layer limits this root-equivalent operation to unscoped Admins;
+    /// this service additionally canonicalizes the target and refuses symlinks.
     pub async fn fix_volume_perms(&self, req: FixVolumePermsRequest) -> Result<(), AppsError> {
-        validate_chown_target(&req.host_path)?;
-        // If the target doesn't exist, create it. Mode 0o755 mirrors
-        // what `mkdir -p` produces; the chown below sets ownership.
-        if tokio::fs::metadata(&req.host_path).await.is_err() {
-            tokio::fs::create_dir_all(&req.host_path)
-                .await
-                .map_err(|e| {
-                    AppsError::CommandFailed(format!("create_dir_all({}): {e}", req.host_path))
-                })?;
-        }
+        let target = existing_chown_target(&req.host_path)?;
         let owner = format!("{}:{}", req.uid, req.gid);
         let mut cmd = if req.recursive {
             nasty_common::priority::bulk_command("chown")
         } else {
             Command::new("chown")
         };
-        if req.recursive {
-            cmd.arg("-R");
-        }
-        cmd.arg(&owner).arg(&req.host_path);
+        cmd.args(chown_args(&owner, &target, req.recursive));
         let output = cmd
             .output()
             .await
@@ -5283,13 +5318,15 @@ impl AppsService {
             return Err(AppsError::CommandFailed(format!(
                 "chown {} {}: {}",
                 owner,
-                req.host_path,
+                target.display(),
                 String::from_utf8_lossy(&output.stderr).trim()
             )));
         }
         info!(
             "Chowned {} to {} (recursive={})",
-            req.host_path, owner, req.recursive
+            target.display(),
+            owner,
+            req.recursive
         );
         Ok(())
     }
@@ -6963,7 +7000,7 @@ mod tests {
         render_startup_override, validate_app_name, validate_new_app_name,
         validate_new_app_request, validate_simple_volumes, validate_volume_name,
     };
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
     #[tokio::test]
@@ -7515,9 +7552,9 @@ services:
     }
 
     use super::{
-        AppsService, CheckComposeRequest, CheckDevicesRequest, CheckVolumesRequest,
-        extract_compose_binds, extract_line_number, parse_compose_diagnostics,
-        validate_chown_target,
+        AppsService, CheckComposeRequest, CheckDevicesRequest, CheckVolumesRequest, chown_args,
+        existing_chown_target, extract_compose_binds, extract_line_number,
+        parse_compose_diagnostics, validate_chown_target,
     };
 
     #[tokio::test]
@@ -7684,8 +7721,13 @@ services:
     fn validate_chown_target_rejects_dangerous_paths() {
         for bad in [
             "/",
+            "//",
+            "/./",
+            "/fs",
+            "/fs/",
             "/etc/../passwd",
             "/var/lib/nasty",
+            "/var//lib/nasty",
             "/var/lib/nasty/auth.json",
             "relative/path",
         ] {
@@ -7707,6 +7749,44 @@ services:
                 "expected accept for {ok}"
             );
         }
+    }
+
+    #[test]
+    fn existing_chown_target_requires_a_real_non_symlink_path() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("data");
+        std::fs::create_dir(&target).unwrap();
+        assert_eq!(
+            existing_chown_target(target.to_str().unwrap()).unwrap(),
+            std::fs::canonicalize(&target).unwrap()
+        );
+
+        let link = temp.path().join("link");
+        symlink(&target, &link).unwrap();
+        assert!(existing_chown_target(link.to_str().unwrap()).is_err());
+        assert!(existing_chown_target(temp.path().join("missing").to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn chown_arguments_do_not_dereference_or_cross_symlinks() {
+        assert_eq!(
+            chown_args("1000:1000", Path::new("/appdata/example"), false),
+            ["-h", "--", "1000:1000", "/appdata/example"]
+        );
+        assert_eq!(
+            chown_args("1000:1000", Path::new("/appdata/example"), true),
+            [
+                "-h",
+                "-R",
+                "-P",
+                "--preserve-root",
+                "--",
+                "1000:1000",
+                "/appdata/example",
+            ]
+        );
     }
 
     #[test]
@@ -7877,6 +7957,29 @@ services:
         assert!(!r[0].exists);
         assert!(!r[0].filesystem_missing);
         assert_eq!(r[0].expected_uid, 3001);
+    }
+
+    #[tokio::test]
+    async fn check_volumes_does_not_offer_repairs_for_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let svc = AppsService::new();
+        for host_path in [link.display().to_string(), format!("{}/.", link.display())] {
+            let mismatches = svc
+                .check_volumes(CheckVolumesRequest {
+                    compose: format!(
+                        "services:\n  app:\n    image: foo\n    user: \"4294967294:4294967294\"\n    volumes:\n      - {host_path}:/data\n"
+                    ),
+                })
+                .await;
+            assert!(mismatches.is_empty(), "got {mismatches:?}");
+        }
     }
 
     #[tokio::test]

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -3103,7 +3103,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "apps.fix_volume_perms",
-                    desc: "Chown a host bind-mount source path to the given uid/gid (optionally recursively), enforcing the same forbidden-bind validation as compose deploys.",
+                    desc: "Chown an existing, non-symlink host bind-mount source path to the given uid/gid (optionally recursively), enforcing the same forbidden-bind validation as compose deploys. Requires an unscoped Admin session.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<FixVolumePermsRequest>(generator)),
                     result: Some(serde_json::json!({

--- a/engine/nasty-engine/src/router/apps.rs
+++ b/engine/nasty-engine/src/router/apps.rs
@@ -19,6 +19,12 @@ fn app_requires_admin(app: &nasty_apps::App) -> bool {
     app.kind == "compose" || app.unsafe_mode || app.network.as_deref() == Some("host")
 }
 
+fn preflight_access_error(req: &Request, session: &Session) -> Option<Response> {
+    (req.method == "apps.fix_volume_perms")
+        .then(|| require_root_equivalent(req, session, "host_volume_ownership_change"))
+        .flatten()
+}
+
 async fn existing_app_requires_admin(state: &AppState, name: &str) -> Result<bool, String> {
     let app = state
         .apps
@@ -118,6 +124,9 @@ pub(super) async fn try_route(
     state: &AppState,
     session: &Session,
 ) -> Option<Response> {
+    if let Some(response) = preflight_access_error(req, session) {
+        return Some(response);
+    }
     let response = match req.method.as_str() {
         "apps.status" => ok(req, state.apps.status().await),
         "apps.enable" => {
@@ -770,5 +779,42 @@ mod tests {
         assert!(app_requires_admin(&existing_app(serde_json::json!({
             "network": "host"
         }))));
+    }
+
+    #[test]
+    fn volume_permission_repair_requires_root_equivalent_access() {
+        fn session(role: Role, filesystem: bool, owner: bool) -> Session {
+            Session {
+                token: "token".into(),
+                username: "user".into(),
+                role,
+                file_principal: None,
+                filesystem: filesystem.then(|| "tank".into()),
+                owner: owner.then(|| "token-a".into()),
+                created_at: 0,
+                must_change_password: false,
+                client_ip: None,
+            }
+        }
+
+        let malformed: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "apps.fix_volume_perms",
+            "params": "not an object"
+        }))
+        .unwrap();
+        assert!(preflight_access_error(&malformed, &session(Role::Admin, false, false)).is_none());
+        assert!(preflight_access_error(&malformed, &session(Role::Admin, true, false)).is_some());
+        assert!(preflight_access_error(&malformed, &session(Role::Admin, false, true)).is_some());
+        assert!(
+            preflight_access_error(&malformed, &session(Role::Operator, false, false)).is_some()
+        );
+
+        let unrelated = Request {
+            method: "apps.check_volumes".into(),
+            ..malformed
+        };
+        assert!(preflight_access_error(&unrelated, &session(Role::Admin, true, true)).is_none());
     }
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -390,7 +390,15 @@ fn audit_detail(request: &Request) -> String {
     };
 
     // Try common identifier fields in order of specificity
-    for key in ["name", "username", "filesystem", "target", "id", "path"] {
+    for key in [
+        "name",
+        "username",
+        "filesystem",
+        "target",
+        "id",
+        "path",
+        "host_path",
+    ] {
         if let Some(val) = params.get(key).and_then(|v| v.as_str()) {
             return val.to_string();
         }
@@ -1892,10 +1900,22 @@ pub(super) async fn read_bcachefs_error_count(uuid: &str) -> (u64, bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AlertCoverage, ReconcileProgress, ReconcileProgressSample, clear_reconcile_tracker,
-        is_operator_allowed, is_read_only, is_universally_allowed, is_user_allowed,
-        reconcile_progress, reconcile_stall_check_at,
+        AlertCoverage, ReconcileProgress, ReconcileProgressSample, audit_detail,
+        clear_reconcile_tracker, is_operator_allowed, is_read_only, is_universally_allowed,
+        is_user_allowed, reconcile_progress, reconcile_stall_check_at,
     };
+
+    #[test]
+    fn audit_detail_includes_host_path_mutations() {
+        let request: nasty_common::Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "apps.fix_volume_perms",
+            "params": {"host_path": "/appdata/example", "uid": 1000, "gid": 1000}
+        }))
+        .unwrap();
+        assert_eq!(audit_detail(&request), "/appdata/example");
+    }
 
     fn smart_attribute_alert(source: &str) -> nasty_system::alerts::ActiveAlert {
         nasty_system::alerts::ActiveAlert {


### PR DESCRIPTION
## Summary
- require an unscoped Admin session for `apps.fix_volume_perms` before request deserialization
- require existing canonical non-symlink targets and invoke `chown` with no-dereference, physical traversal, preserve-root, and option-boundary safeguards
- suppress unsupported symlink repairs, add the host path to mutation audit details, and document the fixed authorization finding

## Testing
- `cargo test -p nasty-apps`
- focused `nasty-engine` router and audit tests
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`