### PR TITLE
apps/storage: recover from missing filesystems

### DIFF
--- a/engine/nasty-apps/src/lib.rs
+++ b/engine/nasty-apps/src/lib.rs
@@ -769,6 +769,38 @@ fn fs_root_is_mounted(path: &str) -> bool {
     child.dev() != parent.dev()
 }
 
+/// Keep the filesystem mount busy for the lifetime of the returned handle.
+/// Opening before checking closes the race where an unmount could otherwise
+/// expose a stale rootfs directory between validation and a destructive write.
+async fn mounted_fs_lease(path: &str) -> Result<tokio::fs::File, AppsError> {
+    let fs_name = fs_root_segment(path).ok_or_else(|| {
+        AppsError::CommandFailed(format!("path '{path}' is not on a managed filesystem"))
+    })?;
+    let fs_root = format!("/fs/{fs_name}");
+    let lease = tokio::fs::File::open(&fs_root)
+        .await
+        .map_err(|error| AppsError::CommandFailed(format!("open {fs_root}: {error}")))?;
+    use std::os::unix::fs::MetadataExt;
+    let lease_metadata = lease
+        .metadata()
+        .await
+        .map_err(|error| AppsError::CommandFailed(format!("stat open {fs_root}: {error}")))?;
+    let current_metadata = tokio::fs::metadata(&fs_root)
+        .await
+        .map_err(|error| AppsError::CommandFailed(format!("stat {fs_root}: {error}")))?;
+    let parent_metadata = tokio::fs::metadata("/fs")
+        .await
+        .map_err(|error| AppsError::CommandFailed(format!("stat /fs: {error}")))?;
+    if lease_metadata.dev() == parent_metadata.dev()
+        || lease_metadata.dev() != current_metadata.dev()
+    {
+        return Err(AppsError::CommandFailed(format!(
+            "filesystem '{fs_name}' is not mounted at {fs_root}"
+        )));
+    }
+    Ok(lease)
+}
+
 /// Security half of the bind validator: no `..` traversal, no host
 /// root, no engine state, must be absolute. These failures are
 /// admin-policy violations the user can't fix from the wizard — the
