### PR TITLE
nixos: bump nasty-top to 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,8 +331,9 @@
   (#672, #693, #705).
 - `diskwatch` moves from 0.1.2 to **0.5.2**, adding runtime-selectable themes,
   configurable Hot Files roots, and process attribution for active writers.
-- `nasty-top` moves from 0.0.8 to **0.0.10**, adding bcachefs cache-memory,
-  per-device queue, target-capacity, and garbage-collection pressure metrics.
+- `nasty-top` moves from 0.0.8 to **0.0.11**, adding bcachefs cache-memory,
+  per-device queue, target-capacity, garbage-collection pressure, peer-latency,
+  and evidence-based advisor diagnostics.
 
 ### Upgrading
 

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -779,15 +779,20 @@ in {
       rustic             # deduplicating encrypted backups (restic-compatible)
       restic-rest-server # REST API server for receiving backups from other machines
       (let
-        nastyTopSrc = pkgs.fetchFromGitHub {
-          owner = "nasty-project";
-          repo = "nasty-top";
-          rev = "v0.0.10";
-          hash = "sha256-yZIYTDJdua6LD3tzXq4lY9Y+O7qiC/Oosim/8LweanA=";
+        nastyTopSrc = pkgs.applyPatches {
+          name = "nasty-top-0.0.11-source";
+          src = pkgs.fetchFromGitHub {
+            owner = "nasty-project";
+            repo = "nasty-top";
+            rev = "v0.0.11";
+            hash = "sha256-rF2R55TVMcw/jsz+Oe4jBUjFFp72CbxeA98/ijvQZOo=";
+          };
+          # The v0.0.11 tag was published with 0.0.10 in both manifests.
+          patches = [ ../nasty-top-0.0.11-version.patch ];
         };
       in pkgs.rustPlatform.buildRustPackage {
         pname = "nasty-top";
-        version = "0.0.10";
+        version = "0.0.11";
         src = nastyTopSrc;
         # Vendor via Cargo.lock instead of a separate cargoHash so a
         # `cargo update` in nasty-top doesn't silently break this build.

--- a/nixos/nasty-top-0.0.11-version.patch
+++ b/nixos/nasty-top-0.0.11-version.patch
@@ -1,0 +1,25 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 043d39c..08c4a31 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -1,6 +1,6 @@
+ [package]
+ name = "nasty-top"
+-version = "0.0.10"
++version = "0.0.11"
+ edition = "2024"
+ license = "GPL-3.0-only"
+ description = "A top-like TUI for bcachefs filesystems"
+diff --git a/Cargo.lock b/Cargo.lock
+index 508c31e..ef430f9 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -801,7 +801,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "nasty-top"
+-version = "0.0.10"
++version = "0.0.11"
+ dependencies = [
+  "clap",
+  "crossterm",

--- a/nixos/tests/appliance-smoke.nix
+++ b/nixos/tests/appliance-smoke.nix
@@ -404,6 +404,7 @@ pkgs.testers.runNixOSTest {
 
     machine.start()
 
+    machine.succeed("nasty-top --version | grep -Fq '0.0.11'")
     machine.succeed("diskwatch --version | grep -Fq '0.5.2'")
     machine.succeed("netwatch --version | grep -Fq '0.29.2'")
     machine.succeed("syswatch --version | grep -Fq '0.10.0'")


### PR DESCRIPTION
## Summary

- bump the bundled nasty-top source and package metadata to v0.0.11
- patch the upstream manifests so the binary reports 0.0.11
- assert the bundled version in the appliance smoke test and update the changelog

## Validation

- verified the fetchFromGitHub recursive source hash
- parsed the NixOS module and appliance smoke test
- built the patched nasty-top derivation for aarch64-linux