### PR TITLE
security: restrict firmware metadata refresh

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -7,9 +7,9 @@ Date: 2026-09-07
 Static review of all 329 methods registered in
 `engine/nasty-engine/src/registry/methods.rs`:
 
-- 126 `Any`
+- 125 `Any`
 - 79 `Operator`
-- 124 `Admin`
+- 125 `Admin`
 
 The registry declarations match the central dispatcher. The findings below are
 semantic authorization problems that the registry/dispatcher consistency tests
@@ -216,10 +216,12 @@ service also requires an existing canonical non-symlink target and invokes
 
 ### `firmware.check` is not a pure read
 
-The `Any` method forces a host-wide LVFS metadata refresh before returning
-available updates.
+Status: fixed by requiring an unscoped Admin for the host-wide LVFS metadata
+refresh. Other management roles retain access to the pure `firmware.devices`
+inventory.
 
 - `engine/nasty-system/src/firmware.rs:133-174`
+- `engine/nasty-engine/src/router/system.rs:803-820`
 
 ## Over-Restricted
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -2122,8 +2122,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "firmware.check",
-                    desc: "Refresh LVFS metadata via `fwupdmgr refresh` then return the device list with `update_available`/`update_version`/`update_description` populated for devices with pending updates.",
-                    role: MethodRole::Any,
+                    desc: "Refresh host-wide LVFS metadata via `fwupdmgr refresh` then return pending firmware updates. Requires an unscoped Admin session.",
+                    role: MethodRole::Admin,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<FirmwareDevice>>(generator)),
                 },

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -343,7 +343,6 @@ fn is_read_only(method: &str) -> bool {
                 | "vm.images.import_info"
                 | "firmware.available"
                 | "firmware.constraints"
-                | "firmware.check"
                 | "firmware.devices"
                 | "apps.inspect_image"
                 | "apps.caddy.routes"
@@ -2272,10 +2271,12 @@ mod tests {
     }
 
     #[test]
-    fn firmware_flash_is_admin_only() {
-        assert!(!is_read_only("firmware.update"));
-        assert!(!is_universally_allowed("firmware.update"));
-        assert!(!is_operator_allowed("firmware.update"));
+    fn firmware_mutations_are_admin_only() {
+        for method in ["firmware.check", "firmware.update"] {
+            assert!(!is_read_only(method));
+            assert!(!is_universally_allowed(method));
+            assert!(!is_operator_allowed(method));
+        }
     }
 
     /// The .list / .get suffix matches that existed before this

--- a/engine/nasty-engine/src/router/system.rs
+++ b/engine/nasty-engine/src/router/system.rs
@@ -803,7 +803,14 @@ pub(super) async fn try_route(
         "firmware.available" => ok(req, state.firmware.is_available().await),
         "firmware.constraints" => ok(req, state.firmware.constraints().await),
         "firmware.devices" => ok(req, state.firmware.list_devices().await),
-        "firmware.check" => ok(req, state.firmware.check_updates().await),
+        "firmware.check" => {
+            if let Some(response) =
+                require_root_equivalent(req, session, "firmware_metadata_refresh")
+            {
+                return Some(response);
+            }
+            ok(req, state.firmware.check_updates().await)
+        }
         "firmware.update" => {
             if let Some(response) = require_root_equivalent(req, session, "firmware_flash") {
                 return Some(response);

--- a/webui/src/routes/update/+page.svelte
+++ b/webui/src/routes/update/+page.svelte
@@ -675,7 +675,9 @@
 			firmwareAvailable = await client.call<boolean>('firmware.available');
 			if (firmwareAvailable) {
 				const [devices, constraints] = await Promise.all([
-					client.call<FirmwareDevice[]>('firmware.check'),
+					canFlashFirmware
+						? client.call<FirmwareDevice[]>('firmware.check')
+						: client.call<FirmwareDevice[]>('firmware.devices'),
 					client.call<FirmwareConstraints>('firmware.constraints'),
 				]);
 				firmwareDevices = devices;


### PR DESCRIPTION
## Summary
- require an unscoped Admin session for `firmware.check` because it refreshes host-wide LVFS metadata
- preserve pure firmware device inventory access for other management roles
- align API registry, policy tests, WebUI behavior, and review documentation

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine router::tests`
- `npm run check`
- `npm test`