### PR TITLE
security: restrict global audit reads

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -197,9 +197,11 @@ boundary now covers global configuration mutation and outbound test delivery.
 
 ### `audit.list` returns every user's records
 
-The method is `Any`; `audit.mine` already provides a self-scoped alternative.
+Status: fixed by requiring an unscoped Admin before reading the global audit
+log. `audit.mine` remains available as the self-scoped alternative.
 
-- `engine/nasty-engine/src/router/audit.rs:20-39`
+- `engine/nasty-engine/src/router/audit.rs:13-49`
+- `engine/nasty-engine/src/registry/methods.rs:1324-1341`
 
 ### `apps.fix_volume_perms` can recursively chown broad host paths
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1322,8 +1322,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "audit.list",
-                    desc: "Return the most recent audit-log entries (default 200, capped by `limit`), parsed line-by-line in reverse chronological order. Entry shape depends on the action being audited.",
-                    role: MethodRole::Any,
+                    desc: "Return the most recent global audit-log entries (default 200, capped by `limit`), parsed line-by-line in reverse chronological order. Requires an unscoped Admin because records include other users' identities, client addresses, denied operations, and mutation details.",
+                    role: MethodRole::Admin,
                     params: MethodParams::AdHoc(serde_json::json!({
                         "type": "object",
                         "properties": {

--- a/engine/nasty-engine/src/router/audit.rs
+++ b/engine/nasty-engine/src/router/audit.rs
@@ -8,14 +8,18 @@ use nasty_common::{ErrorCode, Request, Response};
 use serde::Deserialize;
 
 use super::*;
-use crate::AppState;
 use crate::auth::{Role, Session};
 
-pub(super) async fn try_route(
-    req: &Request,
-    state: &AppState,
-    session: &Session,
-) -> Option<Response> {
+fn preflight_access_error(req: &Request, session: &Session) -> Option<Response> {
+    (req.method == "audit.list")
+        .then(|| require_root_equivalent_read(req, session, "global_audit_log_read"))
+        .flatten()
+}
+
+pub(super) async fn try_route(req: &Request, session: &Session) -> Option<Response> {
+    if let Some(response) = preflight_access_error(req, session) {
+        return Some(response);
+    }
     Some(match req.method.as_str() {
         "audit.list" => {
             let limit = req
@@ -40,4 +44,68 @@ pub(super) async fn try_route(
         }
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{preflight_access_error, try_route};
+    use crate::auth::{Role, Session};
+    use nasty_common::Request;
+
+    fn session(role: Role, filesystem: bool, owner: bool) -> Session {
+        Session {
+            token: "token".into(),
+            username: "user".into(),
+            role,
+            file_principal: None,
+            filesystem: filesystem.then(|| "tank".into()),
+            owner: owner.then(|| "token-a".into()),
+            created_at: 0,
+            must_change_password: false,
+            client_ip: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn global_audit_log_requires_root_equivalent_access() {
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "audit.list",
+            "params": "not an object"
+        }))
+        .unwrap();
+
+        for (denied, expected) in [
+            (
+                session(Role::Admin, true, false),
+                "Scoped credentials cannot access this endpoint",
+            ),
+            (
+                session(Role::Admin, false, true),
+                "Scoped credentials cannot access this endpoint",
+            ),
+            (session(Role::Operator, false, false), "Permission denied"),
+            (session(Role::ReadOnly, false, false), "Permission denied"),
+            (session(Role::User, false, false), "Permission denied"),
+        ] {
+            let response = try_route(&request, &denied).await.unwrap();
+            assert_eq!(response.error.unwrap().message, expected);
+        }
+        assert!(preflight_access_error(&request, &session(Role::Admin, false, false)).is_none());
+    }
+
+    #[test]
+    fn personal_audit_log_remains_self_scoped() {
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "audit.mine",
+            "params": {"limit": 20}
+        }))
+        .unwrap();
+
+        assert!(preflight_access_error(&request, &session(Role::User, false, false)).is_none());
+        assert!(preflight_access_error(&request, &session(Role::Admin, true, true)).is_none());
+    }
 }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -257,6 +257,9 @@ fn is_read_only(method: &str) -> bool {
             | "apps.inspect"
             | "apps.compose.get"
             | "notifications.config.get"
+            // Global audit records contain other users' identities, client
+            // addresses, denied operations, and mutation details.
+            | "audit.list"
     ) {
         return false;
     }
@@ -321,7 +324,6 @@ fn is_read_only(method: &str) -> bool {
                 | "system.version.tagged_release_notice"
                 | "system.log.level"
                 | "system.settings.timezones"
-                | "audit.list"
                 | "audit.mine"
                 | "apps.check_ports"
                 | "apps.check_devices"
@@ -527,7 +529,7 @@ async fn route(req: &Request, state: &AppState, session: &Session) -> Response {
         .unwrap_or(req.method.as_str());
     let resp = match prefix {
         "auth" => auth::try_route(req, state, session).await,
-        "audit" => audit::try_route(req, state, session).await,
+        "audit" => audit::try_route(req, session).await,
         "alert" | "telemetry" => alerts::try_route(req, state, session).await,
         "notifications" => notifications::try_route(req, session).await,
         "backup" => backup::try_route(req, state, session).await,
@@ -630,6 +632,22 @@ pub(super) fn require_root_equivalent(
         crate::auth::EndpointAccess::RootEquivalent,
         reason,
         true,
+    )
+}
+
+/// Gate a sensitive read as root-equivalent without emitting the mutation-style
+/// success preflight event. The dispatcher audits the successful RPC once.
+pub(super) fn require_root_equivalent_read(
+    req: &Request,
+    session: &Session,
+    reason: &str,
+) -> Option<Response> {
+    require_endpoint_access(
+        req,
+        session,
+        crate::auth::EndpointAccess::RootEquivalent,
+        reason,
+        false,
     )
 }
 

--- a/webui/src/routes/help/+page.svelte
+++ b/webui/src/routes/help/+page.svelte
@@ -316,7 +316,7 @@
 				{
 					term: 'Audit Log',
 					summary: 'Append-only record of every action operators take on the box.',
-					detail: 'Lives at /var/lib/nasty/audit.log (mode 0600) and is mirrored to journald with target "audit", so tampering with the file still leaves a trail. Every state-changing RPC the engine accepts is recorded with the username, client IP, method name, and a safelist-filtered parameter summary (secrets like passwords / API tokens / TLS DNS credentials never make it in). Logged in addition to mutations: every login attempt (success and failure), permission denials, terminal / VM-console / log-stream opens, and unsafe app deploys — anything an auditor would want to reconstruct after the fact. Read it via the audit.list RPC or the Logs page in the WebUI; rotated by logrotate at 10 MB.',
+					detail: 'Lives at /var/lib/nasty/audit.log (mode 0600) and is mirrored to journald with target "audit", so tampering with the file still leaves a trail. Every state-changing RPC the engine accepts is recorded with the username, client IP, method name, and a safelist-filtered parameter summary (secrets like passwords / API tokens / TLS DNS credentials never make it in). Logged in addition to mutations: every login attempt (success and failure), permission denials, terminal / VM-console / log-stream opens, and unsafe app deploys — anything an auditor would want to reconstruct after the fact. Unscoped administrators can read the global history via the audit.list RPC or the Logs page; other users can read their own activity via audit.mine. Rotated by logrotate at 10 MB.',
 				},
 				{
 					term: 'WebAuthn / Passkey / Security Key',


### PR DESCRIPTION
## Summary
- require an unscoped Admin session before `audit.list` reads the global audit log
- preserve `audit.mine` for self-scoped activity and align the registry role with the effective central gate
- audit successful global reads once, after the response snapshot, without a duplicate root-equivalent preflight event
- document the access boundary in the API review ledger and WebUI help

## Testing
- `cargo test -p nasty-engine router::audit::tests`
- `cargo test -p nasty-engine router::tests::declared_roles_match_effective_gate`
- `cargo test -p nasty-engine router::tests::standard_user_rpc_policy_is_explicit_and_deny_by_default`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check`
- `npm test -- --run`
- `npm run build`
- `git diff --check`