### PR TITLE
Show complete DNS provider credential hints

### DIFF
--- a/webui/src/routes/tls/+page.svelte
+++ b/webui/src/routes/tls/+page.svelte
@@ -47,10 +47,10 @@
 			case 'linode': return 'LINODE_TOKEN=xxxxx';
 			case 'desec': return 'DESEC_TOKEN=xxxxx';
 			case 'hetzner': return 'HETZNER_API_TOKEN=xxxxx';
-			case 'porkbun': return 'PORKBUN_API_KEY=xxxxx';
-			case 'namecheap': return 'NAMECHEAP_USER=xxxxx';
-			case 'rfc2136': return 'RFC2136_KEY_NAME=xxxxx';
-			case 'route53': return 'AWS_REGION=xxxxx';
+			case 'porkbun': return 'PORKBUN_API_KEY=xxxxx\nPORKBUN_SECRET_API_KEY=xxxxx';
+			case 'namecheap': return 'NAMECHEAP_USER=xxxxx\nNAMECHEAP_API_KEY=xxxxx\nNAMECHEAP_CLIENT_IP=192.0.2.1';
+			case 'rfc2136': return 'RFC2136_KEY_NAME=xxxxx\nRFC2136_KEY=xxxxx\nRFC2136_KEY_ALG=hmac-sha256\nRFC2136_SERVER=192.0.2.1:53';
+			case 'route53': return 'AWS_REGION=xxxxx\nAWS_ACCESS_KEY_ID=xxxxx\nAWS_SECRET_ACCESS_KEY=xxxxx\nAWS_SESSION_TOKEN=xxxxx';
 			default: return 'KEY=VALUE';
 		}
 	});


### PR DESCRIPTION
Follow-up to #868. This additional improvement came out of the previous Cloudflare credential-hint fix: instead of correcting only the Cloudflare example, the TLS form now shows the complete required KEY=VALUE set for each selected DNS provider.

Examples include the full credential sets for RFC2136, Porkbun, Namecheap, and Route53, while single-token providers remain concise.

Validation:
- `npm run check`
- `npm test -- --run` (297 tests passed)