### PR TITLE
authz: expose network inspection reads

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -7,9 +7,9 @@ Date: 2026-09-07
 Static review of all 329 methods registered in
 `engine/nasty-engine/src/registry/methods.rs`:
 
-- 123 `Any`
+- 125 `Any`
 - 80 `Operator`
-- 126 `Admin`
+- 124 `Admin`
 
 The registry declarations match the central dispatcher. The findings below are
 semantic authorization problems that the registry/dispatcher consistency tests
@@ -228,8 +228,9 @@ inventory.
 - Status: fixed. `share.iscsi.set_portals` is now Operator-level like the
   equivalent add/remove operations; existing target-scope, raw-backing, and
   iSER authorization checks still apply.
-- `system.network.pending` and `system.network.nm_preview` are pure reads but
-  Admin-only: `engine/nasty-engine/src/registry/methods.rs:1935-1953`.
+- Status: fixed. `system.network.pending` and `system.network.nm_preview` are
+  management-role reads, including for scoped credentials; standard `User`
+  accounts remain deny-by-default.
 
 ## Additional API Defects
 

--- a/engine/nasty-engine/src/registry/methods.rs
+++ b/engine/nasty-engine/src/registry/methods.rs
@@ -1933,8 +1933,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
             vec![
                 Method {
                     name: "system.network.pending",
-                    desc: "Return the list of network-update transactions still awaiting confirm-or-rollback. (Admin-only by current role-gate even though it's a read.)",
-                    role: MethodRole::Admin,
+                    desc: "Return the list of network-update transactions still awaiting confirm-or-rollback.",
+                    role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<Vec<NetworkPendingTxn>>(generator)),
                 },
@@ -1947,8 +1947,8 @@ pub(super) fn registry(generator: &mut SchemaGenerator) -> Vec<(&'static str, Ve
                 },
                 Method {
                     name: "system.network.nm_preview",
-                    desc: "Compute the diff between desired NetworkManager profiles and NM's current state without applying.",
-                    role: MethodRole::Admin,
+                    desc: "Compute the diff between desired NetworkManager profiles and NM's current state without applying or persisting changes.",
+                    role: MethodRole::Any,
                     params: MethodParams::None,
                     result: Some(gen_schema::<NmDiff>(generator)),
                 },

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -280,6 +280,8 @@ fn is_read_only(method: &str) -> bool {
                 | "system.stats"
                 | "system.disks"
                 | "system.network.get"
+                | "system.network.pending"
+                | "system.network.nm_preview"
                 | "system.logs.units"
                 | "system.ssh.status"
                 | "system.alerts"
@@ -2149,6 +2151,8 @@ mod tests {
             "auth.list_users",
             "fs.list",
             "share.smb.list",
+            "system.network.pending",
+            "system.network.nm_preview",
             "new.feature.list",
             "auth.token.create",
             "auth.webauthn.reset_for_user",
@@ -2168,6 +2172,26 @@ mod tests {
     #[test]
     fn fs_tpm_status_is_read_only() {
         assert!(is_read_only("fs.tpm.status"));
+    }
+
+    #[test]
+    fn network_inspection_methods_are_management_reads() {
+        for method in ["system.network.pending", "system.network.nm_preview"] {
+            assert!(is_read_only(method));
+            assert!(is_universally_allowed(method));
+            assert!(is_operator_allowed(method));
+            assert!(!is_user_allowed(method));
+        }
+
+        for method in [
+            "system.network.update",
+            "system.network.confirm",
+            "system.network.nm_apply",
+        ] {
+            assert!(!is_read_only(method));
+            assert!(!is_operator_allowed(method));
+            assert!(!is_user_allowed(method));
+        }
     }
 
     /// Every status endpoint in the codebase is a pure read.


### PR DESCRIPTION
## Summary
- classify pending network transactions and NetworkManager previews as management-role reads
- keep network update, confirm, and apply operations Admin-only
- keep standard User accounts deny-by-default and align registry documentation

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p nasty-engine router::tests`
- `cargo test -p nasty-system pending_`
- `cargo test -p nasty-system diff_`