### PR TITLE
security: restrict notification management

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -180,11 +180,20 @@ and the shared VM image inventory.
 
 ### Notification webhook credentials are incompletely redacted
 
-`notifications.config.get` masks dedicated secret fields but leaves webhook
-URLs and arbitrary headers visible to ReadOnly callers.
+Status: fixed by requiring an unscoped Admin for notification configuration
+reads and writes and for both supplied and saved-channel test delivery. The
+WebUI hides the notification controls when the session lacks that access.
+
+`notifications.config.get` masks dedicated secret fields, but webhook URLs and
+arbitrary headers can themselves contain credentials. The same root-equivalent
+boundary now covers global configuration mutation and outbound test delivery.
 
 - `engine/nasty-system/src/notifications.rs:57-71`
 - `engine/nasty-system/src/notifications.rs:167-214`
+- `engine/nasty-engine/src/router/notifications.rs:14-34`
+- `engine/nasty-engine/src/registry/methods.rs:2066-2092`
+- `webui/src/routes/settings/+page.svelte:290-297`
+- `webui/src/routes/settings/+page.svelte:821-832`
 
 ### `audit.list` returns every user's records
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2064,21 +2064,21 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "notifications.config.get",
-                    desc: "Return the persisted notification-channels configuration (SMTP / Telegram / Webhook / ntfy / Signal).",
-                    role: MethodRole::Any,
+                    desc: "Return the persisted notification-channels configuration (SMTP / Telegram / Webhook / ntfy / Signal), with dedicated secret fields redacted. Requires an unscoped Admin because endpoint URLs and arbitrary headers can contain credentials.",
+                    role: MethodRole::Admin,
                     params: MethodParams::None,
                     result: Some(gen_schema::<NotificationConfig>(generator)),
                 },
                 Method {
                     name: "notifications.config.update",
-                    desc: "Replace the on-disk notifications config with the supplied one. File is chmod 0600 because it carries SMTP passwords and bot tokens.",
+                    desc: "Replace the on-disk notifications config with the supplied one. Requires an unscoped Admin. File is chmod 0600 because it carries SMTP passwords and bot tokens.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<NotificationConfig>(generator)),
                     result: None,
                 },
                 Method {
                     name: "notifications.test",
-                    desc: "Send a one-shot test message (\"NASty Test\") through the supplied channel configuration without persisting it.",
+                    desc: "Send a one-shot test message (\"NASty Test\") through the supplied channel configuration without persisting it. Requires an unscoped Admin.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(gen_schema::<ChannelType>(generator)),
                     result: Some(
@@ -2087,7 +2087,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "notifications.test_saved",
-                    desc: "Send a test message through an already-saved channel, identified by id. Sealed secrets are resolved server-side, so the secret never has to round-trip through the client.",
+                    desc: "Send a test message through an already-saved channel, identified by id. Requires an unscoped Admin. Sealed secrets are resolved server-side, so the secret never has to round-trip through the client.",
                     role: MethodRole::Admin,
                     params: MethodParams::Schema(serde_json::json!({
                         "type": "object",

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -250,11 +250,13 @@ fn is_read_only(method: &str) -> bool {
             // can hold sensitive settings. Its `.get` suffix would otherwise slip
             // it into the universally-allowed read set; keep it Admin-only.
             | "system.custom_config.get"
-            // These return container environment, raw Docker metadata, or
-            // compose source that can contain credentials.
+            // These return container environment, raw Docker metadata,
+            // compose source, or notification endpoint details that can
+            // contain credentials.
             | "apps.config"
             | "apps.inspect"
             | "apps.compose.get"
+            | "notifications.config.get"
     ) {
         return false;
     }
@@ -341,7 +343,6 @@ fn is_read_only(method: &str) -> bool {
                 | "firmware.constraints"
                 | "firmware.check"
                 | "firmware.devices"
-                | "notifications.config.get"
                 | "apps.inspect_image"
                 | "apps.caddy.routes"
                 | "apps.ingress.check_conflict"
@@ -528,7 +529,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         "auth" => auth::try_route(req, state, session).await,
         "audit" => audit::try_route(req, state, session).await,
         "alert" | "telemetry" => alerts::try_route(req, state, session).await,
-        "notifications" => notifications::try_route(req, state, session).await,
+        "notifications" => notifications::try_route(req, session).await,
         "backup" => backup::try_route(req, state, session).await,
         "fs" | "device" => fs::try_route(req, state, session).await,
         "bcachefs" => bcachefs::try_route(req, state, session).await,

--- a/engine/nasty-engine/src/router/notifications.rs
+++ b/engine/nasty-engine/src/router/notifications.rs
@@ -8,14 +8,24 @@ use nasty_common::{ErrorCode, Request, Response};
 use serde::Deserialize;
 
 use super::*;
-use crate::AppState;
 use crate::auth::{Role, Session};
 
-pub(super) async fn try_route(
-    req: &Request,
-    state: &AppState,
-    session: &Session,
-) -> Option<Response> {
+fn preflight_access_error(req: &Request, session: &Session) -> Option<Response> {
+    matches!(
+        req.method.as_str(),
+        "notifications.config.get"
+            | "notifications.config.update"
+            | "notifications.test"
+            | "notifications.test_saved"
+    )
+    .then(|| require_root_equivalent(req, session, "global_notification_management"))
+    .flatten()
+}
+
+pub(super) async fn try_route(req: &Request, session: &Session) -> Option<Response> {
+    if let Some(response) = preflight_access_error(req, session) {
+        return Some(response);
+    }
     Some(match req.method.as_str() {
         "notifications.config.get" => ok(
             req,
@@ -54,4 +64,71 @@ pub(super) async fn try_route(
 #[derive(Deserialize)]
 struct TestSavedRequest {
     id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{preflight_access_error, try_route};
+    use crate::auth::{Role, Session};
+    use nasty_common::Request;
+
+    fn session(role: Role, filesystem: bool, owner: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role,
+            file_principal: None,
+            filesystem: filesystem.then(|| "tank".into()),
+            owner: owner.then(|| "token-a".into()),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn notification_configuration_and_delivery_require_root_equivalent_access() {
+        for method in [
+            "notifications.config.get",
+            "notifications.config.update",
+            "notifications.test",
+            "notifications.test_saved",
+        ] {
+            let request: Request = serde_json::from_value(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": "not an object"
+            }))
+            .unwrap();
+
+            for (denied, expected) in [
+                (
+                    session(Role::Admin, true, false),
+                    "Scoped credentials cannot access this endpoint",
+                ),
+                (
+                    session(Role::Admin, false, true),
+                    "Scoped credentials cannot access this endpoint",
+                ),
+                (session(Role::Operator, false, false), "Permission denied"),
+                (session(Role::ReadOnly, false, false), "Permission denied"),
+            ] {
+                let response = try_route(&request, &denied).await.unwrap();
+                assert_eq!(response.error.unwrap().message, expected, "{method}");
+            }
+            assert!(
+                preflight_access_error(&request, &session(Role::Admin, false, false)).is_none(),
+                "{method}"
+            );
+        }
+
+        let unrelated: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "notifications.unknown"
+        }))
+        .unwrap();
+        assert!(preflight_access_error(&unrelated, &session(Role::Admin, true, true)).is_none());
+    }
 }

--- a/webui/src/routes/settings/+page.svelte
+++ b/webui/src/routes/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { applyNetworkUpdate } from '$lib/rollbackState.svelte';
 	import { tempUnit } from '$lib/temperature.svelte';
 	import { requiredFieldCls } from '$lib/utils';
+	import { hasRootEquivalentAccess } from '$lib/access';
 	import {
 		promoteOrphanedMembers,
 		validateDnsServer,
@@ -19,7 +20,7 @@
 	import { domain, domainRefresh, domainJoin, domainLeave } from '$lib/domain.svelte';
 	import { dc, dcRefresh, dcProvision } from '$lib/dc.svelte';
 	import DcPanel from '$lib/directory/DcPanel.svelte';
-	import type { Settings, SystemInfo, CustomConfig, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig } from '$lib/types';
+	import type { Settings, SystemInfo, CustomConfig, NetworkState, NetworkConfig, LiveInterface, TuningConfig, NetIfStats, IpConfig, InterfaceConfig, VfConfig, AuthMe } from '$lib/types';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import BridgeCreator from '$lib/components/BridgeCreator.svelte';
@@ -31,6 +32,7 @@
 	import type { NotificationConfig, NotificationChannel } from '$lib/types';
 	let notifConfig: NotificationConfig = $state({ channels: [] });
 	let notifLoaded = $state(false);
+	let canManageNotifications = $state(false);
 	let notifSaving = $state(false);
 	let notifTesting = $state<string | null>(null);
 	let notifAddType: 'smtp' | 'telegram' | 'webhook' | 'ntfy' | 'signal' | null = $state(null);
@@ -288,6 +290,10 @@
 	const client = getClient();
 
 	onMount(async () => {
+		try {
+			const identity = await client.call<AuthMe>('auth.me');
+			canManageNotifications = hasRootEquivalentAccess(identity.role, identity.scoped);
+		} catch { /* Fail closed if session details are unavailable. */ }
 		await withToast(async () => {
 			let liveLogFilter: string;
 			[settings, info, timezones, networkState, liveLogFilter] = await Promise.all([
@@ -815,12 +821,14 @@
 			? 'border-b-2 border-primary text-foreground'
 			: 'text-muted-foreground hover:text-foreground'}"
 	>Network</button>
-	<button
-		onclick={() => switchTab('notifications')}
-		class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'notifications'
-			? 'border-b-2 border-primary text-foreground'
-			: 'text-muted-foreground hover:text-foreground'}"
-	>Notifications</button>
+	{#if canManageNotifications}
+		<button
+			onclick={() => switchTab('notifications')}
+			class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'notifications'
+				? 'border-b-2 border-primary text-foreground'
+				: 'text-muted-foreground hover:text-foreground'}"
+		>Notifications</button>
+	{/if}
 	<button
 		onclick={() => switchTab('tuning')}
 		class="px-4 py-2 text-sm font-medium transition-colors {activeTab === 'tuning'


### PR DESCRIPTION
## Summary
- require an unscoped Admin session before notification configuration reads/writes or outbound test delivery
- align `notifications.config.get` registry metadata and the central role gate with the sensitive endpoint/header data it returns
- hide notification settings unless the WebUI confirms root-equivalent access, failing closed when session details are unavailable
- add route-level coverage proving scoped and lower-role requests are denied before malformed parameters reach handlers

## Testing
- `cargo test -p nasty-engine router::notifications::tests`
- `cargo test -p nasty-engine router::tests::declared_roles_match_effective_gate`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check`
- `npm test -- --run`
- `npm run build`
- `git diff --check`