### PR TITLE
bcachefs: bump bundled tools to v1.39.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
   only static pending totals (#739).
 - The dashboard exposes approximate bcachefs btree-node cache usage. This is one
   component of bcachefs memory, not a total memory figure (#741).
-- The bundled bcachefs tools and DKMS module move from 1.38.8 to **1.39.2**
+- The bundled bcachefs tools and DKMS module move from 1.38.8 to **1.39.6**
   (#745, #756, #772).
 
 ### Security, authorization & privacy

--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1788807635,
-        "narHash": "sha256-k9JW6GMXFwphkYGcYMwA59uafNj0EV96wTnbzeuVM1w=",
+        "lastModified": 1789154473,
+        "narHash": "sha256-cBYn/g6eLT5rTumo4Y24rWSHS2Sc7gFthPuCg1AQ22k=",
         "owner": "koverstreet",
         "repo": "bcachefs-tools",
-        "rev": "5e1272bd83f48fb9f2bfbeaaf2024d3537db8098",
+        "rev": "66d3b1b36ea11a33644f6ee7abb1f5ae1d679e18",
         "type": "github"
       },
       "original": {
         "owner": "koverstreet",
-        "ref": "v1.39.5",
+        "ref": "v1.39.6",
         "repo": "bcachefs-tools",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,10 @@
     tailscale-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # ── bcachefs override (optional) ──────────────────────────────
-    # Pinned to v1.39.5 release tag.
+    # Pinned to v1.39.6 release tag.
     # To revert to pure nixpkgs: comment out these two lines.
     # No other changes needed — bcachefs.nix defaults to pkgs.bcachefs-tools.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.5";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.6";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # ── lanzaboote (Secure Boot for NixOS) ─────────────────────────

--- a/nixos/system-flake/flake.nix.template
+++ b/nixos/system-flake/flake.nix.template
@@ -67,7 +67,7 @@
     # of truth, no second pin to bump. This hardcoded value is used only
     # if that embedded flake.nix can't be parsed; keep it sane (matching
     # the repo-root flake.nix) so even that fallback is correct.
-    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.5";
+    bcachefs-tools.url = "github:koverstreet/bcachefs-tools/v1.39.6";
     bcachefs-tools.inputs.nixpkgs.follows = "nixpkgs";
     # `nasty.packages.<system>.bcachefs-tools` is the package wired into
     # boot.bcachefs.package below. Override nasty's nested source with the

--- a/nixos/tests/bcachefs-smoke.nix
+++ b/nixos/tests/bcachefs-smoke.nix
@@ -20,7 +20,7 @@ pkgs.testers.runNixOSTest {
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
-    machine.succeed("bcachefs version | grep -F 1.39.5")
+    machine.succeed("bcachefs version | grep -F 1.39.6")
     machine.succeed("test -x /etc/systemd/system-generators/bcachefs-mount-generator")
 
     # Format the empty 1 GiB disk and mount it.


### PR DESCRIPTION
## Summary
- pin bcachefs-tools and the DKMS source to v1.39.6
- keep the installer wrapper fallback and smoke-test expectation in sync
- update the bundled-version changelog entry

## Validation
- `docker run --rm -v "$PWD:/src:ro" -w /src nixos/nix:latest nix --extra-experimental-features "nix-command flakes" build --no-link .#packages.aarch64-linux.bcachefs-tools --print-build-logs`
- `cargo test -p nasty-system embedded_default_bcachefs_tools_ref_parses_from_nasty_flake`
- `docker run --rm -v "$PWD:/src:ro" nixos/nix:latest nix-instantiate --parse /src/nixos/system-flake/flake.nix.template`
- `git diff --check`