### PR TITLE
authz: allow operators to replace iSCSI portals

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -7,9 +7,9 @@ Date: 2026-09-07
 Static review of all 329 methods registered in
 `engine/nasty-engine/src/registry/methods.rs`:
 
-- 125 `Any`
-- 79 `Operator`
-- 125 `Admin`
+- 123 `Any`
+- 80 `Operator`
+- 126 `Admin`
 
 The registry declarations match the central dispatcher. The findings below are
 semantic authorization problems that the registry/dispatcher consistency tests
@@ -225,8 +225,9 @@ inventory.
 
 ## Over-Restricted
 
-- `share.iscsi.set_portals` is Admin while equivalent add/remove operations are
-  Operator: `engine/nasty-engine/src/registry/methods.rs:1039-1057`.
+- Status: fixed. `share.iscsi.set_portals` is now Operator-level like the
+  equivalent add/remove operations; existing target-scope, raw-backing, and
+  iSER authorization checks still apply.
 - `system.network.pending` and `system.network.nm_preview` are pure reads but
   Admin-only: `engine/nasty-engine/src/registry/methods.rs:1935-1953`.
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1052,7 +1052,7 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 Method {
                     name: "share.iscsi.set_portals",
                     desc: "Replace an iSCSI target's portal set in one call. The engine orders the transition (adds before removes where possible, conflicting adds after), so swapping the wildcard portal for a specific address on the same port works directly — no temporary portal needed.",
-                    role: MethodRole::Admin,
+                    role: MethodRole::Operator,
                     params: MethodParams::Schema(gen_schema::<SetPortalsRequest>(generator)),
                     result: Some(gen_schema::<IscsiTarget>(generator)),
                 },

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -116,6 +116,7 @@ fn is_operator_allowed(method: &str) -> bool {
                 | "share.iscsi.remove_acl"
                 | "share.iscsi.add_portal"
                 | "share.iscsi.remove_portal"
+                | "share.iscsi.set_portals"
                 | "share.nvmeof.create"
                 | "share.nvmeof.delete"
                 | "share.nvmeof.add_namespace"
@@ -2276,6 +2277,18 @@ mod tests {
             assert!(!is_read_only(method));
             assert!(!is_universally_allowed(method));
             assert!(!is_operator_allowed(method));
+        }
+    }
+
+    #[test]
+    fn iscsi_portal_mutations_are_operator_allowed() {
+        for method in [
+            "share.iscsi.add_portal",
+            "share.iscsi.remove_portal",
+            "share.iscsi.set_portals",
+        ] {
+            assert!(!is_read_only(method));
+            assert!(is_operator_allowed(method));
         }
     }
 


### PR DESCRIPTION
## Summary
- align `share.iscsi.set_portals` with the existing Operator-level add/remove portal methods
- retain target scope, raw-backing, iSER, serialization, and firewall checks
- add a regression test pinning portal-mutation role parity and update the review record

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine router::tests`
- `cargo test -p nasty-sharing planner_`