### PR TITLE
nixos: bump nasty-top to 0.0.10 and diskwatch to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,10 +329,10 @@
 - The Help & Community page links to `r/NAStyProject` (#714).
 - Linux moves from 6.18.38 to **6.18.40** across three weekly nixpkgs updates
   (#672, #693, #705).
-- `diskwatch` moves from 0.1.2 to **0.1.5**, adding independent-filesystem
-  attribution fixes and runtime-selectable themes (#669, #706).
-- `nasty-top` moves from 0.0.8 to **0.0.9**, fixing bcachefs 1.38.8 by-UUID
-  discovery and hardening monitoring (#673). bcachefs remains at 1.38.8.
+- `diskwatch` moves from 0.1.2 to **0.5.2**, adding runtime-selectable themes,
+  configurable Hot Files roots, and process attribution for active writers.
+- `nasty-top` moves from 0.0.8 to **0.0.10**, adding bcachefs cache-memory,
+  per-device queue, target-capacity, and garbage-collection pressure metrics.
 
 ### Upgrading
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -782,12 +782,12 @@ in {
         nastyTopSrc = pkgs.fetchFromGitHub {
           owner = "nasty-project";
           repo = "nasty-top";
-          rev = "v0.0.9";
-          hash = "sha256-Qm2e1pk7cgcIPxL60A2bmYPbaniQGvuOEc/8OpWpXYQ=";
+          rev = "v0.0.10";
+          hash = "sha256-yZIYTDJdua6LD3tzXq4lY9Y+O7qiC/Oosim/8LweanA=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.9";
+        version = "0.0.10";
         src = nastyTopSrc;
         # Vendor via Cargo.lock instead of a separate cargoHash so a
         # `cargo update` in nasty-top doesn't silently break this build.
@@ -810,12 +810,12 @@ in {
         diskwatchSrc = pkgs.fetchFromGitHub {
           owner = "matthart1983";
           repo = "diskwatch";
-          rev = "v0.4.0";
-          hash = "sha256-pKo4zXyoX2OiOIwirCdzQuuFW1dMye/AA4MNVYgki3A=";
+          rev = "v0.5.2";
+          hash = "sha256-aebepClhjC5Gnw9Ct+z04XX0bcDRytk2Z88BeA0lE8Y=";
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "diskwatch";
-        version = "0.4.0";
+        version = "0.5.2";
         src = diskwatchSrc;
         cargoLock.lockFile = "${diskwatchSrc}/Cargo.lock";
         meta.mainProgram = "diskwatch";

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -404,7 +404,7 @@ pkgs.testers.runNixOSTest {
 
     machine.start()
 
-    machine.succeed("diskwatch --version | grep -Fq '0.4.0'")
+    machine.succeed("diskwatch --version | grep -Fq '0.5.2'")
     machine.succeed("netwatch --version | grep -Fq '0.29.2'")
     machine.succeed("syswatch --version | grep -Fq '0.10.0'")
 


### PR DESCRIPTION
## Summary
- bump bundled nasty-top from 0.0.9 to 0.0.10
- bump bundled diskwatch from 0.4.0 to 0.5.2
- update the diskwatch appliance smoke assertion and release notes

## Validation
- verified both fetchFromGitHub hashes with nix-prefetch-url, including matching the existing-tag hashes
- cargo test --locked for nasty-top v0.0.10 (34 passed)
- cargo test --locked for diskwatch v0.5.2 (175 passed)
- verified both binaries report the requested versions
- parsed the edited Nix module and appliance test with nix-instantiate
- git diff --check