### PR TITLE
docs: clarify API role contracts

### DIFF
--- a/docs/api-role-review.md
+++ b/docs/api-role-review.md
@@ -234,10 +234,12 @@ inventory.
 
 ## Additional API Defects
 
-- `apps.compose.get` is documented as returning a string but returns a
-  `ComposeContent` object containing `compose_file` and `env_file`.
-- `MethodRole::Any` says "any authenticated user", but most such methods are
-  unavailable to `Role::User`, which has a separate explicit allowlist.
+- Status: fixed. `apps.compose.get` is registered and documented as returning
+  the `ComposeContent` object containing `compose_file` and `env_file`, with a
+  registry regression test covering that schema contract.
+- Status: fixed. `MethodRole::Any` and generated API documentation now define
+  `any` as any authenticated management role (`Admin`, `Operator`, or
+  `ReadOnly`). Standard `User` API access remains a separate explicit allowlist.
 
 ## Existing Coverage
 

--- a/engine/nasty-engine/src/registry/markdown.rs
+++ b/engine/nasty-engine/src/registry/markdown.rs
@@ -39,6 +39,7 @@ pub fn render_markdown(groups: &[(&str, Vec<Method>)]) -> String {
     out.push_str("| `operator` | Day-to-day storage, sharing, app, and VM operations without Admin-only system or root-equivalent access |\n");
     out.push_str("| `readonly` | Non-privileged read-only API access |\n");
     out.push_str("| `user` | Self-service account methods and authorized file-portal access |\n\n");
+    out.push_str("The method role label `any` means any authenticated management role (`admin`, `operator`, or `readonly`). It does not include the standard `user` role, whose API access is separately allowlisted.\n\n");
     out.push_str(
         "API tokens can additionally be scoped to a single **filesystem** (restricts visibility) ",
     );

--- a/engine/nasty-engine/src/registry/mod.rs
+++ b/engine/nasty-engine/src/registry/mod.rs
@@ -34,8 +34,8 @@ pub use markdown::render_markdown;
 /// *minimum* role needed to call the method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MethodRole {
-    /// Any authenticated user, including ReadOnly. Pure reads + self-mutations
-    /// (logout, change own password, manage own webauthn credentials).
+    /// Any authenticated management role: Admin, Operator, or ReadOnly.
+    /// Standard User access is controlled by a separate explicit allowlist.
     Any,
     /// Operator or Admin. Subvolume/snapshot/share/vm/app management.
     Operator,

--- a/engine/nasty-engine/src/registry/openapi.rs
+++ b/engine/nasty-engine/src/registry/openapi.rs
@@ -42,7 +42,7 @@ pub fn render_openapi(version: &'static str, groups: &[(&str, Vec<Method>)]) -> 
         "info": {
             "title": "NASty JSON-RPC API (REST gateway)",
             "version": version,
-            "description": "NASty's JSON-RPC API surface, exposed over a thin REST gateway.\n\nEach JSON-RPC method `foo.bar.baz` is mounted at `/api/v1/foo/bar/baz` with an HTTP verb inferred from the method's last segment (`.get`/`.list`/`.status` → GET, `.delete`/`.remove` → DELETE, `.set`/`.update` → PUT, everything else → POST).\n\nGET methods take their params as query string; everything else takes a JSON body. Authentication mirrors the WebSocket transport: send the `nasty_session` cookie or an `Authorization: Bearer <token>` header.\n\nStreaming endpoints (log_stream, terminal, vm_console, telemetry pushes, event broadcasts) stay on the WebSocket at `/ws` and are intentionally not modeled here.",
+            "description": "NASty's JSON-RPC API surface, exposed over a thin REST gateway.\n\nEach JSON-RPC method `foo.bar.baz` is mounted at `/api/v1/foo/bar/baz` with an HTTP verb inferred from the method's last segment (`.get`/`.list`/`.status` → GET, `.delete`/`.remove` → DELETE, `.set`/`.update` → PUT, everything else → POST).\n\nGET methods take their params as query string; everything else takes a JSON body. Authentication mirrors the WebSocket transport: send the `nasty_session` cookie or an `Authorization: Bearer <token>` header.\n\nThe method role label `any` means any authenticated management role (`admin`, `operator`, or `readonly`). It does not include the standard `user` role, whose API access is separately allowlisted.\n\nStreaming endpoints (log_stream, terminal, vm_console, telemetry pushes, event broadcasts) stay on the WebSocket at `/ws` and are intentionally not modeled here.",
         },
         "servers": [{"url": "/", "description": "This engine"}],
         "paths": Value::Object(paths),
@@ -84,9 +84,15 @@ fn build_operation(group: &str, m: &Method, schemas: &mut BTreeMap<String, Value
     op.insert(
         "description".into(),
         Value::String(format!(
-            "{}\n\n**Required role:** `{}`",
+            "{}\n\n**Required role:** {}",
             m.desc,
-            m.role.as_str()
+            match m.role {
+                MethodRole::Any => {
+                    "`any` management role (`admin`, `operator`, or `readonly`)"
+                }
+                MethodRole::Operator => "`operator`",
+                MethodRole::Admin => "`admin`",
+            }
         )),
     );
 
@@ -330,5 +336,17 @@ mod tests {
         assert!(doc.get("paths").unwrap().as_object().unwrap().len() > 250);
         // Every registered method maps to an existing path; sample one.
         assert!(doc.pointer("/paths/~1api~1v1~1system~1info/get").is_some());
+        assert!(
+            doc.pointer("/info/description")
+                .and_then(Value::as_str)
+                .unwrap()
+                .contains("`any` means any authenticated management role")
+        );
+        assert!(
+            doc.pointer("/paths/~1api~1v1~1system~1info/get/description")
+                .and_then(Value::as_str)
+                .unwrap()
+                .contains("`any` management role (`admin`, `operator`, or `readonly`)")
+        );
     }
 }

--- a/engine/nasty-engine/src/registry/tests.rs
+++ b/engine/nasty-engine/src/registry/tests.rs
@@ -190,6 +190,29 @@ fn registry_builds_without_panic() {
 }
 
 #[test]
+fn compose_get_result_matches_compose_content() {
+    let (_generator, groups) = super::build_full_registry();
+    let method = groups
+        .iter()
+        .flat_map(|(_, methods)| methods)
+        .find(|method| method.name == "apps.compose.get")
+        .expect("apps.compose.get must be registered");
+    let result = method
+        .result
+        .as_ref()
+        .expect("apps.compose.get must declare a result");
+
+    assert_eq!(result.get("type").and_then(|v| v.as_str()), Some("object"));
+    assert_eq!(
+        result
+            .pointer("/properties/compose_file/type")
+            .and_then(|v| v.as_str()),
+        Some("string")
+    );
+    assert!(result.pointer("/properties/env_file").is_some());
+}
+
+#[test]
 fn markdown_introduction_matches_current_transports_and_names() {
     let (_generator, groups) = super::build_full_registry();
     let rendered = render_markdown(&groups);
@@ -202,6 +225,7 @@ fn markdown_introduction_matches_current_transports_and_names() {
         "`/api/docs`",
         "`/api/openapi.json`",
         "\"event\": \"filesystem\"",
+        "The method role label `any` means any authenticated management role",
     ] {
         assert!(rendered.contains(expected), "missing `{expected}`");
     }

--- a/engine/nasty-engine/src/router/mod.rs
+++ b/engine/nasty-engine/src/router/mod.rs
@@ -23,7 +23,8 @@ mod vm;
 use crate::AppState;
 use crate::auth::{Role, Session};
 
-/// Methods every authenticated user can call regardless of role.
+/// Methods every authenticated management role can call.
+/// Standard users are evaluated separately by `is_user_allowed`.
 /// Two categories:
 ///   1. Pure reads (`is_read_only`).
 ///   2. Mutations that only affect the caller's own session/account —


### PR DESCRIPTION
## Summary
- define the registry `any` label as any authenticated management role, excluding the separately allowlisted standard `user` role
- carry that definition into generated Markdown and OpenAPI operation descriptions without changing authorization behavior or `x-nasty-role` values
- record the existing `apps.compose.get` `ComposeContent` schema fix and add a regression test for its object fields

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --workspace --all-targets --no-fail-fast`