@@ -2476,6 +2508,9 @@ pub struct ComposeBind {
 
 pub struct AppsService {
     docker: std::sync::Mutex<Option<Docker>>,
+    /// Serializes enabled/storage configuration changes with appdata relocation
+    /// so Disable cannot race a stale writer or restart.
+    config_mutations: std::sync::Arc<tokio::sync::Mutex<()>>,
     /// Previous-sample cache for `apps.stats`, keyed by container ID.
     /// The Docker stats endpoint needs *two* samples to compute deltas
     /// (CPU %, network rate, etc.); the natural API for that
@@ -2532,6 +2567,7 @@ impl AppsService {
         }
         Self {
             docker: std::sync::Mutex::new(docker),
+            config_mutations: std::sync::Arc::new(tokio::sync::Mutex::new(())),
             prev_stats: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             appdata_relocate: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         }
@@ -2842,27 +2878,45 @@ impl AppsService {
         Ok(())
     }
 
+    async fn remove_config(path: &Path) -> Result<(), AppsError> {
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(AppsError::Io(error)),
+        }
+    }
+
     pub async fn enable(&self, req: EnableAppsRequest) -> Result<(), AppsError> {
+        let config_guard = self.config_mutations.lock().await;
         if self.is_enabled() {
             return Err(AppsError::AlreadyEnabled);
         }
 
-        let config = AppsConfig {
-            enabled: true,
-            storage_path: None,
-            appdata_path: None,
-        };
         // Configure Docker data-root on bcachefs before recording the runtime
         // as enabled or starting Docker. Existing data must fail closed.
-        configure_docker_data_root(req.filesystem.as_deref()).await?;
+        let storage_path = configure_docker_data_root(req.filesystem.as_deref()).await?;
+        let appdata_path = match fs_root_segment(&storage_path) {
+            Some(fs_name) => match setup_appdata_storage(fs_name).await {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    warn!("appdata setup failed: {error} — /appdata binds won't resolve");
+                    None
+                }
+            },
+            None => None,
+        };
+        let config = AppsConfig {
+            enabled: true,
+            storage_path: Some(storage_path),
+            appdata_path,
+        };
         Self::save_config(&config).await?;
 
         // Start Docker via systemd
         run_cmd("systemctl", &["start", DOCKER_SERVICE]).await?;
+        drop(config_guard);
 
         info!("Apps runtime enabled — Docker starting");
-
-        let filesystem = req.filesystem.clone();
 
         // Bootstrap in background
         tokio::spawn(async move {
@@ -2894,46 +2948,12 @@ impl AppsService {
                 return;
             }
 
-            // Set up storage directory
-            let storage_path = setup_apps_storage(filesystem.as_deref()).await;
-
             // Create compose directory. A failure here means every
             // subsequent compose-app deploy will hit a confusing
             // "no such directory" error — the root cause needs to be
             // visible *now*, in the bootstrap log.
             if let Err(e) = tokio::fs::create_dir_all(COMPOSE_DIR).await {
                 error!("create_dir_all({COMPOSE_DIR}) failed: {e} — compose deploys will fail");
-            }
-
-            // Stable appdata location (#436) on the same filesystem as
-            // the apps storage. Non-fatal: appdata only matters to apps
-            // that bind it, and the boot path retries.
-            let appdata_path = match storage_path.as_deref().and_then(fs_root_segment) {
-                Some(fs_name) => match setup_appdata_storage(fs_name).await {
-                    Ok(p) => Some(p),
-                    Err(e) => {
-                        error!("appdata setup failed: {e} — /appdata binds won't resolve");
-                        None
-                    }
-                },
-                None => None,
-            };
-
-            // Persist storage path in config. A failure here means the
-            // chosen storage path won't survive an engine restart, which
-            // breaks app data persistence — log loudly.
-            if let Some(ref path) = storage_path {
-                let config = AppsConfig {
-                    enabled: true,
-                    storage_path: Some(path.clone()),
-                    appdata_path,
-                };
-                if let Err(e) = AppsService::save_config(&config).await {
-                    error!(
-                        "AppsConfig save failed: {e} — apps storage path won't \
-                         survive engine restart"
-                    );
-                }
             }
 
             info!("Apps bootstrap complete");
@@ -2943,8 +2963,20 @@ impl AppsService {
     }
 
     pub async fn disable(&self) -> Result<(), AppsError> {
+        let _config_guard = self.config_mutations.lock().await;
         if !self.is_enabled() {
             return Err(AppsError::NotEnabled);
+        }
+        if self
+            .appdata_relocate
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|status| status.running)
+        {
+            return Err(AppsError::CommandFailed(
+                "cannot disable Apps while appdata relocation is running".into(),
+            ));
         }
 
         // Stop all managed containers
@@ -2964,8 +2996,10 @@ impl AppsService {
         // Stop Docker
         run_cmd("systemctl", &["stop", DOCKER_SERVICE]).await?;
 
-        // Remove state file
-        let _ = tokio::fs::remove_file(STATE_PATH).await;
+        // Removing this file clears the persisted storage dependency. Report
+        // failures instead of claiming Apps is disabled while Forget remains
+        // blocked by the stale configuration.
+        Self::remove_config(Path::new(STATE_PATH)).await?;
 
         info!("Apps runtime disabled — Docker stopped");
         Ok(())
@@ -2979,12 +3013,14 @@ impl AppsService {
         let storage_path = config.storage_path.clone();
         let storage_ok = storage_path
             .as_ref()
-            .map(|p| Path::new(p).is_dir())
+            .map(|p| Path::new(p).is_dir() && fs_root_is_mounted(p))
             .unwrap_or(false);
         let appdata_path = config.appdata_path.clone();
         // is_dir() follows the symlink — false when /appdata dangles
         // (target filesystem unmounted) or was never set up.
-        let appdata_ok = Path::new(APPDATA_LINK).is_dir();
+        let appdata_ok = appdata_path
+            .as_ref()
+            .is_some_and(|path| Path::new(APPDATA_LINK).is_dir() && fs_root_is_mounted(path));
 
         if !enabled {
             return AppsStatus {
@@ -3083,6 +3119,24 @@ impl AppsService {
         }
 
         let affected = self.appdata_apps().await?;
+        let _config_guard = self.config_mutations.lock().await;
+        let latest_config = Self::load_config_strict()?;
+        if !latest_config.enabled || latest_config.appdata_path.as_deref() != Some(current.as_str())
+        {
+            return Err(AppsError::CommandFailed(
+                "Apps configuration changed while preparing appdata relocation".into(),
+            ));
+        }
+        if !fs_root_is_mounted(&target_path) {
+            return Err(AppsError::CommandFailed(format!(
+                "filesystem '{target_fs}' is no longer mounted at /fs/{target_fs}"
+            )));
+        }
+        if Path::new(&target_path).exists() {
+            return Err(AppsError::CommandFailed(format!(
+                "{target_path} was created while preparing relocation"
+            )));
+        }
         {
             let mut status = self.appdata_relocate.lock().await;
             if status.as_ref().is_some_and(|s| s.running) {
@@ -3105,8 +3159,10 @@ impl AppsService {
             affected.len()
         );
         let status_arc = self.appdata_relocate.clone();
+        let config_mutations = self.config_mutations.clone();
         tokio::spawn(run_appdata_relocation(
             status_arc,
+            config_mutations,
             current,
             target_path,
             affected,
@@ -5400,13 +5456,21 @@ impl AppsService {
         if !self.is_enabled() {
             return None;
         }
+        let config = Self::load_config();
+        if let Some(storage_path) = config.storage_path.as_deref()
+            && !fs_root_is_mounted(storage_path)
+        {
+            error!(
+                "Apps enabled but configured storage {storage_path} is not on a mounted filesystem; not starting Docker"
+            );
+            return None;
+        }
         // Heal the stable /appdata symlink (#436). Pre-feature installs
         // have no appdata_path yet — set it up on the apps storage
         // filesystem. Never blocks the apps boot: appdata only matters
         // to apps that bind it, and a dangling symlink fails their
         // start with a clear Docker error, not a crash loop.
         {
-            let config = Self::load_config();
             let fs_name = config
                 .appdata_path
                 .as_deref()
@@ -5417,7 +5481,11 @@ impl AppsService {
                 match setup_appdata_storage(&fs_name).await {
                     Ok(path) => {
                         if config.appdata_path.as_deref() != Some(path.as_str()) {
-                            let mut cfg = config;
+                            let _config_guard = self.config_mutations.lock().await;
+                            let mut cfg = Self::load_config();
+                            if !cfg.enabled {
+                                return None;
+                            }
                             cfg.appdata_path = Some(path);
                             if let Err(e) = Self::save_config(&cfg).await {
                                 warn!("persist appdata_path failed: {e}");
@@ -6296,61 +6364,6 @@ fn chrono_from_timestamp(ts: i64) -> String {
     format!("{ts}")
 }
 
-/// Create apps storage directory on bcachefs.
-async fn setup_apps_storage(filesystem: Option<&str>) -> Option<String> {
-    let fs_name = if let Some(name) = filesystem {
-        let path = format!("/fs/{name}");
-        if !Path::new(&path).is_dir() {
-            error!("Specified filesystem '{name}' not found at {path}");
-            return None;
-        }
-        name.to_string()
-    } else {
-        let fs_base = Path::new("/fs");
-        let mut entries = match tokio::fs::read_dir(fs_base).await {
-            Ok(e) => e,
-            Err(_) => {
-                error!("No /fs directory — cannot set up apps storage");
-                return None;
-            }
-        };
-
-        let mut found = None;
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
-                found = Some(entry.file_name().to_string_lossy().to_string());
-                break;
-            }
-        }
-
-        match found {
-            Some(n) => n,
-            None => {
-                error!("No filesystems found under /fs — cannot set up apps storage");
-                return None;
-            }
-        }
-    };
-
-    let apps_path = format!("/fs/{fs_name}/apps");
-
-    if Path::new(&apps_path).exists() {
-        info!("Apps storage already exists at {apps_path}");
-        return Some(apps_path);
-    }
-
-    match run_cmd("bcachefs", &["subvolume", "create", &apps_path]).await {
-        Ok(()) => {
-            info!("Created apps subvolume at {apps_path}");
-            Some(apps_path)
-        }
-        Err(e) => {
-            error!("Failed to create apps subvolume at {apps_path}: {e}");
-            None
-        }
-    }
-}
-
 /// Configure Docker's data-root to store images/layers on bcachefs instead of root partition.
 /// Create (if needed) the appdata subvolume on `fs_name` and point the
 /// stable [`APPDATA_LINK`] symlink at it (#436). A dedicated subvolume
@@ -6359,6 +6372,12 @@ async fn setup_apps_storage(filesystem: Option<&str>) -> Option<String> {
 /// without dragging Docker's internal state along. Returns the real
 /// path.
 async fn setup_appdata_storage(fs_name: &str) -> Result<String, AppsError> {
+    let fs_root = format!("/fs/{fs_name}");
+    if !fs_root_is_mounted(&fs_root) {
+        return Err(AppsError::CommandFailed(format!(
+            "filesystem '{fs_name}' is not mounted at {fs_root}"
+        )));
+    }
     let appdata_path = format!("/fs/{fs_name}/appdata");
     if !Path::new(&appdata_path).exists() {
         run_cmd("bcachefs", &["subvolume", "create", &appdata_path])
@@ -6413,6 +6432,7 @@ async fn ensure_appdata_symlink(target: &str, link: &Path) -> Result<(), AppsErr
 /// the old location fully intact and the partial copy gets dropped.
 async fn run_appdata_relocation(
     status: std::sync::Arc<tokio::sync::Mutex<Option<AppdataRelocateStatus>>>,
+    config_mutations: std::sync::Arc<tokio::sync::Mutex<()>>,
     current: String,
     target_path: String,
     affected: Vec<(String, String, bool)>,
@@ -6429,14 +6449,28 @@ async fn run_appdata_relocation(
     // Best-effort restart of whatever we stopped, then record failure.
     async fn fail(
         status: &std::sync::Arc<tokio::sync::Mutex<Option<AppdataRelocateStatus>>>,
+        config_mutations: &std::sync::Arc<tokio::sync::Mutex<()>>,
         stopped: &[(String, String)],
         error: String,
     ) {
         error!("appdata relocation failed: {error}");
         for (name, kind) in stopped {
+            let config_guard = config_mutations.lock().await;
+            match AppsService::load_config_strict() {
+                Ok(config) if config.enabled => {}
+                Ok(_) => {
+                    info!("Apps disabled during relocation; leaving stopped apps stopped");
+                    break;
+                }
+                Err(config_error) => {
+                    warn!("could not verify Apps configuration before restart: {config_error}");
+                    break;
+                }
+            }
             if let Err(e) = appdata_start_app(name, kind).await {
                 warn!("restart of '{name}' after failed relocation also failed: {e}");
             }
+            drop(config_guard);
         }
         if let Some(s) = status.lock().await.as_mut() {
             s.running = false;
@@ -6445,13 +6479,34 @@ async fn run_appdata_relocation(
         }
     }
 
+    let _source_mount_lease = match mounted_fs_lease(&current).await {
+        Ok(lease) => lease,
+        Err(error) => {
+            fail(&status, &config_mutations, &[], error.to_string()).await;
+            return;
+        }
+    };
+    let _target_mount_lease = match mounted_fs_lease(&target_path).await {
+        Ok(lease) => lease,
+        Err(error) => {
+            fail(&status, &config_mutations, &[], error.to_string()).await;
+            return;
+        }
+    };
+
     let mut stopped: Vec<(String, String)> = Vec::new();
     for (name, kind, was_running) in &affected {
         if !*was_running {
             continue;
         }
         if let Err(e) = appdata_stop_app(name, kind).await {
-            fail(&status, &stopped, format!("stopping '{name}': {e}")).await;
+            fail(
+                &status,
+                &config_mutations,
+                &stopped,
+                format!("stopping '{name}': {e}"),
+            )
+            .await;
             return;
         }
         stopped.push((name.clone(), kind.clone()));
@@ -6459,7 +6514,13 @@ async fn run_appdata_relocation(
 
     set_phase(&status, "copying").await;
     if let Err(e) = run_cmd("bcachefs", &["subvolume", "create", &target_path]).await {
-        fail(&status, &stopped, format!("create target subvolume: {e}")).await;
+        fail(
+            &status,
+            &config_mutations,
+            &stopped,
+            format!("create target subvolume: {e}"),
+        )
+        .await;
         return;
     }
     {
@@ -6472,22 +6533,69 @@ async fn run_appdata_relocation(
     if let Err(e) = run_bulk_cmd("cp", &["-a", &format!("{current}/."), &target_path]).await {
         // Drop the partial copy so a retry doesn't hit the no-merge guard.
         let _ = run_cmd("bcachefs", &["subvolume", "delete", &target_path]).await;
-        fail(&status, &stopped, format!("copy failed: {e}")).await;
+        fail(
+            &status,
+            &config_mutations,
+            &stopped,
+            format!("copy failed: {e}"),
+        )
+        .await;
+        return;
+    }
+    if !fs_root_is_mounted(&target_path) {
+        fail(
+            &status,
+            &config_mutations,
+            &stopped,
+            "target filesystem was unmounted during relocation".into(),
+        )
+        .await;
         return;
     }
 
     set_phase(&status, "switching").await;
+    let config_guard = config_mutations.lock().await;
+    let mut cfg = match AppsService::load_config_strict() {
+        Ok(config) if config.enabled => config,
+        Ok(_) => {
+            if let Some(state) = status.lock().await.as_mut() {
+                state.running = false;
+                state.phase = "failed".to_string();
+                state.error = Some("Apps runtime was disabled during relocation".to_string());
+            }
+            return;
+        }
+        Err(error) => {
+            drop(config_guard);
+            fail(
+                &status,
+                &config_mutations,
+                &stopped,
+                format!("verify Apps configuration before switching: {error}"),
+            )
+            .await;
+            return;
+        }
+    };
     if let Err(e) = ensure_appdata_symlink(&target_path, Path::new(APPDATA_LINK)).await {
-        fail(&status, &stopped, format!("flip /appdata symlink: {e}")).await;
+        drop(config_guard);
+        fail(
+            &status,
+            &config_mutations,
+            &stopped,
+            format!("flip /appdata symlink: {e}"),
+        )
+        .await;
         return;
     }
-    let mut cfg = AppsService::load_config();
     cfg.appdata_path = Some(target_path.clone());
     if let Err(e) = AppsService::save_config(&cfg).await {
         // The symlink already points at the new location; a stale
         // config would flip it back on next boot. Loud failure.
+        drop(config_guard);
         fail(
             &status,
+            &config_mutations,
             &stopped,
             format!(
                 "persist new appdata path: {e} — /appdata points at {target_path} but the \
@@ -6497,14 +6605,28 @@ async fn run_appdata_relocation(
         .await;
         return;
     }
+    drop(config_guard);
 
     set_phase(&status, "restarting").await;
     let mut restart_errors = Vec::new();
     for (name, kind) in &stopped {
+        let config_guard = config_mutations.lock().await;
+        match AppsService::load_config_strict() {
+            Ok(config) if config.enabled => {}
+            Ok(_) => {
+                info!("Apps disabled during relocation; leaving remaining apps stopped");
+                break;
+            }
+            Err(error) => {
+                restart_errors.push(format!("verify Apps configuration: {error}"));
+                break;
+            }
+        }
         if let Err(e) = appdata_start_app(name, kind).await {
             warn!("restart of '{name}' after relocation failed: {e}");
             restart_errors.push(format!("'{name}': {e}"));
         }
+        drop(config_guard);
     }
 
     info!("appdata relocated to {target_path}; old copy left at {current}");
@@ -6541,27 +6663,31 @@ async fn appdata_stop_app(name: &str, kind: &str) -> Result<(), AppsError> {
 }
 
 async fn appdata_start_app(name: &str, kind: &str) -> Result<(), AppsError> {
-    if kind == "compose" {
-        run_cmd(
-            "docker",
-            &[
-                "compose",
-                "-f",
-                &format!("{COMPOSE_DIR}/{name}/docker-compose.yml"),
-                "--project-name",
-                name,
-                "start",
-            ],
-        )
-        .await
-    } else {
-        run_cmd("docker", &["start", &container_name(name)]).await
-    }
+    tokio::time::timeout(Duration::from_secs(30), async {
+        if kind == "compose" {
+            run_cmd(
+                "docker",
+                &[
+                    "compose",
+                    "-f",
+                    &format!("{COMPOSE_DIR}/{name}/docker-compose.yml"),
+                    "--project-name",
+                    name,
+                    "start",
+                ],
+            )
+            .await
+        } else {
+            run_cmd("docker", &["start", &container_name(name)]).await
+        }
+    })
+    .await
+    .map_err(|_| AppsError::CommandFailed(format!("starting app '{name}' timed out")))?
 }
 
 /// Ensure Docker stores data on bcachefs by symlinking /var/lib/docker.
 /// Must be called before Docker starts — Docker reads data-root at startup.
-async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), AppsError> {
+async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<String, AppsError> {
     let fs_name = if let Some(name) = filesystem {
         name.to_string()
     } else {
@@ -6571,13 +6697,23 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
             .map_err(|e| AppsError::CommandFailed(format!("cannot read /fs: {e}")))?;
         let mut found = None;
         while let Ok(Some(entry)) = entries.next_entry().await {
-            if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false) {
-                found = Some(entry.file_name().to_string_lossy().to_string());
+            let path = entry.path();
+            if entry.file_type().await.map(|t| t.is_dir()).unwrap_or(false)
+                && fs_root_is_mounted(&path.to_string_lossy())
+            {
+                found = Some(entry.file_name().to_string_lossy().into_owned());
                 break;
             }
         }
-        found.ok_or_else(|| AppsError::CommandFailed("no filesystems under /fs".into()))?
+        found.ok_or_else(|| AppsError::CommandFailed("no mounted filesystems under /fs".into()))?
     };
+
+    let fs_root = format!("/fs/{fs_name}");
+    if !fs_root_is_mounted(&fs_root) {
+        return Err(AppsError::CommandFailed(format!(
+            "filesystem '{fs_name}' is not mounted at {fs_root}"
+        )));
+    }
 
     // Ensure the apps subvolume exists first
     let apps_path = format!("/fs/{fs_name}/apps");
@@ -6600,7 +6736,7 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
         && target.to_string_lossy() == docker_data
     {
         info!("Docker data symlink already points to {docker_data}");
-        return Ok(());
+        return Ok(apps_path);
     }
 
     // Stop Docker if running (we need to move/replace its data dir)
@@ -6620,7 +6756,7 @@ async fn configure_docker_data_root(filesystem: Option<&str>) -> Result<(), Apps
         })?;
 
     info!("Symlinked /var/lib/docker -> {docker_data}");
-    Ok(())
+    Ok(apps_path)
 }
 
 /// Remove an empty directory or symlink at `path` so a fresh symlink can be
@@ -7226,6 +7362,24 @@ services:
         let _ = std::fs::remove_dir_all(&p);
         let _ = std::fs::remove_file(&p);
         p
+    }
+
+    #[tokio::test]
+    async fn apps_config_removal_reports_failures_and_tolerates_absence() {
+        let base = unique_tmp("config-removal");
+        std::fs::create_dir_all(&base).unwrap();
+        let config = base.join("apps-enabled");
+        std::fs::write(&config, b"{}").unwrap();
+
+        super::AppsService::remove_config(&config).await.unwrap();
+        assert!(!config.exists());
+        super::AppsService::remove_config(&config).await.unwrap();
+
+        std::fs::create_dir(&config).unwrap();
+        assert!(super::AppsService::remove_config(&config).await.is_err());
+        assert!(config.is_dir());
+
+        std::fs::remove_dir_all(&base).unwrap();
     }
 
     #[test]

--- a/engine/nasty-storage/src/filesystem.rs
+++ b/engine/nasty-storage/src/filesystem.rs
@@ -1721,11 +1721,6 @@ async fn build_create_plan(
     }
 
     let mount_point = format!("{NASTY_MOUNT_BASE}/{}", req.name);
-    match tokio::fs::symlink_metadata(&mount_point).await {
-        Ok(_) => return Err(FilesystemError::AlreadyExists(req.name.clone())),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(FilesystemError::Io(e)),
-    }
 
     let inventory = read_block_inventory().await?;
     let swaps = read_active_swaps(&inventory).await?;
@@ -1813,13 +1808,68 @@ async fn build_create_plan(
 
 async fn reserve_create_mount_point(plan: &CreateFilesystemPlan) -> Result<(), FilesystemError> {
     tokio::fs::create_dir_all(NASTY_MOUNT_BASE).await?;
-    match tokio::fs::create_dir(&plan.mount_point).await {
+    reserve_create_mount_point_at(&plan.mount_point, &plan.request.name).await
+}
+
+async fn reserve_create_mount_point_at(
+    mount_point: &str,
+    filesystem_name: &str,
+) -> Result<(), FilesystemError> {
+    match tokio::fs::create_dir(mount_point).await {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            Err(FilesystemError::AlreadyExists(plan.request.name.clone()))
+            let metadata = tokio::fs::symlink_metadata(mount_point).await?;
+            if !metadata.is_dir() {
+                return Err(FilesystemError::InvalidInput(format!(
+                    "mount point {mount_point} already exists and is not a plain directory"
+                )));
+            }
+            if is_mountpoint(mount_point).await {
+                return Err(FilesystemError::InvalidInput(format!(
+                    "mount point {mount_point} is occupied"
+                )));
+            }
+
+            // Forget deliberately leaves the canonical directory in place.
+            // Reclaim it only when remove_dir proves atomically that it is
+            // empty; any raced write or operator-owned content fails closed.
+            match tokio::fs::remove_dir(mount_point).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {
+                    return Err(FilesystemError::InvalidInput(format!(
+                        "mount point {mount_point} already exists and is not empty"
+                    )));
+                }
+                Err(error) => return Err(FilesystemError::Io(error)),
+            }
+
+            match tokio::fs::create_dir(mount_point).await {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    Err(FilesystemError::AlreadyExists(filesystem_name.to_string()))
+                }
+                Err(error) => Err(FilesystemError::Io(error)),
+            }
         }
         Err(e) => Err(FilesystemError::Io(e)),
     }
+}
+
+async fn verify_create_mount_point_reserved(mount_point: &str) -> Result<(), FilesystemError> {
+    let metadata = tokio::fs::symlink_metadata(mount_point).await?;
+    if !metadata.is_dir() || is_mountpoint(mount_point).await {
+        return Err(FilesystemError::InvalidInput(format!(
+            "mount point {mount_point} changed after preflight; refusing to format devices"
+        )));
+    }
+    let mut entries = tokio::fs::read_dir(mount_point).await?;
+    if entries.next_entry().await?.is_some() {
+        return Err(FilesystemError::InvalidInput(format!(
+            "mount point {mount_point} is no longer empty; refusing to format devices"
+        )));
+    }
+    Ok(())
 }
 
 fn identity_changed(
@@ -2378,6 +2428,7 @@ impl FilesystemService {
             }
 
             info!("Mounting filesystem '{name}'...");
+            let _mutation_guard = self.block_mutations.lock().await;
             match self.mount_with_opts(name, opts).await {
                 Ok(_) => info!("Filesystem '{name}' mounted at {mount_point}"),
                 Err(e) => {
@@ -2655,6 +2706,7 @@ impl FilesystemService {
             let _ = tokio::fs::remove_dir(&mount_point).await;
             return Err(e);
         }
+        verify_create_mount_point_reserved(&mount_point).await?;
         let args = build_create_format_args(&req, &req.devices);
 
         // Format
@@ -3007,6 +3059,7 @@ impl FilesystemService {
         name: &str,
         force_degraded: bool,
     ) -> Result<Filesystem, FilesystemError> {
+        let _mutation_guard = self.block_mutations.lock().await;
         let state = load_fs_state().await;
         if state
             .get(name)
@@ -7809,6 +7862,19 @@ async fn verify_filesystem_device_identity(fs: &Filesystem) -> Result<(), Filesy
 mod tests {
     use super::*;
 
+    fn unique_tmp(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "nasty-filesystem-test-{tag}-{}-{n}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
     fn create_request(paths: &[&str]) -> CreateFilesystemRequest {
         CreateFilesystemRequest {
             name: "tank".into(),
@@ -7839,6 +7905,57 @@ mod tests {
             version_upgrade: None,
             journal_flush_delay: None,
         }
+    }
+
+    #[tokio::test]
+    async fn create_mount_point_reclaims_only_an_empty_plain_directory() {
+        let base = unique_tmp("mount-reservation");
+        std::fs::create_dir_all(&base).unwrap();
+        let mount_point = base.join("first");
+        std::fs::create_dir(&mount_point).unwrap();
+
+        reserve_create_mount_point_at(mount_point.to_str().unwrap(), "first")
+            .await
+            .unwrap();
+        assert!(mount_point.is_dir());
+
+        let marker = mount_point.join("operator-data");
+        std::fs::write(&marker, b"keep").unwrap();
+        let error = verify_create_mount_point_reserved(mount_point.to_str().unwrap())
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("is no longer empty"));
+        let error = reserve_create_mount_point_at(mount_point.to_str().unwrap(), "first")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("is not empty"));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"keep");
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_mount_point_refuses_a_symlink() {
+        let base = unique_tmp("mount-symlink");
+        let target = base.join("target");
+        let mount_point = base.join("first");
+        std::fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &mount_point).unwrap();
+
+        let error = reserve_create_mount_point_at(mount_point.to_str().unwrap(), "first")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("is not a plain directory"));
+        assert!(
+            mount_point
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(target.is_dir());
+
+        std::fs::remove_dir_all(&base).unwrap();
     }
 
     fn filesystem_fixture(name: &str, uuid: &str) -> Filesystem {

--- a/nixos/modules/nasty.nix
+++ b/nixos/modules/nasty.nix
@@ -30,6 +30,25 @@ let
   '';
   nastyFirewallBaseline = pkgs.writeText "nasty-firewall-baseline.nft" nastyFirewallBaselineText;
 
+  # Socket activation can bypass the engine's Apps restore guard. Verify that
+  # a Docker data-root symlink under /fs resolves through an actual mount, not
+  # a stale directory on the appliance root filesystem.
+  dockerStorageReady = pkgs.writeShellScript "nasty-docker-storage-ready" ''
+    if [[ ! -L /var/lib/docker ]]; then
+      exit 0
+    fi
+    target="$(${pkgs.coreutils}/bin/readlink -f -- /var/lib/docker 2>/dev/null)" || exit 1
+    case "$target" in
+      /fs/*)
+        rest="''${target#/fs/}"
+        filesystem="''${rest%%/*}"
+        [[ -n "$filesystem" ]] || exit 1
+        exec ${pkgs.util-linux}/bin/mountpoint -q -- "/fs/$filesystem"
+        ;;
+      *) exit 0 ;;
+    esac
+  '';
+
   # Secure Boot integration is opt-in per box. The wrapper flake at
   # /etc/nixos/flake.nix passes the lanzaboote input through as a
   # specialArg when it has the input declared; pre-#324-era wrappers
@@ -710,16 +729,12 @@ in {
     systemd.services.docker.wantedBy = lib.mkForce [];
     systemd.sockets.docker.wantedBy = lib.mkForce [];
 
-    # Refuse to start dockerd while its data-root symlink is *dangling*
-    # (#424). The engine symlinks /var/lib/docker onto the apps bcachefs
-    # filesystem; when that FS isn't mounted/unlocked at boot the symlink
-    # dangles, and dockerd's startup mkdir fails with "mkdir
-    # /var/lib/docker: file exists", crash-loops into start-limit-hit, and
-    # wedges the apps UI. The engine's restore() guards the path *it*
-    # drives, but docker.service is TriggeredBy=docker.socket — so a client
-    # connecting to the still-listening socket socket-activates dockerd
-    # behind the engine's back. A `Condition` (skip, not assert) covers
-    # every trigger path with no restart counter.
+    # Refuse to start dockerd while its data-root symlink is unsafe (#424).
+    # A missing filesystem usually leaves the symlink dangling, but stale
+    # directories below /fs can also make it resolve onto the root filesystem.
+    # The conditions reject dangling links; ExecCondition additionally verifies
+    # that a resolving /fs target crosses a real mount boundary. Both apply to
+    # engine starts and docker.socket activation.
     #
     # The two conditions are ORed (the `|` triggering prefix): start docker
     # iff /var/lib/docker resolves to a directory, OR is not a symlink at
@@ -731,12 +746,13 @@ in {
     # (skip) — ConditionPathExists/IsDirectory follow the link and can't.
     #
     #   absent           → IsDirectory=F, !IsSymlink=T → start (dockerd mkdirs it)
-    #   real dir / valid  → IsDirectory=T               → start
+    #   real dir / valid  → IsDirectory=T               → run ExecCondition
     #   dangling symlink → IsDirectory=F, !IsSymlink=F → skip
     systemd.services.docker.unitConfig = {
       ConditionPathIsDirectory = "|/var/lib/docker";
       ConditionPathIsSymbolicLink = "|!/var/lib/docker";
     };
+    systemd.services.docker.serviceConfig.ExecCondition = dockerStorageReady;
 
     # ── System packages ────────────────────────────────────────
 

--- a/webui/src/routes/apps/+page.svelte
+++ b/webui/src/routes/apps/+page.svelte
@@ -148,6 +148,7 @@
 	let appStats = $state<Record<string, AppStats>>({});
 	let loading = $state(true);
 	let enabling = $state(false);
+	let disabling = $state(false);
 	// Inline enable prompt shown when the user clicks Install App while the
 	// runtime is disabled — keeps the empty-state apps page looking like the
 	// running page so the user doesn't see two unrelated layouts.
@@ -647,6 +648,9 @@
 
 	const client = getClient();
 	let startupPoll: ReturnType<typeof setInterval> | null = null;
+	let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+	let startupPollGeneration = 0;
+	let startupTimedOut = $state(false);
 	let statsPoll: ReturnType<typeof setInterval> | null = null;
 	/** Idle poll for the apps list itself. Without this, the page only
 	 * refreshes apps.list after a user action — so a container that
@@ -918,7 +922,7 @@
 	onMount(async () => {
 		await Promise.all([refresh(), loadFilesystems(), refreshAppdataStatus()]);
 		loading = false;
-		if (status?.enabled && !status?.running) startStartupPolling();
+		if (shouldPollForStartup()) startStartupPolling();
 		if (status?.enabled && status?.running) {
 			startStatsPolling();
 			startListPolling();
@@ -987,19 +991,62 @@
 
 	function startStartupPolling() {
 		stopStartupPolling();
+		const generation = ++startupPollGeneration;
+		startupTimedOut = false;
 		startupPoll = setInterval(async () => {
-			await refresh();
-			if (status?.running) {
+			if (!await refreshStartupStatus(generation)) return;
+			if (!shouldPollForStartup()) {
 				stopStartupPolling();
-				startStatsPolling();
+				if (status?.running) {
+					startStatsPolling();
+					startListPolling();
+				}
 			}
 		}, 5000);
+		startupTimeout = setTimeout(async () => {
+			if (!await refreshStartupStatus(generation)) return;
+			if (!shouldPollForStartup()) {
+				stopStartupPolling();
+				if (status?.running) {
+					startStatsPolling();
+					startListPolling();
+				}
+				return;
+			}
+			if (startupPoll) clearInterval(startupPoll);
+			startupPoll = null;
+			startupTimeout = null;
+			startupTimedOut = true;
+		}, 60_000);
 	}
 
 	function stopStartupPolling() {
+		startupPollGeneration++;
 		if (startupPoll) {
 			clearInterval(startupPoll);
 			startupPoll = null;
+		}
+		if (startupTimeout) {
+			clearTimeout(startupTimeout);
+			startupTimeout = null;
+		}
+	}
+
+	function shouldPollForStartup(): boolean {
+		return status?.enabled === true
+			&& !status.running
+			&& (!status.storage_path || status.storage_ok);
+	}
+
+	async function refreshStartupStatus(generation: number): Promise<boolean> {
+		try {
+			const next = await client.call<AppsStatus>('apps.status');
+			if (generation !== startupPollGeneration) return false;
+			status = next;
+			if (!next.enabled || next.running) startupTimedOut = false;
+			return true;
+		} catch {
+			return generation === startupPollGeneration;
 		}
 	}
 
@@ -1056,15 +1103,21 @@
 
 	function onVisibilityChange() {
 		if (document.hidden) {
+			stopStartupPolling();
 			stopStatsPolling();
 			stopListPolling();
-		} else if (status?.enabled && status?.running) {
-			startStatsPolling();
-			startListPolling();
-			// Tab just came back — refresh once immediately so the user
-			// doesn't stare at stale data for up to 5s waiting for the
-			// next interval tick.
-			void refresh();
+		} else {
+			const generation = ++startupPollGeneration;
+			void refreshStartupStatus(generation).then((updated) => {
+				if (!updated) return;
+				if (status?.enabled && status.running) {
+					startStatsPolling();
+					startListPolling();
+					void refresh();
+				} else if (shouldPollForStartup()) {
+					startStartupPolling();
+				}
+			});
 		}
 	}
 
@@ -1081,6 +1134,7 @@
 	async function refresh() {
 		try {
 			status = await client.call<AppsStatus>('apps.status');
+			if (!status.enabled || status.running) startupTimedOut = false;
 			apps = await client.call<App[]>('apps.list');
 			if (status.enabled && status.running) {
 				await loadIngresses();
@@ -1162,7 +1216,25 @@
 		);
 		enabling = false;
 		await refresh();
-		if (status?.enabled && !status?.running) startStartupPolling();
+		if (shouldPollForStartup()) startStartupPolling();
+	}
+
+	async function disableAppsForMissingStorage() {
+		if (!await confirm(
+			'Disable Apps runtime?',
+			'This stops Docker and clears its saved storage association so the missing filesystem can be forgotten. App definitions and data on disk are not deleted.',
+		)) return;
+		disabling = true;
+		const disabled = await withToast(
+			() => client.call('apps.disable', undefined, 60_000),
+			'Apps runtime disabled',
+		);
+		disabling = false;
+		if (disabled !== undefined) {
+			stopStartupPolling();
+			startupTimedOut = false;
+			await refresh();
+		}
 	}
 
 	function addPort() {
@@ -1767,11 +1839,40 @@
 
 {#if loading}
 	<p class="text-muted-foreground">Loading...</p>
+{:else if status?.enabled && status.storage_path && !status.storage_ok}
+	<Card class="max-w-2xl border-destructive/40">
+		<CardContent class="py-8">
+			<h3 class="font-semibold text-destructive">App storage is unavailable</h3>
+			<p class="mt-2 text-sm text-muted-foreground">
+				Docker was not started because its configured storage path <code>{status.storage_path}</code> is not on a mounted filesystem.
+			</p>
+			<p class="mt-2 text-sm text-muted-foreground">
+				Reconnect and mount that filesystem to recover the apps, or disable the runtime to clear this storage association before forgetting the filesystem. Disabling does not erase app definitions or disk data.
+			</p>
+			<div class="mt-4 flex flex-wrap gap-2">
+				<Button size="sm" onclick={() => goto('/filesystems')}>Review Filesystems</Button>
+				<Button size="sm" variant="secondary" onclick={disableAppsForMissingStorage} disabled={disabling}>
+					{disabling ? 'Disabling...' : 'Disable Apps Runtime'}
+				</Button>
+			</div>
+		</CardContent>
+	</Card>
 {:else if filesystems.length === 0}
 	<div class="flex flex-col items-center justify-center py-12 text-center">
 		<p class="text-muted-foreground">Apps need a filesystem to store data.</p>
 		<Button size="sm" class="mt-2" onclick={() => goto('/filesystems?create')}>Create Filesystem</Button>
 	</div>
+{:else if status?.enabled && !status.running && startupTimedOut}
+	<Card class="max-w-2xl border-destructive/40">
+		<CardContent class="py-8 text-center">
+			<p class="font-medium text-destructive">App runtime did not start</p>
+			<p class="mt-1 text-sm text-muted-foreground">Docker did not become ready within 60 seconds. Review the service status before trying again.</p>
+			<div class="mt-4 flex justify-center gap-2">
+				<Button size="sm" onclick={startStartupPolling}>Retry Status Check</Button>
+				<Button size="sm" variant="secondary" onclick={() => goto('/services?configure=docker')}>Review Docker Service</Button>
+			</div>
+		</CardContent>
+	</Card>
 {:else if status?.enabled && !status?.running}
 	<Card class="mb-4">
 		<CardContent class="py-8 text-center">

--- a/webui/src/routes/filesystems/+page.svelte
+++ b/webui/src/routes/filesystems/+page.svelte
@@ -53,6 +53,7 @@
 	let hostTpmAvailable = $state(false);
 	let wizardStep: 0 | 1 | 2 | 3 = $state(0); // 0=hidden, 1=name+devices, 2=profile, 3=review
 	let loading = $state(true);
+	let creating = $state(false);
 
 	// Wizard state
 	let newName = $state('first');
@@ -683,10 +684,12 @@
 	});
 
 	async function createFs() {
+		if (creating) return;
 		if (!newName || selectedPaths.length === 0) return;
 		if (erasureCode && selectedPaths.length < replicas + 1) return;
 		if (encryption && (!passphrase || passphrase !== passphraseConfirm)) return;
 		const profile = activeProfile();
+		creating = true;
 		const ok = await withToast(
 			() => client.call('fs.create', {
 				name: newName,
@@ -711,9 +714,10 @@
 				encoded_extent_max: encodedExtentMax || undefined,
 				version_upgrade: versionUpgrade || undefined,
 				journal_flush_delay: journalFlushDelay ? parseInt(journalFlushDelay) : undefined,
-			}),
+			}, 300_000),
 			`Filesystem "${newName}" created`
 		);
+		creating = false;
 		if (ok !== undefined) {
 			wizardStep = 0;
 			newName = 'first';
@@ -1982,7 +1986,9 @@
 
 				<div class="flex gap-2">
 					<Button variant="secondary" size="sm" onclick={() => wizardStep = 2}>← Back</Button>
-					<Button size="sm" onclick={createFs} disabled={(erasureCode && selectedPaths.length < replicas + 1) || (encryption && (!passphrase || passphrase !== passphraseConfirm))}>Create Filesystem</Button>
+					<Button size="sm" onclick={createFs} disabled={creating || (erasureCode && selectedPaths.length < replicas + 1) || (encryption && (!passphrase || passphrase !== passphraseConfirm))}>
+						{creating ? 'Creating...' : 'Create Filesystem'}
+					</Button>
 				</div>
 			{/if}
 		</CardContent>


### PR DESCRIPTION
## Summary
- surface unavailable Apps storage in the WebUI, bound startup polling, and provide a safe runtime-disable recovery action
- prevent Docker from starting through socket activation unless its `/fs` data root crosses a real mount boundary
- safely reclaim only empty stale filesystem mount directories for same-name recreation and serialize mount/create/Forget mutations
- persist Apps storage before startup and serialize appdata relocation against Disable while leasing source and target mounts
- extend filesystem creation RPCs to five minutes and prevent duplicate submissions

## Testing
- `cargo test -p nasty-apps -p nasty-storage`
- `cargo clippy -p nasty-apps -p nasty-storage --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run check`
- `npm test`
- `npm run build`
- NixOS module evaluation of `systemd.services.docker.serviceConfig.ExecCondition`
- `git diff --check origin/main...HEAD`